### PR TITLE
`nixos/`: remove references to the xorg namespace

### DIFF
--- a/nixos/lib/systemd-lib.nix
+++ b/nixos/lib/systemd-lib.nix
@@ -57,7 +57,7 @@ let
   inherit (lib.strings) toJSON;
 
   cfg = config.systemd;
-  lndir = "${pkgs.buildPackages.xorg.lndir}/bin/lndir";
+  lndir = "${pkgs.buildPackages.lndir}/bin/lndir";
   systemd = cfg.package;
 in
 rec {

--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -12,15 +12,16 @@ let
     {
       runCommand,
       gzip,
-      xorg,
+      font-alias,
+      mkfontscale,
     }:
     runCommand "X11-fonts"
       {
         preferLocalBuild = true;
         nativeBuildInputs = [
           gzip
-          xorg.mkfontscale
-          xorg.mkfontdir
+          mkfontscale
+          mkfontscale
         ];
       }
       ''
@@ -34,7 +35,7 @@ let
         ''}
         mkfontscale
         mkfontdir
-        cat $(find ${pkgs.xorg.fontalias}/ -name fonts.alias) >fonts.alias
+        cat $(find ${pkgs.font-alias}/ -name fonts.alias) >fonts.alias
       ''
   ) { };
 

--- a/nixos/modules/hardware/video/displaylink.nix
+++ b/nixos/modules/hardware/video/displaylink.nix
@@ -35,7 +35,7 @@ in
 
     # make the device available
     services.xserver.displayManager.sessionCommands = ''
-      ${lib.getBin pkgs.xorg.xrandr}/bin/xrandr --setprovideroutputsource 1 0
+      ${lib.getBin pkgs.xrandr}/bin/xrandr --setprovideroutputsource 1 0
     '';
 
     # Those are taken from displaylink-installer.sh and from Arch Linux AUR package.

--- a/nixos/modules/hardware/video/nvidia.nix
+++ b/nixos/modules/hardware/video/nvidia.nix
@@ -488,7 +488,7 @@ in
             lib.optional primeEnabled {
               name = igpuDriver;
               display = offloadCfg.enable;
-              modules = lib.optional (igpuDriver == "amdgpu") pkgs.xorg.xf86videoamdgpu;
+              modules = lib.optional (igpuDriver == "amdgpu") pkgs.xf86-video-amdgpu;
               deviceSection = ''
                 BusID "${igpuBusId}"
               ''
@@ -538,7 +538,7 @@ in
               gpuProviderName =
                 if igpuDriver == "amdgpu" then
                   # find the name of the provider if amdgpu
-                  "`${lib.getExe pkgs.xorg.xrandr} --listproviders | ${lib.getExe pkgs.gnugrep} -i AMD | ${lib.getExe pkgs.gnused} -n 's/^.*name://p'`"
+                  "`${lib.getExe pkgs.xrandr} --listproviders | ${lib.getExe pkgs.gnugrep} -i AMD | ${lib.getExe pkgs.gnused} -n 's/^.*name://p'`"
                 else
                   igpuDriver;
               providerCmdParams =
@@ -548,8 +548,8 @@ in
               (syncCfg.enable || (reverseSyncCfg.enable && reverseSyncCfg.setupCommands.enable))
               ''
                 # Added by nvidia configuration module for Optimus/PRIME.
-                ${lib.getExe pkgs.xorg.xrandr} --setprovideroutputsource ${providerCmdParams}
-                ${lib.getExe pkgs.xorg.xrandr} --auto
+                ${lib.getExe pkgs.xrandr} --setprovideroutputsource ${providerCmdParams}
+                ${lib.getExe pkgs.xrandr} --auto
               '';
 
           environment.etc = {

--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -356,7 +356,7 @@ in
         "GlobalKnownHostsFile ${builtins.concatStringsSep " " knownHostsFiles}"
       ]
       ++ lib.optional (!config.networking.enableIPv6) "AddressFamily inet"
-      ++ lib.optional cfg.setXAuthLocation "XAuthLocation ${pkgs.xorg.xauth}/bin/xauth"
+      ++ lib.optional cfg.setXAuthLocation "XAuthLocation ${pkgs.xauth}/bin/xauth"
       ++ lib.optional (cfg.forwardX11 != null) "ForwardX11 ${lib.boolToYesNo cfg.forwardX11}"
       ++ lib.optional (
         cfg.pubkeyAcceptedKeyTypes != [ ]

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1418,7 +1418,7 @@ let
                 control = "optional";
                 modulePath = "${package}/lib/security/pam_xauth.so";
                 settings = {
-                  xauthpath = "${pkgs.xorg.xauth}/bin/xauth";
+                  xauthpath = "${pkgs.xauth}/bin/xauth";
                   systemuser = 99;
                 };
               }

--- a/nixos/modules/services/display-managers/default.nix
+++ b/nixos/modules/services/display-managers/default.nix
@@ -29,10 +29,10 @@ let
           done
 
           if test -d ${pkg}/share/xsessions; then
-            ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
+            ${pkgs.buildPackages.lndir}/bin/lndir ${pkg}/share/xsessions $out/share/xsessions
           fi
           if test -d ${pkg}/share/wayland-sessions; then
-            ${pkgs.buildPackages.xorg.lndir}/bin/lndir ${pkg}/share/wayland-sessions $out/share/wayland-sessions
+            ${pkgs.buildPackages.lndir}/bin/lndir ${pkg}/share/wayland-sessions $out/share/wayland-sessions
           fi
         '') cfg.sessionPackages}
       '';

--- a/nixos/modules/services/display-managers/lemurs.nix
+++ b/nixos/modules/services/display-managers/lemurs.nix
@@ -87,8 +87,8 @@ in
             system_shell = lib.mkDefault "${pkgs.bash}/bin/bash";
             initial_path = lib.mkDefault "/run/current-system/sw/bin";
             x11 = {
-              xauth_path = lib.mkDefault "${pkgs.xorg.xauth}/bin/xauth";
-              xserver_path = lib.mkDefault "${pkgs.xorg.xorgserver}/bin/X";
+              xauth_path = lib.mkDefault "${pkgs.xauth}/bin/xauth";
+              xserver_path = lib.mkDefault "${pkgs.xorg-server}/bin/X";
               xsessions_path = lib.mkDefault "${desktops}/share/xsessions";
               xsetup_path = lib.mkDefault config.services.displayManager.sessionData.wrapper;
             };

--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -42,7 +42,7 @@ let
     term_restore_cursor_cmd = "${pkgs.ncurses}/bin/tput cnorm";
     waylandsessions = "${dmcfg.sessionData.desktops}/share/wayland-sessions";
     xsessions = "${dmcfg.sessionData.desktops}/share/xsessions";
-    xauth_cmd = lib.optionalString xcfg.enable "${pkgs.xorg.xauth}/bin/xauth";
+    xauth_cmd = lib.optionalString xcfg.enable "${pkgs.xauth}/bin/xauth";
     x_cmd = lib.optionalString xcfg.enable xserverWrapper;
     setup_cmd = dmcfg.sessionData.wrapper;
     brightness_up_cmd = "${lib.getExe pkgs.brightnessctl} -q -n s +10%";

--- a/nixos/modules/services/display-managers/sddm.nix
+++ b/nixos/modules/services/display-managers/sddm.nix
@@ -96,10 +96,10 @@ let
   // optionalAttrs xcfg.enable {
     X11 = {
       ServerPath = toString xserverWrapper;
-      XephyrPath = "${pkgs.xorg.xorgserver.out}/bin/Xephyr";
+      XephyrPath = "${pkgs.xorg-server.out}/bin/Xephyr";
       SessionCommand = toString dmcfg.sessionData.wrapper;
       SessionDir = "${dmcfg.sessionData.desktops}/share/xsessions";
-      XauthPath = "${pkgs.xorg.xauth}/bin/xauth";
+      XauthPath = "${pkgs.xauth}/bin/xauth";
       DisplayCommand = toString Xsetup;
       DisplayStopCommand = toString Xstop;
       EnableHiDPI = cfg.enableHidpi;

--- a/nixos/modules/services/hardware/libinput.nix
+++ b/nixos/modules/services/hardware/libinput.nix
@@ -437,10 +437,10 @@ in
     })
 
     (lib.mkIf (cfg.enable && config.services.xserver.enable) {
-      services.xserver.modules = [ pkgs.xorg.xf86inputlibinput ];
+      services.xserver.modules = [ pkgs.xf86-input-libinput ];
 
       # for man pages
-      environment.systemPackages = [ pkgs.xorg.xf86inputlibinput ];
+      environment.systemPackages = [ pkgs.xf86-input-libinput ];
 
       environment.etc =
         let
@@ -448,7 +448,7 @@ in
         in
         {
           ${cfgPath} = {
-            source = pkgs.xorg.xf86inputlibinput.out + "/share/" + cfgPath;
+            source = pkgs.xf86-input-libinput.out + "/share/" + cfgPath;
           };
         };
 

--- a/nixos/modules/services/misc/autorandr.nix
+++ b/nixos/modules/services/misc/autorandr.nix
@@ -327,7 +327,7 @@ in
                     echo "Unknown profle: $AUTORANDR_CURRENT_PROFILE"
                     exit 1
                 esac
-                echo "Xft.dpi: $DPI" | ''${pkgs.xorg.xrdb}/bin/xrdb -merge
+                echo "Xft.dpi: $DPI" | ''${pkgs.xrdb}/bin/xrdb -merge
               ''';
             };
           }

--- a/nixos/modules/services/monitoring/grafana.nix
+++ b/nixos/modules/services/monitoring/grafana.nix
@@ -85,7 +85,10 @@ let
       fi
     '';
   provisionConfDir =
-    pkgs.runCommand "grafana-provisioning" { nativeBuildInputs = [ pkgs.xorg.lndir ]; }
+    pkgs.runCommand "grafana-provisioning"
+      {
+        nativeBuildInputs = [ pkgs.lndir ];
+      }
       ''
         mkdir -p $out/{alerting,datasources,dashboards,plugins}
         ${ln {

--- a/nixos/modules/services/monitoring/smartd.nix
+++ b/nixos/modules/services/monitoring/smartd.nix
@@ -57,7 +57,7 @@ let
 
       $SMARTD_FULLMESSAGE
       EOF
-      } | ${pkgs.xorg.xmessage}/bin/xmessage -file - 2>/dev/null &
+      } | ${pkgs.xmessage}/bin/xmessage -file - 2>/dev/null &
     ''}
   '';
 

--- a/nixos/modules/services/networking/jibri/default.nix
+++ b/nixos/modules/services/networking/jibri/default.nix
@@ -355,7 +355,7 @@ in
 
         StateDirectory = "jibri";
 
-        ExecStart = "${pkgs.xorg.xorgserver}/bin/Xorg -nocursor -noreset +extension RANDR +extension RENDER -config ${pkgs.jibri}/etc/jitsi/jibri/xorg-video-dummy.conf -logfile /dev/null :0";
+        ExecStart = "${pkgs.xorg-server}/bin/Xorg -nocursor -noreset +extension RANDR +extension RENDER -config ${pkgs.jibri}/etc/jitsi/jibri/xorg-video-dummy.conf -logfile /dev/null :0";
       };
     };
 

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -831,7 +831,7 @@ in
             { port, addr, ... }:
             "ListenAddress ${addr}${lib.optionalString (port != null) (":" + toString port)}"
           ) cfg.listenAddresses
-          ++ lib.optional cfgc.setXAuthLocation "XAuthLocation ${lib.getExe pkgs.xorg.xauth}"
+          ++ lib.optional cfgc.setXAuthLocation "XAuthLocation ${lib.getExe pkgs.xauth}"
           ++ lib.optional cfg.allowSFTP "Subsystem sftp ${cfg.sftpServerExecutable} ${lib.concatStringsSep " " cfg.sftpFlags}"
           ++ [
             "AuthorizedKeysFile ${toString cfg.authorizedKeysFiles}"

--- a/nixos/modules/services/networking/x2goserver.nix
+++ b/nixos/modules/services/networking/x2goserver.nix
@@ -165,8 +165,8 @@ in
         "L+ /usr/local/bin/cp - - - - ${coreutils}/bin/cp"
         "L+ /usr/local/bin/sed - - - - ${gnused}/bin/sed"
         "L+ /usr/local/bin/setsid - - - - ${util-linux}/bin/setsid"
-        "L+ /usr/local/bin/xrandr - - - - ${xorg.xrandr}/bin/xrandr"
-        "L+ /usr/local/bin/xmodmap - - - - ${xorg.xmodmap}/bin/xmodmap"
+        "L+ /usr/local/bin/xrandr - - - - ${xrandr}/bin/xrandr"
+        "L+ /usr/local/bin/xmodmap - - - - ${xmodmap}/bin/xmodmap"
       ];
 
     systemd.services.x2goserver = {

--- a/nixos/modules/services/web-apps/akkoma.md
+++ b/nixos/modules/services/web-apps/akkoma.md
@@ -187,7 +187,7 @@ derivation.
         };
         nativeBuildInputs = with pkgs; [
           jq
-          xorg.lndir
+          lndir
         ];
         passAsFile = [ "config" ];
       }

--- a/nixos/modules/services/x11/desktop-managers/cde.nix
+++ b/nixos/modules/services/x11/desktop-managers/cde.nix
@@ -17,7 +17,7 @@ in
 
     extraPackages = mkOption {
       type = with types; listOf package;
-      default = with pkgs.xorg; [
+      default = with pkgs; [
         xclock
         bitmap
         xlsfonts
@@ -30,7 +30,7 @@ in
         xwud
       ];
       defaultText = literalExpression ''
-        with pkgs.xorg; [
+        with pkgs; [
           xclock bitmap xlsfonts xfd xrefresh xload xwininfo xdpyinfo xwd xwud
         ]
       '';

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -61,7 +61,7 @@ in
       enlightenment.ephoto
       enlightenment.rage
       enlightenment.terminology
-      xorg.xcursorthemes
+      xcursor-themes
     ]) config.environment.enlightenment.excludePackages;
 
     environment.pathsToLink = [

--- a/nixos/modules/services/x11/display-managers/default.nix
+++ b/nixos/modules/services/x11/display-managers/default.nix
@@ -24,7 +24,6 @@ let
     ;
 
   cfg = config.services.xserver;
-  xorg = pkgs.xorg;
 
   fontconfig = config.fonts.fontconfig;
   xresourcesXft = pkgs.writeText "Xresources-Xft" ''
@@ -90,11 +89,11 @@ let
     ''}
 
     # Load X defaults. This should probably be safe on wayland too.
-    ${xorg.xrdb}/bin/xrdb -merge ${xresourcesXft}
+    ${pkgs.xrdb}/bin/xrdb -merge ${xresourcesXft}
     if test -e ~/.Xresources; then
-        ${xorg.xrdb}/bin/xrdb -merge ~/.Xresources
+        ${pkgs.xrdb}/bin/xrdb -merge ~/.Xresources
     elif test -e ~/.Xdefaults; then
-        ${xorg.xrdb}/bin/xrdb -merge ~/.Xdefaults
+        ${pkgs.xrdb}/bin/xrdb -merge ~/.Xdefaults
     fi
 
     # Import environment variables into the systemd user environment.
@@ -147,8 +146,8 @@ in
 
       xauthBin = mkOption {
         internal = true;
-        default = "${xorg.xauth}/bin/xauth";
-        defaultText = literalExpression ''"''${pkgs.xorg.xauth}/bin/xauth"'';
+        default = "${pkgs.xauth}/bin/xauth";
+        defaultText = literalExpression ''"''${pkgs.xauth}/bin/xauth"'';
         description = "Path to the {command}`xauth` program used by display managers.";
       };
 
@@ -236,7 +235,7 @@ in
   config = {
     services.displayManager.sessionData.wrapper = xsessionWrapper;
 
-    services.xserver.displayManager.xserverBin = "${xorg.xorgserver.out}/bin/X";
+    services.xserver.displayManager.xserverBin = "${pkgs.xorg-server.out}/bin/X";
 
     services.xserver.displayManager.importedVariables = [
       # This is required by user units using the session bus.

--- a/nixos/modules/services/x11/display-managers/startx.nix
+++ b/nixos/modules/services/x11/display-managers/startx.nix
@@ -77,7 +77,7 @@ in
 
     # Implement xserverArgs via xinit's system-wide xserverrc
     environment.etc."X11/xinit/xserverrc".source = pkgs.writeShellScript "xserverrc" ''
-      exec ${pkgs.xorg.xorgserver}/bin/X \
+      exec ${pkgs.xorg-server}/bin/X \
         ${toString config.services.xserver.displayManager.xserverArgs} "$@"
     '';
 
@@ -100,7 +100,7 @@ in
       '';
     };
 
-    environment.systemPackages = with pkgs; [ xorg.xinit ];
+    environment.systemPackages = with pkgs; [ xinit ];
 
   };
 

--- a/nixos/modules/services/x11/display-managers/sx.nix
+++ b/nixos/modules/services/x11/display-managers/sx.nix
@@ -20,7 +20,7 @@ in
           ~/.config/sx/sxrc file containing session startup commands, see
           {manpage}`sx(1)`. This is not automatically generated from the desktopManager
           and windowManager settings. sx doesn't have a way to directly set
-          X server flags, but it can be done by overriding its xorgserver
+          X server flags, but it can be done by overriding its xorg-server
           dependency.
         '';
       };

--- a/nixos/modules/services/x11/extra-layouts.nix
+++ b/nixos/modules/services/x11/extra-layouts.nix
@@ -83,7 +83,7 @@ let
     };
   };
 
-  xkb_patched = pkgs.xorg.xkeyboardconfig_custom {
+  xkb_patched = pkgs.xkeyboard-config_custom {
     layouts = config.services.xserver.xkb.extraLayouts;
   };
 

--- a/nixos/modules/services/x11/hardware/synaptics.nix
+++ b/nixos/modules/services/x11/hardware/synaptics.nix
@@ -26,7 +26,7 @@ let
     Option "TapButton2" "0"
     Option "TapButton3" "0"
   '';
-  pkg = pkgs.xorg.xf86inputsynaptics;
+  pkg = pkgs.xf86-input-synaptics;
   etcFile = "X11/xorg.conf.d/70-synaptics.conf";
 in
 {

--- a/nixos/modules/services/x11/terminal-server.nix
+++ b/nixos/modules/services/x11/terminal-server.nix
@@ -29,11 +29,11 @@
       description = "Terminal Server";
 
       path = [
-        pkgs.xorg.xorgserver.out
+        pkgs.xorg-server.out
         pkgs.gawk
         pkgs.which
         pkgs.openssl
-        pkgs.xorg.xauth
+        pkgs.xauth
         pkgs.net-tools
         pkgs.shadow
         pkgs.procps

--- a/nixos/modules/services/x11/window-managers/twm.nix
+++ b/nixos/modules/services/x11/window-managers/twm.nix
@@ -28,12 +28,12 @@ in
     services.xserver.windowManager.session = singleton {
       name = "twm";
       start = ''
-        ${pkgs.xorg.twm}/bin/twm &
+        ${pkgs.tab-window-manager}/bin/twm &
         waitPID=$!
       '';
     };
 
-    environment.systemPackages = [ pkgs.xorg.twm ];
+    environment.systemPackages = [ pkgs.tab-window-manager ];
 
   };
 

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -53,7 +53,7 @@ let
           --set XMONAD_GHC "${xmonadEnv}/bin/ghc" \
         ''
         + ''
-          --set XMONAD_XMESSAGE "${pkgs.xorg.xmessage}/bin/xmessage"
+          --set XMONAD_XMESSAGE "${pkgs.xmessage}/bin/xmessage"
         ''
       );
 

--- a/nixos/modules/services/x11/xfs.nix
+++ b/nixos/modules/services/x11/xfs.nix
@@ -43,7 +43,7 @@ in
       description = "X Font Server";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
-      path = [ pkgs.xorg.xfs ];
+      path = [ pkgs.xfs ];
       script = "xfs -config ${configFile}";
     };
   };

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -12,7 +12,6 @@ let
 
   # Abbreviations.
   cfg = config.services.xserver;
-  xorg = pkgs.xorg;
 
   knownVideoDriverPackages = {
     inherit (pkgs)
@@ -108,8 +107,8 @@ let
     # old non-fontconfig applications.  (Possibly this could be done
     # better using a fontconfig rule.)
     [
-      pkgs.xorg.fontadobe100dpi
-      pkgs.xorg.fontadobe75dpi
+      pkgs.font-adobe-100dpi
+      pkgs.font-adobe-75dpi
     ];
 
   xrandrOptions = {
@@ -231,7 +230,7 @@ let
   # If not running a fancy desktop environment, the cursor is likely set to
   # the default `cursor.pcf` bitmap font. This is 17px wide, so it's very
   # small and almost invisible on 4K displays.
-  fontcursormisc_hidpi = pkgs.xorg.fontxfree86type1.overrideAttrs (
+  fontcursormisc_hidpi = pkgs.font-xfree86-type1.overrideAttrs (
     old:
     let
       # The scaling constant is 230/96: the scalable `left_ptr` glyph at
@@ -878,27 +877,27 @@ in
           cfgPath = "X11/xorg.conf.d/10-evdev.conf";
         in
         {
-          ${cfgPath}.source = xorg.xf86inputevdev.out + "/share/" + cfgPath;
+          ${cfgPath}.source = xf86-input-evdev.out + "/share/" + cfgPath;
         }
       );
 
     environment.systemPackages =
       utils.removePackagesByName [
-        xorg.xorgserver.out
-        xorg.xrandr
-        xorg.xrdb
-        xorg.setxkbmap
-        xorg.iceauth # required for KDE applications (it's called by dcopserver)
-        xorg.xlsclients
-        xorg.xset
-        xorg.xsetroot
-        xorg.xinput
-        xorg.xprop
-        xorg.xauth
+        pkgs.xorg-server.out
+        pkgs.xrandr
+        pkgs.xrdb
+        pkgs.setxkbmap
+        pkgs.iceauth # required for KDE applications (it's called by dcopserver)
+        pkgs.xlsclients
+        pkgs.xset
+        pkgs.xsetroot
+        pkgs.xinput
+        pkgs.xprop
+        pkgs.xauth
         pkgs.xterm
-        xorg.xf86inputevdev.out # get evdev.4 man page
+        pkgs.xf86-input-evdev.out # get evdev.4 man page
       ] config.services.xserver.excludePackages
-      ++ optional (elem "virtualbox" cfg.videoDrivers) xorg.xrefresh;
+      ++ optional (elem "virtualbox" cfg.videoDrivers) pkgs.xrefresh;
 
     environment.pathsToLink = [ "/share/X11" ];
 
@@ -947,8 +946,8 @@ in
     ++ optional cfg.terminateOnReset "-terminate";
 
     services.xserver.modules = concatLists (catAttrs "modules" cfg.drivers) ++ [
-      xorg.xorgserver.out
-      xorg.xf86inputevdev.out
+      pkgs.xorg-server.out
+      pkgs.xf86-input-evdev.out
     ];
 
     system.checks = singleton (
@@ -1073,7 +1072,7 @@ in
     '';
 
     fonts.packages = [
-      (if cfg.upscaleDefaultCursor then fontcursormisc_hidpi else pkgs.xorg.fontcursormisc)
+      (if cfg.upscaleDefaultCursor then fontcursormisc_hidpi else pkgs.font-cursor-misc)
       pkgs.font-misc-misc
       pkgs.font-alias
     ];

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -14,21 +14,87 @@ let
   cfg = config.services.xserver;
   xorg = pkgs.xorg;
 
+  knownVideoDriverPackages = {
+    inherit (pkgs)
+      xf86-video-amdgpu
+      xf86-video-apm
+      xf86-video-ark
+      xf86-video-ast
+      xf86-video-ati
+      xf86-video-chips
+      xf86-video-cirrus
+      xf86-video-dummy
+      xf86-video-fbdev
+      xf86-video-geode
+      xf86-video-i128
+      xf86-video-i740
+      xf86-video-intel
+      xf86-video-mga
+      xf86-video-neomagic
+      xf86_video_nested
+      xf86-video-nouveau
+      xf86-video-nv
+      xf86-video-omap
+      xf86-video-openchrome
+      xf86-video-qxl
+      xf86-video-r128
+      xf86-video-s3virge
+      xf86-video-savage
+      xf86-video-siliconmotion
+      xf86-video-sis
+      xf86-video-sisusb
+      xf86-video-suncg6
+      xf86-video-sunffb
+      xf86-video-sunleo
+      xf86-video-tdfx
+      xf86-video-trident
+      xf86-video-v4l
+      xf86-video-vbox
+      xf86-video-vesa
+      xf86-video-vmware
+      xf86-video-voodoo
+      ;
+  };
+
   # Map video driver names to driver packages. FIXME: move into card-specific modules.
-  knownVideoDrivers = {
+  videoDrivers =
+    mapAttrs' (name: value: rec {
+      name = removePrefix "xf86-video-" value.pname;
+      value = {
+        modules = value;
+      };
+    }) knownVideoDriverPackages
+    // videoDriverAliases
+    // videoDriverOverrides;
+
+  videoDriverOverrides = {
+    # Override the driver name of vbox is "vboxvideo".
+    vbox = {
+      driverName = "vboxvideo";
+      modules = [ knownVideoDriverPackages.xf86-video-vbox ];
+    };
+  };
+
+  videoDriverAliases = {
     # Alias so people can keep using "virtualbox" instead of "vboxvideo".
     virtualbox = {
-      modules = [ xorg.xf86videovboxvideo ];
+      modules = [ knownVideoDriverPackages.xf86-video-vbox ];
+      driverName = "vboxvideo";
+    };
+
+    # Alias so people can keep using "vboxvideo" instead of "vbox".
+    vboxvideo = {
+      modules = [ knownVideoDriverPackages.xf86-video-vbox ];
       driverName = "vboxvideo";
     };
 
     # Alias so that "radeon" uses the xf86-video-ati driver.
     radeon = {
-      modules = [ xorg.xf86videoati ];
+      modules = [ knownVideoDriverPackages.xf86-video-ati ];
       driverName = "ati";
     };
 
-    # modesetting does not have a xf86videomodesetting package as it is included in xorgserver
+    # modesetting does not have a xf86-video-modesetting package as it is included in xorg-server
     modesetting = { };
   };
 
@@ -399,19 +465,11 @@ in
           "nvidia"
           "amdgpu"
         ];
-        # TODO(@oxij): think how to easily add the rest, like those nvidia things
-        relatedPackages = concatLists (
-          mapAttrsToList (
-            n: v:
-            optional (hasPrefix "xf86video" n) {
-              path = [
-                "xorg"
-                n
-              ];
-              title = removePrefix "xf86video" n;
-            }
-          ) pkgs.xorg
-        );
+        relatedPackages = mapAttrsToList (name: value: {
+          path = [ name ];
+          title = removePrefix "xf86-video-" value.pname;
+        }) knownVideoDriverPackages;
+
         description = ''
           The names of the video drivers the configuration
           supports. They will be tried in order until one that
@@ -777,19 +835,14 @@ in
     # FIXME: somehow check for unknown driver names.
     services.xserver.drivers = flip concatMap cfg.videoDrivers (
       name:
-      let
-        driver = attrByPath [ name ] (
-          if xorg ? ${"xf86video" + name} then { modules = [ xorg.${"xf86video" + name} ]; } else null
-        ) knownVideoDrivers;
-      in
-      optional (driver != null) (
+      lib.optional (videoDrivers ? name) (
         {
           inherit name;
           modules = [ ];
           driverName = name;
           display = true;
         }
-        // driver
+        // videoDrivers.${name}
       )
     );
 

--- a/nixos/modules/testing/test-instrumentation.nix
+++ b/nixos/modules/testing/test-instrumentation.nix
@@ -214,7 +214,7 @@ in
     ];
 
     # `xwininfo' is used by the test driver to query open windows.
-    environment.systemPackages = [ pkgs.xorg.xwininfo ];
+    environment.systemPackages = [ pkgs.xwininfo ];
 
     # Log everything to the serial console.
     services.journald.extraConfig = ''

--- a/nixos/modules/virtualisation/vmware-guest.nix
+++ b/nixos/modules/virtualisation/vmware-guest.nix
@@ -18,7 +18,6 @@ let
     types
     ;
   cfg = config.virtualisation.vmware.guest;
-  xf86inputvmmouse = pkgs.xorg.xf86inputvmmouse;
 in
 {
   imports = [
@@ -94,7 +93,7 @@ in
     environment.etc.vmware-tools.source = "${cfg.package}/etc/vmware-tools/*";
 
     services.xserver = mkIf (!cfg.headless) {
-      modules = optionals pkgs.stdenv.hostPlatform.isx86 [ xf86inputvmmouse ];
+      modules = optionals pkgs.stdenv.hostPlatform.isx86 [ pkgs.xf86-input-vmmouse ];
 
       config = optionalString (pkgs.stdenv.hostPlatform.isx86) ''
         Section "InputClass"

--- a/nixos/tests/containers-imperative.nix
+++ b/nixos/tests/containers-imperative.nix
@@ -53,7 +53,7 @@
           docbook5
           libxml2
           docbook_xsl_ns
-          xorg.lndir
+          lndir
           documentation-highlighter
           perlPackages.ConfigIniFiles
         ];

--- a/nixos/tests/ec2.nix
+++ b/nixos/tests/ec2.nix
@@ -44,7 +44,7 @@ let
             stdenvNoCC
             texinfo
             unionfs-fuse
-            xorg.lndir
+            lndir
 
             # These are used in the configure-from-userdata tests
             # for EC2. Httpd and valgrind are requested by the

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -740,7 +740,7 @@ let
                   switch-to-configuration-ng
                   texinfo
                   unionfs-fuse
-                  xorg.lndir
+                  lndir
                   shellcheck-minimal
 
                   # Only the out output is included here, which is what is

--- a/nixos/tests/os-prober.nix
+++ b/nixos/tests/os-prober.nix
@@ -118,7 +118,7 @@ import ./make-test-python.nix (
             switch-to-configuration-ng
             texinfo
             unionfs-fuse
-            xorg.lndir
+            lndir
             shellcheck-minimal
 
             # Only the out output is included here, which is what is

--- a/nixos/tests/qtile/default.nix
+++ b/nixos/tests/qtile/default.nix
@@ -37,7 +37,7 @@
 
       environment.systemPackages = [
         pkgs.kitty
-        pkgs.xorg.xwininfo
+        pkgs.xwininfo
       ];
     };
 

--- a/nixos/tests/tigervnc.nix
+++ b/nixos/tests/tigervnc.nix
@@ -17,7 +17,7 @@ makeTest {
       {
         environment.systemPackages = with pkgs; [
           tigervnc # for Xvnc
-          xorg.xwininfo
+          xwininfo
           imagemagickBig # for display with working label: support
         ];
         networking.firewall.allowedTCPPorts = [ 5901 ];


### PR DESCRIPTION
part of #479553

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
