### PR TITLE
bombardier: maintain

### DIFF
--- a/pkgs/by-name/bo/bombardier/package.nix
+++ b/pkgs/by-name/bo/bombardier/package.nix
@@ -42,7 +42,7 @@ buildGoModule rec {
     homepage = "https://github.com/codesenberg/bombardier";
     changelog = "https://github.com/codesenberg/bombardier/releases/tag/${src.rev}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "bombardier";
   };
 }

--- a/pkgs/by-name/bo/bombardier/package.nix
+++ b/pkgs/by-name/bo/bombardier/package.nix
@@ -5,6 +5,7 @@
   testers,
   bombardier,
   versionCheckHook,
+  nix-update-script,
 }:
 
 buildGoModule (finalAttrs: {
@@ -37,6 +38,7 @@ buildGoModule (finalAttrs: {
   versionCheckProgramArg = "--version";
 
   passthru.tests = {
+    updateScript = nix-update-script { };
     version = testers.testVersion {
       package = bombardier;
     };

--- a/pkgs/by-name/bo/bombardier/package.nix
+++ b/pkgs/by-name/bo/bombardier/package.nix
@@ -4,16 +4,17 @@
   fetchFromGitHub,
   testers,
   bombardier,
+  versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "bombardier";
   version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "codesenberg";
     repo = "bombardier";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-FoaiUky0WcipkGN8KIpSd+iizinlqtHC5lskvNCnx/Y=";
   };
 
@@ -26,10 +27,14 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X=main.version=${version}"
+    "-X=main.version=${finalAttrs.version}"
   ];
 
   __darwinAllowLocalNetworking = true;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
 
   passthru.tests = {
     version = testers.testVersion {
@@ -40,9 +45,9 @@ buildGoModule rec {
   meta = {
     description = "Fast cross-platform HTTP benchmarking tool written in Go";
     homepage = "https://github.com/codesenberg/bombardier";
-    changelog = "https://github.com/codesenberg/bombardier/releases/tag/${src.rev}";
+    changelog = "https://github.com/codesenberg/bombardier/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.progrm_jarvis ];
     mainProgram = "bombardier";
   };
-}
+})


### PR DESCRIPTION
Take maintenance over `bombardier` as part of https://github.com/NixOS/nixpkgs/issues/458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
