### PR TITLE
nixosTests.kmscon: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -834,6 +834,7 @@ in
   kimai = runTest ./kimai.nix;
   kismet = runTest ./kismet.nix;
   kmonad = runTest ./kmonad.nix;
+  kmscon = runTest ./kmscon.nix;
   knot = runTest ./knot.nix;
   komga = runTest ./komga.nix;
   komodo-periphery = runTest ./komodo-periphery.nix;

--- a/nixos/tests/kmscon.nix
+++ b/nixos/tests/kmscon.nix
@@ -1,0 +1,43 @@
+{ ... }:
+{
+  name = "kmscon";
+
+  nodes.machine =
+    {
+      pkgs,
+      lib,
+      ...
+    }:
+    {
+      imports = [
+        ./common/user-account.nix
+      ];
+
+      services.kmscon = {
+        enable = true;
+        hwRender = true;
+        fonts = [
+          {
+            name = "JetBrainsMono Nerd Font";
+            package = pkgs.nerd-fonts.jetbrains-mono;
+          }
+        ];
+        package = pkgs.kmscon;
+      };
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    machine.succeed(":")
+    # ^ this create a screen
+
+    with subtest("ensure we can open a tty"):
+      machine.wait_for_text("machine login:")
+      machine.send_chars("alice\n")
+      machine.wait_for_text("Password:")
+      machine.send_chars("foobar\n")
+      machine.wait_for_text("alice@machine")
+      machine.screenshot("tty.png")
+  '';
+}

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -10,24 +10,25 @@
   libGLU,
   libGL,
   pango,
-  pixman,
   pkg-config,
   docbook_xsl,
   libxslt,
   libgbm,
   ninja,
   check,
+  bash,
   buildPackages,
+  nix-update-script,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kmscon";
-  version = "9.0.0-unstable-2025-01-09";
+  version = "9.3.0";
 
   src = fetchFromGitHub {
-    owner = "Aetf";
+    owner = "kmscon";
     repo = "kmscon";
-    rev = "a81941f4464e6f9cee75bfb8a1db88c253ede33d";
-    sha256 = "sha256-l7Prt7CsYi4VCnp9xktvqqNT+4djSdO2GvP1JdxhNSI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vdM/3n3Y2FM+PLDgVuU10kkNLCSzTrFI35CaY5NxWks=";
   };
 
   strictDeps = true;
@@ -43,10 +44,11 @@ stdenv.mkDerivation {
     libtsm
     libxkbcommon
     pango
-    pixman
     systemdLibs
     libgbm
     check
+    # Needed for autoPatchShebangs when strictDeps = true
+    bash
   ];
 
   nativeBuildInputs = [
@@ -57,22 +59,18 @@ stdenv.mkDerivation {
     libxslt # xsltproc
   ];
 
-  env.NIX_CFLAGS_COMPILE =
-    lib.optionalString stdenv.cc.isGNU "-O "
-    + "-Wno-error=maybe-uninitialized -Wno-error=unused-result -Wno-error=implicit-function-declaration";
-
-  enableParallelBuilding = true;
-
   patches = [
     ./sandbox.patch # Generate system units where they should be (nix store) instead of /etc/systemd/system
   ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
 
   meta = {
     description = "KMS/DRM based System Console";
     mainProgram = "kmscon";
     homepage = "https://www.freedesktop.org/wiki/Software/kmscon/";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ccicnce113424 ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -19,6 +19,7 @@
   bash,
   buildPackages,
   nix-update-script,
+  nixosTests,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kmscon";
@@ -63,7 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./sandbox.patch # Generate system units where they should be (nix store) instead of /etc/systemd/system
   ];
 
-  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+  passthru = {
+    tests.kmscon = nixosTests.kmscon;
+    updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
+  };
 
   meta = {
     description = "KMS/DRM based System Console";

--- a/pkgs/by-name/km/kmscon/sandbox.patch
+++ b/pkgs/by-name/km/kmscon/sandbox.patch
@@ -1,25 +1,13 @@
-From d51e35a7ab936983b2a544992adae66093c6028f Mon Sep 17 00:00:00 2001
-From: hustlerone <nine-ball@tutanota.com>
-Date: Thu, 20 Feb 2025 11:05:56 +0100
-Subject: [PATCH] Patch for nixpkgs
-
----
- meson.build | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
 diff --git a/meson.build b/meson.build
-index 964b44b..4415084 100644
+index de29a32..e731bbd 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -39,7 +39,7 @@ mandir = get_option('mandir')
  moduledir = get_option('libdir') / meson.project_name()
  
  systemd_deps = dependency('systemd', required: false)
--systemdsystemunitdir = systemd_deps.get_variable('systemdsystemunitdir', default_value: get_option('libdir') / 'systemd/system')
+-systemdsystemunitdir = systemd_deps.get_variable('systemdsystemunitdir', default_value: 'lib/systemd/system')
 +systemdsystemunitdir = get_option('libdir') / 'systemd'
  
  #
  # Required dependencies
--- 
-2.47.2
-

--- a/pkgs/by-name/li/libtsm/package.nix
+++ b/pkgs/by-name/li/libtsm/package.nix
@@ -4,32 +4,39 @@
   fetchFromGitHub,
   libxkbcommon,
   pkg-config,
-  cmake,
+  meson,
+  ninja,
+  check,
+  nix-update-script,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtsm";
-  version = "4.0.2-unstable-2023-12-24";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
-    owner = "Aetf";
+    owner = "kmscon";
     repo = "libtsm";
-    rev = "69922bde02c7af83b4d48a414cc6036af7388626";
-    sha256 = "sha256-Rug3OWSbbiIivItULPNNptClIZ/PrXdQeUypAAxrUY8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8db/amwcV1a5Ho0dymQxKtOFsTN6nLUnwSobuAowSwk=";
   };
 
   buildInputs = [ libxkbcommon ];
 
   nativeBuildInputs = [
-    cmake
+    meson
+    ninja
     pkg-config
+    check
   ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--use-github-releases" ]; };
 
   meta = {
     description = "Terminal-emulator State Machine";
     homepage = "https://www.freedesktop.org/wiki/Software/kmscon/libtsm/";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ccicnce113424 ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
- Wrote this to test https://github.com/NixOS/nixpkgs/pull/483176

<img width="961" height="588" alt="image" src="https://github.com/user-attachments/assets/9358ebcf-9bd9-4529-80fb-8dd543af7924" />


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
