### PR TITLE
nixos/gitea-actions-runner: Add support for LoadCredential

### DIFF
--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -8,6 +8,7 @@
 
 let
   inherit (lib)
+    all
     any
     attrValues
     concatStringsSep
@@ -15,6 +16,7 @@ let
     hasInfix
     hasSuffix
     optionalAttrs
+    optionalString
     optionals
     literalExpression
     mapAttrs'
@@ -49,8 +51,13 @@ let
 
   tokenXorTokenFile =
     instance:
-    (instance.token == null && instance.tokenFile != null)
-    || (instance.token != null && instance.tokenFile == null);
+    builtins.length (
+      builtins.filter (x: x != null) [
+        instance.token
+        instance.tokenFile
+        instance.tokenCredentialFile
+      ]
+    ) == 1;
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -96,10 +103,31 @@ in
           tokenFile = mkOption {
             type = nullOr (either str path);
             default = null;
+            example = "/run/keys/gitea-runner.env";
             description = ''
               Path to an environment file, containing the `TOKEN` environment
               variable, that holds a token to register at the configured
               Gitea/Forgejo instance.
+
+              The file must be in systemd's `EnvironmentFile=` format, e.g. a
+              single line `TOKEN=<token>`.
+
+              For a file containing only the raw token, use
+              {option}`tokenCredentialFile` instead.
+            '';
+          };
+
+          tokenCredentialFile = mkOption {
+            type = nullOr path;
+            default = null;
+            example = "/run/secrets/forgejo-runner-token";
+            description = ''
+              Path to a file containing only the raw token to register at the
+              configured Gitea/Forgejo instance. The file is loaded via
+              systemd's `LoadCredential=` mechanism, so it only needs to be
+              readable by root at unit start.
+
+              Mutually exclusive with {option}`tokenFile`.
             '';
           };
 
@@ -173,8 +201,8 @@ in
   config = mkIf (cfg.instances != { }) {
     assertions = [
       {
-        assertion = any tokenXorTokenFile (attrValues cfg.instances);
-        message = "Instances of gitea-actions-runner can have `token` or `tokenFile`, not both.";
+        assertion = all tokenXorTokenFile (attrValues cfg.instances);
+        message = "Instances of gitea-actions-runner must set exactly one of `token`, `tokenFile`, or `tokenCredentialFile`.";
       }
       {
         assertion = wantsContainerRuntime -> hasDocker || hasPodman;
@@ -236,33 +264,38 @@ in
               RestartSec = 2;
 
               ExecStartPre = [
-                (pkgs.writeShellScript "gitea-register-runner-${name}" ''
-                  export INSTANCE_DIR="$STATE_DIRECTORY/${name}"
-                  mkdir -vp "$INSTANCE_DIR"
-                  cd "$INSTANCE_DIR"
+                (pkgs.writeShellScript "gitea-register-runner-${name}" (
+                  (optionalString (instance.tokenCredentialFile != null) ''
+                    TOKEN="$(cat "$CREDENTIALS_DIRECTORY/token")"
+                  '')
+                  + ''
+                    export INSTANCE_DIR="$STATE_DIRECTORY/${name}"
+                    mkdir -vp "$INSTANCE_DIR"
+                    cd "$INSTANCE_DIR"
 
-                  # force reregistration on changed labels
-                  export LABELS_FILE="$INSTANCE_DIR/.labels"
-                  export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
-                  export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
+                    # force reregistration on changed labels
+                    export LABELS_FILE="$INSTANCE_DIR/.labels"
+                    export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
+                    export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
 
-                  if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED" != "$LABELS_CURRENT" ]; then
-                    # remove existing registration file, so that changing the labels forces a re-registration
-                    rm -v "$INSTANCE_DIR/.runner" || true
+                    if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED" != "$LABELS_CURRENT" ]; then
+                      # remove existing registration file, so that changing the labels forces a re-registration
+                      rm -v "$INSTANCE_DIR/.runner" || true
 
-                    # perform the registration
-                    ${cfg.package}/bin/act_runner register --no-interactive \
-                      --instance ${escapeShellArg instance.url} \
-                      --token "$TOKEN" \
-                      --name ${escapeShellArg instance.name} \
-                      --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
-                      --config ${configFile}
+                      # perform the registration
+                      ${cfg.package}/bin/act_runner register --no-interactive \
+                        --instance ${escapeShellArg instance.url} \
+                        --token "$TOKEN" \
+                        --name ${escapeShellArg instance.name} \
+                        --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
+                        --config ${configFile}
 
-                    # and write back the configured labels
-                    echo "$LABELS_WANTED" > "$LABELS_FILE"
-                  fi
+                      # and write back the configured labels
+                      echo "$LABELS_WANTED" > "$LABELS_FILE"
+                    fi
 
-                '')
+                  ''
+                ))
               ];
               ExecStart = "${cfg.package}/bin/act_runner daemon --config ${configFile}";
               SupplementaryGroups =
@@ -275,6 +308,9 @@ in
             }
             // optionalAttrs (instance.tokenFile != null) {
               EnvironmentFile = instance.tokenFile;
+            }
+            // optionalAttrs (instance.tokenCredentialFile != null) {
+              LoadCredential = "token:${instance.tokenCredentialFile}";
             };
           };
       in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The service gitea-actions-runner has the option to provide a token using a file. But the file has to contain `TOKEN=` and either have to be globally viewable because the service is configured with DynamicUser or one has to overwrite the systemd service.

All of this makes it incompatible with sops and age.

## Things done

I have changed the way the tokenFile option works. Now LoadCredential will ensure that a file with the token is accessible by the systemd service gitea-actions-runner no matter the permissions set in sops or age.

This is not a breaking change since the token is only used once, and so if gitea-actions-runner is already registered, it does not need the file. However, it does change what the file should contain since the `TOKEN=` prefix is no longer required.

**Note:** I tried to see if `LoadCredential=` worked with `EnvironmentFile=` but it seems that `EnvironmentFile=` is handled before `LoadCredential=` so that did not work.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
