### PR TITLE
libepoxy: build egl support with x11Support = false

### DIFF
--- a/pkgs/by-name/li/libepoxy/package.nix
+++ b/pkgs/by-name/li/libepoxy/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs =
-    lib.optionals (x11Support && !stdenv.hostPlatform.isDarwin) [
+    lib.optionals (!stdenv.hostPlatform.isDarwin) [
       libGL
     ]
     ++ lib.optionals x11Support [
@@ -63,14 +63,14 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   mesonFlags = [
-    "-Degl=${lib.boolToYesNo (x11Support && !stdenv.hostPlatform.isDarwin)}"
+    "-Degl=${lib.boolToYesNo (!stdenv.hostPlatform.isDarwin)}"
     "-Dglx=${lib.boolToYesNo x11Support}"
     "-Dtests=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     "-Dx11=${lib.boolToString x11Support}"
   ];
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString (
-    x11Support && !stdenv.hostPlatform.isDarwin
+    !stdenv.hostPlatform.isDarwin
   ) ''-DLIBGL_PATH="${lib.getLib libGL}/lib"'';
 
   doCheck = true;


### PR DESCRIPTION
## Things done

allows building EGL support through libGL (libglvnd) even if x11 and GLX are disabled

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
