### PR TITLE
nixos-artwork.wallpapers.*: set pname and version

### DIFF
--- a/pkgs/data/misc/nixos-artwork/wallpapers.nix
+++ b/pkgs/data/misc/nixos-artwork/wallpapers.nix
@@ -7,7 +7,8 @@
 let
   mkNixBackground =
     {
-      name,
+      pname,
+      version,
       src,
       description,
       license ? lib.licenses.free,
@@ -15,7 +16,11 @@ let
 
     let
       pkg = stdenv.mkDerivation {
-        inherit name src;
+        inherit
+          pname
+          version
+          src
+          ;
 
         dontUnpack = true;
 
@@ -27,12 +32,12 @@ let
                   ln -s $src $out/share/backgrounds/nixos/${src.name}
 
                   mkdir -p $out/share/gnome-background-properties/
-                  cat <<EOF > $out/share/gnome-background-properties/${name}.xml
+                  cat <<EOF > $out/share/gnome-background-properties/${pname}.xml
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
           <wallpapers>
             <wallpaper deleted="false">
-              <name>${name}</name>
+              <name>${pname}</name>
               <filename>${src}</filename>
               <options>zoom</options>
               <shade_type>solid</shade_type>
@@ -47,12 +52,12 @@ let
                   ln -s $src $out/share/artwork/gnome/${src.name}
 
                   # KDE
-                  mkdir -p $out/share/wallpapers/${name}/contents/images
-                  ln -s $src $out/share/wallpapers/${name}/contents/images/${src.name}
-                  cat >>$out/share/wallpapers/${name}/metadata.desktop <<_EOF
+                  mkdir -p $out/share/wallpapers/${pname}/contents/images
+                  ln -s $src $out/share/wallpapers/${pname}/contents/images/${src.name}
+                  cat >>$out/share/wallpapers/${pname}/metadata.desktop <<_EOF
           [Desktop Entry]
-          Name=${name}
-          X-KDE-PluginInfo-Name=${name}
+          Name=${pname}
+          X-KDE-PluginInfo-Name=${pname}
           _EOF
 
                   runHook postInstall
@@ -60,7 +65,7 @@ let
 
         passthru = {
           gnomeFilePath = "${pkg}/share/backgrounds/nixos/${src.name}";
-          kdeFilePath = "${pkg}/share/wallpapers/${name}/contents/images/${src.name}";
+          kdeFilePath = "${pkg}/share/wallpapers/${pname}/contents/images/${src.name}";
         };
 
         meta = {
@@ -77,7 +82,8 @@ in
 rec {
 
   binary-black = mkNixBackground {
-    name = "binary-black-2024-02-15";
+    pname = "binary-black";
+    version = "2024-02-15";
     description = "Black binary wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-black.png";
@@ -87,7 +93,8 @@ rec {
   };
 
   binary-blue = mkNixBackground {
-    name = "binary-blue-2024-02-15";
+    pname = "binary-blue";
+    version = "2024-02-15";
     description = "Blue binary wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-blue.png";
@@ -97,7 +104,8 @@ rec {
   };
 
   binary-red = mkNixBackground {
-    name = "binary-red-2024-02-15";
+    pname = "binary-red";
+    version = "2024-02-15";
     description = "Red binary wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-red.png";
@@ -107,7 +115,8 @@ rec {
   };
 
   binary-white = mkNixBackground {
-    name = "binary-white-2024-02-15";
+    pname = "binary-white";
+    version = "2024-02-15";
     description = "White binary wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/8957e93c95867faafec7f9988cedddd6837859fa/wallpapers/nix-wallpaper-binary-white.png";
@@ -117,7 +126,8 @@ rec {
   };
 
   catppuccin-frappe = mkNixBackground {
-    name = "catppuccin-frappe-2024-02-15";
+    pname = "catppuccin-frappe";
+    version = "2024-02-15";
     description = "Catppuccin Frappé colorscheme wallpaper for NixOS";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-frappe.png";
@@ -127,7 +137,8 @@ rec {
   };
 
   catppuccin-latte = mkNixBackground {
-    name = "catppuccin-latte-2024-02-15";
+    pname = "catppuccin-latte";
+    version = "2024-02-15";
     description = "Catppuccin Latte colorscheme wallpaper for NixOS";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-latte.png";
@@ -137,7 +148,8 @@ rec {
   };
 
   catppuccin-macchiato = mkNixBackground {
-    name = "catppuccin-macchiato-2024-02-15";
+    pname = "catppuccin-macchiato";
+    version = "2024-02-15";
     description = "Catppuccin Macchiato colorscheme wallpaper for NixOS";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-macchiato.png";
@@ -147,7 +159,8 @@ rec {
   };
 
   catppuccin-mocha = mkNixBackground {
-    name = "catppuccin-mocha-2024-02-15";
+    pname = "catppuccin-mocha";
+    version = "2024-02-15";
     description = "Catppuccin Mochacolorscheme wallpaper for NixOS";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/97444e18b7fe97705e8caedd29ae05e62cb5d4b7/wallpapers/nixos-wallpaper-catppuccin-mocha.png";
@@ -157,7 +170,8 @@ rec {
   };
 
   dracula = mkNixBackground {
-    name = "dracula-2020-07-02";
+    pname = "dracula";
+    version = "2020-07-02";
     description = "Nix background based on the Dracula color palette";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/03c6c20be96c38827037d2238357f2c777ec4aa5/wallpapers/nix-wallpaper-dracula.png";
@@ -167,7 +181,8 @@ rec {
   };
 
   gear = mkNixBackground {
-    name = "gear-2022-04-19";
+    pname = "gear";
+    version = "2022-04-19";
     description = "3D wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-gear.png";
@@ -179,7 +194,8 @@ rec {
   gnome-dark = simple-dark-gray-bottom;
 
   gradient-grey = mkNixBackground {
-    name = "gradient-grey-2018-10-20";
+    pname = "gradient-grey";
+    version = "2018-10-20";
     description = "Simple grey gradient background for NixOS";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/3f7695afe75239720a32d6c38df7c9888b5ed581/wallpapers/NixOS-Gradient-grey.png";
@@ -189,7 +205,8 @@ rec {
   };
 
   moonscape = mkNixBackground {
-    name = "moonscape-2022-04-19";
+    pname = "moonscape";
+    version = "2022-04-19";
     description = "3D wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-moonscape.png";
@@ -199,7 +216,8 @@ rec {
   };
 
   mosaic-blue = mkNixBackground {
-    name = "mosaic-blue-2016-02-19";
+    pname = "mosaic-blue";
+    version = "2016-02-19";
     description = "Mosaic blue background for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-mosaic-blue.png";
@@ -209,7 +227,8 @@ rec {
   };
 
   nineish = mkNixBackground {
-    name = "nineish-2019-12-04";
+    pname = "nineish";
+    version = "2019-12-04";
     description = "Nix background inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/da01f68d21ddfdc9f1c6e520c2170871c81f1cf5/wallpapers/nix-wallpaper-nineish.png";
@@ -219,7 +238,8 @@ rec {
   };
 
   nineish-dark-gray = mkNixBackground {
-    name = "nineish-dark-gray-2020-07-02";
+    pname = "nineish-dark-gray";
+    version = "2020-07-02";
     description = "Dark gray Nix background inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f07707cecfd89bc1459d5dad76a3a4c5315efba1/wallpapers/nix-wallpaper-nineish-dark-gray.png";
@@ -229,7 +249,8 @@ rec {
   };
 
   nineish-solarized-dark = mkNixBackground {
-    name = "nineish-dark-gray-2021-07-20";
+    pname = "nineish-solarized-dark";
+    version = "2021-07-20";
     description = "Solarized dark Nix background inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f99638d8d1a11d97a99ff7e0e1e7df58c28643ff/wallpapers/nix-wallpaper-nineish-solarized-dark.png";
@@ -239,7 +260,8 @@ rec {
   };
 
   nineish-solarized-light = mkNixBackground {
-    name = "nineish-dark-light-2021-07-20";
+    pname = "nineish-dark-light";
+    version = "2021-07-20";
     description = "Solarized light Nix background inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/f99638d8d1a11d97a99ff7e0e1e7df58c28643ff/wallpapers/nix-wallpaper-nineish-solarized-light.png";
@@ -249,7 +271,8 @@ rec {
   };
 
   nineish-catppuccin-frappe-alt = mkNixBackground {
-    name = "nineish-catppuccin-frappe-alt-2025-01-27";
+    pname = "nineish-catppuccin-frappe-alt";
+    version = "2025-01-27";
     description = "Alternative Catppuccin Frappe wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-frappe-alt.png";
@@ -259,7 +282,8 @@ rec {
   };
 
   nineish-catppuccin-frappe = mkNixBackground {
-    name = "nineish-catppuccin-frappe-2025-01-27";
+    pname = "nineish-catppuccin-frappe";
+    version = "2025-01-27";
     description = "Catppuccin Frappe wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-frappe.png";
@@ -269,7 +293,8 @@ rec {
   };
 
   nineish-catppuccin-latte-alt = mkNixBackground {
-    name = "nineish-catppuccin-latte-alt-2025-01-27";
+    pname = "nineish-catppuccin-latte-alt";
+    version = "2025-01-27";
     description = "Alternative Catppuccin Latte wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-latte-alt.png";
@@ -279,7 +304,8 @@ rec {
   };
 
   nineish-catppuccin-latte = mkNixBackground {
-    name = "nineish-catppuccin-latte-2025-01-27";
+    pname = "nineish-catppuccin-latte";
+    version = "2025-01-27";
     description = "Catppuccin Latte wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-latte.png";
@@ -289,7 +315,8 @@ rec {
   };
 
   nineish-catppuccin-macchiato-alt = mkNixBackground {
-    name = "nineish-catppuccin-macchiato-alt-2025-01-27";
+    pname = "nineish-catppuccin-macchiato-alt";
+    version = "2025-01-27";
     description = "Alternative Catppuccin Macchiato wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-macchiato-alt.png";
@@ -299,7 +326,8 @@ rec {
   };
 
   nineish-catppuccin-macchiato = mkNixBackground {
-    name = "nineish-catppuccin-macchiato-2025-01-27";
+    pname = "nineish-catppuccin-macchiato";
+    version = "2025-01-27";
     description = "Catppuccin Macchiato wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-macchiato.png";
@@ -309,7 +337,8 @@ rec {
   };
 
   nineish-catppuccin-mocha-alt = mkNixBackground {
-    name = "nineish-catppuccin-mocha-alt-2025-01-27";
+    pname = "nineish-catppuccin-mocha-alt";
+    version = "2025-01-27";
     description = "Alternative Catppuccin Mocha wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-mocha-alt.png";
@@ -319,7 +348,8 @@ rec {
   };
 
   nineish-catppuccin-mocha = mkNixBackground {
-    name = "nineish-catppuccin-mocha-2025-01-27";
+    pname = "nineish-catppuccin-mocha";
+    version = "2025-01-27";
     description = "Catppuccin Mocha wallpaper for Nix inspired by simpler times";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/33856d7837cb8ba76c4fc9e26f91a659066ee31f/wallpapers/nix-wallpaper-nineish-catppuccin-mocha.png";
@@ -329,7 +359,8 @@ rec {
   };
 
   recursive = mkNixBackground {
-    name = "recursive-2022-04-19";
+    pname = "recursive";
+    version = "2022-04-19";
     description = "3D wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-recursive.png";
@@ -339,7 +370,8 @@ rec {
   };
 
   simple-blue = mkNixBackground {
-    name = "simple-blue-2016-02-19";
+    pname = "simple-blue";
+    version = "2016-02-19";
     description = "Simple blue background for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-blue.png";
@@ -349,7 +381,8 @@ rec {
   };
 
   simple-dark-gray = mkNixBackground {
-    name = "simple-dark-gray-2016-02-19";
+    pname = "simple-dark-gray";
+    version = "2016-02-19";
     description = "Simple dark gray background for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-dark-gray.png";
@@ -359,7 +392,8 @@ rec {
   };
 
   simple-dark-gray-bootloader = mkNixBackground {
-    name = "simple-dark-gray-bootloader-2018-08-28";
+    pname = "simple-dark-gray-bootloader";
+    version = "2018-08-28";
     description = "Simple dark gray background for NixOS, specifically bootloaders";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/9d1f11f652ed5ffe460b6c602fbfe2e7e9a08dff/bootloader/nix-wallpaper-simple-dark-gray_bootloader.png";
@@ -369,7 +403,8 @@ rec {
   };
 
   simple-dark-gray-bottom = mkNixBackground {
-    name = "simple-dark-gray-2018-08-28";
+    pname = "simple-dark-gray";
+    version = "2018-08-28";
     description = "Simple dark gray background for NixOS, specifically bootloaders and graphical login";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/783c38b22de09f6ee33aacc817470a4513392d83/wallpapers/nix-wallpaper-simple-dark-gray_bottom.png";
@@ -379,7 +414,8 @@ rec {
   };
 
   simple-light-gray = mkNixBackground {
-    name = "simple-light-gray-2016-02-19";
+    pname = "simple-light-gray";
+    version = "2016-02-19";
     description = "Simple light gray background for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-light-gray.png";
@@ -389,7 +425,8 @@ rec {
   };
 
   simple-red = mkNixBackground {
-    name = "simple-red-2016-02-19";
+    pname = "simple-red";
+    version = "2016-02-19";
     description = "Simple red background for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-simple-red.png";
@@ -399,7 +436,8 @@ rec {
   };
 
   stripes-logo = mkNixBackground {
-    name = "stripes-logo-2016-02-19";
+    pname = "stripes-logo";
+    version = "2016-02-19";
     description = "Stripes logo background for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes-logo.png";
@@ -409,7 +447,8 @@ rec {
   };
 
   stripes = mkNixBackground {
-    name = "stripes-2016-02-19";
+    pname = "stripes";
+    version = "2016-02-19";
     description = "Stripes background for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/766f10e0c93cb1236a85925a089d861b52ed2905/wallpapers/nix-wallpaper-stripes.png";
@@ -419,7 +458,8 @@ rec {
   };
 
   waterfall = mkNixBackground {
-    name = "waterfall-2022-04-19";
+    pname = "waterfall";
+    version = "2022-04-19";
     description = "3D wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-waterfall.png";
@@ -429,7 +469,8 @@ rec {
   };
 
   watersplash = mkNixBackground {
-    name = "watersplash-2022-04-19";
+    pname = "watersplash";
+    version = "2022-04-19";
     description = "3D wallpaper for Nix";
     src = fetchurl {
       url = "https://raw.githubusercontent.com/NixOS/nixos-artwork/bcdd2770f5f4839fddc9b503e68db2bc3a87ca4d/wallpapers/nix-wallpaper-watersplash.png";


### PR DESCRIPTION
#485742

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
