### PR TITLE
{sigrok-cli, libsigrok, pulseview, libsigrok-sipeed}: bump version, init libsigrok fork

### DIFF
--- a/pkgs/applications/science/electronics/pulseview/default.nix
+++ b/pkgs/applications/science/electronics/pulseview/default.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation {
   pname = "pulseview";
-  version = "0.4.2-unstable-2025-05-15";
+  version = "0.5.0-unstable-2025-11-10";
 
   src = fetchFromGitHub {
     owner = "sigrokproject";
     repo = "pulseview";
-    rev = "e2fe9dfb91c7de85c410922ee9268c3f526bcc54";
-    hash = "sha256-b9pqtsF5J9MA7XMIgFZltrVqi64ZPObBTiaws3zSDRg=";
+    rev = "af02198741b4e57c9f9b796bd5e6c0f2ae9f2f2b";
+    hash = "sha256-4K3sMCTlFnu8iiokMYc1O7jNVQ7vTtSiT2dCpLRC44s=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libsigrok-sipeed/package.nix
+++ b/pkgs/by-name/li/libsigrok-sipeed/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  libzip,
+  glib,
+  libusb1,
+  libftdi1,
+  check,
+  libserialport,
+  doxygen,
+  glibmm,
+  python3,
+  hidapi,
+  libieee1284,
+  bluez,
+  sigrok-firmware-fx2lafw,
+}:
+#To future maintainers this package should be deprecated and or removed when https://github.com/sigrokproject/libsigrok/pull/275 gets merged
+stdenv.mkDerivation {
+  pname = "libsigrok-sipeed";
+  version = "0.6.0-unstable-2025-12-17";
+
+  #Use sipeed fork since it seems to be more up to date and supports my device
+  src = fetchFromGitHub {
+    owner = "sipeed";
+    repo = "libsigrok";
+    rev = "0ce0720421b6bcc8e65a0c94c5b2883cbfe22d7e";
+    hash = "sha256-4aqX+OX4bBsvvb7b1XHKqG6u1Ek3floXDfjr27usZwo=";
+  };
+
+  enableParallelBuilding = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    doxygen
+    pkg-config
+    python3
+  ];
+  buildInputs = [
+    libzip
+    glib
+    libusb1
+    libftdi1
+    check
+    libserialport
+    glibmm
+    hidapi
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libieee1284
+    bluez
+  ];
+
+  strictDeps = true;
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    cp contrib/*.rules $out/etc/udev/rules.d
+
+    mkdir -p "$out/share/sigrok-firmware/"
+    cp ${sigrok-firmware-fx2lafw}/share/sigrok-firmware/* "$out/share/sigrok-firmware/"
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # assert that c++ bindings are included
+    # note that this is only true for modern (>0.5) versions; the 0.3 series does not have these
+    [[ -f $out/include/libsigrokcxx/libsigrokcxx.hpp ]] \
+      || { echo 'C++ bindings were not generated; check configure output'; false; }
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "A fork of libsigrok with slogic devices support ";
+    homepage = "https://github.com/sipeed/libsigrok/";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
+      qubic
+    ];
+  };
+}

--- a/pkgs/by-name/li/libsigrok/package.nix
+++ b/pkgs/by-name/li/libsigrok/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  fetchgit,
   autoreconfHook,
   pkg-config,
   libzip,
@@ -17,16 +16,16 @@
   libieee1284,
   bluez,
   sigrok-firmware-fx2lafw,
+  fetchgit,
 }:
-
 stdenv.mkDerivation {
   pname = "libsigrok";
-  version = "0.5.2-unstable-2024-10-20";
+  version = "0.6.0-unstable-2025-11-20";
 
   src = fetchgit {
     url = "git://sigrok.org/libsigrok";
-    rev = "f06f788118191d19fdbbb37046d3bd5cec91adb1";
-    hash = "sha256-8aco5tymkCJ6ya1hyp2ODrz+dlXvZmcYoo4o9YC6D6o=";
+    rev = "0bc2487778e660f4d3116729b6f4aee2b1996bb0";
+    hash = "sha256-j79Wx5FFFKptcwtIjQ0Cvtzl46lnow6bExpMNzI8KlM=";
   };
 
   enableParallelBuilding = true;
@@ -76,6 +75,11 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Core library of the sigrok signal analysis software suite";
+    longDescription = "
+      Core library of the sigrok signal analysis software suite
+
+      Please note that if you are using slogic devices you must overlay libsigrok-sipeed as this library for your device to work
+    ";
     homepage = "https://sigrok.org/";
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/si/sigrok-cli/package.nix
+++ b/pkgs/by-name/si/sigrok-cli/package.nix
@@ -11,12 +11,12 @@
 
 stdenv.mkDerivation {
   pname = "sigrok-cli";
-  version = "0.7.2-unstable-2023-04-10";
+  version = "0.8.0-unstable-2024-08-26";
 
   src = fetchgit {
     url = "git://sigrok.org/sigrok-cli";
-    rev = "9d9f7b82008e3b3665bda12a63a3339e9f7aabc3";
-    hash = "sha256-B2FJxRkfKELrtqxZDv5QTvntpu9zJnTK15CAUYbf+5M=";
+    rev = "f44dd91347e7ac797cefc23162b9fcf0b7329f1f";
+    hash = "sha256-LJ+32XiQYfjMLYze/zICVKvqmhtyc85zvxAXXi2HIi0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated sigrok packages, and swiched libsigrok to a fork so I can use my devices (its just libsigrok with extra drivers)
Tested pulseview and sigrok-cli seems to work fine

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
