### PR TITLE
python3.pkgs.numba: support Numpy 2.4

### DIFF
--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -2,19 +2,23 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python,
   buildPythonPackage,
-  setuptools,
-  numpy,
-  numpy_1,
-  llvmlite,
   replaceVars,
-  writers,
+
+  # nativeBuildInputs
+  setuptools,
+
+  # dependencies
+  llvmlite,
+  numpy,
+
+  # tests
   numba,
   pytestCheckHook,
   writableTmpDirAsHomeHook,
-
-  config,
+  numpy_1,
+  writers,
+  python,
 
   # CUDA-only dependencies:
   addDriverRunpath,
@@ -22,6 +26,7 @@
   cudaPackages,
 
   # CUDA flags:
+  config,
   cudaSupport ? config.cudaSupport,
   testsWithoutSandbox ? false,
   doFullCheck ? false,

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -32,7 +32,7 @@
 let
   cudatoolkit = cudaPackages.cuda_nvcc;
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   version = "0.63.1";
   pname = "numba";
   pyproject = true;
@@ -40,14 +40,14 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "numba";
     repo = "numba";
-    tag = version;
+    tag = finalAttrs.version;
     # Upstream uses .gitattributes to inject information about the revision
     # hash and the refname into `numba/_version.py`, see:
     #
     # - https://git-scm.com/docs/gitattributes#_export_subst and
     # - https://github.com/numba/numba/blame/5ef7c86f76a6e8cc90e9486487294e0c34024797/numba/_version.py#L25-L31
     postFetch = ''
-      sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${src.tag})"/' $out/numba/_version.py
+      sed -i 's/git_refnames = "[^"]*"/git_refnames = " (tag: ${finalAttrs.src.tag})"/' $out/numba/_version.py
     '';
     hash = "sha256-M7Hdc1Qakclz7i/HujBUqVEWFsHj9ZGQDzb8Ze9AztA=";
   };
@@ -147,10 +147,10 @@ buildPythonPackage rec {
   };
 
   meta = {
-    changelog = "https://numba.readthedocs.io/en/stable/release/${version}-notes.html";
+    changelog = "https://numba.readthedocs.io/en/stable/release/${finalAttrs.version}-notes.html";
     description = "Compiling Python code using LLVM";
     homepage = "https://numba.pydata.org/";
     license = lib.licenses.bsd2;
     mainProgram = "numba";
   };
-}
+})

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -12,6 +12,7 @@
   writers,
   numba,
   pytestCheckHook,
+  writableTmpDirAsHomeHook,
 
   config,
 
@@ -86,11 +87,11 @@ buildPythonPackage (finalAttrs: {
 
   nativeCheckInputs = [
     pytestCheckHook
+    writableTmpDirAsHomeHook
   ];
 
+  # https://github.com/NixOS/nixpkgs/issues/255262
   preCheck = ''
-    export HOME="$(mktemp -d)"
-    # https://github.com/NixOS/nixpkgs/issues/255262
     cd $out
   '';
 

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -1,10 +1,7 @@
 {
   lib,
   stdenv,
-  pythonAtLeast,
-  pythonOlder,
   fetchFromGitHub,
-  fetchpatch2,
   python,
   buildPythonPackage,
   setuptools,

--- a/pkgs/development/python-modules/numba/numpy2.4.patch
+++ b/pkgs/development/python-modules/numba/numpy2.4.patch
@@ -1,0 +1,28 @@
+diff --git a/numba/__init__.py b/numba/__init__.py
+index 33f752018..7d3b3ae8d 100644
+--- a/numba/__init__.py
++++ b/numba/__init__.py
+@@ -39,8 +39,8 @@ def _ensure_critical_deps():
+                f"{numpy_version[0]}.{numpy_version[1]}.")
+         raise ImportError(msg)
+ 
+-    if numpy_version > (2, 3):
+-        msg = (f"Numba needs NumPy 2.3 or less. Got NumPy "
++    if numpy_version > (2, 4):
++        msg = (f"Numba needs NumPy 2.4 or less. Got NumPy "
+                 f"{numpy_version[0]}.{numpy_version[1]}.")
+         raise ImportError(msg)
+
+diff --git a/setup.py b/setup.py
+index 9eaa191cb..a5febef1e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -23,7 +23,7 @@ min_python_version = "3.10"
+ max_python_version = "3.15"  # exclusive
+ min_numpy_build_version = "2.0.0rc1"
+ min_numpy_run_version = "1.22"
+-max_numpy_run_version = "2.4"
++max_numpy_run_version = "2.5"
+ min_llvmlite_version = "0.46.0dev0"
+ max_llvmlite_version = "0.47"
+


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test