### PR TITLE
or-tools: fix python installation in sandbox

### DIFF
--- a/pkgs/by-name/or/or-tools/package.nix
+++ b/pkgs/by-name/or/or-tools/package.nix
@@ -232,7 +232,12 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     cmake . -DBUILD_EXAMPLES=OFF -DBUILD_PYTHON=OFF -DBUILD_SAMPLES=OFF
     cmake --install .
-    pip install --prefix="$python" python/
+
+    # Install the Python bindings.
+    # --no-build-isolation: Required because Nix provides build tools (setuptools/wheel)
+    #   locally; without this, pip tries to download them from the internet.
+    # --no-index: Prevents pip from searching PyPI for packages.
+    pip install --no-index --no-build-isolation --prefix="$python" python/
   '';
 
   outputs = [
@@ -249,5 +254,10 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "fzn-cp-sat";
     maintainers = with lib.maintainers; [ andersk ];
     platforms = with lib.platforms; linux ++ darwin;
+
+    # Only version 9.15 adds support for Python 3.14: https://github.com/google/or-tools/releases/tag/v9.15
+    # Also this package is tied to pybind 2.13.6, and only 3.0.0 supports Python 3.14: https://github.com/pybind/pybind11/releases/tag/v3.0.0
+    # Also, nix review fails to build python314Packages.ortools
+    broken = python3.pythonAtLeast "3.14";
   };
 })


### PR DESCRIPTION
or-tools: fix python installation in sandbox
    
  - add --no-index, --no-deps, and --no-build-isolation to pip install to
    prevent network access and environment isolation in the nix sandbox
  - move BUILD_EXAMPLES and BUILD_SAMPLES to cmakeFlags to avoid
    redundant configuration in installPhase
  - add runHook preInstall/postInstall to installPhase
  - clean up bin output by disabling sample builds at the source

This fixes the librelane build which depends on this via openroad.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
