### PR TITLE
carapace: fix build with proxyVendor

### DIFF
--- a/pkgs/by-name/ca/carapace/package.nix
+++ b/pkgs/by-name/ca/carapace/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "carapace";
-  version = "1.5.5";
+  version = "1.6.0";
 
   src = fetchFromGitHub {
     owner = "carapace-sh";
     repo = "carapace-bin";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-q7G7odkRwh4/w8H09exXYSC7n4CUeoG2iKb/k2D/gek=";
+    hash = "sha256-btExAFj3nnq5vv3LJgUA7pdmQhd6ANUexC/AQcIg0Ms=";
   };
 
-  vendorHash = "sha256-eADiOSLqouH9saTgbbQY18wc3DxCBvqdVKI32I7sTWQ=";
+  vendorHash = "sha256-7Gmt4ZHmYK5IukQYuY0felhW+ul23wSDX9PJyI6rDWQ=";
 
   proxyVendor = true;
 

--- a/pkgs/by-name/ca/carapace/package.nix
+++ b/pkgs/by-name/ca/carapace/package.nix
@@ -20,6 +20,8 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-eADiOSLqouH9saTgbbQY18wc3DxCBvqdVKI32I7sTWQ=";
 
+  proxyVendor = true;
+
   ldflags = [
     "-s"
     "-w"


### PR DESCRIPTION
## Things done

Upstream's go.mod uses replace directives for forked dependencies (`carapace-pflag`, `ssh_config`). However, buildGoModule's vendor generation produces a modules.txt that Go rejects as inconsistent due to these replace directives.                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                    
In this PR, I set `proxyVendor` to true, which bypasses this problem by using the module proxy when building instead of the generated vendor directory. I've also bumped carapace to 1.6.0.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
