### PR TITLE
pawn-appetit: init at 0.11.0

### DIFF
--- a/pkgs/by-name/pa/pawn-appetit/package.nix
+++ b/pkgs/by-name/pa/pawn-appetit/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  cargo-tauri,
+  jq,
+  moreutils,
+  pkg-config,
+  wrapGAppsHook3,
+  makeBinaryWrapper,
+
+  openssl,
+  webkitgtk_4_1,
+  gst_all_1,
+
+  nix-update-script,
+}:
+
+let
+  pnpm = pnpm_10;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "pawn-appetit";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "Pawn-Appetit";
+    repo = "pawn-appetit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WJ/tFOizESDqdLy4maMKUZ79mgyyxqLuwCxWZ0+NVX4=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-amXrz/ZzvjvNYlqxzTtQXiZw/NnUVJ7PhqG8oHsEe88=";
+  };
+
+  postPatch = ''
+    jq '.plugins.updater.endpoints = [ ] | .bundle.createUpdaterArtifacts = false' src-tauri/tauri.conf.json | sponge src-tauri/tauri.conf.json
+  '';
+
+  cargoRoot = "src-tauri";
+
+  cargoHash = "sha256-UKaW+NiNA398nyGs9+SjY+tUvLjCPrSxX6bZLSl7/EQ=";
+
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+
+  nativeBuildInputs = [
+    nodejs
+    pnpm
+    pnpmConfigHook
+
+    cargo-tauri.hook
+    jq
+    moreutils
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook3 ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeBinaryWrapper ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    openssl
+    webkitgtk_4_1
+
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+  ];
+
+  doCheck = false; # many scoring tests fail
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    makeWrapper "$out"/Applications/pawn-appetit.app/Contents/MacOS/pawn-appetit $out/bin/pawn-appetit
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Ultimate Chess Toolkit (fork of en-croissant)";
+    homepage = "https://github.com/Pawn-Appetit/pawn-appetit/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "pawn-appetit";
+    maintainers = with lib.maintainers; [ snu ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
pawn-appetit is a fork of en-croissant (see https://github.com/NixOS/nixpkgs/pull/483350).

https://github.com/Pawn-Appetit/pawn-appetit/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
