### PR TITLE
python3Packages.foundrytools-cli: init at 2.0.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21523,6 +21523,12 @@
     githubId = 12017109;
     name = "Rabindra Dhakal";
   };
+  qb114514 = {
+    name = "qb114514";
+    email = "GNUqb114514@outlook.com";
+    github = "GNUqb114514";
+    githubId = 110373832;
+  };
   qbisi = {
     name = "qbisicwate";
     email = "qbisicwate@gmail.com";

--- a/pkgs/development/python-modules/foundrytools-cli/default.nix
+++ b/pkgs/development/python-modules/foundrytools-cli/default.nix
@@ -1,0 +1,45 @@
+{
+  buildPythonPackage,
+  click,
+  foundrytools,
+  loguru,
+  pathvalidate,
+  rich,
+  lib,
+  uv,
+  uv-build,
+  wheel,
+  fetchPypi,
+}:
+buildPythonPackage rec {
+  pname = "foundrytools_cli";
+  version = "2.0.4";
+  pyproject = true;
+
+  nativeBuildInputs = [
+    uv
+    uv-build
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    click
+    foundrytools
+    loguru
+    pathvalidate
+    rich
+  ];
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-gmt4GqRPs4y+CjofaBPuwaSUAZkDMMC3NpXA4x+pfuQ=";
+  };
+  meta = {
+    description = "A set of command line tools to inspect, manipulate and convert font files";
+    homepage = "https://github.com/ftCLI/FoundryTools-CLI";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      qb114514
+    ];
+  };
+}

--- a/pkgs/development/python-modules/foundrytools/default.nix
+++ b/pkgs/development/python-modules/foundrytools/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  afdko,
+  cffsubr,
+  defcon,
+  dehinter,
+  fonttools,
+  ttfautohint-py,
+  ufo2ft,
+  ufolib2,
+  fetchPypi,
+  ufo-extractor,
+}:
+buildPythonPackage rec {
+  pname = "foundrytools";
+  version = "0.1.4"; # NEWER AVAILABLE: 0.1.5
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pWHSIhj0g1jUs6ij5o2NGcDBrgJDBCXjQyJmSpYOxfo=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+  ];
+
+  propagatedBuildInputs = [
+    afdko
+    cffsubr
+    defcon
+    dehinter
+    fonttools
+    ttfautohint-py
+    ufo-extractor
+    ufo2ft
+    ufolib2
+  ];
+
+  meta = {
+    description = "A library for working with fonts in Python.";
+    homepage = "https://github.com/ftCLI/FoundryTools";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      qb114514
+    ];
+  };
+}

--- a/pkgs/development/python-modules/ufo-extractor/default.nix
+++ b/pkgs/development/python-modules/ufo-extractor/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  setuptools,
+  setuptools-scm,
+  fonttools,
+  fontfeatures,
+  fetchPypi,
+}:
+buildPythonPackage rec {
+  pname = "ufo-extractor";
+  version = "0.8.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "ufo_extractor";
+    inherit version;
+    extension = "zip";
+    hash = "sha256-5MK6NFjcwO4gOjoW2Ibzc25Qw2taTpBrl+XcxIbhhj0=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    setuptools-scm
+  ];
+
+  propagatedBuildInputs = [
+    fonttools
+    fontfeatures
+  ];
+
+  meta = {
+    description = "Tools for extracting data from font binaries into UFO objects.";
+    homepage = "https://github.com/robotools/extractor";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      qb114514
+    ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5783,6 +5783,8 @@ self: super: with self; {
     inherit (pkgs) foundationdb;
   };
 
+  foundrytools = callPackage ../development/python-modules/foundrytools { };
+
   fountains = callPackage ../development/python-modules/fountains { };
 
   foxdot = callPackage ../development/python-modules/foxdot { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20010,6 +20010,8 @@ self: super: with self; {
 
   ufmt = callPackage ../development/python-modules/ufmt { };
 
+  ufo-extractor = callPackage ../development/python-modules/ufo-extractor { };
+
   ufo2ft = callPackage ../development/python-modules/ufo2ft { };
 
   ufolib2 = callPackage ../development/python-modules/ufolib2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5785,6 +5785,8 @@ self: super: with self; {
 
   foundrytools = callPackage ../development/python-modules/foundrytools { };
 
+  foundrytools-cli = callPackage ../development/python-modules/foundrytools-cli { };
+
   fountains = callPackage ../development/python-modules/fountains { };
 
   foxdot = callPackage ../development/python-modules/foxdot { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A set of command line tools to inspect, manipulate and convert font files

Homepage: https://github.com/ftCLI/FoundryTools-CLI
PyPI page: https://pypi.org/project/foundrytools-cli/

This pull request should be merged after #483275.

This package has a newer version, but it can't be packed since one of its dependencies, uv-build, is too old.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
