### PR TITLE
librepods: init at 0.1.0-unstable-2025-12-07

### DIFF
--- a/pkgs/by-name/li/librepods/package.nix
+++ b/pkgs/by-name/li/librepods/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  libpulseaudio,
+  openssl,
+  qt6,
+  cmake,
+  pkg-config,
+  lib,
+}:
+
+stdenv.mkDerivation {
+  pname = "librepods";
+  version = "0.1.0-unstable-2025-12-07";
+
+  src = fetchFromGitHub {
+    owner = "kavishdevar";
+    repo = "librepods";
+    rev = "0e1f784737122913c21b429810d059aadfb4479e";
+    hash = "sha256-nXEMIyQWEDMjyKGPAleqqSttznNmrdSHKT4Kr2tLHBY=";
+  };
+
+  sourceRoot = "source/linux";
+
+  buildInputs = [
+    libpulseaudio
+    openssl
+    qt6.qtbase
+    qt6.qtconnectivity
+    qt6.qtquick3d
+    qt6.qttools
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  meta = {
+    homepage = "https://github.com/kavishdevar/librepods";
+    description = "AirPods liberated from Apple's ecosystem";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.thefossguy ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
