### PR TITLE
doc: explain persistentTimer option in borgbackups

### DIFF
--- a/nixos/modules/services/backup/borgbackup.md
+++ b/nixos/modules/services/backup/borgbackup.md
@@ -150,9 +150,15 @@ To backup your home directory to borgbase you have to:
                 environment = { BORG_RSH = "ssh -i /run/keys/id_ed25519_borgbase"; };
                 compression = "auto,lzma";
                 startAt = "daily";
+                persistentTimer = true;
             };
           };
-        }}
+        }
+
+    The
+    [persistentTimer](https://search.nixos.org/options?show=services.borgbackup.jobs.%3Cname%3E.persistentTimer)
+    option is recommended for remote backups since this instructs the
+    backup timer to wait before the network is online.
 
 ## Vorta backup client for the desktop {#opt-services-backup-borgbackup-vorta}
 


### PR DESCRIPTION
[borgbackup.nix](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/services/backup/borgbackup.nix#L199) considers a backup as remote when the repo path is not a local path, and if `persistentTimer` is `true`. This commit explains this link in the manual.

Alternatively it could be an option to simplify this in `borgbackup.nix` since I think the repo being remote is sufficient for systemd to want to wait for network-online.target. However, since I'm new to NixOS I thought explaining the current (perhaps strange) link in the manual is better for now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
