### PR TITLE
spade: 0.13.0 -> 0.16.0

### DIFF
--- a/pkgs/by-name/sp/spade/package.nix
+++ b/pkgs/by-name/sp/spade/package.nix
@@ -10,24 +10,24 @@
   git,
   pkg-config,
   openssl,
-  python312,
+  python314,
   swim,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "spade";
-  version = "0.13.0";
+  version = "0.16.0";
 
   src = fetchFromGitLab {
     owner = "spade-lang";
     repo = "spade";
     rev = "v${version}";
-    hash = "sha256-eWeEbwIm+PC0XHmvV3xZqUIcA01arnalbGFtPTUP9tg=";
+    hash = "sha256-Q9LiyCkrHQxnTorAqPOykS4F06c01pYPW9t82xEn6DY=";
     # only needed for vatch, which contains test data
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-YMUeHr9eUOYIcO7PbaFgZa0Ib10GMF+jT10ZCSG7PNo=";
+  cargoHash = "sha256-zuj34DpQKu7uWYgL/JTq7zLTPvZKQ/eedBXrkN1Pvg0=";
 
   # TODO: somehow respect https://nixos.org/manual/nixpkgs/stable/#var-passthru-updateScript-commit
   passthru.updateScript = _experimental-update-script-combinators.sequence [
@@ -55,8 +55,19 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [
     openssl
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ python312 ];
-  env.NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isDarwin "-L${python312}/lib/python3.12/config-3.12-darwin -lpython3.12";
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    python314
+  ];
+  env.NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isDarwin "-L${python314}/lib/python3.14/config-3.14-darwin -lpython3.14";
+
+  cargoBuildFlags = [
+    "--workspace"
+    # TODO: --exclude the excluded crates listed in release.sh?
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # "Undefined symbols for architecture arm:" ...
+    "--exclude=spade-surfer-plugin"
+  ];
 
   passthru.tests = {
     inherit swim;

--- a/pkgs/by-name/sw/swim/package.nix
+++ b/pkgs/by-name/sw/swim/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "swim";
-  version = "0.13.0";
+  version = "0.16.0";
 
   src = fetchFromGitLab {
     owner = "spade-lang";
     repo = "swim";
     rev = "v${version}";
-    hash = "sha256-0H45kOIwFMdp+eIQJNutLUC/jEpWKsPfEZXDUOUa12g=";
+    hash = "sha256-8JUy5gMZv7qzksrnoCwS4Wxk8xvy02sYGKHxwncAy7c=";
   };
 
-  cargoHash = "sha256-fF+43tZzr6lxVovMCIaDwf9JKweqiMMR+BNojIqQREY=";
+  cargoHash = "sha256-M4gwOAEPN3J7Ftirotbdk/UOE0hqbYpxBDO65YPXxBc=";
 
   preConfigure = ''
     # de-vendor spade git submodule


### PR DESCRIPTION
- **spade: 0.13.0 -> 0.16.0**
- **swim: 0.13.0 -> 0.16.0**

blogs:

* https://blog.spade-lang.org/v0-14-0/
* https://blog.spade-lang.org/v0-15-0/
* https://blog.spade-lang.org/v0-16-0/

closes https://github.com/NixOS/nixpkgs/pull/420405


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
