### PR TITLE
en-croissant: 0.11.1 -> 0.12.2

### DIFF
--- a/pkgs/by-name/en/en-croissant/en-croissant-update-tauri-utils.patch
+++ b/pkgs/by-name/en/en-croissant/en-croissant-update-tauri-utils.patch
@@ -1,0 +1,166 @@
+diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
+index f4bc16e..cae6562 100644
+--- a/src-tauri/Cargo.lock
++++ b/src-tauri/Cargo.lock
+@@ -545,6 +545,17 @@ dependencies = [
+  "brotli-decompressor",
+ ]
+ 
++[[package]]
++name = "brotli"
++version = "7.0.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
++dependencies = [
++ "alloc-no-stdlib",
++ "alloc-stdlib",
++ "brotli-decompressor",
++]
++
+ [[package]]
+ name = "brotli-decompressor"
+ version = "4.0.1"
+@@ -690,16 +701,16 @@ dependencies = [
+ 
+ [[package]]
+ name = "cargo_metadata"
+-version = "0.18.1"
++version = "0.19.2"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
++checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+ dependencies = [
+  "camino",
+  "cargo-platform",
+  "semver",
+  "serde",
+  "serde_json",
+- "thiserror 1.0.63",
++ "thiserror 2.0.17",
+ ]
+ 
+ [[package]]
+@@ -2661,7 +2672,19 @@ version = "2.0.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+ dependencies = [
+- "jsonptr",
++ "jsonptr 0.4.7",
++ "serde",
++ "serde_json",
++ "thiserror 1.0.63",
++]
++
++[[package]]
++name = "json-patch"
++version = "3.0.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
++dependencies = [
++ "jsonptr 0.6.3",
+  "serde",
+  "serde_json",
+  "thiserror 1.0.63",
+@@ -2678,6 +2701,16 @@ dependencies = [
+  "serde_json",
+ ]
+ 
++[[package]]
++name = "jsonptr"
++version = "0.6.3"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
++dependencies = [
++ "serde",
++ "serde_json",
++]
++
+ [[package]]
+ name = "keyboard-types"
+ version = "0.7.0"
+@@ -4614,13 +4647,15 @@ dependencies = [
+ 
+ [[package]]
+ name = "serde_json"
+-version = "1.0.114"
++version = "1.0.149"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
++checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+ dependencies = [
+  "itoa 1.0.10",
+- "ryu",
++ "memchr",
+  "serde",
++ "serde_core",
++ "zmij",
+ ]
+ 
+ [[package]]
+@@ -5237,7 +5272,7 @@ dependencies = [
+  "dirs",
+  "glob",
+  "heck 0.5.0",
+- "json-patch",
++ "json-patch 2.0.0",
+  "schemars",
+  "semver",
+  "serde",
+@@ -5255,9 +5290,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "95d7443dd4f0b597704b6a14b964ee2ed16e99928d8e6292ae9825f09fbcd30e"
+ dependencies = [
+  "base64 0.22.1",
+- "brotli",
++ "brotli 6.0.0",
+  "ico",
+- "json-patch",
++ "json-patch 2.0.0",
+  "plist",
+  "png",
+  "proc-macro2",
+@@ -5573,18 +5608,19 @@ dependencies = [
+ 
+ [[package]]
+ name = "tauri-utils"
+-version = "2.0.1"
++version = "2.1.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c38b0230d6880cf6dd07b6d7dd7789a0869f98ac12146e0d18d1c1049215a045"
++checksum = "96fb10e7cc97456b2d5b9c03e335b5de5da982039a303a20d10006885e4523a0"
+ dependencies = [
+- "brotli",
++ "brotli 7.0.0",
+  "cargo_metadata",
+  "ctor",
+  "dunce",
+  "glob",
+  "html5ever",
++ "http 1.1.0",
+  "infer",
+- "json-patch",
++ "json-patch 3.0.1",
+  "kuchikiki",
+  "log",
+  "memchr",
+@@ -5599,7 +5635,7 @@ dependencies = [
+  "serde_json",
+  "serde_with",
+  "swift-rs",
+- "thiserror 1.0.63",
++ "thiserror 2.0.17",
+  "toml 0.8.2",
+  "url",
+  "urlpattern",
+@@ -7031,6 +7067,12 @@ dependencies = [
+  "zstd",
+ ]
+ 
++[[package]]
++name = "zmij"
++version = "1.0.12"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
++
+ [[package]]
+ name = "zopfli"
+ version = "0.8.1"

--- a/pkgs/by-name/en/en-croissant/package.nix
+++ b/pkgs/by-name/en/en-croissant/package.nix
@@ -3,54 +3,73 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
-
-  pnpm_9,
   fetchPnpmDeps,
-  pnpmConfigHook,
+
   nodejs,
-  cargo-tauri_1,
+  pnpm_10,
+  pnpmConfigHook,
+  cargo-tauri,
+  jq,
+  moreutils,
   pkg-config,
   wrapGAppsHook3,
   makeBinaryWrapper,
 
   openssl,
-  libsoup_2_4,
-  # webkitgtk_4_0,
+  webkitgtk_4_1,
   gst_all_1,
+
+  nix-update-script,
 }:
-rustPlatform.buildRustPackage rec {
+
+let
+  pnpm = pnpm_10;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "en-croissant";
-  version = "0.11.1";
+  version = "0.12.2";
 
   src = fetchFromGitHub {
     owner = "franciscoBSalgueiro";
     repo = "en-croissant";
-    tag = "v${version}";
-    hash = "sha256-EiGML3oFCJR4TZkd+FekUrJwCYe/nGdWD9mAtKKtITQ=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ef6O8C1PPjCmF5lashpBQXWwjsEEKCl5R98QMOFDIBM=";
   };
 
   pnpmDeps = fetchPnpmDeps {
-    inherit
+    inherit (finalAttrs)
       pname
       version
       src
       ;
-    pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-hvWXSegUWJvwCU5NLb2vqnl+FIWpCLxw96s9NUIgJTI=";
+    inherit pnpm;
+    fetcherVersion = 2;
+    hash = "sha256-p2j886NRBw/8c2UJ94o6w7YtKnOfm7hU9SgEUrzAwco=";
   };
+
+  cargoPatches = [
+    # Bump the tauri-utils package to at least 2.1.0, to fix resource path resolution on NixOS.
+    ./en-croissant-update-tauri-utils.patch
+  ];
+
+  postPatch = ''
+    jq '.plugins.updater.endpoints = [ ] | .bundle.createUpdaterArtifacts = false' src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+  '';
 
   cargoRoot = "src-tauri";
 
-  cargoHash = "sha256-6cBGOdJ7jz+mOl2EEXxoLNeX9meW+ybQxAxnnHAplIc=";
+  cargoHash = "sha256-cTb6nKHlazyOu3cpwAAp20j3QmrDxC507ZRpYT5fgQs=";
 
-  buildAndTestSubdir = cargoRoot;
+  buildAndTestSubdir = finalAttrs.cargoRoot;
 
   nativeBuildInputs = [
-    pnpmConfigHook
-    pnpm_9
     nodejs
-    cargo-tauri_1.hook
+    pnpm
+    pnpmConfigHook
+
+    cargo-tauri.hook
+    jq
+    moreutils
     pkg-config
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook3 ]
@@ -58,12 +77,12 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     openssl
-    libsoup_2_4
-    # webkitgtk_4_0
+    webkitgtk_4_1
+
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
-    gst_all_1.gst-plugins-bad
     gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
   ];
 
   doCheck = false; # many scoring tests fail
@@ -72,14 +91,17 @@ rustPlatform.buildRustPackage rec {
     makeWrapper "$out"/Applications/en-croissant.app/Contents/MacOS/en-croissant $out/bin/en-croissant
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
-    # webkitgtk_4_0 was removed
-    broken = true;
     description = "Ultimate Chess Toolkit";
     homepage = "https://github.com/franciscoBSalgueiro/en-croissant/";
     license = lib.licenses.gpl3Only;
     mainProgram = "en-croissant";
-    maintainers = with lib.maintainers; [ tomasajt ];
+    maintainers = with lib.maintainers; [
+      tomasajt
+      snu
+    ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
Un-break the package by updating to a Tauri-v2 based release.

This is a follow up of https://github.com/NixOS/nixpkgs/pull/466013

In preparation for loading the sound effects from bundled resources, this also bumps the `tauri-utils` crate version to fix resource path resolution on NixOS. The cargo dependencies on the new package release are still very old.

> [!NOTE]
> Playing bundled sounds on Linux requires a GStreamer plugin and some environment settings. This should be packaged transparently in the hook for all tauri apps, so it is not included here.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
