### PR TITLE
onlyoffice-documentserver: reintroduce mobile assets

### DIFF
--- a/pkgs/by-name/x2/x2t/web-apps-mobile-no-spinner.patch
+++ b/pkgs/by-name/x2/x2t/web-apps-mobile-no-spinner.patch
@@ -1,0 +1,20 @@
+diff --git a/vendor/framework7-react/build/build.js b/vendor/framework7-react/build/build.js
+index 50828275f1..48a609e033 100644
+--- a/build/build.js
++++ b/build/build.js
+@@ -12,14 +12,13 @@ Promise.all([
+     const { default: ora } = oramodule,
+         { default: chalk } = chalkmodule;
+ 
+-    const spinner = ora(env === 'production' ? 'building for production...' : 'building development version...').start();
++    console.log(env === 'production' ? 'building for production...' : 'building development version...');
+ 
+     rm('./www/', (removeErr) => {
+       if (removeErr) throw removeErr;
+ 
+       webpack(config, (err, stats) => {
+         if (err) throw err;
+-        spinner.stop();
+ 
+         process.stdout.write(`${stats.toString({
+           colors: true,

--- a/pkgs/by-name/x2/x2t/web-apps-no-mobile.patch
+++ b/pkgs/by-name/x2/x2t/web-apps-no-mobile.patch
@@ -1,0 +1,13 @@
+diff --git a/build/Gruntfile.js b/build/Gruntfile.js
+index 044fa02213..d4fac2ff01 100644
+--- a/Gruntfile.js
++++ b/Gruntfile.js
+@@ -830,7 +830,7 @@ module.exports = function(grunt) {
+                                                             'replace:writeVersion', 'replace:prepareHelp', 'clean:postbuild']);
+ 
+     grunt.registerTask('deploy-app-mobile',             ['mobile-app-init', 'clean:deploy', /*'cssmin',*/ /*'copy:template-backup',*/
+-                                                            'htmlmin', /*'requirejs',*/ 'exec:webpack_install', 'exec:webpack_app_build', /*'copy:template-restore',*/
++                                                            'htmlmin', /*'requirejs',*/ /*'exec:webpack_install', 'exec:webpack_app_build',*/ /*'copy:template-restore',*/
+                                                             /*'clean:template-backup',*/ 'copy:localization', 'copy:index-page',
+                                                             'copy:images-app', 'copy:webpack-dist', 'concat', 'json-minify'/*,*/
+                                                             /*'replace:writeVersion', 'replace:fixResourceUrl'*/]);


### PR DESCRIPTION
These got lost in #473316

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
