### PR TITLE
filtr: init at 1.1.0

### DIFF
--- a/pkgs/by-name/fi/filtr/package.nix
+++ b/pkgs/by-name/fi/filtr/package.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  fontconfig,
+  freetype,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXdmcp,
+  libXext,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  writableTmpDirAsHomeHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "filtr";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "tiagolr";
+    repo = "filtr";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-LRVwJ/Eh+XeNGnlbd2c56hWV8StHZGhxy0XLjGZ0toY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    writableTmpDirAsHomeHook # fontconfig cache
+  ];
+
+  buildInputs = [
+    fontconfig
+    freetype
+  ]
+  ++ lib.optionals stdenv.isLinux [
+    alsa-lib
+    libX11
+    libXcomposite
+    libXcursor
+    libXdmcp
+    libXext
+    libXinerama
+    libXrandr
+    libXtst
+  ];
+
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    (lib.cmakeBool "COPY_PLUGIN_AFTER_BUILD" false)
+    (lib.cmakeFeature "BUILD_STANDALONE" "OFF")
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux (toString [
+    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+    # a Link Time Optimization flag, and instructs the plugin compiled here to
+    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+    # successful linking while still providing LTO benefits. If our build of
+    # `juce` was used as a dependency, we could have patched that `-flto` line
+    # in our juce's source, but that is not possible because it is used as a
+    # Git Submodule.
+    "-ffat-lto-objects"
+  ]);
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2
+
+    cp -r "FILTR_artefacts/Release/LV2/FILT-R.lv2" $out/lib/lv2
+    cp -r "FILTR_artefacts/Release/VST3/FILT-R.vst3" $out/lib/vst3
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Envelope based filter modulator";
+    homepage = "https://github.com/tiagolr/filtr";
+    changelog = "https://github.com/tiagolr/filtr/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ magnetophon ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
https://github.com/tiagolr/filtr
From the same series of plugins as https://github.com/NixOS/nixpkgs/pull/482839

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
