### PR TITLE
balatro: add official icon

### DIFF
--- a/pkgs/by-name/ba/balatro/package.nix
+++ b/pkgs/by-name/ba/balatro/package.nix
@@ -1,4 +1,5 @@
 {
+  fetchurl,
   stdenv,
   lib,
   love,
@@ -20,6 +21,12 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://store.steampowered.com/app/2379780/Balatro/";
     # Use `nix --extra-experimental-features nix-command hash file --sri --type sha256` to get the correct hash
     hash = "sha256-DXX+FkrM8zEnNNSzesmHiN0V8Ljk+buLf5DE5Z3pP0c=";
+  };
+
+  srcIcon = fetchurl {
+    name = "balatro.png";
+    url = "https://play-lh.googleusercontent.com/RSPv_SMlA3Lun8VHaJD7xCBQg29eCJR9sNJtZNJGlybVs8byYVLz4WnohrbLScC9srg";
+    hash = "sha256-GoStvXBYI8x5b8T0wwH5D5C3Kahu0ssCyOM8MoLxy8Q=";
   };
 
   nativeBuildInputs = [
@@ -54,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   # 'official' way of doing it.
   installPhase = ''
     runHook preInstall
-    install -Dm444 $tmpdir/resources/textures/2x/balatro.png -t $out/share/icons/
+    install -Dm644 $srcIcon $out/share/icons/hicolor/scalable/apps/balatro.png
 
     cat ${lib.getExe love} $patchedExe > $out/share/Balatro
     chmod +x $out/share/Balatro


### PR DESCRIPTION
The current Balatro icon is a texture from the game's resources folder that is incomplete on its own.  (There's a hole in the middle where the cards are supposed to go.)

This PR replaces it with the official icon, as seen on the Google and Apple storefronts.  The storefronts use CDNs like FIFE, whose URLs are liable to expire.  Rather than hardcode a URL that could be rotated, I've used `requireFile` like you have for the original `src`, along with a comment explaining how to use it.

This could eventually be automated with a `passthru.updateScript` from either store:

- Google:
  - Use the MIT-licensed [`app-icon`](https://github.com/StellarSand/app-icon), either as its own derivation or copied into the `balatro` folder as a helper.
  - Store the URL in `sources.json`, and use that as an input to `fetchurl`.

- Apple:
  - Query their JSON API: https://itunes.apple.com/search?term=com.playstack.balatro&entity=software
  - Grab [`artworkUrl512`](https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/6d/d3/0c/6dd30caf-f830-22d5-ba44-448cdff0df30/iOS_AppIcon_Premium-0-0-1x_U007epad-0-1-85-220.png/512x512bb.jpg) for `com.playstack.balatropremium`.
  - Store the URL in `sources.json`, and use that as an input to `fetchurl`.

I've got other improvements in [my home-manager config](https://github.com/appsforartists/device-config/blob/master/modules/balatro/default.nix) that I intend to upstream in future PRs.  The biggest one is a patch that expands support for the derivation to include the mobile and Game Pass versions.  I had to disable `withLinuxPatch` to make it work; we may have to tweak that if you want to keep it.