### PR TITLE
tixati: init at 3.42

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8797,6 +8797,12 @@
     githubId = 100240294;
     name = "Florian Sanders";
   };
+  FlorisMenninga = {
+    email = "fl-ris@protonmail.com";
+    github = "Fl-ris";
+    githubId = 117688953;
+    name = "Floris Menninga";
+  };
   flosse = {
     email = "mail@markus-kohlhase.de";
     github = "flosse";

--- a/pkgs/by-name/ti/tixati/package.nix
+++ b/pkgs/by-name/ti/tixati/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  zlib,
+  dbus,
+  glib,
+  gtk3,
+  pango,
+  gdk-pixbuf,
+  dbus-glib,
+  cairo,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tixati";
+  version = "3.42";
+
+  src = fetchurl {
+    url = "https://download.tixati.com/tixati-${finalAttrs.version}-1.x86_64.manualinstall.tar.gz";
+    hash = "sha256-tuejoQQ3W9PyvABPieiYle3QYy2JKNqDvRlorSxPuHc=";
+  };
+
+  nativeBuildInputs = [ autoPatchelfHook ];
+
+  buildInputs = [
+    zlib
+    dbus
+    glib
+    gtk3
+    pango
+    gdk-pixbuf
+    dbus-glib
+    cairo
+  ];
+
+  sourceRoot = "tixati-${finalAttrs.version}-1.x86_64.manualinstall";
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 tixati $out/bin/tixati
+    install -Dm644 tixati.png $out/share/pixmaps/tixati.png
+    install -Dm644 tixati.desktop $out/share/applications/tixati.desktop
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Simple and Easy to Use Bittorrent Client";
+    homepage = "https://www.tixati.com/";
+    downloadPage = "https://tixati.com/linux";
+    changelog = "https://tixati.com/news";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ FlorisMenninga ];
+    mainProgram = "tixati";
+  };
+})


### PR DESCRIPTION
Add Tixati, a feature rich, closed source BitTorrent client with GTK3 interface.

Homepage: https://tixati.com/
This package used to be in the repository but was removed due to having no maintainer.

## Things done

- Built on platform:
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ x ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ x ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ x ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
