### PR TITLE
prometheus-opnsense-exporter: 0.0.11 -> 0.0.12

### DIFF
--- a/pkgs/by-name/pr/prometheus-opnsense-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-opnsense-exporter/package.nix
@@ -6,13 +6,13 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "prometheus-opnsense-exporter";
-  version = "0.0.11";
+  version = "0.0.12";
 
   src = fetchFromGitHub {
-    owner = "athennamind";
+    owner = "AthennaMind";
     repo = "opnsense-exporter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-j16ATUeFqPiPElUqCPwylcujN/qiD9GrrBOXelAbgNs=";
+    hash = "sha256-k+o7zvCJypzbBdZQWlTosauvdk1E207H75+fjtE/Ckk=";
   };
 
   ldflags = [
@@ -29,9 +29,9 @@ buildGoModule (finalAttrs: {
   doInstallCheck = true;
   meta = {
     changelog = "https://github.com/AthennaMind/opnsense-exporter/releases/tag/v${finalAttrs.version}";
-    homepage = "https://githbub.com/AthennaMind/opnsense-exporter";
+    homepage = "https://github.com/AthennaMind/opnsense-exporter";
     description = "Prometheus exporter for opnsense firewall appliances";
-    license = lib.licenses.mit;
+    license = lib.licenses.asl20;
     mainProgram = "opnsense-exporter";
     maintainers = with lib.maintainers; [ paepcke ];
   };


### PR DESCRIPTION
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


fixes typo and license
