### PR TITLE
guix: 1.4.0-unstable-2025-06-24 -> 1.5.0

### DIFF
--- a/pkgs/by-name/gu/guile-git/package.nix
+++ b/pkgs/by-name/gu/guile-git/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitLab,
+  fetchpatch,
   guile,
   libgit2,
   scheme-bytestructures,
@@ -20,6 +21,21 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-ihKpEnng6Uemrguecbd25vElEhIu2Efb86aM8679TAc=";
   };
+
+  patches = [
+    # remove > 0.10.0
+    (fetchpatch {
+      name = "catch-git-error-guile";
+      url = "https://gitlab.com/guile-git/guile-git/-/commit/9c76c6b31e217c470c8576172b123be9c373dc9b.diff";
+      hash = "sha256-H0s7Ebl+HNL8Zak58kJmFETWZJcNq+Z5gTGRqU9gj58=";
+    })
+    # remove > 0.10.0
+    (fetchpatch {
+      name = "test-typo";
+      url = "https://gitlab.com/guile-git/guile-git/-/commit/4451c0808fbdf8cd13d486a18b03881f998f6e88.diff";
+      hash = "sha256-K2f67WXUBLI/09eF8Xg3JMX7gkISFTZK3yHu0VDVQ4E=";
+    })
+  ];
 
   strictDeps = true;
   nativeBuildInputs = [

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -38,17 +38,14 @@
   storeDir ? "/gnu/store",
   confDir ? "/etc",
 }:
-let
-  rev = "30a5d140aa5a789a362749d057754783fea83dde";
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "guix";
-  version = "1.4.0-unstable-2025-06-24";
+  version = "1.5.0";
 
   src = fetchgit {
     url = "https://codeberg.org/guix/guix.git";
-    inherit rev;
-    hash = "sha256-QsOYApnwA2hb1keSv6p3EpMT09xCs9uyoSeIdXzftF0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/g8JMUGM5GaZjtPLnl4vlrBNYMxSTjsHUDdhKLtHaQA=";
   };
 
   patches = [
@@ -124,6 +121,9 @@ stdenv.mkDerivation (finalAttrs: {
     "--localstatedir=${stateDir}"
     "--sysconfdir=${confDir}"
     "--with-bash-completion-dir=$(out)/etc/bash_completion.d"
+    "--with-zsh-completion-dir=$(out)/share/zsh/site-functions"
+    "--with-fish-completion-dir=$(out)/share/fish/vendor_completions.d"
+    "--with-apparmor-profile-dir=$(out)/etc/apparmor.d"
   ];
 
   preAutoreconf = ''
@@ -161,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
       Guix is based on the Nix package manager.
     '';
     homepage = "https://guix.gnu.org/";
-    changelog = "https://codeberg.org/guix/guix/raw/commit/${finalAttrs.version}/NEWS";
+    changelog = "https://codeberg.org/guix/guix/raw/tag/v${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     mainProgram = "guix";
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/gu/guix/package.nix
+++ b/pkgs/by-name/gu/guix/package.nix
@@ -41,7 +41,7 @@
 let
   rev = "30a5d140aa5a789a362749d057754783fea83dde";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "guix";
   version = "1.4.0-unstable-2025-06-24";
 
@@ -127,7 +127,7 @@ stdenv.mkDerivation rec {
   ];
 
   preAutoreconf = ''
-    echo ${version} > .tarball-version
+    echo ${finalAttrs.version} > .tarball-version
     ./bootstrap
   '';
 
@@ -161,7 +161,7 @@ stdenv.mkDerivation rec {
       Guix is based on the Nix package manager.
     '';
     homepage = "https://guix.gnu.org/";
-    changelog = "https://codeberg.org/guix/guix/raw/commit/${rev}/NEWS";
+    changelog = "https://codeberg.org/guix/guix/raw/commit/${finalAttrs.version}/NEWS";
     license = lib.licenses.gpl3Plus;
     mainProgram = "guix";
     maintainers = with lib.maintainers; [
@@ -170,4 +170,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://codeberg.org/guix/guix/raw/tag/v1.5.0/NEWS
Announcement: https://guix.gnu.org/blog/2026/gnu-guix-1.5.0-released/

## Things done

I opted to move this back to a tag-based setup, given their announcement indicates they hope to start releasing yearly. Let me know if you'd prefer to stick with an unstable version.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
