### PR TITLE
stc: init at 5.0

### DIFF
--- a/pkgs/by-name/st/stc/package.nix
+++ b/pkgs/by-name/st/stc/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  flex,
+  meson,
+  ninja,
+  pkg-config,
+  testers,
+  validatePkgConfig,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stc";
+  version = "5.0";
+
+  outputs = [
+    "out"
+    "dev"
+    "doc"
+  ];
+
+  src = fetchFromGitHub {
+    owner = "stclib";
+    repo = "STC";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JiFyJN+hAbzTHqim1i6TJFmKfHlnOfP3yDLCZDE7uqo=";
+  };
+
+  patches = [
+    # Backport pkg-config support and follow-up fixes from upstream.
+    (fetchpatch {
+      url = "https://github.com/stclib/STC/commit/92751b4d04b2d980d640b28bd22a9cd651d77c6a.patch";
+      hash = "sha256-11sE5pS7sqdfCGsGlvajkfgCf+QIkRFp4Js2//kAI3s=";
+    })
+    (fetchpatch {
+      url = "https://github.com/stclib/STC/commit/0fa9ad03516ba0f71b38674f0ec631929368f385.patch";
+      hash = "sha256-e1rhrKaf9fFAmSi8Puo494iG+hAdHZFzyn8IJoKjdAI=";
+    })
+  ];
+
+  postPatch = ''
+    meson rewrite kwargs set project / version '${finalAttrs.version}'
+  '';
+
+  nativeBuildInputs = [
+    flex
+    meson
+    ninja
+    pkg-config
+    validatePkgConfig
+  ];
+
+  doCheck = true;
+
+  passthru.tests.pkg-config = testers.hasPkgConfigModules {
+    package = finalAttrs.finalPackage;
+    versionCheck = true;
+  };
+
+  meta = {
+    description = "C99 container library with generic and type-safe data structures";
+    homepage = "https://github.com/stclib/STC";
+    changelog = "https://github.com/stclib/STC/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anthonyroussel ];
+    pkgConfigModules = [ "stc" ];
+  };
+})


### PR DESCRIPTION
C99 container library with generic and type-safe data structures

https://github.com/stclib/STC


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
