### PR TITLE
openttd-grfcodec: unstable-2021-03-10 -> 6.2.0, embed & check version

### DIFF
--- a/pkgs/by-name/op/openttd-grfcodec/package.nix
+++ b/pkgs/by-name/op/openttd-grfcodec/package.nix
@@ -5,24 +5,38 @@
   boost,
   cmake,
   git,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openttd-grfcodec";
-  version = "unstable-2021-03-10";
+  version = "6.2.0";
 
   src = fetchFromGitHub {
     owner = "OpenTTD";
     repo = "grfcodec";
-    rev = "045774dee7cab1a618a3e0d9b39bff78a12b6efa";
-    sha256 = "0b4xnnkqc01d3r834lhkq744ymar6c8iyxk51wc4c7hvz0vp9vmy";
+    tag = finalAttrs.version;
+    hash = "sha256-zIRHo2glD738Rmg4dhetIGtbIY/AgMKnzAJaP00lsqk=";
+    leaveDotGit = true;
+    postFetch = ''
+      # git arguments taken from generate_version.cmake
+      git_date=$(git -C $out show -s --pretty=%cd --date=short)
+      echo "${finalAttrs.version};$git_date" > $out/.version
+      rm -rf $out/.git
+    '';
   };
 
   buildInputs = [ boost ];
+
   nativeBuildInputs = [
     cmake
     git
   ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/grfcodec";
 
   installPhase = ''
     mkdir -p $out/bin
@@ -35,4 +49,4 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ ToxicFrog ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
