### PR TITLE
ejabberd: fix rebar-deps.nix, add missing nixfmt to updateScript

### DIFF
--- a/pkgs/by-name/ej/ejabberd/rebar-deps.nix
+++ b/pkgs/by-name/ej/ejabberd/rebar-deps.nix
@@ -128,7 +128,7 @@ let
       src = fetchHex {
         pkg = "p1_pgsql";
         version = "1.1.38";
-        sha256 = "";
+        sha256 = "sha256-Bs9kQwCBeOujh7ou6STTYgBBuuTaGyyWloAoSgXMdZ4=";
       };
       beamDeps = [ xmpp ];
     };
@@ -148,7 +148,7 @@ let
       src = fetchHex {
         pkg = "p1_mysql";
         version = "1.0.27";
-        sha256 = "";
+        sha256 = "sha256-BmBR8kACenZzJUfmnZagl05w3BTe2UU77yYyIYQe2ps=";
       };
       beamDeps = [ ];
     };
@@ -261,6 +261,17 @@ let
         p1_utils
         stun
       ];
+    };
+    erlydtl = builder {
+      name = "erlydtl";
+      version = "git";
+      src = fetchFromGitHub {
+        owner = "erlydtl";
+        repo = "erlydtl";
+        rev = "aae414692b6052e96d890e03bbeeeca0f4dc01c2";
+        sha256 = "00p194jgmvzqza7xr7fdm2n091ymkyy66aj4gc82n0kzdlh03vbm";
+      };
+      beamDeps = [ ];
     };
     eredis = builder {
       name = "eredis";

--- a/pkgs/by-name/ej/ejabberd/update.sh
+++ b/pkgs/by-name/ej/ejabberd/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts "rebar3WithPlugins {globalPlugins = [beamPackages.rebar3-nix];}" erlang autoconf automake
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq common-updater-scripts "rebar3WithPlugins {globalPlugins = [beamPackages.rebar3-nix];}" erlang autoconf automake nixfmt
 #shellcheck shell=bash
 
 set -eu -o pipefail


### PR DESCRIPTION
Supersedes #483598

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
