### PR TITLE
qdelay: remove standalone

### DIFF
--- a/pkgs/by-name/qd/qdelay/package.nix
+++ b/pkgs/by-name/qd/qdelay/package.nix
@@ -55,7 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   cmakeFlags = [
-    "-DCOPY_PLUGIN_AFTER_BUILD=FALSE"
+    (lib.cmakeBool "COPY_PLUGIN_AFTER_BUILD" false)
+    (lib.cmakeFeature "BUILD_STANDALONE" "OFF")
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-DCMAKE_OSX_ARCHITECTURES=${stdenv.hostPlatform.darwinArch}"
@@ -75,30 +76,9 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/lib/vst3
+    mkdir -p $out/lib/vst3 $out/lib/lv2
 
-  ''
-  + (
-    if stdenv.hostPlatform.isDarwin then
-      ''
-        mkdir -p $out/Applications
-        cp -R QDelay_artefacts/Release/Standalone/QDelay.app \
-          $out/Applications/QDelay.app
-        ln -s \
-          $out/Applications/QDelay.app/Contents/MacOS/QDelay \
-          $out/bin/QDelay
-      ''
-    else
-      ''
-        install -Dm755 \
-          QDelay_artefacts/Release/Standalone/QDelay \
-          $out/bin/QDelay
-
-        mkdir -p $out/bin $out/lib/lv2
-        cp -r "QDelay_artefacts/Release/LV2/QDelay.lv2" $out/lib/lv2
-      ''
-  )
-  + ''
+    cp -r "QDelay_artefacts/Release/LV2/QDelay.lv2" $out/lib/lv2
     cp -r "QDelay_artefacts/Release/VST3/QDelay.vst3" $out/lib/vst3
 
     runHook postInstall
@@ -110,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/tiagolr/qdelay/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ magnetophon ];
-    mainProgram = "QDelay";
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
see: https://github.com/tiagolr/reevr/issues/11


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
