### PR TITLE
mkFont: init builder (also migrate fonts as proof-of-concept)

### DIFF
--- a/pkgs/build-support/mkfont/default.nix
+++ b/pkgs/build-support/mkfont/default.nix
@@ -1,0 +1,52 @@
+{ lib, stdenvNoCC }:
+
+lib.extendMkDerivation {
+  constructDrv = stdenvNoCC.mkDerivation;
+  excludeDrvArgNames = [
+    "installWebfonts"
+    "noUnpackFonts"
+  ];
+  extendDrvArgs =
+    finalAttrs:
+    {
+      noUnpackFonts ? false,
+      installWebfonts ? false,
+      ...
+    }@args:
+    {
+      strictDeps = true;
+      __structuredAttrs = true;
+
+      sourceRoot = args.sourceRoot or lib.optionalString (noUnpackFonts || lib.hasAttr "srcs" args) ".";
+
+      unpackCmd = args.unpackCmd or lib.optionalString noUnpackFonts ''
+        filename="$(basename "$(stripHash "$curSrc")")"
+        cp "$curSrc" "./$filename"
+      '';
+
+      outputs = args.outputs or [ "out" ] ++ lib.optionals installWebfonts [ "webfont" ];
+
+      installPhase =
+        args.installPhase or ''
+          runHook preInstall
+
+          # these come up in some source trees, but are never useful to us
+          find -iname __MACOSX -type d -print0 | xargs -0 rm -rf
+
+          find -iname '*.ttf' -print0 | xargs -0 -r install -m644 -D -t $out/share/fonts/truetype
+          find -iname '*.ttc' -print0 | xargs -0 -r install -m644 -D -t $out/share/fonts/truetype
+          find -iname '*.otf' -print0 | xargs -0 -r install -m644 -D -t $out/share/fonts/opentype
+          find -iname '*.svg' -print0 | xargs -0 -r install -m644 -D -t $out/share/fonts/svg
+          find -iname '*.bdf' -print0 | xargs -0 -r install -m644 -D -t $out/share/fonts/misc
+          find -iname '*.otb' -print0 | xargs -0 -r install -m644 -D -t $out/share/fonts/misc
+          find -iname '*.psf' -print0 | xargs -0 -r install -m644 -D -t $out/share/consolefonts
+
+          ${lib.optionalString installWebfonts ''
+            find -iname '*.woff' -print0 | xargs -0 -r install -m644 -D -t $webfont/share/fonts/woff
+            find -iname '*.woff2' -print0 | xargs -0 -r install -m644 -D -t $webfont/share/fonts/woff2
+          ''}
+
+          runHook postInstall
+        '';
+    };
+}

--- a/pkgs/by-name/ag/agave/package.nix
+++ b/pkgs/by-name/ag/agave/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchurl,
-  stdenv,
+  mkFont,
 }:
 
 let
@@ -22,16 +22,11 @@ let
   ];
 
 in
-stdenv.mkDerivation {
+mkFont {
   inherit pname version;
   srcs = fonts;
-  sourceRoot = ".";
 
-  dontUnpack = true;
-
-  installPhase = ''
-    install -D $srcs -t $out/share/fonts/truetype/
-  '';
+  noUnpackFonts = true;
 
   meta = {
     description = "TrueType monospaced typeface designed for X environments";

--- a/pkgs/by-name/ba/barlow/package.nix
+++ b/pkgs/by-name/ba/barlow/package.nix
@@ -1,31 +1,21 @@
 {
   lib,
-  stdenvNoCC,
+  mkFont,
   fetchFromGitHub,
 }:
 
-stdenvNoCC.mkDerivation rec {
+mkFont (finalAttrs: {
   pname = "barlow";
   version = "1.422";
 
   src = fetchFromGitHub {
     owner = "jpt";
     repo = "barlow";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-FG68o6qN/296RhSNDHFXYXbkhlXSZJgGhVjzlJqsksY=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 fonts/otf/*.otf -t $out/share/fonts/opentype
-    install -Dm644 fonts/ttf/*.ttf fonts/gx/*.ttf -t $out/share/fonts/truetype
-    install -Dm644 fonts/eot/*.eot -t $out/share/fonts/eot
-    install -Dm644 fonts/woff/*.woff -t $out/share/fonts/woff
-    install -Dm644 fonts/woff2/*.woff2 -t $out/share/fonts/woff2
-
-    runHook postInstall
-  '';
+  installWebfonts = true;
 
   meta = {
     description = "Grotesk variable font superfamily";
@@ -34,4 +24,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/by-name/ko/komika-fonts/package.nix
+++ b/pkgs/by-name/ko/komika-fonts/package.nix
@@ -1,5 +1,5 @@
 {
-  stdenvNoCC,
+  mkFont,
   lib,
   fetchzip,
   variants ? [
@@ -68,17 +68,10 @@ let
         variants;
 
 in
-stdenvNoCC.mkDerivation {
+mkFont {
   pname = "komika-fonts";
   version = "0-unstable-2001-06-16";
-  sourceRoot = ".";
-
   srcs = map (variant: fetchFont fontMap.${variant}) selectedFonts;
-  installPhase = ''
-    runHook preInstall
-    install -Dm444 **/*.ttf -t $out/share/fonts/ttf
-    runHook postInstall
-  '';
 
   meta = {
     homepage = "https://pedroreina.net/apostrophiclab/";

--- a/pkgs/by-name/ne/newcomputermodern/package.nix
+++ b/pkgs/by-name/ne/newcomputermodern/package.nix
@@ -1,12 +1,12 @@
 {
   lib,
-  stdenvNoCC,
+  mkFont,
   fetchgit,
   fontforge,
   gitUpdater,
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+mkFont (finalAttrs: {
   pname = "newcomputermodern";
   version = "7.1.1";
 
@@ -29,12 +29,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
         ' $i;
     done
     runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    install -m444 -Dt $out/share/fonts/opentype/public sfd/*.otf
-    runHook postInstall
   '';
 
   passthru.updateScript = gitUpdater { };

--- a/pkgs/by-name/si/signwriting/package.nix
+++ b/pkgs/by-name/si/signwriting/package.nix
@@ -1,37 +1,33 @@
 {
   lib,
-  runCommand,
+  mkFont,
   fetchurl,
 }:
 
-runCommand "signwriting-1.1.4"
-  {
-    src1 = fetchurl {
+mkFont {
+  pname = "signwriting";
+  version = "1.1.4";
+
+  srcs = [
+    (fetchurl {
       url = "https://github.com/Slevinski/signwriting_2010_fonts/raw/61c8e7123a1168657b5d34d85266a637f67b9d2b/fonts/SignWriting%202010.ttf";
       name = "SignWriting_2010.ttf";
       sha256 = "1abjzykbjx2hal8mrxp51rvblv3q84akyn9qhjfaj20rwphkf5zj";
-    };
-
-    src2 = fetchurl {
+    })
+    (fetchurl {
       url = "https://github.com/Slevinski/signwriting_2010_fonts/raw/61c8e7123a1168657b5d34d85266a637f67b9d2b/fonts/SignWriting%202010%20Filling.ttf";
       name = "SignWriting_2010_Filling.ttf";
       sha256 = "0am5wbf7jdy9szxkbsc5f3959cxvbj7mr0hy1ziqmkz02c6xjw2m";
-    };
+    })
+  ];
 
-    outputHashAlgo = "sha256";
-    outputHashMode = "recursive";
-    outputHash = "0cn37s3lc7gbr8036l7ia2869qmxglkmgllh3r9q5j54g3sfjc7q";
+  noUnpackFonts = true;
 
-    meta = {
-      homepage = "https://github.com/Slevinski/signwriting_2010_fonts";
-      description = "Typeface for written sign languages";
-      maintainers = with lib.maintainers; [ mathnerd314 ];
-      license = lib.licenses.ofl;
-      platforms = lib.platforms.all;
-    };
-  }
-  ''
-    mkdir -p $out/share/fonts/truetype
-    cp $src1 $out/share/fonts/truetype/SignWriting_2010.ttf
-    cp $src2 $out/share/fonts/truetype/SignWriting_2010_Filling.ttf
-  ''
+  meta = {
+    homepage = "https://github.com/Slevinski/signwriting_2010_fonts";
+    description = "Typeface for written sign languages";
+    maintainers = with lib.maintainers; [ mathnerd314 ];
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -748,6 +748,8 @@ with pkgs;
 
   mkBinaryCache = callPackage ../build-support/binary-cache { };
 
+  mkFont = callPackage ../build-support/mkfont { };
+
   mkShell = callPackage ../build-support/mkshell { };
   mkShellNoCC = mkShell.override { stdenv = stdenvNoCC; };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is mostly a resurrection of #91518, but I have addressed a few of the issues people had, and also some general thoughts
- webfonts: woff only comes up in 93 files according to github search, vs 616 for ttf, which is probably the most common format we have. I've decided to create `installWebfonts` that defaults to false, so that way fonts that particularly want to package these can, but I figure in the general case they won't be missed (or were already in src but forgotten about to package)
  - I have decided to not bother with .eot fonts, as explained in the comments of the original PR, it is even more outdated of a format now
- disabling phases: personally, I'd rather have a clean general case, and most fonts are packaged as not much more than moving files around. I've left `patchPhase` enabled because this seems the most contentious. If a font has a really complicated build process, it should probably be using `stdenv` anyway, no sense in trying to handle every single font with this just because of the function name
  - EDIT: actually, this is mostly only an annoyance with fixupPhase, so we only really need to bother with that. 
  - EDIT2: messing with phases turns out to be not really worth the effort or the odd results for people using this
  - as a quick heuristic, only 41 files match `ttf AND buildPhase` in github search, but scanning through, many of these are just doing essentially the same thing as our new `installPhase`  
- selective installation: deletion can be done easily in postInstall if there's weird issues, I'm really not too fussed about this, if it's a massive set of multiple sources it should (imo) have it's own mechanism for subsets (see `komika-fonts`)
- fontconfig: out of scope for what I know how to handle, could be interesting later but it is out of scope as far as I'm concerned here

Oh also I attempted to make finalAttrs work based off of another PR I saw, no idea if I did it properly, but that's why I chose to migrate these two packages in particular for a start.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
