### PR TITLE
geminicommit: 0.6.1 -> 0.7.0 and fix comments

### DIFF
--- a/pkgs/by-name/ge/geminicommit/package.nix
+++ b/pkgs/by-name/ge/geminicommit/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "geminicommit";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "tfkhdyt";
     repo = "geminicommit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PAL14mxeWYEDaFL/rniLN+FNDFE/T3t2+pAK4BGqcJY=";
+    hash = "sha256-BLCnBym69O6s4UnogopcccI5PnniOFJ3BcWFyxEsUUI=";
   };
 
-  vendorHash = "sha256-4aVUD16zhzWvgD90gttmoDRoKKb0dRgDdH1HMfgd3LU=";
+  vendorHash = "sha256-FFWptw1kSbl7f8DR3FrM0jAfr06NaJT+i/8ZaQjav/E=";
 
   nativeBuildInputs = [
     installShellFiles
@@ -29,8 +29,8 @@ buildGoModule (finalAttrs: {
       cmd = finalAttrs.meta.mainProgram;
       goDefaultCmd = finalAttrs.pname;
     in
-    # The official github released binary is renamed since v0.6.1,
-    # see: https://github.com/tfkhdyt/geminicommit/releases/tag/v0.6.1
+    # The official github released binary is renamed since v0.7.0,
+    # see: https://github.com/tfkhdyt/geminicommit/releases/tag/v0.7.0
     # Here we link the old name (which is also the `go build` default name)
     # for backward compatibility:
     ''

--- a/pkgs/by-name/ge/geminicommit/package.nix
+++ b/pkgs/by-name/ge/geminicommit/package.nix
@@ -29,8 +29,8 @@ buildGoModule (finalAttrs: {
       cmd = finalAttrs.meta.mainProgram;
       goDefaultCmd = finalAttrs.pname;
     in
-    # The official github released binary is renamed since v0.7.0,
-    # see: https://github.com/tfkhdyt/geminicommit/releases/tag/v0.7.0
+    # The official github released binary is renamed since v0.4.1,
+    # see: https://github.com/tfkhdyt/geminicommit/releases/tag/v0.4.1
     # Here we link the old name (which is also the `go build` default name)
     # for backward compatibility:
     ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #482569.
- This supersedes #482569 by fixing the mistakenly updated versions in comment strings. This is a known issue of `nixpkgs-update` as documented in https://github.com/nix-community/nixpkgs-update/issues/85

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
