### PR TITLE
[Backport release-25.11] nixos/rqbit: init service module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1539,6 +1539,7 @@
   ./services/torrent/opentracker.nix
   ./services/torrent/peerflix.nix
   ./services/torrent/qbittorrent.nix
+  ./services/torrent/rqbit.nix
   ./services/torrent/rtorrent.nix
   ./services/torrent/torrentstream.nix
   ./services/torrent/transmission.nix

--- a/nixos/modules/services/torrent/rqbit.nix
+++ b/nixos/modules/services/torrent/rqbit.nix
@@ -1,0 +1,151 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    mkPackageOption
+    mkIf
+    ;
+
+  cfg = config.services.rqbit;
+  stateDir = "/var/lib/rqbit";
+  defaultDownloadDir = "${stateDir}/downloads";
+in
+{
+  options.services.rqbit = {
+    enable = mkEnableOption "rqbit BitTorrent daemon";
+
+    package = mkPackageOption pkgs "rqbit" { };
+
+    user = mkOption {
+      type = types.str;
+      default = "rqbit";
+      description = "User account under which rqbit runs.";
+    };
+
+    group = mkOption {
+      type = types.str;
+      default = "rqbit";
+      description = "Group account under which rqbit runs.";
+    };
+
+    downloadDir = mkOption {
+      type = types.path;
+      default = defaultDownloadDir;
+      example = "/mnt/storage/torrents";
+      description = "Directory where to download torrents.";
+    };
+
+    httpPort = mkOption {
+      type = types.port;
+      default = 3030;
+      description = "The listen port for the HTTP API.";
+    };
+
+    httpHost = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = "The listen host for the HTTP API.";
+    };
+
+    peerPort = mkOption {
+      type = types.port;
+      default = 4240;
+      description = "The port to listen for incoming BitTorrent peer connections (TCP and uTP).";
+    };
+
+    openFirewall = mkEnableOption "opening of the HTTP and Peer ports in the firewall";
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.rqbit = {
+      description = "rqbit BitTorrent Service";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment = {
+        HOME = stateDir;
+        RQBIT_HTTP_API_LISTEN_ADDR = "${
+          if (lib.hasInfix ":" cfg.httpHost) then "[${cfg.httpHost}]" else cfg.httpHost
+        }:${toString cfg.httpPort}";
+        RQBIT_LISTEN_PORT = toString cfg.peerPort;
+        RQBIT_SESSION_PERSISTENCE_LOCATION = stateDir;
+      };
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} server start ${cfg.downloadDir}";
+        User = cfg.user;
+        Group = cfg.group;
+
+        StateDirectory = "rqbit";
+        StateDirectoryMode = "0750";
+
+        # systemd-analyze security rqbit
+        ReadWritePaths = mkIf (cfg.downloadDir != defaultDownloadDir) [ cfg.downloadDir ];
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        PrivateUsers = true;
+        RemoveIPC = true;
+        CapabilityBoundingSet = "";
+        NoNewPrivileges = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectClock = true;
+        ProtectHostname = true;
+        RestrictNamespaces = true;
+        SystemCallFilter = [
+          "@system-service"
+          "@network-io"
+          "@file-system"
+          "~@privileged"
+          "~@resources"
+        ];
+        SystemCallArchitectures = "native";
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        UMask = "0027";
+      };
+    };
+
+    users = {
+      users = mkIf (cfg.user == "rqbit") {
+        rqbit = {
+          inherit (cfg) group;
+          isSystemUser = true;
+        };
+      };
+      groups = mkIf (cfg.group == "rqbit") { rqbit = { }; };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [
+        cfg.httpPort
+        cfg.peerPort
+      ];
+      allowedUDPPorts = [ cfg.peerPort ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ CodedNil ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1363,6 +1363,7 @@ in
   rosenpass = runTest ./rosenpass.nix;
   roundcube = runTest ./roundcube.nix;
   routinator = handleTest ./routinator.nix { };
+  rqbit = handleTest ./rqbit.nix { };
   rshim = handleTest ./rshim.nix { };
   rspamd = handleTest ./rspamd.nix { };
   rspamd-trainer = runTest ./rspamd-trainer.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1363,7 +1363,7 @@ in
   rosenpass = runTest ./rosenpass.nix;
   roundcube = runTest ./roundcube.nix;
   routinator = handleTest ./routinator.nix { };
-  rqbit = handleTest ./rqbit.nix { };
+  rqbit = runTest ./rqbit.nix;
   rshim = handleTest ./rshim.nix { };
   rspamd = handleTest ./rspamd.nix { };
   rspamd-trainer = runTest ./rspamd-trainer.nix;

--- a/nixos/tests/rqbit.nix
+++ b/nixos/tests/rqbit.nix
@@ -1,0 +1,30 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  let
+    port = 3030;
+  in
+  {
+    name = "rqbit";
+    meta = {
+      maintainers = with pkgs.lib.maintainers; [ CodedNil ];
+    };
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.rqbit = {
+          httpPort = port;
+          enable = true;
+          openFirewall = true;
+        };
+      };
+
+    testScript = /* python */ ''
+      machine.start()
+      machine.wait_for_unit("rqbit.service")
+      machine.wait_for_open_port(${toString port})
+
+      machine.succeed("curl --fail http://localhost:${toString port}")
+    '';
+  }
+)

--- a/nixos/tests/rqbit.nix
+++ b/nixos/tests/rqbit.nix
@@ -1,30 +1,28 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  let
-    port = 3030;
-  in
-  {
-    name = "rqbit";
-    meta = {
-      maintainers = with pkgs.lib.maintainers; [ CodedNil ];
+{ pkgs, ... }:
+let
+  port = 3030;
+in
+{
+  name = "rqbit";
+  meta = {
+    maintainers = with pkgs.lib.maintainers; [ CodedNil ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.rqbit = {
+        httpPort = port;
+        enable = true;
+        openFirewall = true;
+      };
     };
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        services.rqbit = {
-          httpPort = port;
-          enable = true;
-          openFirewall = true;
-        };
-      };
+  testScript = /* python */ ''
+    machine.start()
+    machine.wait_for_unit("rqbit.service")
+    machine.wait_for_open_port(${toString port})
 
-    testScript = /* python */ ''
-      machine.start()
-      machine.wait_for_unit("rqbit.service")
-      machine.wait_for_open_port(${toString port})
-
-      machine.succeed("curl --fail http://localhost:${toString port}")
-    '';
-  }
-)
+    machine.succeed("curl --fail http://localhost:${toString port}")
+  '';
+}

--- a/pkgs/by-name/rq/rqbit/package.nix
+++ b/pkgs/by-name/rq/rqbit/package.nix
@@ -8,6 +8,7 @@
   buildNpmPackage,
   nodejs_20,
   nix-update-script,
+  nixosTests,
 }:
 let
   pname = "rqbit";
@@ -64,13 +65,15 @@ rustPlatform.buildRustPackage {
 
   doCheck = false;
 
-  passthru.webui = rqbit-webui;
-
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--subpackage"
-      "webui"
-    ];
+  passthru = {
+    webui = rqbit-webui;
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "webui"
+      ];
+    };
+    tests.testService = nixosTests.rqbit;
   };
 
   meta = {


### PR DESCRIPTION
backports #483071
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
