### PR TITLE
yaziPlugins: update on 2026-01-24

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/compress/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/compress/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "compress.yazi";
-  version = "0-unstable-2026-01-10";
+  version = "25.12.29-unstable-2026-01-24";
 
   src = fetchFromGitHub {
     owner = "KKV9";
     repo = "compress.yazi";
-    rev = "e6007f7c3f364cdb7146f5b6b282790948fb0bd6";
-    hash = "sha256-m5FfN2gnTHsbwP2aYaE+K6kNGfAC7HBVtCyy6HzNRrE=";
+    rev = "cb6e8ec0141915dc319ccd6b904dcd2f03502576";
+    hash = "sha256-D/EpcRDIc3toeyjHqi+vGw0v9B22HVvKJua5EVEAc0U=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/diff/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/diff/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "diff.yazi";
-  version = "25.2.7-unstable-2025-12-31";
+  version = "26.1.22-unstable-2026-01-24";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "398796d88fee7bf9c99c4dc29089b865d4f47722";
-    hash = "sha256-LOQ/0LYVrXsqQjeBeERKQ2M8BwN8xo3yej1mxNHphOU=";
+    rev = "6c71385af67c71cb3d62359e94077f2e940b15df";
+    hash = "sha256-+akz8E6Fmk6KwmeZOePEm/KqfbDaKeL4wiUgtm12SAE=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/lsar/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "lsar.yazi";
-  version = "25.5.31-unstable-2025-12-31";
+  version = "26.1.22-unstable-2026-01-24";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "398796d88fee7bf9c99c4dc29089b865d4f47722";
-    hash = "sha256-LOQ/0LYVrXsqQjeBeERKQ2M8BwN8xo3yej1mxNHphOU=";
+    rev = "6c71385af67c71cb3d62359e94077f2e940b15df";
+    hash = "sha256-+akz8E6Fmk6KwmeZOePEm/KqfbDaKeL4wiUgtm12SAE=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2026-01-07";
+  version = "25.5.31-unstable-2026-01-24";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "7cd6b042aba45367701e00819705bd0bac2c963c";
-    hash = "sha256-Ehg8PFiOLy4iKgsOjj8KiNGTdj3VwkdmNP3lvdBi9aY=";
+    rev = "ae2a1f18feb55ea9148032ce247109f2303ddbfd";
+    hash = "sha256-QH1vvPjPYGbf47kSgxV97pxZrdSFcqAEyXtQbJhusLg=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/piper/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/piper/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "piper.yazi";
-  version = "25.9.15-unstable-2026-01-12";
+  version = "26.1.22-unstable-2026-01-24";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "c179ea49753b3a784935986d36b077a6df24bdb3";
-    hash = "sha256-0VKoUusTmKVxW8fJkYf0lm17bMjvkN1/tmx7+pNJdWI=";
+    rev = "6c71385af67c71cb3d62359e94077f2e940b15df";
+    hash = "sha256-+akz8E6Fmk6KwmeZOePEm/KqfbDaKeL4wiUgtm12SAE=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/recycle-bin/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "recycle-bin.yazi";
-  version = "0-unstable-2026-01-04";
+  version = "0-unstable-2026-01-17";
 
   src = fetchFromGitHub {
     owner = "uhs-robert";
     repo = "recycle-bin.yazi";
-    rev = "69d7d4ce9e102b9249166c8ea783cfd24bdf7bb4";
-    hash = "sha256-oGmgqe8ZUJM3cxIPw019PwcNaQjLYquFpD1awabPrPc=";
+    rev = "fa687116c46a784e664ef96619b32abf51f29b06";
+    hash = "sha256-lpxTGWA15szM5VJ+qvV2+GTg7HXiZaZfyWyjeNMsTSM=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/vcs-files/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "vcs-files.yazi";
-  version = "25.12.29-unstable-2026-01-06";
+  version = "26.1.22-unstable-2026-01-24";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "4e5590280db0de5f130bf377e9c32a202110f575";
-    hash = "sha256-/yGS8R1YsYqqX4JTlIJeg+NfFSxGUHvSdKQZGk6KiBU=";
+    rev = "6c71385af67c71cb3d62359e94077f2e940b15df";
+    hash = "sha256-+akz8E6Fmk6KwmeZOePEm/KqfbDaKeL4wiUgtm12SAE=";
   };
 
   meta = {


### PR DESCRIPTION
- compress: 0-unstable-2026-01-10 → 25.12.29-unstable-2026-01-24
  Compare: https://github.com/KKV9/compress.yazi/compare/e6007f7c3f364cdb7146f5b6b282790948fb0bd6...cb6e8ec0141915dc319ccd6b904dcd2f03502576
- diff: 25.2.7-unstable-2025-12-31 → 26.1.22-unstable-2026-01-24
  Compare: https://github.com/yazi-rs/plugins/compare/398796d88fee7bf9c99c4dc29089b865d4f47722...6c71385af67c71cb3d62359e94077f2e940b15df
- lsar: 25.5.31-unstable-2025-12-31 → 26.1.22-unstable-2026-01-24
  Compare: https://github.com/yazi-rs/plugins/compare/398796d88fee7bf9c99c4dc29089b865d4f47722...6c71385af67c71cb3d62359e94077f2e940b15df
- mediainfo: 25.5.31-unstable-2026-01-07 → 25.5.31-unstable-2026-01-24
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/7cd6b042aba45367701e00819705bd0bac2c963c...ae2a1f18feb55ea9148032ce247109f2303ddbfd
- piper: 25.9.15-unstable-2026-01-12 → 26.1.22-unstable-2026-01-24
  Compare: https://github.com/yazi-rs/plugins/compare/c179ea49753b3a784935986d36b077a6df24bdb3...6c71385af67c71cb3d62359e94077f2e940b15df
- recycle-bin: 0-unstable-2026-01-04 → 0-unstable-2026-01-17
  Compare: https://github.com/uhs-robert/recycle-bin.yazi/compare/69d7d4ce9e102b9249166c8ea783cfd24bdf7bb4...fa687116c46a784e664ef96619b32abf51f29b06
- vcs-files: 25.12.29-unstable-2026-01-06 → 26.1.22-unstable-2026-01-24
  Compare: https://github.com/yazi-rs/plugins/compare/4e5590280db0de5f130bf377e9c32a202110f575...6c71385af67c71cb3d62359e94077f2e940b15df


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
