### PR TITLE
[Backport release-25.11] nixos/bluesky-pds: prefer goat & add rate limit by deafult 

### DIFF
--- a/nixos/modules/services/web-apps/bluesky-pds.nix
+++ b/nixos/modules/services/web-apps/bluesky-pds.nix
@@ -17,6 +17,7 @@ let
     concatMapStringsSep
     types
     literalExpression
+    optional
     ;
 
   pdsadminWrapper =
@@ -32,7 +33,7 @@ let
           ${getExe pkgs.bluesky-pdsadmin} "$@"
     '';
 in
-# All defaults are from https://github.com/bluesky-social/pds/blob/8b9fc24cec5f30066b0d0b86d2b0ba3d66c2b532/installer.sh
+# All defaults are from https://github.com/bluesky-social/pds/blob/9a72155fee4e7e1de0e0add5454c5571b89e05e0/installer.sh
 {
   imports = [
     (lib.mkRenamedOptionModule [ "services" "pds" "enable" ] [ "services" "bluesky-pds" "enable" ])
@@ -130,6 +131,12 @@ in
             default = "true";
             description = "Enable logging";
           };
+
+          PDS_RATE_LIMITS_ENABLED = mkOption {
+            type = types.nullOr types.str;
+            default = "true";
+            description = "Enable rate limiting";
+          };
         };
       };
 
@@ -169,12 +176,20 @@ in
         description = "Add pdsadmin script to PATH";
       };
     };
+
+    goat = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        defaultText = false;
+        description = "Add goat to PATH";
+      };
+    };
   };
 
   config = mkIf cfg.enable {
-    environment = mkIf cfg.pdsadmin.enable {
-      systemPackages = [ pdsadminWrapper ];
-    };
+    environment.systemPackages =
+      optional cfg.pdsadmin.enable pdsadminWrapper ++ optional cfg.goat.enable pkgs.atproto-goat;
 
     systemd.services.bluesky-pds = {
       description = "bluesky pds";


### PR DESCRIPTION
see
https://github.com/bluesky-social/pds/commit/65c9efc6d5177141552136a7e51b1ac9413cb889 and
https://github.com/bluesky-social/pds/commit/9a72155fee4e7e1de0e0add5454c5571b89e05e0

(cherry picked from commit 35b20dfd9ec9a4d8953ffd8877e8c82b801b5bf7)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
