### PR TITLE
cargo-geiger: fix build, modernize

### DIFF
--- a/pkgs/by-name/ca/cargo-geiger/package.nix
+++ b/pkgs/by-name/ca/cargo-geiger/package.nix
@@ -13,14 +13,14 @@
   cargo-geiger,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-geiger";
   version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "geiger-rs";
     repo = "cargo-geiger";
-    tag = "cargo-geiger-${version}";
+    tag = "cargo-geiger-${finalAttrs.version}";
     hash = "sha256-dZ71WbTKsR6g5UhWuJNfNAAqNNxbTgwL5fsgkm50BaM=";
   };
 
@@ -83,7 +83,7 @@ rustPlatform.buildRustPackage rec {
       code is appropriate.
     '';
     homepage = "https://github.com/geiger-rs/cargo-geiger";
-    changelog = "https://github.com/geiger-rs/cargo-geiger/blob/cargo-geiger-${version}/CHANGELOG.md";
+    changelog = "https://github.com/geiger-rs/cargo-geiger/blob/cargo-geiger-${finalAttrs.version}/CHANGELOG.md";
     mainProgram = "cargo-geiger";
     license = with lib.licenses; [
       asl20 # or
@@ -96,4 +96,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-geiger/package.nix
+++ b/pkgs/by-name/ca/cargo-geiger/package.nix
@@ -26,6 +26,13 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-GgCmUNOwvyTB82Y/ddgJIAb1SpO4mRPjECqCagJ8GmE=";
 
+  postPatch = ''
+    # https://github.com/geiger-rs/cargo-geiger/pull/562
+    # Fix unused import warning which is treated as an error
+    substituteInPlace cargo-geiger/tests/integration_tests.rs \
+      --replace-fail "use std::env;" ""
+  '';
+
   buildInputs = [
     openssl
   ]


### PR DESCRIPTION
If upstream accepts https://github.com/geiger-rs/cargo-geiger/pull/562 we can just add that commit or bump the version instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
