### PR TITLE
nixos/terminusdb: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -12,6 +12,8 @@
 
 - [tranquil](https://tangled.org/tranquil.farm/tranquil-pds) is an ATProto PDS (personal data server) implementation in Rust. A featureful, spec conscious and community driven alternative to the Bluesky reference implementation PDS. Available as [services.tranquil-pds](#opt-services.tranquil-pds.enable).
 
+- [TerminusDB](https://terminusdb.org), an open-source, in-memory graph database with Git-like operations for collaborative knowledge work. Available as [services.terminusdb](#opt-services.terminusdb.enable).
+
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).
 
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -552,6 +552,7 @@
   ./services/databases/redis.nix
   ./services/databases/rethinkdb.nix
   ./services/databases/surrealdb.nix
+  ./services/databases/terminusdb.nix
   ./services/databases/tigerbeetle.nix
   ./services/databases/victorialogs.nix
   ./services/databases/victoriametrics.nix

--- a/nixos/modules/services/databases/terminusdb.nix
+++ b/nixos/modules/services/databases/terminusdb.nix
@@ -1,0 +1,260 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.terminusdb;
+in
+{
+  meta.maintainers = with lib.maintainers; [ daniel-fahey ];
+
+  options.services.terminusdb = {
+    enable = lib.mkEnableOption "TerminusDB server";
+
+    package = lib.mkPackageOption pkgs "terminusdb" { };
+
+    host = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = "127.0.0.1";
+      description = ''
+        The IP interface to bind to.
+        `null` means "all interfaces" (0.0.0.0).
+      '';
+      example = "0.0.0.0";
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 6363;
+      description = "The TCP port to accept connections.";
+    };
+
+    workers = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 8;
+      description = "The number of worker threads to use.";
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "error"
+        "warn"
+        "info"
+        "debug"
+      ];
+      default = "info";
+      description = "Log level for TerminusDB server.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/terminusdb";
+      description = "Directory for TerminusDB data storage.";
+    };
+
+    autoInit = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Automatically initialise the TerminusDB store on startup.
+        If enabled, the store will be initialised if it does not exist.
+      '';
+    };
+
+    jwtEnabled = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Enable JWT authentication.";
+    };
+
+    adminPasswordFile = lib.mkOption {
+      type = with lib.types; nullOr path;
+      default = null;
+      description = ''
+        Path to a file containing the admin password for store initialisation.
+        The password should be stored as a single line in the file.
+        If null, a default password will be used.
+      '';
+      example = "/run/keys/terminusdb-admin-password";
+    };
+
+    extraFlags = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      description = "Extra flags to pass to the TerminusDB server command.";
+      example = [ "--interactive" ];
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the configured port in the firewall.";
+    };
+
+    # Additional environment variable options from TerminusDB source
+
+    logFormat = lib.mkOption {
+      type = lib.types.enum [
+        "text"
+        "json"
+      ];
+      default = "text";
+      description = "Log format for TerminusDB server.";
+    };
+
+    fileStoragePath = lib.mkOption {
+      type = with lib.types; nullOr path;
+      default = null;
+      description = "Path for file upload storage. If null, uses default location.";
+      example = "/var/lib/terminusdb/files";
+    };
+
+    jwksEndpoint = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      description = "JWKS endpoint for JWT verification.";
+      example = "https://example.com/.well-known/jwks.json";
+    };
+
+    insecureUserHeaderEnabled = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Enable insecure user header authentication.
+        WARNING: This should only be used in development/trusted environments.
+        The header name is specified by {option}`services.terminusdb.insecureUserHeader`.
+      '';
+    };
+
+    insecureUserHeader = lib.mkOption {
+      type = with lib.types; nullOr str;
+      default = null;
+      description = ''
+        HTTP header name for insecure user authentication.
+        Only used when {option}`services.terminusdb.insecureUserHeaderEnabled` is true.
+        The header value will be converted to lowercase with dashes replaced by underscores.
+      '';
+      example = "X-User-Email";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall cfg.port;
+
+    environment.systemPackages = [ cfg.package ];
+
+    users.users.terminusdb = {
+      description = "TerminusDB server user";
+      isSystemUser = true;
+      group = "terminusdb";
+    };
+    users.groups.terminusdb = { };
+
+    systemd.services.terminusdb = {
+      description = "TerminusDB server";
+
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      environment = {
+        TERMINUSDB_SERVER_NAME = if (cfg.host == null) then "0.0.0.0" else cfg.host;
+        TERMINUSDB_SERVER_PORT = toString cfg.port;
+        TERMINUSDB_SERVER_WORKERS = toString cfg.workers;
+        TERMINUSDB_SERVER_DB_PATH = cfg.dataDir;
+        TERMINUSDB_LOG_LEVEL = cfg.logLevel;
+        TERMINUSDB_JWT_ENABLED = lib.boolToString cfg.jwtEnabled;
+        # Additional environment variables
+        TERMINUSDB_LOG_FORMAT = cfg.logFormat;
+        TERMINUSDB_FILE_STORAGE_PATH = lib.mkIf (cfg.fileStoragePath != null) cfg.fileStoragePath;
+        TERMINUSDB_SERVER_JWKS_ENDPOINT = lib.mkIf (cfg.jwksEndpoint != null) cfg.jwksEndpoint;
+        TERMINUSDB_INSECURE_USER_HEADER_ENABLED = lib.boolToString cfg.insecureUserHeaderEnabled;
+        TERMINUSDB_INSECURE_USER_HEADER = lib.mkIf (cfg.insecureUserHeader != null) cfg.insecureUserHeader;
+      };
+
+      # Auto-initialise the TerminusDB store if it doesn't exist
+      preStart = lib.mkIf cfg.autoInit ''
+        DATA_DIR="${cfg.dataDir}"
+        STORAGE_FLAG="$DATA_DIR/storage/db"
+
+        if [ ! -d "$STORAGE_FLAG" ]; then
+          echo "Initialising TerminusDB store at $DATA_DIR..."
+          if [ -f "$CREDENTIALS_DIRECTORY/admin-password" ]; then
+            ADMIN_PASSWORD=$(cat "$CREDENTIALS_DIRECTORY/admin-password")
+            ${lib.getExe cfg.package} store init --key "$ADMIN_PASSWORD" --force
+          else
+            ${lib.getExe cfg.package} store init --force
+          fi
+          echo "TerminusDB store initialised successfully."
+        else
+          echo "TerminusDB store already exists at $DATA_DIR"
+        fi
+      '';
+
+      serviceConfig = {
+        ExecStart = lib.escapeShellArgs (
+          [
+            (lib.getExe cfg.package)
+            "serve"
+          ]
+          ++ cfg.extraFlags
+        );
+
+        User = "terminusdb";
+        Group = "terminusdb";
+
+        LoadCredential = lib.optional (
+          cfg.adminPasswordFile != null
+        ) "admin-password:${cfg.adminPasswordFile}";
+        StateDirectory = "terminusdb";
+        StateDirectoryMode = "0700";
+        WorkingDirectory = cfg.dataDir;
+
+        Type = "exec";
+
+        # Filesystem access
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ReadWritePaths = [ cfg.dataDir ] ++ lib.optional (cfg.fileStoragePath != null) cfg.fileStoragePath;
+
+        # Process isolation
+        NoNewPrivileges = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false; # Needed for SWI-Prolog JIT compiler
+
+        # Kernel access
+        ProtectClock = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+
+        # Network
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        # Syscalls
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "~@cpu-emulation @debug @keyring @mount @obsolete @privileged @resources @setuid";
+
+        # Capabilities
+        CapabilityBoundingSet = "";
+
+        # Additional
+        PrivateMounts = true;
+        UMask = "0077";
+        RestartSec = "5s";
+        Restart = "on-failure";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1690,6 +1690,7 @@ in
   teleports = runTest ./teleports.nix;
   temporal = runTest ./temporal.nix;
   terminal-emulators = handleTest ./terminal-emulators.nix { };
+  terminusdb = runTest ./terminusdb.nix;
   test-containers-bittorrent = runTest ./test-containers-bittorrent.nix;
   thanos = runTest ./thanos.nix;
   thelounge = handleTest ./thelounge.nix { };

--- a/nixos/tests/terminusdb.nix
+++ b/nixos/tests/terminusdb.nix
@@ -1,0 +1,189 @@
+{ pkgs, lib, ... }:
+
+let
+  adminPasswordFile = pkgs.writeText "admin-password" "test-admin-password";
+in
+{
+  name = "terminusdb";
+  meta.maintainers = with lib.maintainers; [ daniel-fahey ];
+
+  nodes = {
+    # Default configuration node
+    machine =
+      { config, pkgs, ... }:
+      {
+        services.terminusdb = {
+          enable = true;
+        };
+      };
+
+    # Custom configuration node
+    custom =
+      { config, pkgs, ... }:
+      {
+        services.terminusdb = {
+          enable = true;
+          host = "0.0.0.0";
+          port = 7373;
+          workers = 4;
+          logLevel = "debug";
+          logFormat = "json";
+        };
+      };
+
+    # JWT configuration node
+    jwt =
+      { config, pkgs, ... }:
+      {
+        services.terminusdb = {
+          enable = true;
+          jwtEnabled = true;
+        };
+      };
+
+    # Admin password node
+    admin =
+      { config, pkgs, ... }:
+      {
+        services.terminusdb = {
+          enable = true;
+          adminPasswordFile = adminPasswordFile;
+        };
+      };
+  };
+
+  testScript = ''
+    import json
+
+
+    def assert_contains(haystack, needle):
+        if needle not in haystack:
+            print("The haystack that will cause the following exception is:")
+            print("---")
+            print(haystack)
+            print("---")
+            raise Exception(f"Expected string '{needle}' was not found")
+
+
+    def assert_lacks(haystack, needle):
+        if needle in haystack:
+            print("The haystack that will cause the following exception is:")
+            print("---")
+            print(haystack, end="")
+            print("---")
+            raise Exception(f"Unexpected string '{needle}' was found")
+
+
+    start_all()
+
+    # Test 1: Basic service startup on default machine
+    with subtest("service starts on default machine"):
+        machine.wait_for_unit("terminusdb.service")
+        machine.wait_for_open_port(6363)
+        machine.succeed("systemctl is-active terminusdb.service")
+
+
+    # Test 2: API connectivity
+    with subtest("api info endpoint works"):
+        # Check that endpoint returns valid JSON
+        resp = json.loads(machine.succeed("curl --fail --silent http://localhost:6363/api/info"))
+        # API should return a JSON object with TerminusDB metadata
+        assert isinstance(resp, dict), "API response should be a JSON object"
+
+
+    # Test 3: Data directory ownership and structure
+    with subtest("data directory is correctly set up"):
+        machine.succeed("test -d /var/lib/terminusdb")
+        # Verify ownership is correct
+        stat = machine.succeed("stat -c '%U %G' /var/lib/terminusdb")
+        assert_contains(stat, "terminusdb terminusdb")
+
+
+    # Test 4: Custom configuration
+    with subtest("custom configuration is applied"):
+        custom.wait_for_unit("terminusdb.service")
+        custom.wait_for_open_port(7373)
+        # Verify custom port works and API returns valid JSON
+        resp = json.loads(custom.succeed("curl --fail --silent http://localhost:7373/api/info"))
+        assert isinstance(resp, dict), "API response should be a JSON object"
+        # Verify custom configuration is reflected
+        env = custom.succeed("systemctl show terminusdb.service")
+        assert_contains(env, "TERMINUSDB_SERVER_PORT=7373")
+        assert_contains(env, "TERMINUSDB_LOG_LEVEL=debug")
+        assert_contains(env, "TERMINUSDB_LOG_FORMAT=json")
+
+
+    # Test 5: JWT configuration
+    with subtest("jwt configuration is applied"):
+        jwt.wait_for_unit("terminusdb.service")
+        # Check that JWT env vars are set in the service
+        jwt_env = jwt.succeed("systemctl show terminusdb.service")
+        assert_contains(jwt_env, "TERMINUSDB_JWT_ENABLED=true")
+
+
+    # Test 6: Admin password file
+    with subtest("admin password file is used"):
+        admin.wait_for_unit("terminusdb.service")
+        # Service should start successfully with the admin password file
+        # Verify API still works with password configured
+        resp = json.loads(admin.succeed("curl --fail --silent http://localhost:6363/api/info"))
+        assert isinstance(resp, dict), "API response should be a JSON object with admin password configured"
+
+
+    # Test 7: Environment variables are set correctly
+    with subtest("environment variables are set"):
+        # Check that critical env vars are set
+        env = machine.succeed("systemctl show terminusdb.service")
+        assert_contains(env, "TERMINUSDB_SERVER_PORT=6363")
+        assert_contains(env, "TERMINUSDB_LOG_LEVEL=info")
+        assert_contains(env, "TERMINUSDB_LOG_FORMAT=text")
+        # Ensure default env var for file storage is NOT set
+        assert_lacks(env, "TERMINUSDB_FILE_STORAGE_PATH=")
+
+
+    # Test 8: systemd hardening options
+    with subtest("systemd hardening is applied"):
+        # Get full service configuration
+        systemd_config = machine.succeed("systemctl show terminusdb.service")
+        # Check key security options that should be visible
+        assert_contains(systemd_config, "ProtectSystem=strict")
+        assert_contains(systemd_config, "NoNewPrivileges=yes")
+
+
+    # Test 9: Service restart recovery
+    with subtest("service restarts successfully"):
+        machine.wait_for_unit("terminusdb.service")
+        machine.succeed("systemctl restart terminusdb.service")
+        machine.wait_for_unit("terminusdb.service")
+        machine.wait_for_open_port(6363)
+        # Verify API still returns valid JSON after restart
+        resp = json.loads(machine.succeed("curl --fail --silent http://localhost:6363/api/info"))
+        assert isinstance(resp, dict), "API response should be a JSON object after restart"
+
+
+    # Test 10: User and group setup
+    with subtest("user and group are correctly configured"):
+        # Verify user and group exist with correct names
+        passwd = machine.succeed("getent passwd terminusdb")
+        assert_contains(passwd, "terminusdb:x:")
+        group = machine.succeed("getent group terminusdb")
+        assert_contains(group, "terminusdb:x:")
+        # Verify user can be queried
+        machine.succeed("id terminusdb")
+
+
+    # Test 11: Invalid API endpoint handling
+    with subtest("invalid endpoints are rejected"):
+        # Test that invalid endpoints return errors (404, 400, etc)
+        machine.fail("curl --fail --silent http://localhost:6363/api/invalid-endpoint")
+
+
+    # Test 12: Password security - not logged
+    with subtest("admin password is not logged"):
+        # Verify that password is not visible in logs
+        admin.fail("journalctl --since -5m --unit terminusdb.service --grep 'test-admin-password'")
+
+
+    print("=== All TerminusDB tests passed ===")
+  '';
+}


### PR DESCRIPTION
NixOS service module for TerminusDB, corresponding test module, and 26.05 release note. This is my first NixOS module contribution, I've just imitated prior art in the repo for databases, it's likely not fully idiomatic to current NixOS style.

> [!TIP]
> ~~~~bash
> nix build github:daniel-fahey/nixpkgs/modules/terminusdb#nixosTests.terminusdb \
> --no-link --print-build-logs

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
