### PR TITLE
nixos/tests/rqbit: convert to runTest

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1389,7 +1389,7 @@ in
   rosenpass = runTest ./rosenpass.nix;
   roundcube = runTest ./roundcube.nix;
   routinator = handleTest ./routinator.nix { };
-  rqbit = handleTest ./rqbit.nix { };
+  rqbit = runTest ./rqbit.nix;
   rshim = handleTest ./rshim.nix { };
   rspamd = handleTest ./rspamd.nix { };
   rspamd-trainer = runTest ./rspamd-trainer.nix;

--- a/nixos/tests/rqbit.nix
+++ b/nixos/tests/rqbit.nix
@@ -1,30 +1,28 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  let
-    port = 3030;
-  in
-  {
-    name = "rqbit";
-    meta = {
-      maintainers = with pkgs.lib.maintainers; [ CodedNil ];
+{ pkgs, ... }:
+let
+  port = 3030;
+in
+{
+  name = "rqbit";
+  meta = {
+    maintainers = with pkgs.lib.maintainers; [ CodedNil ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.rqbit = {
+        httpPort = port;
+        enable = true;
+        openFirewall = true;
+      };
     };
 
-    nodes.machine =
-      { pkgs, ... }:
-      {
-        services.rqbit = {
-          httpPort = port;
-          enable = true;
-          openFirewall = true;
-        };
-      };
+  testScript = /* python */ ''
+    machine.start()
+    machine.wait_for_unit("rqbit.service")
+    machine.wait_for_open_port(${toString port})
 
-    testScript = /* python */ ''
-      machine.start()
-      machine.wait_for_unit("rqbit.service")
-      machine.wait_for_open_port(${toString port})
-
-      machine.succeed("curl --fail http://localhost:${toString port}")
-    '';
-  }
-)
+    machine.succeed("curl --fail http://localhost:${toString port}")
+  '';
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
