### PR TITLE
Shopify-cli: run pnpm (build-time) with nodejs_22 to avoid ENOTDIR on Node 24

### DIFF
--- a/pkgs/by-name/sh/shopify-cli/package.nix
+++ b/pkgs/by-name/sh/shopify-cli/package.nix
@@ -7,82 +7,93 @@
   pnpm,
   faketty,
   nodejs,
+  nodejs_22,
   versionCheckHook,
   makeBinaryWrapper,
   nix-update-script,
 }:
-stdenv.mkDerivation (finalAttrs: {
-  pname = "shopify";
-  version = "3.86.1";
+stdenv.mkDerivation (
+  finalAttrs:
+  let
+    pnpmForBuild = pnpm.override { nodejs = nodejs_22; };
+  in
+  {
+    pname = "shopify";
+    version = "3.86.1";
 
-  src = fetchFromGitHub {
-    owner = "shopify";
-    repo = "cli";
-    tag = finalAttrs.version;
-    hash = "sha256-wEddzW5/+qdtNTxdUs7YEA5vk6/KjrVOgWvIeo0o2ww=";
-  };
+    src = fetchFromGitHub {
+      owner = "shopify";
+      repo = "cli";
+      tag = finalAttrs.version;
+      hash = "sha256-wEddzW5/+qdtNTxdUs7YEA5vk6/KjrVOgWvIeo0o2ww=";
+    };
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    fetcherVersion = 2;
-    hash = "sha256-JhyZpkrp78FECH6UKYYuhWF2w/mYW1BQG5FIsWh5GRE=";
-  };
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      fetcherVersion = 2;
+      hash = "sha256-JhyZpkrp78FECH6UKYYuhWF2w/mYW1BQG5FIsWh5GRE=";
+    };
 
-  nativeBuildInputs = [
-    faketty
-    nodejs
-    pnpmConfigHook
-    pnpm
-    makeBinaryWrapper
-  ];
-
-  # workaround for https://github.com/nrwl/nx/issues/22445
-  buildPhase = ''
-    runHook preBuild
-
-    faketty pnpm run bundle-for-release --disableRemoteCache=true --nxBail=true --outputStyle=static
-
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib/node_modules/@shopify/cli/{dist,bin}
-    mkdir -p $out/bin
-    pushd packages/cli
-    rm -rf dist/*.map
-    mv dist/* $out/lib/node_modules/@shopify/cli/dist
-    mv bin/run.js $out/lib/node_modules/@shopify/cli/bin/run.js
-    mv package.json oclif.manifest.json $out/lib/node_modules/@shopify/cli
-    popd
-    # Install runtime dependencies
-    rm -rf node_modules
-    pnpm config set nodeLinker hoisted
-    pnpm install --offline --prod --force --ignore-scripts --frozen-lockfile
-    mv node_modules $out/lib/node_modules/@shopify/cli/node_modules
-
-    makeWrapper ${lib.getExe nodejs} $out/bin/shopify \
-      --add-flags "$out/lib/node_modules/@shopify/cli/bin/run.js"
-
-    runHook postInstall
-  '';
-
-  nativeInstallCheckInputs = [ versionCheckHook ];
-  doInstallCheck = true;
-
-  passthru.updateScript = nix-update-script { };
-
-  meta = {
-    platforms = lib.platforms.unix;
-    mainProgram = "shopify";
-    description = "CLI which helps you build against the Shopify platform faster";
-    homepage = "https://github.com/Shopify/cli";
-    changelog = "https://github.com/Shopify/cli/releases/tag/${finalAttrs.version}";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      fd
-      onny
+    nativeBuildInputs = [
+      faketty
+      nodejs
+      pnpmConfigHook
+      pnpmForBuild
+      makeBinaryWrapper
     ];
-  };
-})
+
+    # workaround for https://github.com/nrwl/nx/issues/22445
+    buildPhase = ''
+      runHook preBuild
+
+      faketty pnpm run bundle-for-release --disableRemoteCache=true --nxBail=true --outputStyle=static
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+        runHook preInstall
+
+        mkdir -p $out/lib/node_modules/@shopify/cli/{dist,bin}
+        mkdir -p $out/bin
+        pushd packages/cli
+        rm -rf dist/*.map
+        mv dist/* $out/lib/node_modules/@shopify/cli/dist
+        mv bin/run.js $out/lib/node_modules/@shopify/cli/bin/run.js
+        mv package.json oclif.manifest.json $out/lib/node_modules/@shopify/cli
+        popd
+        # Install runtime dependencies
+        rm -rf node_modules
+      pnpm config set nodeLinker hoisted
+      # Avoid pnpm trying to replace directories with files (ENOTDIR) by
+      # preferring non-symlinked executables and removing --force which can
+      # exacerbate move/rename races during install.
+      pnpm config set preferSymlinkedExecutables false
+      pnpm install --offline --prod --ignore-scripts --frozen-lockfile
+        mv node_modules $out/lib/node_modules/@shopify/cli/node_modules
+
+        makeWrapper ${lib.getExe nodejs} $out/bin/shopify \
+          --add-flags "$out/lib/node_modules/@shopify/cli/bin/run.js"
+
+        runHook postInstall
+    '';
+
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
+
+    passthru.updateScript = nix-update-script { };
+
+    meta = {
+      platforms = lib.platforms.unix;
+      mainProgram = "shopify";
+      description = "CLI which helps you build against the Shopify platform faster";
+      homepage = "https://github.com/Shopify/cli";
+      changelog = "https://github.com/Shopify/cli/releases/tag/${finalAttrs.version}";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [
+        fd
+        onny
+      ];
+    };
+  }
+)


### PR DESCRIPTION
Related issues
- Nixpkgs: Fixes #476726 — https://github.com/NixOS/nixpkgs/issues/476726

This change fixes an intermittent ENOTDIR rename failure observed during `pnpm install` in `pkgs/by-name/sh/shopify-cli` when pnpm is run under Node 24. The fix is minimal and scoped: the package now uses a build-time `pnpm` overridden to run under `nodejs_22` (`pnpmForBuild = pnpm.override { nodejs = nodejs_22; }`) so installs succeed reproducibly. The shipped runtime node is unchanged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
       I ran ./result/bin/shopify --version and ./result/bin/shopify help (main binary validated).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
