### PR TITLE
filen-desktop: refactor

### DIFF
--- a/pkgs/by-name/fi/filen-desktop/package.nix
+++ b/pkgs/by-name/fi/filen-desktop/package.nix
@@ -4,10 +4,10 @@
   buildNpmPackage,
   fetchFromGitHub,
   makeDesktopItem,
-  desktopToDarwinBundle,
-  pkg-config,
-  electron,
+  copyDesktopItems,
   makeWrapper,
+  electron,
+  pkg-config,
   pixman,
   cairo,
   pango,
@@ -16,6 +16,8 @@ let
   packageName = "filen-desktop";
   packageVersion = "3.0.47";
   desktopName = "Filen Desktop";
+  appName = "Filen";
+
   desktopItem = makeDesktopItem {
     name = packageName;
     exec = packageName;
@@ -34,9 +36,6 @@ let
       "encrypted"
     ];
   };
-
-  iconPrefix = if stdenv.hostPlatform.isDarwin then "darwin" else "linux";
-  iconSuffix = if stdenv.hostPlatform.isDarwin then "icns" else "png";
 in
 buildNpmPackage {
   pname = packageName;
@@ -51,20 +50,13 @@ buildNpmPackage {
   };
 
   npmDepsHash = "sha256-+Ul2z6faZvAeCHq35janVTUNoqTQ5JNDeLbCV220nFU=";
-  npmBuildScript = "build";
-
-  env = {
-    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
-    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
-  };
 
   nativeBuildInputs = [
     pkg-config
-    electron
     makeWrapper
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    desktopToDarwinBundle
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    copyDesktopItems
   ];
 
   buildInputs = [
@@ -73,34 +65,87 @@ buildNpmPackage {
     pango
   ];
 
-  # Override package-lock.json electron version to use what's given by nixpkgs
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+  };
+
   postPatch = ''
+    # Use nixpkgs electron instead of downloading
     substituteInPlace package.json \
       --replace-fail '"electron": "^34.1.1"' '"electron": "*"'
+
+    # Disable code signing (not needed for Nix)
+    substituteInPlace package.json \
+      --replace-fail '"afterSign": "build/notarize.js",' ""
+
+    # Fix app name and userData paths inside filen-desktop app source
+    substituteInPlace src/index.ts \
+      --replace-fail 'const options = await this.options.get()' \ '
+      app.setName("${desktopName}")
+      app.setPath("userData", pathModule.join(app.getPath("appData"), "@filen", "desktop"))
+      const options = await this.options.get()
+    '
   '';
 
-  # Set up icon assets in path required by desktopItem
-  preInstall = ''
-    install -D $src/assets/icons/app/${iconPrefix}.${iconSuffix} $out/share/icons/hicolor/128x128/apps/${packageName}.${iconSuffix}
-    install -D $src/assets/icons/app/${iconPrefix}Notification.${iconSuffix} $out/share/icons/hicolor/128x128/apps/${packageName}-notification.${iconSuffix}
+  buildPhase = ''
+    runHook preBuild
+
+    # Compile TypeScript
+    npm run build
+
+    # Prepare nixpkgs electron for electron-builder
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    # Build platform bundle
+    npx electron-builder \
+      --dir \
+      --${if stdenv.hostPlatform.isDarwin then "mac" else "linux"} \
+      -c.electronDist=electron-dist \
+      -c.electronVersion="${electron.version}"
+
+    runHook postBuild
   '';
 
-  # Create binary wrapper and desktopItem
-  # desktopItem auto-creates the .app bundle for Darwin
-  postInstall = ''
-    makeWrapper ${electron}/bin/electron $out/bin/${packageName} \
-      --set-default ELECTRON_IS_DEV 0 \
-      --add-flags $out/lib/node_modules/@filen/desktop/dist/index.js \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}"
+  installPhase = ''
+    runHook preInstall
 
-    mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications/
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          # Install macOS .app bundle
+          mkdir -p $out/Applications
+          cp -r prod/mac*/${appName}.app $out/Applications/
+
+          # Create bin symlink
+          mkdir -p $out/bin
+          makeWrapper "$out/Applications/${appName}.app/Contents/MacOS/${appName}" $out/bin/${packageName}
+        ''
+      else
+        ''
+          # Copy built resources
+          mkdir -p $out/share/${packageName}
+          cp -r prod/*-unpacked/{locales,resources{,.pak}} $out/share/${packageName}
+
+          # Create desktop icon
+          mkdir -p $out/share/icons/hicolor/128x128/apps
+          cp assets/icons/app/linux.png $out/share/icons/hicolor/128x128/apps/${packageName}.png
+
+          # Create launcher with electron
+          makeWrapper ${lib.getExe electron} $out/bin/${packageName} \
+            --set ELECTRON_IS_DEV 0 \
+            --add-flags $out/share/${packageName}/resources/app.asar \
+            --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+            --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ stdenv.cc.cc.lib ]}" \
+            --inherit-argv0
+        ''
+    }
+
+    runHook postInstall
   '';
 
-  # Write correct darwin icons to .app contents
-  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    cp -rf $out/share/pixmaps/* "$out/Applications/${desktopName}.app/Contents/Resources"
-  '';
+  desktopItems = lib.optionals (!stdenv.hostPlatform.isDarwin) [ desktopItem ];
 
   meta = {
     homepage = "https://filen.io/products";


### PR DESCRIPTION
- Better build from source with nix electron
- Better cross platform support for icons/shortcuts
- Include manual patches for app name / data paths
- Better support for Wayland

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
