### PR TITLE
compressFirmwareZstd: enable __structuredAttrs and fix allowedRequisites

### DIFF
--- a/pkgs/build-support/kernel/compress-firmware.nix
+++ b/pkgs/build-support/kernel/compress-firmware.nix
@@ -24,7 +24,8 @@ let
     .${type} or (throw "Unsupported compressor type for firmware.");
 
   args = {
-    allowedRequisites = [ ];
+    outputChecks.out.allowedRequisites = [ "out" ];
+    __structuredAttrs = true;
     inherit (compressor) nativeBuildInputs;
   }
   // lib.optionalAttrs (firmware ? meta) { inherit (firmware) meta; };


### PR DESCRIPTION
This fixes the build, but at what cost?

Even if I run an `rm -rf $out/*` at the end of the `runCommand`, the derivation still refers to itself.

If a derivation always does, should we need to add its respective inputs to `allowedRequisites` manually, or should this be fixed in `make-derivation.nix` (e.g. always add `"<name>"` to `outputChecks.<name>.allowedRequisites` if it is set) or is this a `nix`-the-program issue?

The actual use of `allowedRequisites` in nixpkgs is rather rare, and it's passed through a bunch of layers, so I'm happy to defer to someone who has a proper solution.

Testing done via `nix-build --expr "let pkgs = import ./. { }; in pkgs.compressFirmwareZstd pkgs.alsa-firmware"`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
