### PR TITLE
hayase: init at 6.4.50

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8742,6 +8742,12 @@
     matrix = "@flandweber:envs.net";
     name = "Finn Landweber";
   };
+  flaxeneel2 = {
+    email = "me@flaxeneel2.net";
+    github = "flaxeneel2";
+    githubId = 60919292;
+    name = "Siddhant Misra";
+  };
   fleaz = {
     email = "mail@felixbreidenstein.de";
     matrix = "@fleaz:rainbownerds.de";

--- a/pkgs/by-name/ha/hayase/package.nix
+++ b/pkgs/by-name/ha/hayase/package.nix
@@ -1,0 +1,55 @@
+{
+  pkgs,
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  pname = "hayase";
+  version = "6.4.50";
+
+  src = pkgs.fetchurl {
+    url = "https://api.hayase.watch/files/linux-hayase-${version}-linux.AppImage";
+    hash = "sha256-uHtTMlbE53UrKAirEbyn/9dSGZjoCkVpkXE+y4ye1Ko=";
+  };
+in
+pkgs.appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      alsa-lib
+      at-spi2-atk
+      atk
+      cairo
+      cups
+      dbus
+      gdk-pixbuf
+      gtk3
+      libdrm
+      libglvnd
+      libsecret
+      mesa
+      nspr
+      nss
+      pango
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXi
+      xorg.libXrender
+      xorg.libxshmfence
+      xorg.libXtst
+    ];
+
+  meta = {
+    description = "Hayase is a bring your own torrent streaming application primarily geared towards anime watchers";
+    homepage = "https://hayase.watch";
+    license = lib.licenses.bsl11;
+    maintainers = [ lib.maintainers.flaxeneel2 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Added a wrapped version of [hayase](https://hayase.watch)'s AppImage release. Hayase is a "bring your own content" torrent streaming client that allows users to bring their own extensions for torrenting content. It is primarily geared towards anime watchers. It is an electron app so I have also included the common electron requirements in `extraPkgs`. I tested the app for its functionality such as setup and streaming, and all seem to work well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
