### PR TITLE
whatsapp-chat-exporter: 0.12.1 → 0.13.0

### DIFF
--- a/pkgs/by-name/wh/whatsapp-chat-exporter/package.nix
+++ b/pkgs/by-name/wh/whatsapp-chat-exporter/package.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "0.12.1";
+  version = "0.13.0";
 in
 python3Packages.buildPythonApplication {
   pname = "whatsapp-chat-exporter";
@@ -16,15 +16,15 @@ python3Packages.buildPythonApplication {
     owner = "KnugiHK";
     repo = "Whatsapp-Chat-Exporter";
     tag = version;
-    hash = "sha256-AyxRIjcAGjxCe0m2cSESQWd75v5tzpsCmb+3wChbH7c=";
+    hash = "sha256-nD8rpA1BbKbHpjAuIDdhaiMUjQCypDuo0pNAYbkoOxo=";
   };
 
   propagatedBuildInputs = with python3Packages; [
     bleach
+    javaobj-py3
     jinja2
     pycryptodome
-    javaobj-py3
-    vobject
+    tqdm
   ];
 
   meta = {


### PR DESCRIPTION
Release Notes: https://github.com/KnugiHK/WhatsApp-Chat-Exporter/releases/tag/0.13.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
