### PR TITLE
bottles-unwrapped: 60.1 -> 61.1

### DIFF
--- a/pkgs/by-name/bo/bottles-unwrapped/package.nix
+++ b/pkgs/by-name/bo/bottles-unwrapped/package.nix
@@ -32,13 +32,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "bottles-unwrapped";
-  version = "60.1";
+  version = "61.1";
 
   src = fetchFromGitHub {
     owner = "bottlesdevs";
     repo = "bottles";
     tag = version;
-    hash = "sha256-d9nRT6AvFxnhI/theJtPg79EdmA+9UFS4OWDlkV03sA=";
+    hash = "sha256-LW+os+5DtdUBZWONu2YX4FYMtAYg4BDlKbnVF64T2xI=";
   };
 
   patches = [
@@ -96,6 +96,7 @@ python3Packages.buildPythonApplication rec {
       urllib3
       certifi
       pefile
+      yara-python
     ]
     ++ [
       cabextract

--- a/pkgs/by-name/bo/bottles-unwrapped/remove-flatpak-check.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/remove-flatpak-check.patch
@@ -16,10 +16,10 @@ index 6ff7c011..c26ea0b9 100644
    '__init__.py',
    'main.py',
 diff --git a/bottles/frontend/views/bottle_details.py b/bottles/frontend/views/bottle_details.py
-index 65667ea9..7ae1eb19 100644
+index f897953c..393572ed 100644
 --- a/bottles/frontend/views/bottle_details.py
 +++ b/bottles/frontend/views/bottle_details.py
-@@ -436,20 +436,19 @@ class BottleView(Adw.PreferencesPage):
+@@ -824,20 +824,17 @@ class BottleView(Adw.PreferencesPage):
              dialog.connect("response", execute)
              dialog.show()
  
@@ -33,7 +33,7 @@ index 65667ea9..7ae1eb19 100644
 -                    ),
 -                )
 -                dialog.add_response("dismiss", _("_Dismiss"))
--                dialog.connect("response", show_chooser)
+-                dialog.connect("response", lambda *args: show_chooser())
 -                dialog.present()
 -            else:
 -                show_chooser()
@@ -48,16 +48,14 @@ index 65667ea9..7ae1eb19 100644
 +            dialog.add_response("dismiss", _("_Dismiss"))
 +            dialog.connect("response", show_chooser)
 +            dialog.present()
-+        else:
-+            show_chooser()
+         else:
+             show_chooser()
  
-     def __backup(self, widget, backup_type):
-         """
 diff --git a/bottles/frontend/views/bottle_preferences.py b/bottles/frontend/views/bottle_preferences.py
-index 288e693b..b8b57618 100644
+index 1e0090f8..983097f2 100644
 --- a/bottles/frontend/views/bottle_preferences.py
 +++ b/bottles/frontend/views/bottle_preferences.py
-@@ -139,7 +139,7 @@ class PreferencesView(Adw.PreferencesPage):
+@@ -148,7 +148,7 @@ class PreferencesView(Adw.PreferencesPage):
          self.queue = details.queue
          self.details = details
  
@@ -67,7 +65,7 @@ index 288e693b..b8b57618 100644
  
          _not_available = _("This feature is unavailable on your system.")
 diff --git a/bottles/frontend/views/list.py b/bottles/frontend/views/list.py
-index 43ab9c22..a283b178 100644
+index 6bd8fc81..0f96ab70 100644
 --- a/bottles/frontend/views/list.py
 +++ b/bottles/frontend/views/list.py
 @@ -82,8 +82,6 @@ class BottlesBottleRow(Adw.ActionRow):
@@ -80,10 +78,10 @@ index 43ab9c22..a283b178 100644
          def set_path(_dialog, response):
              if response != Gtk.ResponseType.ACCEPT:
 diff --git a/bottles/frontend/views/new_bottle_dialog.py b/bottles/frontend/views/new_bottle_dialog.py
-index a8b007d4..c6f0a156 100644
+index 9c386862..3ed98f7c 100644
 --- a/bottles/frontend/views/new_bottle_dialog.py
 +++ b/bottles/frontend/views/new_bottle_dialog.py
-@@ -80,7 +80,7 @@ class BottlesNewBottleDialog(Adw.Dialog):
+@@ -86,7 +86,7 @@ class BottlesNewBottleDialog(Adw.Dialog):
          super().__init__(**kwargs)
          # common variables and references
          self.window = GtkUtils.get_parent_window()

--- a/pkgs/by-name/bo/bottles-unwrapped/terminal.patch
+++ b/pkgs/by-name/bo/bottles-unwrapped/terminal.patch
@@ -1,12 +1,28 @@
 diff --git a/bottles/backend/utils/terminal.py b/bottles/backend/utils/terminal.py
-index 1f28e093..cca8018a 100644
+index 943cface..1f67822e 100644
 --- a/bottles/backend/utils/terminal.py
 +++ b/bottles/backend/utils/terminal.py
-@@ -138,7 +138,7 @@ class TerminalUtils:
-                 full_cmd = f"{template} {cmd_for_shell}"
-
-         elif term_bin in ["kitty", "foot", "konsole", "gnome-terminal"]:
+@@ -132,21 +132,21 @@ class TerminalUtils:
+                 full_cmd = f"{template} {palette} {cmd_for_shell}"
+ 
+         elif term_bin == "xfce4-terminal":
 -            cmd_for_shell = shlex.quote(f"sh -c {command}")
++            cmd_for_shell = f"sh -c {command}"
+             try:
+                 full_cmd = template % cmd_for_shell
+             except Exception:
+                 full_cmd = f"{template} {cmd_for_shell}"
+ 
+         elif term_bin in ["kitty", "foot", "konsole", "gnome-terminal", "wezterm"]:
+-            cmd_for_shell = shlex.quote(f"sh -c {command}")
++            cmd_for_shell = f"sh -c {command}"
+             try:
+                 full_cmd = template % cmd_for_shell
+             except Exception:
+                 full_cmd = f"{template} {cmd_for_shell}"
+ 
+         else:
+-            cmd_for_shell = shlex.quote(f"bash -c {command}")
 +            cmd_for_shell = f"sh -c {command}"
              try:
                  full_cmd = template % cmd_for_shell


### PR DESCRIPTION
Changelog: https://github.com/bottlesdevs/Bottles/releases/tag/61.1
Diff: https://github.com/bottlesdevs/Bottles/compare/60.1...61.1

Added `yara-python` as a new required runtime dep and improved `terminal.patch` to also work when using `xfce4-terminal` or any terminal which is not in the hardcoded list. I didn't test the later, but it should work.

I noticed one issue when running a program with `gamescope`, the program will fail to open and print this error `$LAUNCH_CMD _v2-entry-point: invalid option -- 'f'`. This seem to be an upstream issue as I can repro with the flatpak package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
