### PR TITLE
nixos/bitmagnet: Use up to date configuration values, add restart trigger

### DIFF
--- a/nixos/modules/services/torrent/bitmagnet.nix
+++ b/nixos/modules/services/torrent/bitmagnet.nix
@@ -14,8 +14,8 @@ let
     optional
     ;
   inherit (lib.types)
+    nullOr
     bool
-    int
     port
     str
     submodule
@@ -44,10 +44,10 @@ in
             type = submodule {
               inherit freeformType;
               options = {
-                port = mkOption {
+                local_address = mkOption {
                   type = str;
                   default = ":3333";
-                  description = "HTTP server listen port";
+                  description = "HTTP server listen address";
                 };
               };
             };
@@ -95,6 +95,20 @@ in
               };
             };
           };
+          tmdb = mkOption {
+            default = { };
+            description = "TMDB api settings";
+            type = submodule {
+              inherit freeformType;
+              options = {
+                api_key = mkOption {
+                  type = nullOr str;
+                  default = null;
+                  description = "TMDB api key, to avoid api limits. Leave null to use the default shared key.";
+                };
+              };
+            };
+          };
         };
       };
     };
@@ -130,6 +144,7 @@ in
       ]
       ++ optional cfg.useLocalPostgresDB "postgresql.target";
       requires = optional cfg.useLocalPostgresDB "postgresql.target";
+      restartTriggers = [ config.environment.etc."xdg/bitmagnet/config.yml".source ];
       serviceConfig = {
         Type = "simple";
         DynamicUser = true;
@@ -139,6 +154,7 @@ in
         Restart = "on-failure";
         WorkingDirectory = "/var/lib/bitmagnet";
         StateDirectory = "bitmagnet";
+        BindReadOnlyPaths = [ "/etc/xdg/bitmagnet/config.yml" ];
 
         # Sandboxing (sorted by occurrence in https://www.freedesktop.org/software/systemd/man/systemd.exec.html)
         ProtectSystem = "strict";


### PR DESCRIPTION
Updates http_server.port to http_server.local_address, as port no longer works.
Exposes tmdb api_key config.
Gives the service read permissions to the config dir as it had issues without this.
Opens up the HTTP port for the webui to the firewall when openFirewall is true.
Adds a restart trigger so the service restarts when the configuration has changed.

Not sure if this needs a module update in release notes? It's pretty minor, and the options is freeform so it won't cause any errors.

## Things done

Tested the service to confirm configuration values are being set correctly with bitmagnet config show

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
