### PR TITLE
kotlin-lsp: init at 261.13587.0

### DIFF
--- a/pkgs/by-name/ko/kotlin-lsp/no-chmod.diff
+++ b/pkgs/by-name/ko/kotlin-lsp/no-chmod.diff
@@ -1,0 +1,12 @@
+diff --git a/kotlin-lsp.sh b/kotlin-lsp.sh
+index c08d876..9f79758 100644
+--- a/kotlin-lsp.sh
++++ b/kotlin-lsp.sh
+@@ -21,7 +21,6 @@ else
+ fi
+ 
+ if [ -d "$LOCAL_JRE_PATH" ] && [ -f "$LOCAL_JRE_PATH/bin/java" ]; then
+-    chmod +x "$LOCAL_JRE_PATH/bin/java"
+     JAVA_BIN="$LOCAL_JRE_PATH/bin/java"
+ else
+     echo >&2 -e "'java' was not found at $LOCAL_JRE_PATH, installation corrupted"

--- a/pkgs/by-name/ko/kotlin-lsp/package.nix
+++ b/pkgs/by-name/ko/kotlin-lsp/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  makeWrapper,
+  autoPatchelfHook,
+  zlib,
+  testers,
+}:
+
+let
+  selectSystem =
+    attrs:
+    attrs.${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  platform = selectSystem {
+    "x86_64-linux" = "linux-x64";
+    "aarch64-linux" = "linux-aarch64";
+    "x86_64-darwin" = "mac-x64";
+    "aarch64-darwin" = "mac-aarch64";
+  };
+
+  hash = selectSystem {
+    "x86_64-linux" = "sha256-EweSqy30NJuxvlJup78O+e+JOkzvUdb6DshqAy1j9jE=";
+    "aarch64-linux" = "sha256-MhHEYHBctaDH9JVkN/guDCG1if9Bip1aP3n+JkvHCvA=";
+  };
+in
+
+stdenv.mkDerivation (finalAttrs: rec {
+  pname = "kotlin-lsp";
+  version = "261.13587.0";
+
+  src = fetchzip {
+    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${version}/kotlin-lsp-${version}-${platform}.zip";
+    inherit hash;
+    stripRoot = false; # fix for "error: zip file must contain a single file or directory"
+  };
+
+  patches = [
+    ./no-chmod.diff
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [
+    zlib
+    stdenv.cc.cc.lib # for libgcc_s
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    chmod +x ./kotlin-lsp.sh
+    chmod +x ./jre/bin/java
+
+    # kotlin-lsp is headless so we can reduce the auto-patchelf dependencies
+    rm ./jre/lib/lib{awt_{wl,x}awt,jawt,fontmanager,jsound,{wl,}splashscreen}*
+
+    # retain original directory structure to reduce necessary patching
+    mkdir -p $out/opt/kotlin-lsp $out/bin
+    cp -r ./* $out/opt/kotlin-lsp
+    ln -s "$out/opt/kotlin-lsp/kotlin-lsp.sh" "$out/bin/kotlin-lsp"
+  '';
+
+  passthru.tests.help = testers.testVersion {
+    # not checking the version but this checks the JVM classpath and statically (i.e. at import time) loaded native libraries
+    package = finalAttrs.finalPackage;
+    command = "${finalAttrs.meta.mainProgram} --help";
+    version = "Usage: ${finalAttrs.meta.mainProgram}";
+  };
+
+  meta = {
+    description = "Official Kotlin language server based on IntelliJ IDEA and the IntelliJ IDEA Kotlin Plugin.";
+    homepage = "https://github.com/Kotlin/kotlin-lsp";
+    changelog = "https://github.com/Kotlin/kotlin-lsp/releases";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ axka ];
+    platforms = lib.platforms.linux; # macOS people, feel free to expand this!
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    mainProgram = "kotlin-lsp";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

JetBrains's partially closed-source (at the moment) LSP for Kotlin: https://github.com/Kotlin/kotlin-lsp/

Seems to work with Neovim.

See here: https://github.com/Kotlin/kotlin-lsp/#source-code

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
