### PR TITLE
app2unit: fix missing runtime dependency

### DIFF
--- a/pkgs/by-name/ap/app2unit/package.nix
+++ b/pkgs/by-name/ap/app2unit/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenvNoCC,
   dash,
+  xdg-terminal-exec,
   scdoc,
   fetchFromGitHub,
   nix-update-script,
@@ -48,7 +49,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontPatchShebangs = true;
   postFixup = ''
     substituteInPlace $out/bin/app2unit \
-      --replace-fail '#!/bin/sh' '#!${lib.getExe dash}'
+      --replace-fail '#!/bin/sh' '#!${lib.getExe dash}' \
+      --replace-fail 'A2U__TERMINAL_HANDLER=xdg-terminal-exec' \
+                     'A2U__TERMINAL_HANDLER=${lib.getExe xdg-terminal-exec}'
   '';
 
   meta = {

--- a/pkgs/by-name/ap/app2unit/package.nix
+++ b/pkgs/by-name/ap/app2unit/package.nix
@@ -7,6 +7,7 @@
   fetchFromGitHub,
   nix-update-script,
   installShellFiles,
+  withTerminalSupport ? true,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "app2unit";
@@ -49,7 +50,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontPatchShebangs = true;
   postFixup = ''
     substituteInPlace $out/bin/app2unit \
-      --replace-fail '#!/bin/sh' '#!${lib.getExe dash}' \
+      --replace-fail '#!/bin/sh' '#!${lib.getExe dash}'
+  ''
+  + lib.optionalString withTerminalSupport ''
+    substituteInPlace $out/bin/app2unit \
       --replace-fail 'A2U__TERMINAL_HANDLER=xdg-terminal-exec' \
                      'A2U__TERMINAL_HANDLER=${lib.getExe xdg-terminal-exec}'
   '';


### PR DESCRIPTION
The runtime dependency of xdg-terminal-exec is missing from app2unit. This PR replaces `xdg-terminal-exec` with the nix store path of the xdg-terminal-exec executable. This makes it possible to run terminal applications with app2unit without having to install xdg-terminal-exec as well.

Currently this command fails with exit code 1:

```
$ nix shell -i -k LANG -k HOME \
    .#bash .#app2unit .#htop .#which .#toybox \
    --command bash -c 'app2unit -- \
        "$(which htop | xargs dirname)/../share/applications/htop.desktop"'
Terminal launch requested but 'xdg-terminal-exec' is unavailable!
```

With the changes of the PR the above command will fail with exit code 127 instead:
```
/nix/store/j38q7z3rbj92pfxzprsay028487jxay5-app2unit-1.2.1/bin/app2unit: 2099: exec: systemd-run: not found
```

At which point it is probably okay to assume that systemd is installed for a program that only works with systemd.

If I additionally add systemd and the required env variables then `xdg-terminal-exec` will have some issues:
```
$ nix shell -i -k LANG -k HOME -k DBUS_SESSION_BUS_ADDRESS -k XDG_RUNTIME_DIR \   
    .#bash .#app2unit .#htop .#which .#toybox .#systemd \
    --command bash -c 'app2unit -- \
        "$(which htop | xargs dirname)/../share/applications/htop.desktop"'
/nix/store/ghv368xc0jihqgxkvh9z8j48xl48g1w6-xdg-terminal-exec-0.14.1/bin/.xdg-terminal-exec-wrapped: 1129: tr: not found
```

Is it okay for those packages to assume that `systemd` and `tr` is installed or should those be patched as well?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
