### PR TITLE
earlyoom: 1.8.2 -> 1.9.0

### DIFF
--- a/pkgs/by-name/ea/earlyoom/0000-fix-dbus-path.patch
+++ b/pkgs/by-name/ea/earlyoom/0000-fix-dbus-path.patch
@@ -1,11 +1,10 @@
 --- a/kill.c
 +++ b/kill.c
-@@ -55,7 +55,7 @@ static void notify(const char* summary, const char* body)
-     }
-     // Complete command line looks like this:
-     // dbus-send --system / net.nuetzlich.SystemNotifications.Notify 'string:summary text' 'string:and body text'
--    execl("/usr/bin/dbus-send", "dbus-send", "--system", "/", "net.nuetzlich.SystemNotifications.Notify",
-+    execlp("dbus-send", "dbus-send", "--system", "/", "net.nuetzlich.SystemNotifications.Notify",
-         summary2, body2, NULL);
-     warn("notify: exec failed: %s\n", strerror(errno));
-     exit(1);
+@@ -175,7 +175,7 @@ static void notify_dbus(const char* body)
+         body2,
+         NULL
+     };
+-    const char* dbus_send_path = "/usr/bin/dbus-send";
++    const char* dbus_send_path = "dbus-send";
+     notify_spawn_subprocess(dbus_send_path, argv, NULL, 0);
+ }

--- a/pkgs/by-name/ea/earlyoom/package.nix
+++ b/pkgs/by-name/ea/earlyoom/package.nix
@@ -4,7 +4,6 @@
   pandoc,
   stdenv,
   nixosTests,
-  fetchpatch,
   # The man page requires pandoc to build and resides in a separate "man"
   # output which is pulled in on-demand. There is no need to disabled it unless
   # pandoc is hard to build on your platform.
@@ -13,36 +12,26 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "earlyoom";
-  version = "1.8.2";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "rfjakob";
     repo = "earlyoom";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-HZ7llMNdx2u1a6loIFjXt5QNkYpJp8GqLKxDf9exuzE=";
+    hash = "sha256-eNWg96+uQn/s+iBCm8TH26pXVVzBdqbeQxVP2t4W7YA=";
   };
 
   outputs = [ "out" ] ++ lib.optionals withManpage [ "man" ];
 
-  patches = [
-    ./0000-fix-dbus-path.patch
-    # Respect `MANDIR`.
-    (fetchpatch {
-      url = "https://github.com/rfjakob/earlyoom/commit/c5a1799a5ff4b3fd3132d50a510e8c126933cf4a.patch";
-      hash = "sha256-64AkpTMmjiqZ6Byq6687zNIqrQ/IGRGgzzjyyAfcg14=";
-    })
-    # Correctly handle `PREFIX` as a default rather than always-concatenate.
-    (fetchpatch {
-      url = "https://github.com/rfjakob/earlyoom/commit/f7d6f1cc925962fbdcf57b1c2aeeabbf11e2d542.patch";
-      hash = "sha256-DJDeQzcEGJMoMGIi1D/ogMaKG1VQvPZN9jXtUDGjyjk=";
-    })
-  ];
+  patches = [ ./0000-fix-dbus-path.patch ];
 
   nativeBuildInputs = lib.optionals withManpage [ pandoc ];
 
   makeFlags = [
     "VERSION=${finalAttrs.version}"
     "PREFIX=${placeholder "out"}"
+    "SYSCONFDIR=${placeholder "out"}/etc"
+    "SYSTEMDUNITDIR=${placeholder "out"}/etc/systemd/system"
   ]
   ++ lib.optional withManpage "MANDIR=${placeholder "man"}/share/man";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Updated to 1.9.0 that had merged fixes for all the patches that were being used so they were no longer necesary

[Fix for the first fetchPatch](https://github.com/rfjakob/earlyoom/pull/322), [Fix for the second](https://github.com/rfjakob/earlyoom/pull/324)

The patch in 000-fix-dbus-path.patch was fixed [here](https://github.com/rfjakob/earlyoom/commit/4fb4ab89a495427305c82983d168a0efb3482921)

Closes #483354

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
