### PR TITLE
hev-socks5-tunnel: init at 2.14.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7755,6 +7755,12 @@
     name = "Emilia";
     keys = [ { fingerprint = "F772 3569 4B43 B599 73C2  A931 1EFB E941 B89B B810"; } ];
   };
+  EmilioPeJu = {
+    email = "emiliopeju@gmail.com";
+    github = "EmilioPeJu";
+    githubId = 26623273;
+    name = "Emilio Perez";
+  };
   emilioziniades = {
     email = "emilioziniades@protonmail.com";
     github = "emilioziniades";

--- a/pkgs/by-name/he/hev-socks5-tunnel/package.nix
+++ b/pkgs/by-name/he/hev-socks5-tunnel/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation rec {
+  name = "hev-socks5-tunnel";
+  version = "2.14.3";
+
+  src = fetchFromGitHub {
+    owner = "heiher";
+    repo = name;
+    rev = "${version}";
+    hash = "sha256-0Xcv9hfXOEwndEwy8K5TAQsCSStXkPZ0t7geNohKFGQ=";
+    fetchSubmodules = true;
+  };
+
+  installPhase = ''
+    make install INSTDIR=$out
+  '';
+
+  meta = {
+    description = "A simple, lightweight tunnel over Socks5 proxy (tun2socks)";
+    homepage = "https://github.com/heiher/hev-socks5-tunnel";
+    license = lib.licenses.mit;
+    mainProgram = "hev-socks5-tunnel";
+    maintainers = with lib.maintainers; [ EmilioPeJu ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
A simple, lightweight tunnel over Socks5 proxy (tun2socks).

Homepage: https://github.com/heiher/hev-socks5-tunnel

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
