### PR TITLE
claude-code-config-switcher: init at 0-unstable-2025-07-15

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17445,6 +17445,12 @@
     githubId = 24192522;
     name = "MithicSpirit";
   };
+  MiyakoMeow = {
+    email = "miyakomeowaqwq@gmail.com";
+    github = "MiyakoMeow";
+    githubId = 110924386;
+    name = "MiyakoMeow";
+  };
   miyu = {
     email = "miyu@allthingslinux.org";
     github = "fndov";

--- a/pkgs/by-name/cl/claude-code-config-switcher/package.nix
+++ b/pkgs/by-name/cl/claude-code-config-switcher/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  jq,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation {
+  pname = "claude-code-config-switcher";
+  version = "0-unstable-2025-07-15";
+
+  src = fetchFromGitHub {
+    owner = "yoyooyooo";
+    repo = "claude-code-config";
+    rev = "449866d7daae8087abdfb8275eeb1367d8e35d72";
+    hash = "sha256-mVs9IHXl7zYz77Jq3KjNV5/cR7yywiUvMWaORdjZiYI=";
+  };
+
+  propagatedBuildInputs = [ jq ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp ccc $out/bin/claude-code-config-switcher
+    chmod +x $out/bin/claude-code-config-switcher
+
+    # Create symbolic links for convenience
+    ln -s claude-code-config-switcher $out/bin/ccc
+    ln -s claude-code-config-switcher $out/bin/cccs
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [ "--version=branch" ];
+    };
+  };
+
+  meta = {
+    description = "Claude Code configuration switcher - tool for managing different Claude API configurations";
+    homepage = "https://github.com/yoyooyooo/claude-code-config";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ MiyakoMeow ];
+    platforms = lib.platforms.unix;
+    mainProgram = "claude-code-config-switcher";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
