### PR TITLE
masscan: fix wrapper

### DIFF
--- a/pkgs/by-name/ma/masscan/package.nix
+++ b/pkgs/by-name/ma/masscan/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     install -Dm444 -t $out/share/licenses/masscan LICENSE
 
     wrapProgram $out/bin/masscan \
-      --prefix LD_LIBRARY_PATH : "${libpcap}/lib"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libpcap ]}"
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
This fixes masscan wrapper - sets `LD_LIBRARY_PATH` correctly. Without it, it complains about libpcap missing:

```
$ masscan
[-] FAIL: failed to load libpcap shared library
    [hint]: you must install libpcap or WinPcap
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
