### PR TITLE
pyradio: add maintainer magicquark, install .desktop file and icon

### DIFF
--- a/pkgs/by-name/py/pyradio/package.nix
+++ b/pkgs/by-name/py/pyradio/package.nix
@@ -54,6 +54,7 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       contrun
+      magicquark
       yayayayaka
     ];
   };

--- a/pkgs/by-name/py/pyradio/package.nix
+++ b/pkgs/by-name/py/pyradio/package.nix
@@ -44,6 +44,12 @@ python3Packages.buildPythonApplication rec {
 
   postInstall = ''
     installManPage *.1
+
+    install -Dm644 $src/devel/pyradio.desktop \
+      "$out/share/applications/pyradio.desktop"
+
+    install -Dm644 "$src/pyradio/icons/pyradio.png" \
+      "$out/share/icons/hicolor/512x512/apps/pyradio.png"
   '';
 
   meta = {


### PR DESCRIPTION
### Update Maintainers
- I have added myself as a maintainer for this package.

### Install Desktop File and Icon
- The upstream package provides a `.desktop` [file](https://github.com/coderholic/pyradio/blob/master/devel/pyradio.desktop) and an icon for it.
- This PR installs both of those files so that an entry for `PyRadio` appears in application switchers etc.
- Tested locally using `Rofi`.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
