### PR TITLE
vscode-extensions: add optional Marketplace signature verification

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/README.md
+++ b/pkgs/applications/editors/vscode/extensions/README.md
@@ -15,6 +15,15 @@
 
 * Use `hash` instead of `sha256`.
 
+* Add `signatureHash` to enable automatic cryptographic signature verification (optional) or pass `--with-signature` to the update script to populate it.
+  For multi-platform extensions with per-system `hash` values, the update script fetches a `signatureHash` per platform and inserts it into each per-system block.
+
+  Signature verification runs only when the `vscode` package exposes `passthru.hasVsceSign = true`.
+  Microsoft's build does; `vscodium` does not because it ships without the `vsce-sign` binary).
+  Users who overlay `vscode = vscodium` or other variant without `vsce-sign` get verification automatically skipped.
+
+  For per-extension opt-out set `allowMissingVsceSign = true` via `overrideAttrs`: `(pkgs.vscode-extensions.publisher.extension.overrideAttrs { allowMissingVsceSign = true; })`.
+
 * On `meta` field:
   - add a `changelog`.
   - `description` should mention it is a Visual Studio Code extension.

--- a/pkgs/applications/editors/vscode/extensions/README.md
+++ b/pkgs/applications/editors/vscode/extensions/README.md
@@ -15,6 +15,18 @@
 
 * Use `hash` instead of `sha256`.
 
+* Add `signatureHash` to pin the extension's Marketplace signature, or pass `--with-signature` to the update script to populate it.
+  For multi-platform extensions with per-system `hash` values, the update script fetches a `signatureHash` per platform and inserts it into each per-system block.
+
+  Passing `--with-signature` also verifies each pinned VSIX against its signature with Microsoft's `vsce-sign` on every supported platform, so a missing or invalid signature fails the update; pass `--skip-verify` to populate hashes without verifying.
+  When updating through `nix-update` or `passthru.updateScript` (which cannot forward these flags), set `VSCODE_EXTENSION_WITH_SIGNATURE=1` (and optionally `VSCODE_EXTENSION_SKIP_VERIFY=1`) in the environment instead.
+  Routine updates that only refresh an existing `signatureHash` (e.g. automated `r-ryantm` runs) do not verify, so they stay free and never pull the unfree `vsce-sign`.
+
+  Build-time verification is opt-in: it re-checks the signature with `vsce-sign` during the build.
+  Enable it per extension with `verifySignature = true`, or for every signed extension by setting `vscodeExtensions.verifySignature = true` in your nixpkgs config.
+  This pulls the unfree `vsce-sign` (bundled with `vscode`) into the build closure, so it is off by default to keep extensions free-buildable on Hydra and usable with `vscodium`.
+  It only runs when the `vscode` package exposes `passthru.hasVsceSign = true` (Microsoft's build does; `vscodium` does not), so overlaying `vscode = vscodium` skips it automatically.
+
 * On `meta` field:
   - add a `changelog`.
   - `description` should mention it is a Visual Studio Code extension.

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -23,18 +23,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         "x86_64-linux" = {
           arch = "linux-x64";
           hash = "sha256-cDR/E5ATkKHUhvfQ+721M1DbNNxbSzWdnah7kEpyIxc=";
+          signatureHash = "sha256-X18dx/5ZbDYA+nxHPwPUe9+smEemHPoDX/KGq+117Ls=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
           hash = "sha256-8vJHvwYdCdQb0kHNbM6KNp27BJh8RGrBmw++Zz7nLf4=";
+          signatureHash = "sha256-tB+7NtUaH96SjWzYrlgLmfFWtnqNT6wcHxqLQ8pFO0k=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
           hash = "sha256-y93nqrqeLrOSPu+/NsKVg1yYPGT1x5XENO3VE/+uQU4=";
+          signatureHash = "sha256-CAV+CiAY3Y+6uE5n1wjrk5ZNFrHEX0Shf7mDOLyVlJA=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
           hash = "sha256-CYewM/KAk/WrEBiDK/aCkNc4/sGMIDnrHAoHIYU/h+o=";
+          signatureHash = "sha256-btKfHI2TWuyf51UZnr+MnbrncDhVS2iiALIUOkSABus=";
         };
       };
     in

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -6,6 +6,7 @@
   alsa-lib,
   testers,
   vscode-utils,
+  vscode-extension-update-script,
 }:
 
 vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {

--- a/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/anthropic.claude-code/default.nix
@@ -23,18 +23,22 @@ vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
         "x86_64-linux" = {
           arch = "linux-x64";
           hash = "sha256-792UABRtJEpG4ipQsoiN1lkGeaNqHyg69Sv3g26BZBA=";
+          signatureHash = "sha256-nEF9JKIyuJOo1porjjdupLUwOOTUxgcEzZNNVLRNBPQ=";
         };
         "aarch64-linux" = {
           arch = "linux-arm64";
           hash = "sha256-NDiCBtQ/BWPPOAbDs/ACZ68at0gAqJJMPBLCsILnBho=";
+          signatureHash = "sha256-wNl2Zli7QaXBI9j2Ec/ue5vLlQe3TGZCkVmQSIxa4Kw=";
         };
         "x86_64-darwin" = {
           arch = "darwin-x64";
           hash = "sha256-j81bcYqopNTAO/faiugARwAaVZ8s+1Atf8oHDTS8fR4=";
+          signatureHash = "sha256-r7puhlgKwooRUg1+Mj+Efp1CPwHrxeBprCwEL4obYQs=";
         };
         "aarch64-darwin" = {
           arch = "darwin-arm64";
           hash = "sha256-Y6M110iwzKdzJoHb6zEKWyR4NyxyQtuvNJ4ucOrUYdY=";
+          signatureHash = "sha256-GGbiWtyeW+vDVx/7hyDk4LJ5iJTnv2HZK3MvDqCmCJs=";
         };
       };
     in

--- a/pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix
+++ b/pkgs/applications/editors/vscode/extensions/mktplcExtRefToFetchArgs.nix
@@ -5,6 +5,7 @@
   arch ? "",
   sha256 ? "",
   hash ? "",
+  signatureHash ? "",
 }:
 let
   archurl = (if arch == "" then "" else "?targetPlatform=${arch}");

--- a/pkgs/applications/editors/vscode/extensions/verify-vsix-signature-setup-hook.sh
+++ b/pkgs/applications/editors/vscode/extensions/verify-vsix-signature-setup-hook.sh
@@ -1,0 +1,57 @@
+# Verify VSIX signature using VS Code's bundled vsce-sign binary
+# This hook runs at the start of unpackPhase before sources are processed.
+# At this point, $src points to the main source (the VSIX file).
+
+_verifyVsixSignaturePreUnpack() {
+    # Only verify if signatureArchive is provided
+    if [[ -z "${signatureArchive:-}" ]]; then
+        return 0
+    fi
+
+    # Opt-out: user has explicitly accepted that verification may not run here.
+    # Covers environments where vsce-sign is absent (custom VS Code variants) or
+    # can't access the OS trust store (Darwin strict sandbox, where keychain
+    # reads are blocked and vsce-sign would otherwise fail with exit code 36).
+    if [[ "${allowMissingVsceSign:-}" == "1" || "${allowMissingVsceSign:-}" == "true" ]]; then
+        echo "WARNING: signature verification SKIPPED (allowMissingVsceSign=true)" >&2
+        return 0
+    fi
+
+    # $src should be the VSIX file path
+    if [[ -z "${src:-}" ]]; then
+        echo "WARNING: \$src is not set, cannot verify signature" >&2
+        return 0
+    fi
+
+    local vsceSign="@vsceSign@"
+
+    if [[ ! -x "$vsceSign" ]]; then
+        echo "ERROR: vsce-sign not found at $vsceSign" >&2
+        echo "       Signature verification was requested (signatureArchive is set) but the verifier is unavailable." >&2
+        echo "       Set allowMissingVsceSign = true on the extension to skip verification with a warning." >&2
+        return 1
+    fi
+
+    echo "Verifying VSIX signature..."
+    local exitCode=0
+    "$vsceSign" verify --package "$src" --signaturearchive "$signatureArchive" || exitCode=$?
+
+    if [[ $exitCode -eq 0 ]]; then
+        echo "Signature verification: PASSED"
+        return 0
+    fi
+
+    echo "Signature verification: FAILED (exit code: $exitCode)" >&2
+    case $exitCode in
+        30) echo "ERROR: Package integrity check failed - contents don't match signature" >&2 ;;
+        31) echo "ERROR: Invalid signature format" >&2 ;;
+        35) echo "ERROR: Package has been tampered with" >&2 ;;
+        36) echo "ERROR: Certificate is not trusted" >&2 ;;
+        37) echo "ERROR: Certificate has been revoked" >&2 ;;
+        *)  echo "ERROR: Unknown verification error" >&2 ;;
+    esac
+    return 1
+}
+
+# Run signature verification before unpacking
+preUnpackHooks+=(_verifyVsixSignaturePreUnpack)

--- a/pkgs/applications/editors/vscode/extensions/verify-vsix-signature-setup-hook.sh
+++ b/pkgs/applications/editors/vscode/extensions/verify-vsix-signature-setup-hook.sh
@@ -1,0 +1,22 @@
+# Verify VSIX signature using VS Code's bundled vsce-sign binary.
+# Thin wrapper around verify-vsix-signature.sh (the shared verifier) that runs
+# in preUnpackHooks, before the VSIX is unpacked. At that point $src points to
+# the downloaded VSIX, i.e. the exact bytes Microsoft signed.
+#
+# Opt-in: this hook is only attached when `verifySignature` is enabled (per
+# extension, or globally via nixpkgs config `vscodeExtensions.verifySignature`)
+# and vsce-sign is available (see vscode-utils.nix), so the default build stays
+# free and buildable on Hydra / with vscodium.
+
+_verifyVsixSignaturePreUnpack() {
+    # Defensive: the hook is only attached when both are set, but guard anyway.
+    if [[ -z "${signatureArchive:-}" || -z "${src:-}" ]]; then
+        echo "WARNING: missing \$src or \$signatureArchive, skipping signature verification" >&2
+        return 0
+    fi
+
+    @verifyScript@ "@vsceSign@" "$src" "$signatureArchive"
+}
+
+# Run signature verification before unpacking
+preUnpackHooks+=(_verifyVsixSignaturePreUnpack)

--- a/pkgs/applications/editors/vscode/extensions/verify-vsix-signature.sh
+++ b/pkgs/applications/editors/vscode/extensions/verify-vsix-signature.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Verify a VSIX package's VS Code Marketplace signature using Microsoft's
+# vsce-sign binary.
+#
+# Single source of truth for signature verification, shared between the
+# build-time setup hook (verify-vsix-signature-setup-hook.sh) and the update
+# script (vscode_extension_update.py), so both honour the same verifier and
+# exit-code semantics. Takes everything as arguments so it has no build-time
+# or Nix dependencies and can be invoked directly (e.g. `bash this.sh ...`).
+#
+# Usage: verify-vsix-signature.sh <vsce-sign> <vsix> <signature-archive>
+set -uo pipefail
+
+vsceSign="${1:?vsce-sign path required}"
+vsix="${2:?vsix path required}"
+signatureArchive="${3:?signature archive path required}"
+
+if [[ ! -x "$vsceSign" ]]; then
+    echo "ERROR: vsce-sign not found at $vsceSign" >&2
+    exit 1
+fi
+
+echo "Verifying VSIX signature..."
+exitCode=0
+"$vsceSign" verify --package "$vsix" --signaturearchive "$signatureArchive" || exitCode=$?
+
+if [[ $exitCode -eq 0 ]]; then
+    echo "Signature verification: PASSED"
+    exit 0
+fi
+
+echo "Signature verification: FAILED (exit code: $exitCode)" >&2
+case $exitCode in
+    30) echo "ERROR: Package integrity check failed - contents don't match signature" >&2 ;;
+    31) echo "ERROR: Invalid signature format" >&2 ;;
+    35) echo "ERROR: Package has been tampered with" >&2 ;;
+    36) echo "ERROR: Certificate is not trusted" >&2 ;;
+    37) echo "ERROR: Certificate has been revoked" >&2 ;;
+    *)  echo "ERROR: Unknown verification error" >&2 ;;
+esac
+exit "$exitCode"

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -18,6 +18,17 @@ let
       unzip = "${unzip}/bin/unzip";
     };
   } ./unpack-vsix-setup-hook.sh;
+
+  verifyVsixSignatureSetupHook = makeSetupHook {
+    name = "verify-vsix-signature-setup-hook";
+    substitutions = {
+      vsceSign =
+        if stdenv.hostPlatform.isDarwin then
+          "${vscode}/Applications/${vscode.longName}.app/Contents/Resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign"
+        else
+          "${vscode}/lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign";
+    };
+  } ./verify-vsix-signature-setup-hook.sh;
   buildVscodeExtension = lib.extendMkDerivation {
     constructDrv = stdenv.mkDerivation;
     excludeDrvArgNames = [
@@ -71,7 +82,33 @@ let
         # This cannot be removed, it is used by some extensions.
         installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
 
-        nativeBuildInputs = [ unpackVsixSetupHook ] ++ nativeBuildInputs;
+        nativeBuildInputs = [
+          unpackVsixSetupHook
+        ]
+        ++ lib.optional (
+          (finalAttrs.signatureArchive or null) != null
+          && !(finalAttrs.allowMissingVsceSign or false)
+          && vscode.hasVsceSign
+        ) verifyVsixSignatureSetupHook
+        ++ nativeBuildInputs;
+
+        # vsce-sign validates Microsoft's certificate chain via Apple's
+        # Security.framework, which reads the system keychain and MDS store.
+        # Grant those reads under Darwin's relaxed sandbox.
+        sandboxProfile =
+          lib.optionalString
+            (
+              (finalAttrs.signatureArchive or null) != null
+              && stdenv.hostPlatform.isDarwin
+              && !(finalAttrs.allowMissingVsceSign or false)
+              && vscode.hasVsceSign
+            )
+            ''
+              (allow file-read*
+                (literal "/Library/Keychains/System.keychain")
+                (literal "/private/var/db/mds/system/mdsDirectory.db")
+                (literal "/private/var/db/mds/system/mdsObject.db"))
+            '';
 
         installPhase =
           args.installPhase or ''
@@ -85,8 +122,35 @@ let
       };
   };
 
+  mktplcAssetBaseUrl =
+    {
+      publisher,
+      name,
+      version,
+      ...
+    }:
+    "https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${name}/${version}/assetbyname";
+
   fetchVsixFromVscodeMarketplace =
     mktplcExtRef: fetchurl (import ./mktplcExtRefToFetchArgs.nix mktplcExtRef);
+
+  # Fetch signature archive for cryptographic verification
+  fetchSignatureFromVscodeMarketplace =
+    mktplcExtRef:
+    let
+      inherit (mktplcExtRef) publisher name;
+      arch = mktplcExtRef.arch or "";
+      archurl = if arch == "" then "" else "?targetPlatform=${arch}";
+      signatureHash = mktplcExtRef.signatureHash or "";
+    in
+    if signatureHash != "" then
+      fetchurl {
+        url = "${mktplcAssetBaseUrl mktplcExtRef}/Microsoft.VisualStudio.Services.VsixSignature${archurl}";
+        name = "${publisher}-${name}.sigzip";
+        hash = signatureHash;
+      }
+    else
+      null;
 
   buildVscodeMarketplaceExtension = lib.extendMkDerivation {
     constructDrv = buildVscodeExtension;
@@ -112,6 +176,7 @@ let
         vscodeExtPublisher = mktplcRef.publisher;
         vscodeExtName = mktplcRef.name;
         vscodeExtUniqueId = "${mktplcRef.publisher}.${mktplcRef.name}";
+        signatureArchive = fetchSignatureFromVscodeMarketplace mktplcRef;
       };
   };
 
@@ -122,6 +187,7 @@ let
     "sha256"
     "hash"
     "arch"
+    "signatureHash"
   ];
 
   mktplcExtRefToExtDrv =

--- a/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
+++ b/pkgs/applications/editors/vscode/extensions/vscode-utils.nix
@@ -1,4 +1,5 @@
 {
+  config,
   stdenv,
   lib,
   buildEnv,
@@ -8,7 +9,7 @@
   buildPackages,
   unzip,
   makeSetupHook,
-  writeScript,
+  writeShellScript,
   jq,
   vscode-extension-update-script,
 }:
@@ -20,6 +21,33 @@ let
     };
     meta.license = lib.licenses.mit;
   } ./unpack-vsix-setup-hook.sh;
+
+  # Path to Microsoft's vsce-sign binary bundled with the (unfree) vscode.
+  # Exported below so the update script can verify signatures at update time
+  # using the same verifier the build-time hook uses.
+  vsceSignExe =
+    if stdenv.hostPlatform.isDarwin then
+      "${vscode}/Applications/${vscode.longName}.app/Contents/Resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign"
+    else
+      "${vscode}/lib/vscode/resources/app/node_modules/@vscode/vsce-sign/bin/vsce-sign";
+
+  # Single source of truth for the verification logic, shared with the update
+  # script (pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py).
+  verifyVsixSignatureScript = writeShellScript "verify-vsix-signature" (
+    builtins.readFile ./verify-vsix-signature.sh
+  );
+
+  verifyVsixSignatureSetupHook = makeSetupHook {
+    name = "verify-vsix-signature-setup-hook";
+    substitutions = {
+      vsceSign = vsceSignExe;
+      verifyScript = verifyVsixSignatureScript;
+    };
+  } ./verify-vsix-signature-setup-hook.sh;
+
+  # Global default for `verifySignature`, set via nixpkgs config:
+  # `vscodeExtensions.verifySignature = true` verifies every signed extension.
+  globalVerifySignature = config.vscodeExtensions.verifySignature or false;
   buildVscodeExtension = lib.extendMkDerivation {
     constructDrv = stdenv.mkDerivation;
     excludeDrvArgNames = [
@@ -73,7 +101,36 @@ let
         # This cannot be removed, it is used by some extensions.
         installPrefix = "share/vscode/extensions/${vscodeExtUniqueId}";
 
-        nativeBuildInputs = [ unpackVsixSetupHook ] ++ nativeBuildInputs;
+        nativeBuildInputs = [
+          unpackVsixSetupHook
+        ]
+        # Opt-in: verification pulls the unfree vsce-sign (from vscode) into the
+        # build closure, so it is off by default to keep signed extensions free
+        # and buildable on Hydra / with vscodium. Enable with `verifySignature`.
+        ++ lib.optional (
+          (finalAttrs.verifySignature or globalVerifySignature)
+          && (finalAttrs.signatureArchive or null) != null
+          && vscode.hasVsceSign
+        ) verifyVsixSignatureSetupHook
+        ++ nativeBuildInputs;
+
+        # vsce-sign validates Microsoft's certificate chain via Apple's
+        # Security.framework, which reads the system keychain and MDS store.
+        # Grant those reads under Darwin's relaxed sandbox.
+        sandboxProfile =
+          lib.optionalString
+            (
+              (finalAttrs.verifySignature or globalVerifySignature)
+              && (finalAttrs.signatureArchive or null) != null
+              && stdenv.hostPlatform.isDarwin
+              && vscode.hasVsceSign
+            )
+            ''
+              (allow file-read*
+                (literal "/Library/Keychains/System.keychain")
+                (literal "/private/var/db/mds/system/mdsDirectory.db")
+                (literal "/private/var/db/mds/system/mdsObject.db"))
+            '';
 
         installPhase =
           args.installPhase or ''
@@ -87,8 +144,35 @@ let
       };
   };
 
+  mktplcAssetBaseUrl =
+    {
+      publisher,
+      name,
+      version,
+      ...
+    }:
+    "https://${publisher}.gallery.vsassets.io/_apis/public/gallery/publisher/${publisher}/extension/${name}/${version}/assetbyname";
+
   fetchVsixFromVscodeMarketplace =
     mktplcExtRef: fetchurl (import ./mktplcExtRefToFetchArgs.nix mktplcExtRef);
+
+  # Fetch signature archive for cryptographic verification
+  fetchSignatureFromVscodeMarketplace =
+    mktplcExtRef:
+    let
+      inherit (mktplcExtRef) publisher name;
+      arch = mktplcExtRef.arch or "";
+      archurl = if arch == "" then "" else "?targetPlatform=${arch}";
+      signatureHash = mktplcExtRef.signatureHash or "";
+    in
+    if signatureHash != "" then
+      fetchurl {
+        url = "${mktplcAssetBaseUrl mktplcExtRef}/Microsoft.VisualStudio.Services.VsixSignature${archurl}";
+        name = "${publisher}-${name}.sigzip";
+        hash = signatureHash;
+      }
+    else
+      null;
 
   buildVscodeMarketplaceExtension = lib.extendMkDerivation {
     constructDrv = buildVscodeExtension;
@@ -114,6 +198,7 @@ let
         vscodeExtPublisher = mktplcRef.publisher;
         vscodeExtName = mktplcRef.name;
         vscodeExtUniqueId = "${mktplcRef.publisher}.${mktplcRef.name}";
+        signatureArchive = fetchSignatureFromVscodeMarketplace mktplcRef;
       };
   };
 
@@ -124,6 +209,7 @@ let
     "sha256"
     "hash"
     "arch"
+    "signatureHash"
   ];
 
   mktplcExtRefToExtDrv =
@@ -194,6 +280,7 @@ let
 in
 {
   inherit
+    vsceSignExe
     fetchVsixFromVscodeMarketplace
     buildVscodeExtension
     buildVscodeMarketplaceExtension

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -188,6 +188,7 @@ stdenv.mkDerivation (
     passthru = {
       inherit
         executableName
+        hasVsceSign
         longName
         tests
         updateScript

--- a/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
+++ b/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
@@ -40,16 +40,29 @@ class VSCodeExtensionUpdater:
         self.parser.add_argument(
             "--commit", action="store_true", help="commit the updated package"
         )
+        self.parser.add_argument(
+            "--with-signature",
+            action="store_true",
+            help="fetch and add signatureHash for cryptographic verification",
+        )
+        self.parser.add_argument(
+            "--force",
+            action="store_true",
+            help="force update even if version is the same (useful for hash-only updates)",
+        )
         self.args = self.parser.parse_args()
         self.attribute_path = self.args.attribute
         if not self.attribute_path:
             logger.error("Error: Attribute path is required.")
             sys.exit(1)
+        self._has_platform_source_cache: Optional[bool] = None
         self.target_vscode_version = self._get_nix_vscode_version()
         self.current_version = self._get_nix_vscode_extension_version()
         self.override_filename = self.args.override_filename
         self.allow_pre_release = self.args.pre_release
         self.commit = self.args.commit
+        self.with_signature = self.args.with_signature
+        self.force = self.args.force
         self.extension_publisher = self._get_nix_vscode_extension_publisher()
         self.extension_name = self._get_nix_vscode_extension_name()
         self.extension_marketplace_id = (
@@ -130,8 +143,28 @@ class VSCodeExtensionUpdater:
         return ([system] if system is not None else []) + extra_platforms
 
     def _has_platform_source(self) -> bool:
-        source_url = self._get_nix_attribute(f"{self.attribute_path}.src.url")
-        return "targetPlatform=" in source_url
+        if self._has_platform_source_cache is None:
+            source_url = self._get_nix_attribute(f"{self.attribute_path}.src.url")
+            self._has_platform_source_cache = "targetPlatform=" in source_url
+        return self._has_platform_source_cache
+
+    def _prefetch_url_sri(self, url: str) -> str:
+        """
+        Fetches a URL and returns its SRI hash.
+        """
+        sha256 = self.execute_command(["nix-prefetch-url", url])
+        return self.execute_command([
+            "nix",
+            "--extra-experimental-features",
+            "nix-command",
+            "hash",
+            "convert",
+            "--to",
+            "sri",
+            "--hash-algo",
+            "sha256",
+            sha256,
+        ])
 
     def _get_nix_vscode_extension_src_hash(self, system: str) -> str:
         url = self.execute_command([
@@ -146,19 +179,26 @@ class VSCodeExtensionUpdater:
             "--system",
             system,
         ])
-        sha256 = self.execute_command(["nix-prefetch-url", url])
-        return self.execute_command([
-            "nix",
-            "--extra-experimental-features",
-            "nix-command",
-            "hash",
-            "convert",
-            "--to",
-            "sri",
-            "--hash-algo",
-            "sha256",
-            sha256,
-        ])
+        return self._prefetch_url_sri(url)
+
+    def _fetch_signature_hash(self, version: str, target_platform: Optional[str] = None) -> Optional[str]:
+        """
+        Fetches the signature hash for an extension version from the VS Code Marketplace.
+        Returns the SRI hash or None if fetch fails.
+        """
+        platform_suffix = f"?targetPlatform={target_platform}" if target_platform else ""
+        url = (
+            f"https://{self.extension_publisher}.gallery.vsassets.io/_apis/public/gallery/"
+            f"publisher/{self.extension_publisher}/extension/{self.extension_name}/{version}/"
+            f"assetbyname/Microsoft.VisualStudio.Services.VsixSignature{platform_suffix}"
+        )
+        try:
+            sri_hash = self._prefetch_url_sri(url)
+            logger.info(f"Fetched signature hash: {sri_hash}")
+            return sri_hash
+        except subprocess.CalledProcessError:
+            logger.warning("Failed to fetch signature hash")
+            return None
 
     def get_target_platform(self, nix_system: str) -> str:
         """
@@ -336,6 +376,122 @@ class VSCodeExtensionUpdater:
         )
         Path(self.override_filename).write_text(updated_content, encoding="utf-8")
 
+    def _find_block_end(self, content: str, brace_start: int) -> Optional[int]:
+        """
+        Given the position of an opening '{', find the matching closing '}'.
+        Returns the index of the closing brace, or None on mismatch.
+        """
+        count = 0
+        pos = brace_start
+        while pos < len(content):
+            if content[pos] == "{":
+                count += 1
+            elif content[pos] == "}":
+                count -= 1
+                if count == 0:
+                    return pos
+            pos += 1
+        return None
+
+    def _insert_signature_hash_in_block(
+        self, content: str, block_start_pattern: re.Pattern, signature_hash: str
+    ) -> Optional[str]:
+        """
+        Finds a block matching `block_start_pattern` in `content` and inserts or
+        updates its `signatureHash` field. Returns the updated content, or None
+        if the block or its hash line could not be located.
+        """
+        block_match = block_start_pattern.search(content)
+        if not block_match:
+            return None
+
+        brace_start = content.rfind("{", 0, block_match.end())
+        if brace_start == -1:
+            return None
+        block_end = self._find_block_end(content, brace_start)
+        if block_end is None:
+            return None
+
+        block_text = content[brace_start:block_end + 1]
+
+        sig_pattern = re.compile(r'(\s*)(signatureHash\s*=\s*")([^"]+)(";)')
+        if sig_pattern.search(block_text):
+            new_block_text = sig_pattern.sub(
+                rf'\g<1>signatureHash = "{signature_hash}";', block_text
+            )
+            logger.info("Updated existing signatureHash")
+        else:
+            hash_pattern = re.compile(r'([ \t]*)(hash|sha256)\s*=\s*"[^"]+";')
+            hash_match = hash_pattern.search(block_text)
+            if not hash_match:
+                return None
+            indent = hash_match.group(1)
+            insert_pos = hash_match.end()
+            new_line = f'\n{indent}signatureHash = "{signature_hash}";'
+            new_block_text = (
+                block_text[:insert_pos] + new_line + block_text[insert_pos:]
+            )
+            logger.info("Added signatureHash after hash line")
+
+        return content[:brace_start] + new_block_text + content[block_end + 1:]
+
+    def _has_existing_signature_hash(self) -> bool:
+        """
+        Returns True if the extension's source file already declares a
+        `signatureHash` attribute. Used to auto-enable signature fetching.
+        """
+        if not self.override_filename:
+            return False
+        try:
+            content = Path(self.override_filename).read_text(encoding="utf-8")
+        except (FileNotFoundError, OSError):
+            return False
+        return bool(
+            re.search(
+                r'^\s*(?:signatureHash|"signatureHash")\s*=\s*"',
+                content,
+                re.MULTILINE,
+            )
+        )
+
+    def update_signature_hash(
+        self, signature_hash: str, nix_system: Optional[str] = None
+    ) -> bool:
+        """
+        Adds or updates signatureHash in the extension's definition. If `nix_system`
+        is given, targets the per-system block (e.g. `x86_64-linux = { ... };`) used
+        by multi-platform extensions. Otherwise, targets the `mktplcRef = { ... }`
+        block used by single-platform extensions.
+
+        Returns True on success, False otherwise.
+        """
+        if not self.override_filename:
+            logger.warning("No override filename set, cannot update signature hash")
+            return False
+
+        content = Path(self.override_filename).read_text(encoding="utf-8")
+
+        if nix_system is not None:
+            # Match both bare and quoted attribute keys: `x86_64-linux = {`
+            # and `"x86_64-linux" = {`.
+            block_pattern = re.compile(
+                rf'"?{re.escape(nix_system)}"?\s*=\s*\{{', re.MULTILINE
+            )
+            description = f"per-system block '{nix_system}'"
+        else:
+            block_pattern = re.compile(r'mktplcRef\s*=\s*\{', re.MULTILINE)
+            description = "mktplcRef block"
+
+        updated = self._insert_signature_hash_in_block(
+            content, block_pattern, signature_hash
+        )
+        if updated is None:
+            logger.warning(f"Could not update signatureHash in {description}")
+            return False
+
+        Path(self.override_filename).write_text(updated, encoding="utf-8")
+        return True
+
     def run_nix_update(self, new_version: str, system: str) -> None:
         """
         Builds and executes the nix-update command.
@@ -410,11 +566,41 @@ class VSCodeExtensionUpdater:
             self.get_target_platform(self.nix_vscode_extension_platforms[0]),
         )
         if not Version.parse(self.current_version).match(f"<{self.new_version}"):
-            logger.info("Already up to date or new version is older!")
-            sys.exit(0)
+            if not self.force:
+                logger.info("Already up to date or new version is older!")
+                sys.exit(0)
+            logger.info(f"Force mode: re-fetching even though version unchanged ({self.current_version})")
         for i, system in enumerate(self.nix_vscode_extension_platforms):
             version = self.new_version if i == 0 else "skip"
             self.run_nix_update(version, system)
+        if not self.with_signature and self._has_existing_signature_hash():
+            logger.info(
+                "Detected existing signatureHash in source; "
+                "auto-fetching updated signature."
+            )
+            self.with_signature = True
+
+        # Fetch and add signature hash if requested
+        if self.with_signature:
+            logger.info("Fetching signature hash...")
+            if self._has_platform_source():
+                # Multi-platform: fetch and update a signatureHash for each platform.
+                for system in self.nix_vscode_extension_platforms:
+                    target_platform = self.get_target_platform(system)
+                    signature_hash = self._fetch_signature_hash(
+                        self.new_version, target_platform
+                    )
+                    if not signature_hash:
+                        logger.error(f"Failed to fetch signature hash for {system}")
+                        sys.exit(1)
+                    self.update_signature_hash(signature_hash, nix_system=system)
+            else:
+                # Single-platform: fetch once and update the mktplcRef block.
+                signature_hash = self._fetch_signature_hash(self.new_version)
+                if not signature_hash:
+                    logger.error("Failed to fetch signature hash")
+                    sys.exit(1)
+                self.update_signature_hash(signature_hash)
         if self.commit:
             self.execute_command(["git", "add", self.override_filename])
             self.execute_command([

--- a/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
+++ b/pkgs/by-name/vs/vscode-extension-update/vscode_extension_update.py
@@ -13,6 +13,16 @@ from typing import Optional
 from loguru import logger
 from semver.version import Version
 
+# Shared verifier (single source of truth with the build-time setup hook),
+# resolved relative to the repository root, which is the working directory the
+# script already assumes for all `nix eval -f .` calls.
+VERIFY_SCRIPT = "pkgs/applications/editors/vscode/extensions/verify-vsix-signature.sh"
+
+
+def _env_flag(name: str) -> bool:
+    """True when environment variable `name` is set to a truthy value."""
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
+
 
 class VSCodeExtensionUpdater:
     """
@@ -40,16 +50,46 @@ class VSCodeExtensionUpdater:
         self.parser.add_argument(
             "--commit", action="store_true", help="commit the updated package"
         )
+        self.parser.add_argument(
+            "--with-signature",
+            action="store_true",
+            help="fetch, add, and verify signatureHash (runs vsce-sign on every "
+            "platform); also via VSCODE_EXTENSION_WITH_SIGNATURE=1",
+        )
+        self.parser.add_argument(
+            "--skip-verify",
+            action="store_true",
+            help="with --with-signature, populate signatureHash without running "
+            "vsce-sign; also via VSCODE_EXTENSION_SKIP_VERIFY=1",
+        )
+        self.parser.add_argument(
+            "--force",
+            action="store_true",
+            help="force update even if version is the same (useful for hash-only updates)",
+        )
         self.args = self.parser.parse_args()
         self.attribute_path = self.args.attribute
         if not self.attribute_path:
             logger.error("Error: Attribute path is required.")
             sys.exit(1)
+        self._has_platform_source_cache: Optional[bool] = None
+        self._vsce_sign_exe_cache: Optional[str] = None
         self.target_vscode_version = self._get_nix_vscode_version()
         self.current_version = self._get_nix_vscode_extension_version()
         self.override_filename = self.args.override_filename
         self.allow_pre_release = self.args.pre_release
         self.commit = self.args.commit
+        # Flags are also accepted via env vars, since update runners (nix-update,
+        # update.py) pass the environment through but cannot forward CLI args.
+        self.with_signature = self.args.with_signature or _env_flag(
+            "VSCODE_EXTENSION_WITH_SIGNATURE"
+        )
+        self.force = self.args.force
+        skip_verify = self.args.skip_verify or _env_flag("VSCODE_EXTENSION_SKIP_VERIFY")
+        # Verify only when signatures are explicitly managed, never on routine/
+        # auto-detected updates, so automated updaters (r-ryantm) don't pull the
+        # unfree vsce-sign.
+        self.should_verify = self.with_signature and not skip_verify
         self.extension_publisher = self._get_nix_vscode_extension_publisher()
         self.extension_name = self._get_nix_vscode_extension_name()
         self.extension_marketplace_id = (
@@ -130,22 +170,15 @@ class VSCodeExtensionUpdater:
         return ([system] if system is not None else []) + extra_platforms
 
     def _has_platform_source(self) -> bool:
-        source_url = self._get_nix_attribute(f"{self.attribute_path}.src.url")
-        return "targetPlatform=" in source_url
+        if self._has_platform_source_cache is None:
+            source_url = self._get_nix_attribute(f"{self.attribute_path}.src.url")
+            self._has_platform_source_cache = "targetPlatform=" in source_url
+        return self._has_platform_source_cache
 
-    def _get_nix_vscode_extension_src_hash(self, system: str) -> str:
-        url = self.execute_command([
-            "nix",
-            "--extra-experimental-features",
-            "nix-command",
-            "eval",
-            "--raw",
-            "-f",
-            ".",
-            f"{self.attribute_path}.src.url",
-            "--system",
-            system,
-        ])
+    def _prefetch_url_sri(self, url: str) -> str:
+        """
+        Fetches a URL and returns its SRI hash.
+        """
         sha256 = self.execute_command(["nix-prefetch-url", url])
         return self.execute_command([
             "nix",
@@ -159,6 +192,109 @@ class VSCodeExtensionUpdater:
             "sha256",
             sha256,
         ])
+
+    def _prefetch_url_path(self, url: str) -> str:
+        """
+        Fetches a URL into the Nix store and returns its store path.
+        """
+        output = self.execute_command(["nix-prefetch-url", "--print-path", url])
+        return output.splitlines()[-1].strip()
+
+    def _src_url(self, system: str) -> str:
+        """
+        Retrieves the extension's VSIX download URL for a given Nix system.
+        """
+        return self.execute_command([
+            "nix",
+            "--extra-experimental-features",
+            "nix-command",
+            "eval",
+            "--raw",
+            "-f",
+            ".",
+            f"{self.attribute_path}.src.url",
+            "--system",
+            system,
+        ])
+
+    def _get_nix_vscode_extension_src_hash(self, system: str) -> str:
+        return self._prefetch_url_sri(self._src_url(system))
+
+    def _signature_url(self, version: str, target_platform: Optional[str] = None) -> str:
+        """
+        Builds the VsixSignature asset URL for an extension version.
+        """
+        platform_suffix = f"?targetPlatform={target_platform}" if target_platform else ""
+        return (
+            f"https://{self.extension_publisher}.gallery.vsassets.io/_apis/public/gallery/"
+            f"publisher/{self.extension_publisher}/extension/{self.extension_name}/{version}/"
+            f"assetbyname/Microsoft.VisualStudio.Services.VsixSignature{platform_suffix}"
+        )
+
+    def _fetch_signature_hash(self, version: str, target_platform: Optional[str] = None) -> Optional[str]:
+        """
+        Fetches the signature hash for an extension version from the VS Code Marketplace.
+        Returns the SRI hash or None if fetch fails.
+        """
+        try:
+            sri_hash = self._prefetch_url_sri(self._signature_url(version, target_platform))
+            logger.info(f"Fetched signature hash: {sri_hash}")
+            return sri_hash
+        except subprocess.CalledProcessError:
+            logger.warning("Failed to fetch signature hash")
+            return None
+
+    def _vsce_sign_exe(self) -> str:
+        """
+        Returns the path to vsce-sign (bundled with the unfree vscode), building
+        vscode if needed. Errors with guidance when unfree is disallowed.
+        """
+        if self._vsce_sign_exe_cache is None:
+            logger.info("Realizing vsce-sign (from vscode) for signature verification...")
+            try:
+                self.execute_command([
+                    "nix", "--extra-experimental-features", "nix-command",
+                    "build", "--no-link", "-f", ".", "vscode",
+                ])
+                self._vsce_sign_exe_cache = self.execute_command([
+                    "nix", "--extra-experimental-features", "nix-command",
+                    "eval", "--raw", "-f", ".", "vscode-utils.vsceSignExe",
+                ])
+            except subprocess.CalledProcessError as error:
+                logger.error(
+                    "Could not realize vsce-sign for signature verification. It "
+                    "ships with the unfree vscode; allow unfree (e.g. "
+                    "NIXPKGS_ALLOW_UNFREE=1) or pass --skip-verify.\n"
+                    f"{error.stderr or error.stdout}"
+                )
+                sys.exit(1)
+        return self._vsce_sign_exe_cache
+
+    def _verify_signature(
+        self, version: str, system: str, target_platform: Optional[str]
+    ) -> None:
+        """
+        Verifies the pinned VSIX against its pinned signature for one platform,
+        using the shared verify-vsix-signature.sh. For opt-out extensions this is
+        the only place a signature is ever checked, so a failure aborts the
+        update rather than shipping an unverified hash.
+        """
+        vsix_path = self._prefetch_url_path(self._src_url(system))
+        signature_path = self._prefetch_url_path(
+            self._signature_url(version, target_platform)
+        )
+        logger.info(f"Verifying signature for {system}...")
+        try:
+            output = self.execute_command([
+                "bash", VERIFY_SCRIPT, self._vsce_sign_exe(), vsix_path, signature_path,
+            ])
+            logger.info(output)
+        except subprocess.CalledProcessError as error:
+            logger.error(
+                f"Signature verification failed for {system}:\n"
+                f"{error.stderr or error.stdout}"
+            )
+            sys.exit(1)
 
     def get_target_platform(self, nix_system: str) -> str:
         """
@@ -357,6 +493,122 @@ class VSCodeExtensionUpdater:
         )
         Path(self.override_filename).write_text(updated_content, encoding="utf-8")
 
+    def _find_block_end(self, content: str, brace_start: int) -> Optional[int]:
+        """
+        Given the position of an opening '{', find the matching closing '}'.
+        Returns the index of the closing brace, or None on mismatch.
+        """
+        count = 0
+        pos = brace_start
+        while pos < len(content):
+            if content[pos] == "{":
+                count += 1
+            elif content[pos] == "}":
+                count -= 1
+                if count == 0:
+                    return pos
+            pos += 1
+        return None
+
+    def _insert_signature_hash_in_block(
+        self, content: str, block_start_pattern: re.Pattern, signature_hash: str
+    ) -> Optional[str]:
+        """
+        Finds a block matching `block_start_pattern` in `content` and inserts or
+        updates its `signatureHash` field. Returns the updated content, or None
+        if the block or its hash line could not be located.
+        """
+        block_match = block_start_pattern.search(content)
+        if not block_match:
+            return None
+
+        brace_start = content.rfind("{", 0, block_match.end())
+        if brace_start == -1:
+            return None
+        block_end = self._find_block_end(content, brace_start)
+        if block_end is None:
+            return None
+
+        block_text = content[brace_start:block_end + 1]
+
+        sig_pattern = re.compile(r'(\s*)(signatureHash\s*=\s*")([^"]+)(";)')
+        if sig_pattern.search(block_text):
+            new_block_text = sig_pattern.sub(
+                rf'\g<1>signatureHash = "{signature_hash}";', block_text
+            )
+            logger.info("Updated existing signatureHash")
+        else:
+            hash_pattern = re.compile(r'([ \t]*)(hash|sha256)\s*=\s*"[^"]+";')
+            hash_match = hash_pattern.search(block_text)
+            if not hash_match:
+                return None
+            indent = hash_match.group(1)
+            insert_pos = hash_match.end()
+            new_line = f'\n{indent}signatureHash = "{signature_hash}";'
+            new_block_text = (
+                block_text[:insert_pos] + new_line + block_text[insert_pos:]
+            )
+            logger.info("Added signatureHash after hash line")
+
+        return content[:brace_start] + new_block_text + content[block_end + 1:]
+
+    def _has_existing_signature_hash(self) -> bool:
+        """
+        Returns True if the extension's source file already declares a
+        `signatureHash` attribute. Used to auto-enable signature fetching.
+        """
+        if not self.override_filename:
+            return False
+        try:
+            content = Path(self.override_filename).read_text(encoding="utf-8")
+        except (FileNotFoundError, OSError):
+            return False
+        return bool(
+            re.search(
+                r'^\s*(?:signatureHash|"signatureHash")\s*=\s*"',
+                content,
+                re.MULTILINE,
+            )
+        )
+
+    def update_signature_hash(
+        self, signature_hash: str, nix_system: Optional[str] = None
+    ) -> bool:
+        """
+        Adds or updates signatureHash in the extension's definition. If `nix_system`
+        is given, targets the per-system block (e.g. `x86_64-linux = { ... };`) used
+        by multi-platform extensions. Otherwise, targets the `mktplcRef = { ... }`
+        block used by single-platform extensions.
+
+        Returns True on success, False otherwise.
+        """
+        if not self.override_filename:
+            logger.warning("No override filename set, cannot update signature hash")
+            return False
+
+        content = Path(self.override_filename).read_text(encoding="utf-8")
+
+        if nix_system is not None:
+            # Match both bare and quoted attribute keys: `x86_64-linux = {`
+            # and `"x86_64-linux" = {`.
+            block_pattern = re.compile(
+                rf'"?{re.escape(nix_system)}"?\s*=\s*\{{', re.MULTILINE
+            )
+            description = f"per-system block '{nix_system}'"
+        else:
+            block_pattern = re.compile(r'mktplcRef\s*=\s*\{', re.MULTILINE)
+            description = "mktplcRef block"
+
+        updated = self._insert_signature_hash_in_block(
+            content, block_pattern, signature_hash
+        )
+        if updated is None:
+            logger.warning(f"Could not update signatureHash in {description}")
+            return False
+
+        Path(self.override_filename).write_text(updated, encoding="utf-8")
+        return True
+
     def run_nix_update(self, new_version: str, system: str) -> None:
         """
         Builds and executes the nix-update command.
@@ -431,11 +683,49 @@ class VSCodeExtensionUpdater:
             self.get_target_platform(self.nix_vscode_extension_platforms[0]),
         )
         if not Version.parse(self.current_version).match(f"<{self.new_version}"):
-            logger.info("Already up to date or new version is older!")
-            sys.exit(0)
+            if not self.force:
+                logger.info("Already up to date or new version is older!")
+                sys.exit(0)
+            logger.info(f"Force mode: re-fetching even though version unchanged ({self.current_version})")
         for i, system in enumerate(self.nix_vscode_extension_platforms):
             version = self.new_version if i == 0 else "skip"
             self.run_nix_update(version, system)
+        if not self.with_signature and self._has_existing_signature_hash():
+            logger.info(
+                "Detected existing signatureHash in source; "
+                "auto-fetching updated signature."
+            )
+            self.with_signature = True
+
+        # Fetch and add signature hash if requested
+        if self.with_signature:
+            logger.info("Fetching signature hash...")
+            if self._has_platform_source():
+                # Multi-platform: fetch and update a signatureHash for each platform.
+                for system in self.nix_vscode_extension_platforms:
+                    target_platform = self.get_target_platform(system)
+                    signature_hash = self._fetch_signature_hash(
+                        self.new_version, target_platform
+                    )
+                    if not signature_hash:
+                        logger.error(f"Failed to fetch signature hash for {system}")
+                        sys.exit(1)
+                    self.update_signature_hash(signature_hash, nix_system=system)
+                    # Verify the bytes we just pinned actually carry a valid
+                    # Microsoft signature, for every platform (explicit opt-in).
+                    if self.should_verify:
+                        self._verify_signature(
+                            self.new_version, system, target_platform
+                        )
+            else:
+                # Single-platform: fetch once and update the mktplcRef block.
+                signature_hash = self._fetch_signature_hash(self.new_version)
+                if not signature_hash:
+                    logger.error("Failed to fetch signature hash")
+                    sys.exit(1)
+                self.update_signature_hash(signature_hash)
+                if self.should_verify:
+                    self._verify_signature(self.new_version, self.nix_system, None)
         if self.commit:
             self.execute_command(["git", "add", self.override_filename])
             self.execute_command([


### PR DESCRIPTION
## vscode-extensions: add opt-in Marketplace signature verification

Adds **opt-in** cryptographic signature verification for VS Code Marketplace extensions, honoring the same signing contract VS Code enforces as a layer alongside hash pinning.

It is designed to **not disrupt the free build path**: verification uses Microsoft's unfree `vsce-sign`, so it is off by default and is never pulled into the default extension build, Hydra, or vscodium. Unfree is only ever reached through an explicit opt-in.

### Relates to #522775

While resolving merge conflicts for this work I found it is possible to update to and install an extension whose signature is unavailable. #522775 filters those out via marketplace metadata; this PR adds actual cryptographic verification of the signature itself.

### How it works

**Pinning (always free).** Setting `signatureHash` on `mktplcRef` fetches and pins the extension's signature archive (a fixed-output derivation) alongside the VSIX `hash`. This alone pulls nothing unfree.

**Build-time verification (opt-in).** Set `verifySignature = true` on an extension, or `vscodeExtensions.verifySignature = true` in nixpkgs config to cover every signed extension. The build then verifies the VSIX against its signature with `vsce-sign` in `preUnpackHooks`. Because `vsce-sign` is unfree it is off by default, so signed extensions stay free-buildable on Hydra and usable with vscodium. It is also skipped automatically when the `vscode` package does not expose `passthru.hasVsceSign = true` (e.g. vscodium), keeping that path free regardless of the flag.

**Update-time verification.** The update script and the build hook share one verifier (`verify-vsix-signature.sh`), so both honor the same `vsce-sign` invocation and exit codes. `--with-signature` fetches, adds, and verifies `signatureHash` on every platform (cross-arch from a single host); `--skip-verify` populates hashes without verifying. Both are also accepted via `VSCODE_EXTENSION_WITH_SIGNATURE` / `VSCODE_EXTENSION_SKIP_VERIFY` env vars, since `nix-update`/`update.py` pass the environment through but cannot forward CLI flags. Verification respects the ambient unfree policy and never forces `allowUnfree`.

Routine updates auto-detect and refresh an existing `signatureHash` **without** verifying, so automated updaters such as r-ryantm keep signatures current without pulling the unfree `vsce-sign`.

### What changed

- **New `verify-vsix-signature.sh`** shared verifier (single source of truth) wrapping `vsce-sign verify` with exit-code handling.
- **`verify-vsix-signature-setup-hook.sh`** thin `preUnpackHooks` wrapper around the shared verifier.
- **`vscode-utils.nix`** `verifySignature` (per-extension or global `config.vscodeExtensions.verifySignature`) gates the hook; `signatureArchive` is fetched from `signatureHash`; exports `vsceSignExe` for the update script.
- **`vscode_extension_update.py`** `--with-signature`/`--skip-verify` (and env equivalents), per-platform update time verification, `--force` to re-fetch on unchanged versions, auto-detect/refresh of existing hashes without verifying.
- **`vscode` (`generic.nix`/`vscode.nix`)** `passthru.hasVsceSign`.

### Usage

Opt in per extension:
```nix
mktplcRef = {
  publisher = "example";
  name = "extension";
  version = "1.0.0";
  hash = "sha256-...";
  signatureHash = "sha256-...";  # pins the signature
};
# ...
verifySignature = true;          # verify at build time
```

Manage signatures with the update script:

```bash
# Add + verify a signature (needs unfree allowed for vsce-sign)
vscode-extension-update vscode-extensions.publisher.name --with-signature

# Through nix-update / passthru.updateScript (cannot forward flags):
VSCODE_EXTENSION_WITH_SIGNATURE=1 nix-update --use-update-script vscode-extensions.publisher.name
```

## Verification in action
Passing build `verifySignature = true`:
```
Running phase: unpackPhase
Verifying VSIX signature...
Signature verification: PASSED
```

A VSIX that does not match its signature (the case
hash-pinning alone cannot catch) fails the build:
```
Verifying VSIX signature...
Signature verification: FAILED (exit code: 30)
ERROR: Package integrity check failed - contents don't match signature
```

Cross-arch update-time verification: a darwin-arm64 VSIX verifies
PASSED on an x86_64-linux host, so one machine can verify all
platforms.

## Backwards compatibility
Fully backwards compatible. Extensions without signatureHash are
unchanged. Extensions with signatureHash but no verifySignature build
exactly as before (free), with the signature pinned and verifiable on
demand. No extension is forced to pull vsce-sign unless it (or the
user's config) opts in.

---

## Things done

- Built on platform(s):
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) and other READMEs.
