### PR TITLE
nixos/chrony: add makestep and dispatcherScript option, use pool option for pool server

### DIFF
--- a/nixos/modules/services/networking/ntp/chrony.nix
+++ b/nixos/modules/services/networking/ntp/chrony.nix
@@ -16,7 +16,12 @@ let
 
   configFile = pkgs.writeText "chrony.conf" ''
     ${lib.concatMapStringsSep "\n" (
-      server: "server " + server + " " + cfg.serverOption + lib.optionalString (cfg.enableNTS) " nts"
+      server:
+      (if lib.strings.hasInfix "pool" server then "pool " else "server ")
+      + server
+      + " "
+      + cfg.serverOption
+      + lib.optionalString (cfg.enableNTS) " nts"
     ) cfg.servers}
 
     ${lib.optionalString (

--- a/nixos/modules/services/networking/ntp/chrony.nix
+++ b/nixos/modules/services/networking/ntp/chrony.nix
@@ -50,6 +50,20 @@ let
   ]
   ++ lib.optional cfg.enableMemoryLocking "-m"
   ++ cfg.extraFlags;
+
+  dispathcerScriptFile = pkgs.callPackage (
+    {
+      runCommand,
+      srcOnly,
+    }:
+    runCommand "10-chrony-onoffline" { } ''
+      cp ${srcOnly chronyPkg}/examples/chrony.nm-dispatcher.onoffline $out
+      substituteInPlace $out \
+        --replace-fail '/usr/bin/chronyc' '${chronyPkg}/bin/chronyc'
+      chmod +x $out
+      patchShebangs $out
+    ''
+  ) { };
 in
 {
   options = {
@@ -196,6 +210,16 @@ in
         description = "Directory where chrony state is stored.";
       };
 
+      dispatcherScript = lib.mkOption {
+        type = lib.types.bool;
+        default = config.networking.networkmanager.enable;
+        defaultText = lib.literalExpression "config.networking.networkmanager.enable";
+        description = ''
+          Whether to install the chrony NetworkManager dispatcher script
+          to handle connectivity changes.
+        '';
+      };
+
       extraConfig = lib.mkOption {
         type = lib.types.lines;
         default = "";
@@ -230,6 +254,13 @@ in
       description = "chrony daemon user";
       home = stateDir;
     };
+
+    networking.networkmanager.dispatcherScripts = lib.mkIf cfg.dispatcherScript [
+      {
+        type = "basic";
+        source = dispathcerScriptFile;
+      }
+    ];
 
     services.timesyncd.enable = lib.mkForce false;
 

--- a/nixos/modules/services/networking/ntp/chrony.nix
+++ b/nixos/modules/services/networking/ntp/chrony.nix
@@ -23,6 +23,8 @@ let
       cfg.initstepslew.enabled && (cfg.servers != [ ])
     ) "initstepslew ${toString cfg.initstepslew.threshold} ${lib.concatStringsSep " " cfg.servers}"}
 
+    ${lib.optionalString cfg.makestep.enable "makestep ${toString cfg.makestep.threshold} ${toString cfg.makestep.limit}"}
+
     driftfile ${driftFile}
     keyfile ${keyFile}
     ${lib.optionalString (cfg.enableRTCTrimming) "rtcfile ${rtcFile}"}
@@ -134,8 +136,9 @@ in
       initstepslew = {
         enabled = lib.mkOption {
           type = lib.types.bool;
-          default = true;
+          default = false;
           description = ''
+            DEPRECATED. Consider using `services.chrony.makestep` instead.
             Allow chronyd to make a rapid measurement of the system clock error
             at boot time, and to correct the system clock by stepping before
             normal operation begins.
@@ -149,6 +152,35 @@ in
             The threshold of system clock error (in seconds) above which the
             clock will be stepped. If the correction required is less than the
             threshold, a slew is used instead.
+          '';
+        };
+      };
+
+      makestep = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = ''
+            Allow chronyd to step the system clock if the error is larger than
+            the specified threshold.
+          '';
+        };
+
+        threshold = lib.mkOption {
+          type = lib.types.either lib.types.float lib.types.int;
+          default = 0.1;
+          description = ''
+            The threshold of system clock error (in seconds) above which the
+            clock will be stepped. If the correction required is less than the
+            threshold, a slew is used instead.
+          '';
+        };
+
+        limit = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 3;
+          description = ''
+            The maximum number of times the system clock will be stepped.
           '';
         };
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
