### PR TITLE
nixos/lavalink: refactor

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -126,6 +126,8 @@
     IMAP_CERTIFICATE_VALIDATION=false
     ```
 
+- The option {option}`services.lavalink.password` has been deprecated in favor of an out of store file in {option}`services.lavalink.passwordFile`
+
 - `python3packages.pillow-avif-plugin` has been removed as the functionality is included in `python3packages.pillow` directly since version 11.3.
 
 - `services.openssh.settings.AcceptEnv` now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
@@ -149,6 +151,36 @@
 - `fetchPnpmDeps` and `pnpmConfigHook` were added as top-level attributes, replacing the now deprecated `pnpm.fetchDeps` and `pnpm.configHook` attributes.
 
 - Added `dell-bios-fan-control` package and service.
+
+- The option {option}`services.lavalink.plugins` has changed significantly. Instead of being a list of plugin settings and their fetchers in one set, it
+  is now attributes of a plugin fetcher and an additional option {option}`services.lavalink.plugins.<name>.settings` defining the plugin's settings.
+
+  If you had the youtube plugin installed, your configuration probably looks similar to the following:
+  ```nix
+  {
+    services.lavalink.plugins = [
+      {
+        dependency = "dev.lavalink.youtube:youtube-plugin:1.16.0";
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+        configName = "youtube";
+        extraConfig.enabled = true;
+      }
+    ];
+  }
+  ```
+
+  This is what the migration could look like:
+  ```nix
+  {
+    services.lavalink.plugins.youtube = {
+      dependency = "dev.lavalink.youtube:youtube-plugin:1.16.0";
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+      settings.enabled = true;
+    };
+  }
+  ```
 
 - `openrgb` was updated to 1.0rc2, which now uses Plugin API version 4.
   Some existing OpenRGB plugins may be incompatible or require updates.

--- a/nixos/modules/services/audio/lavalink.nix
+++ b/nixos/modules/services/audio/lavalink.nix
@@ -11,45 +11,137 @@ let
     mkEnableOption
     mkIf
     types
+    literalExpression
+    mkRemovedOptionModule
+    mkRenamedOptionModule
+    attrValues
+    pipe
+    filterAttrs
+    mapAttrs
+    optionalString
     ;
 
   cfg = config.services.lavalink;
 
   format = pkgs.formats.yaml { };
+
+  hasPlugins = cfg.plugins != { };
+  isDeprecatedPlugin = (builtins.typeOf cfg.plugins) == "list";
+  pluginModule.options = {
+    dependency = mkOption {
+      type = types.str;
+      example = "dev.lavalink.youtube:youtube-plugin:1.8.0";
+      description = ''
+        The coordinates of the plugin.
+      '';
+    };
+
+    repository = mkOption {
+      type = types.str;
+      default = "https://maven.lavalink.dev/releases";
+      example = "https://maven.example.com/releases";
+      description = ''
+        The plugin repository. Defaults to the lavalink releases repository.
+
+        To use the snapshots repository, use <https://maven.lavalink.dev/snapshots> instead.
+      '';
+    };
+
+    hash = mkOption {
+      type = types.str;
+      default = "";
+      example = lib.fakeHash;
+      description = ''
+        The hash of the plugin's jar file
+      '';
+    };
+
+    settings = mkOption {
+      type = types.submodule { freeformType = format.type; };
+      default = { };
+      example = literalExpression ''
+        {
+          # Settings part of the youtube plugin
+          enabled = true;
+          allowSearch = true;
+          allowDirectVideoIds = true;
+          allowDirectPlaylistIds = true;
+        }
+      '';
+      description = ''
+        The settings for the plugin.
+      '';
+    };
+  };
 in
 
 {
+  imports = [
+    (mkRemovedOptionModule
+      [
+        "services"
+        "lavalink"
+        "password"
+      ]
+      ''
+        The {option}`services.lavalink.password` option was removed,
+        because it's insecure to store passwords in the nix store.
+
+        Define a path to a file, outside the nix store, containing the
+        password in {option}`services.lavalink.passwordFile` instead.
+
+        See the [NixOS release notes] for more information.
+
+        [NixOS release notes]: https://nixos.org/manual/nixos/unstable/release-notes#sec-release-26.05-incompatibilities
+      ''
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "lavalink"
+        "extraConfig"
+      ]
+      [
+        "services"
+        "lavalink"
+        "settings"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "lavalink"
+        "enableHttp2"
+      ]
+      [
+        "services"
+        "lavalink"
+        "settings"
+        "server"
+        "http2"
+        "enabled"
+      ]
+    )
+    (mkRenamedOptionModule
+      [
+        "services"
+        "lavalink"
+        "port"
+      ]
+      [
+        "services"
+        "lavalink"
+        "settings"
+        "server"
+        "port"
+      ]
+    )
+  ];
+
   options.services.lavalink = {
     enable = mkEnableOption "Lavalink";
 
     package = lib.mkPackageOption pkgs "lavalink" { };
-
-    password = mkOption {
-      type = types.nullOr types.str;
-      default = null;
-      example = "s3cRe!p4SsW0rD";
-      description = ''
-        The password for Lavalink's authentication in plain text.
-      '';
-    };
-
-    port = mkOption {
-      type = types.port;
-      default = 2333;
-      example = 4567;
-      description = ''
-        The port that Lavalink will use.
-      '';
-    };
-
-    address = mkOption {
-      type = types.str;
-      default = "0.0.0.0";
-      example = "127.0.0.1";
-      description = ''
-        The network address to bind to.
-      '';
-    };
 
     openFirewall = mkOption {
       type = types.bool;
@@ -63,7 +155,7 @@ in
     user = mkOption {
       type = types.str;
       default = "lavalink";
-      example = "root";
+      example = "media";
       description = ''
         The user of the service.
       '';
@@ -72,7 +164,7 @@ in
     group = mkOption {
       type = types.str;
       default = "lavalink";
-      example = "medias";
+      example = "media";
       description = ''
         The group of the service.
       '';
@@ -81,20 +173,28 @@ in
     home = mkOption {
       type = types.str;
       default = "/var/lib/lavalink";
-      example = "/home/lavalink";
+      example = "/srv/lavalink";
       description = ''
-        The home directory for lavalink.
+        The home directory containing lavalink's state files,
+        {file}`application.yml` configuration, and plugins.
       '';
     };
 
-    enableHttp2 = mkEnableOption "HTTP/2 support";
-
     jvmArgs = mkOption {
       type = types.str;
-      default = "-Xmx4G";
+      default = "";
       example = "-Djava.io.tmpdir=/var/lib/lavalink/tmp -Xmx6G";
       description = ''
         Set custom JVM arguments.
+      '';
+    };
+
+    passwordFile = mkOption {
+      type = types.nullOr types.externalPath;
+      default = null;
+      example = "/run/secrets/lavalinkPassword";
+      description = ''
+        A file containing the password for authentication with lavalink.
       '';
     };
 
@@ -104,88 +204,139 @@ in
       example = "/run/secrets/lavalink/passwordEnvFile";
       description = ''
         Add custom environment variables from a file.
-        See <https://lavalink.dev/configuration/index.html#example-environment-variables> for the full documentation.
+
+        See <https://lavalink.dev/configuration/index.html#example-environment-variables>
+        for the full documentation.
       '';
     };
 
     plugins = mkOption {
-      type = types.listOf (
-        types.submodule {
-          options = {
-            dependency = mkOption {
-              type = types.str;
-              example = "dev.lavalink.youtube:youtube-plugin:1.8.0";
-              description = ''
-                The coordinates of the plugin.
-              '';
+      type =
+        types.either
+          # Pre 26.05 definition
+          (types.listOf (
+            types.submodule {
+              options = (removeAttrs pluginModule.options [ "settings" ]) // {
+                configName = mkOption {
+                  type = types.nullOr types.str;
+                  default = null;
+                  description = ''
+                    The configuration key of the plugin in the server's
+                    {file}`application.yml` under `plugins`.
+
+                    This option is deprecated. Please migrate to the
+                    attribute set definition instead.
+
+                    See the [NixOS release notes] for more information.
+
+                    [NixOS release notes]: https://nixos.org/manual/nixos/unstable/release-notes#sec-release-26.05-incompatibilities
+                  '';
+                };
+
+                extraConfig = pluginModule.options.settings // {
+                  description = pluginModule.options.settings.description + ''
+                    This option is deprecated. Please migrate to the
+                    attribute set definition instead.
+
+                    See the [NixOS release notes] for more information.
+
+                    [NixOS release notes]: https://nixos.org/manual/nixos/unstable/release-notes#sec-release-26.05-incompatibilities
+                  '';
+                };
+              };
+            }
+          ))
+          (types.attrsOf (types.submodule pluginModule));
+
+      # Migrate lists
+      apply =
+        config:
+
+        if (lib.typeOf config) != "list" then
+          config
+        else
+          let
+            updatePlugin = plugin: {
+              name = if plugin.configName != null then plugin.configName else plugin.dependency;
+              value = (removeAttrs plugin [ "extraConfig" ]) // {
+                settings = plugin.extraConfig;
+              };
             };
+          in
+          pipe config [
+            (map updatePlugin)
+            builtins.listToAttrs
+          ];
 
-            repository = mkOption {
-              type = types.str;
-              example = "https://maven.example.com/releases";
-              default = "https://maven.lavalink.dev/releases";
-              description = ''
-                The plugin repository. Defaults to the lavalink releases repository.
+      default = { };
 
-                To use the snapshots repository, use <https://maven.lavalink.dev/snapshots> instead
-              '';
-            };
-
-            hash = mkOption {
-              type = types.str;
-              example = lib.fakeHash;
-              description = ''
-                The hash of the plugin.
-              '';
-            };
-
-            configName = mkOption {
-              type = types.nullOr types.str;
-              example = "youtube";
-              default = null;
-              description = ''
-                The name of the plugin to use as the key for the plugin configuration.
-              '';
-            };
-
-            extraConfig = mkOption {
-              type = types.submodule { freeformType = format.type; };
-              default = { };
-              description = ''
-                The configuration for the plugin.
-
-                The {option}`services.lavalink.plugins.*.configName` option must be set.
-              '';
-            };
-          };
-        }
-      );
-      default = [ ];
-
-      example = lib.literalExpression ''
-        [
-          {
+      example = literalExpression ''
+        {
+          youtube = {
+            # Fetcher arguments
             dependency = "dev.lavalink.youtube:youtube-plugin:1.8.0";
             repository = "https://maven.lavalink.dev/snapshots";
             hash = lib.fakeHash;
-            configName = "youtube";
-            extraConfig = {
+
+            # Add an object called "youtube" with the
+            # following settings at the root of the
+            # application.yaml
+            settings = {
               enabled = true;
               allowSearch = true;
               allowDirectVideoIds = true;
               allowDirectPlaylistIds = true;
             };
           }
-        ]
+
+          lavasrc = {
+            dependency = "com.github.topi314.lavasrc:lavasrc-plugin:4.8.1";
+            hash = lib.fakeHash;
+
+            settings = {
+              providers = [ "ytsearch:%QUERY%" ];
+              lyrics-sources.youtube = true;
+            };
+          }
+        }
       '';
 
       description = ''
-        A list of plugins for lavalink.
+        Plugins mapped to fetcher arguments and their settings.
+
+        Make sure to set the same attribute name as the key used
+        for configuration under `plugins`. Usually, if the plugin
+        provides server settings, those are found in the
+        {file}`README.md` of the project's repository.
       '';
     };
 
-    extraConfig = mkOption {
-      type = types.submodule { freeformType = format.type; };
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = format.type;
+
+        options.server = {
+          address = mkOption {
+            type = types.str;
+            default = "0.0.0.0";
+            example = "127.0.0.1";
+            description = ''
+              The network address to bind to.
+            '';
+          };
+
+          port = mkOption {
+            type = types.port;
+            default = 2333;
+            example = 4567;
+            description = ''
+              The port that to bind to.
+            '';
+          };
+
+          http2.enabled = mkEnableOption "HTTP/2 support";
+        };
+      };
 
       description = ''
         Configuration to write to {file}`application.yml`.
@@ -197,7 +348,7 @@ in
 
       default = { };
 
-      example = lib.literalExpression ''
+      example = literalExpression ''
         {
           lavalink.server = {
             sources.twitch = true;
@@ -211,125 +362,153 @@ in
     };
   };
 
-  config =
-    let
-      pluginSymlinks = lib.concatStringsSep "\n" (
-        map (
-          pluginCfg:
-          let
-            pluginParts = lib.match ''^(.*?:(.*?):)([0-9]+\.[0-9]+\.[0-9]+)$'' pluginCfg.dependency;
+  config = mkIf cfg.enable {
+    assertions = lib.optionals isDeprecatedPlugin [
+      {
+        assertion = lib.lists.all (
+          pluginCfg: pluginCfg.extraConfig == { } || pluginCfg.configName != null
+        ) cfg.plugins;
+        message = "Plugins with {option}`extraConfig` defined require the option {option}`configName`";
+      }
+    ];
 
-            pluginWebPath = lib.replaceStrings [ "." ":" ] [ "/" "/" ] (lib.elemAt pluginParts 0);
+    warnings = lib.optionals isDeprecatedPlugin [
+      ''
+        Defining a list of plugins has been deprecated in favor of an attribute set.
+        See the [NixOS release notes] for more information.
 
-            pluginFileName = lib.elemAt pluginParts 1;
-            pluginVersion = lib.elemAt pluginParts 2;
+        [NixOS release notes]: https://nixos.org/manual/nixos/unstable/release-notes#sec-release-26.05-incompatibilities
+      ''
+    ];
 
-            pluginFile = "${pluginFileName}-${pluginVersion}.jar";
-            pluginUrl = "${pluginCfg.repository}/${pluginWebPath}${pluginVersion}/${pluginFile}";
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
 
-            plugin = pkgs.fetchurl {
-              url = pluginUrl;
-              inherit (pluginCfg) hash;
-            };
-          in
-          "ln -sf ${plugin} ${cfg.home}/plugins/${pluginFile}"
-        ) cfg.plugins
-      );
-
-      pluginExtraConfigs = builtins.listToAttrs (
-        map (pluginConfig: lib.attrsets.nameValuePair pluginConfig.configName pluginConfig.extraConfig) (
-          lib.lists.filter (pluginCfg: pluginCfg.configName != null) cfg.plugins
-        )
-      );
-
-      config = lib.attrsets.recursiveUpdate cfg.extraConfig {
-        server = {
-          inherit (cfg) port address;
-          http2.enabled = cfg.enableHttp2;
-        };
-
-        plugins = pluginExtraConfigs;
-        lavalink.plugins = (
-          map (
-            pluginConfig:
-            removeAttrs pluginConfig [
-              "name"
-              "extraConfig"
-              "hash"
-            ]
-          ) cfg.plugins
-        );
-      };
-
-      configWithPassword = lib.attrsets.recursiveUpdate config (
-        lib.attrsets.optionalAttrs (cfg.password != null) { lavalink.server.password = cfg.password; }
-      );
-
-      configFile = format.generate "application.yml" configWithPassword;
-    in
-    mkIf cfg.enable {
-      assertions = [
-        {
-          assertion =
-            !(lib.lists.any (
-              pluginCfg: pluginCfg.extraConfig != { } && pluginCfg.configName == null
-            ) cfg.plugins);
-          message = "Plugins with extra configuration need to have the `configName` attribute defined";
-        }
-      ];
-
-      networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
-
-      users.groups = mkIf (cfg.group == "lavalink") { lavalink = { }; };
-      users.users = mkIf (cfg.user == "lavalink") {
-        lavalink = {
-          inherit (cfg) home;
-          group = "lavalink";
-          description = "The user for the Lavalink server";
-          isSystemUser = true;
-        };
-      };
-
-      systemd.tmpfiles.settings."10-lavalink" =
-        let
-          dirConfig = {
-            inherit (cfg) user group;
-            mode = "0700";
-          };
-        in
-        {
-          "${cfg.home}/plugins".d = mkIf (cfg.plugins != [ ]) dirConfig;
-          ${cfg.home}.d = dirConfig;
-        };
-
-      systemd.services.lavalink = {
-        description = "Lavalink Service";
-
-        wantedBy = [ "multi-user.target" ];
-        after = [
-          "syslog.target"
-          "network.target"
-        ];
-
-        script = ''
-          ${pluginSymlinks}
-
-          ln -sf ${configFile} ${cfg.home}/application.yml
-          export _JAVA_OPTIONS="${cfg.jvmArgs}"
-
-          ${lib.getExe cfg.package}
-        '';
-
-        serviceConfig = {
-          User = cfg.user;
-          Group = cfg.group;
-
-          Type = "simple";
-          Restart = "on-failure";
-
-          EnvironmentFile = cfg.environmentFile;
-          WorkingDirectory = cfg.home;
-        };
+    users.groups = mkIf (cfg.group == "lavalink") { lavalink = { }; };
+    users.users = mkIf (cfg.user == "lavalink") {
+      lavalink = {
+        isSystemUser = true;
+        description = "The user for the Lavalink server";
+        group = "lavalink";
+        inherit (cfg) home;
       };
     };
+
+    systemd.services.lavalink = {
+      description = "Lavalink Service";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "syslog.target"
+        "network.target"
+      ];
+
+      environment = mkIf (cfg.jvmArgs != "") { JAVA_TOOL_OPTIONS = cfg.jvmArgs; };
+
+      preStart =
+        let
+          fetchPlugin =
+            plugin:
+            let
+              pluginParts = lib.match ''^(.*?:(.*?):)([0-9]+\.[0-9]+\.[0-9]+)$'' plugin.dependency;
+
+              pluginWebPath = lib.replaceStrings [ "." ":" ] [ "/" "/" ] (lib.elemAt pluginParts 0);
+
+              pluginFileName = lib.elemAt pluginParts 1;
+              pluginVersion = lib.elemAt pluginParts 2;
+
+              pluginFile = "${pluginFileName}-${pluginVersion}.jar";
+              pluginUrl = "${plugin.repository}/${pluginWebPath}${pluginVersion}/${pluginFile}";
+            in
+            pkgs.fetchurl {
+              url = pluginUrl;
+              inherit (plugin) hash;
+            };
+
+          pluginFarm = pipe cfg.plugins [
+            attrValues
+            (map fetchPlugin)
+            (pkgs.linkFarmFromDrvs "lavalink-plugins")
+          ];
+
+          configWithPlugins = lib.attrsets.recursiveUpdate cfg.settings {
+            plugins = pipe cfg.plugins [
+              (filterAttrs (_: plugin: plugin.settings != { }))
+              (mapAttrs (_: plugin: plugin.settings))
+            ];
+
+            lavalink.pluginsDir = pluginFarm;
+            lavalink.plugins = pipe cfg.plugins [
+              attrValues
+              (map (
+                pluginConfig:
+                removeAttrs pluginConfig [
+                  "configName"
+                  "extraConfig"
+                  "settings"
+                  "hash"
+                ]
+              ))
+            ];
+          };
+
+          configFile = format.generate "application.yml" (
+            if hasPlugins then configWithPlugins else cfg.settings
+          );
+        in
+        ''
+          ln -sf ${configFile} "${cfg.home}/application.yml"
+        '';
+
+      script = ''
+        ${optionalString (cfg.passwordFile != null) ''
+          export LAVALINK_SERVER_PASSWORD="$(cat "$CREDENTIALS_DIRECTORY/lavalink_password")"
+        ''}
+        ${lib.getExe cfg.package}
+      '';
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+
+        Type = "simple";
+        Restart = "on-failure";
+
+        EnvironmentFile = cfg.environmentFile;
+        LoadCredential = mkIf (cfg.passwordFile != null) [ "lavalink_password:${cfg.passwordFile}" ];
+        StateDirectory = mkIf (cfg.home == "/var/lib/lavalink") "lavalink";
+        WorkingDirectory = "~";
+
+        # Hardening
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+        ];
+        UMask = "0027";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ nanoyaki ];
 }

--- a/nixos/tests/lavalink.nix
+++ b/nixos/tests/lavalink.nix
@@ -2,6 +2,49 @@
 
 let
   password = "s3cRe!p4SsW0rD";
+
+  common =
+    { pkgs, ... }:
+
+    {
+      services.lavalink = {
+        enable = true;
+        passwordFile = "/etc/lavalink-password";
+
+        settings = {
+          # Disable deprecated youtube source
+          lavalink.server.sources.youtube = false;
+          # Disable twitch web requests
+          lavalink.server.sources.twitch = false;
+        };
+      };
+
+      environment.etc."lavalink-password".text = password;
+
+      # Imitate the actual repository
+      # so that the plugin update check doesn't
+      # crash the program
+      services.httpd = {
+        enable = true;
+        virtualHosts."maven.lavalink.dev".locations."/releases/dev/lavalink/youtube/youtube-plugin/maven-metadata.xml".alias =
+          pkgs.writeText "maven-metadata.xml" ''
+            <metadata>
+              <groupId>dev.lavalink.youtube</groupId>
+              <artifactId>youtube-plugin</artifactId>
+              <versioning>
+                <latest>1.16.0</latest>
+                <release>1.16.0</release>
+                <versions>
+                  <version>1.16.0</version>
+                </versions>
+                <lastUpdated>20251103203930</lastUpdated>
+              </versioning>
+            </metadata>
+          '';
+      };
+
+      networking.hosts."127.0.0.1" = [ "maven.lavalink.dev" ];
+    };
 in
 
 {
@@ -9,35 +52,65 @@ in
   meta.maintainers = with lib.maintainers; [ nanoyaki ];
 
   nodes = {
-    machine = {
-      services.lavalink = {
-        enable = true;
-        port = 1234;
-        inherit password;
-      };
-    };
-    machine2 =
-      { pkgs, ... }:
+    default_2605.imports = [
+      common
+
       {
-        services.lavalink = {
-          enable = true;
-          port = 1235;
-          environmentFile = "${pkgs.writeText "passwordEnvFile" ''
-            LAVALINK_SERVER_PASSWORD=${password}
-          ''}";
+        services.lavalink.settings.server.port = 1234;
+        services.lavalink.plugins.youtube = {
+          # Use http for the test; the fetcher
+          # will redirect automatically anyway
+          repository = "http://maven.lavalink.dev/releases";
+          dependency = "dev.lavalink.youtube:youtube-plugin:1.16.0";
+          hash = "sha256-wKD+C7Y3nj+MpQDIRWvSIJ678jnRxzxEW0e0JkoszA4=";
+
+          settings.enabled = true;
         };
-      };
+      }
+    ];
+
+    deprecated.imports = [
+      common
+
+      {
+        services.lavalink.settings.server.port = 1235;
+        services.lavalink.plugins = [
+          {
+            # Use http for the test; the fetcher
+            # will redirect automatically anyway
+            repository = "http://maven.lavalink.dev/releases";
+            dependency = "dev.lavalink.youtube:youtube-plugin:1.16.0";
+            hash = "sha256-wKD+C7Y3nj+MpQDIRWvSIJ678jnRxzxEW0e0JkoszA4=";
+
+            configName = "youtube";
+            extraConfig.enabled = true;
+          }
+        ];
+      }
+    ];
   };
 
   testScript = ''
     start_all()
 
-    machine.wait_for_unit("lavalink.service")
-    machine.wait_for_open_port(1234)
-    machine.succeed("curl --header \"User-Id: 1204475253028429844\" --header \"Client-Name: shoukaku/4.1.1\" --header \"Authorization: ${password}\" http://localhost:1234/v4/info --fail -v")
+    default_2605.wait_for_unit('lavalink.service')
+    default_2605.wait_for_open_port(1234)
+    default_2605.succeed(
+      'curl --fail -v '
+      + '--header "User-Id: 1204475253028429844" '
+      + '--header "Client-Name: shoukaku/4.1.1" '
+      + '--header "Authorization: ${password}" '
+      + 'http://localhost:1234/v4/info'
+    )
 
-    machine2.wait_for_unit("lavalink.service")
-    machine2.wait_for_open_port(1235)
-    machine2.succeed("curl --header \"User-Id: 1204475253028429844\" --header \"Client-Name: shoukaku/4.1.1\" --header \"Authorization: ${password}\" http://localhost:1235/v4/info --fail -v")
+    deprecated.wait_for_unit('lavalink.service')
+    deprecated.wait_for_open_port(1235)
+    deprecated.succeed(
+      'curl --fail -v '
+      + '--header "User-Id: 1204475253028429844" '
+      + '--header "Client-Name: shoukaku/4.1.1" '
+      + '--header "Authorization: ${password}" '
+      + 'http://localhost:1235/v4/info'
+    )
   '';
 }


### PR DESCRIPTION
- Improved settings and plugins to be more nix idiomatic
- Deprecated 'password' in favor of 'passwordFile'
- Update associated tests to match the module update
- Hardened the lavalink service
- Added a release note describing the changes

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
