### PR TITLE
rootbar: unstable-2020-11-13 → unstable-2024-08-07

### DIFF
--- a/pkgs/by-name/ro/rootbar/package.nix
+++ b/pkgs/by-name/ro/rootbar/package.nix
@@ -38,11 +38,11 @@ gcc14Stdenv.mkDerivation {
 
   meta = {
     homepage = "https://hg.sr.ht/~scoopta/rootbar";
-    description = "Bar for Wayland WMs";
+    description = "Bar for wlroots-based Wayland compositors";
     mainProgram = "rootbar";
     longDescription = ''
-      Root Bar is a bar for wlroots based wayland compositors such as sway and
-      was designed to address the lack of good bars for wayland.
+      Root Bar is a bar for wlroots-based Wayland compositors such as Sway and
+      was designed to address the lack of good bars for Wayland.
     '';
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];

--- a/pkgs/by-name/ro/rootbar/package.nix
+++ b/pkgs/by-name/ro/rootbar/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchhg,
   pkg-config,
   meson,
@@ -12,7 +12,7 @@
   wrapGAppsHook3,
 }:
 
-stdenv.mkDerivation {
+gcc14Stdenv.mkDerivation {
   pname = "rootbar";
   version = "unstable-2024-08-07";
 
@@ -47,6 +47,6 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
     platforms = lib.platforms.unix;
-    broken = stdenv.hostPlatform.isDarwin;
+    broken = gcc14Stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/by-name/ro/rootbar/package.nix
+++ b/pkgs/by-name/ro/rootbar/package.nix
@@ -14,12 +14,12 @@
 
 stdenv.mkDerivation {
   pname = "rootbar";
-  version = "unstable-2020-11-13";
+  version = "unstable-2024-08-07";
 
   src = fetchhg {
     url = "https://hg.sr.ht/~scoopta/rootbar";
-    rev = "a018e10cfc5e";
-    sha256 = "sha256-t6oDIYCVaCxaYy4bS1vxESaFDNxsx5JQLQK77eVuafE=";
+    rev = "36333af9fd8d";
+    sha256 = "sha256-CpORCSJyHZhcK14EhjxoPt/h0026NU5J/kicL1dX96o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixed English issues too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.