### PR TITLE
fetchFrom{Forgejo,Codeberg}: init, treewide: fetchFromGitea -> fetchFromCodeberg, docs

### DIFF
--- a/doc/build-helpers/fetchers.chapter.md
+++ b/doc/build-helpers/fetchers.chapter.md
@@ -855,9 +855,11 @@ Used with Mercurial. Expects `url`, `rev`, `hash`, overridable with [`<pkg>.over
 
 A number of fetcher functions wrap part of `fetchurl` and `fetchzip`. They are mainly convenience functions intended for commonly used destinations of source code in Nixpkgs. These wrapper fetchers are listed below.
 
-## `fetchFromGitea` {#fetchfromgitea}
+## `fetchFromGitea`, `fetchFromForgejo` and `fetchFromCodeberg` {#fetchfromgitea}
 
-`fetchFromGitea` expects five arguments. `domain` is the gitea server name. `owner` is a string corresponding to the Gitea user or organization that controls this repository. `repo` corresponds to the name of the software repository. These are located at the top of every Gitea HTML page as `owner`/`repo`. `rev` corresponds to the Git commit hash or tag (e.g `v1.0`) that will be downloaded from Git. Finally, `hash` corresponds to the hash of the extracted directory. Again, other hash algorithms are also available but `hash` is currently preferred.
+`fetchFromGitea`, also aliased to `fetchFromForgejo`, expects five arguments. `domain` is the Gitea/Forgejo server name. `owner` is a string corresponding to the user or organization that controls this repository. `repo` corresponds to the name of the software repository. These are located at the top of every Gitea/Forgejo HTML page as `owner`/`repo`. `rev` corresponds to the Git commit hash or tag (e.g `v1.0`) that will be downloaded from Git. Finally, `hash` corresponds to the hash of the extracted directory. Again, other hash algorithms are also available but `hash` is currently preferred.
+
+As <codeberg.org> is currently the most popular public Forgejo server, the `fetchFromCodeberg` fetcher is also available, which pre-fills the `domain` attribute.
 
 ## `fetchFromGitHub` {#fetchfromgithub}
 

--- a/pkgs/applications/editors/vim/plugins/non-generated/cmp-async-path/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/cmp-async-path/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   vimUtils,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
   vimPlugins,
 }:
@@ -9,8 +9,7 @@ vimUtils.buildVimPlugin {
   pname = "cmp-async-path";
   version = "0-unstable-2026-01-09";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "FelipeLema";
     repo = "cmp-async-path";
     rev = "9c2374deb32c2bec8b27e928c6f57090e9a875d2";

--- a/pkgs/applications/editors/vim/plugins/non-generated/zig-vim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/zig-vim/default.nix
@@ -1,15 +1,14 @@
 {
   lib,
   vimUtils,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
 }:
 vimUtils.buildVimPlugin {
   pname = "zig.vim";
   version = "0-unstable-2026-01-16";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ziglang";
     repo = "zig.vim";
     rev = "fc01f73ce0636723a03b784b63a7a89f2f9a84ae";

--- a/pkgs/applications/networking/browsers/librewolf/src.nix
+++ b/pkgs/applications/networking/browsers/librewolf/src.nix
@@ -1,17 +1,16 @@
 {
   lib,
   fetchurl,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 let
   src = lib.importJSON ./src.json;
 in
 {
   inherit (src) packageVersion;
-  source = fetchFromGitea (
+  source = fetchFromCodeberg (
     src.source
     // {
-      domain = "codeberg.org";
       owner = "librewolf";
       repo = "source";
       fetchSubmodules = true;

--- a/pkgs/build-support/fetchcodeberg/default.nix
+++ b/pkgs/build-support/fetchcodeberg/default.nix
@@ -1,0 +1,2 @@
+{ lib, fetchFromGitea }:
+lib.makeOverridable (args: fetchFromGitea ({ domain = "codeberg.org"; } // args))

--- a/pkgs/by-name/ar/arcan/sources.nix
+++ b/pkgs/by-name/ar/arcan/sources.nix
@@ -1,6 +1,6 @@
 {
   fetchFromGitHub,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 {
@@ -10,8 +10,7 @@
         pname = "arcan";
         version = "0.7.1";
 
-        src = fetchFromGitea {
-          domain = "codeberg.org";
+        src = fetchFromCodeberg {
           owner = "letoram";
           repo = "arcan";
           tag = self.version;

--- a/pkgs/by-name/bi/bibiman/package.nix
+++ b/pkgs/by-name/bi/bibiman/package.nix
@@ -1,5 +1,5 @@
 {
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
   nix-update-script,
   rustPlatform,
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage rec {
   pname = "bibiman";
   version = "0.15.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "lukeflo";
     repo = "bibiman";
     tag = "v${version}";

--- a/pkgs/by-name/bi/biboumi/package.nix
+++ b/pkgs/by-name/bi/biboumi/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
   libuuid,
   expat,
@@ -28,8 +28,7 @@ stdenv.mkDerivation {
   pname = "biboumi";
   version = "9.0-unstable-2025-10-27";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "poezio";
     repo = "biboumi";
     rev = "61242c35bc825d58c9db4301b5696bc17428bf98";

--- a/pkgs/by-name/ca/caffeine-ng/package.nix
+++ b/pkgs/by-name/ca/caffeine-ng/package.nix
@@ -1,5 +1,5 @@
 {
-  fetchFromGitea,
+  fetchFromCodeberg,
   meson,
   ninja,
   pkg-config,
@@ -22,8 +22,7 @@ python3Packages.buildPythonApplication rec {
   version = "4.2.0";
   pyproject = false;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "WhyNotHugo";
     repo = "caffeine-ng";
     rev = "v${version}";

--- a/pkgs/by-name/ca/calamares/package.nix
+++ b/pkgs/by-name/ca/calamares/package.nix
@@ -5,7 +5,7 @@
   writeShellScriptBin,
   xdg-utils,
 
-  fetchFromGitea,
+  fetchFromCodeberg,
 
   cmake,
   ninja,
@@ -38,8 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "calamares";
   version = "3.4.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Calamares";
     repo = "calamares";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ca/cat9/package.nix
+++ b/pkgs/by-name/ca/cat9/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   stdenvNoCC,
 }:
 
@@ -8,8 +8,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cat9";
   version = "0-unstable-2025-12-26";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "letoram";
     repo = "cat9";
     rev = "8d2b30545c3e87c8f2e161d755b53c23a48bcf05";

--- a/pkgs/by-name/ce/censor/package.nix
+++ b/pkgs/by-name/ce/censor/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   python3Packages,
   wrapGAppsHook4,
   gobject-introspection,
@@ -16,8 +16,7 @@ python3Packages.buildPythonApplication rec {
   version = "0.3.0";
   pyproject = false;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "censor";
     repo = "Censor";
     tag = "v${version}";

--- a/pkgs/by-name/co/codeberg-cli/package.nix
+++ b/pkgs/by-name/co/codeberg-cli/package.nix
@@ -1,5 +1,5 @@
 {
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
   lib,
   openssl,
@@ -11,8 +11,7 @@ rustPlatform.buildRustPackage rec {
   pname = "codeberg-cli";
   version = "0.5.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Aviac";
     repo = "codeberg-cli";
     rev = "v${version}";

--- a/pkgs/by-name/co/codeberg-pages/package.nix
+++ b/pkgs/by-name/co/codeberg-pages/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildGoModule,
   nix-update-script,
 }:
@@ -9,8 +9,7 @@ buildGoModule rec {
   pname = "codeberg-pages";
   version = "6.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Codeberg";
     repo = "pages-server";
     rev = "v${version}";

--- a/pkgs/by-name/co/colorpanes/package.nix
+++ b/pkgs/by-name/co/colorpanes/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "colorpanes";
   version = "3.0.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "colorpanes";
     rev = "v${version}";

--- a/pkgs/by-name/co/comaps/package.nix
+++ b/pkgs/by-name/co/comaps/package.nix
@@ -2,7 +2,7 @@
   lib,
   organicmaps,
   fetchurl,
-  fetchFromGitea,
+  fetchFromCodeberg,
   boost,
   gtest,
   glm,
@@ -38,8 +38,7 @@ organicmaps.overrideAttrs (oldAttrs: rec {
   pname = "comaps";
   version = "2025.11.07-2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "comaps";
     repo = "comaps";
     tag = "v${version}";

--- a/pkgs/by-name/cu/cunicu/package.nix
+++ b/pkgs/by-name/cu/cunicu/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
   versionCheckHook,
   protobuf,
@@ -14,8 +14,7 @@ buildGoModule rec {
   pname = "cunicu";
   version = "0.12.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "cunicu";
     repo = "cunicu";
     rev = "v${version}";

--- a/pkgs/by-name/cu/curv/package.nix
+++ b/pkgs/by-name/cu/curv/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
   git,
   pkg-config,
@@ -29,8 +29,7 @@ stdenv.mkDerivation {
   pname = "curv";
   version = "0.5-unstable-2026-01-23";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "doug-moen";
     repo = "curv";
     rev = "17d03b534c69976ed60936beb8b7cc38e8c12c13";

--- a/pkgs/by-name/da/dabet/package.nix
+++ b/pkgs/by-name/da/dabet/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "dabet";
   version = "3.0.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "dabet";
     rev = "v${version}";

--- a/pkgs/by-name/de/delfin/package.nix
+++ b/pkgs/by-name/de/delfin/package.nix
@@ -4,7 +4,7 @@
   appstream,
   cargo,
   desktop-file-utils,
-  fetchFromGitea,
+  fetchFromCodeberg,
   gitUpdater,
   gtk4,
   libadwaita,
@@ -24,8 +24,7 @@ stdenv.mkDerivation rec {
   pname = "delfin";
   version = "0.4.8";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "avery42";
     repo = "delfin";
     rev = "v${version}";

--- a/pkgs/by-name/de/deltatouch/package.nix
+++ b/pkgs/by-name/de/deltatouch/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchFromGitHub,
   cmake,
   intltool,
@@ -32,8 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "deltatouch";
   version = "2.25.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "lk108";
     repo = "deltatouch";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/de/dev86/package.nix
+++ b/pkgs/by-name/de/dev86/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "dev86";
   version = "1.0.1-unstable-2025-02-12";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jbruchon";
     repo = "dev86";
     rev = "0332db1ceb238fa7f98603cdf4223a1d839d4b31";

--- a/pkgs/by-name/di/didu/package.nix
+++ b/pkgs/by-name/di/didu/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "didu";
   version = "2.5.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "didu";
     rev = "v${version}";

--- a/pkgs/by-name/do/door-knocker/package.nix
+++ b/pkgs/by-name/do/door-knocker/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   blueprint-compiler,
   desktop-file-utils,
   glib,
@@ -17,8 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "door-knocker";
   version = "0.8.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "tytan652";
     repo = "door-knocker";
     rev = finalAttrs.version;

--- a/pkgs/by-name/du/durden/package.nix
+++ b/pkgs/by-name/du/durden/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   stdenvNoCC,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "durden";
   version = "0.6.3";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "letoram";
     repo = "durden";
     tag = finalAttrs.version;

--- a/pkgs/by-name/du/dut/package.nix
+++ b/pkgs/by-name/du/dut/package.nix
@@ -1,15 +1,14 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 stdenv.mkDerivation {
   pname = "dut";
   version = "0-unstable-2024-07-31";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "201984";
     repo = "dut";
     rev = "041c6f26162c2286776fac246ddbda312da1563d";

--- a/pkgs/by-name/dw/dwl/package.nix
+++ b/pkgs/by-name/dw/dwl/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
   libX11,
   libinput,
@@ -41,8 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "dwl";
   version = "0.7";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dwl";
     repo = "dwl";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/ed/eduvpn-client/package.nix
+++ b/pkgs/by-name/ed/eduvpn-client/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   gdk-pixbuf,
   gobject-introspection,
   gtk3,
@@ -16,8 +16,7 @@ python3Packages.buildPythonApplication rec {
   version = "4.6.0";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "eduVPN";
     repo = "linux-app";
     rev = version;

--- a/pkgs/by-name/ev/evscript/package.nix
+++ b/pkgs/by-name/ev/evscript/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "evscript";
   version = "0.1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "valpackett";
     repo = "evscript";
     rev = version;

--- a/pkgs/by-name/fa/faircamp/package.nix
+++ b/pkgs/by-name/fa/faircamp/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   makeWrapper,
   pkg-config,
   glib,
@@ -17,8 +17,7 @@ rustPlatform.buildRustPackage rec {
   pname = "faircamp";
   version = "1.7.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "simonrepp";
     repo = "faircamp";
     rev = version;

--- a/pkgs/by-name/fc/fcft/package.nix
+++ b/pkgs/by-name/fc/fcft/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   meson,
   ninja,
@@ -35,8 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fcft";
   version = "3.3.3";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "fcft";
     rev = finalAttrs.version;

--- a/pkgs/by-name/fe/fehlstart/package.nix
+++ b/pkgs/by-name/fe/fehlstart/package.nix
@@ -5,15 +5,14 @@
   gtk3,
   glib,
   keybinder3,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 stdenv.mkDerivation {
   pname = "fehlstart";
   version = "0.5-unstable-2025-01-12";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "chuvok";
     repo = "fehlstart";
     rev = "cf08d6c3964da9abc8d1af0725894fef62352064";

--- a/pkgs/by-name/fi/find-billy/package.nix
+++ b/pkgs/by-name/fi/find-billy/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   godot_4,
   makeWrapper,
   just,
@@ -14,8 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "find-billy";
   version = "1.1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "Find-Billy";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/fj/fjo/package.nix
+++ b/pkgs/by-name/fj/fjo/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   openssl,
   pkg-config,
@@ -11,8 +11,7 @@ rustPlatform.buildRustPackage rec {
   pname = "fjo";
   version = "0.3.5";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "VoiDD";
     repo = "fjo";
     rev = "v${version}";

--- a/pkgs/by-name/fn/fnott/package.nix
+++ b/pkgs/by-name/fn/fnott/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   gitUpdater,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   meson,
   ninja,
@@ -23,8 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fnott";
   version = "1.8.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "fnott";
     rev = finalAttrs.version;

--- a/pkgs/by-name/fo/foot/package.nix
+++ b/pkgs/by-name/fo/foot/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchurl,
   runCommand,
   fcft,
@@ -99,8 +99,7 @@ stdenv.mkDerivation {
   pname = "foot";
   inherit version;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "foot";
     tag = version;

--- a/pkgs/by-name/fo/forgejo-cli/package.nix
+++ b/pkgs/by-name/fo/forgejo-cli/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   installShellFiles,
   writableTmpDirAsHomeHook,
@@ -15,8 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "forgejo-cli";
   version = "0.4.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "forgejo-contrib";
     repo = "forgejo-cli";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -24,14 +24,13 @@
   lndir,
   runCommand,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildNpmPackage,
   writableTmpDirAsHomeHook,
 }:
 
 let
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "forgejo";
     repo = "forgejo";
     inherit rev hash;

--- a/pkgs/by-name/fu/fuzzel/package.nix
+++ b/pkgs/by-name/fu/fuzzel/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   meson,
   ninja,
@@ -29,8 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "fuzzel";
   version = "1.13.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "fuzzel";
     rev = finalAttrs.version;

--- a/pkgs/by-name/fy/fyi/package.nix
+++ b/pkgs/by-name/fy/fyi/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   meson,
   ninja,
@@ -12,8 +12,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "fyi";
   version = "1.0.4";
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "fyi";
     rev = finalAttrs.version;

--- a/pkgs/by-name/ga/game-devices-udev-rules/package.nix
+++ b/pkgs/by-name/ga/game-devices-udev-rules/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   bash,
   udevCheckHook,
 }:
@@ -10,8 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "game-devices-udev-rules";
   version = "0.25";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "fabiscafe";
     repo = "game-devices-udev";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ga/gamja/package.nix
+++ b/pkgs/by-name/ga/gamja/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildNpmPackage,
   writeText,
   # https://codeberg.org/emersion/gamja/src/branch/master/doc/config-file.md
@@ -10,8 +10,7 @@ buildNpmPackage rec {
   pname = "gamja";
   version = "1.0.0-beta.11";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "emersion";
     repo = "gamja";
     rev = "v${version}";

--- a/pkgs/by-name/ge/gex/package.nix
+++ b/pkgs/by-name/ge/gex/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   libgit2,
   nix-update-script,
@@ -13,8 +13,7 @@ rustPlatform.buildRustPackage rec {
   pname = "gex";
   version = "0.6.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Piturnah";
     repo = "gex";
     tag = "v${version}";

--- a/pkgs/by-name/gi/git-pages-cli/package.nix
+++ b/pkgs/by-name/gi/git-pages-cli/package.nix
@@ -1,6 +1,6 @@
 {
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
   nix-update-script,
   versionCheckHook,
@@ -10,8 +10,7 @@ buildGoModule (finalAttrs: {
   pname = "git-pages-cli";
   version = "1.5.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "git-pages";
     repo = "git-pages-cli";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/gi/git-unroll/package.nix
+++ b/pkgs/by-name/gi/git-unroll/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   makeWrapper,
   bash,
 
@@ -17,8 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "git-unroll";
   version = "0-unstable-2025-08-14";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "gm6k";
     repo = "git-unroll";
     rev = "a66aad56af0440e1d6e807518af298264861b2c7";

--- a/pkgs/by-name/gi/gitolite/package.nix
+++ b/pkgs/by-name/gi/gitolite/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   coreutils,
-  fetchFromGitea,
+  fetchFromCodeberg,
   git,
   lib,
   makeWrapper,
@@ -14,8 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gitolite";
   version = "3.6.14";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "sitaramc";
     repo = "gitolite";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/go/go-errorlint/package.nix
+++ b/pkgs/by-name/go/go-errorlint/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
 }:
 
@@ -9,8 +9,7 @@ buildGoModule rec {
   pname = "go-errorlint";
   version = "1.9.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "polyfloyd";
     repo = "go-errorlint";
     rev = "v${version}";

--- a/pkgs/by-name/go/gose/package.nix
+++ b/pkgs/by-name/go/gose/package.nix
@@ -3,14 +3,13 @@
   buildNpmPackage,
   nix-update-script,
   versionCheckHook,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
 }:
 let
   version = "0.11.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     repo = "gose";
     owner = "stv0g";
     tag = "v${version}";

--- a/pkgs/by-name/go/gotosocial/package.nix
+++ b/pkgs/by-name/go/gotosocial/package.nix
@@ -1,19 +1,18 @@
 {
   lib,
   fetchurl,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildGo124Module,
   nixosTests,
 }:
 let
-  domain = "codeberg.org";
   owner = "superseriousbusiness";
   repo = "gotosocial";
 
   version = "0.20.3";
 
   web-assets = fetchurl {
-    url = "https://${domain}/${owner}/${repo}/releases/download/v${version}/${repo}_${version}_web-assets.tar.gz";
+    url = "https://codeberg.org/${owner}/${repo}/releases/download/v${version}/${repo}_${version}_web-assets.tar.gz";
     hash = "sha256-Xh4SgzBG2Cm4SaMb9lebW/gBv94HuVXNSjd8L+bowUg=";
   };
 in
@@ -21,8 +20,8 @@ buildGo124Module rec {
   inherit version;
   pname = repo;
 
-  src = fetchFromGitea {
-    inherit domain owner repo;
+  src = fetchFromCodeberg {
+    inherit owner repo;
     tag = "v${version}";
     hash = "sha256-tWICsPN9r3mJqcs0EHE1+QFhQCzI1pD1eXZXSi2Peo4=";
   };

--- a/pkgs/by-name/gu/guile-hoot/package.nix
+++ b/pkgs/by-name/gu/guile-hoot/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoreconfHook,
   guile,
   pkg-config,
@@ -13,8 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "guile-hoot";
   version = "0.7.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "spritely";
     repo = "hoot";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/gu/guile-json-rpc/package.nix
+++ b/pkgs/by-name/gu/guile-json-rpc/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   guile,
   pkg-config,
   guile-srfi-145,
@@ -11,8 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "guile-json-rpc";
   version = "0.5.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "scheme-json-rpc";
     tag = finalAttrs.version;

--- a/pkgs/by-name/gu/guile-lsp-server/package.nix
+++ b/pkgs/by-name/gu/guile-lsp-server/package.nix
@@ -2,7 +2,7 @@
   lib,
   guile,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   bash,
   makeWrapper,
@@ -12,8 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "guile-lsp-server";
   version = "0.4.8";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "scheme-lsp-server";
     tag = finalAttrs.version;

--- a/pkgs/by-name/gu/guile-srfi-145/package.nix
+++ b/pkgs/by-name/gu/guile-srfi-145/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   guile,
   guile-irregex,
 }:
@@ -9,8 +9,7 @@ stdenv.mkDerivation {
   pname = "guile-srfi-145";
   version = "0-unstable-2023-06-04";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "srfi";
     rev = "e598c28eb78e9c3e44f5c3c3d997ef28abb6f32e";

--- a/pkgs/by-name/gu/guile-srfi-180/package.nix
+++ b/pkgs/by-name/gu/guile-srfi-180/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   guile,
   guile-irregex,
 }:
@@ -9,8 +9,7 @@ stdenv.mkDerivation {
   pname = "guile-srfi-180";
   version = "0-unstable-2023-06-04";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "rgherdt";
     repo = "srfi";
     rev = "e598c28eb78e9c3e44f5c3c3d997ef28abb6f32e";

--- a/pkgs/by-name/gu/gumbo/package.nix
+++ b/pkgs/by-name/gu/gumbo/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoreconfHook,
 }:
 
@@ -9,8 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gumbo";
   version = "0.13.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "gumbo-parser";
     repo = "gumbo-parser";
     rev = finalAttrs.version;

--- a/pkgs/by-name/gu/gummy/package.nix
+++ b/pkgs/by-name/gu/gummy/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   testers,
   cmake,
   libX11,
@@ -23,8 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "gummy";
   version = "0.6.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "fusco";
     repo = "gummy";
     rev = finalAttrs.version;

--- a/pkgs/by-name/ha/hail/package.nix
+++ b/pkgs/by-name/ha/hail/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   fontconfig,
   freetype,
@@ -17,8 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hail";
   version = "0.3.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "periwinkle";
     repo = "hail";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ha/harmonist/package.nix
+++ b/pkgs/by-name/ha/harmonist/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "harmonist";
   version = "0.6.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "anaseto";
     repo = "harmonist";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/hx/hxtools/package.nix
+++ b/pkgs/by-name/hx/hxtools/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   autoreconfHook,
   bash,
@@ -15,8 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "hxtools";
   version = "20251011";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     tag = "rel-${finalAttrs.version}";
     owner = "jengelh";
     repo = "hxtools";

--- a/pkgs/by-name/if/ifstate/package.nix
+++ b/pkgs/by-name/if/ifstate/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   yq,
   python3Packages,
-  fetchFromGitea,
+  fetchFromCodeberg,
   iproute2,
   libbpf,
   nixosTests,
@@ -14,8 +14,7 @@
 
 let
   version = "2.2.3";
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "liske";
     repo = "ifstate";
     tag = version;

--- a/pkgs/by-name/ij/ijq/package.nix
+++ b/pkgs/by-name/ij/ijq/package.nix
@@ -1,6 +1,6 @@
 {
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
   jq,
   installShellFiles,
@@ -13,8 +13,7 @@ buildGoModule rec {
   pname = "ijq";
   version = "1.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "gpanders";
     repo = "ijq";
     rev = "v${version}";

--- a/pkgs/by-name/in/inhibridge/package.nix
+++ b/pkgs/by-name/in/inhibridge/package.nix
@@ -1,14 +1,13 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "inhibridge";
   version = "0.3.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Scrumplex";
     repo = "inhibridge";
     rev = version;

--- a/pkgs/by-name/in/inxi/package.nix
+++ b/pkgs/by-name/in/inxi/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   perl,
   perlPackages,
   makeWrapper,
@@ -65,8 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "inxi";
   version = "3.3.39-1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "smxi";
     repo = "inxi";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ip/ipam/package.nix
+++ b/pkgs/by-name/ip/ipam/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
 }:
 
@@ -10,8 +10,7 @@ buildGoModule rec {
   pname = "ipam";
   version = "0.3.0-1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "lauralani";
     repo = "ipam";
     rev = "v${version}";

--- a/pkgs/by-name/ip/ipmitool/package.nix
+++ b/pkgs/by-name/ip/ipmitool/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoreconfHook,
   pkg-config,
   openssl,
@@ -19,8 +19,7 @@ stdenv.mkDerivation {
   pname = "ipmitool";
   version = "1.8.19-unstable-2025-02-18";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "IPMITool";
     repo = "ipmitool";
     rev = "3c91e6d91ec6090fe548c55ef301c33ff20c8ed8";

--- a/pkgs/by-name/jd/jdupes/package.nix
+++ b/pkgs/by-name/jd/jdupes/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   libjodycode,
 }:
 
@@ -9,8 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "jdupes";
   version = "1.31.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jbruchon";
     repo = "jdupes";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/jo/jogger/package.nix
+++ b/pkgs/by-name/jo/jogger/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   meson,
   ninja,
@@ -23,8 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "jogger";
   version = "1.2.5";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "baarkerlounger";
     repo = "jogger";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ka/kabeljau/package.nix
+++ b/pkgs/by-name/ka/kabeljau/package.nix
@@ -1,7 +1,7 @@
 {
   stdenvNoCC,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   just,
   imagemagick,
   makeWrapper,
@@ -13,8 +13,7 @@ stdenvNoCC.mkDerivation rec {
   pname = "kabeljau";
   version = "2.1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "kabeljau";
     rev = "v${version}";

--- a/pkgs/by-name/ka/katawa-shoujo-re-engineered/package.nix
+++ b/pkgs/by-name/ka/katawa-shoujo-re-engineered/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenvNoCC,
-  fetchFromGitea,
+  fetchFromCodeberg,
   makeDesktopItem,
   copyDesktopItems,
   makeWrapper,
@@ -12,9 +12,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "katawa-shoujo-re-engineered";
   version = "2.0.3";
 
-  src = fetchFromGitea {
+  src = fetchFromCodeberg {
     # GitHub mirror at fleetingheart/ksre
-    domain = "codeberg.org";
     owner = "fhs";
     repo = "katawa-shoujo-re-engineered";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/ka/kaufkauflist/package.nix
+++ b/pkgs/by-name/ka/kaufkauflist/package.nix
@@ -3,7 +3,7 @@
   buildPackages,
   fetchFromGitHub,
   buildNpmPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
 }:
 
@@ -30,8 +30,7 @@ buildNpmPackage rec {
   pname = "kaufkauflist";
   version = "4.0.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "kaufkauflist";
     rev = "v${version}";

--- a/pkgs/by-name/ke/keyoxide-cli/package.nix
+++ b/pkgs/by-name/ke/keyoxide-cli/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchYarnDeps,
   yarnConfigHook,
   yarnBuildHook,
@@ -14,8 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "keyoxide-cli";
   version = "0.4.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "keyoxide";
     repo = "keyoxide-cli";
     tag = finalAttrs.version;

--- a/pkgs/by-name/ki/kitget/package.nix
+++ b/pkgs/by-name/ki/kitget/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   openssl,
   pkg-config,
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kitget";
   version = "0.0.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "koibtw";
     repo = "kitget";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ko/komikku/package.nix
+++ b/pkgs/by-name/ko/komikku/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   desktop-file-utils,
   gettext,
   glib,
@@ -27,8 +27,7 @@ python3.pkgs.buildPythonApplication rec {
   version = "1.101.0";
   pyproject = false;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "valos";
     repo = "Komikku";
     tag = "v${version}";

--- a/pkgs/by-name/kx/kx-aspe-cli/package.nix
+++ b/pkgs/by-name/kx/kx-aspe-cli/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   openssl,
 }:
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage rec {
   pname = "kx-aspe-cli";
   version = "0-unstable-2024-04-06";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "keyoxide";
     repo = "kx-aspe-cli";
     rev = "492df7edae95a8636bb59c4e5c1607053dab2c78";

--- a/pkgs/by-name/l8/l8w8jwt/package.nix
+++ b/pkgs/by-name/l8/l8w8jwt/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
 }:
 
@@ -9,8 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "l8w8jwt";
   version = "2.5.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "GlitchedPolygons";
     repo = "l8w8jwt";
     tag = finalAttrs.version;

--- a/pkgs/by-name/la/lauti/package.nix
+++ b/pkgs/by-name/la/lauti/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   callPackage,
   nixosTests,
 }:
 
 let
   version = "1.1.0";
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Klasse-Methode";
     repo = "lauti";
     tag = "v${version}";

--- a/pkgs/by-name/lc/lcagent/package.nix
+++ b/pkgs/by-name/lc/lcagent/package.nix
@@ -1,5 +1,5 @@
 {
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
   stdenv,
   flex,
@@ -12,8 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "lcagent";
   version = "0.1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "librecast";
     repo = "lcagent";
     tag = finalAttrs.version;

--- a/pkgs/by-name/lc/lcrq/package.nix
+++ b/pkgs/by-name/lc/lcrq/package.nix
@@ -1,14 +1,13 @@
 {
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "lcrq";
   version = "0.3.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "librecast";
     repo = "lcrq";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/lc/lcsync/package.nix
+++ b/pkgs/by-name/lc/lcsync/package.nix
@@ -1,5 +1,5 @@
 {
-  fetchFromGitea,
+  fetchFromCodeberg,
   lcrq,
   lib,
   librecast,
@@ -10,8 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "lcsync";
   version = "0.3.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "librecast";
     repo = "lcsync";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/lc/lctime/package.nix
+++ b/pkgs/by-name/lc/lctime/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   python3Packages,
-  fetchFromGitea,
+  fetchFromCodeberg,
   runCommand,
   lctime,
   ngspice,
@@ -14,8 +14,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "0.0.28";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "librecell";
     repo = "lctime";
     tag = finalAttrs.version;

--- a/pkgs/by-name/li/libHX/package.nix
+++ b/pkgs/by-name/li/libHX/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoreconfHook,
   nix-update-script,
 }:
@@ -10,8 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libHX";
   version = "5.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     tag = "v${finalAttrs.version}";
     owner = "jengelh";
     repo = "libhx";

--- a/pkgs/by-name/li/libid3tag/package.nix
+++ b/pkgs/by-name/li/libid3tag/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchpatch,
   cmake,
   gperf,
@@ -17,8 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "tenacityteam";
     repo = "libid3tag";
     rev = finalAttrs.version;

--- a/pkgs/by-name/li/libjodycode/package.nix
+++ b/pkgs/by-name/li/libjodycode/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   jdupes,
   fixDarwinDylibNames,
 }:
@@ -16,8 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jbruchon";
     repo = "libjodycode";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/li/librecast/package.nix
+++ b/pkgs/by-name/li/librecast/package.nix
@@ -1,6 +1,6 @@
 {
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lcrq,
   lib,
   libsodium,
@@ -10,8 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "librecast";
   version = "0.11.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "librecast";
     repo = "librecast";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/li/libssc/package.nix
+++ b/pkgs/by-name/li/libssc/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   meson,
   ninja,
   glib,
@@ -15,8 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "libssc";
   version = "0.2.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "DylanVanAssche";
     repo = "libssc";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/li/listenbrainz-mpd/package.nix
+++ b/pkgs/by-name/li/listenbrainz-mpd/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   stdenv,
   openssl,
@@ -15,8 +15,7 @@ rustPlatform.buildRustPackage rec {
   pname = "listenbrainz-mpd";
   version = "2.3.9";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "elomatreb";
     repo = "listenbrainz-mpd";
     rev = "v${version}";

--- a/pkgs/by-name/li/litemdview/package.nix
+++ b/pkgs/by-name/li/litemdview/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   gtkmm3,
   autoreconfHook,
   pkg-config,
@@ -12,8 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "litemdview";
   version = "0.0.32";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "g0tsu";
     repo = "litemdview";
     rev = "litemdview-${finalAttrs.version}";

--- a/pkgs/by-name/ls/lspmux/package.nix
+++ b/pkgs/by-name/ls/lspmux/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
 }:
 
@@ -8,8 +8,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lspmux";
   version = "0.3.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "p2502";
     repo = "lspmux";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/lx/lxqt-panel-profiles/package.nix
+++ b/pkgs/by-name/lx/lxqt-panel-profiles/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   python3Packages,
   qt6,
   bash,
@@ -15,8 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "lxqt-panel-profiles";
   version = "1.3";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "MrReplikant";
     repo = "lxqt-panel-profiles";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -1,6 +1,6 @@
 {
   callPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
   libxcb,
   linux-pam,
@@ -19,8 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "ly";
   version = "1.3.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "fairyglade";
     repo = "ly";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/md/mdhtml/package.nix
+++ b/pkgs/by-name/md/mdhtml/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 buildGoModule rec {
   pname = "mdhtml";
   version = "1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Tomkoid";
     repo = "mdhtml";
     rev = version;

--- a/pkgs/by-name/me/meme-bingo-web/package.nix
+++ b/pkgs/by-name/me/meme-bingo-web/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   makeWrapper,
   nix-update-script,
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage rec {
   pname = "meme-bingo-web";
   version = "1.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "meme-bingo-web";
     rev = "v${version}";

--- a/pkgs/by-name/me/mergiraf/package.nix
+++ b/pkgs/by-name/me/mergiraf/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   nix-update-script,
 
@@ -13,8 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mergiraf";
   version = "0.16.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "mergiraf";
     repo = "mergiraf";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/me/mew/package.nix
+++ b/pkgs/by-name/me/mew/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
 
   # nativeBuildInputs
   pkg-config,
@@ -18,8 +18,7 @@ stdenv.mkDerivation {
   pname = "mew";
   version = "1.0-unstable-2025-06-20";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "sewn";
     repo = "mew";
     rev = "af6440da8fe6683cf0b873e0a98c293bf02c3447";

--- a/pkgs/by-name/mi/mitra/package.nix
+++ b/pkgs/by-name/mi/mitra/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
 }:
 
@@ -10,8 +10,7 @@ rustPlatform.buildRustPackage rec {
   pname = "mitra";
   version = "4.16.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "silverpill";
     repo = "mitra";
     rev = "v${version}";

--- a/pkgs/by-name/mk/mkvtoolnix/package.nix
+++ b/pkgs/by-name/mk/mkvtoolnix/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   autoreconfHook,
   rake,
@@ -54,8 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "mkvtoolnix";
   version = "96.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "mbunkus";
     repo = "mkvtoolnix";
     tag = "release-${finalAttrs.version}";

--- a/pkgs/by-name/ml/mlmmj/package.nix
+++ b/pkgs/by-name/ml/mlmmj/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoreconfHook,
   atf,
   pkg-config,
@@ -11,8 +11,7 @@ stdenv.mkDerivation rec {
   pname = "mlmmj";
   version = "1.5.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "mlmmj";
     repo = "mlmmj";
     tag = "RELEASE_" + lib.replaceStrings [ "." ] [ "_" ] version;

--- a/pkgs/by-name/mo/mozhi/package.nix
+++ b/pkgs/by-name/mo/mozhi/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   unstableGitUpdater,
 }:
 buildGoModule {
   pname = "mozhi";
   version = "0-unstable-2026-01-10";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "aryak";
     repo = "mozhi";
     rev = "6b3f675b8d4c8fb852e88f0696d0c4d72516e618";

--- a/pkgs/by-name/mp/mpv/scripts/sponsorblock-minimal.nix
+++ b/pkgs/by-name/mp/mpv/scripts/sponsorblock-minimal.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildLua,
-  fetchFromGitea,
+  fetchFromCodeberg,
   unstableGitUpdater,
   curl,
   coreutils,
@@ -12,8 +12,7 @@ buildLua {
   version = "0-unstable-2025-12-21";
   scriptPath = "sponsorblock_minimal.lua";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jouni";
     repo = "mpv_sponsorblock_minimal";
     rev = "8f4b186d6ea46e6fe0e5e94a53dda2f50dceb576";

--- a/pkgs/by-name/ne/newsraft/package.nix
+++ b/pkgs/by-name/ne/newsraft/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   curl,
   expat,
@@ -14,8 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "newsraft";
   version = "0.35";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "newsraft";
     repo = "newsraft";
     rev = "newsraft-${finalAttrs.version}";

--- a/pkgs/by-name/ng/ngn-k/package.nix
+++ b/pkgs/by-name/ng/ngn-k/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   runtimeShell,
 }:
 
@@ -9,8 +9,7 @@ stdenv.mkDerivation {
   pname = "ngn-k";
   version = "0-unstable-2025-01-04";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ngn";
     repo = "k";
     rev = "feb51a61443dac03213c4e97edd8df679a4a3aaa";

--- a/pkgs/by-name/ni/nix-web/package.nix
+++ b/pkgs/by-name/ni/nix-web/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   openssl,
   nixVersions,
@@ -19,8 +19,7 @@ rustPlatform.buildRustPackage rec {
   pname = "nix-web";
   version = "0.4.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "gorgon";
     repo = "gorgon";
     rev = "nix-web-v${version}";

--- a/pkgs/by-name/nm/nm-file-secret-agent/package.nix
+++ b/pkgs/by-name/nm/nm-file-secret-agent/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   dbus,
   networkmanager,
@@ -11,8 +11,7 @@ rustPlatform.buildRustPackage rec {
   pname = "nm-file-secret-agent";
   version = "1.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "lilly";
     repo = "nm-file-secret-agent";
     rev = "v${version}";

--- a/pkgs/by-name/no/nodeinfo/package.nix
+++ b/pkgs/by-name/no/nodeinfo/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildGoModule,
 }:
 buildGoModule rec {
@@ -8,8 +8,7 @@ buildGoModule rec {
   version = "1.0.0";
   vendorHash = "sha256-P0klk3YWa2qprCUNUjiuF+Akxh246WCu4vwUAZmSDCw=";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "thefederationinfo";
     repo = "nodeinfo-go";
     tag = "v${version}";

--- a/pkgs/by-name/ns/nsxiv/package.nix
+++ b/pkgs/by-name/ns/nsxiv/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   giflib,
   imlib2Full,
   libXft,
@@ -15,8 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "nsxiv";
   version = "33";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "nsxiv";
     repo = "nsxiv";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/nu/nucleus/package.nix
+++ b/pkgs/by-name/nu/nucleus/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchFromGitea,
+  fetchFromCodeberg,
   ninja,
   meson,
   pkg-config,
@@ -21,8 +21,7 @@ python3Packages.buildPythonApplication {
   inherit version;
   pyproject = false;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "lo-vely";
     repo = "nucleus";
     tag = "v${version}";

--- a/pkgs/by-name/op/openpgp-card-tools/package.nix
+++ b/pkgs/by-name/op/openpgp-card-tools/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
   pkg-config,
   pcsclite,
@@ -15,8 +15,7 @@ rustPlatform.buildRustPackage rec {
   pname = "openpgp-card-tools";
   version = "0.11.10";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "openpgp-card";
     repo = "openpgp-card-tools";
     rev = "v${version}";

--- a/pkgs/by-name/ou/outfly/package.nix
+++ b/pkgs/by-name/ou/outfly/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   makeDesktopItem,
   pkg-config,
@@ -18,8 +18,7 @@
 rustPlatform.buildRustPackage rec {
   pname = "outfly";
   version = "0.14.0";
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "outfly";
     repo = "outfly";
     tag = "v${version}";

--- a/pkgs/by-name/pa/pam_mount/package.nix
+++ b/pkgs/by-name/pa/pam_mount/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoreconfHook,
   perl,
   pkg-config,
@@ -19,8 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "pam_mount";
   version = "2.22";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     tag = "v${finalAttrs.version}";
     owner = "jengelh";
     repo = "pam_mount";

--- a/pkgs/by-name/pa/pay-respects/package.nix
+++ b/pkgs/by-name/pa/pay-respects/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   versionCheckHook,
 }:
@@ -8,8 +8,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pay-respects";
   version = "0.7.9";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "iff";
     repo = "pay-respects";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/pc/pcapc/package.nix
+++ b/pkgs/by-name/pc/pcapc/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   libpcap,
 }:
 
@@ -9,8 +9,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "pcapc";
   version = "1.0.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "post-factum";
     repo = "pcapc";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/ph/phantom/package.nix
+++ b/pkgs/by-name/ph/phantom/package.nix
@@ -1,6 +1,6 @@
 {
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   qt6,
   cmark-gfm,
   cmake,
@@ -12,8 +12,7 @@ stdenv.mkDerivation {
   pname = "phantom";
   version = "0.0.0-unstable-2025-12-22";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ItsZariep";
     repo = "Phantom";
     rev = "7bba1e0a2d9b33d881fb999bb543324d14355505";

--- a/pkgs/by-name/po/poezio/package.nix
+++ b/pkgs/by-name/po/poezio/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   python3,
 }:
@@ -10,8 +10,7 @@ python3.pkgs.buildPythonApplication rec {
   version = "0.14";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "poezio";
     repo = "poezio";
     rev = "v${version}";

--- a/pkgs/by-name/qi/qiv/package.nix
+++ b/pkgs/by-name/qi/qiv/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   gtk3,
   file,
@@ -13,8 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "qiv";
   version = "3.0.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ciberandy";
     repo = "qiv";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ra/ratman/package.nix
+++ b/pkgs/by-name/ra/ratman/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchNpmDeps,
   installShellFiles,
   pkg-config,
@@ -15,8 +15,7 @@ rustPlatform.buildRustPackage rec {
   pname = "ratman";
   version = "0.7.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "irdest";
     repo = "irdest";
     tag = version;

--- a/pkgs/by-name/re/readeck/package.nix
+++ b/pkgs/by-name/re/readeck/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchNpmDeps,
   buildGoModule,
   nodejs_22,
@@ -12,8 +12,7 @@ buildGoModule rec {
   pname = "readeck";
   version = "0.21.5";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "readeck";
     repo = "readeck";
     tag = version;

--- a/pkgs/by-name/re/recordbox/package.nix
+++ b/pkgs/by-name/re/recordbox/package.nix
@@ -6,7 +6,7 @@
   cargo,
   dbus,
   desktop-file-utils,
-  fetchFromGitea,
+  fetchFromCodeberg,
   glib,
   libglycin,
   glycin-loaders,
@@ -31,8 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "recordbox";
   version = "0.10.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "edestcroix";
     repo = "Recordbox";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ri/rimgo/package.nix
+++ b/pkgs/by-name/ri/rimgo/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   buildGoModule,
   tailwindcss_3,
 }:
@@ -8,8 +8,7 @@ buildGoModule rec {
   pname = "rimgo";
   version = "1.2.6";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "rimgo";
     repo = "rimgo";
     rev = "v${version}";

--- a/pkgs/by-name/ri/river-classic/package.nix
+++ b/pkgs/by-name/ri/river-classic/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   callPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   libGL,
   libX11,
   libevdev,
@@ -29,8 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [ "out" ] ++ lib.optionals withManpages [ "man" ];
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "river";
     repo = "river-classic";
     hash = "sha256-UhWA7jmBDhktHqHds06C0GY+xzlQZZezYopsLmIAGgI=";

--- a/pkgs/by-name/rp/rpPPPoE/package.nix
+++ b/pkgs/by-name/rp/rpPPPoE/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   ppp,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "rp-pppoe";
   version = "4.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dskoll";
     repo = "rp-pppoe";
     tag = finalAttrs.version;

--- a/pkgs/by-name/rs/rsop/package.nix
+++ b/pkgs/by-name/rs/rsop/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   pcsclite,
   nix-update-script,
@@ -13,8 +13,7 @@ rustPlatform.buildRustPackage rec {
   pname = "rsop";
   version = "0.9.3";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "heiko";
     repo = "rsop";
     rev = "rsop/v${version}";

--- a/pkgs/by-name/rw/rwedid/package.nix
+++ b/pkgs/by-name/rw/rwedid/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   udevCheckHook,
   xz,
@@ -11,8 +11,7 @@ rustPlatform.buildRustPackage rec {
   pname = "rwedid";
   version = "0.3.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ral";
     repo = "rwedid";
     rev = version;

--- a/pkgs/by-name/sa/sanctity/package.nix
+++ b/pkgs/by-name/sa/sanctity/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "sanctity";
   version = "1.3.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "sanctity";
     rev = "v${version}";

--- a/pkgs/by-name/sa/satellite/package.nix
+++ b/pkgs/by-name/sa/satellite/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3,
-  fetchFromGitea,
+  fetchFromCodeberg,
   gobject-introspection,
   libadwaita,
   modemmanager,
@@ -15,8 +15,7 @@ python3.pkgs.buildPythonApplication rec {
 
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "tpikonen";
     repo = "satellite";
     tag = version;

--- a/pkgs/by-name/se/seehecht/package.nix
+++ b/pkgs/by-name/se/seehecht/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "seehecht";
   version = "3.0.3";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "seehecht";
     rev = "v${version}";

--- a/pkgs/by-name/se/seppo/package.nix
+++ b/pkgs/by-name/se/seppo/package.nix
@@ -1,6 +1,6 @@
 {
   ocamlPackages,
-  fetchFromGitea,
+  fetchFromCodeberg,
   ocaml-crunch,
   seppo,
   lib,
@@ -14,8 +14,7 @@ ocamlPackages.buildDunePackage {
   pname = "seppo";
   version = "0-unstable-2025-08-07";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "seppo";
     repo = "seppo";
     rev = "d927311cae64883fe2b88f5a1c7e17c8cc525bad";

--- a/pkgs/by-name/sn/snac2/package.nix
+++ b/pkgs/by-name/sn/snac2/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   curl,
   openssl,
   nix-update-script,
@@ -12,8 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "snac2";
   version = "2.89";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "grunfink";
     repo = "snac2";
     tag = finalAttrs.version;

--- a/pkgs/by-name/sn/snekim/package.nix
+++ b/pkgs/by-name/sn/snekim/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   buildNimPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 buildNimPackage (finalAttrs: {
   pname = "snekim";
   version = "1.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "annaaurora";
     repo = "snekim";
     rev = "v${finalAttrs.version}";

--- a/pkgs/by-name/so/soju/package.nix
+++ b/pkgs/by-name/so/soju/package.nix
@@ -1,6 +1,6 @@
 {
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
   lib,
   nixosTests,
@@ -14,8 +14,7 @@ buildGoModule (finalAttrs: {
   pname = "soju";
   version = "0.10.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "emersion";
     repo = "soju";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/so/soundalike/package.nix
+++ b/pkgs/by-name/so/soundalike/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   chromaprint,
   makeWrapper,
   versionCheckHook,
@@ -11,8 +11,7 @@ buildGoModule rec {
   pname = "soundalike";
   version = "0.1.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "derat";
     repo = "soundalike";
     tag = "v${version}";
@@ -36,8 +35,7 @@ buildGoModule rec {
   doCheck = true;
   # need to grab another repo for music test data
   testDataVersion = "0.0.1";
-  testData = fetchFromGitea {
-    domain = "codeberg.org";
+  testData = fetchFromCodeberg {
     owner = "derat";
     repo = "soundalike-testdata";
     tag = "v${testDataVersion}";

--- a/pkgs/by-name/so/soundtouch/package.nix
+++ b/pkgs/by-name/so/soundtouch/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoconf,
   automake,
   libtool,
@@ -11,8 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "soundtouch";
   version = "2.4.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "soundtouch";
     repo = "soundtouch";
     rev = finalAttrs.version;

--- a/pkgs/by-name/sq/sqlauncher/package.nix
+++ b/pkgs/by-name/sq/sqlauncher/package.nix
@@ -1,6 +1,6 @@
 {
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
   ninja,
   qt6,
@@ -11,8 +11,7 @@ stdenv.mkDerivation {
   pname = "sqlauncher";
   version = "0.0.0-unstable-2025-12-30";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ItsZariep";
     repo = "SQLauncher";
     rev = "4a82d0f5d1394f3ff850297939b62357f7f3ce0f";

--- a/pkgs/by-name/ss/ssh-openpgp-auth/generic.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/generic.nix
@@ -3,7 +3,7 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   just,
   rust-script,
@@ -23,8 +23,7 @@
 rustPlatform.buildRustPackage {
   inherit pname version;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "wiktor";
     repo = "ssh-openpgp-auth";
     # See also: https://codeberg.org/wiktor/ssh-openpgp-auth/pulls/92#issuecomment-1635274

--- a/pkgs/by-name/ss/ssh-tools/package.nix
+++ b/pkgs/by-name/ss/ssh-tools/package.nix
@@ -2,7 +2,7 @@
   lib,
   bash,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
   perl,
 }:
@@ -11,8 +11,7 @@ buildGoModule rec {
   pname = "ssh-tools";
   version = "1.9";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "vaporup";
     repo = "ssh-tools";
     tag = "v${version}";

--- a/pkgs/by-name/st/stockpile/package.nix
+++ b/pkgs/by-name/st/stockpile/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   meson,
   ninja,
   pkg-config,
@@ -17,8 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "stockpile";
   version = "0.5.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "turtle";
     repo = "stockpile";
     tag = finalAttrs.version;

--- a/pkgs/by-name/sx/sxcs/package.nix
+++ b/pkgs/by-name/sx/sxcs/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   libxcursor,
   libx11,
   installShellFiles,
@@ -11,8 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sxcs";
   version = "1.1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "NRK";
     repo = "sxcs";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/sy/synadm/package.nix
+++ b/pkgs/by-name/sy/synadm/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3Packages,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
 }:
 
@@ -10,8 +10,7 @@ python3Packages.buildPythonApplication rec {
   version = "0.49.2";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "synadm";
     repo = "synadm";
     tag = "v${version}";

--- a/pkgs/by-name/te/tenacity/package.nix
+++ b/pkgs/by-name/te/tenacity/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
   ninja,
   wxGTK32,
@@ -52,8 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "tenacity";
   version = "1.3.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "tenacityteam";
     repo = "tenacity";
     fetchSubmodules = true;

--- a/pkgs/by-name/tl/tllist/package.nix
+++ b/pkgs/by-name/tl/tllist/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   meson,
   ninja,
 }:
@@ -10,8 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "tllist";
   version = "1.1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "tllist";
     rev = finalAttrs.version;

--- a/pkgs/by-name/tu/turbocase/package.nix
+++ b/pkgs/by-name/tu/turbocase/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   python3,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -9,8 +9,7 @@ python3.pkgs.buildPythonApplication rec {
   version = "1.8.0";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "MartijnBraam";
     repo = "TurboCase";
     rev = version;

--- a/pkgs/by-name/tu/turnon/package.nix
+++ b/pkgs/by-name/tu/turnon/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   cairo,
   pango,
@@ -20,8 +20,7 @@ rustPlatform.buildRustPackage {
   pname = "turnon";
   version = version;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "swsnr";
     repo = "turnon";
     rev = "v${version}";

--- a/pkgs/by-name/tu/turntable/package.nix
+++ b/pkgs/by-name/tu/turntable/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   meson,
   ninja,
   pkg-config,
@@ -25,8 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "turntable";
   version = "0.4.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "GeopJr";
     repo = "Turntable";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ty/typesetter/package.nix
+++ b/pkgs/by-name/ty/typesetter/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
 
   # nativeBuildInputs
@@ -32,8 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "typesetter";
   version = "0.9.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "haydn";
     repo = "typesetter";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/ub/ubpm/package.nix
+++ b/pkgs/by-name/ub/ubpm/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   qt6,
   udev,
   pkg-config,
@@ -12,8 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.13.0-unstable-2025-10-18";
   baseVersion = lib.head (lib.splitString "-" finalAttrs.version);
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "LazyT";
     repo = "ubpm";
     rev = "748ce8504185ae96dbdbd1cff5352d1eef2c046d";

--- a/pkgs/by-name/up/upsies/package.nix
+++ b/pkgs/by-name/up/upsies/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchpatch,
   ffmpeg-headless,
   mediainfo,
@@ -21,8 +21,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   version = "2026.01.03";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "plotski";
     repo = "upsies";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/uw/uwu-colors/package.nix
+++ b/pkgs/by-name/uw/uwu-colors/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
 }:
 
@@ -8,8 +8,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "uwu-colors";
   version = "0.4.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "q60";
     repo = "uwu_colors";
     tag = finalAttrs.version;

--- a/pkgs/by-name/wa/wallust/package.nix
+++ b/pkgs/by-name/wa/wallust/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   rustPlatform,
   nix-update-script,
   imagemagick,
@@ -11,8 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wallust";
   version = "3.5.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "explosion-mental";
     repo = "wallust";
     rev = finalAttrs.version;

--- a/pkgs/by-name/wa/waylock/package.nix
+++ b/pkgs/by-name/wa/waylock/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   callPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   libxkbcommon,
   pam,
   pkg-config,
@@ -17,8 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "waylock";
   version = "1.5.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ifreund";
     repo = "waylock";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/wb/wbg/package.nix
+++ b/pkgs/by-name/wb/wbg/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   meson,
   ninja,
@@ -24,8 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "wbg";
   version = "1.3.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "wbg";
     tag = finalAttrs.version;

--- a/pkgs/by-name/wl/wlock/package.nix
+++ b/pkgs/by-name/wl/wlock/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   wayland-scanner,
   wayland,
@@ -16,8 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "wlock";
   version = "1.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "sewn";
     repo = "wlock";
     tag = finalAttrs.version;

--- a/pkgs/by-name/wm/wmenu/package.nix
+++ b/pkgs/by-name/wm/wmenu/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   meson,
   ninja,
@@ -20,8 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "adnano";
     repo = "wmenu";
     tag = finalAttrs.version;

--- a/pkgs/by-name/wo/woodpecker-pipeline-transform/package.nix
+++ b/pkgs/by-name/wo/woodpecker-pipeline-transform/package.nix
@@ -1,14 +1,13 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 buildGoModule rec {
   pname = "woodpecker-pipeline-transform";
   version = "0.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "lafriks";
     repo = "woodpecker-pipeline-transform";
     rev = "v${version}";

--- a/pkgs/by-name/wo/wownero/package.nix
+++ b/pkgs/by-name/wo/wownero/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchpatch,
   cmake,
   python3,
@@ -29,8 +29,7 @@ let
     rev = "633500ad8c8759995049ccd022107d1fa8a1bbc9";
     hash = "sha256-26UmESotSWnQ21VbAYEappLpkEMyl0jiuCaezRYd/sE=";
   };
-  randomwow = fetchFromGitea {
-    domain = "codeberg.org";
+  randomwow = fetchFromCodeberg {
     owner = "wownero";
     repo = "RandomWOW";
     rev = "27b099b6dd6fef6e17f58c6dfe00009e9c5df587";
@@ -41,8 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "wownero";
   version = "0.11.3.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "wownero";
     repo = "wownero";
     tag = "v${finalAttrs.version}";

--- a/pkgs/by-name/wx/wxc/package.nix
+++ b/pkgs/by-name/wx/wxc/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
   libGL,
   wxGTK32,
@@ -11,8 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "wxc";
   version = "1.0.0.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "wxHaskell";
     repo = "wxHaskell";
     rev = "wxc-${finalAttrs.version}";

--- a/pkgs/by-name/x1/x11basic/package.nix
+++ b/pkgs/by-name/x1/x11basic/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoreconfHook,
   fig2dev,
   readline,
@@ -14,8 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "x11basic";
   version = "1.28-65";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "kollo";
     repo = "X11Basic";
     tag = finalAttrs.version;

--- a/pkgs/by-name/xa/xarcan/package.nix
+++ b/pkgs/by-name/xa/xarcan/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   arcan,
   audit,
   dbus,
@@ -44,8 +44,7 @@ stdenv.mkDerivation (finalPackages: rec {
   pname = "xarcan";
   version = "0.7.1";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "letoram";
     repo = "xarcan";
     tag = version;

--- a/pkgs/by-name/xc/xcalib/package.nix
+++ b/pkgs/by-name/xc/xcalib/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
   ninja,
   libX11,
@@ -15,8 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xcalib";
   version = "0.11";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "OpenICC";
     repo = "xcalib";
     tag = finalAttrs.version;

--- a/pkgs/by-name/xd/xdg-terminal-exec-mkhl/package.nix
+++ b/pkgs/by-name/xd/xdg-terminal-exec-mkhl/package.nix
@@ -1,14 +1,13 @@
 {
   lib,
   rustPlatform,
-  fetchFromGitea,
+  fetchFromCodeberg,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "xdg-terminal-exec-mkhl";
   version = "0.2.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "mkhl";
     repo = "xdg-terminal-exec";
     rev = "v${version}";

--- a/pkgs/by-name/xm/xmppc/package.nix
+++ b/pkgs/by-name/xm/xmppc/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   autoconf-archive,
   autoreconfHook,
   pkg-config,
@@ -14,8 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "xmppc";
   version = "0.1.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "Anoxinon_e.V.";
     repo = "xmppc";
     rev = finalAttrs.version;

--- a/pkgs/by-name/xr/xrsh/package.nix
+++ b/pkgs/by-name/xr/xrsh/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   makeWrapper,
   unstableGitUpdater,
   writeShellApplication,
@@ -12,9 +12,8 @@ stdenv.mkDerivation {
   pname = "xrsh";
   version = "0-unstable-2025-05-23";
 
-  src = fetchFromGitea {
+  src = fetchFromCodeberg {
     fetchSubmodules = true;
-    domain = "codeberg.org";
     owner = "xrsh";
     repo = "xrsh";
     rev = "ab5efe4a337459886394b9c13550a543c4c4ae25";

--- a/pkgs/by-name/ya/yambar/package.nix
+++ b/pkgs/by-name/ya/yambar/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   alsa-lib,
   bison,
   fcft,
@@ -34,8 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "yambar";
   version = "1.11.0";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "yambar";
     rev = finalAttrs.version;

--- a/pkgs/by-name/zi/zig-shell-completions/package.nix
+++ b/pkgs/by-name/zi/zig-shell-completions/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
   unstableGitUpdater,
 }:
@@ -10,8 +10,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "zig-shell-completions";
   version = "0-unstable-2025-11-25";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ziglang";
     repo = "shell-completions";
     rev = "c2983a75dcbcaf3a1df74ab563a9bd3c8e7f448e";

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   cmake,
   llvmPackages,
   xcbuild,
@@ -22,8 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "zig";
   inherit version;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "ziglang";
     repo = "zig";
     rev = finalAttrs.version;

--- a/pkgs/development/hare-third-party/hare-toml/default.nix
+++ b/pkgs/development/hare-third-party/hare-toml/default.nix
@@ -1,5 +1,5 @@
 {
-  fetchFromGitea,
+  fetchFromCodeberg,
   fetchpatch,
   hareHook,
   lib,
@@ -11,8 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "hare-toml";
   version = "0.1.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "lunacb";
     repo = "hare-toml";
     rev = "v${finalAttrs.version}";

--- a/pkgs/development/misc/haskell/changelog-d/default.nix
+++ b/pkgs/development/misc/haskell/changelog-d/default.nix
@@ -6,7 +6,7 @@
   Cabal-syntax,
   containers,
   directory,
-  fetchFromGitea,
+  fetchFromCodeberg,
   filepath,
   generic-lens-lite,
   lib,
@@ -20,8 +20,7 @@
 mkDerivation rec {
   pname = "changelog-d";
   version = "1.0.2";
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "fgaz";
     repo = "changelog-d";
     rev = "v${version}";

--- a/pkgs/development/python-modules/aiobtclientapi/default.nix
+++ b/pkgs/development/python-modules/aiobtclientapi/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   aiobtclientrpc,
   async-timeout,
   httpx,
@@ -17,8 +17,7 @@ buildPythonPackage (finalAttrs: {
   version = "1.1.4";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "plotski";
     repo = "aiobtclientapi";
     tag = "v${finalAttrs.version}";

--- a/pkgs/development/python-modules/aiobtclientrpc/default.nix
+++ b/pkgs/development/python-modules/aiobtclientrpc/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   async-timeout,
   httpx,
   httpx-socks,
@@ -20,8 +20,7 @@ buildPythonPackage (finalAttrs: {
   version = "5.0.1";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "plotski";
     repo = "aiobtclientrpc";
     tag = "v${finalAttrs.version}";

--- a/pkgs/development/python-modules/aioxmpp/default.nix
+++ b/pkgs/development/python-modules/aioxmpp/default.nix
@@ -5,7 +5,7 @@
   babel,
   buildPythonPackage,
   dnspython,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lxml,
   multidict,
   pyasn1-modules,
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   version = "0.13.3";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jssfr";
     repo = "aioxmpp";
     tag = "v${version}";

--- a/pkgs/development/python-modules/clickclick/default.nix
+++ b/pkgs/development/python-modules/clickclick/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   click,
-  fetchFromGitea,
+  fetchFromCodeberg,
   flake8,
   pytest-cov-stub,
   pytestCheckHook,
@@ -16,8 +16,7 @@ buildPythonPackage rec {
   version = "20.10.2";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "hjacobs";
     repo = "python-clickclick";
     rev = version;

--- a/pkgs/development/python-modules/countryguess/default.nix
+++ b/pkgs/development/python-modules/countryguess/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pytest-mock,
   pytestCheckHook,
   setuptools,
@@ -12,8 +12,7 @@ buildPythonPackage (finalAttrs: {
   version = "0.4.9";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "plotski";
     repo = "countryguess";
     tag = "v${finalAttrs.version}";

--- a/pkgs/development/python-modules/desktop-entry-lib/default.nix
+++ b/pkgs/development/python-modules/desktop-entry-lib/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   pytestCheckHook,
-  fetchFromGitea,
+  fetchFromCodeberg,
   setuptools,
 }:
 
@@ -12,8 +12,7 @@ buildPythonPackage rec {
   pyproject = true;
 
   # We could use fetchPypi, but then the tests won't run
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "JakobDev";
     repo = "desktop-entry-lib";
     rev = version;

--- a/pkgs/development/python-modules/django-allauth/default.nix
+++ b/pkgs/development/python-modules/django-allauth/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   python,
 
   # build-system
@@ -44,8 +44,7 @@ buildPythonPackage rec {
   version = "65.14.0";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "allauth";
     repo = "django-allauth";
     tag = version;

--- a/pkgs/development/python-modules/eheimdigital/default.nix
+++ b/pkgs/development/python-modules/eheimdigital/default.nix
@@ -1,7 +1,7 @@
 {
   aiohttp,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   hatchling,
   lib,
   yarl,
@@ -12,8 +12,7 @@ buildPythonPackage rec {
   version = "1.5.0";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "autinerd";
     repo = "eheimdigital";
     tag = version;

--- a/pkgs/development/python-modules/fortune/default.nix
+++ b/pkgs/development/python-modules/fortune/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   setuptools,
 }:
 let
@@ -12,8 +12,7 @@ buildPythonPackage {
   inherit version;
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "jamesansley";
     repo = "fortune";
     tag = "v${version}";

--- a/pkgs/development/python-modules/highctidh/default.nix
+++ b/pkgs/development/python-modules/highctidh/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   setuptools,
   pytestCheckHook,
-  fetchFromGitea,
+  fetchFromCodeberg,
   gitUpdater,
 }:
 buildPythonPackage rec {
@@ -11,8 +11,7 @@ buildPythonPackage rec {
   version = "1.0.2025051200";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "vula";
     repo = "highctidh";
     tag = "v${version}";

--- a/pkgs/development/python-modules/inflate64/default.nix
+++ b/pkgs/development/python-modules/inflate64/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nix-update-script,
   setuptools,
   setuptools-scm,
@@ -13,8 +13,7 @@ buildPythonPackage rec {
   version = "1.0.2";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "miurahr";
     repo = "inflate64";
     tag = "v${version}";

--- a/pkgs/development/python-modules/liberty-parser/default.nix
+++ b/pkgs/development/python-modules/liberty-parser/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   setuptools,
   lark,
   numpy,
@@ -14,8 +14,7 @@ buildPythonPackage rec {
   version = "0.0.29";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "tok";
     repo = "liberty-parser";
     tag = version;

--- a/pkgs/development/python-modules/multivolumefile/default.nix
+++ b/pkgs/development/python-modules/multivolumefile/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   setuptools,
   setuptools-scm,
   hypothesis,
@@ -14,8 +14,7 @@ buildPythonPackage rec {
   version = "0.2.3";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "miurahr";
     repo = "multivolume";
     tag = "v${version}";

--- a/pkgs/development/python-modules/psnawp/default.nix
+++ b/pkgs/development/python-modules/psnawp/default.nix
@@ -1,6 +1,6 @@
 {
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
   poetry-core,
   pycountry,
@@ -14,8 +14,7 @@ buildPythonPackage rec {
   version = "3.0.1";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "YoshikageKira";
     repo = "psnawp";
     tag = "v${version}";

--- a/pkgs/development/python-modules/pybcj/default.nix
+++ b/pkgs/development/python-modules/pybcj/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   setuptools,
   setuptools-scm,
   hypothesis,
@@ -13,8 +13,7 @@ buildPythonPackage rec {
   version = "1.0.3";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "miurahr";
     repo = "pybcj";
     tag = "v${version}";

--- a/pkgs/development/python-modules/pydle/default.nix
+++ b/pkgs/development/python-modules/pydle/default.nix
@@ -1,6 +1,6 @@
 {
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   lib,
   nix-update-script,
   poetry-core,
@@ -13,8 +13,7 @@ buildPythonPackage rec {
   pname = "pydle";
   version = "1.1.0";
   pyproject = true;
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "shiz";
     repo = "pydle";
     tag = "v${version}";

--- a/pkgs/development/python-modules/pyimgbox/default.nix
+++ b/pkgs/development/python-modules/pyimgbox/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   beautifulsoup4,
   httpx,
   pytest-asyncio,
@@ -16,8 +16,7 @@ buildPythonPackage (finalAttrs: {
   version = "1.0.7";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "plotski";
     repo = "pyimgbox";
     tag = "v${finalAttrs.version}";

--- a/pkgs/development/python-modules/pykakasi/default.nix
+++ b/pkgs/development/python-modules/pykakasi/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   deprecated,
-  fetchFromGitea,
+  fetchFromCodeberg,
   jaconv,
   py-cpuinfo,
   pytest-benchmark,
@@ -15,8 +15,7 @@ buildPythonPackage rec {
   version = "2.3.0";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "miurahr";
     repo = "pykakasi";
     tag = "v${version}";

--- a/pkgs/development/python-modules/pyppmd/default.nix
+++ b/pkgs/development/python-modules/pyppmd/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   setuptools,
   setuptools-scm,
   hypothesis,
@@ -15,8 +15,7 @@ buildPythonPackage rec {
   version = "1.1.1";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "miurahr";
     repo = "pyppmd";
     tag = "v${version}";

--- a/pkgs/kde/third-party/krohnkite/default.nix
+++ b/pkgs/kde/third-party/krohnkite/default.nix
@@ -2,7 +2,7 @@
   lib,
   nix-update-script,
   buildNpmPackage,
-  fetchFromGitea,
+  fetchFromCodeberg,
   nodejs_22,
   kwin,
   kpackage,
@@ -12,8 +12,7 @@ buildNpmPackage (finalAttrs: {
   pname = "krohnkite";
   version = "0.9.9.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "anametologin";
     repo = "Krohnkite";
     rev = finalAttrs.version;

--- a/pkgs/os-specific/linux/shufflecake/default.nix
+++ b/pkgs/os-specific/linux/shufflecake/default.nix
@@ -3,7 +3,7 @@
   kernel,
   kernelModuleMakeFlags,
   stdenv,
-  fetchFromGitea,
+  fetchFromCodeberg,
   libgcrypt,
   lvm2,
 }:
@@ -11,8 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   name = "shufflecake";
   version = "0.5.5";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "shufflecake";
     repo = "shufflecake-c";
     rev = "v${finalAttrs.version}";

--- a/pkgs/servers/home-assistant/custom-components/gpio/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/gpio/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildHomeAssistantComponent,
-  fetchFromGitea,
+  fetchFromCodeberg,
   libgpiod,
 }:
 
@@ -10,8 +10,7 @@ buildHomeAssistantComponent rec {
   domain = "gpio";
   version = "0.0.4";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "raboof";
     repo = "ha-gpio";
     rev = "v${version}";

--- a/pkgs/tools/networking/knock/package.nix
+++ b/pkgs/tools/networking/knock/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildGoModule,
-  fetchFromGitea,
+  fetchFromCodeberg,
   installShellFiles,
 }:
 
@@ -9,8 +9,7 @@ buildGoModule rec {
   pname = "knock";
   version = "0.0.2";
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "nat-418";
     repo = "knock";
     rev = "v${version}";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -645,6 +645,8 @@ with pkgs;
 
   fetchFromGitea = callPackage ../build-support/fetchgitea { };
 
+  fetchFromForgejo = fetchFromGitea;
+
   fetchFromCodeberg = callPackage ../build-support/fetchcodeberg { };
 
   fetchFromGitHub = callPackage ../build-support/fetchgithub { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -645,6 +645,8 @@ with pkgs;
 
   fetchFromGitea = callPackage ../build-support/fetchgitea { };
 
+  fetchFromCodeberg = callPackage ../build-support/fetchcodeberg { };
+
   fetchFromGitHub = callPackage ../build-support/fetchgithub { };
 
   fetchFromBitbucket = callPackage ../build-support/fetchbitbucket { };


### PR DESCRIPTION
Closes #482855

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
