### PR TITLE
python3Packages.inky: init at 2.3.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26189,6 +26189,12 @@
     githubId = 18369995;
     keys = [ { fingerprint = "3D8C A43C FBA2 5D28 0196  19F0 AB11 0475 B417 291D"; } ];
   };
+  theconcierge = {
+    name = "TheConcierge";
+    email = "therealconcierge@proton.me";
+    github = "TheConcierge";
+    githubId = 10949861;
+  };
   thedavidmeister = {
     email = "thedavidmeister@gmail.com";
     github = "thedavidmeister";

--- a/pkgs/development/python-modules/gpiodevice/default.nix
+++ b/pkgs/development/python-modules/gpiodevice/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  pytestCheckHook,
+  fetchFromGitHub,
+  hatchling,
+  hatch-fancy-pypi-readme,
+  libgpiod,
+  mock,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "gpiodevice";
+  version = "0.0.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pimoroni";
+    repo = "gpiodevice-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1vZHRCHUmG+t0TYxYzc2qwElKrcLa0WmQ+FI5GTN1A8=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-fancy-pypi-readme
+  ];
+
+  dependencies = [
+    libgpiod
+  ];
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "gpiodevice" ];
+
+  # The build explicitly copies over these docs files, which cause collisions with other pimoroni repos.
+  # Preserve the files (especially license), but move elsewhere.
+  postInstall = ''
+    mkdir -p $out/share/doc/${finalAttrs.pname}
+    mkdir -p $out/share/licenses/${finalAttrs.pname}
+
+    mv "$out/${python.sitePackages}/LICENSE" $out/share/licenses/${finalAttrs.pname}
+    mv "$out/${python.sitePackages}/README.md" $out/share/doc/${finalAttrs.pname}/
+    mv "$out/${python.sitePackages}/CHANGELOG.md" $out/share/doc/${finalAttrs.pname}/
+  '';
+
+  meta = {
+    description = "Helper library for working with Linux gpiochip devices";
+    homepage = "https://github.com/pimoroni/gpiodevice-python";
+    changelog = "https://github.com/pimoroni/gpiodevice-python/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theconcierge ];
+  };
+})

--- a/pkgs/development/python-modules/inky/default.nix
+++ b/pkgs/development/python-modules/inky/default.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  python,
+  buildPythonPackage,
+  pytestCheckHook,
+  fetchFromGitHub,
+  hatchling,
+  hatch-fancy-pypi-readme,
+  hatch-requirements-txt,
+  numpy,
+  pillow,
+  smbus2,
+  spidev,
+  gpiodevice,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "inky";
+  version = "2.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pimoroni";
+    repo = "inky";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-1z2AZr6mlrl1O071iWS+tbWopUEUzLZe/QTmvl2atxQ=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-fancy-pypi-readme
+    hatch-requirements-txt
+  ];
+
+  dependencies = [
+    numpy
+    pillow
+    smbus2
+    spidev
+    gpiodevice
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "inky" ];
+
+  # The build explicitly copies over these docs files, which cause collisions with other pimoroni repos.
+  # Preserve the files (especially license), but move elsewhere.
+  postInstall = ''
+    mkdir -p $out/share/doc/${finalAttrs.pname}
+    mkdir -p $out/share/licenses/${finalAttrs.pname}
+
+    mv "$out/${python.sitePackages}/LICENSE" $out/share/licenses/${finalAttrs.pname}/
+    mv "$out/${python.sitePackages}/README.md" $out/share/doc/${finalAttrs.pname}/
+    mv "$out/${python.sitePackages}/CHANGELOG.md" $out/share/doc/${finalAttrs.pname}/
+  '';
+
+  meta = {
+    description = "Python library for Inky pHAT, Inky wHAT and Inky Impression e-paper displays for Raspberry Pi.";
+    homepage = "https://github.com/pimoroni/inky";
+    changelog = "https://github.com/pimoroni/inky/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ theconcierge ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7390,6 +7390,8 @@ self: super: with self; {
 
   inkex = callPackage ../development/python-modules/inkex { };
 
+  inky = callPackage ../development/python-modules/inky { };
+
   inline-snapshot = callPackage ../development/python-modules/inline-snapshot { };
 
   inotify = callPackage ../development/python-modules/inotify { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6478,6 +6478,8 @@ self: super: with self; {
 
   gpib-ctypes = callPackage ../development/python-modules/gpib-ctypes { };
 
+  gpiodevice = callPackage ../development/python-modules/gpiodevice { };
+
   gpiozero = callPackage ../development/python-modules/gpiozero { };
 
   gprof2dot = callPackage ../development/python-modules/gprof2dot { inherit (pkgs) graphviz; };


### PR DESCRIPTION
`inky` is a Python library for driving Pimoroni displays, like the [Inky Impression](https://shop.pimoroni.com/products/inky-impression-7-3?variant=55186435244411).

This change also packages another dependency created by Pimoroni, `gpiodevice`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
