### PR TITLE
pam: adding assertion for use of googleAuthenticator

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2280,6 +2280,16 @@ in
   config = {
     assertions = [
       {
+        assertion =
+          (config.security.pam.services.sshd.googleAuthenticator.enable or false)
+          -> (config.services.openssh.settings.PasswordAuthentication != false);
+        message = ''
+          Using security.pam.services.sshd.googleAuthenticator requires
+          services.openssh.settings.PasswordAuthentication to not be disabled.
+          See https://github.com/NixOS/nixpkgs/issues/115044
+        '';
+      }
+      {
         assertion = config.users.motd == "" || config.users.motdFile == null;
         message = ''
           Only one of users.motd and users.motdFile can be set.


### PR DESCRIPTION
At the moment the use of googleAuthenticator with openssh requires PasswordAuthentication to not be disabled. If it is it will silently fail to write the relevant entries to the sshd pam config.

This is supposed to provide clearer and faster feedback for this particular setup.
I do think it would be nice to solve this issue more deeply, but I understand that changes to pam.nix might be tricky,
so as a pragmatic first step this should already be a mild improvement.

I didn't add any tests because there was no place yet for such small assertion tests and I didn't feel like it's worth starting for this one.

https://github.com/NixOS/nixpkgs/issues/115044

cc @curbengh 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
