### PR TITLE
cargo-tauri: gstreamer plugin for asset protocol

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/gst-plugin.nix
+++ b/pkgs/by-name/ca/cargo-tauri/gst-plugin.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  gst_all_1,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tauri-asset-gst-plugin";
+  version = "0.1.0";
+
+  # From upstream PR https://github.com/tauri-apps/tauri/pull/14402
+  src = fetchFromGitHub {
+    owner = "aaalloc";
+    repo = "tauri";
+    rev = "bc502b45a6995aab5687ce3e50b3d218ca5ee105";
+    hash = "sha256-H27n2rsqmGbk7ru8K7LhEvvftpz6mxgTow/18SpQn1Q=";
+  };
+
+  cargoHash = "sha256-n9CZ92ezRP9i4JpARwLpW4KIo9/6cB481YuG3qN1BKo=";
+
+  cargoBuildFlags = [ "--package tauri-asset-gst-plugin" ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+  ];
+
+  postInstall = ''
+    mkdir $out/lib/gstreamer-1.0
+    mv $out/lib/*.so $out/lib/gstreamer-1.0/
+  '';
+
+  meta = {
+    description = "GStreamer plugin to handle the tauri asset:// protocol";
+    homepage = "https://github.com/tauri-apps/tauri/pull/14402";
+    license = [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    maintainers = with lib.maintainers; [ snu ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ca/cargo-tauri/hook.nix
+++ b/pkgs/by-name/ca/cargo-tauri/hook.nix
@@ -18,6 +18,9 @@ makeSetupHook {
   propagatedBuildInputs = [
     cargo
     cargo-tauri
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    cargo-tauri.gst-plugin
   ];
 
   substitutions = {
@@ -32,6 +35,14 @@ makeSetupHook {
         linux = "deb";
       }
       .${kernelName} or (throw "${kernelName} is not supported by cargo-tauri.hook");
+
+    fixupScript = lib.optionalString stdenv.hostPlatform.isLinux ''
+      gappsWrapperArgs+=(
+        --prefix WEBKIT_GST_ALLOWED_URI_PROTOCOLS : "asset"
+        # Not picked up automatically by the wrappers from the propagatedBuildInputs.
+        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${cargo-tauri.gst-plugin}/lib/gstreamer-1.0/"
+      )
+    '';
 
     # $targetDir is the path to the build artifacts (i.e., `./target/release`)
     installScript =

--- a/pkgs/by-name/ca/cargo-tauri/hook.sh
+++ b/pkgs/by-name/ca/cargo-tauri/hook.sh
@@ -92,8 +92,17 @@ tauriInstallHook() {
     echo "Finished tauriInstallHook"
 }
 
+tauriFixupHook() {
+  # NOTE: This runs as a preFixupPhase and does not replace the original hook.
+  @fixupScript@
+}
+
 if [ -z "${dontTauriBuild:-}" ] && [ -z "${buildPhase:-}" ]; then
     buildPhase=tauriBuildHook
+fi
+
+if [ -z "${dontTauriFixup:-}" ] && [ -z "${fixupPhase:-}" ]; then
+    preFixupPhases+=(tauriFixupHook)
 fi
 
 if [ -z "${dontTauriInstall:-}" ] && [ -z "${installPhase:-}" ]; then

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -49,6 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     # See ./doc/hooks/tauri.section.md
     hook = callPackage ./hook.nix { cargo-tauri = finalAttrs.finalPackage; };
+    gst-plugin = callPackage ./gst-plugin.nix { };
 
     tests = {
       hook = callPackage ./test-app.nix { cargo-tauri = finalAttrs.finalPackage; };


### PR DESCRIPTION
Tauri uses the `asset:` protocol to load media files from the bundled resources. With WebkitGtk, this requires a GStreamer plugin to resolve this as a file path.

This PR bundles the plugin from the yet unmerged upstream PR and tweaks the existing hook to include it by default with the necessary environment variables set.

These changes should not have any effect on Darwin, and should not influence packages that do not explicitly bundle the regular gstreamer plugins already. For those that do, media playback of resources should start working transparently.

See https://github.com/tauri-apps/tauri/pull/14402

## Things done

Tested with updated `en-croissant` and new `pawn-appetit` packages (https://github.com/NixOS/nixpkgs/pull/483350 and https://github.com/NixOS/nixpkgs/pull/483352).

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
