### PR TITLE
nixos/xen: deprecate org.xenproject.bootspec.v1

### DIFF
--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -741,22 +741,14 @@ in
 
       # Xen Bootspec extension. This extension allows NixOS bootloaders to
       # fetch the dom0 kernel paths and access the `cfg.boot.params` option.
-      bootspec.extensions = {
-        # Bootspec extension v1 is deprecated, and will be removed in 26.05
-        # It is present for backwards compatibility
-        "org.xenproject.bootspec.v1" = {
-          xen = cfg.boot.efi.path;
-          xenParams = cfg.boot.params;
-        };
-        # Bootspec extension v2 includes more detail,
-        # including supporting multiboot, and is the current supported
-        # bootspec extension
-        "org.xenproject.bootspec.v2" = {
-          efiPath = cfg.boot.efi.path;
-          multibootPath = cfg.boot.bios.path;
-          version = cfg.package.version;
-          params = cfg.boot.params;
-        };
+      # Bootspec extension v2 includes more detail,
+      # including supporting multiboot, and is the current supported
+      # bootspec extension
+      bootspec.extensions."org.xenproject.bootspec.v2" = {
+        efiPath = cfg.boot.efi.path;
+        multibootPath = cfg.boot.bios.path;
+        version = cfg.package.version;
+        params = cfg.boot.params;
       };
 
       # See the `xenBootBuilder` script in the main `let...in` statement of this file.


### PR DESCRIPTION
Slated for deprecation in NixOS 26.05. It has been fully replaced in Nixpkgs by org.xenproject.bootspec.v2 for some time now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
