### PR TITLE
python3.pkgs.inkex: Fix schematron tests

### DIFF
--- a/pkgs/applications/graphics/inkscape/extensions/inkstitch/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/inkstitch/default.nix
@@ -2,37 +2,17 @@
   lib,
   python3,
   fetchFromGitHub,
-  fetchFromGitLab,
+  fetchpatch,
   gettext,
 }:
 let
-  # on update check compatibility to nixpkgs inkex
   version = "3.2.2";
-
-  # remove and use nixpkgs version is recent enough
-  inkex' = python3.pkgs.inkex.overrideAttrs (old: rec {
-    # this is no special commit, just the most recent as of writing
-    version = "3150a5b3b06f7e4c2104d9e8eb6dc448982bb2b0";
-    src = fetchFromGitLab {
-      owner = "inkscape";
-      repo = "extensions";
-      rev = "${version}";
-      hash = "sha256-FYBZ66ERC3nVYCaAmFPqKnBxDOKAoQwT14C0fKLn10c=";
-    };
-
-    postPatch = ''
-      substituteInPlace pyproject.toml \
-        --replace-fail 'scour = "^0.37"' 'scour = ">=0.37"'
-    '';
-  });
 
   dependencies =
     with python3.pkgs;
     [
       pyembroidery
-      # inkex upstream release & nixpkgs is too old
-      # use nixpkgs inkex once up to date
-      inkex'
+      inkex
       wxpython
       networkx
       platformdirs
@@ -94,6 +74,13 @@ python3.pkgs.buildPythonApplication {
     ./0002-plugin-invocation-use-python-script-as-entrypoint.patch
     ./0003-lazy-load-module-to-access-global_settings.patch
     ./0004-enable-force-insertion-of-python-path.patch
+
+    # Fix compatibility with inkex 1.4
+    # https://github.com/inkstitch/inkstitch/pull/3825
+    (fetchpatch {
+      url = "https://github.com/inkstitch/inkstitch/commit/454b5ee1a00e9d4b96f5f057a8611da68a6cc796.patch";
+      hash = "sha256-nAs1rAr3lvN5Qwhj0I+7puM3R2X1NoHpB0ltvlwHDXA=";
+    })
   ];
 
   doCheck = false;

--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
+  fetchpatch,
   inkscape,
   poetry-core,
   cssselect,
@@ -24,6 +25,17 @@ buildPythonPackage {
   pyproject = true;
 
   inherit (inkscape) src;
+
+  patches = [
+    # Fix tests with newer libxml2
+    # https://gitlab.com/inkscape/extensions/-/merge_requests/712
+    (fetchpatch {
+      url = "https://gitlab.com/inkscape/extensions/-/commit/b04ab718b400778a264f2085bbc779faebc08368.patch";
+      hash = "sha256-BXRcfoeX7X8+x6CuKKBhrnzUHIwgnPay22Z8+rPZS54=";
+      stripLen = 1;
+      extraPrefix = "share/extensions/";
+    })
+  ];
 
   build-system = [ poetry-core ];
 
@@ -72,9 +84,6 @@ buildPythonPackage {
     "tests/test_inkex_gui_window.py"
     # Failed to find pixmap 'image-missing' in /build/source/tests/data/
     "tests/test_inkex_gui_pixmaps.py"
-    # Fails with libxml2 >= 2.15 with "lxml.etree was compiled without Schematron support"
-    "inkex/tester/test_inx_file.py"
-    "tests/test_inkex_inx.py"
   ];
 
   postPatch = ''


### PR DESCRIPTION
libxml2 2.15 disables schematron support by default, using upstream by @uninsane patch that switches to lxml-specific implementation.

Fixes: #483060


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
