### PR TITLE
magic-vlsi: fix build failure with -D_FORTIFY_SOURCE

### DIFF
--- a/pkgs/by-name/ma/magic-vlsi/package.nix
+++ b/pkgs/by-name/ma/magic-vlsi/package.nix
@@ -2,7 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  git,
+  fetchpatch,
+  gitMinimal,
   python3,
   m4,
   cairo,
@@ -16,21 +17,35 @@
   fixDarwinDylibNames,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "magic-vlsi";
   version = "8.3.573";
 
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";
     repo = "magic";
-    tag = version;
-    sha256 = "sha256-P5qfMsn3DGHjeF7zsZWeG9j38C6j5UEwUqGyjaEVO1E=";
+    tag = finalAttrs.version;
+    hash = "sha256-P5qfMsn3DGHjeF7zsZWeG9j38C6j5UEwUqGyjaEVO1E=";
     leaveDotGit = true;
   };
 
+  patches = [
+    (fetchpatch {
+      name = "fix-buffer-overflow-runstats.patch";
+      url = "https://github.com/RTimothyEdwards/magic/commit/6a07bc172b4bdae8bc22f51905194cdd427912cc.patch";
+      hash = "sha256-QPVl+SfUWj51u/G+EjTCVQZdG7tTdOlEFN/hS7E1Ojg=";
+    })
+
+    (fetchpatch {
+      name = "neuer-fix-name.patch";
+      url = "https://github.com/RTimothyEdwards/magic/commit/a70ca249c3a4e7a256a4482bd887452267c8cd52.patch";
+      hash = "sha256-sNQDz4/hBtwJeDrOCe+LfJkuaB0zRzX7w1aDv8ZD7Pw=";
+    })
+  ];
+
   nativeBuildInputs = [
     python3
-    git
+    gitMinimal
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     fixDarwinDylibNames
@@ -97,4 +112,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ thoughtpolice ];
   };
-}
+})


### PR DESCRIPTION
- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

   Fix buf size.
    
    While building the nix package I get the following error:
    
    gonsolo nixpkgs:nix build .#magic-vlsi
    error: Cannot build '/nix/store/hg91v7gd3xx7fq9z831xhaq8ylr4k84q-magic-vlsi-8.3.593.drv'.
           Reason: builder failed with exit code 2.
           Output paths:
             /nix/store/fa3xr6gxxghn33246d8987mbvss7zfv7-magic-vlsi-8.3.593
           Last 25 log lines:
           >   213 |     sprintf(buf, "%ld:%02ld.%ld %ld:%02ld.%ld",
           >       |                                     ^~~~~
           > runstats.c:213:18: note: directive argument in the range [-9223372036854775808, 59]
           >   213 |     sprintf(buf, "%ld:%02ld.%ld %ld:%02ld.%ld",
           >       |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           > runstats.c:213:18: note: directive argument in the range [-92233720368547, 9]
           > In file included from /nix/store/rwalsamz4246k8f1zzxa54qx7w3fbzdg-glibc-2.42-47-dev/include/stdio.h:970,
           >                  from runstats.c:30:
           > In function 'sprintf',
           >     inlined from 'RunStatsRealTime' at runstats.c:213:5:
           > /nix/store/rwalsamz4246k8f1zzxa54qx7w3fbzdg-glibc-2.42-47-dev/include/bits/stdio2.h:30:10: note: '__builtin___sprintf_chk' output between 14 and 116 bytes into a destination of size 50

Upstream PR: https://github.com/RTimothyEdwards/magic/pull/485