### PR TITLE
nixos/lix: fail hard when auto-allocate-uids enabled, but experimental feature isn't

### DIFF
--- a/nixos/modules/programs/lix.nix
+++ b/nixos/modules/programs/lix.nix
@@ -111,6 +111,19 @@ in
     # Set up the environment variables for running Nix.
     environment.sessionVariables = cfg.envVars;
 
+    assertions = [
+      {
+        assertion =
+          cfg.settings.auto-allocate-uids or false
+          -> builtins.elem "auto-allocate-uids" (
+            cfg.settings.experimental-features or [ ] ++ cfg.settings.extra-experimental-features or [ ]
+          );
+        message = ''
+          Cannot enable `auto-allocate-uids` for Lix when experimental feature `auto-allocate-uids` isn't enabled!
+        '';
+      }
+    ];
+
     nix.nrBuildUsers = lib.mkDefault (
       if cfg.settings.auto-allocate-uids or false then
         0


### PR DESCRIPTION
So I wanted to try out `auto-allocate-uids`, for reviewing a different PR, but obviously I didn't check the manual and ended up with a system that couldn't build anything anymore since I had this enabled, but the experimental feature was turned off.

While one can of course roll back, I think it's trivial enough to check for this case to prevent others from running into the exact same issue.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
