### PR TITLE
by-name-overlay: enable `structuredAttrs`, `strictDeps` and `parallelBuilding` for some directories

### DIFF
--- a/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
+++ b/pkgs/applications/networking/instant-messengers/telegram/telegram-desktop/default.nix
@@ -51,14 +51,18 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   qtWrapperArgs = lib.optionals (stdenv.hostPlatform.isLinux && withWebkit) [
-    "--prefix"
-    "LD_LIBRARY_PATH"
-    ":"
-    (lib.makeLibraryPath [
-      geoclue2
-      webkitgtk_4_1
-    ])
+    [
+      "--prefix"
+      "LD_LIBRARY_PATH"
+      ":"
+      (lib.makeLibraryPath [
+        geoclue2
+        webkitgtk_4_1
+      ])
+    ]
   ];
+
+  __structuredAttrs = true;
 
   dontUnpack = true;
   dontWrapGApps = true;

--- a/pkgs/by-name/_0/_010editor/package.nix
+++ b/pkgs/by-name/_0/_010editor/package.nix
@@ -20,7 +20,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = ".";
 
-  strictDeps = true;
   dontBuild = true;
   dontConfigure = true;
 

--- a/pkgs/by-name/_0/_0xffff/package.nix
+++ b/pkgs/by-name/_0/_0xffff/package.nix
@@ -17,8 +17,6 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-RTpiH6OpC1hRbhLW5Em01oDQdpAZ/mfggCDLSUzOC9s=";
   };
 
-  strictDeps = true;
-
   buildInputs = [ libusb-compat-0_1 ];
 
   installFlags = [

--- a/pkgs/by-name/_0/_0xpropo/package.nix
+++ b/pkgs/by-name/_0/_0xpropo/package.nix
@@ -3,16 +3,16 @@
   stdenvNoCC,
   fetchzip,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "0xpropo";
   version = "1.100";
 
   src =
     let
-      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version;
     in
     fetchzip {
-      url = "https://github.com/0xType/0xPropo/releases/download/${version}/0xPropo_${underscoreVersion}.zip";
+      url = "https://github.com/0xType/0xPropo/releases/download/${finalAttrs.version}/0xPropo_${underscoreVersion}.zip";
       hash = "sha256-ZlZNvn9xiOxS+dfGI1rGbh6XlXo3/puAm2vhKh63sK4=";
     };
 
@@ -26,9 +26,9 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Proportional version of the 0xProto font";
     homepage = "https://github.com/0xType/0xPropo";
-    changelog = "https://github.com/0xType/0xPropo/releases/tag/${version}";
+    changelog = "https://github.com/0xType/0xPropo/releases/tag/${finalAttrs.version}";
     license = lib.licenses.ofl;
     maintainers = with lib.maintainers; [ vinnymeller ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/_0/_0xproto/package.nix
+++ b/pkgs/by-name/_0/_0xproto/package.nix
@@ -4,16 +4,16 @@
   fetchzip,
   nix-update-script,
 }:
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "0xproto";
   version = "2.502";
 
   src =
     let
-      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] version;
+      underscoreVersion = builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version;
     in
     fetchzip {
-      url = "https://github.com/0xType/0xProto/releases/download/${version}/0xProto_${underscoreVersion}.zip";
+      url = "https://github.com/0xType/0xProto/releases/download/${finalAttrs.version}/0xProto_${underscoreVersion}.zip";
       hash = "sha256-ffYvfEGMoIJKVEcs2XzhDrq++SkTbQOVvb6X9q+uyu8=";
       stripRoot = false;
     };
@@ -38,4 +38,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [ edswordsmith ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/_1/_1fps/package.nix
+++ b/pkgs/by-name/_1/_1fps/package.nix
@@ -5,16 +5,15 @@
   libxtst,
   libxi,
   libx11,
-  stdenv,
 }:
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "1fps";
   version = "0.1.17";
 
   src = fetchFromGitHub {
     owner = "1fpsvideo";
     repo = "1fps";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8dtcW/niwmhVXB2kZdR/RjNg2ArSClL1w4nGI5rP3+Y=";
   };
 
@@ -35,4 +34,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ renesat ];
     mainProgram = "1fps";
   };
-}
+})

--- a/pkgs/by-name/_1/_1oom/package.nix
+++ b/pkgs/by-name/_1/_1oom/package.nix
@@ -41,9 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     readline
   ];
 
-  strictDeps = true;
-  enableParallelBuilding = true;
-
   postInstall = ''
     install -d $doc/share/doc/1oom
     install -t $doc/share/doc/1oom \

--- a/pkgs/by-name/_1/_1password-cli/package.nix
+++ b/pkgs/by-name/_1/_1password-cli/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
     versionCheckHook
   ]
   ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook
-  ++ lib.optional stdenv.hostPlatform.isDarwin [
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
     xar
     cpio
   ];

--- a/pkgs/by-name/_2/_2048-in-terminal/package.nix
+++ b/pkgs/by-name/_2/_2048-in-terminal/package.nix
@@ -6,7 +6,7 @@
   pkg-config,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "2048-in-terminal";
   version = "0-unstable-2022-06-13";
 
@@ -14,13 +14,11 @@ stdenv.mkDerivation rec {
     owner = "alewmoose";
     repo = "2048-in-terminal";
     rev = "bf22f868a2e0e572f22153468585ec0226a4b8b2";
-    sha256 = "sha256-Y5ZQYWOiG3QZZsr+d7olUDGAQ1LhRG9X2hBNQDx+Ztw=";
+    hash = "sha256-Y5ZQYWOiG3QZZsr+d7olUDGAQ1LhRG9X2hBNQDx+Ztw=";
   };
 
   buildInputs = [ ncurses ];
   nativeBuildInputs = [ pkg-config ];
-
-  enableParallelBuilding = true;
 
   preInstall = ''
     mkdir -p $out/bin
@@ -28,10 +26,10 @@ stdenv.mkDerivation rec {
   installFlags = [ "PREFIX=$(out)" ];
 
   meta = {
-    inherit (src.meta) homepage;
+    inherit (finalAttrs.src.meta) homepage;
     description = "Animated console version of the 2048 game";
     mainProgram = "2048-in-terminal";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/_2/_20kly/package.nix
+++ b/pkgs/by-name/_2/_20kly/package.nix
@@ -4,7 +4,7 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "20kly";
   version = "1.5.0";
 
@@ -13,13 +13,13 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "20kly";
     repo = "20kly";
-    tag = "v${version}";
-    sha256 = "1zxsxg49a02k7zidx3kgk2maa0vv0n1f9wrl5vch07sq3ghvpphx";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hd674RtYHwDZLjTz5IIFewOlqphvjt7iP1MAlcjruv8=";
   };
 
   patchPhase = ''
     substituteInPlace lightyears \
-      --replace \
+      --replace-fail \
         "LIGHTYEARS_DIR = \".\"" \
         "LIGHTYEARS_DIR = \"$out/share\""
   '';
@@ -45,4 +45,4 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ fgaz ];
   };
-}
+})

--- a/pkgs/by-name/_2/_2ship2harkinian/package.nix
+++ b/pkgs/by-name/_2/_2ship2harkinian/package.nix
@@ -171,8 +171,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "OPUSFILE_INCLUDE_DIR" "${lib.getDev opusfile}/include/opus")
   ];
 
-  strictDeps = true;
-
   dontAddPrefix = true;
 
   # Linking fails without this

--- a/pkgs/by-name/_3/_3270font/package.nix
+++ b/pkgs/by-name/_3/_3270font/package.nix
@@ -4,13 +4,13 @@
   fetchzip,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "3270font";
   version = "3.0.1";
 
   src = fetchzip {
-    url = "https://github.com/rbanffy/3270font/releases/download/v${version}/3270_fonts_d916271.zip";
-    sha256 = "sha256-Zi6Lp5+sqfjIaHmnaaemaw3i+hXq9mqIsK/81lTkwfM=";
+    url = "https://github.com/rbanffy/3270font/releases/download/v${finalAttrs.version}/3270_fonts_d916271.zip";
+    hash = "sha256-Zi6Lp5+sqfjIaHmnaaemaw3i+hXq9mqIsK/81lTkwfM=";
     stripRoot = false;
   };
 
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation rec {
   meta = {
     description = "Monospaced font based on IBM 3270 terminals";
     homepage = "https://github.com/rbanffy/3270font";
-    changelog = "https://github.com/rbanffy/3270font/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/rbanffy/3270font/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = [
       lib.licenses.bsd3
       lib.licenses.ofl
@@ -40,4 +40,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/_3/_389-ds-base/package.nix
+++ b/pkgs/by-name/_3/_389-ds-base/package.nix
@@ -139,8 +139,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-debug"
   ];
 
-  enableParallelBuilding = true;
-  # Disable parallel builds as those lack some dependencies:
+  # Disable parallel installation as those lack some dependencies:
   #   ld: cannot find -lslapd: No such file or directory
   # https://hydra.nixos.org/log/h38bj77gav0r6jbi4bgzy1lfjq22k2wy-389-ds-base-2.3.1.drv
   enableParallelInstalling = false;

--- a/pkgs/by-name/_3/_389-ds-base/package.nix
+++ b/pkgs/by-name/_3/_389-ds-base/package.nix
@@ -75,7 +75,8 @@ stdenv.mkDerivation (finalAttrs: {
     cargo
     rustc
   ]
-  ++ lib.optional withCockpit rsync;
+  ++ lib.optional withCockpit rsync
+  ++ lib.optional withNetSnmp net-snmp;
 
   buildInputs = [
     cracklib
@@ -95,8 +96,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withSystemd systemd
   ++ lib.optional withOpenldap openldap
-  ++ lib.optional withBdb db
-  ++ lib.optional withNetSnmp net-snmp;
+  ++ lib.optional withBdb db;
 
   postPatch = ''
     patchShebangs ./buildnum.py ./ldap/servers/slapd/mkDBErrStrs.py
@@ -119,7 +119,9 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-systemdsystemunitdir=${placeholder "out"}/etc/systemd/system"
   ]
   ++ lib.optionals withOpenldap [
-    "--with-openldap"
+    "--with-openldap-inc=${lib.getDev openldap}/include"
+    "--with-openldap-lib=${lib.getLib openldap}/lib"
+    "--with-openldap-bin=${openldap}/bin"
   ]
   ++ lib.optionals withBdb [
     "--with-db-inc=${lib.getDev db}/include"

--- a/pkgs/by-name/_3/_3cpio/package.nix
+++ b/pkgs/by-name/_3/_3cpio/package.nix
@@ -1,21 +1,19 @@
 {
   fetchFromGitHub,
   lib,
-  lz4,
-  lzop,
   nix-update-script,
   rustPlatform,
   stdenv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "3cpio";
   version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "bdrung";
     repo = "3cpio";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-4ERSH5Kz/e2MuIIgi3XQVnhW0csBPDIvdmEw05OdREA=";
   };
 
@@ -36,4 +34,4 @@ rustPlatform.buildRustPackage rec {
     # https://github.com/rust-lang/libc/issues/4360
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/_3/_3mux/package.nix
+++ b/pkgs/by-name/_3/_3mux/package.nix
@@ -6,15 +6,15 @@
   makeWrapper,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "3mux";
   version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "aaronjanse";
     repo = "3mux";
-    tag = "v${version}";
-    sha256 = "sha256-QT4QXTlJf2NfTqXE4GF759EoW6Ri12lxDyodyEFc+ag=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QT4QXTlJf2NfTqXE4GF759EoW6Ri12lxDyodyEFc+ag=";
   };
 
   patches = [
@@ -64,4 +64,4 @@ buildGoModule rec {
     ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/_4/_4th/package.nix
+++ b/pkgs/by-name/_4/_4th/package.nix
@@ -21,7 +21,8 @@ stdenv.mkDerivation (finalAttrs: {
   dontConfigure = true;
 
   makeFlags = [
-    "-C sources"
+    "-C"
+    "sources"
     "CC:=$(CC)"
     "AR:=$(AR)"
   ];

--- a/pkgs/by-name/_4/_4ti2/package.nix
+++ b/pkgs/by-name/_4/_4ti2/package.nix
@@ -7,14 +7,14 @@
   gmp,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "4ti2";
   version = "1.6.13";
 
   src = fetchFromGitHub {
     owner = "4ti2";
     repo = "4ti2";
-    rev = "Release_${builtins.replaceStrings [ "." ] [ "_" ] version}";
+    tag = "Release_${builtins.replaceStrings [ "." ] [ "_" ] finalAttrs.version}";
     hash = "sha256-gbYG55LfVhjJJFJu0L8AWIAnFDViHIW2N1qtS8xOFAc=";
   };
 
@@ -29,6 +29,9 @@ stdenv.mkDerivation rec {
 
   installFlags = [ "install-exec" ];
 
+  # two parallel processes try to install ppi into the same directory
+  enableParallelInstalling = false;
+
   meta = {
     homepage = "https://4ti2.github.io/";
     description = "Software package for algebraic, geometric and combinatorial problems on linear spaces";
@@ -36,4 +39,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/_6/_64gram/package.nix
+++ b/pkgs/by-name/_6/_64gram/package.nix
@@ -8,14 +8,14 @@
 telegram-desktop.override {
   pname = "64gram";
   inherit withWebkit;
-  unwrapped = telegram-desktop.unwrapped.overrideAttrs (old: rec {
+  unwrapped = telegram-desktop.unwrapped.overrideAttrs (finalAttrs: {
     pname = "64gram-unwrapped";
     version = "1.1.93";
 
     src = fetchFromGitHub {
       owner = "TDesktop-x64";
       repo = "tdesktop";
-      tag = "v${version}";
+      tag = "v${finalAttrs.version}";
       hash = "sha256-AwzTmEaN6MsJNq1W+cyAbg+QkYrPaV2LXmt3NzKc/vQ=";
       fetchSubmodules = true;
     };
@@ -25,7 +25,7 @@ telegram-desktop.override {
       license = lib.licenses.gpl3Only;
       platforms = lib.platforms.all;
       homepage = "https://github.com/TDesktop-x64/tdesktop";
-      changelog = "https://github.com/TDesktop-x64/tdesktop/releases/tag/v${version}";
+      changelog = "https://github.com/TDesktop-x64/tdesktop/releases/tag/v${finalAttrs.version}";
       maintainers = with lib.maintainers; [ clot27 ];
       mainProgram = "Telegram";
     };

--- a/pkgs/by-name/_6/_6tunnel/package.nix
+++ b/pkgs/by-name/_6/_6tunnel/package.nix
@@ -5,15 +5,15 @@
   autoreconfHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "6tunnel";
   version = "0.14";
 
   src = fetchFromGitHub {
     owner = "wojtekka";
     repo = "6tunnel";
-    tag = version;
-    sha256 = "sha256-ftTAFjHlXRrXH6co8bX0RY092lAmv15svZn4BKGVuq0=";
+    tag = finalAttrs.version;
+    hash = "sha256-ftTAFjHlXRrXH6co8bX0RY092lAmv15svZn4BKGVuq0=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
@@ -22,8 +22,8 @@ stdenv.mkDerivation rec {
     description = "Tunnelling for application that don't speak IPv6";
     mainProgram = "6tunnel";
     homepage = "https://github.com/wojtekka/6tunnel";
-    changelog = "https://github.com/wojtekka/6tunnel/blob/${version}/ChangeLog";
+    changelog = "https://github.com/wojtekka/6tunnel/blob/${finalAttrs.version}/ChangeLog";
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/_7/_7kaa/package.nix
+++ b/pkgs/by-name/_7/_7kaa/package.nix
@@ -51,12 +51,12 @@ gccStdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     autoconf-archive
     pkg-config
+    SDL2
   ];
 
   buildInputs = [
     openal
     enet
-    SDL2
     curl
     gettext
     libiconv

--- a/pkgs/by-name/_7/_7z2hashcat/package.nix
+++ b/pkgs/by-name/_7/_7z2hashcat/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "philsmd";
     repo = "7z2hashcat";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-BmpO2VLcuUtQaN4qmLm0YQEfK5iE+2hw4k6uBbwcFS4=";
   };
 

--- a/pkgs/by-name/_7/_7zz/package.nix
+++ b/pkgs/by-name/_7/_7zz/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = lib.optionalString stdenv.hostPlatform.isMinGW ''
     substituteInPlace CPP/7zip/7zip_gcc.mak C/7zip_gcc_c.mak \
-      --replace windres.exe ${stdenv.cc.targetPrefix}windres
+      --replace-fail windres.exe ${stdenv.cc.targetPrefix}windres
   '';
 
   env.NIX_CFLAGS_COMPILE = toString (
@@ -100,8 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = lib.optionals useUasm [ uasm ];
 
   setupHook = ./setup-hook.sh;
-
-  enableParallelBuilding = true;
 
   preBuild = "cd CPP/7zip/Bundles/Alone2";
 

--- a/pkgs/by-name/_9/_90secondportraits/package.nix
+++ b/pkgs/by-name/_9/_90secondportraits/package.nix
@@ -17,7 +17,7 @@ let
 
   icon = fetchurl {
     url = "http://tangramgames.dk/img/thumb/90secondportraits.png";
-    sha256 = "13k6cq8s7jw77j81xfa5ri41445m778q6iqbfplhwdpja03c6faw";
+    hash = "sha256-XDnDBlDyNg7pdQtHg9E5tRASSMxFuR6QPIfLoxFmZo4=";
   };
 
   desktopItems = [
@@ -33,14 +33,14 @@ let
   ];
 
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname desktopItems;
   version = "1.01b";
 
   src = fetchFromGitHub {
     owner = "SimonLarsen";
     repo = "90-Second-Portraits";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-xxgB8Aw7QTK9lPus7Q4E7iP2/rRfCwwiYbk5NqzujHI=";
     fetchSubmodules = true;
   };
@@ -88,5 +88,4 @@ stdenv.mkDerivation rec {
     ];
     downloadPage = "http://tangramgames.dk/games/90secondportraits";
   };
-
-}
+})

--- a/pkgs/by-name/_9/_915resolution/package.nix
+++ b/pkgs/by-name/_9/_915resolution/package.nix
@@ -4,13 +4,13 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "915resolution";
   version = "0.5.3";
 
   src = fetchurl {
-    url = "http://915resolution.mango-lang.org/915resolution-${version}.tar.gz";
-    sha256 = "0hmmy4kkz3x6yigz6hk99416ybznd67dpjaxap50nhay9f1snk5n";
+    url = "http://915resolution.mango-lang.org/915resolution-${finalAttrs.version}.tar.gz";
+    hash = "sha256-tkyrg0teQQvKVV3J245p9i9vAklpQvNf9KaPPyfxtUI=";
   };
 
   patchPhase = "rm *.o";
@@ -26,4 +26,4 @@ stdenv.mkDerivation rec {
     ];
     license = lib.licenses.publicDomain;
   };
-}
+})

--- a/pkgs/by-name/_9/_9base/package.nix
+++ b/pkgs/by-name/_9/_9base/package.nix
@@ -39,11 +39,9 @@ stdenv.mkDerivation {
   # the 9yacc script needs to be executed to build other items
   preBuild = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     substituteInPlace ./yacc/9yacc \
-      --replace "../yacc/yacc" "${lib.getExe' pkgsBuildHost._9base "yacc"}"
+      --replace-fail "../yacc/yacc" "${lib.getExe' pkgsBuildHost._9base "yacc"}"
   '';
 
-  enableParallelBuilding = true;
-  strictDeps = true;
   nativeBuildInputs = [ pkg-config ];
   env.NIX_CFLAGS_COMPILE = toString [
     # workaround build failure on -fno-common toolchains like upstream

--- a/pkgs/by-name/_9/_9pfs/package.nix
+++ b/pkgs/by-name/_9/_9pfs/package.nix
@@ -7,19 +7,19 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "9pfs";
   version = "0.5";
 
   src = fetchFromGitHub {
     owner = "ftrvxmtrx";
     repo = "9pfs";
-    tag = version;
-    sha256 = "sha256-NT8oIQK8Os3HRZLOH2OvauiCvh5bXZFbeEtTFbzNvrs=";
+    tag = finalAttrs.version;
+    hash = "sha256-NT8oIQK8Os3HRZLOH2OvauiCvh5bXZFbeEtTFbzNvrs=";
   };
 
   postPatch = ''
-    substituteInPlace Makefile --replace "pkg-config" "$PKG_CONFIG"
+    substituteInPlace Makefile --replace-fail "pkg-config" "$PKG_CONFIG"
   '';
 
   makeFlags = [
@@ -28,7 +28,6 @@ stdenv.mkDerivation rec {
   ];
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ fuse ];
-  enableParallelBuilding = true;
 
   passthru.updateScript = gitUpdater { };
 
@@ -43,4 +42,4 @@ stdenv.mkDerivation rec {
       bsd2
     ];
   };
-}
+})

--- a/pkgs/by-name/_9/_9ptls/package.nix
+++ b/pkgs/by-name/_9/_9ptls/package.nix
@@ -5,10 +5,8 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  inherit (tlsclient) src version enableParallelBuilding;
+  inherit (tlsclient) src version;
   pname = "9ptls";
-
-  strictDeps = true;
 
   buildFlags = [ "mount.9ptls" ];
   installFlags = [

--- a/pkgs/top-level/by-name-overlay.nix
+++ b/pkgs/top-level/by-name-overlay.nix
@@ -19,6 +19,26 @@ let
     mergeAttrsList
     ;
 
+  # Folder ranges that should have enhanced defaults applied
+  # Each range is { from = "aa"; to = "az"; } (inclusive)
+  # Packages in these ranges get structuredAttrsByDefault, enableParallelBuilding
+  # and strictDeps unless explicitly set to false
+  # Starting with underscore-prefixed directories which have minimal reverse deps
+  enhancedDefaultRanges = [
+    {
+      from = "_0";
+      to = "a-";
+    }
+  ];
+
+  # Check if a shard falls within any of the enhanced default ranges
+  shardInRange =
+    shard:
+    let
+      inSingleRange = range: shard >= range.from && shard <= range.to;
+    in
+    builtins.any inSingleRange enhancedDefaultRanges;
+
   # Package files for a single shard
   # Type: String -> String -> AttrsOf Path
   namesForShard =
@@ -36,10 +56,23 @@ let
         readDir (baseDirectory + "/${shard}")
       );
 
+  # Set of shards that should have enhanced defaults
+  enhancedShards = lib.genAttrs (builtins.filter shardInRange (
+    builtins.attrNames (readDir baseDirectory)
+  )) (_: true);
+
   # The attribute set mapping names to the package files defining them
   # This is defined up here in order to allow reuse of the value (it's kind of expensive to compute)
   # if the overlay has to be applied multiple times
   packageFiles = mergeAttrsList (mapAttrsToList namesForShard (readDir baseDirectory));
+
+  # Enhanced defaults to apply
+  enhancedDefaults = {
+    __structuredAttrs = true;
+    enableParallelBuilding = true;
+    strictDeps = true;
+  };
+
 in
 self: super:
 {
@@ -49,6 +82,23 @@ self: super:
   # and whether it's defined by this file here or `all-packages.nix`.
   # TODO: This can be removed once `pkgs/by-name` can handle custom `callPackage` arguments without `all-packages.nix` (or any other way of achieving the same result).
   # Because at that point the code in ./stage.nix can be changed to not allow definitions in `all-packages.nix` to override ones from `pkgs/by-name` anymore and throw an error if that happens instead.
-  _internalCallByNamePackageFile = file: self.callPackage file { };
+  _internalCallByNamePackageFile =
+    file:
+    let
+      result = self.callPackage file { };
+      # Extract shard from path to check if enhanced
+      pathParts = lib.splitString "/" (toString file);
+      shard = builtins.elemAt pathParts (builtins.length pathParts - 3);
+      isEnhanced = enhancedShards ? ${shard};
+    in
+    # Only apply enhanced defaults to packages that use stdenv directly
+    if isEnhanced && result ? overrideAttrs then
+      result.overrideAttrs (prev: {
+        __structuredAttrs = prev.__structuredAttrs or enhancedDefaults.__structuredAttrs;
+        enableParallelBuilding = prev.enableParallelBuilding or enhancedDefaults.enableParallelBuilding;
+        strictDeps = prev.strictDeps or enhancedDefaults.strictDeps;
+      })
+    else
+      result;
 }
 // mapAttrs (name: self._internalCallByNamePackageFile) packageFiles


### PR DESCRIPTION
This PR introduces a mechanism to progressively enable modern Nix build defaults (`__structuredAttrs`, `strictDeps`, `enableParallelBuilding`) for packages in `pkgs/by-name`, starting with directories that have minimal reverse dependencies.

### Changes

Adds configurable `enhancedDefaultRanges` to `pkgs/top-level/by-name-overlay.nix` to specify which shard ranges get enhanced defaults. Packages in these ranges automatically receive:
- `__structuredAttrs = true`
- `strictDeps = true`
- `enableParallelBuilding = true`

Initial range is `_0` to `a-`. Multiple ranges supported so people are not limited to sequential migration
```nix
enhancedDefaultRanges = [
  { from = "_0"; to = "a-"; }
  { from = "b0"; to = "c-"; }
  { from = "z0"; to = "zz"; }
];
```

Remaining commits fix packages that broke with these new defaults.

### Trade-off

This makes moving packages from `all-packages.nix` to `pkgs/by-name` harder for affected ranges, as it will trigger rebuilds due to the new defaults being applied.

---

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test