### PR TITLE
quickshell: fix unneccessary reloads

### DIFF
--- a/pkgs/by-name/qu/quickshell/0001-fix-unneccessary-reloads.patch
+++ b/pkgs/by-name/qu/quickshell/0001-fix-unneccessary-reloads.patch
@@ -1,0 +1,23 @@
+diff --git a/src/core/generation.cpp b/src/core/generation.cpp
+index c68af71..4967562 100644
+--- a/src/core/generation.cpp
++++ b/src/core/generation.cpp
+@@ -172,12 +172,18 @@ void EngineGeneration::setWatchingFiles(bool watching) {
+ 		if (this->watcher == nullptr) {
+ 			this->watcher = new QFileSystemWatcher();
+ 
++			// note: not using canonicalFilePath() here on purpose,
++			//       since the path could be a link to the nix store
++			//       and the link might change
++
+ 			for (auto& file: this->scanner.scannedFiles) {
++				if (file.startsWith("/nix/store/")) continue;
+ 				this->watcher->addPath(file);
+ 				this->watcher->addPath(QFileInfo(file).dir().absolutePath());
+ 			}
+ 
+ 			for (auto& file: this->extraWatchedFiles) {
++				if (file.startsWith("/nix/store/")) continue;
+ 				this->watcher->addPath(file);
+ 				this->watcher->addPath(QFileInfo(file).dir().absolutePath());
+ 			}

--- a/pkgs/by-name/qu/quickshell/package.nix
+++ b/pkgs/by-name/qu/quickshell/package.nix
@@ -32,6 +32,9 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-e++Ogy91Sv7gGLMdAqZaBzbH/UmPWZ4GAt7VDCA66aU=";
   };
+  patches = [
+    ./0001-fix-unneccessary-reloads.patch
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
When running quickshell, the application reloads itself whenever files change on disk that quickshell loaded.
When using e.g. https://github.com/noctalia-dev/noctalia-shell which is run by quickshell, the application reloads when `nix flake update` or `sudo nixos-rebuild switch` is used.
This behavior can be prevented if nix store paths are ignored whenever files are changed on disk.

Note that noctalia-shell is using quickshell like this:
https://github.com/noctalia-dev/noctalia-shell/blob/5573409fe3ba13c829d0ee44c181e52c332fa7ee/nix/package.nix#L84-L96

At the moment I am using quickshell like this using home-manager:

```nix
inputs.nixos-noctalia = {
  /* revision: 21ba2184849a0fcbf0511fed04b30bd92b128dfd */
  url = "github:noctalia-dev/noctalia-shell";
  /* revision: 88d3861acdd3d2f0e361767018218e51810df8a1 */
  inputs.nixpkgs.follows = "nixos-nixpkgs-unstable";
};
```

```nix
imports = [
  inputs.nixos-noctalia.homeModules.default
];
programs.noctalia-shell = {
  enable = true;
  systemd.enable = true;
  package = pkgs.noctalia-shell.override {
    quickshell = pkgs.quickshell.overrideAttrs (oldAttrs: {
      patches = (oldAttrs.patches or [ ]) ++ [
        ./0001-fix-unneccessary-reloads.patch
      ];
    });
  };
  /* colors and settings omitted */
};
```

I am suggesting this change in nixpkgs and not upstream, because this change is specific to the way it is packaged in nixpkgs.

With my changes noctalia-shell is not restarted when running `nix flake update`.
It can be uncomfortable when quickshell is reloading itself, as there is a lot of visual changes happening.

### Open Questions

1. I am using `"/nix/store/"` in this patch, but maybe the store path could be overridden on the target system?
2. I am just using `file`, but I wonder if `QFileInfo(file).dir().absolutePath()` should be used instead, since it would be the absolute path and needs to be calculated already.
3. @outfoxxed Maybe this fix could be added to upstream using a compiler flag containing ignored path prefixes?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
