### PR TITLE
terminusdb: use installShellFiles and add man page

### DIFF
--- a/pkgs/by-name/te/terminusdb/package.nix
+++ b/pkgs/by-name/te/terminusdb/package.nix
@@ -14,6 +14,7 @@
   pkg-config,
   callPackage,
   applyPatches,
+  installShellFiles,
 }:
 let
   tusVersion = "0.0.16";
@@ -109,6 +110,7 @@ stdenv.mkDerivation (finalAttrs: {
       bindgenHook # provides libclang
     ])
     cargo
+    installShellFiles
     protobuf
     swi-prologWithDeps
   ];
@@ -153,7 +155,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    install -Dm755 terminusdb -t $out/bin
+    installBin terminusdb
+    installManPage $src/docs/terminusdb.1
     runHook postInstall
   '';
 


### PR DESCRIPTION
Whilst preparing https://github.com/NixOS/nixpkgs/pull/483680 I realised I forgot to include TerminusDB's man page in https://github.com/NixOS/nixpkgs/pull/303209, here it is.

> [!TIP]
> ~~~~bash
> nix shell github:daniel-fahey/nixpkgs/fix/terminusdb#terminusdb --command man terminusdb
> ~~~~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
