### PR TITLE
bdf2ttf: apply `gcc-15` build fix

### DIFF
--- a/pkgs/by-name/bd/bdf2ttf/gcc-15.patch
+++ b/pkgs/by-name/bd/bdf2ttf/gcc-15.patch
@@ -1,0 +1,38 @@
+Fetched as:
+$ curl -L https://patch-diff.githubusercontent.com/raw/koron/bdf2ttf/pull/9.patch
+
+From 87d9f987517c78c444d1d425e33c9a5f06ced3ce Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Thu, 22 Jan 2026 06:35:12 +0000
+Subject: [PATCH] bdf.c: fix the build against -std=c23
+
+`gcc-15` switched to `c23` by default and `bdf2tff`
+started to fail the build as:
+
+````
+src/bdf.c:131:1: error: conflicting types for 'glyph_open'; have 'bdf_glyph_t *(int,  int)' {aka 'struct _bdf_glyph_t *(int,  int)'}
+  131 | glyph_open(int width, int height)
+      | ^~~~~~~~~~
+src/bdf.c:60:25: note: previous declaration of 'glyph_open' with type 'bdf_glyph_t *(void)' {aka 'struct _bdf_glyph_t *(void)'}
+   60 | static bdf_glyph_t*     glyph_open();
+      |                         ^~~~~~~~~~
+````
+
+THe change fixed explicit prototype for a forward declaration.
+---
+ src/bdf.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/bdf.c b/src/bdf.c
+index 0832092..08272ed 100644
+--- a/src/bdf.c
++++ b/src/bdf.c
+@@ -57,7 +57,7 @@ static width_table_t cell_width_table[] = {
+ 
+ static int	bdf_load_fh(bdf_t* font, FILE* fp);
+ static void	count_validglyph(bdf_t* font);
+-static bdf_glyph_t*	glyph_open();
++static bdf_glyph_t*	glyph_open(int width, int height);
+ static void		glyph_close(bdf_glyph_t *glyph);
+ static char*	iscmd(char* target, char* keyword);
+ static int	atoi_next(char** str);

--- a/pkgs/by-name/bd/bdf2ttf/package.nix
+++ b/pkgs/by-name/bd/bdf2ttf/package.nix
@@ -15,6 +15,11 @@ stdenv.mkDerivation {
     hash = "sha256-235BTcTaC/30yLlgo0OO2cp3YCHWa87GFJGBx5lmz6o=";
   };
 
+  patches = [
+    # gcc-15 build fix: https://github.com/koron/bdf2ttf/pull/9
+    ./gcc-15.patch
+  ];
+
   dontConfigure = true;
 
   makeFlags = [ "gcc" ];


### PR DESCRIPTION
Without the chnage the build fails as https://hydra.nixos.org/build/317973907 on `master as:

    gcc    -c -o src/bdf.o src/bdf.c
    src/bdf.c:131:1: error: conflicting types for 'glyph_open'; have 'bdf_glyph_t *(int,  int)' {aka 'struct _bdf_glyph_t *(int,  int)'}
      131 | glyph_open(int width, int height)
          | ^~~~~~~~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
