### PR TITLE
woeusb-ng: include upstream packaging fixes

### DIFF
--- a/pkgs/by-name/wo/woeusb-ng/package.nix
+++ b/pkgs/by-name/wo/woeusb-ng/package.nix
@@ -10,25 +10,18 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "woeusb-ng";
-  version = "0.2.12";
+  version = "0.2.12-unstable-2026-01-25";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "WoeUSB";
     repo = "WoeUSB-ng";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-2opSiXbbk0zDRt6WqMh97iAt6/KhwNDopOas+OZn6TU=";
+    # tag = "v${finalAttrs.version}";
+    rev = "cc52ffc6aedad12540c2315c9101e4a4b919d4be";
+    hash = "sha256-TfrXq8zYtlqcA/jbxQul7HIGdYrn73ljKVY2x4BfS2E=";
   };
 
   build-system = [ python3Packages.setuptools ];
-
-  postPatch = ''
-    substituteInPlace setup.py WoeUSB/utils.py \
-      --replace-fail "/usr/local/" "$out/" \
-      --replace-fail "/usr/" "$out/"
-    substituteInPlace miscellaneous/WoeUSB-ng.desktop \
-      --replace-fail "/usr/" "$out/" \
-  '';
 
   nativeBuildInputs = [
     wrapGAppsHook3


### PR DESCRIPTION
include fixes from https://github.com/WoeUSB/WoeUSB-ng/pull/79

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
