### PR TITLE
nixos/redmine: symlink /run/redmine dirs in preStart

### DIFF
--- a/nixos/modules/services/misc/redmine.nix
+++ b/nixos/modules/services/misc/redmine.nix
@@ -356,16 +356,6 @@ in
       "d '${cfg.stateDir}/public/plugin_assets' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/themes' 0750 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.stateDir}/tmp' 0750 ${cfg.user} ${cfg.group} - -"
-
-      "d /run/redmine/public - - - - -"
-      "L+ /run/redmine/config - - - - ${cfg.stateDir}/config"
-      "L+ /run/redmine/files - - - - ${cfg.stateDir}/files"
-      "L+ /run/redmine/log - - - - ${cfg.stateDir}/log"
-      "L+ /run/redmine/plugins - - - - ${cfg.stateDir}/plugins"
-      "L+ /run/redmine/public/assets - - - - ${cfg.stateDir}/public/assets"
-      "L+ /run/redmine/public/plugin_assets - - - - ${cfg.stateDir}/public/plugin_assets"
-      "L+ /run/redmine/themes - - - - ${cfg.stateDir}/themes"
-      "L+ /run/redmine/tmp - - - - ${cfg.stateDir}/tmp"
     ];
 
     systemd.services.redmine = {
@@ -392,6 +382,19 @@ in
         ++ lib.optional cfg.components.ghostscript ghostscript;
 
       preStart = ''
+        # Create symlinks for the basic directory layout the redmine package
+        # expects. This part must be done in preStart rather than tmpfiles,
+        # because /run/redmine is re-created when the service is restarted
+        mkdir /run/redmine/public
+        ln -s "${cfg.stateDir}/config" /run/redmine/config
+        ln -s "${cfg.stateDir}/files" /run/redmine/files
+        ln -s "${cfg.stateDir}/log" /run/redmine/log
+        ln -s "${cfg.stateDir}/plugins" /run/redmine/plugins
+        ln -s "${cfg.stateDir}/public/assets" /run/redmine/public/assets
+        ln -s "${cfg.stateDir}/public/plugin_assets" /run/redmine/public/plugin_assets
+        ln -s "${cfg.stateDir}/themes" /run/redmine/themes
+        ln -s "${cfg.stateDir}/tmp" /run/redmine/tmp
+
         rm -rf "${cfg.stateDir}/plugins/"*
         rm -rf "${cfg.stateDir}/themes/"*
 

--- a/nixos/tests/redmine.nix
+++ b/nixos/tests/redmine.nix
@@ -46,4 +46,30 @@ in
     name = "pgsql";
     type = "postgresql";
   };
+
+  restart = makeTest {
+    name = "redmine-restart";
+    nodes.machine =
+      { config, pkgs, ... }:
+      {
+        services.redmine = {
+          enable = true;
+          package = pkgs.redmine;
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("redmine.service")
+      machine.wait_for_open_port(3000)
+      machine.succeed("curl --fail http://localhost:3000/")
+
+      machine.systemctl("stop redmine.service")
+      machine.systemctl("start redmine.service")
+
+      machine.wait_for_unit("redmine.service")
+      machine.wait_for_open_port(3000)
+      machine.succeed("curl --fail http://localhost:3000/")
+    '';
+  };
 }


### PR DESCRIPTION
This fixes #481126. /run/redmine gets re-created (and its contents wiped) every time the service is started, so we must re-link it at that point.

There was another solution proposed to move everything to tmpfilesd. If that solution is better, I'm happy for another PR to supercede this one.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
