### PR TITLE
incus: 6.20.0 -> 6.21.0,  incus-lts: 6.0.5 -> 6.0.5-unstable-2026-01-23

### DIFF
--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -1,8 +1,9 @@
 {
   hash,
   lts ? false,
-  patches ? [ ],
   nixUpdateExtraArgs ? [ ],
+  patches ? [ ],
+  rev ? null,
   vendorHash,
   version,
 }:
@@ -65,12 +66,14 @@ buildGoModule (finalAttrs: {
     "doc"
   ];
 
-  src = fetchFromGitHub {
-    owner = "lxc";
-    repo = "incus";
-    tag = "v${version}";
-    inherit hash;
-  };
+  src = fetchFromGitHub (
+    {
+      owner = "lxc";
+      repo = "incus";
+      inherit hash;
+    }
+    // (if (rev == null) then { tag = "v${version}"; } else { inherit rev; })
+  );
 
   patches = [ ./docs.patch ] ++ patches;
 

--- a/pkgs/by-name/in/incus/lts.nix
+++ b/pkgs/by-name/in/incus/lts.nix
@@ -1,11 +1,20 @@
 import ./generic.nix {
-  hash = "sha256-B29HLuw48j7/Er7p/sHen7ohbbACsAjzPr9Nn8eZNR0=";
-  version = "6.0.5";
+  hash = "sha256-Sg3+399EgwEcZ8fp9cb2KEWQtBpYr5PkwTdnGl/AdfA";
+  version = "6.0.5-unstable-2026-01-23";
+  rev = "f8da60633e493bb5c0521981fa031bc909988c95";
   vendorHash = "sha256-KOJqPvp+w7G505ZMJ1weRD2SATmfq1aeyCqmbJ6WMAY=";
   patches = [
     # qemu 9.1 compat, remove when added to LTS
     ./572afb06f66f83ca95efa1b9386fceeaa1c9e11b.patch
     ./0c37b7e3ec65b4d0e166e2127d9f1835320165b8.patch
+    # post 6.0.5 patches, remove >= 6.0.6
+    # ./c5359c809836c0f3b1e6022bf0528bb90ce06ad7.patch
+    # ./57096066959c843e1c413c4a97f64077b95cb397.patch
+    # ./f3dc9c0e6b77bb8765b347564702e026c2a8f9c6.patch
+    # ./d6a1ea3912938dae740cf821cd070e66e7a623ff.patch
+    # ./d6f0a77dd26df4c1ced80ffa63848279fd4330cc.patch
+    # ./92ac6ac999a4928cfdb92c485a048e4d51f471d0.patch
+    # ./f8da60633e493bb5c0521981fa031bc909988c95,patch
   ];
   lts = true;
   nixUpdateExtraArgs = [

--- a/pkgs/by-name/in/incus/package.nix
+++ b/pkgs/by-name/in/incus/package.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
-  hash = "sha256-nhf7defhiFBHsqfZ6y+NN3TuteII6t8zCvpTsPsO+EE=";
-  version = "6.20.0";
-  vendorHash = "sha256-jIOV6vIkptHEuZcD/aS386o2M2AQHTjHngBxFi2tESA=";
+  hash = "sha256-zn4U44aGBQGjCyvziIPKqhR6RbQJTR0yF8GkyxGeSMc=";
+  version = "6.21.0";
+  vendorHash = "sha256-ECk3gB94B5vv9N2S7beU6B3jSsq1x8vXtcpXg/KBHYI=";
   patches = [ ];
   nixUpdateExtraArgs = [
     "--override-filename=pkgs/by-name/in/incus/package.nix"


### PR DESCRIPTION
Changelog: https://github.com/lxc/incus/releases/tag/v6.21.0

https://discuss.linuxcontainers.org/t/incus-6-21-has-been-released/26005


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
