### PR TITLE
liquidsoap: 2.3.3 → 2.4.2

### DIFF
--- a/pkgs/development/ocaml-modules/ffmpeg/base.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/base.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub }:
 
 rec {
-  version = "1.2.5";
+  version = "1.2.8";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-ffmpeg";
     tag = "v${version}";
-    hash = "sha256-MWO8B/L/KHLuq/BIIIidsLbFwGIwt/xj+/M1zEp8Z/8=";
+    hash = "sha256-wQvpbvAAg4tybAFdGq0O9vfCc0v2iPFk04Q3zgTwa7Y=";
   };
 
   meta = {
@@ -18,6 +18,7 @@ rec {
     maintainers = with lib.maintainers; [
       dandellion
       momeemt
+      juaningan
     ];
   };
 }

--- a/pkgs/development/ocaml-modules/ffmpeg/default.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/default.nix
@@ -14,7 +14,7 @@
 buildDunePackage {
   pname = "ffmpeg";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-av.nix
@@ -12,7 +12,7 @@
 buildDunePackage {
   pname = "ffmpeg-av";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix
@@ -11,7 +11,7 @@
 buildDunePackage {
   pname = "ffmpeg-avcodec";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix
@@ -11,7 +11,7 @@
 buildDunePackage {
   pname = "ffmpeg-avdevice";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix
@@ -11,7 +11,7 @@
 buildDunePackage {
   pname = "ffmpeg-avfilter";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix
@@ -11,7 +11,7 @@
 buildDunePackage {
   pname = "ffmpeg-avutil";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix
@@ -12,7 +12,7 @@
 buildDunePackage {
   pname = "ffmpeg-swresample";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix
@@ -11,7 +11,7 @@
 buildDunePackage {
   pname = "ffmpeg-swscale";
 
-  minimalOCamlVersion = "4.08";
+  minimalOCamlVersion = "4.12";
 
   inherit (ffmpeg-base) version src;
 

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -21,26 +21,22 @@
     yt-dlp
   ],
 }:
-
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "liquidsoap";
-  version = "2.3.3";
-in
-stdenv.mkDerivation {
-  inherit pname version;
+  version = "2.4.2";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "liquidsoap";
-    tag = "v${version}";
-    hash = "sha256-EQFWFtgWvwsV+ZhO36Sd7mpxYOnd4Vv6Z+6xsgi335k=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ViJlG+AUncL37mltlFFXVho98Up11qZI3wwSnrd9C8g=";
   };
 
   postPatch = ''
-    substituteInPlace src/lang/dune \
+    substituteInPlace src/lang/base/dune \
       --replace-warn "(run git rev-parse --short HEAD)" "(run echo -n nixpkgs)"
     # Compatibility with camlimages 5.0.5
-    substituteInPlace src/core/dune \
+    substituteInPlace src/core/optionals/camlimages/dune \
       --replace-warn camlimages.all_formats camlimages.core
   '';
 
@@ -141,6 +137,7 @@ stdenv.mkDerivation {
     ocamlPackages.shine
     ocamlPackages.soundtouch
     ocamlPackages.speex
+    ocamlPackages.ocaml_sqlite3
     ocamlPackages.srt
     ocamlPackages.ssl
     ocamlPackages.taglib
@@ -160,8 +157,9 @@ stdenv.mkDerivation {
     changelog = "https://raw.githubusercontent.com/savonet/liquidsoap/main/CHANGES.md";
     maintainers = with lib.maintainers; [
       dandellion
+      juaningan
     ];
     license = lib.licenses.gpl2Plus;
     platforms = ocamlPackages.ocaml.meta.platforms or [ ];
   };
-}
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -626,25 +626,25 @@ let
 
         ffmpeg = callPackage ../development/ocaml-modules/ffmpeg { };
         ffmpeg-av = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-av.nix {
-          ffmpeg = pkgs.ffmpeg_6;
+          ffmpeg = pkgs.ffmpeg_8;
         };
         ffmpeg-avcodec = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avcodec.nix {
-          ffmpeg = pkgs.ffmpeg_6;
+          ffmpeg = pkgs.ffmpeg_8;
         };
         ffmpeg-avdevice = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avdevice.nix {
-          ffmpeg = pkgs.ffmpeg_6;
+          ffmpeg = pkgs.ffmpeg_8;
         };
         ffmpeg-avfilter = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avfilter.nix {
-          ffmpeg = pkgs.ffmpeg_6;
+          ffmpeg = pkgs.ffmpeg_8;
         };
         ffmpeg-avutil = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-avutil.nix {
-          ffmpeg = pkgs.ffmpeg_6;
+          ffmpeg = pkgs.ffmpeg_8;
         };
         ffmpeg-swresample = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swresample.nix {
-          ffmpeg = pkgs.ffmpeg_6;
+          ffmpeg = pkgs.ffmpeg_8;
         };
         ffmpeg-swscale = callPackage ../development/ocaml-modules/ffmpeg/ffmpeg-swscale.nix {
-          ffmpeg = pkgs.ffmpeg_6;
+          ffmpeg = pkgs.ffmpeg_8;
         };
 
         fiber = callPackage ../development/ocaml-modules/fiber { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

liquidsoap: 2.3.3 → 2.4.2
ocamlPackages.ffmpeg-*: 1.2.5 → 1.2.8 (ffmpeg_6.dev → ffmepg_8.dev)

https://github.com/savonet/liquidsoap/blob/v2.4.2/CHANGES.md
https://github.com/savonet/ocaml-ffmpeg/blob/v1.2.8/CHANGES

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
