### PR TITLE
treewide: expand pythonPath bash array for structuredAttrs for wrapPythonProgramsIn

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
@@ -81,7 +81,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/share/inkscape/extensions/" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/inkscape/extensions/" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
@@ -113,7 +113,7 @@ python3.pkgs.buildPythonApplication rec {
 
   postFixup = ''
     # Wrap the project so it can find runtime dependencies.
-    wrapPythonProgramsIn "$out/share/inkscape/extensions/textext" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/inkscape/extensions/textext" "$out ''${pythonPath[*]}"
     cp ${launchScript} $out/share/inkscape/extensions/textext/launch.sh
   '';
 

--- a/pkgs/applications/misc/dupeguru/default.nix
+++ b/pkgs/applications/misc/dupeguru/default.nix
@@ -67,7 +67,7 @@ python3Packages.buildPythonApplication rec {
   # Executable in $out/bin is a symlink to $out/share/dupeguru/run.py
   # so wrapPythonPrograms hook does not handle it automatically.
   postFixup = ''
-    wrapPythonProgramsIn "$out/share/dupeguru" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/dupeguru" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/applications/science/logic/easycrypt/default.nix
+++ b/pkgs/applications/science/logic/easycrypt/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
     dune install --prefix $out easycrypt
     rm $out/bin/ec-runtest
-    wrapPythonProgramsIn "$out/lib/easycrypt/commands" "$pythonPath"
+    wrapPythonProgramsIn "$out/lib/easycrypt/commands" "''${pythonPath[*]}"
     runHook postInstall
   '';
 

--- a/pkgs/applications/science/robotics/sumorobot-manager/default.nix
+++ b/pkgs/applications/science/robotics/sumorobot-manager/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   preFixup = ''
     patchShebangs $out/opt/sumorobot-manager/main.py
-    wrapPythonProgramsIn "$out/opt" "$pythonPath"
+    wrapPythonProgramsIn "$out/opt" "''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/applications/version-management/cgit/default.nix
+++ b/pkgs/applications/version-management/cgit/default.nix
@@ -102,7 +102,7 @@ stdenv.mkDerivation {
     mkdir -p "$out/share/man/man5"
     cp cgitrc.5 "$out/share/man/man5"
 
-    wrapPythonProgramsIn "$out/lib/cgit/filters" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/lib/cgit/filters" "$out ''${pythonPath[*]}"
 
     for script in $out/lib/cgit/filters/*.sh $out/lib/cgit/filters/html-converters/txt2html; do
       wrapProgram $script --prefix PATH : '${

--- a/pkgs/by-name/ar/arubaotp-seed-extractor/package.nix
+++ b/pkgs/by-name/ar/arubaotp-seed-extractor/package.nix
@@ -33,7 +33,7 @@ python3Packages.buildPythonApplication {
     mkdir -p "$libdir"
     cp scripts/* "$libdir"
     chmod +x "$libdir/main.py"
-    wrapPythonProgramsIn "$libdir" "$pythonPath"
+    wrapPythonProgramsIn "$libdir" "''${pythonPath[*]}"
     mkdir -p $out/bin
     ln -s "$libdir/main.py" $out/bin/arubaotp-seed-extractor
   '';

--- a/pkgs/by-name/ba/bada-bib/package.nix
+++ b/pkgs/by-name/ba/bada-bib/package.nix
@@ -69,7 +69,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/libexec" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/libexec" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/bc/bcc/package.nix
+++ b/pkgs/by-name/bc/bcc/package.nix
@@ -118,7 +118,7 @@ python3Packages.buildPythonApplication rec {
   pythonImportsCheck = [ "bcc" ];
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/share/bcc/tools" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/bcc/tools" "$out ''${pythonPath[*]}"
   '';
 
   outputs = [

--- a/pkgs/by-name/be/better-control/package.nix
+++ b/pkgs/by-name/be/better-control/package.nix
@@ -88,7 +88,7 @@ python3Packages.buildPythonApplication rec {
   doCheck = false;
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/share/better-control" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/better-control" "$out ''${pythonPath[*]}"
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/bl/blueberry/package.nix
+++ b/pkgs/by-name/bl/blueberry/package.nix
@@ -84,7 +84,7 @@ python3Packages.buildPythonApplication rec {
 
   postFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-    wrapPythonProgramsIn $out/lib "$out $pythonPath"
+    wrapPythonProgramsIn $out/lib "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/bl/blueman/package.nix
+++ b/pkgs/by-name/bl/blueman/package.nix
@@ -89,8 +89,8 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     # This mimics ../../../development/interpreters/python/wrap.sh
-    wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
-    wrapPythonProgramsIn "$out/libexec" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/bin" "$out ''${pythonPath[*]}"
+    wrapPythonProgramsIn "$out/libexec" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/bo/botamusique/package.nix
+++ b/pkgs/by-name/bo/botamusique/package.nix
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share $out/bin
     cp -r . $out/share/botamusique
     chmod +x $out/share/botamusique/mumbleBot.py
-    wrapPythonProgramsIn $out/share/botamusique "$out $pythonPath"
+    wrapPythonProgramsIn $out/share/botamusique "$out ''${pythonPath[*]}"
 
     # Convenience binary and wrap with ffmpeg dependency
     makeWrapper $out/share/botamusique/mumbleBot.py $out/bin/botamusique \

--- a/pkgs/by-name/ca/cambalache/package.nix
+++ b/pkgs/by-name/ca/cambalache/package.nix
@@ -79,7 +79,7 @@ python3.pkgs.buildPythonApplication rec {
 
   postFixup = ''
     # Wrap a helper script in an unusual location.
-    wrapPythonProgramsIn "$out/${python3.sitePackages}/cambalache/priv/merengue" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/${python3.sitePackages}/cambalache/priv/merengue" "$out ''${pythonPath[*]}"
   '';
 
   passthru = {

--- a/pkgs/by-name/ca/carla/package.nix
+++ b/pkgs/by-name/ca/carla/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     # Also sets program_PYTHONPATH and program_PATH variables
     wrapPythonPrograms
-    wrapPythonProgramsIn "$out/share/carla/resources" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/carla/resources" "$out ''${pythonPath[*]}"
 
     find "$out/share/carla" -maxdepth 1 -type f -not -name "*.py" -print0 | while read -d "" f; do
       patchPythonScript "$f"

--- a/pkgs/by-name/ca/cartridges/package.nix
+++ b/pkgs/by-name/ca/cartridges/package.nix
@@ -60,7 +60,7 @@ python3Packages.buildPythonApplication rec {
   makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
 
   postFixup = ''
-    wrapPythonProgramsIn $out/libexec $out $pythonPath
+    wrapPythonProgramsIn $out/libexec "$out ''${pythonPath[*]}"
   '';
 
   # NOTE: `postCheck` is intentionally not used here, as the entire checkPhase

--- a/pkgs/by-name/du/duplicity/package.nix
+++ b/pkgs/by-name/du/duplicity/package.nix
@@ -143,7 +143,7 @@ let
       # tests need writable $HOME
       HOME=$PWD/.home
 
-      wrapPythonProgramsIn "$PWD/testing/overrides/bin" "$pythonPath"
+      wrapPythonProgramsIn "$PWD/testing/overrides/bin" "''${pythonPath[*]}"
     '';
 
     doCheck = true;

--- a/pkgs/by-name/fa/fast-downward/package.nix
+++ b/pkgs/by-name/fa/fast-downward/package.nix
@@ -51,8 +51,8 @@ stdenv.mkDerivation rec {
     mkdir -p $out/${python3.sitePackages}
     cp -r driver $out/${python3.sitePackages}
 
-    wrapPythonProgramsIn $out/bin "$out $pythonPath"
-    wrapPythonProgramsIn $out/libexec/fast-downward/translate "$out $pythonPath"
+    wrapPythonProgramsIn $out/bin "$out ''${pythonPath[*]}"
+    wrapPythonProgramsIn $out/libexec/fast-downward/translate "$out ''${pythonPath[*]}"
     # Because fast-downward calls `python translate.py` we need to return wrapped scripts back.
     for i in $out/libexec/fast-downward/translate/.*-wrapped; do
       name="$(basename "$i")"

--- a/pkgs/by-name/fi/fio/package.nix
+++ b/pkgs/by-name/fi/fio/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation rec {
   ];
 
   postInstall = ''
-    wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/bin" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/gd/gdal/package.nix
+++ b/pkgs/by-name/gd/gdal/package.nix
@@ -221,7 +221,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pythonPath = [ python3Packages.numpy ];
   postInstall = ''
-    wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/bin" "$out ''${pythonPath[*]}"
   ''
   + lib.optionalString useJava ''
     cd $out/lib

--- a/pkgs/by-name/gn/gnome-tweaks/package.nix
+++ b/pkgs/by-name/gn/gnome-tweaks/package.nix
@@ -79,7 +79,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/libexec" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/libexec" "$out ''${pythonPath[*]}"
   '';
 
   passthru = {

--- a/pkgs/by-name/gp/gpsd/package.nix
+++ b/pkgs/by-name/gp/gpsd/package.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # remove binaries for x-less install because xgps sconsflag is partially broken
   postFixup = ''
-    wrapPythonProgramsIn $out/bin "$out $pythonPath"
+    wrapPythonProgramsIn $out/bin "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/ha/hamster/package.nix
+++ b/pkgs/by-name/ha/hamster/package.nix
@@ -62,7 +62,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn $out/libexec "$out $pythonPath"
+    wrapPythonProgramsIn $out/libexec "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/in/ingen/package.nix
+++ b/pkgs/by-name/in/ingen/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation {
   ];
 
   postInstall = ''
-    wrapPythonProgramsIn "$out/bin" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/bin" "$out ''${pythonPath[*]}"
     wrapProgram "$out/bin/ingen" --set INGEN_UI_PATH "$out/share/ingen/ingen_gui.ui"
   '';
 

--- a/pkgs/by-name/ko/koboldcpp/package.nix
+++ b/pkgs/by-name/ko/koboldcpp/package.nix
@@ -116,7 +116,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/bin" "$pythonPath"
+    wrapPythonProgramsIn "$out/bin" "''${pythonPath[*]}"
     makeWrapper "$out/bin/koboldcpp.unwrapped" "$out/bin/koboldcpp" \
       --prefix PATH : ${lib.makeBinPath [ tk ]} ${libraryPathWrapperArgs}
   '';

--- a/pkgs/by-name/mi/mininet/package.nix
+++ b/pkgs/by-name/mi/mininet/package.nix
@@ -85,7 +85,7 @@ stdenv.mkDerivation rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/bin" "$py $pythonPath"
+    wrapPythonProgramsIn "$out/bin" "$py ''${pythonPath[*]}"
     wrapProgram "$out/bin/mnexec" \
       --prefix PATH : "${generatedPath}"
     wrapProgram "$out/bin/mn" \

--- a/pkgs/by-name/ne/neard/package.nix
+++ b/pkgs/by-name/ne/neard/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
 
   preFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-    wrapPythonProgramsIn "$out/lib/neard" "$pythonPath"
+    wrapPythonProgramsIn "$out/lib/neard" "''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/op/open-fprintd/package.nix
+++ b/pkgs/by-name/op/open-fprintd/package.nix
@@ -49,7 +49,7 @@ python3Packages.buildPythonPackage rec {
   makeWrapperArgs = [ "\${gappsWrapperArgs[@]}" ];
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/lib/open-fprintd" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/lib/open-fprintd" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/op/openbox/package.nix
+++ b/pkgs/by-name/op/openbox/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation rec {
     wrapProgram "$out/bin/openbox-session" --prefix XDG_DATA_DIRS : "$out/share"
     wrapProgram "$out/bin/openbox-gnome-session" --prefix XDG_DATA_DIRS : "$out/share"
     wrapProgram "$out/bin/openbox-kde-session" --prefix XDG_DATA_DIRS : "$out/share"
-    wrapPythonProgramsIn "$out/libexec" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/libexec" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/pa/patchance/package.nix
+++ b/pkgs/by-name/pa/patchance/package.nix
@@ -47,7 +47,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/share/patchance/src" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/patchance/src" "$out ''${pythonPath[*]}"
     for file in $out/bin/*; do
       wrapQtApp "$file"
     done

--- a/pkgs/by-name/pi/pince/package.nix
+++ b/pkgs/by-name/pi/pince/package.nix
@@ -164,7 +164,7 @@ python3Packages.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/lib/pince" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/lib/pince" "$out ''${pythonPath[*]}"
   '';
 
   passthru = {

--- a/pkgs/by-name/po/pokete/package.nix
+++ b/pkgs/by-name/po/pokete/package.nix
@@ -37,7 +37,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   postFixup = ''
-    wrapPythonProgramsIn $out/share/pokete "$pythonPath"
+    wrapPythonProgramsIn $out/share/pokete "''${pythonPath[*]}"
   '';
 
   passthru.tests = {

--- a/pkgs/by-name/ra/raysession/package.nix
+++ b/pkgs/by-name/ra/raysession/package.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postFixup = ''
-    wrapPythonProgramsIn "$out/share/raysession/src" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/raysession/src" "$out ''${pythonPath[*]}"
     for file in $out/bin/*; do
       wrapQtApp "$file"
     done

--- a/pkgs/by-name/tu/tuhi/package.nix
+++ b/pkgs/by-name/tu/tuhi/package.nix
@@ -62,7 +62,7 @@ python3Packages.buildPythonApplication rec {
       --replace "/usr/bin/env sh" "sh"
   '';
   postFixup = ''
-    wrapPythonProgramsIn $out/libexec "$out $pythonPath"
+    wrapPythonProgramsIn $out/libexec "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/wi/wike/package.nix
+++ b/pkgs/by-name/wi/wike/package.nix
@@ -60,7 +60,7 @@ python3Packages.buildPythonApplication rec {
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
   postFixup = ''
-    wrapPythonProgramsIn "$out/share/wike" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/wike" "$out ''${pythonPath[*]}"
   '';
 
   passthru = {

--- a/pkgs/by-name/xe/xen/package.nix
+++ b/pkgs/by-name/xe/xen/package.nix
@@ -317,7 +317,7 @@ stdenv.mkDerivation (finalAttrs: {
     # We also need to wrap pygrub, which lies in $out/libexec/xen/bin.
     ''
       wrapPythonPrograms
-      wrapPythonProgramsIn "$out/libexec/xen/bin" "$out $pythonPath"
+      wrapPythonProgramsIn "$out/libexec/xen/bin" "$out ''${pythonPath[*]}"
     '';
 
   postFixup = ''

--- a/pkgs/by-name/xf/xfce4-dockbarx-plugin/package.nix
+++ b/pkgs/by-name/xf/xfce4-dockbarx-plugin/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   postFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
     chmod +x $out/share/dockbarx/xfce4-panel-plug
-    wrapPythonProgramsIn "$out/share/dockbarx" "$out $pythonPath"
+    wrapPythonProgramsIn "$out/share/dockbarx" "$out ''${pythonPath[*]}"
   '';
 
   meta = {

--- a/pkgs/by-name/xt/xtf/package.nix
+++ b/pkgs/by-name/xt/xtf/package.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
     # This is necessary because the real xtf-runner should
     # be in the same directory as the tests/ directory.
     + ''
-      wrapPythonProgramsIn "''${!outputBin}/share/xtf" "''${!outputBin} $pythonPath"
+      wrapPythonProgramsIn "''${!outputBin}/share/xtf" "''${!outputBin} ''${pythonPath[*]}"
       mkdir -p ''${!outputBin}/bin
       ln -s ''${!outputBin}/share/xtf/xtf-runner ''${!outputBin}/bin/xtf-runner
     '';

--- a/pkgs/development/python-modules/maubot/wrapper.nix
+++ b/pkgs/development/python-modules/maubot/wrapper.nix
@@ -58,7 +58,9 @@ let
         mkdir -p $out/bin
         cp $unwrapped/bin/.mbc-wrapped $out/bin/mbc
         cp $unwrapped/bin/.maubot-wrapped $out/bin/maubot
-        wrapPythonProgramsIn "$out/bin" "${lib.optionalString (baseConfig != null) "$out "}$pythonPath"
+        wrapPythonProgramsIn "$out/bin" "${
+          lib.optionalString (baseConfig != null) "$out "
+        }''${pythonPath[*]}"
       '';
 
       passthru = {

--- a/pkgs/servers/tautulli/default.nix
+++ b/pkgs/servers/tautulli/default.nix
@@ -37,7 +37,7 @@ buildPythonApplication rec {
     # Can't just symlink to the main script, since it uses __file__ to
     # import bundled packages and manage the service
     makeWrapper $out/libexec/tautulli/Tautulli.py $out/bin/tautulli
-    wrapPythonProgramsIn "$out/libexec/tautulli" "$pythonPath"
+    wrapPythonProgramsIn "$out/libexec/tautulli" "''${pythonPath[*]}"
 
     # Creat backwards compatibility symlink to bin/plexpy
     ln -s $out/bin/tautulli $out/bin/plexpy


### PR DESCRIPTION
Without `__structuredAttrs`, this just uses the same string and is a no-op (apart from the fact that the bash code changes, so it does cause rebuilds), but wihout this change and `__structuredAttrs` enabled only the first element of the `pythonPath` would be used.

This is the bulk counterpart to https://github.com/NixOS/nixpkgs/pull/471986 .

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
