### PR TITLE
fcitx5-array: init at 0.9.6

### DIFF
--- a/nixos/modules/i18n/input-method/default.md
+++ b/nixos/modules/i18n/input-method/default.md
@@ -108,6 +108,8 @@ Available extra Fcitx5 addons are:
 
   - Anthy (`fcitx5-anthy`): Anthy is a system for
     Japanese input method. It converts Hiragana text to Kana Kanji mixed text.
+  - Array (`fcitx5-array`): Array is a Chinese shape-based input method that
+    uses a grid of 30 keys.
   - Chewing (`fcitx5-chewing`): Chewing is an
     intelligent Zhuyin input method. It is one of the most popular input
     methods among Traditional Chinese Unix users.

--- a/pkgs/by-name/fc/fcitx5-array/package.nix
+++ b/pkgs/by-name/fc/fcitx5-array/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fmt,
+  cmake,
+  extra-cmake-modules,
+  gettext,
+  fcitx5,
+  sqlite,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fcitx5-array";
+  version = "0.9.6";
+
+  src = fetchFromGitHub {
+    owner = "ray2501";
+    repo = "fcitx5-array";
+    tag = finalAttrs.version;
+    hash = "sha256-YDFT/CawFiPN3kXzHMpenCzWMJSA1dFUhVe22EDfnU8=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    extra-cmake-modules
+    gettext
+  ];
+
+  buildInputs = [
+    fmt
+    fcitx5
+    sqlite
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "Array wrapper for Fcitx5";
+    homepage = "https://github.com/ray2501/fcitx5-array";
+    license = with lib.licenses; [
+      gpl2Plus
+      lgpl21Plus
+    ];
+    maintainers = with lib.maintainers; [ yanganto ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/tools/inputmethods/fcitx5/update.py
+++ b/pkgs/tools/inputmethods/fcitx5/update.py
@@ -5,24 +5,27 @@ import requests
 import subprocess
 
 REPOS = [
-        "libime",
-        "xcb-imdkit",
+        ( "fcitx", "libime" ),
+        ( "fcitx", "xcb-imdkit"),
 
-        "fcitx5",
-        "fcitx5-anthy",
-        "fcitx5-chewing",
-        "fcitx5-chinese-addons",
-        "fcitx5-configtool",
-        "fcitx5-gtk",
-        "fcitx5-hangul",
-        "fcitx5-lua",
-        "fcitx5-m17n",
-        "fcitx5-qt",
-        "fcitx5-rime",
-        "fcitx5-skk",
-        "fcitx5-table-extra",
-        "fcitx5-table-other",
-        "fcitx5-unikey"
+        ( "fcitx", "fcitx5" ),
+        ( "fcitx", "fcitx5-anthy" ),
+        ( "fcitx", "fcitx5-chewing" ),
+        ( "fcitx", "fcitx5-chinese-addons" ),
+        ( "fcitx", "fcitx5-configtool" ),
+        ( "fcitx", "fcitx5-gtk" ),
+        ( "fcitx", "fcitx5-hangul" ),
+        ( "fcitx", "fcitx5-lua" ),
+        ( "fcitx", "fcitx5-m17n" ),
+        ( "fcitx", "fcitx5-qt" ),
+        ( "fcitx", "fcitx5-rime" ),
+        ( "fcitx", "fcitx5-skk" ),
+        ( "fcitx", "fcitx5-table-extra" ),
+        ( "fcitx", "fcitx5-table-other" ),
+        ( "fcitx", "fcitx5-unikey" ),
+        ( "fcitx", "fcitx5-unikey" )
+
+        ( "ray2501", "fcitx5-array" )
         ]
 
 OWNER = "fcitx"
@@ -32,8 +35,8 @@ def get_latest_tag(repo, owner=OWNER):
     return r.json()[0].get("name")
 
 def main():
-    for repo in REPOS:
-        rev = get_latest_tag(repo)
+    for (owner, repo) in REPOS:
+        rev = get_latest_tag(repo, owner)
         if repo == "fcitx5-qt":
             subprocess.run(["nix-update", "--commit", "--version", rev, "qt6Packages.{}".format(repo)])
         else:


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [X] Build and test on ROG Z13 based on nisos-25.11-small (e9c37a8d3d3e5b7dcdbdc36bad30e8558caabad7)
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

![Fcitx5-array](https://github.com/user-attachments/assets/1fd3d8d3-1c52-4827-a8f6-4ba452dd3a82)
