### PR TITLE
llama-swap: fix build on Darwin

### DIFF
--- a/pkgs/by-name/ll/llama-swap/package.nix
+++ b/pkgs/by-name/ll/llama-swap/package.nix
@@ -81,8 +81,8 @@ buildGoModule (finalAttrs: {
 
   checkFlags =
     let
-      skippedTests = lib.optionals (stdenv.isDarwin && stdenv.isx86_64) [
-        # Fail only on x86_64-darwin intermittently
+      skippedTests = lib.optionals (stdenv.isDarwin) [
+        # Fail only on *-darwin intermittently
         # https://github.com/mostlygeek/llama-swap/issues/320
         "TestProcess_AutomaticallyStartsUpstream"
         "TestProcess_WaitOnMultipleStarts"
@@ -98,6 +98,7 @@ buildGoModule (finalAttrs: {
         "TestProcess_ForceStopWithKill"
         "TestProcess_StopCmd"
         "TestProcess_EnvironmentSetCorrectly"
+        "TestProcess_ReverseProxyPanicIsHandled"
       ];
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];


### PR DESCRIPTION
`llama-swap` has added a new test `TestProcess_ReverseProxyPanicIsHandled` that isn't covered by the existing `skippedTests` list, and which fails in a similar way to those tests on the `x86_64` build.

Meanwhile, the `aarch64` build is now failing on the same tests that previously only had problems on `x86_64`. (At least on Hydra - don't have an Apple Silicon machine to test locally on.)

This adds the new test to `skippedTests`, and enables the `skippedTests` list for both Darwin platforms, rather than just `x86_64`.

Fixes #483423.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - **Note**: Only tested `result/bin/llama-swap` - don't really know how to test `result-wol/bin/wol-proxy` properly.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
