### PR TITLE
formats.xenLight: init

### DIFF
--- a/nixos/doc/manual/development/settings-options.section.md
+++ b/nixos/doc/manual/development/settings-options.section.md
@@ -498,6 +498,41 @@ have a predefined type and string generator already declared under
 
     :   Creates PHP array that contains both indexed and associative values. For example, `lib.mkMixedArray [ "hello" "world" ] { "nix" = "is-great"; }` returns `['hello', 'world', 'nix' => 'is-great']`
 
+`pkgs.formats.xenLight { type ? "cfg" }` []{#pkgs-formats-xenLight}
+
+:   A function taking an attribute set with values and returning a set with Xen Project Hypervisor-specific attributes `type` and `generate` as specified [below](#pkgs-formats-result).
+
+:   The `generate` function produces a minified, one-line configuration file.
+
+:   It is important to note that this function may not always produce parseable `libxenlight` configuration files. While it complies with the syntax requirements as defined in the {manpage}`xl.cfg(5)` documentation, Xen has some undocumented parsing quirks regarding the order of `SPECSTRING` key-value pairs. These quirks are most notable with `DISK_SPEC_STRING`, but a workaround for such ordering issues is to simply define values for keys that require a specific order as a preformatted string instead of an attribute set.
+
+:   For instance, the following disk configuration will produce `disk=["access=ro,vdev=hdc,devtype=cdrom,format=raw,target=/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-image.iso"]`, which *should* be valid (as none of the parameters are [Positional Parameters](https://xenbits.xen.org/docs/unstable/man/xl-disk-configuration.5.html#Positional-Parameters)), but will fail, as `libxenlight` requires `format` to be the first attribute.
+    ```nix
+    {
+      disk = [
+        {
+          format = "raw";
+          vdev = "hdc";
+          access = "ro";
+          devtype = "cdrom";
+          target = "${imageFile}";
+        }
+      ];
+    }
+    ```
+    This can be resolved by using a preformatted string instead of an attribute set:
+    ```nix
+    {
+      disk = [
+        "format=raw,vdev=hdc,access=ro,devtype=cdrom,target=${imageFile}"
+      ];
+    }
+    ```
+
+    `type`
+
+    :   A variable to determine if the function is parsing `xl.cfg` (The system-wide `xl` configuration) or `xl.conf` (Per-domain definitions). Setting this variable to anything other than `cfg` or `conf` is invalid.
+
 []{#pkgs-formats-result}
 These functions all return an attribute set with these values:
 

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1974,6 +1974,9 @@
   "pkgs-formats-php": [
     "index.html#pkgs-formats-php"
   ],
+  "pkgs-formats-xenLight": [
+    "index.html#pkgs-formats-xenLight"
+  ],
   "pkgs-formats-result": [
     "index.html#pkgs-formats-result"
   ],

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -30,19 +30,18 @@ let
     ;
 
   inherit (lib.generators)
+    mkLuaInline
     mkValueStringDefault
     toGitINI
     toINI
     toINIWithGlobalSection
     toKeyValue
     toLua
-    mkLuaInline
+    toPlist
     ;
 
   inherit (lib.types)
-    serializableValueWith
     attrsOf
-    atom
     bool
     coercedTo
     either
@@ -55,6 +54,7 @@ let
     nullOr
     oneOf
     path
+    serializableValueWith
     str
     submodule
     ;
@@ -388,7 +388,7 @@ optionalAttrs allowAliases aliases
     // {
       generate =
         name: value:
-        lib.warn
+        warn
           "Direct use of `pkgs.formats.systemd` has been deprecated, please use `pkgs.formats.systemd { }` instead."
           rawFormat.generate
           name
@@ -801,7 +801,7 @@ optionalAttrs allowAliases aliases
             ''
         ) { };
       # Alias for mkLuaInline
-      lib.mkRaw = lib.mkLuaInline;
+      lib.mkRaw = mkLuaInline;
     };
 
   nixConf =
@@ -874,7 +874,7 @@ optionalAttrs allowAliases aliases
             ${mkKeyValuePairs (filterAttrs (key: _: isExtra key) value)}
             ${extraOptions}
           '';
-          checkPhase = lib.optionalString checkConfig (
+          checkPhase = optionalString checkConfig (
             if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then
               ''
                 echo "Ignoring validation for cross-compilation"
@@ -1051,7 +1051,7 @@ optionalAttrs allowAliases aliases
         in
         valueType;
 
-      generate = name: value: pkgs.writeText name (lib.generators.toPlist { inherit escape; } value);
+      generate = name: value: pkgs.writeText name (toPlist { inherit escape; } value);
     };
 
   hcl1 =

--- a/pkgs/pkgs-lib/formats.nix
+++ b/pkgs/pkgs-lib/formats.nix
@@ -1,12 +1,18 @@
 { lib, pkgs }:
 let
   inherit (lib)
+    all
+    assertOneOf
     boolToString
+    concatLists
+    concatMapStringsSep
+    concatStrings
     concatStringsSep
     escape
     filterAttrs
     flatten
     hasPrefix
+    hasSuffix
     id
     isAttrs
     isBool
@@ -21,6 +27,8 @@ let
     optionalAttrs
     optionalString
     pipe
+    removePrefix
+    removeSuffix
     singleton
     strings
     toPretty
@@ -30,6 +38,7 @@ let
     ;
 
   inherit (lib.generators)
+    mkKeyValueDefault
     mkLuaInline
     mkValueStringDefault
     toGitINI
@@ -1076,4 +1085,153 @@ optionalAttrs allowAliases aliases
       generate = name: value: jsonFormat.generate name (mapAttrs (_: transform) value);
     };
 
+  # The Xen Project Hypervisor's `xl` configuration syntax.
+  # Useful for the entire Xen module and declarative VM configurations.
+  # https://xenbits.xen.org/docs/unstable/man/xl.cfg.5.html
+  # https://xenbits.xen.org/docs/unstable/man/xl.conf.5.html
+  xenLight =
+    {
+      type ? "cfg",
+    }:
+    assert assertOneOf "pkgs.formats.xenLight's 'type' attribute" type [
+      "cfg"
+      "conf"
+    ];
+    {
+      type =
+        let
+          valueType =
+            oneOf [
+              bool
+              float
+              int
+              path
+              str
+              (listOf valueType)
+              (listOf (attrsOf valueType))
+            ]
+            // {
+              description = "xl.${type} value";
+            };
+        in
+        attrsOf valueType;
+      generate =
+        let
+          # Modified version of lib.generators.toKeyValue that does not use
+          # newlines and parses Xen's `SPEC` and `SPEC_STRING` value types.
+          generator =
+            let
+              # This function prevents standardisedString from adding extra quotes to SPECs and SPEC_STRINGs.
+              escapedString = mapAttrs (name: value: if (isString value) then "{${value}}" else value);
+
+              # This function:
+              # - Converts our native `true` and `false` types to numeric booleans,
+              # - Adds quotes to strings that aren't lists or escaped with '{}'.
+              standardisedString =
+                v:
+                if isString v then
+                  if ((hasPrefix "[" v) && (hasSuffix "]" v)) then
+                    v
+                  else if ((hasPrefix "{" v) && (hasSuffix "}" v)) then
+                    removePrefix "{" (removeSuffix "}" v)
+                  else
+                    ''"${v}"''
+                else if v then
+                  1
+                else if !v then
+                  0
+                else
+                  v;
+
+              mkKeyValue = mkKeyValueDefault { } "=";
+
+              mkConfig =
+                {
+                  semicolon,
+                  quotes,
+                }:
+                k: v:
+                optionalString quotes ''"''
+                + (mkKeyValue k (standardisedString v))
+                + optionalString quotes ''"''
+                + optionalString semicolon ";";
+
+              mkConfigFile =
+                {
+                  semicolon ? true,
+                  quotes ? false,
+                }:
+                k: v: [
+                  (mkConfig { inherit semicolon quotes; } k (
+                    let
+                      specString = concatStringsSep "," (
+                        flatten (
+                          map (
+                            val:
+                            (concatStringsSep "" (
+                              [ ''"'' ]
+                              ++ [
+                                (concatStringsSep "," (
+                                  flatten (
+                                    mapAttrsToList (mkConfigFile {
+                                      semicolon = false;
+                                    }) (escapedString val)
+                                  )
+                                ))
+                              ]
+                              ++ [ ''"'' ]
+                            ))
+                          ) v
+                        )
+                      );
+
+                      spec = concatStringsSep "," (
+                        map (
+                          val:
+                          (concatStringsSep "" (
+                            flatten (
+                              map (
+                                val2:
+                                [ "[" ]
+                                ++ [
+                                  (concatStringsSep "," (
+                                    flatten (
+                                      mapAttrsToList (mkConfigFile {
+                                        semicolon = false;
+                                        quotes = true;
+                                      }) (escapedString val2)
+                                    )
+                                  ))
+                                ]
+                                ++ [ "]" ]
+                              ) val
+                            )
+                          ))
+                        ) v
+                      );
+
+                      standard = concatMapStringsSep "," standardisedString v;
+
+                      keyValuePairs =
+                        if (all isAttrs v) then
+                          specString
+                        else if (all isList v) then
+                          spec
+                        else if (all (!isAttrs) v) then
+                          standard
+                        else
+                          throw "pkgs.formats.xenLight: lists must include only attribute sets (SPEC_STRING), only lists (SPEC), or only simple types.";
+                    in
+                    if isList v then "[${keyValuePairs}]" else v
+                  ))
+                ];
+            in
+            attrs:
+            (removeSuffix ";" (
+              concatStrings (concatLists (mapAttrsToList (name: value: mkConfigFile { } name value) attrs))
+            ))
+            + "\n";
+        in
+        name: value: pkgs.writeText name (generator value);
+    };
 }


### PR DESCRIPTION
Split-off #363388. This PR contains the new `xenLight` format generator, with some things still pending:

- [x] Apply any outstanding reviews from the previous PR.
  - [ ] Only one left is [this review](https://github.com/NixOS/nixpkgs/pull/363388#discussion_r2239216573), but I haven't found a good way to apply it because of `flatten`. Perhaps in `spec` instead of `specString`, but generally it might be better to abstract both calls into a new function.
- [ ] Figure out how to order SPEC_STRING attributes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
