### PR TITLE
norgolith: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14487,6 +14487,12 @@
     github = "juuyokka";
     githubId = 15185244;
   };
+  Ladas552 = {
+    email = "l.tokshalov@gmail.com";
+    github = "Ladas552";
+    githubId = 94762349;
+    name = "Ladas552";
+  };
   lafrenierejm = {
     email = "joseph@lafreniere.xyz";
     github = "lafrenierejm";

--- a/pkgs/by-name/no/norgolith/package.nix
+++ b/pkgs/by-name/no/norgolith/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  libgit2,
+  openssl,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "norgolith";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "NTBBloodbath";
+    repo = "norgolith";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-n9Obf2PoTQ8EyxF/i5YU9/AlN9IizWYW/sG89Z8qp1k=";
+  };
+
+  cargoHash = "sha256-1DOys3N42jlC/tc5D0Ixg+yXV/RRMIi4qcXzUwpl7XQ=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libgit2
+    openssl
+    zlib
+  ];
+
+  useNextest = true;
+
+  env = {
+    LIBGIT2_NO_VENDOR = true;
+    OPENSSL_NO_VENDOR = true;
+  };
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "The monolithic Norg static site generator built with Rust";
+    homepage = "https://norgolith.amartin.beer";
+    changelog = "https://github.com/NTBBloodbath/norgolith/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ Ladas552 ];
+    mainProgram = "lith";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Static Site Generator for Norg markup language.
Github homepage: https://github.com/NTBBloodbath/norgolith
Project's site homepage: https://norgolith.amartin.beer
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
