### PR TITLE
onnxruntime: only set NIX_LDFLAGS on linux

### DIFF
--- a/pkgs/by-name/on/onnxruntime/package.nix
+++ b/pkgs/by-name/on/onnxruntime/package.nix
@@ -317,28 +317,29 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "onnxruntime_USE_COMPOSABLE_KERNEL_CK_TILE" false)
   ];
 
-  env = {
-    NIX_LDFLAGS = "-z,noexecstack";
-  }
-  // lib.optionalAttrs rocmSupport {
-    MIOPEN_PATH = rocmPackages.miopen;
-    # HIP steps fail to find ROCm libs when not in HIPFLAGS, causing
-    # fatal error: 'rocrand/rocrand.h' file not found
-    HIPFLAGS = lib.concatMapStringsSep " " (pkg: "-I${lib.getInclude pkg}/include") [
-      rocmPackages.hipblas
-      rocmPackages.hipcub
-      rocmPackages.hiprand
-      rocmPackages.hipsparse
-      rocmPackages.rocblas
-      rocmPackages.rocprim
-      rocmPackages.rocrand
-      rocmPackages.rocthrust
-    ];
-  }
-  // lib.optionalAttrs effectiveStdenv.hostPlatform.isMusl {
-    NIX_CFLAGS_COMPILE = "-DFLATBUFFERS_LOCALE_INDEPENDENT=0";
-    GTEST_FILTER = "*:-ContribOpTest.StringNormalizer*";
-  };
+  env =
+    lib.optionalAttrs effectiveStdenv.hostPlatform.isLinux {
+      NIX_LDFLAGS = "-z,noexecstack";
+    }
+    // lib.optionalAttrs rocmSupport {
+      MIOPEN_PATH = rocmPackages.miopen;
+      # HIP steps fail to find ROCm libs when not in HIPFLAGS, causing
+      # fatal error: 'rocrand/rocrand.h' file not found
+      HIPFLAGS = lib.concatMapStringsSep " " (pkg: "-I${lib.getInclude pkg}/include") [
+        rocmPackages.hipblas
+        rocmPackages.hipcub
+        rocmPackages.hiprand
+        rocmPackages.hipsparse
+        rocmPackages.rocblas
+        rocmPackages.rocprim
+        rocmPackages.rocrand
+        rocmPackages.rocthrust
+      ];
+    }
+    // lib.optionalAttrs effectiveStdenv.hostPlatform.isMusl {
+      NIX_CFLAGS_COMPILE = "-DFLATBUFFERS_LOCALE_INDEPENDENT=0";
+      GTEST_FILTER = "*:-ContribOpTest.StringNormalizer*";
+    };
 
   doCheck =
     !(

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage {
     chmod +w dist
   '';
 
-  env = {
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
     NIX_LDFLAGS = "-z,noexecstack";
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Following up on https://github.com/NixOS/nixpkgs/pull/482435
```
ld: unknown option: -z
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
