### PR TITLE
python3Packages.docling-core: 2.50.1 -> 2.60.2

### DIFF
--- a/pkgs/development/python-modules/docling-core/default.nix
+++ b/pkgs/development/python-modules/docling-core/default.nix
@@ -18,10 +18,12 @@
   semchunk,
   tabulate,
   transformers,
+  tree-sitter,
   typer,
   typing-extensions,
 
   # tests
+  gitpython,
   jsondiff,
   pytestCheckHook,
   requests,
@@ -29,14 +31,14 @@
 
 buildPythonPackage rec {
   pname = "docling-core";
-  version = "2.50.1";
+  version = "2.60.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "docling-project";
     repo = "docling-core";
     tag = "v${version}";
-    hash = "sha256-pLIWskl5nXdOC5UwvfJ3Yhl8qV6jg42P89gLj7ASpTA=";
+    hash = "sha256-KrWeh5b3w1dBk3l7S1FpgONWqP9gS6nhbLIly3Nbtvg=";
   };
 
   build-system = [
@@ -55,6 +57,7 @@ buildPythonPackage rec {
     semchunk
     tabulate
     transformers
+    tree-sitter
     typer
     typing-extensions
   ];
@@ -68,6 +71,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    gitpython
     jsondiff
     pytestCheckHook
     requests
@@ -75,13 +79,15 @@ buildPythonPackage rec {
 
   disabledTestPaths = [
     # attempts to download models
+    "test/test_code_chunker.py"
+    "test/test_code_chunking_strategy.py"
     "test/test_hybrid_chunker.py"
   ];
 
   meta = {
-    changelog = "https://github.com/DS4SD/docling-core/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/docling-project/docling-core/blob/${src.tag}/CHANGELOG.md";
     description = "Python library to define and validate data types in Docling";
-    homepage = "https://github.com/DS4SD/docling-core";
+    homepage = "https://github.com/docling-project/docling-core";
     license = lib.licenses.mit;
     maintainers = [ ];
   };


### PR DESCRIPTION
Changes:
- Add tree-sitter dependency (now required for code chunking)
- Add `gitpython` to test dependencies
- Disable tests that require network access to download models
- Update meta URLs from DS4SD to docling-project


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
