### PR TITLE
lib: re-export missing pure builtins in lib

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -105,12 +105,14 @@ let
       # network
       network = callLibs ./network;
 
+      # flakes
+      flakes = callLibs ./flakes.nix;
+
       inherit (builtins)
         getContext
         hasContext
         convertHash
         hashString
-        hasFile
         parseDrvName
         placeholder
         fromJSON
@@ -391,6 +393,8 @@ let
         toInt
         toIntBase10
         fileContents
+        appendContext
+        unsafeDiscardStringContext
         ;
       inherit (self.stringsWithDeps)
         textClosureList
@@ -415,7 +419,13 @@ let
         renameCrossIndexTo
         mapCrossIndex
         ;
-      inherit (self.derivations) lazyDerivation optionalDrvAttr warnOnInstantiate;
+      inherit (self.derivations)
+        lazyDerivation
+        optionalDrvAttr
+        warnOnInstantiate
+        addDrvOutputDependencies
+        unsafeDiscardOutputDependency
+        ;
       inherit (self.generators) mkLuaInline;
       inherit (self.meta)
         addMetaAttrs
@@ -443,6 +453,9 @@ let
         dirOf
         isPath
         packagesFromDirectoryRecursive
+        hashFile
+        readDir
+        readFileType
         ;
       inherit (self.sources)
         cleanSourceFilter
@@ -592,6 +605,10 @@ let
         ;
       inherit (self.network.ipv6)
         mkEUI64Suffix
+        ;
+      inherit (self.flakes)
+        parseFlakeRef
+        flakeRefToString
         ;
     }
   );

--- a/lib/derivations.nix
+++ b/lib/derivations.nix
@@ -21,6 +21,11 @@ let
     if pkg ? meta.position && isString pkg.meta.position then "${prefix}${pkg.meta.position}" else "";
 in
 {
+  inherit (builtins)
+    addDrvOutputDependencies
+    unsafeDiscardOutputDependency
+    ;
+
   /**
     Restrict a derivation to a predictable set of attribute names, so
     that the returned attrset is not strict in the actual derivation,

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -31,6 +31,12 @@ in
     isPath
     ;
 
+  inherit (builtins)
+    readDir
+    readFileType
+    hashFile
+    ;
+
   /**
     The type of a path. The path needs to exist and be accessible.
     The result is either `"directory"` for a directory, `"regular"` for a

--- a/lib/flakes.nix
+++ b/lib/flakes.nix
@@ -1,0 +1,12 @@
+/**
+  Flake operations.
+*/
+{ lib }:
+{
+
+  inherit (builtins)
+    parseFlakeRef
+    flakeRefToString
+    ;
+
+}

--- a/lib/strings.nix
+++ b/lib/strings.nix
@@ -39,6 +39,7 @@ rec {
     toJSON
     typeOf
     unsafeDiscardStringContext
+    appendContext
     ;
 
   /**


### PR DESCRIPTION
I have tried to expose the last missing pure builtins considering @infinisil comments in https://github.com/NixOS/nixpkgs/issues/369215:

> hink would fit:
> 
>     * `langVersion`, `nixVersion`, `nixPath`, `currentSystem`, `import`, `scopedImport`, `storeDir` (impure)
> 
>     * `abort`/`throw`, `null`/`true`/`false`, `builtins` (effectively language features, accessible without `builtins.`)
> 
>     * `toPath` (deprecated)
> 
>     * `derivation`/`derivationStrict`, `fetchGit`/`fetchTarball`/... (complex behavior, probably doesn't fit into `lib`, confusable with `pkgs.fetch*`)
> 
>     * `findFile` (bad name)
> 
>     * (maybe others)

The flake functions have been added to a new `flakes` attribute set.

If we also want to add impure builtins, then those can be added in a new PR.

EDIT: I have also removed a non-existent `hasFile` function from https://github.com/NixOS/nixpkgs/pull/482743

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
