### PR TITLE
python3Packages.foundrytools: init at 0.1.5

### DIFF
--- a/pkgs/development/python-modules/foundrytools/default.nix
+++ b/pkgs/development/python-modules/foundrytools/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  afdko,
+  cffsubr,
+  defcon,
+  dehinter,
+  fonttools,
+  ttfautohint-py,
+  ufo2ft,
+  ufolib2,
+  ufo-extractor,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "foundrytools";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ftCLI";
+    repo = "FoundryTools";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dmMu9FTr754ax6dSfz1cn/CgmMVbEECQgyZaW+66UrU=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    afdko
+    cffsubr
+    defcon
+    dehinter
+    fonttools
+    ttfautohint-py
+    ufo-extractor
+    ufo2ft
+    ufolib2
+  ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Library for working with fonts in Python";
+    homepage = "https://github.com/ftCLI/FoundryTools";
+    changelog = "https://github.com/ftCLI/FoundryTools/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      qb114514
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5832,6 +5832,8 @@ self: super: with self; {
     inherit (pkgs) foundationdb;
   };
 
+  foundrytools = callPackage ../development/python-modules/foundrytools { };
+
   fountains = callPackage ../development/python-modules/fountains { };
 
   foxdot = callPackage ../development/python-modules/foxdot { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A library for working with fonts in Python.

Homepage: https://github.com/ftCLI/FoundryTools
PyPI page: https://pypi.org/project/foundrytools/

This is a python package that is a dependent of a package uploaded in #483334.

This package has a newer version, but it can't be packed since one of its dependencies, afdko, is too old.

This pull request should be merged after #482691.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
