### PR TITLE
remark42: init at 1.15.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11738,6 +11738,12 @@
     githubId = 1358764;
     name = "Jamie Magee";
   };
+  janhencic = {
+    name = "Jan Hencic";
+    email = "jan@hencic.com";
+    github = "janhencic";
+    githubId = 61284133;
+  };
   jankaifer = {
     name = "Jan Kaifer";
     email = "jan@kaifer.cz";

--- a/pkgs/by-name/re/remark42/package.nix
+++ b/pkgs/by-name/re/remark42/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildGoModule,
+  nodejs_22,
+  pnpm_8,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  testers,
+}:
+
+let
+  version = "1.15.0";
+
+  src = fetchFromGitHub {
+    owner = "umputun";
+    repo = "remark42";
+    tag = "v${version}";
+    hash = "sha256-yd/qTRSZj0nZpgK77xP+XHyHcVXlNpyMzdfj6EbVcXQ=";
+  };
+
+  remark42-web = stdenv.mkDerivation (finalAttrs: {
+    pname = "remark42-web";
+    inherit version src;
+
+    strictDeps = true;
+
+    pnpmRoot = "frontend";
+
+    nativeBuildInputs = [
+      nodejs_22
+      pnpm_8
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      sourceRoot = "${finalAttrs.src.name}/frontend";
+      pnpm = pnpm_8;
+      fetcherVersion = 3;
+      hash = "sha256-E2tUZXhcufuztXS+Z//uZk9omvaPrevNbGqVd41Lwhw=";
+    };
+
+    buildPhase = ''
+      runHook preBuild
+      pushd "$pnpmRoot"
+      pnpm --filter ./apps/remark42 --fail-if-no-match run build
+      popd
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/web
+      cp -r "$pnpmRoot/apps/remark42/public/." $out/web/
+      runHook postInstall
+    '';
+  });
+in
+buildGoModule (finalAttrs: {
+  pname = "remark42";
+  inherit version src;
+
+  strictDeps = true;
+
+  modRoot = "backend";
+
+  # build the main package in ./backend/app
+  subPackages = [ "app" ];
+
+  preBuild = ''
+    rm -rf app/cmd/web
+    mkdir -p app/cmd/web
+    cp -r ${remark42-web}/web/. app/cmd/web/
+  '';
+
+  vendorHash = null;
+
+  # set the version string in the built binary.
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "main.revision=v${version}"
+  ];
+
+  postInstall = ''
+    mv "$out/bin/app" "$out/bin/remark42"
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "remark42 --help";
+    version = "v${finalAttrs.version}";
+  };
+
+  meta = with lib; {
+    description = "Self-hosted comment engine that embeds a statically built frontend";
+    homepage = "https://remark42.com/";
+    license = licenses.mit;
+    mainProgram = "remark42";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ janhencic ];
+  };
+})


### PR DESCRIPTION
This PR adds [remark42](https://github.com/umputun/remark42) at version `v1.15.0`. It builds the pnpm frontend offline (via fetchPnpmDeps/pnpmConfigHook) and embeds the resulting web assets into the Go backend, producing a self-contained executable (as described in upstream docs). I’ve also added myself as maintainer.

Tested with:

* `./ci/nixpkgs-vet.sh master`
* `nix build -L .#remark42`
* `nix build -L .#remark42.tests.version`
* `./result/bin/remark42 --help`
* `nix-shell --run treefmt`
* `nix run 'nixpkgs#nixpkgs-review' -- wip`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
