### PR TITLE
nixos/goatcounter: add automigrate flag by default

### DIFF
--- a/nixos/modules/services/web-apps/goatcounter.nix
+++ b/nixos/modules/services/web-apps/goatcounter.nix
@@ -61,6 +61,7 @@ in
             "serve"
             "-listen"
             "${cfg.address}:${toString cfg.port}"
+            "-automigrate"
           ]
           ++ lib.optionals cfg.proxy [
             "-tls"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds the `-automigrate` flag to the default `ExecStart` for the goatcounter module.

See https://github.com/arp242/goatcounter/?tab=readme-ov-file#updating for details about the `-automigrate` flag.

I think that the other alternatives I considered:

1. Adding a config option for whether or not to automigrate (I don't understand why anyone would want to disable this, though).
2. Run `goatcounter db migrate all` in an `ExecStartPre` script (this would separate out the migration from the running of goatcounter, but I don't really see any functional difference with this approach)

Signed-off-by: Sumner Evans <me@sumnerevans.com>


## Things done

I added `-automigrate` to the `extraArgs` in my setup, and it worked as expected. The migrations ran, and goatcounter is back to working (it was previously failing to store any hits due to a missing column that was added by a migration).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
