### PR TITLE
onscripter-yuri: init at 0.7.6beta2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11389,6 +11389,12 @@
     email = "itepastra@gmail.com";
     keys = [ { fingerprint = "E681 4CAF 06AE B076 D55D  3E32 A16C DCBF 1472 541F"; } ];
   };
+  itsmyowninvention = {
+    email = "changlong.zhao@outlook.com";
+    github = "itsmyowninvention";
+    githubId = 89126591;
+    name = "itsmyowninvention";
+  };
   itsvic-dev = {
     email = "contact@itsvic.dev";
     name = "Victor B.";

--- a/pkgs/by-name/on/onscripter-yuri/package.nix
+++ b/pkgs/by-name/on/onscripter-yuri/package.nix
@@ -1,0 +1,57 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  SDL2,
+  SDL2_image,
+  SDL2_ttf,
+  SDL2_mixer,
+  lua,
+  bzip2,
+  libjpeg,
+  libogg,
+  libvorbis,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "onscripter-yuri";
+  version = "0.7.6beta2";
+
+  src = fetchFromGitHub {
+    owner = "YuriSizuku";
+    repo = "OnscripterYuri";
+    rev = "v${version}";
+    hash = "sha256-NKB11h/s9ZX9HvhPaCK2qZenB8df2sEprGKb1DGNvOg=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    SDL2
+    SDL2_image
+    SDL2_ttf
+    SDL2_mixer
+    lua
+    bzip2
+    libjpeg
+    libogg
+    libvorbis
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  meta = with lib; {
+    description = "An enhancement ONScripter project porting to many platforms, especially web";
+    homepage = "https://github.com/YuriSizuku/OnscripterYuri";
+    license = licenses.gpl2Only;
+    maintainers = [ ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/by-name/on/onscripter-yuri/package.nix
+++ b/pkgs/by-name/on/onscripter-yuri/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     description = "An enhancement ONScripter project porting to many platforms, especially web";
     homepage = "https://github.com/YuriSizuku/OnscripterYuri";
     license = licenses.gpl2Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ itsmyowninvention ];
     platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
onscripter-yuri is a optimized version of the ONScripter engine, providing better compatibility, performance for visual novels and better encoding supporting.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
