### PR TITLE
python3Packages.adios2: link against installed libraries

### DIFF
--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -183,6 +183,11 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "CMAKE_INSTALL_PYTHONDIR" python3Packages.python.sitePackages)
   ];
 
+  # python binding libraries should be linked against installed libraries
+  preInstall = lib.optionalString pythonSupport ''
+    export adios2_DIR=$out/lib/cmake/adios2
+  '';
+
   # Tests are time-consuming and moved to passthru.tests.withCheck.
   doCheck = false;
   dontUseNinjaCheck = true;

--- a/pkgs/by-name/ad/adios2/package.nix
+++ b/pkgs/by-name/ad/adios2/package.nix
@@ -126,8 +126,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs =
     lib.optional mpiSupport mpi
-    ++ lib.optional pythonSupport python3Packages.numpy
-    ++ lib.optional (mpiSupport && pythonSupport) adios2Packages.mpi4py;
+    # create meta package providing dist-info for python3Pacakges.adios2
+    ++ lib.optional pythonSupport (
+      python3Packages.mkPythonMetaPackage {
+        inherit (finalAttrs) pname version meta;
+        dependencies = [
+          python3Packages.numpy
+        ]
+        ++ lib.optional mpiSupport adios2Packages.mpi4py;
+      }
+    );
 
   cmakeFlags = [
     # adios2 builtin modules


### PR DESCRIPTION
This pr fix  $out/lib/python3.13/site-packages/adios2/bindings/adios2_bindings.cpython-313-darwin.so link to libraries in BUILD tree (e.g. /nix/var/nix/build/....) rather than installed libraries in $out.

Note, this is only needed  for darwin platform in recent master branch. Before that adios2_bindings.cpython-313-darwin.so refer to libraries in /nix/store/... . I am not sure what has changed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
