### PR TITLE
gslapper: init at 1.4.0

### DIFF
--- a/pkgs/by-name/gs/gslapper/package.nix
+++ b/pkgs/by-name/gs/gslapper/package.nix
@@ -1,0 +1,82 @@
+{
+  meson,
+  pkg-config,
+  wayland-protocols,
+  wayland,
+  egl-wayland,
+  libglvnd,
+  gst_all_1,
+  systemd,
+  wayland-scanner,
+  ninja,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  lib,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gslapper";
+  version = "v1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "Nomadcxx";
+    repo = "gSlapper";
+    tag = finalAttrs.version;
+    hash = "sha256-+FcKKp73Ooq+IB6wpLOoVSkS52AmNox9KbKtexH9PIo=";
+  };
+
+  nativeBuildInputs = [
+    wayland-protocols
+    egl-wayland
+    libglvnd
+    systemd
+    wayland-scanner
+    wayland
+    wrapGAppsHook4
+  ]
+  ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+  ]);
+
+  buildInputs = [
+    meson
+    pkg-config
+    wayland-protocols
+    wayland
+    egl-wayland
+    libglvnd
+    systemd
+    wayland-scanner
+    ninja
+  ]
+  ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-plugins-bad
+  ]);
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A wallpaper utility that handles static images and a huge number of video types via gstreamer.";
+    longDescription = ''
+      gSlapper is a wallpaper utility for Wayland that combines the best of
+      swww and mpvpaper by allowing both static and video wallpapers. It uses
+      GStreamer instead of libmpv making it more efficient and NVIDIA
+      friendly for Wayland.
+    '';
+    homepage = "https://github.com/Nomadcxx/gSlapper";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      nikolaizombie1
+    ];
+    mainProgram = "gslapper";
+    platforms = [ "x86_64-linux" ];
+  };
+})


### PR DESCRIPTION
<!--
https://github.com/Nomadcxx/gSlapper
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
