### PR TITLE
quai-cli-wallet: init at 1.0.1

### DIFF
--- a/pkgs/by-name/qu/quai-cli-wallet/package.nix
+++ b/pkgs/by-name/qu/quai-cli-wallet/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "quai-cli-wallet";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "dominant-strategies";
+    repo = "quai-cli-wallet";
+    tag = version;
+    hash = "sha256-yjchqrwjMNjp9+qBgAJqvrA0BMtHMkeKA04ZSY9Mawc=";
+  };
+
+  npmDepsHash = "sha256-tmnc9TDfyj3OP9buWEJH02/Erg+6vELgLinDs9jtcb0=";
+
+  meta = {
+    description = "A command-line wallet for Quai Network";
+    mainProgram = "quai-cli-wallet";
+    homepage = "https://github.com/dominant-strategies/quai-cli-wallet";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nintron ];
+  };
+}


### PR DESCRIPTION
Quai CLI Wallet is an application that can be used to create and interact with QUAI ledger accounts (support for Qi ledger may come in the future), on the Quai Network blockchain. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
