### PR TITLE
qimgv: Build with Qt6, add support for more image formats

### DIFF
--- a/pkgs/by-name/qi/qimgv/package.nix
+++ b/pkgs/by-name/qi/qimgv/package.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation {
     kdePackages.qtimageformats
     kdePackages.qtsvg
     kdePackages.qttools
+    kdePackages.kimageformats
   ];
 
   postPatch = ''

--- a/pkgs/by-name/qi/qimgv/package.nix
+++ b/pkgs/by-name/qi/qimgv/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  libsForQt5,
+  kdePackages,
   exiv2,
   mpv,
   opencv4,
@@ -24,21 +24,22 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
-    libsForQt5.wrapQtAppsHook
+    kdePackages.wrapQtAppsHook
   ];
 
   cmakeFlags = [
     "-DVIDEO_SUPPORT=ON"
+    "-DUSE_QT5=OFF"
   ];
 
   buildInputs = [
     exiv2
     mpv
     opencv4.cxxdev
-    libsForQt5.qtbase
-    libsForQt5.qtimageformats
-    libsForQt5.qtsvg
-    libsForQt5.qttools
+    kdePackages.qtbase
+    kdePackages.qtimageformats
+    kdePackages.qtsvg
+    kdePackages.qttools
   ];
 
   postPatch = ''
@@ -53,7 +54,7 @@ stdenv.mkDerivation {
   ];
 
   meta = {
-    description = "Qt5 image viewer with optional video support";
+    description = "Qt6 image viewer with optional video support";
     mainProgram = "qimgv";
     homepage = "https://github.com/easymodo/qimgv";
     license = lib.licenses.gpl3;


### PR DESCRIPTION
* Changed to build against Qt6 instead of Qt5
* Added `kimageformats` as a build input to support more file formats such as AVIF

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
