### PR TITLE
veridian: add updateScript

### DIFF
--- a/pkgs/by-name/ve/veridian/package.nix
+++ b/pkgs/by-name/ve/veridian/package.nix
@@ -15,10 +15,11 @@
 
   verible,
   verilator,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage {
   pname = "veridian";
-  version = "0-unstable-2025-12-01";
+  version = "0-unstable-2025-11-30";
 
   src = fetchFromGitHub {
     owner = "vivekmalneedi";
@@ -69,6 +70,16 @@ rustPlatform.buildRustPackage {
     RUSTFLAGS = "-C link-args=-lmimalloc";
     # this is needed so that veridian doesn't try to build the sv-lang package itself
     SLANG_INSTALL_PATH = sv-lang;
+  };
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version=branch"
+        # Avoid using "nightly" tag: https://github.com/Mic92/nix-update/pull/430
+        "--version-regex=(0-unstable-.*)"
+      ];
+    };
   };
 
   meta = {


### PR DESCRIPTION
Addresses https://github.com/NixOS/nixpkgs/pull/466822#pullrequestreview-3688369961

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
