### PR TITLE
shaderc: 2025.5 -> 2026.1

### DIFF
--- a/pkgs/by-name/sh/shaderc/fix-pc-file-generation.patch
+++ b/pkgs/by-name/sh/shaderc/fix-pc-file-generation.patch
@@ -44,21 +44,7 @@ diff --git a/cmake/write_pkg_config.cmake b/cmake/write_pkg_config.cmake
 index d367ce3..18502ee 100644
 --- a/cmake/write_pkg_config.cmake
 +++ b/cmake/write_pkg_config.cmake
-@@ -16,16 +16,18 @@
- file(STRINGS ${CHANGES_FILE} CHANGES_CONTENT)
- string(
- REGEX
--  MATCH "v[0-9]+(.[0-9]+)?(-dev)? [0-9]+-[0-9]+-[0-9]+"
-+  MATCH "v[0-9]+(.[0-9]+)?(-dev)?"
-   FIRST_VERSION_LINE
-   ${CHANGES_CONTENT})
- string(
- REGEX
--  REPLACE "^v([^ ]+) .+$" "\\1"
-+  REPLACE "^v([^ ]+)$" "\\1"
-   CURRENT_VERSION
-   "${FIRST_VERSION_LINE}")
- # If this is a development version, replace "-dev" by ".0" as pkg-config nor
+@@ -28,4 +28,6 @@ REGEX
  # CMake support "-dev" in the version.
  # If it's not a "-dev" version then ensure it ends with ".1"
  string(REGEX REPLACE "-dev.1" ".0" CURRENT_VERSION "${CURRENT_VERSION}.1")

--- a/pkgs/by-name/sh/shaderc/package.nix
+++ b/pkgs/by-name/sh/shaderc/package.nix
@@ -14,7 +14,7 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "shaderc";
-  version = "2025.5";
+  version = "2026.1";
 
   outputs = [
     "out"
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "google";
     repo = "shaderc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PmGRZDXblrBhZe16QfpHfRdsRhXnGsN7o+qh14nlOUQ=";
+    hash = "sha256-OiBv18zxeE/gqY4zOMXTsCdkAEWo9BIehdu/adw0+cE=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/google/shaderc/blob/v2026.1/CHANGES

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
