### PR TITLE
openscreen: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22204,6 +22204,13 @@
     github = "renesat";
     githubId = 11363539;
   };
+  Renna42 = {
+    name = "Renna Z.";
+    email = "is@renna.dev";
+    github = "Renna42";
+    githubId = 47046832;
+    keys = [ { fingerprint = "7E33 7F70 6F89 4D13 D8E6  B718 9676 3FAE 10AC 74FC"; } ];
+  };
   rennsax = {
     name = "Bojun Ren";
     email = "bj.ren.coding@outlook.com";

--- a/pkgs/by-name/op/openscreen/electron-avoid-phantomjs.patch
+++ b/pkgs/by-name/op/openscreen/electron-avoid-phantomjs.patch
@@ -1,0 +1,10 @@
+--- a/package.json
++++ b/package.json
+@@ -63,7 +63,6 @@
+     "autoprefixer": "^10.4.21",
+     "electron": "^39.2.7",
+     "electron-builder": "^24.13.3",
+-    "electron-icon-builder": "^2.0.1",
+     "electron-rebuild": "^3.2.9",
+     "eslint": "^8.57.0",
+     "eslint-plugin-react-hooks": "^4.6.0",

--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -1,0 +1,125 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  copyDesktopItems,
+  makeWrapper,
+  makeDesktopItem,
+  electron_39,
+  nodejs_22,
+  nix-update-script,
+
+  nodejs ? nodejs_22,
+  electron ? electron_39,
+}:
+buildNpmPackage (finalAttrs: {
+  inherit nodejs;
+
+  pname = "openscreen";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "siddharthvaddem";
+    repo = "openscreen";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eneZ/2oCjIimlqGpwKGdxiPPsDTdaBOHpTUfWOQSD54=";
+  };
+
+  npmDepsHash = "sha256-TNUbF0YVpAGZFGYf3cgM2oTrSGTo6tTvckqLrvdiE6g=";
+
+  npmRebuildFlags = [ "--ignore-scripts" ]; # Prevent running `node-gyp build`
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  patches = [
+    # Avoid downloading `phantomjs` within the build sandbox
+    # by completely removing `electron-icon-builder`
+    ./electron-avoid-phantomjs.patch
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm exec tsc
+    npm exec vite build
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      # electronDist needs to be modifiable on Darwin
+      cp -r ${electron.dist} electron-dist
+      chmod -R u+w electron-dist
+      # Disable code signing during build on macOS.
+      # https://github.com/electron-userland/electron-builder/blob/fa6fc16/docs/code-signing.md#how-to-disable-code-signing-during-the-build-process-on-macos
+      export CSC_IDENTITY_AUTO_DISCOVERY=false
+    ''}
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      ln -s ${electron.dist} electron-dist
+    ''}
+
+    npm exec electron-builder -- \
+      --dir \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p $out/share/openscreen
+      cp -r release/*/*-unpacked/{locales,resources{,.pak}} $out/share/openscreen
+
+      makeWrapper ${lib.getExe electron} $out/bin/openscreen \
+          --add-flags $out/share/openscreen/resources/app.asar \
+          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+          --set-default ELECTRON_IS_DEV 0 \
+          --inherit-argv0
+
+      install -Dm644 icons/icons/png/512x512.png $out/share/icons/hicolor/512x512/apps/openscreen.png
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      cp -R release/*/mac*/Openscreen.app $out/Applications/
+      makeWrapper $out/Applications/Openscreen.app/Contents/MacOS/Openscreen $out/bin/openscreen
+    ''}
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "openscreen";
+      desktopName = "OpenScreen";
+      comment = finalAttrs.meta.description;
+      icon = "openscreen";
+      exec = "openscreen %u";
+      categories = [
+        "AudioVideo"
+        "Video"
+        "Utility"
+      ];
+      terminal = false;
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Free, open-source alternative to Screen Studio (sort of)";
+    homepage = "https://openscreen.vercel.app";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      Renna42
+    ];
+    mainProgram = "openscreen";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Free, open-source alternative to Screen Studio (sort of)

Homepage: https://openscreen.vercel.app/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
