### PR TITLE
nixos/nm-file-secret-agent: add `trim` option

### DIFF
--- a/nixos/modules/services/networking/nm-file-secret-agent.nix
+++ b/nixos/modules/services/networking/nm-file-secret-agent.nix
@@ -24,6 +24,7 @@ let
       // lib.optionalAttrs (i.matchSetting != null) {
         match_setting = i.matchSetting;
       }
+      // lib.optionalAttrs (i.trim != null) { trim = i.trim; }
     ) cfg.ensureProfiles.secrets.entries;
   };
   nmFileSecretAgentConfigFile = toml.generate "config.toml" nmFileSecretAgentConfig;
@@ -107,6 +108,11 @@ in
               file = lib.mkOption {
                 description = "file from which the secret value is read";
                 type = lib.types.str;
+              };
+              trim = lib.mkOption {
+                description = "whether leading and trailing whitespace should be stripped from the files content before being passed to NetworkManager";
+                type = lib.types.nullOr lib.types.bool;
+                default = null;
               };
             };
           }


### PR DESCRIPTION
`nm-file-secret-agent` was updated to `v1.2.0` in https://github.com/NixOS/nixpkgs/pull/469889
This release added the `trim` option.

We could consider making the default `true`, but that could be a breaking change for some people.