### PR TITLE
cos-cli: init at 0.1.0-git

### DIFF
--- a/pkgs/by-name/co/cos-cli/package.nix
+++ b/pkgs/by-name/co/cos-cli/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+  cosmic-comp,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cos-cli";
+  version = "0.1.0-git";
+
+  src = fetchFromGitHub {
+    owner = "estin";
+    repo = "cos-cli";
+    rev = "9c23bd2f66b05e54e36a82f6dc93c14a62fc054f";
+    hash = "sha256-xTRJjgi3FDCKoxRdQU6Xuf2vV5PEZXWhNcon17LIbfw=";
+  };
+
+  cargoHash = "sha256-11jOmXTkp/J0j7BZuLltnSk4I5Ssj8iyeRvE2pYXDhw=";
+
+  doInstallCheck = true;
+
+  # TODO
+  # nativeInstallCheckInputs = [ versionCheckHook ];
+  # versionCheckProgram = #"${placeholder "out"}/bin/cos-cli";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A CLI utility for COSMIC Wayland toplevel and workspace management";
+
+    # TODO
+    # changelog = "https://github.com/cosmic-utils/cosmic-ctl/releases/tag/v${finalAttrs.version}";
+
+    homepage = "https://github.com/estin/cos-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hiro98 ];
+    mainProgram = "cos-cli";
+    inherit (cosmic-comp.meta) platforms;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
