### PR TITLE
airshipper: fix crash due to missing libasound2.so

### DIFF
--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -109,6 +109,7 @@ rustPlatform.buildRustPackage {
         libXrandr
         libXi
         libXcursor
+        alsa-lib
       ];
     in
     ''


### PR DESCRIPTION
1. Try: `airshipper run`
2. It fails with: `error while loading shared libraries: libasound.so.2: cannot open shared object file: No such file or directory`

<details>
<summary>Full log</summary>

```
nix run .#airshipper run
2026-01-25T14:47:00.443385Z  INFO airshipper::logger: Setup terminal and file logging. path="/home/user/.local/share/airshipper" file="airshipper.log"
2026-01-25T14:47:00.443403Z  INFO airshipper::cli: Visit https://book.veloren.net/ for an FAQ and Troubleshooting
2026-01-25T14:47:00.443954Z ERROR airshipper::profiles: failed to query WGPU Backends, falling back to defaults
[00:00:00] [----------------------------------------] Evaluating Update [0s]                                                                                                  2026-01-25T14:47:00.450027Z  INFO airshipper::update: Evaluating remote version...
2026-01-25T14:47:00.756193Z  INFO remozipsy::proto::sync::state: Need to download 0 bytes in 0 batches and delete 0 files
2026-01-25T14:47:00.766438Z  INFO airshipper::cli: Starting...
2026-01-25T14:47:00.767120Z  INFO airshipper::cli: [Veloren] /home/user/.local/share/airshipper/profiles/default/veloren-voxygen: error while loading shared libraries: libasound.so.2: cannot open shared object file: No such file or directory
2026-01-25T14:47:00.767147Z  INFO airshipper::cli: Veloren exited with exit status: 127
```

It worked in #458636, and the only change afterwards was #478585 so I guess it broke then.

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
