### PR TITLE
python3Packages.torchtune: skip failing tests on x86_64-linux

### DIFF
--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   pkgs,
   buildPythonPackage,
   fetchFromGitHub,
@@ -198,6 +199,15 @@ buildPythonPackage (finalAttrs: {
     "test_resnet18_export_to_executorch"
     "test_resnet50_export_to_executorch"
     "test_vit_export_to_executorch"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) [
+    # RuntimeError: Error in dlopen:
+    # /tmp/AP8CBk/vision_encoder/data/aotinductor/model/chm6ca425mbz7jdmmwcbnyrm6x6tedrfmaoyr4vee625vxhjibbt.wrapper.so:
+    # cannot enable executable stack as shared object requires: Invalid argument
+    "TestImageTransform"
+    "test_flamingo_vision_encoder"
+    "test_llama3_2_text_decoder_aoti"
+    "test_tile_positional_embedding_aoti"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/torchtune/default.nix
+++ b/pkgs/development/python-modules/torchtune/default.nix
@@ -111,6 +111,14 @@ buildPythonPackage (finalAttrs: {
     "test_forward_with_curr_pos"
     "test_forward_with_packed_pos"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) [
+    # RuntimeError: Error in dlopen:
+    # /tmp/yae2xK/mha/data/aotinductor/model/ckk2zlroqn6hgq5vvpy7bcjikztqmwqkek3njxe2gvvwp244hjny.wrapper.so:
+    # cannot enable executable stack as shared object requires: Invalid argument
+    "test_attention_aoti"
+    "test_tile_positional_embedding_aoti"
+    "test_tiled_token_positional_embedding_aoti"
+  ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
     # Fatal Python error: Segmentation fault
     "test_forward_gqa"


### PR DESCRIPTION
## Things done

```
        path = os.fspath(path)  # AOTIModelPackageLoader expects (str, str)
>       loader = torch._C._aoti.AOTIModelPackageLoader(
            path, model_name, run_single_threaded, num_runners, device_index
        )
E       RuntimeError: Error in dlopen: /tmp/YrvJIS/tpe/data/aotinductor/model/c6obodzaot56wszmluag42nfsd46qixeii2siknbrzoxk4iydrpc.wrapper.so: cannot enable executable stack as shared object requires: Invalid argument

device_index = -1
model_name = 'model'
num_runners = 1
path       = '/build/tmpak4zd9oh/tpe.pt2'
run_single_threaded = False
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
