### PR TITLE
python3Packages.lm-eval: 0.4.9.1 -> 0.4.9.2; python3Packages.mlx: 0.30.1 -> 0.30.3; python3Packages.mlx-lm: 0.30.2 -> 0.30.4

### DIFF
--- a/pkgs/development/python-modules/lm-eval/default.nix
+++ b/pkgs/development/python-modules/lm-eval/default.nix
@@ -34,6 +34,8 @@
   tenacity,
   tiktoken,
   tqdm,
+  # dscrim_eval
+  statsmodels,
   # hf_transfer
   hf-transfer,
   # ifeval
@@ -62,16 +64,16 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "lm-eval";
-  version = "0.4.9.1";
+  version = "0.4.9.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "EleutherAI";
     repo = "lm-evaluation-harness";
-    tag = "v${version}";
-    hash = "sha256-N5NRRabjWxPchwOIkjqYTCKInCmVSY6T5cAmdxNbCkU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Foz49XfIIzGJkgzjBu9P1J9cwYjl3fjAAJG9GKRwfq8=";
   };
 
   build-system = [
@@ -108,6 +110,7 @@ buildPythonPackage rec {
       tiktoken
       tqdm
     ];
+    discrim_eval = [ statsmodels ];
     hf_transfer = [ hf-transfer ];
     ifeval = [
       immutabledict
@@ -144,7 +147,7 @@ buildPythonPackage rec {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ optional-dependencies.api;
+  ++ finalAttrs.passthru.optional-dependencies.api;
 
   disabledTests = [
     "test_deepsparse" # deepsparse is not available
@@ -156,6 +159,7 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # attempts to download models
+    "tests/models/test_bos_handling.py"
     "tests/models/test_huggingface.py"
     "tests/test_evaluator.py"
     "tests/test_include_path.py"
@@ -172,10 +176,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/${src.tag}";
+    changelog = "https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/${finalAttrs.src.tag}";
     description = "Framework for few-shot evaluation of language models";
     homepage = "https://github.com/EleutherAI/lm-evaluation-harness";
     license = [ lib.licenses.mit ];
     maintainers = [ lib.maintainers.booxter ];
   };
-}
+})

--- a/pkgs/development/python-modules/mlx-lm/default.nix
+++ b/pkgs/development/python-modules/mlx-lm/default.nix
@@ -15,22 +15,23 @@
   transformers,
 
   # tests
+  aiohttp,
   lm-eval,
-  sentencepiece,
   pytestCheckHook,
+  sentencepiece,
   writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "mlx-lm";
-  version = "0.30.2";
+  version = "0.30.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ml-explore";
     repo = "mlx-lm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6WlKAchze5B724XYwzpVHy+17HlMcGSYjJw0aOdm5yw=";
+    hash = "sha256-ncDg7C84d1tAgk1300N7wY6kD1BocNNIqDUl0xBLhqY=";
   };
 
   build-system = [
@@ -50,6 +51,7 @@ buildPythonPackage (finalAttrs: {
   ];
 
   nativeCheckInputs = [
+    aiohttp
     lm-eval
     pytestCheckHook
     sentencepiece

--- a/pkgs/development/python-modules/mlx/dont-fetch-nanobind.patch
+++ b/pkgs/development/python-modules/mlx/dont-fetch-nanobind.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ed30932..e5842707 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -339,13 +339,7 @@ if(MLX_BUILD_PYTHON_BINDINGS)
+     Python 3.10
+     COMPONENTS Interpreter Development.Module
+     REQUIRED)
+-  FetchContent_Declare(
+-    nanobind
+-    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+-    GIT_TAG v2.10.2
+-    GIT_SHALLOW TRUE
+-    EXCLUDE_FROM_ALL)
+-  FetchContent_MakeAvailable(nanobind)
++  find_package(nanobind CONFIG REQUIRED)
+   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/python/src)
+ endif()
+ 


### PR DESCRIPTION
## Things done

- **python3Packages.lm-eval: 0.4.9.1 -> 0.4.9.2**
  - Diff: https://github.com/EleutherAI/lm-evaluation-harness/compare/v0.4.9.1...v0.4.9.2
  - Changelog: https://github.com/EleutherAI/lm-evaluation-harness/releases/tag/v0.4.9.2
- **python3Packages.mlx: 0.30.1 -> 0.30.3**
  - Diff: https://github.com/ml-explore/mlx/compare/v0.30.1...v0.30.3
  - Changelog: https://github.com/ml-explore/mlx/releases/tag/v0.30.3
- **python3Packages.mlx-lm: 0.30.2 -> 0.30.4**
  - Diff: https://github.com/ml-explore/mlx-lm/compare/v0.30.2...v0.30.4
  - Changelog: https://github.com/ml-explore/mlx-lm/releases/tag/v0.30.4

cc @booxter

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test