### PR TITLE
reactguard: init at 0.9.9

### DIFF
--- a/pkgs/by-name/re/reactguard/package.nix
+++ b/pkgs/by-name/re/reactguard/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "reactguard";
+  version = "0.9.9";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "theori-io";
+    repo = "reactguard";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ysXdqMny6c1ATTpjI4Ev4T1yjs2jNu4mf7azO/IsAKI=";
+  };
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    httpx
+    typing-extensions
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytestCheckHook
+    pytest-cov-stub
+    pytest-xdist
+  ];
+
+  pythonImportsCheck = [ "reactguard" ];
+
+  meta = {
+    description = "Vulnerability detection tool for CVE-2025-55182 (React2Shell";
+    homepage = "https://github.com/theori-io/reactguard";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "reactguard";
+  };
+})


### PR DESCRIPTION
Vulnerability detection tool for CVE-2025-55182 (React2Shell

https://github.com/theori-io/reactguard

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
