### PR TITLE
particle-cli: patch usb udev rules to not apply the `plugdev` group

### DIFF
--- a/pkgs/by-name/pa/particle-cli/0001-Don-t-apply-plugdev-group-in-udev-rules.patch
+++ b/pkgs/by-name/pa/particle-cli/0001-Don-t-apply-plugdev-group-in-udev-rules.patch
@@ -1,0 +1,37 @@
+From 3e25951b7681873f96542a5cec0cbf4f2701680c Mon Sep 17 00:00:00 2001
+From: Jess <jess@jessie.cafe>
+Date: Sun, 25 Jan 2026 18:35:57 +1300
+Subject: [PATCH] Don't apply plugdev group in udev rules
+
+---
+ assets/50-particle.rules | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/assets/50-particle.rules b/assets/50-particle.rules
+index 61092467..66b3d406 100644
+--- a/assets/50-particle.rules
++++ b/assets/50-particle.rules
+@@ -13,15 +13,15 @@
+ # Particle device.
+ #
+ # Core
+-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="607[df]", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
++SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="607[df]", MODE="0660", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+ # Gen 2 (Photon/P1/Electron), Gen 3 (Argon/Boron/Xenon, SoM)
+-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b04", ATTRS{idProduct}=="[cd]0??", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
++SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b04", ATTRS{idProduct}=="[cd]0??", MODE="0660", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+ # Particle Programmer Shield v1.0
+-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
++SUBSYSTEMS=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", MODE="0660", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+ # Particle Debugger
+-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
++SUBSYSTEMS=="usb", ATTRS{idVendor}=="0d28", ATTRS{idProduct}=="0204", MODE="0660", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+ # Tachyon in EDL mode
+-SUBSYSTEM=="usb", ATTRS{idProduct}=="9008", ATTRS{idVendor}=="05c6", GROUP="plugdev", MODE="0666"
++SUBSYSTEM=="usb", ATTRS{idProduct}=="9008", ATTRS{idVendor}=="05c6", MODE="0660", TAG+="uaccess"
+ #
+ # If you share your linux system with other users, or just don't like the
+ # idea of write permission for everybody, you can replace MODE:="0666" with
+-- 
+2.52.0
+

--- a/pkgs/by-name/pa/particle-cli/package.nix
+++ b/pkgs/by-name/pa/particle-cli/package.nix
@@ -19,6 +19,10 @@ buildNpmPackage (finalAttrs: {
 
   npmDepsHash = "sha256-rHT8ZLBe3uO1NxrbVBdrh0fn9gvBVq4XE8Gfhcshq/E=";
 
+  patches = [
+    ./0001-Don-t-apply-plugdev-group-in-udev-rules.patch
+  ];
+
   buildInputs = [
     udev
   ];


### PR DESCRIPTION
The udev rules were failing as the `plugdev` group does not exist, so replace it with `TAG+="uaccess"` and `MODE="0660"` https://github.com/NixOS/nixpkgs/issues/76482#issuecomment-56890081
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
