### PR TITLE
ocaml: default to version 5.4

### DIFF
--- a/pkgs/by-name/fl/flow/package.nix
+++ b/pkgs/by-name/fl/flow/package.nix
@@ -8,7 +8,7 @@
 }:
 
 let
-  ocamlPackages = ocaml-ng.ocamlPackages.overrideScope (
+  ocamlPackages = ocaml-ng.ocamlPackages_5_3.overrideScope (
     self: super: {
       ppxlib = super.ppxlib.override { version = "0.34.0"; };
     }

--- a/pkgs/development/ocaml-modules/synchronizer/default.nix
+++ b/pkgs/development/ocaml-modules/synchronizer/default.nix
@@ -10,7 +10,7 @@ buildDunePackage (finalAttrs: {
   pname = "synchronizer";
   version = "0.2";
 
-  minimalOCamlVersion = "5.1";
+  minimalOCamlVersion = "5.2";
 
   src = fetchFromGitHub {
     owner = "OCamlPro";

--- a/pkgs/os-specific/linux/sgx/sdk/default.nix
+++ b/pkgs/os-specific/linux/sgx/sdk/default.nix
@@ -12,7 +12,6 @@
   git,
   libtool,
   linkFarmFromDrvs,
-  ocaml,
   ocamlPackages,
   openssl,
   perl,
@@ -83,7 +82,7 @@ stdenv.mkDerivation rec {
     cmake
     file
     git
-    ocaml
+    ocamlPackages.ocaml
     ocamlPackages.ocamlbuild
     perl
     python3

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9556,7 +9556,9 @@ with pkgs;
 
   rfkill_udev = callPackage ../os-specific/linux/rfkill/udev.nix { };
 
-  sgx-sdk = callPackage ../os-specific/linux/sgx/sdk { };
+  sgx-sdk = callPackage ../os-specific/linux/sgx/sdk {
+    ocamlPackages = ocaml-ng.ocamlPackages_5_3;
+  };
 
   sgx-psw = callPackage ../os-specific/linux/sgx/psw {
     protobuf = protobuf_21;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4625,6 +4625,10 @@ with pkgs;
   haxePackages = recurseIntoAttrs (callPackage ./haxe-packages.nix { });
   inherit (haxePackages) hxcpp;
 
+  heptagon = callPackage ../by-name/he/heptagon/package.nix {
+    ocamlPackages = ocaml-ng.ocamlPackages_5_3;
+  };
+
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix { });
 
   gopro-tool = callPackage ../by-name/go/gopro-tool/package.nix {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2355,7 +2355,7 @@ rec {
 
   ocamlPackages_latest = ocamlPackages_5_4;
 
-  ocamlPackages = ocamlPackages_5_3;
+  ocamlPackages = ocamlPackages_5_4;
 
   # We still have packages that rely on unsafe-string, which is deprecated in OCaml 4.06.0.
   # Below are aliases for porting them to the latest versions of the OCaml 4 series.


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
