### PR TITLE
vintagestory: add update script

### DIFF
--- a/pkgs/by-name/vi/vintagestory/package.nix
+++ b/pkgs/by-name/vi/vintagestory/package.nix
@@ -120,6 +120,8 @@ stdenv.mkDerivation (finalAttrs: {
       done
     '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "In-development indie sandbox game about innovation and exploration";
     homepage = "https://www.vintagestory.at/";

--- a/pkgs/by-name/vi/vintagestory/update.sh
+++ b/pkgs/by-name/vi/vintagestory/update.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -I../../../.. -i bash -p curl jq common-updater-scripts
+
+set -euo pipefail
+
+new_version="$(curl -sL https://mods.vintagestory.at/api/gameversions | jq -r '.gameversions | map(.name | select(contains("-") | not)) | last')"
+update-source-version vintagestory "$new_version"


### PR DESCRIPTION
cc @powerofthe69

Tested, of course doesn't do anything right now. I trust `update-source-version` will do the job just fine.

Closes https://github.com/NixOS/nixpkgs/issues/460371

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
