### PR TITLE
mate.eom: 1.28.0 -> 1.28.1

### DIFF
--- a/pkgs/desktops/mate/eom/default.nix
+++ b/pkgs/desktops/mate/eom/default.nix
@@ -1,8 +1,11 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchFromGitHub,
+  autoconf-archive,
+  autoreconfHook,
+  gtk-doc,
+  mate-common,
   pkg-config,
   gettext,
   itstool,
@@ -18,31 +21,31 @@
   mate-desktop,
   hicolor-icon-theme,
   wrapGAppsHook3,
+  yelp-tools,
   gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eom";
-  version = "1.28.0";
+  version = "1.28.1";
 
-  src = fetchurl {
-    url = "https://pub.mate-desktop.org/releases/${lib.versions.majorMinor finalAttrs.version}/eom-${finalAttrs.version}.tar.xz";
-    sha256 = "mgHKsplaGoxyWMhl6uXxgu1HMMRGcq/cOgfkI+3VOrw=";
+  src = fetchFromGitHub {
+    owner = "mate-desktop";
+    repo = "eom";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2MO8z30Styv5vAnNVFpETAZtZ+LMbgBSDq1mUQZ9X1c=";
   };
 
-  patches = [
-    # Switch to girepository-2.0
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/eom/raw/84b45dc6302f378926be390d39a7cca3ec4f26ea/f/libpeas1_pygobject352.patch";
-      hash = "sha256-HcwWXAnVzz5uuAz8Mljci2FA72TZJTD28qLvczXVtZU=";
-    })
-  ];
-
   nativeBuildInputs = [
+    autoconf-archive
+    autoreconfHook
+    gtk-doc
+    mate-common # mate-common.m4 macros
     pkg-config
     gettext
     itstool
     wrapGAppsHook3
+    yelp-tools
   ];
 
   buildInputs = [
@@ -62,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
 
   passthru.updateScript = gitUpdater {
-    url = "https://git.mate-desktop.org/eom";
     odd-unstable = true;
     rev-prefix = "v";
   };


### PR DESCRIPTION
https://github.com/mate-desktop/eom/compare/v1.28.0...v1.28.1




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
