### PR TITLE
nixos/prometheus: don't create empty rule files

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/default.nix
+++ b/nixos/modules/services/monitoring/prometheus/default.nix
@@ -66,7 +66,7 @@ let
     rule_files = optionals (!(cfg.enableAgentMode)) (
       map (promtoolCheck "check rules" "rules") (
         cfg.ruleFiles
-        ++ [
+        ++ optionals (builtins.length cfg.rules > 0) [
           (pkgs.writeText "prometheus.rules" (concatStringsSep "\n" cfg.rules))
         ]
       )


### PR DESCRIPTION
When `services.prometheus.rules` is an empty list (which is the default), an empty file is still created and added to the `rule_files` list in the Prometheus configuration. That's especially inconvenient if `services.prometheus.ruleFiles` is not empty. The Prometheus configuration refers to multiple files with similar names, and one of them is empty.
```
rule_files:
- /nix/store/vblcpg8k2c9q63hqy8fxlcz9n0y3qdl0-rules-checkrules-checked
- /nix/store/2cdv4s5myskgflq86cq1qqrcyv33dc09-rules-checkrules-checked
```

So if I want to examine the rules, I get an empty file half of the time.

The goal of this change is to stop adding an empty rules file when `services.prometheus.rules` is an empty list.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
