### PR TITLE
nixos-install: document --closure, add --store-path alias.

### DIFF
--- a/pkgs/by-name/ni/nixos-install/nixos-install.8
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.8
@@ -12,7 +12,7 @@
 .Op Fl -verbose | v
 .Op Fl I Ar path
 .Op Fl -root Ar root
-.Op Fl -system | -closure Ar path
+.Op Fl -system | -closure | -store-path Ar path
 .Op Fl -flake Ar flake-uri
 .Op Fl -file | f Ar path
 .Op Fl -attr | A Ar attrPath
@@ -94,7 +94,7 @@ Defaults to
 .Ar root
 as the root of the NixOS installation.
 .
-.It Fl -system Ar path , Fl -closure Ar path
+.It Fl -system Ar path , Fl -closure Ar path , Fl -store-path Ar path
 If one of those options is provided,
 .Nm
 will install the specified closure rather than attempt to build one from

--- a/pkgs/by-name/ni/nixos-install/nixos-install.8
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.8
@@ -12,7 +12,7 @@
 .Op Fl -verbose | v
 .Op Fl I Ar path
 .Op Fl -root Ar root
-.Op Fl -system Ar path
+.Op Fl -system | -closure Ar path
 .Op Fl -flake Ar flake-uri
 .Op Fl -file | f Ar path
 .Op Fl -attr | A Ar attrPath
@@ -94,8 +94,8 @@ Defaults to
 .Ar root
 as the root of the NixOS installation.
 .
-.It Fl -system Ar path
-If this option is provided,
+.It Fl -system Ar path , Fl -closure Ar path
+If one of those options is provided,
 .Nm
 will install the specified closure rather than attempt to build one from
 .Pa /mnt/etc/nixos/configuration.nix Ns

--- a/pkgs/by-name/ni/nixos-install/nixos-install.sh
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.sh
@@ -36,7 +36,7 @@ while [ "$#" -gt 0 ]; do
         --root)
             mountPoint="$1"; shift 1
             ;;
-        --system|--closure)
+        --system|--closure|--store-path)
             system="$1"; shift 1
             ;;
         --flake)


### PR DESCRIPTION
* Add `--closure` to the man page.
* Add `--store-path` as yet another alias in an attempt to keep it consistent with the similar named flag in `nixos-rebuild` following the discussion in: https://github.com/NixOS/nixpkgs/pull/482430#issuecomment-3785562376



- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
