### PR TITLE
python3Packages.pydivsufsort: init at 0.0.20

### DIFF
--- a/pkgs/development/python-modules/pydivsufsort/default.nix
+++ b/pkgs/development/python-modules/pydivsufsort/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  cmake,
+  cython,
+  fetchPypi,
+  lib,
+  numpy,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pydivsufsort";
+  version = "0.0.20";
+
+  pyproject = true;
+
+  # The repo hosted on github does not have tags, so we use fetchPypi, though
+  # we should replace with fetchFromGitHub when we have
+  # https://github.com/louisabraham/pydivsufsort/issues/52
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-aFpXkfrl4gDOi3pOXVFbYVP/3nF1MxvQ34GkIRCK1N8=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py --replace-fail /bin/bash bash
+    patchShebangs build.sh
+  '';
+
+  nativeBuildInputs = [ cmake ];
+  dontUseCmakeConfigure = true;
+
+  build-system = [ setuptools ];
+  dependencies = [
+    cython
+    numpy
+  ];
+
+  meta = {
+    description = "Bindings to `libdivsufsort`";
+    homepage = "https://github.com/louisabraham/pydivsufsort";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jmbaur ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13354,6 +13354,8 @@ self: super: with self; {
 
   pydispatcher = callPackage ../development/python-modules/pydispatcher { };
 
+  pydivsufsort = callPackage ../development/python-modules/pydivsufsort { };
+
   pydle = callPackage ../development/python-modules/pydle { };
 
   pydmd = callPackage ../development/python-modules/pydmd { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
