### PR TITLE
python3Packages.logfire: init at 4.6.0

### DIFF
--- a/pkgs/development/python-modules/fastapi-versionizer/default.nix
+++ b/pkgs/development/python-modules/fastapi-versionizer/default.nix
@@ -1,0 +1,58 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  fastapi,
+  natsort,
+
+  # test dependencies
+  httpx,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fastapi-versionizer";
+  version = "4.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "alexschimpf";
+    repo = "fastapi-versionizer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Kj7tjy8TDV9MYhqJdVUBRohkIsYoqbQX5qnnkNBJPig=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    fastapi
+    natsort
+  ];
+
+  pythonImportsCheck = [
+    "fastapi_versionizer"
+    "fastapi_versionizer.versionizer"
+  ];
+
+  nativeCheckInputs = [
+    httpx
+    pytestCheckHook
+  ];
+
+  meta = {
+    changelog = "https://github.com/alexschimpf/fastapi-versionizer/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "API versionizer for FastAPI web applications";
+    downloadPage = "https://github.com/alexschimpf/fastapi-versionizer/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://github.com/alexschimpf/fastapi-versionizer";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/development/python-modules/logfire-api/default.nix
+++ b/pkgs/development/python-modules/logfire-api/default.nix
@@ -1,0 +1,23 @@
+{
+  buildPythonPackage,
+  logfire,
+
+  # build system
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "logfire-api";
+  inherit (logfire) version src;
+  pyproject = true;
+
+  sourceRoot = "${finalAttrs.src.name}/logfire-api";
+
+  build-system = [ hatchling ];
+
+  pythonImportsCheck = [ "logfire_api" ];
+
+  meta = logfire.meta // {
+    description = "Shim for the Logfire SDK which does nothing unless Logfire is installed";
+  };
+})

--- a/pkgs/development/python-modules/logfire/default.nix
+++ b/pkgs/development/python-modules/logfire/default.nix
@@ -1,0 +1,200 @@
+{
+  buildPythonPackage,
+  callPackage,
+  fetchFromGitHub,
+  lib,
+
+  # build-system
+  hatchling,
+
+  # dependencies
+  executing,
+  opentelemetry-exporter-otlp-proto-http,
+  opentelemetry-instrumentation,
+  opentelemetry-sdk,
+  protobuf,
+  rich,
+  tomli,
+  typing-extensions,
+
+  # optional dependencies
+  opentelemetry-instrumentation-aiohttp-client,
+  opentelemetry-instrumentation-asgi,
+  opentelemetry-instrumentation-celery,
+  opentelemetry-instrumentation-django,
+  opentelemetry-instrumentation-fastapi,
+  opentelemetry-instrumentation-flask,
+  opentelemetry-instrumentation-httpx,
+  opentelemetry-instrumentation-psycopg2,
+  opentelemetry-instrumentation-redis,
+  opentelemetry-instrumentation-requests,
+  opentelemetry-instrumentation-sqlalchemy,
+  opentelemetry-instrumentation-wsgi,
+  packaging,
+
+  # test dependencies
+  anthropic,
+  anyio,
+  asyncpg,
+  cloudpickle,
+  dirty-equals,
+  google-genai,
+  inline-snapshot,
+  logfire-api,
+  loguru,
+  mysql-connector,
+  openai-agents,
+  pandas,
+  psycopg,
+  pymongo,
+  pymysql,
+  pytest-django,
+  pytest-vcr,
+  pytest-xdist,
+  pytestCheckHook,
+  redis,
+  requests-mock,
+  sqlmodel,
+  structlog,
+  testcontainers,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "logfire";
+  version = "4.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pydantic";
+    repo = "logfire";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dAkT3xh0RsGTnW7Mqml2wV16VHJGUUkjjxiFLg9bUKc=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    executing
+    opentelemetry-exporter-otlp-proto-http
+    opentelemetry-instrumentation
+    opentelemetry-sdk
+    protobuf
+    rich
+    tomli
+    typing-extensions
+  ];
+
+  # Some optional dependencies are commented out because the deps they require
+  # are not in nixpkgs as of writing
+  optional-dependencies = {
+    aiohttp = [ opentelemetry-instrumentation-aiohttp-client ];
+    aiohttp-client = [ opentelemetry-instrumentation-aiohttp-client ];
+    # aiohttp-server = [ opentelemetry-instrumentation-aiohttp-server ];
+    asgi = [ opentelemetry-instrumentation-asgi ];
+    # asyncpg = [ opentelemetry-instrumentation-asyncpg ];
+    # aws-lambda = [ opentelemetry-instrumentation-aws-lambda ];
+    celery = [ opentelemetry-instrumentation-celery ];
+    django = [
+      opentelemetry-instrumentation-asgi
+      opentelemetry-instrumentation-django
+    ];
+    # dspy = [ opentelemetry-instrumentation-dspy ];
+    fastapi = [ opentelemetry-instrumentation-fastapi ];
+    flask = [ opentelemetry-instrumentation-flask ];
+    # google-genai = [ opentelemetry-instrumentation-google-genai ];
+    httpx = [ opentelemetry-instrumentation-httpx ];
+    # litellm = [ opentelemetry-instrumentation-litellm ];
+    # mysql = [ opentelemetry-instrumentation-mysql ];
+    psycopg = [
+      # opentelemetry-instrumentation-psycopg
+      packaging
+    ];
+    psycopg2 = [
+      opentelemetry-instrumentation-psycopg2
+      packaging
+    ];
+    # pymongo = [ opentelemetry-instrumentation-pymongo ];
+    redis = [ opentelemetry-instrumentation-redis ];
+    requests = [ opentelemetry-instrumentation-requests ];
+    sqlalchemy = [ opentelemetry-instrumentation-sqlalchemy ];
+    # sqlite3 = [ opentelemetry-instrumentation-sqlite3 ];
+    # starlette = [ opentelemetry-instrumentation-starlette ];
+    # system-metrics = [ opentelemetry-instrumentation-system-metrics ];
+    wsgi = [ opentelemetry-instrumentation-wsgi ];
+  };
+
+  pythonImportsCheck = [ "logfire" ];
+
+  # Too many outdated snapshots that fail with inline-snapshot
+  doCheck = false;
+
+  nativeCheckInputs = [
+    anthropic
+    anyio
+    asyncpg
+    cloudpickle
+    dirty-equals
+    google-genai
+    inline-snapshot
+    logfire-api
+    loguru
+    mysql-connector
+    openai-agents
+    pandas
+    psycopg
+    pymongo
+    pymysql
+    pytest-django
+    pytest-vcr
+    pytest-xdist
+    pytestCheckHook
+    redis
+    requests-mock
+    sqlmodel
+    structlog
+    testcontainers
+  ]
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
+
+  disabledTestPaths = [
+    # Tests that require the commented optional dependencies above
+    "tests/otel_integrations/test_aiohttp_server.py"
+    "tests/otel_integrations/test_asyncpg.py"
+    "tests/otel_integrations/test_aws_lambda.py"
+    "tests/otel_integrations/test_google_genai.py"
+    "tests/otel_integrations/test_mysql.py"
+    "tests/otel_integrations/test_psycopg.py"
+    "tests/otel_integrations/test_pymongo.py"
+    "tests/otel_integrations/test_sqlalchemy.py"
+    "tests/otel_integrations/test_sqlite3.py"
+    "tests/otel_integrations/test_starlette.py"
+    "tests/otel_integrations/test_system_metrics.py"
+
+    # No module named 'litellm'
+    "tests/otel_integrations/test_litellm.py::test_litellm_instrumentation"
+
+    # No module named 'pydantic_ai'
+    "tests/otel_integrations/test_pydantic_ai.py"
+
+    # DeprecationWarning: The @wait_container_is_ready decorator is deprecated and will be removed in a future version. Use structured wait strategies instead: container.waiting_for(HttpWaitStrategy(8080).for_status_code(200)) or container.waiting_for(LogMessageWaitStrategy('ready'))
+    "tests/otel_integrations/test_celery.py"
+    "tests/otel_integrations/test_redis.py"
+
+    # Requires network
+    "tests/test_query_client.py"
+    "tests/otel_integrations/test_openai.py"
+    "tests/otel_integrations/test_openai_agents.py"
+  ];
+
+  meta = {
+    changelog = "https://logfire.pydantic.dev/docs/release-notes";
+    description = "Uncomplicated Observability for Python and beyond";
+    downloadPage = "https://github.com/pydantic/logfire/releases/tag/${finalAttrs.src.tag}";
+    homepage = "https://logfire.pydantic.dev";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5272,6 +5272,8 @@ self: super: with self; {
 
   fastapi-sso = callPackage ../development/python-modules/fastapi-sso { };
 
+  fastapi-versionizer = callPackage ../development/python-modules/fastapi-versionizer { };
+
   fastavro = callPackage ../development/python-modules/fastavro { };
 
   fastbencode = callPackage ../development/python-modules/fastbencode { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9106,6 +9106,10 @@ self: super: with self; {
 
   logboth = callPackage ../development/python-modules/logboth { };
 
+  logfire = callPackage ../development/python-modules/logfire { };
+
+  logfire-api = callPackage ../development/python-modules/logfire-api { };
+
   logfury = callPackage ../development/python-modules/logfury { };
 
   logging-journald = callPackage ../development/python-modules/logging-journald { };


### PR DESCRIPTION
https://github.com/pydantic/logfire/blob/v4.6.0

I'm not initialising this at a newer version since it breaks with older `opentelemetry-exporter-otlp-proto-http` and `opentelemetry-instrumentation` versions currently in nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
