### PR TITLE
libredirect: add more functions and fixes

### DIFF
--- a/pkgs/by-name/li/libredirect/libredirect.c
+++ b/pkgs/by-name/li/libredirect/libredirect.c
@@ -390,7 +390,7 @@ WRAPPER_DEF(opendir)
 #if !defined(__APPLE__)
 WRAPPER(ssize_t, listxattr)(const char * path, char * list, size_t size)
 {
-    int (*listxattr_real) (const char *, char *, size_t) = LOOKUP_REAL(listxattr);
+    ssize_t (*listxattr_real) (const char *, char *, size_t) = LOOKUP_REAL(listxattr);
     char buf[PATH_MAX];
     return listxattr_real(rewrite(path, buf), list, size);
 }
@@ -400,7 +400,7 @@ WRAPPER_DEF(listxattr);
 #if !defined(__APPLE__)
 WRAPPER(ssize_t, llistxattr)(const char * path, char * list, size_t size)
 {
-    int (*llistxattr_real) (const char *, char *, size_t) = LOOKUP_REAL(llistxattr);
+    ssize_t (*llistxattr_real) (const char *, char *, size_t) = LOOKUP_REAL(llistxattr);
     char buf[PATH_MAX];
     return llistxattr_real(rewrite(path, buf), list, size);
 }

--- a/pkgs/by-name/li/libredirect/libredirect.c
+++ b/pkgs/by-name/li/libredirect/libredirect.c
@@ -117,14 +117,14 @@ WRAPPER(int, bind)(int socket, const struct sockaddr *addr, socklen_t addr_len)
     char buf[PATH_MAX];
     const struct sockaddr *real_addr = addr;
     if (addr->sa_family == AF_UNIX) {
-	    struct sockaddr_un real_addr_un = *(struct sockaddr_un *)addr;
-	    const char *sun_path = rewrite(real_addr_un.sun_path, buf);
-	    if (sun_path != real_addr_un.sun_path) {
-		    strncpy(real_addr_un.sun_path, buf, sizeof(real_addr_un.sun_path) - 1);
-		    real_addr_un.sun_path[sizeof(real_addr_un.sun_path) - 1] = '\0';
-		    real_addr = (struct sockaddr *)&real_addr_un;
-		    addr_len = offsetof(struct sockaddr_un, sun_path) + strlen(real_addr_un.sun_path) + 1;
-	    }
+        struct sockaddr_un real_addr_un = *(struct sockaddr_un *)addr;
+        const char *sun_path = rewrite(real_addr_un.sun_path, buf);
+        if (sun_path != real_addr_un.sun_path) {
+            strncpy(real_addr_un.sun_path, buf, sizeof(real_addr_un.sun_path) - 1);
+            real_addr_un.sun_path[sizeof(real_addr_un.sun_path) - 1] = '\0';
+            real_addr = (struct sockaddr *)&real_addr_un;
+            addr_len = offsetof(struct sockaddr_un, sun_path) + strlen(real_addr_un.sun_path) + 1;
+        }
     }
     return bind_real(socket, real_addr, addr_len);
 }
@@ -136,14 +136,14 @@ WRAPPER(int, connect)(int socket, const struct sockaddr *addr, socklen_t addr_le
     char buf[PATH_MAX];
     const struct sockaddr *real_addr = addr;
     if (addr->sa_family == AF_UNIX) {
-	    struct sockaddr_un real_addr_un = *(struct sockaddr_un *)addr;
-	    const char *sun_path = rewrite(real_addr_un.sun_path, buf);
-	    if (sun_path != real_addr_un.sun_path) {
-		    strncpy(real_addr_un.sun_path, buf, sizeof(real_addr_un.sun_path) - 1);
-		    real_addr_un.sun_path[sizeof(real_addr_un.sun_path) - 1] = '\0';
-		    real_addr = (struct sockaddr *)&real_addr_un;
-		    addr_len = offsetof(struct sockaddr_un, sun_path) + strlen(real_addr_un.sun_path) + 1;
-	    }
+        struct sockaddr_un real_addr_un = *(struct sockaddr_un *)addr;
+        const char *sun_path = rewrite(real_addr_un.sun_path, buf);
+        if (sun_path != real_addr_un.sun_path) {
+            strncpy(real_addr_un.sun_path, buf, sizeof(real_addr_un.sun_path) - 1);
+            real_addr_un.sun_path[sizeof(real_addr_un.sun_path) - 1] = '\0';
+            real_addr = (struct sockaddr *)&real_addr_un;
+            addr_len = offsetof(struct sockaddr_un, sun_path) + strlen(real_addr_un.sun_path) + 1;
+        }
     }
     return connect_real(socket, real_addr, addr_len);
 }

--- a/pkgs/by-name/li/libredirect/libredirect.c
+++ b/pkgs/by-name/li/libredirect/libredirect.c
@@ -120,8 +120,10 @@ WRAPPER(int, bind)(int socket, const struct sockaddr *addr, socklen_t addr_len)
         struct sockaddr_un real_addr_un = *(struct sockaddr_un *)addr;
         const char *sun_path = rewrite(real_addr_un.sun_path, buf);
         if (sun_path != real_addr_un.sun_path) {
-            strncpy(real_addr_un.sun_path, buf, sizeof(real_addr_un.sun_path) - 1);
-            real_addr_un.sun_path[sizeof(real_addr_un.sun_path) - 1] = '\0';
+            int n = snprintf(real_addr_un.sun_path, sizeof(real_addr_un.sun_path), "%s", buf);
+            if (n < 0 || n >= sizeof(real_addr_un.sun_path)) {
+                abort();
+            }
             real_addr = (struct sockaddr *)&real_addr_un;
             addr_len = offsetof(struct sockaddr_un, sun_path) + strlen(real_addr_un.sun_path) + 1;
         }
@@ -139,8 +141,10 @@ WRAPPER(int, connect)(int socket, const struct sockaddr *addr, socklen_t addr_le
         struct sockaddr_un real_addr_un = *(struct sockaddr_un *)addr;
         const char *sun_path = rewrite(real_addr_un.sun_path, buf);
         if (sun_path != real_addr_un.sun_path) {
-            strncpy(real_addr_un.sun_path, buf, sizeof(real_addr_un.sun_path) - 1);
-            real_addr_un.sun_path[sizeof(real_addr_un.sun_path) - 1] = '\0';
+            int n = snprintf(real_addr_un.sun_path, sizeof(real_addr_un.sun_path), "%s", buf);
+            if (n < 0 || n >= sizeof(real_addr_un.sun_path)) {
+                abort();
+            }
             real_addr = (struct sockaddr *)&real_addr_un;
             addr_len = offsetof(struct sockaddr_un, sun_path) + strlen(real_addr_un.sun_path) + 1;
         }

--- a/pkgs/by-name/li/libredirect/libredirect.c
+++ b/pkgs/by-name/li/libredirect/libredirect.c
@@ -388,6 +388,26 @@ WRAPPER(DIR *, opendir)(const char * path)
 WRAPPER_DEF(opendir)
 
 #if !defined(__APPLE__)
+WRAPPER(ssize_t, getxattr)(const char * path, const char * name, void * value, size_t size)
+{
+    ssize_t (*getxattr_real) (const char *, const char *, void *, size_t) = LOOKUP_REAL(getxattr);
+    char buf[PATH_MAX];
+    return getxattr_real(rewrite(path, buf), name, value, size);
+}
+WRAPPER_DEF(getxattr);
+#endif
+
+#if !defined(__APPLE__)
+WRAPPER(ssize_t, lgetxattr)(const char * path, const char * name, void * value, size_t size)
+{
+    ssize_t (*lgetxattr_real) (const char *, const char *, void *, size_t) = LOOKUP_REAL(lgetxattr);
+    char buf[PATH_MAX];
+    return lgetxattr_real(rewrite(path, buf), name, value, size);
+}
+WRAPPER_DEF(lgetxattr);
+#endif
+
+#if !defined(__APPLE__)
 WRAPPER(ssize_t, listxattr)(const char * path, char * list, size_t size)
 {
     ssize_t (*listxattr_real) (const char *, char *, size_t) = LOOKUP_REAL(listxattr);
@@ -405,6 +425,46 @@ WRAPPER(ssize_t, llistxattr)(const char * path, char * list, size_t size)
     return llistxattr_real(rewrite(path, buf), list, size);
 }
 WRAPPER_DEF(llistxattr);
+#endif
+
+#if !defined(__APPLE__)
+WRAPPER(int, setxattr)(const char * path, const char * name, const void * value, size_t size, int flags)
+{
+    int (*setxattr_real) (const char *, const char *, const void *, size_t, int) = LOOKUP_REAL(setxattr);
+    char buf[PATH_MAX];
+    return setxattr_real(rewrite(path, buf), name, value, size, flags);
+}
+WRAPPER_DEF(setxattr);
+#endif
+
+#if !defined(__APPLE__)
+WRAPPER(int, lsetxattr)(const char * path, const char * name, const void * value, size_t size, int flags)
+{
+    int (*lsetxattr_real) (const char *, const char *, const void *, size_t, int) = LOOKUP_REAL(lsetxattr);
+    char buf[PATH_MAX];
+    return lsetxattr_real(rewrite(path, buf), name, value, size, flags);
+}
+WRAPPER_DEF(setxattr);
+#endif
+
+#if !defined(__APPLE__)
+WRAPPER(int, removexattr)(const char * path, const char * name)
+{
+    int (*removexattr_real) (const char *, const char *) = LOOKUP_REAL(removexattr);
+    char buf[PATH_MAX];
+    return removexattr_real(rewrite(path, buf), name);
+}
+WRAPPER_DEF(removexattr);
+#endif
+
+#if !defined(__APPLE__)
+WRAPPER(int, lremovexattr)(const char * path, const char * name)
+{
+    int (*lremovexattr_real) (const char *, const char *) = LOOKUP_REAL(lremovexattr);
+    char buf[PATH_MAX];
+    return lremovexattr_real(rewrite(path, buf), name);
+}
+WRAPPER_DEF(lremovexattr);
 #endif
 
 #define SYSTEM_CMD_MAX 512


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Several commits:

*  libredirect: fixup TAB -> SPACE for indentation
*  libredirect: abort if rewritten UNIX socket path is too long
*  libredirect: fix type of listxattr, llistxattr func pointers
*  libredirect: add remaining sys/xattr.h functions that take a path

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
