### PR TITLE
synology-drive-client: 4.0.1-17885 -> 4.0.2-17889

### DIFF
--- a/pkgs/by-name/sy/synology-drive-client/package.nix
+++ b/pkgs/by-name/sy/synology-drive-client/package.nix
@@ -17,8 +17,8 @@
 let
   pname = "synology-drive-client";
   baseUrl = "https://global.synologydownload.com/download/Utility/SynologyDriveClient";
-  version = "4.0.1-17885";
-  buildNumber = lib.last (lib.splitString "-" version);
+  version = "4.0.2-17889";
+  buildNumberFn = ver: lib.last (lib.splitString "-" ver);
   meta = {
     description = "Desktop application to synchronize files and folders between the computer and the Synology Drive server";
     homepage = "https://www.synology.com/en-global/dsm/feature/drive";
@@ -36,34 +36,18 @@ let
     ];
     mainProgram = "synology-drive";
   };
-  passthru.updateScript = writeScript "update-synology-drive-client" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl jq common-updater-scripts
+  updateScript = ./update.sh;
 
-    set -eu -o pipefail
-
-    version=$(curl -s "https://www.synology.com/api/releaseNote/findChangeLog?identify=SynologyDriveClient&lang=en-uk" \
-              | jq -r '.info.versions | to_entries | .[0].value.all_versions[0].version')
-
-    if [[ "$version" =~ ^[0-9.]+(-[0-9]+)?$ ]]; then
-      update-source-version synology-drive-client "$version"
-    else
-      echo "Error: Invalid version format: '$version'"
-      exit 1
-    fi
-  '';
-
-  linux = stdenv.mkDerivation {
+  linux = stdenv.mkDerivation (finalAttrs: {
     inherit
       pname
       version
       meta
-      passthru
       ;
 
     src = fetchurl {
-      url = "${baseUrl}/${version}/Ubuntu/Installer/synology-drive-client-${buildNumber}.x86_64.deb";
-      sha256 = "sha256-DMHqh8o0RknWTycANSbMpJj133/MZ8uZ18ytDZVaKMg=";
+      url = "${baseUrl}/${finalAttrs.version}/Ubuntu/Installer/synology-drive-client-${buildNumberFn finalAttrs.version}.x86_64.deb";
+      sha256 = "sha256-refsAzqYmKAr107D4HiJViBQE1Qa6QoOECtX+TPjSwU=";
     };
 
     nativeBuildInputs = [
@@ -99,19 +83,20 @@ let
     postInstall = ''
       substituteInPlace $out/bin/synology-drive --replace /opt $out/opt
     '';
-  };
 
-  darwin = stdenv.mkDerivation {
+    passthru = { inherit updateScript; };
+  });
+
+  darwin = stdenv.mkDerivation (finalAttrs: {
     inherit
       pname
       version
       meta
-      passthru
       ;
 
     src = fetchurl {
-      url = "${baseUrl}/${version}/Mac/Installer/synology-drive-client-${buildNumber}.dmg";
-      sha256 = "sha256-0rK7w4/RCv4qml+8XYPwLQmxHen3pB793Co4DvnDVuU=";
+      url = "${baseUrl}/${finalAttrs.version}/Mac/Installer/synology-drive-client-${buildNumberFn finalAttrs.version}.dmg";
+      sha256 = "sha256-KAoc31Y2RTHu7RWgC61brtoeFR1c+pNi4Odub2JHrfQ=";
     };
 
     nativeBuildInputs = [
@@ -132,6 +117,8 @@ let
       mkdir -p $out/Applications/
       cp -R 'Synology Drive Client.app' $out/Applications/
     '';
-  };
+
+    passthru = { inherit updateScript; };
+  });
 in
 if stdenv.hostPlatform.isDarwin then darwin else linux

--- a/pkgs/by-name/sy/synology-drive-client/update.sh
+++ b/pkgs/by-name/sy/synology-drive-client/update.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -euo pipefail
+
+version=$(curl -s "https://www.synology.com/api/releaseNote/findChangeLog?identify=SynologyDriveClient&lang=en-uk" | jq -r '.info.versions | to_entries[0].value.all_versions[0].version')
+build="${version##*-}"
+
+update_hash() {
+    local system=$1
+    if [[ "$system" == *"linux"* ]]; then
+        url="https://global.synologydownload.com/download/Utility/SynologyDriveClient/$version/Ubuntu/Installer/synology-drive-client-$build.x86_64.deb"
+    else
+        url="https://global.synologydownload.com/download/Utility/SynologyDriveClient/$version/Mac/Installer/synology-drive-client-$build.dmg"
+    fi
+
+    hash=$(nix --extra-experimental-features nix-command hash to-sri --type sha256 $(nix-prefetch-url --type sha256 "$url"))
+    update-source-version synology-drive-client "$version" "$hash" --system="$system" --ignore-same-version
+}
+
+update_hash x86_64-linux
+update_hash aarch64-darwin


### PR DESCRIPTION
- update script changed to also generate the darwin hash (modified version of the vivaldi update script)
- version update to 4.0.2-17889
- added the version via finalAttrs 

Changelog: https://www.synology.com/de-de/releaseNote/SynologyDriveClient

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
