### PR TITLE
python313Packages.pyairobotrest: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/development/python-modules/pyairobotrest/default.nix
+++ b/pkgs/development/python-modules/pyairobotrest/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyairobotrest";
-  version = "0.2.0";
+  version = "0.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mettolen";
     repo = "pyairobotrest";
-    tag = "v${version}";
-    hash = "sha256-a0xsmknDe96cOBewhwVLy2Tw5sYffh8lZR4e+q6uGz4=";
+    tag = version;
+    hash = "sha256-PYrxQgWlcF7a/gwbJLL1JFrM+5HM3nQco9Yzy3qV1HM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/pyairobotrest/default.nix
+++ b/pkgs/development/python-modules/pyairobotrest/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyairobotrest";
   version = "0.3.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "mettolen";
     repo = "pyairobotrest";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-PYrxQgWlcF7a/gwbJLL1JFrM+5HM3nQco9Yzy3qV1HM=";
   };
 
@@ -34,10 +34,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/mettolen/pyairobotrest/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/mettolen/pyairobotrest/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Python library for controlling Airobot TE1 thermostats via local REST API";
     homepage = "https://github.com/mettolen/pyairobotrest";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.dotlambda ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/mettolen/pyairobotrest/compare/0.2.0...0.3.0

Changelog: https://github.com/mettolen/pyairobotrest/blob/0.3.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
