### PR TITLE
cargo-watchdoc: init at 0.3.9

### DIFF
--- a/pkgs/by-name/ca/cargo-watchdoc/package.nix
+++ b/pkgs/by-name/ca/cargo-watchdoc/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cargo-watchdoc";
+  version = "0.3.9";
+
+  src = fetchFromGitHub {
+    owner = "romnn";
+    repo = "cargo-watchdoc";
+    rev = "v${version}";
+    sha256 = "sha256-7GBGqEWSy4ncR4o+IdUVXireg+ju6AUBSDyqmKcYUaI=";
+  };
+
+  cargoHash = "sha256-P5RlnZyzVcKYgD2TZRgUdafssJRj4ueYA+iLEltV8O0=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "Generate and serve your crates documentation with hot-reloading during development";
+    mainProgram = "cargo-watchdoc";
+    homepage = "https://github.com/romnn/cargo-watchdoc";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [
+      matthiasbeyer
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

:warning: this packages https://github.com/romnn/cargo-watchdoc - which _seems_ to be a fork of the (seemingly) not maintained https://github.com/ModProg/cargo-watchdoc - which is what is on crates.io.

One thing to note: The git commit history of the former does not include anything from the latter repository. Which is _kinda_ suspicious.

I don't know whether this is okay in nixpkgs... please tell me what the right thing to do is here.

:warning: Because of the above, this is a draft.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
