### PR TITLE
etterna: fix replay directory

### DIFF
--- a/pkgs/by-name/et/etterna/0002-replays-dir-fix.patch
+++ b/pkgs/by-name/et/etterna/0002-replays-dir-fix.patch
@@ -1,0 +1,58 @@
+diff --git a/src/Etterna/Models/HighScore/Replay.cpp b/src/Etterna/Models/HighScore/Replay.cpp
+index 77e85b7ca0..1375e59142 100644
+--- a/src/Etterna/Models/HighScore/Replay.cpp
++++ b/src/Etterna/Models/HighScore/Replay.cpp
+@@ -344,7 +344,7 @@ Replay::WriteReplayData() -> bool
+ 		return false;
+ 	}
+ 
+-	const auto path = FULL_REPLAY_DIR + scoreKey;
++	const auto path = FILEMAN->ResolvePath(FULL_REPLAY_DIR + scoreKey);
+ 
+ 	std::ofstream fileStream(path, std::ios::binary);
+ 	if (!fileStream) {
+@@ -412,7 +412,7 @@ Replay::WriteInputData() -> bool
+ 		SetHighScoreMods();
+ 	}
+ 
+-	const auto path = INPUT_DATA_DIR + scoreKey;
++	const auto path = FILEMAN->ResolvePath(INPUT_DATA_DIR + scoreKey);
+ 	const auto path_z = path + "z";
+ 
+ 	std::ofstream fileStream(path, std::ios::binary);
+@@ -566,7 +566,7 @@ Replay::LoadInputData(const std::string& replayDir) -> bool
+ 		return loadResultInputData;
+ 	}
+ 
+-	const auto path = replayDir + scoreKey;
++	const auto path = FILEMAN->ResolvePath(replayDir + scoreKey);
+ 	const auto path_z = path + "z";
+ 	std::vector<InputDataEvent> readInputs;
+ 	std::vector<HoldReplayResult> vHoldReplayDataVector;
+@@ -827,7 +827,7 @@ Replay::LoadReplayDataBasic(const std::string& replayDir) -> bool
+ 	std::string profiledir;
+ 	std::vector<int> vNoteRowVector;
+ 	std::vector<float> vOffsetVector;
+-	const auto path = replayDir + scoreKey;
++	const auto path = FILEMAN->ResolvePath(replayDir + scoreKey);
+ 
+ 	std::ifstream fileStream(path, std::ios::binary);
+ 	std::string line;
+@@ -917,7 +917,7 @@ Replay::LoadReplayDataFull(const std::string& replayDir) -> bool
+ 	std::vector<int> vTrackVector;
+ 	std::vector<TapNoteType> vTapNoteTypeVector;
+ 	std::vector<HoldReplayResult> vHoldReplayDataVector;
+-	const auto path = replayDir + scoreKey;
++	const auto path = FILEMAN->ResolvePath(replayDir + scoreKey);
+ 
+ 	std::ifstream fileStream(path, std::ios::binary);
+ 	std::string line;
+@@ -1050,7 +1050,7 @@ Replay::LoadOnlineDataFromDisk(const std::string& replayDir) -> bool
+ 	std::vector<int> tracks;
+ 	std::vector<int> rows;
+ 	std::vector<TapNoteType> types;
+-	const auto path = replayDir + scoreKey;
++	const auto path = FILEMAN->ResolvePath(replayDir + scoreKey);
+ 
+ 	std::ifstream fileStream(path, std::ios::binary);
+ 

--- a/pkgs/by-name/et/etterna/package.nix
+++ b/pkgs/by-name/et/etterna/package.nix
@@ -32,6 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # https://github.com/etternagame/etterna/pull/1396
     ./0001-Add-aarch64-linux-support.patch
+    ./0002-replays-dir-fix.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
This fixes an issue with the replay system. Replays currently do not persist if the game is closed. This is due to the replay directory not being resolved correctly. This patch rectifies this similarly to the download manager patch. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
