### PR TITLE
maintainers: drop maaslalani

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15766,12 +15766,6 @@
     githubId = 36235154;
     name = "Sean Haugh";
   };
-  maaslalani = {
-    email = "maaslalani0@gmail.com";
-    github = "maaslalani";
-    githubId = 42545625;
-    name = "Maas Lalani";
-  };
   mabster314 = {
     name = "Max Haland";
     email = "max@haland.org";

--- a/pkgs/by-name/ch/charm-freeze/package.nix
+++ b/pkgs/by-name/ch/charm-freeze/package.nix
@@ -31,7 +31,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       caarlos0
-      maaslalani
     ];
   };
 }

--- a/pkgs/by-name/gu/gum/package.nix
+++ b/pkgs/by-name/gu/gum/package.nix
@@ -49,7 +49,6 @@ buildGoModule rec {
     changelog = "https://github.com/charmbracelet/gum/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      maaslalani
       savtrip
     ];
     mainProgram = "gum";

--- a/pkgs/by-name/na/nap/package.nix
+++ b/pkgs/by-name/na/nap/package.nix
@@ -26,7 +26,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       phdcybersec
-      maaslalani
     ];
   };
 }

--- a/pkgs/by-name/po/pom/package.nix
+++ b/pkgs/by-name/po/pom/package.nix
@@ -28,7 +28,6 @@ buildGoModule rec {
     homepage = "https://github.com/maaslalani/pom";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      maaslalani
       redyf
     ];
     mainProgram = "pom";

--- a/pkgs/by-name/po/pop/package.nix
+++ b/pkgs/by-name/po/pop/package.nix
@@ -47,7 +47,6 @@ buildGoModule rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       caarlos0
-      maaslalani
     ];
     mainProgram = "pop";
   };

--- a/pkgs/by-name/re/revive/package.nix
+++ b/pkgs/by-name/re/revive/package.nix
@@ -53,6 +53,6 @@ buildGoModule rec {
     mainProgram = "revive";
     homepage = "https://revive.run";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ maaslalani ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sl/slides/package.nix
+++ b/pkgs/by-name/sl/slides/package.nix
@@ -35,7 +35,7 @@ buildGoModule rec {
     homepage = "https://github.com/maaslalani/slides";
     changelog = "https://github.com/maaslalani/slides/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ maaslalani ];
+    maintainers = [ ];
     mainProgram = "slides";
   };
 }

--- a/pkgs/by-name/vh/vhs/package.nix
+++ b/pkgs/by-name/vh/vhs/package.nix
@@ -60,6 +60,6 @@ buildGoModule rec {
     homepage = "https://github.com/charmbracelet/vhs";
     changelog = "https://github.com/charmbracelet/vhs/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ maaslalani ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
## Reasons

- Last commented in [July 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Amaaslalani)
- Hasn't created any PRs / Issues since [October 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Amaaslalani)
- About 48 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Amaaslalani%20-commenter%3Amaaslalani%20-author%3Amaaslalani%20-reviewed-by%3Amaaslalani) PRs / Issues

See [lossing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. If you are still active in `nipxkgs`, just respond to this PR and I will close it :) 

## Packages 

Those packages only have them as their maintainer and would need at least one new maintainer.

- [ ] revive
- [ ] slides
- [ ] vhs
