### PR TITLE
kronosnet: fix sources hash and build

### DIFF
--- a/pkgs/by-name/kr/kronosnet/package.nix
+++ b/pkgs/by-name/kr/kronosnet/package.nix
@@ -27,8 +27,18 @@ stdenv.mkDerivation rec {
     owner = "kronosnet";
     repo = "kronosnet";
     rev = "v${version}";
-    sha256 = "sha256-g2AgVAFEmRlMaqH7uRabSNJP0ehUQ6Iws4LT2iB8kTA=";
+    sha256 = "sha256-6W8b5M97L1KxissLJej67v1+OhB7Pm+qLDSpjp8PF4c=";
   };
+
+  # Fix autoreconf issue: libtool puts ltmain.sh in ../../ but automake expects ./
+  preAutorreconf = ''
+    # Run libtollize first to generate ltmain.sh in the correct location
+    libtoolize --copy --force --install
+    # Now copy ltmain.sh to where automake expects it
+    if [ -f ../../ltmain.sh ]; then
+      cp ../../ltmain.sh ./ltmain.sh
+    fi
+  '';
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
Looks like the archive with sources has changed and custom cache builders fail with hash mismatch error. Also, it looks like with new sources there is a problem with automake cannot find ltmain.sh in the expected location


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
