### PR TITLE
netgen: fix UB in Archive::operator&

### DIFF
--- a/pkgs/by-name/ne/netgen/ensure_python_before_getting_gil.patch
+++ b/pkgs/by-name/ne/netgen/ensure_python_before_getting_gil.patch
@@ -1,0 +1,24 @@
+diff --git a/libsrc/core/python_ngcore.hpp b/libsrc/core/python_ngcore.hpp
+index 2ce84481..4fc8aa4e 100644
+--- a/libsrc/core/python_ngcore.hpp
++++ b/libsrc/core/python_ngcore.hpp
+@@ -2,6 +2,7 @@
+ #define NETGEN_CORE_PYTHON_NGCORE_HPP
+ 
+ #include "ngcore_api.hpp" // for operator new
++#include <pybind11/embed.h>
+ #include <pybind11/pybind11.h>
+ #include <pybind11/operators.h>
+ #include <pybind11/numpy.h>
+diff --git a/ng/ngappinit.cpp b/ng/ngappinit.cpp
+index f6b4be0a..e21937b5 100644
+--- a/ng/ngappinit.cpp
++++ b/ng/ngappinit.cpp
+@@ -256,6 +256,7 @@ int main(int argc, char ** argv)
+       Tk_MainLoop();
+       Tcl_DeleteInterp (myinterp); 
+ #ifdef NETGEN_PYTHON
++      py::scoped_interpreter guard{};
+       py::gil_scoped_acquire ensure_gil;
+ #endif
+ 

--- a/pkgs/by-name/ne/netgen/macos_use_tk_default_color_map.patch
+++ b/pkgs/by-name/ne/netgen/macos_use_tk_default_color_map.patch
@@ -1,0 +1,80 @@
+diff --git a/ng/Togl2.1/togl.c b/ng/Togl2.1/togl.c
+index 78faa6c1..522a71f1 100644
+--- a/ng/Togl2.1/togl.c
++++ b/ng/Togl2.1/togl.c
+@@ -3018,7 +3018,6 @@ Togl_MakeWindow(Tk_Window tkwin, Window parent, ClientData instanceData)
+ 
+     dpy = Tk_Display(tkwin);
+     scrnum = Tk_ScreenNumber(tkwin);
+-
+     /* 
+      * Windows and Mac OS X need the window created before OpenGL context
+      * is created.  So do that now and set the window variable. 
+@@ -3140,7 +3139,7 @@ Togl_MakeWindow(Tk_Window tkwin, Window parent, ClientData instanceData)
+         goto error;
+     }
+ #endif
+-#if defined(TOGL_WGL) || defined(TOGL_AGL) || defined(TOGL_NSOPENGL)
++#if defined(TOGL_WGL)
+     if (togl->VisInfo == NULL) {
+         /* 
+          * Create a new OpenGL rendering context. And check to share lists.
+@@ -3417,7 +3416,6 @@ Togl_MakeWindow(Tk_Window tkwin, Window parent, ClientData instanceData)
+     DescribePixelFormat(togl->tglGLHdc, (int) togl->PixelFormat, sizeof (pfd),
+             &pfd);
+ #endif
+-
+     /* 
+      * find a colormap
+      */
+@@ -3432,7 +3430,8 @@ Togl_MakeWindow(Tk_Window tkwin, Window parent, ClientData instanceData)
+             cmap = DefaultColormap(dpy, scrnum);
+         }
+ #elif defined(TOGL_AGL) || defined(TOGL_NSOPENGL)
+-        cmap = DefaultColormap(dpy, scrnum);
++        /* macOS: get colormap from Tk */
++        cmap = Tk_Colormap(tkwin);
+ #endif
+     } else {
+         /* Colormap for CI mode */
+@@ -3457,10 +3456,11 @@ Togl_MakeWindow(Tk_Window tkwin, Window parent, ClientData instanceData)
+ #elif defined(TOGL_WGL)
+             cmap = Win32CreateCiColormap(togl);
+ #elif defined(TOGL_AGL) || defined(TOGL_NSOPENGL)
+-            /* need to figure out how to do this correctly on Mac... */
+-            cmap = DefaultColormap(dpy, scrnum);
++            /* macOS: use Tk default colormap */
++            cmap = Tk_Colormap(tkwin);
+ #endif
+         } else {
++#if defined(TOGL_X11)
+             if (togl->VisInfo->visual == DefaultVisual(dpy, scrnum)) {
+                 /* share default/root colormap */
+                 cmap = Tk_Colormap(tkwin);
+@@ -3470,14 +3470,25 @@ Togl_MakeWindow(Tk_Window tkwin, Window parent, ClientData instanceData)
+                         XRootWindow(dpy, togl->VisInfo->screen),
+                         togl->VisInfo->visual, AllocNone);
+             }
++#else
++            /* Windows, AGL, NSOPENGL: use Tk default colormap */
++            cmap = Tk_Colormap(tkwin);
++#endif
+         }
+     }
+ 
+     /* Make sure Tk knows to switch to the new colormap when the cursor is over
+      * this window when running in color index mode. */
++#if defined(TOGL_X11)
+     (void) Tk_SetWindowVisual(tkwin, togl->VisInfo->visual,
+             togl->VisInfo->depth, cmap);
+-
++#elif defined(TOGL_WGL)
++    /* Windows: use default visual */
++    (void) Tk_SetWindowVisual(tkwin, DefaultVisual(dpy, scrnum),
++            DefaultDepth(dpy, scrnum), cmap);
++#elif defined(TOGL_AGL) || defined(TOGL_NSOPENGL)
++    /* Macos: use Tk default colormap */
++#endif
+ #ifdef TOGL_WGL
+     /* Install the colormap */
+     SelectPalette(togl->tglGLHdc, ((TkWinColormap *) cmap)->palette, TRUE);

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -61,6 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "${patchSource}/include_stdlib.patch";
       hash = "sha256-W+NgGBuy/UmzVbPTSqR8FRUlyN/9dl9l9e9rxKklmIc=";
     })
+    ./ensure_python_before_getting_gil.patch
+    ./macos_use_tk_default_color_map.patch
   ];
 
   # when generating python stub file utilizing system python pybind11_stubgen module

--- a/pkgs/by-name/ne/netgen/package.nix
+++ b/pkgs/by-name/ne/netgen/package.nix
@@ -79,6 +79,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace ng/Togl2.1/CMakeLists.txt \
       --replace-fail "/usr/bin/gcc" "$CC"
+
+    # Fix UB when size == 0, otherwise test_archive will fail when hardening enable glibcxxassertions
+    substituteInPlace libsrc/core/archive.hpp \
+      --replace-fail "Do(&v[0], size);" "Do(v.data(), size);"
   ''
   + lib.optionalString (!stdenv.hostPlatform.isx86_64) ''
     # mesh generation differs on x86_64 and aarch64 platform


### PR DESCRIPTION
fix test SIGTRAP on darwin platform cause darwin has more strict index out-of-bound check.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
