### PR TITLE
contour: remove unused pcre dependency

### DIFF
--- a/pkgs/by-name/co/contour/package.nix
+++ b/pkgs/by-name/co/contour/package.nix
@@ -11,7 +11,6 @@
   libutempter,
   termbench-pro,
   qt6,
-  pcre,
   boost,
   catch2_3,
   fmt,
@@ -65,7 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     termbench-pro
     qt6.qtmultimedia
     qt6.qt5compat
-    pcre
     boost
     catch2_3
     fmt


### PR DESCRIPTION
Per issue https://github.com/NixOS/nixpkgs/issues/356387 we would like to remove pcre from nixpkgs.

## Things done

Removed pcre from build inputs. It is no longer required as pcre2 is propagated via qt6's build inputs. Built the package and ran it to test.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
