### PR TITLE
home-assistant: 2026.1.2 -> 2026.1.3

### DIFF
--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -406,15 +406,14 @@ in
             http = {
               # https://www.home-assistant.io/integrations/http/
               server_host = mkOption {
-                type = types.nullOr (types.either types.str (types.listOf types.str));
-                default = null;
-                example = [
-                  "::1"
-                  "127.0.0.1"
+                type = types.either types.str (types.listOf types.str);
+                default = [
+                  "0.0.0.0"
+                  "::"
                 ];
+                example = "::1";
                 description = ''
-                  Only listen to incoming requests on specific IP/host.
-                  The option is unset by default, meaning that Home Assistant listens on all available addresses.
+                  Only listen to incoming requests on specific IP/host. The default listed assumes support for IPv4 and IPv6.
                 '';
               };
 

--- a/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix
+++ b/pkgs/development/python-modules/insteon-frontend-home-assistant/default.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "insteon-frontend-home-assistant";
-  version = "0.6.0";
+  version = "0.6.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "insteon_frontend_home_assistant";
     inherit version;
-    hash = "sha256-oBTk7gblJA6/w0wSx+efdEmY5ioJiRMUfDqjyg0LkFg=";
+    hash = "sha256-r6xXEZFAGgXByl+urpXfzhuCedBPjqkwT8Q0sEHQA2w=";
   };
 
   nativeBuildInputs = [ setuptools ];

--- a/pkgs/development/python-modules/music-assistant-client/default.nix
+++ b/pkgs/development/python-modules/music-assistant-client/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-client";
-  version = "1.3.2";
+  version = "1.3.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "client";
     tag = version;
-    hash = "sha256-7u7P3uYFxx1UFzPIOgo0fCEEJrEEdBbBE7INhinkgLQ=";
+    hash = "sha256-f5+25MWuovG/g3PscWt0jls/5Y/Qdt2kq9Ai7/9P4aI=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/music-assistant-models/default.nix
+++ b/pkgs/development/python-modules/music-assistant-models/default.nix
@@ -22,14 +22,14 @@ buildPythonPackage rec {
   pname = "music-assistant-models";
   # Must be compatible with music-assistant-client package
   # nixpkgs-update: no auto update
-  version = "1.1.70";
+  version = "1.1.89";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "models";
     tag = version;
-    hash = "sha256-yJ0MaXbzhvbqdMA1M2l7QC+0ExAHuTU1N4XIkJOj6pg=";
+    hash = "sha256-/eNCgAB5G8g1r2fcW27lySEqg+q/1bJvwwyntigGWjo=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/opower/default.nix
+++ b/pkgs/development/python-modules/opower/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "opower";
-  version = "0.16.4";
+  version = "0.16.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tronikos";
     repo = "opower";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-r1evfPKvuMXlOvpwqqOSyC80TpZWphYhDVQCi9IiI+8=";
+    hash = "sha256-MeHM6ro6SNz9w4PTCJhc3zZAIkXKujthEJaq9A5zbI8=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/volkswagencarnet/default.nix
+++ b/pkgs/development/python-modules/volkswagencarnet/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "volkswagencarnet";
-  version = "5.4.1";
+  version = "5.4.5";
   pyproject = true;
 
   src = fetchFromGitHub {

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2,7 +2,7 @@
 # Do not edit!
 
 {
-  version = "2026.1.2";
+  version = "2026.1.3";
   components = {
     "3_day_blinds" =
       ps: with ps; [

--- a/pkgs/servers/home-assistant/custom-components/daikin_onecta/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/daikin_onecta/package.nix
@@ -7,13 +7,13 @@
 buildHomeAssistantComponent rec {
   owner = "jwillemsen";
   domain = "daikin_onecta";
-  version = "4.4.4";
+  version = "4.4.5";
 
   src = fetchFromGitHub {
     owner = "jwillemsen";
     repo = "daikin_onecta";
     tag = "v${version}";
-    hash = "sha256-8a5P+eoa3iEER4b2SlsYi+feyPnc4n4RYzl6Lg+nqmQ=";
+    hash = "sha256-NO0ZRNSKE3fSSTpw9cwyD8jmKVV986bEKh27d4iiJpk=";
   };
 
   meta = {

--- a/pkgs/servers/home-assistant/custom-components/fellow/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/fellow/package.nix
@@ -7,16 +7,16 @@
   pydantic,
 }:
 
-buildHomeAssistantComponent {
+buildHomeAssistantComponent rec {
   owner = "NewsGuyTor";
   domain = "fellow";
-  version = "0-unstable-2026-01-11";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "NewsGuyTor";
     repo = "FellowAiden-HomeAssistant";
-    rev = "3a999d0e761fa1e791339753d3ccc9938adf27f6";
-    hash = "sha256-2sR8LQsV+qXrmuhr2uKuzBhM6G9IySJVA/UjRr4crDQ=";
+    tag = "v${version}";
+    hash = "sha256-cGyGobR0lMNReWCxK7RzeqsnYJZQNRPjYqirLHjeCFI=";
   };
 
   passthru.updateScript = unstableGitUpdater { };
@@ -27,6 +27,7 @@ buildHomeAssistantComponent {
   ];
 
   meta = {
+    changelog = "https://github.com/NewsGuyTor/FellowAiden-HomeAssistant/releases/tag/${src.tag}";
     description = "Home Assistant integration for Fellow Aiden coffee brewer";
     homepage = "https://github.com/NewsGuyTor/FellowAiden-HomeAssistant";
     license = lib.licenses.gpl3Only;

--- a/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mypyllant/package.nix
@@ -19,13 +19,13 @@
 buildHomeAssistantComponent rec {
   owner = "signalkraft";
   domain = "mypyllant";
-  version = "0.9.10";
+  version = "0.9.11";
 
   src = fetchFromGitHub {
     owner = "signalkraft";
     repo = "mypyllant-component";
     tag = "v${version}";
-    hash = "sha256-4IfLd+NEaWyxgdnAz7YGM/6i0usoqwgKlBJFzDOlJ4A=";
+    hash = "sha256-wkUz5pPO50yfWbZBa+Z+9WKIZKCJhJVn8/HlzZwSZVY=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/powercalc/package.nix
@@ -17,13 +17,13 @@
 buildHomeAssistantComponent rec {
   owner = "bramstroker";
   domain = "powercalc";
-  version = "1.20.2";
+  version = "1.20.3";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = "homeassistant-powercalc";
     tag = "v${version}";
-    hash = "sha256-NzWivgvDUv41fSA/6g4mYIuoUCobVUdf3bbfmKl0kWg=";
+    hash = "sha256-z66VHJ/ZzQKvx4l00XGKvTBt9o4T+hv64oCGZNDRUng=";
   };
 
   dependencies = [ numpy ];

--- a/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
@@ -10,13 +10,13 @@
 buildHomeAssistantComponent rec {
   owner = "jmcollin78";
   domain = "versatile_thermostat";
-  version = "8.6.0";
+  version = "8.6.1";
 
   src = fetchFromGitHub {
     inherit owner;
     repo = domain;
     tag = version;
-    hash = "sha256-rzNznV2YfBUxgYdc+qZeDIBVeMfwPwvDyYVON980SCg=";
+    hash = "sha256-yQMTuNinRVHIsaS8Q7aqGozN1sTbkLGvXFhEw47jUkA=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/custom-components/volkswagencarnet/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/volkswagencarnet/package.nix
@@ -10,13 +10,13 @@
 buildHomeAssistantComponent rec {
   owner = "robinostlund";
   domain = "volkswagencarnet";
-  version = "5.4.1";
+  version = "5.4.5";
 
   src = fetchFromGitHub {
     owner = "robinostlund";
     repo = "homeassistant-volkswagencarnet";
     tag = "v${version}";
-    hash = "sha256-nlidbT5dILw4rin4uUDQ8OSqUijpQuoePk20UIl5Uvo=";
+    hash = "sha256-Ye++ialp9ryC6J+ZXrRqLkuLct6sbk3+NknZo4sx4hc=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/xiaomi_miot/package.nix
@@ -11,13 +11,13 @@
 buildHomeAssistantComponent rec {
   owner = "al-one";
   domain = "xiaomi_miot";
-  version = "1.1.1";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "al-one";
     repo = "hass-xiaomi-miot";
     rev = "v${version}";
-    hash = "sha256-0B+rG2h2OMb363t0529/XjqZ9ORaT7XXk4qVyEAfNx8=";
+    hash = "sha256-S1rkrNf1rV9TDjcAfFxFj/IlHMngjp4qysx+8pN0TdI=";
   };
 
   dependencies = [

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -293,7 +293,7 @@ let
   extraBuildInputs = extraPackages python.pkgs;
 
   # Don't forget to run update-component-packages.py after updating
-  hassVersion = "2026.1.2";
+  hassVersion = "2026.1.3";
 
 in
 python.pkgs.buildPythonApplication rec {
@@ -314,13 +314,13 @@ python.pkgs.buildPythonApplication rec {
     owner = "home-assistant";
     repo = "core";
     tag = version;
-    hash = "sha256-+H+ujcJ7uYLNFfm05V7FBdogGGUSkC1b6PaWJ5Zu24k=";
+    hash = "sha256-zmS5OZaUFe45rbCil7sbVlhy0wwA+F9tBO10KvBM2PY=";
   };
 
   # Secondary source is pypi sdist for translations
   sdist = fetchPypi {
     inherit pname version;
-    hash = "sha256-uWcSCmarOtfYIVYPz8wAgO8tx15MJcEP1Wv3h8YT0xI=";
+    hash = "sha256-gs5YyR1MofSMV8TDeBGp9keIREcszZGcLvtnHOYR7uc=";
   };
 
   build-system = with python.pkgs; [

--- a/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
+++ b/pkgs/servers/home-assistant/pytest-homeassistant-custom-component.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "pytest-homeassistant-custom-component";
-  version = "0.13.307";
+  version = "0.13.308";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "MatthewFlamm";
     repo = "pytest-homeassistant-custom-component";
     tag = version;
-    hash = "sha256-E3kZEwyEmUxeRzwXQgI769mikyL1FkazmZXQFaknvlA=";
+    hash = "sha256-ErRtbRwlke4UMJuXgfvEz6rM5VY583a7Jn+sU0nLnNo=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/servers/home-assistant/stubs.nix
+++ b/pkgs/servers/home-assistant/stubs.nix
@@ -10,7 +10,7 @@
 
 buildPythonPackage rec {
   pname = "homeassistant-stubs";
-  version = "2026.1.2";
+  version = "2026.1.3";
   pyproject = true;
 
   disabled = python.version != home-assistant.python.version;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
     owner = "KapJI";
     repo = "homeassistant-stubs";
     tag = version;
-    hash = "sha256-f1decOoOyavabUC2KnScB+bnuernkyKMnKwnilViuRQ=";
+    hash = "sha256-BfowhNb9A6zyCSsSJevjEal6PXkIwmnhm4a2tNt0Qg4=";
   };
 
   build-system = [


### PR DESCRIPTION
https://github.com/home-assistant/core/releases/tag/2026.1.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
