### PR TITLE
imwheel: fixing build

### DIFF
--- a/pkgs/by-name/im/imwheel/package.nix
+++ b/pkgs/by-name/im/imwheel/package.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation rec {
     libXtst
   ];
 
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
   makeFlags = [
     "sysconfdir=/etc"
     "ETCDIR=/etc"


### PR DESCRIPTION
Fixes build failure due to incompatible pointer types in signal handlers.
```
[...]
util.c:335:43: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
[...]
```
https://hydra.nixos.org/build/319945419
Related to: https://github.com/NixOS/nixpkgs/issues/475479

It's ancient and I don't think it's worth patching it, but I assume there is still quite some use out there, so we can't just ditch the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
