### PR TITLE
userborn: 0.4.0 -> 0.5.0

### DIFF
--- a/nixos/tests/userborn-immutable-etc.nix
+++ b/nixos/tests/userborn-immutable-etc.nix
@@ -21,7 +21,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -38,7 +38,7 @@ in
         inheritParentConfig = false;
         configuration = {
           nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+            inherit pkgs;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-immutable-users.nix
+++ b/nixos/tests/userborn-immutable-users.nix
@@ -16,7 +16,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -33,7 +33,7 @@ in
         inheritParentConfig = false;
         configuration = {
           nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+            inherit pkgs;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-mutable-etc.nix
+++ b/nixos/tests/userborn-mutable-etc.nix
@@ -20,7 +20,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -37,7 +37,7 @@ in
         inheritParentConfig = false;
         configuration = {
           nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+            inherit pkgs;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-mutable-users.nix
+++ b/nixos/tests/userborn-mutable-users.nix
@@ -16,7 +16,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -34,7 +34,7 @@ in
         inheritParentConfig = false;
         configuration = {
           nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+            inherit pkgs;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-mutable-users.nix
+++ b/nixos/tests/userborn-mutable-users.nix
@@ -42,6 +42,10 @@ in
             new-normalo = {
               isNormalUser = true;
             };
+            mutable-to-declarative = {
+              isNormalUser = true;
+              description = "I'm now declaratively managed";
+            };
           };
         };
       };
@@ -54,16 +58,25 @@ in
       assert 1000 == int(machine.succeed("id --user normalo")), "normalo user doesn't have UID 1000"
       assert "${normaloHashedPassword}" in machine.succeed("getent shadow normalo"), "normalo user password is not correct"
 
-    with subtest("Add new user manually"):
+    with subtest("Add new user manual-normalo manually"):
       machine.succeed("useradd manual-normalo")
       assert 1001 == int(machine.succeed("id --user manual-normalo")), "manual-normalo user doesn't have UID 1001"
 
-    with subtest("Delete manual--normalo user manually"):
-      machine.succeed("userdel manual-normalo")
-
+    with subtest("Add new user mutable-to-declarative manually"):
+      machine.succeed("useradd --comment 'I was created imperatively' mutable-to-declarative")
+      assert 1002 == int(machine.succeed("id --user mutable-to-declarative")), "mutable-to-declarative user doesn't have UID 1002"
 
     machine.succeed("/run/current-system/specialisation/new-generation/bin/switch-to-configuration switch")
 
+    with subtest("manual-normalo user is still enabled"):
+      manual_normalo_shadow = machine.succeed("getent shadow manual-normalo")
+      print(manual_normalo_shadow)
+      t.assertNotIn("!*", manual_normalo_shadow, "manual-normalo user is falsely disabled")
+
+    with subtest("mutable-to-declarative user description has changed"):
+      mutable_to_declarative_passwd = machine.succeed("getent passwd mutable-to-declarative")
+      print(mutable_to_declarative_passwd)
+      t.assertIn("I'm now declaratively managed", mutable_to_declarative_passwd, "mutable-to-declarative user description is unchanged")
 
     with subtest("normalo user is disabled"):
       print(machine.succeed("getent shadow normalo"))
@@ -71,6 +84,9 @@ in
 
     with subtest("new-normalo user is created after switching to new generation"):
       print(machine.succeed("getent passwd new-normalo"))
-      assert 1001 == int(machine.succeed("id --user new-normalo")), "new-normalo user doesn't have UID 1001"
+      assert 1003 == int(machine.succeed("id --user new-normalo")), "new-normalo user doesn't have UID 1003"
+
+    with subtest("Delete manual-normalo user manually"):
+      machine.succeed("userdel manual-normalo")
   '';
 }

--- a/pkgs/by-name/us/userborn/package.nix
+++ b/pkgs/by-name/us/userborn/package.nix
@@ -9,18 +9,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "userborn";
-  version = "0.4.0";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "nikstur";
     repo = "userborn";
     rev = version;
-    hash = "sha256-Zh2u7we/MAIM7varuJA4AmEWeSMuA/C+0NSIUJN7zTs=";
+    hash = "sha256-mXXakR75Iz6AFf/TYgIHE8SxOri2HyReYUYTT3lCEPA=";
   };
 
   sourceRoot = "${src.name}/rust/userborn";
 
-  cargoHash = "sha256-oLw/I8PEv75tz+KxbIJrwl8Wr0I/RzDh1SDZ6mRQpL8=";
+  cargoHash = "sha256-uAid5GsM9lasVQAYfeo9jwp4xg1MrXdJqtD0l6ME6OQ=";
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
 


### PR DESCRIPTION
0.5.0 now properly implements mutable users.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
