### PR TITLE
multiple-outputs.sh: move gi-docgen docs automatically

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -175,3 +175,14 @@
 ### Additions and Improvements {#sec-nixpkgs-release-26.05-lib-additions-improvements}
 
 - The builder `php.buildComposerProject2` for PHP applications has been improved for better reliability and stability.
+
+- `multiple-outputs.sh`, used by `stdenv.mkDerivation`, now automatically moves `*devhelp*` files to `devdoc` output if needed. This makes the following common `postFixup` not needed.
+
+```nix
+{
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+}
+```

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -307,11 +307,6 @@ stdenv.mkDerivation (finalAttrs: {
     }")
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     # The declarations for `gimp-with-plugins` wrapper,
     # used for determining plug-in installation paths

--- a/pkgs/build-support/setup-hooks/multiple-outputs.sh
+++ b/pkgs/build-support/setup-hooks/multiple-outputs.sh
@@ -154,6 +154,18 @@ _multioutDocs() {
 
     moveToOutput share/info "${!outputInfo}"
     moveToOutput share/doc "${!outputDoc}"
+
+    # Move gi-docgen-generated Devhelp docs to devdoc.
+    local docgenPath
+    for output in $(getAllOutputNames); do
+        if [ -d "${!output}/share/doc" ]; then
+            find ${!output}/share/doc -type f -name '*devhelp*' \ -printf '%P\0' |\
+                while IFS= read -r -d $'\0' docgenPath; do
+                moveToOutput "$(dirname "$docgenPath")" "${!outputDevdoc}"
+            done
+        fi
+    done
+
     moveToOutput share/gtk-doc "${!outputDevdoc}"
     moveToOutput share/devhelp/books "${!outputDevdoc}"
 

--- a/pkgs/by-name/ba/babl/package.nix
+++ b/pkgs/by-name/ba/babl/package.nix
@@ -56,11 +56,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-Denable-gir=true"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   meta = {
     description = "Image pixel format conversion library";
     mainProgram = "babl";

--- a/pkgs/by-name/de/devhelp/package.nix
+++ b/pkgs/by-name/de/devhelp/package.nix
@@ -69,11 +69,6 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput share/doc/devhelp-3 "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "devhelp";

--- a/pkgs/by-name/eo/eog/package.nix
+++ b/pkgs/by-name/eo/eog/package.nix
@@ -118,11 +118,6 @@ stdenv.mkDerivation rec {
     )
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "eog";

--- a/pkgs/by-name/ev/evince/package.nix
+++ b/pkgs/by-name/ev/evince/package.nix
@@ -130,11 +130,6 @@ stdenv.mkDerivation (finalAttrs: {
     gappsWrapperArgs+=(--prefix XDG_DATA_DIRS : "${shared-mime-info}/share")
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "evince";

--- a/pkgs/by-name/fw/fwupd/package.nix
+++ b/pkgs/by-name/fw/fwupd/package.nix
@@ -343,9 +343,6 @@ stdenv.mkDerivation (finalAttrs: {
         wrapGApp "$file"
       fi
     done
-
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
     moveToOutput "etc/doc" "$devdoc"
   '';
 

--- a/pkgs/by-name/gc/gcr/package.nix
+++ b/pkgs/by-name/gc/gcr/package.nix
@@ -100,11 +100,6 @@ stdenv.mkDerivation rec {
     substituteInPlace meson_post_install.py --replace ".so" "${stdenv.hostPlatform.extensions.sharedLibrary}"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gcr";

--- a/pkgs/by-name/gc/gcr_4/package.nix
+++ b/pkgs/by-name/gc/gcr_4/package.nix
@@ -105,11 +105,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs gcr/fixtures/
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "gcr_4";

--- a/pkgs/by-name/gd/gdk-pixbuf/package.nix
+++ b/pkgs/by-name/gd/gdk-pixbuf/package.nix
@@ -141,11 +141,6 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  postFixup = lib.optionalString withIntrospection ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   # The tests take an excessive amount of time (> 1.5 hours) and memory (> 6 GB).
   inherit doCheck;
 

--- a/pkgs/by-name/ge/gegl/package.nix
+++ b/pkgs/by-name/ge/gegl/package.nix
@@ -114,11 +114,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tests/ff-load-save/tests_ff_load_save.sh tests/opencl/opencl_test.sh tools/xml_insert.sh
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   # tests fail to connect to the com.apple.fonts daemon in sandboxed mode
   doCheck = !stdenv.hostPlatform.isDarwin;
 

--- a/pkgs/by-name/gh/ghex/package.nix
+++ b/pkgs/by-name/gh/ghex/package.nix
@@ -63,11 +63,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dmmap-buffer-backend=false"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "ghex";

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -303,9 +303,6 @@ stdenv.mkDerivation (finalAttrs: {
     for i in $dev/bin/*; do
       moveToOutput "share/man/man1/''${i##*/}.1.*" "$dev"
     done
-
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
   '';
 
   # Conditional necessary to break infinite recursion with passthru.tests

--- a/pkgs/by-name/gn/gnome-builder/package.nix
+++ b/pkgs/by-name/gn/gnome-builder/package.nix
@@ -154,11 +154,6 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput share/doc/libide "$devdoc"
-  '';
-
   passthru.updateScript = gnome.updateScript {
     packageName = "gnome-builder";
   };

--- a/pkgs/by-name/gn/gnome-online-accounts/package.nix
+++ b/pkgs/by-name/gn/gnome-online-accounts/package.nix
@@ -88,11 +88,6 @@ stdenv.mkDerivation (finalAttrs: {
     keyutils
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   separateDebugInfo = true;
 
   passthru = {

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -239,9 +239,6 @@ stdenv.mkDerivation (finalAttrs: {
     for svc in org.gnome.ScreenSaver org.gnome.Shell.Extensions org.gnome.Shell.Notifications org.gnome.Shell.Screencast; do
       wrapGApp $out/share/gnome-shell/$svc
     done
-
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
   '';
 
   separateDebugInfo = true;

--- a/pkgs/by-name/gs/gssdp/package.nix
+++ b/pkgs/by-name/gs/gssdp/package.nix
@@ -80,15 +80,6 @@ stdenv.mkDerivation rec {
   # Bail out! GLib-GIO-FATAL-CRITICAL: g_inet_address_to_string: assertion 'G_IS_INET_ADDRESS (address)' failed
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  postFixup = lib.optionalString withIntrospection ''
-    # Move developer documentation to devdoc output.
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    find -L "$out/share/doc" -type f -regex '.*\.devhelp2?' -print0 \
-      | while IFS= read -r -d ''' file; do
-        moveToOutput "$(dirname "''${file/"$out/"/}")" "$devdoc"
-    done
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gssdp";

--- a/pkgs/by-name/gs/gssdp_1_6/package.nix
+++ b/pkgs/by-name/gs/gssdp_1_6/package.nix
@@ -62,15 +62,6 @@ stdenv.mkDerivation (finalAttrs: {
   # On Darwin: Failed to bind socket, Operation not permitted
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  postFixup = ''
-    # Move developer documentation to devdoc output.
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    find -L "$out/share/doc" -type f -regex '.*\.devhelp2?' -print0 \
-      | while IFS= read -r -d ''' file; do
-        moveToOutput "$(dirname "''${file/"$out/"/}")" "$devdoc"
-    done
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "gssdp_1_6";

--- a/pkgs/by-name/gt/gtk-vnc/package.nix
+++ b/pkgs/by-name/gt/gtk-vnc/package.nix
@@ -71,11 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dpulseaudio=disabled"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gtk-vnc";

--- a/pkgs/by-name/gt/gtk4/package.nix
+++ b/pkgs/by-name/gt/gtk4/package.nix
@@ -262,19 +262,14 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Wrap demos
-  postFixup =
-    lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-      demos=(gtk4-demo gtk4-demo-application gtk4-widget-factory)
+  postFixup = lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    demos=(gtk4-demo gtk4-demo-application gtk4-widget-factory)
 
-      for program in ''${demos[@]}; do
-        wrapProgram $dev/bin/$program \
-          --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${finalAttrs.pname}-${finalAttrs.version}"
-      done
-    ''
-    + lib.optionalString x11Support ''
-      # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-      moveToOutput "share/doc" "$devdoc"
-    '';
+    for program in ''${demos[@]}; do
+      wrapProgram $dev/bin/$program \
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${finalAttrs.pname}-${finalAttrs.version}"
+    done
+  '';
 
   passthru = {
     updateScript = gnome.updateScript {

--- a/pkgs/by-name/gu/gupnp_1_6/package.nix
+++ b/pkgs/by-name/gu/gupnp_1_6/package.nix
@@ -57,11 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
   # On Darwin: Failed to bind socket, Operation not permitted
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "gupnp_1_6";

--- a/pkgs/by-name/gu/gusb/package.nix
+++ b/pkgs/by-name/gu/gusb/package.nix
@@ -90,11 +90,6 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # tests try to access USB
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   meta = {
     description = "GLib libusb wrapper";
     mainProgram = "gusbcmd";

--- a/pkgs/by-name/js/json-glib/package.nix
+++ b/pkgs/by-name/js/json-glib/package.nix
@@ -80,17 +80,6 @@ stdenv.mkDerivation rec {
 
   doCheck = true;
 
-  postFixup = ''
-    # Move developer documentation to devdoc output.
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    if [[ -d "$out/share/doc" ]]; then
-        find -L "$out/share/doc" -type f -regex '.*\.devhelp2?' -print0 \
-          | while IFS= read -r -d ''' file; do
-            moveToOutput "$(dirname "''${file/"$out/"/}")" "$devdoc"
-        done
-    fi
-  '';
-
   passthru = {
     tests = {
       installedTests = nixosTests.installed-tests.json-glib;

--- a/pkgs/by-name/js/jsonrpc-glib/package.nix
+++ b/pkgs/by-name/js/jsonrpc-glib/package.nix
@@ -50,11 +50,6 @@ stdenv.mkDerivation rec {
   # https://gitlab.gnome.org/GNOME/jsonrpc-glib/issues/2
   doCheck = false;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = pname;

--- a/pkgs/by-name/li/libadwaita/package.nix
+++ b/pkgs/by-name/li/libadwaita/package.nix
@@ -109,9 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-
     # Put all resources related to demo app into devdoc output.
     for d in applications icons metainfo; do
       moveToOutput "share/$d" "$devdoc"

--- a/pkgs/by-name/li/libdex/package.nix
+++ b/pkgs/by-name/li/libdex/package.nix
@@ -48,11 +48,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru.updateScript = gnome.updateScript {
     packageName = "libdex";
     versionPolicy = "odd-unstable";

--- a/pkgs/by-name/li/libgflow/package.nix
+++ b/pkgs/by-name/li/libgflow/package.nix
@@ -43,11 +43,6 @@ stdenv.mkDerivation rec {
     glib
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   mesonFlags = [
     "-Denable_valadoc=true"
     "-Denable_gtk3=false"

--- a/pkgs/by-name/li/libgtkflow3/package.nix
+++ b/pkgs/by-name/li/libgtkflow3/package.nix
@@ -45,11 +45,6 @@ stdenv.mkDerivation rec {
     libgflow
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   mesonFlags = [
     "-Denable_valadoc=true"
     "-Denable_gtk4=false"

--- a/pkgs/by-name/li/libgtkflow4/package.nix
+++ b/pkgs/by-name/li/libgtkflow4/package.nix
@@ -45,11 +45,6 @@ stdenv.mkDerivation rec {
     libgflow
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   mesonFlags = [
     "-Denable_valadoc=true"
     "-Denable_gtk3=false"

--- a/pkgs/by-name/li/libgweather/package.nix
+++ b/pkgs/by-name/li/libgweather/package.nix
@@ -103,11 +103,6 @@ stdenv.mkDerivation rec {
       "dependency('vapigen', native: true, required: enable_vala == 'true')"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   strictDeps = true;
 
   passthru = {

--- a/pkgs/by-name/li/libhandy/package.nix
+++ b/pkgs/by-name/li/libhandy/package.nix
@@ -114,11 +114,6 @@ stdenv.mkDerivation rec {
     runHook postCheck
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "libhandy";

--- a/pkgs/by-name/li/libmanette/package.nix
+++ b/pkgs/by-name/li/libmanette/package.nix
@@ -73,11 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
   strictDeps = true;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "libmanette";

--- a/pkgs/by-name/li/libopenmpt/package.nix
+++ b/pkgs/by-name/li/libopenmpt/package.nix
@@ -55,10 +55,6 @@ stdenv.mkDerivation rec {
 
   doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
 
-  postFixup = ''
-    moveToOutput share/doc $dev
-  '';
-
   passthru.updateScript = ./update.sh;
 
   meta = {

--- a/pkgs/by-name/li/libpanel/package.nix
+++ b/pkgs/by-name/li/libpanel/package.nix
@@ -55,11 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "install-examples" true)
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "libpanel";

--- a/pkgs/by-name/li/libportal/package.nix
+++ b/pkgs/by-name/li/libportal/package.nix
@@ -88,11 +88,6 @@ stdenv.mkDerivation rec {
     (lib.mesonBool "docs" (variant != "qt5")) # requires introspection=true
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   # we don't have any binaries
   dontWrapQtApps = true;
 

--- a/pkgs/by-name/li/libproxy/package.nix
+++ b/pkgs/by-name/li/libproxy/package.nix
@@ -100,11 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     hardcodeGsettingsPatch = makeHardcodeGsettingsPatch {
       schemaIdToVariableMapping = {

--- a/pkgs/by-name/li/librsvg/package.nix
+++ b/pkgs/by-name/li/librsvg/package.nix
@@ -168,11 +168,6 @@ stdenv.mkDerivation (finalAttrs: {
         --zsh <(${emulator} $out/bin/rsvg-convert --completion zsh)
     '';
 
-  postFixup = lib.optionalString withIntrospection ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript =
       let

--- a/pkgs/by-name/li/libsecret/package.nix
+++ b/pkgs/by-name/li/libsecret/package.nix
@@ -184,11 +184,6 @@ stdenv.mkDerivation rec {
     rm "$out/lib/libmock-service.so"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "libsecret";

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -95,11 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput share/doc/libshumate-1.0 "$devdoc"
-  '';
-
   strictDeps = true;
 
   passthru = {

--- a/pkgs/by-name/li/libspelling/package.nix
+++ b/pkgs/by-name/li/libspelling/package.nix
@@ -55,11 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     gtksourceview5
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru.updateScript = gnome.updateScript {
     packageName = "libspelling";
   };

--- a/pkgs/by-name/na/nautilus/package.nix
+++ b/pkgs/by-name/na/nautilus/package.nix
@@ -116,11 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
     )
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "nautilus";

--- a/pkgs/by-name/pa/pango/package.nix
+++ b/pkgs/by-name/pa/pango/package.nix
@@ -97,11 +97,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = false; # test-font: FAIL
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "pango";

--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -133,11 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     install_name_tool -add_rpath "$out/lib" "$out/bin/papers"
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript =
       let

--- a/pkgs/by-name/te/template-glib/package.nix
+++ b/pkgs/by-name/te/template-glib/package.nix
@@ -53,11 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput share/doc/template-glib-1.0 "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "template-glib";

--- a/pkgs/by-name/ti/tinysparql/package.nix
+++ b/pkgs/by-name/ti/tinysparql/package.nix
@@ -157,11 +157,6 @@ stdenv.mkDerivation (finalAttrs: {
     rm -r $out/lib
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript { packageName = finalAttrs.pname; };
     tests.pkg-config = testers.hasPkgConfigModules {

--- a/pkgs/by-name/vi/vips/package.nix
+++ b/pkgs/by-name/vi/vips/package.nix
@@ -140,10 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
   )
   ++ lib.optional (imagemagick == null) (lib.mesonEnable "magick" false);
 
-  postFixup = ''
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     tests = {
       pkg-config = testers.hasPkgConfigModules {

--- a/pkgs/by-name/vi/vips_8_17/package.nix
+++ b/pkgs/by-name/vi/vips_8_17/package.nix
@@ -139,10 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
   )
   ++ lib.optional (imagemagick == null) (lib.mesonEnable "magick" false);
 
-  postFixup = ''
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     tests = {
       pkg-config = testers.hasPkgConfigModules {

--- a/pkgs/by-name/vt/vte/package.nix
+++ b/pkgs/by-name/vt/vte/package.nix
@@ -138,11 +138,6 @@ stdenv.mkDerivation (finalAttrs: {
       src/modes.py
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "vte";

--- a/pkgs/development/libraries/gtksourceview/5.x.nix
+++ b/pkgs/development/libraries/gtksourceview/5.x.nix
@@ -96,11 +96,6 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postCheck
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "gtksourceview";

--- a/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/kdoctools/default.nix
@@ -52,7 +52,6 @@ mkDerivation {
     "-DDocBookXSL_DIR=${docbook_xsl_ns}/xml/xsl/docbook"
   ];
   postFixup = ''
-    moveToOutput "share/doc" "$dev"
     moveToOutput "share/man" "$dev"
   '';
 }

--- a/pkgs/development/libraries/libpeas/2.x.nix
+++ b/pkgs/development/libraries/libpeas/2.x.nix
@@ -96,11 +96,6 @@ stdenv.mkDerivation rec {
         "run_command('${stdenv.hostPlatform.emulator buildPackages}', [lua_prg, "
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "libpeas2";

--- a/pkgs/development/libraries/libpeas/default.nix
+++ b/pkgs/development/libraries/libpeas/default.nix
@@ -85,11 +85,6 @@ stdenv.mkDerivation rec {
     "-Dgtk_doc=true"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       packageName = "libpeas";

--- a/pkgs/development/libraries/librest/1.0.nix
+++ b/pkgs/development/libraries/librest/1.0.nix
@@ -54,11 +54,6 @@ stdenv.mkDerivation rec {
     "-Dca_certificates_path=/etc/ssl/certs/ca-certificates.crt"
   ];
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   separateDebugInfo = true;
 
   passthru = {

--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -95,11 +95,6 @@ stdenv.mkDerivation rec {
     patchShebangs libsoup/
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "libsoup_3";

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -249,11 +249,6 @@ clangStdenv.mkDerivation (finalAttrs: {
     patchShebangs .
   '';
 
-  postFixup = ''
-    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
-    moveToOutput "share/doc" "$devdoc"
-  '';
-
   requiredSystemFeatures = [ "big-parallel" ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;


### PR DESCRIPTION
A remake of https://github.com/NixOS/nixpkgs/pull/187042 with release notes added, and changes to packages done in separate commits - to trigger review requests of maintainers (mostly the @NixOS/gnome team).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
