### PR TITLE
bpftune: 0-unstable-2025-03-20 → 0.4-2

### DIFF
--- a/nixos/modules/services/system/bpftune.nix
+++ b/nixos/modules/services/system/bpftune.nix
@@ -22,6 +22,9 @@ in
 
   config = lib.mkIf cfg.enable {
     systemd.packages = [ cfg.package ];
-    systemd.services.bpftune.wantedBy = [ "multi-user.target" ];
+    systemd.services.bpftune = {
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.kmod ]; # bpftune calls modprobe
+    };
   };
 }

--- a/pkgs/by-name/bp/bpftune/package.nix
+++ b/pkgs/by-name/bp/bpftune/package.nix
@@ -9,29 +9,27 @@
   libcap,
   libnl,
   nixosTests,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "bpftune";
-  version = "0-unstable-2025-03-20";
+  version = "0.4-2";
 
   src = fetchFromGitHub {
     owner = "oracle";
     repo = "bpftune";
-    rev = "8c6a3ffc09265bd44ed89b75c400ef97959d1aff";
-    hash = "sha256-TQ8WaGvMcvyeZC4B9gSjJ2k5NOxpTaV4n7Qi36aA78Q=";
+    tag = finalAttrs.version;
+    hash = "sha256-clfR2nZKB9ztfUEw+znr9/Rdefv4K+mTeRCSBLIBmVY=";
   };
 
   postPatch = ''
     # otherwise shrink rpath would drop $out/lib from rpath
     substituteInPlace src/Makefile \
-      --replace-fail /sbin    /bin \
+      --replace-fail /sbin /bin \
       --replace-fail ldconfig true
     substituteInPlace src/bpftune.service \
       --replace-fail /usr/sbin/bpftune "$out/bin/bpftune"
-    substituteInPlace src/libbpftune.c \
-      --replace-fail /lib/modules /run/booted-system/kernel-modules/lib/modules
   '';
 
   nativeBuildInputs = [
@@ -56,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   hardeningDisable = [
-    "stackprotector"
     "zerocallusedregs"
   ];
 
@@ -64,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     tests = {
       inherit (nixosTests) bpftune;
     };
-    updateScript = unstableGitUpdater { };
+    updateScript = nix-update-script { };
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updated bpftune from 0-unstable-2025-03-20 → 0.4-2
Added `pkgs.kmod` to path of bpftune.service to provide modprobe
Removed unneeded hardening and changed the update script

Fixes #473904 and supersedes #473980 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
