### PR TITLE
librelane: 3.0.0.dev47-unstable-2026-01-12 -> 3.0.0.dev49

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -22,14 +22,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.0.dev47-unstable-2026-01-12";
+  version = "3.0.0.dev49";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
-    rev = "f1efecac3151f3275fa2ea7d656f8ea7e3225a9d";
-    hash = "sha256-XZHypZ+Ht1Zbb0N9VBUmrZKwWuqYA0/w7DpZBOO9KU8=";
+    tag = finalAttrs.version;
+    hash = "sha256-g6bQMg9W0gbvJzVvO4ESeAtswbBoUVY3NXLK4UdOcGs=";
   };
 
   build-system = [


### PR DESCRIPTION
Update to 3.0.0.dev48

https://github.com/librelane/librelane/releases/tag/3.0.0.dev48

Depends on:
https://github.com/NixOS/nixpkgs/pull/483150
https://github.com/NixOS/nixpkgs/pull/483019

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
