### PR TITLE
nixos/scx-loader: init scx-loader at 1.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18972,6 +18972,11 @@
     githubId = 72071763;
     name = "Yusup Urazaev";
   };
+  name-tar-xz = {
+    github = "name-tar-xz";
+    githubId = 54463026;
+    name = "name-tar-xz";
+  };
   namore = {
     email = "namor@hemio.de";
     github = "namore";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19125,6 +19125,11 @@
     githubId = 72071763;
     name = "Yusup Urazaev";
   };
+  name-tar-xz = {
+    github = "name-tar-xz";
+    githubId = 54463026;
+    name = "name-tar-xz";
+  };
   namore = {
     email = "namor@hemio.de";
     github = "namore";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -154,6 +154,8 @@
 
 - [whois](https://packages.qa.debian.org/w/whois.html), an intelligent WHOIS client. Available as `programs.whois`.
 
+- [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
+
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -158,6 +158,8 @@
 
 - [whois](https://packages.qa.debian.org/w/whois.html), an intelligent WHOIS client. Available as `programs.whois`.
 
+- [scx_loader](https://github.com/sched-ext/scx-loader), a system daemon and DBus-based loader for sched_ext schedulers. `scxctl` is the command-line client for interacting with the loader, allowing users to switch schedulers, modes, and arguments dynamically. Available as [services.scx-loader](#opt-services.scx-loader.enable)
+
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
 - [LogiOps](https://github.com/PixlOne/logiops), a unofficial userspace driver for HID++ Logitech devices. Available as [services.logiops](#opt-services.logiops.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1480,6 +1480,7 @@
   ./services/scheduling/cron.nix
   ./services/scheduling/fcron.nix
   ./services/scheduling/prefect.nix
+  ./services/scheduling/scx-loader.nix
   ./services/scheduling/scx.nix
   ./services/search/elasticsearch-curator.nix
   ./services/search/elasticsearch.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1482,6 +1482,7 @@
   ./services/scheduling/cron.nix
   ./services/scheduling/fcron.nix
   ./services/scheduling/prefect.nix
+  ./services/scheduling/scx-loader.nix
   ./services/scheduling/scx.nix
   ./services/search/elasticsearch-curator.nix
   ./services/search/elasticsearch.nix

--- a/nixos/modules/services/scheduling/scx-loader.nix
+++ b/nixos/modules/services/scheduling/scx-loader.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.scx-loader;
+  settingsFormat = pkgs.formats.toml { };
+in
+{
+  options.services.scx-loader = {
+    enable = lib.mkEnableOption "" // {
+      description = ''
+        Whether to enable SCX Loader service, a daemon to run schedulers from userspace using dbus.
+
+        ::: {.note}
+        This service requires a kernel with the Sched-ext feature.
+        Generally, kernel version 6.12 and later are supported.
+        :::
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "scx.loader" { };
+
+    schedsPackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [ pkgs.scx.rustscheds ];
+      defaultText = lib.literalExpression "[ pkgs.scx.rustscheds ]";
+      example = lib.literalExpression "[ pkgs.scx.full ]";
+      description = ''
+        `scx` package to use. `scx.rustscheds`, which includes all schedulers currently supported by `scx_loader`, is the default.
+
+        ::: {.note}
+        Overriding this does not change the default scheduler; you should set `services.scx-loader.settings.default_sched` for it.
+        :::
+      '';
+    };
+
+    settings = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = { };
+      description = ''
+        Configuration for SCX Loader in the TOML format
+        See the [example config](https://github.com/sched-ext/scx-loader/blob/main/configs/scx_loader.toml) for more details.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.versionAtLeast config.boot.kernelPackages.kernel.version "6.12";
+        message = "SCX is only supported on kernel version >= 6.12.";
+      }
+      {
+        assertion = !(cfg.enable && config.services.scx.enable);
+        message = "services.scx and services.scx_loader cannot be enabled simultaneously. Please enable only one of them.";
+      }
+    ];
+
+    environment = {
+      systemPackages = [ cfg.package ] ++ cfg.schedsPackages;
+      etc = lib.mkIf (cfg.settings != { }) {
+        "scx_loader.toml".source = settingsFormat.generate "scx_loader.toml" cfg.settings;
+      };
+    };
+
+    systemd.services.scx-loader = {
+      description = "DBUS on-demand loader of sched-ext schedulers";
+
+      unitConfig.ConditionPathIsDirectory = "/sys/kernel/sched_ext";
+
+      serviceConfig = {
+        Type = "dbus";
+        BusName = "org.scx.Loader";
+        ExecStart = lib.getExe cfg.package;
+        KillSignal = "SIGINT";
+        ProtectSystem = "full";
+        PrivateTmp = "disconnected";
+        PrivateMounts = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        LockPersonality = true;
+        RestrictRealtime = true;
+        ProtectClock = true;
+        MemoryDenyWriteExecute = true;
+        RestrictAddressFamilies = "AF_UNIX";
+        CapabilityBoundingSet = "~CAP_BLOCK_SUSPEND CAP_CHOWN CAP_MKNOD CAP_NET_RAW CAP_SYS_BOOT CAP_SYS_CHROOT CAP_SYS_MODULE CAP_SYS_PACCT CAP_SYS_PTRACE CAP_SYS_TIME CAP_SYSLOG CAP_WAKE_ALARM";
+        SocketBindDeny = [
+          "ipv4:tcp"
+          "ipv4:udp"
+          "ipv6:tcp"
+          "ipv6:udp"
+        ];
+        SystemCallFilter = [
+          "~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @keyring:EPERM @module:EPERM @mount:EPERM @obsolete:EPERM @pkey:EPERM @raw-io:EPERM @reboot:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM"
+          "perf_event_open"
+        ];
+      };
+
+      path = cfg.schedsPackages;
+
+      wantedBy = [ "multi-user.target" ];
+    };
+  };
+
+  meta = {
+    inherit (pkgs.scx.loader.meta) maintainers;
+  };
+}

--- a/pkgs/os-specific/linux/scx/default.nix
+++ b/pkgs/os-specific/linux/scx/default.nix
@@ -5,6 +5,7 @@
 
 lib.mapAttrs (name: scheduler: callPackage scheduler { }) {
   cscheds = import ./scx_cscheds.nix;
-  rustscheds = import ./scx_rustscheds.nix;
   full = import ./scx_full.nix;
+  loader = import ./scx_loader.nix;
+  rustscheds = import ./scx_rustscheds.nix;
 }

--- a/pkgs/os-specific/linux/scx/scx_loader.nix
+++ b/pkgs/os-specific/linux/scx/scx_loader.nix
@@ -1,0 +1,42 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "scx-loader";
+  version = "1.1.0";
+
+  cargoHash = "sha256-dw1Y2BAqb47HeJVEkznCh0IPNgrhvBYrWKUyI8H+xoU=";
+
+  src = fetchFromGitHub {
+    owner = "sched-ext";
+    repo = "scx-loader";
+    tag = "v${version}";
+    hash = "sha256-B66+Awt+q3GuriRSFWmGKh6GicQiPlpQMPlpwbItUrk=";
+  };
+
+  postInstall = ''
+    install -Dm444 services/org.scx.Loader.service -t $out/share/dbus-1/system-services/
+    install -Dm444 configs/org.scx.Loader.conf -t $out/share/dbus-1/system.d/
+    install -Dm444 configs/org.scx.Loader.xml -t $out/share/dbus-1/interfaces/
+    install -Dm444 configs/org.scx.Loader.policy -t $out/share/polkit-1/actions/
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "scx_loader";
+    homepage = "https://github.com/sched-ext/scx-loader";
+    changelog = "https://github.com/sched-ext/scx-loader/releases/tag/v${version}";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
+    maintainers = with lib.maintainers; [
+      name-tar-xz
+      Gliczy
+      michaelBelsanti
+    ];
+  };
+}

--- a/pkgs/os-specific/linux/scx/scx_loader.nix
+++ b/pkgs/os-specific/linux/scx/scx_loader.nix
@@ -1,0 +1,40 @@
+{
+  fetchFromGitHub,
+  rustPlatform,
+  lib,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "scx-loader";
+  version = "1.1.1";
+
+  cargoHash = "sha256-uX2lCVDa8eAKWi/bj94+JQHoOLll0OjKRHT0EPZELNc=";
+
+  src = fetchFromGitHub {
+    owner = "sched-ext";
+    repo = "scx-loader";
+    tag = "v${version}";
+    hash = "sha256-5OvdtW/Li+ubHDBSKe2ssE9ZyNSCcxNFSJffzxQ9WMk=";
+  };
+
+  postInstall = ''
+    VENDOR_PREFIX="" VENDOR_DATADIR="/share" cargo xtask install --destdir $out
+    rm $out/bin/xtask
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "scx_loader";
+    homepage = "https://github.com/sched-ext/scx-loader";
+    changelog = "https://github.com/sched-ext/scx-loader/releases/tag/v${version}";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    badPlatforms = [ "aarch64-linux" ];
+    maintainers = with lib.maintainers; [
+      name-tar-xz
+      Gliczy
+      michaelBelsanti
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added package scx_loader as `pkgs.scx.loader`
Added module `services.scx-loader`
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
