### PR TITLE
pdf-parser: switch to stdenv.mkDerivation

### DIFF
--- a/pkgs/by-name/pd/pdf-parser/package.nix
+++ b/pkgs/by-name/pd/pdf-parser/package.nix
@@ -1,14 +1,14 @@
 {
   lib,
-  python3Packages,
+  stdenv,
   fetchzip,
+  python3,
   writeScript,
 }:
 
-python3Packages.buildPythonApplication rec {
+stdenv.mkDerivation rec {
   pname = "pdf-parser";
   version = "0.7.10";
-  pyproject = false;
 
   src = fetchzip {
     url = "https://didierstevens.com/files/software/pdf-parser_V${
@@ -16,6 +16,8 @@ python3Packages.buildPythonApplication rec {
     }.zip";
     hash = "sha256-RhgEGue3RcALjLXKOnnXyx/0subXHNuXfDg8hbO3VDg=";
   };
+
+  buildInputs = [ python3 ];
 
   postPatch = ''
     # quote regular expressions correctly
@@ -34,7 +36,7 @@ python3Packages.buildPythonApplication rec {
 
   preFixup = ''
     substituteInPlace $out/bin/pdf-parser.py \
-      --replace-fail '/usr/bin/python' '${python3Packages.python}/bin/python'
+      --replace-fail '/usr/bin/python' '${python3}/bin/python'
   '';
 
   passthru.updateScript = writeScript "update-pdf-parser" ''


### PR DESCRIPTION
- Refactored the package to use stdenv.mkDerivation instead of buildPythonApplication. This prevents the Python interpreter from being propagated into the consumer's environment (e.g., in a devShell), which was causing unexpected Python version overrides.

Fixes #477525


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
