### PR TITLE
makeBinaryWrapper: fix passthru.extractCmd on darwin

### DIFF
--- a/pkgs/by-name/ma/makeBinaryWrapper/package.nix
+++ b/pkgs/by-name/ma/makeBinaryWrapper/package.nix
@@ -24,9 +24,13 @@ makeSetupHook {
 
   passthru = {
     # Extract the function call used to create a binary wrapper from its embedded docstring
-    extractCmd = writeShellScript "extract-binary-wrapper-cmd" ''
-      ${targetPackages.gnuStdenv.cc.bintools.targetPrefix}strings -dw "$1" | sed -n '/^makeCWrapper/,/^$/ p'
-    '';
+    extractCmd =
+      let
+        bintools = targetPackages.gnuStdenv.cc.bintools;
+      in
+      writeShellScript "extract-binary-wrapper-cmd" ''
+        ${lib.getExe' bintools "${bintools.targetPrefix}strings"} -dw "$1" | sed -n '/^makeCWrapper/,/^$/ p'
+      '';
 
     tests = tests.makeBinaryWrapper;
   };


### PR DESCRIPTION
On darwin, strings does not support -d. Regardless of darwin, the
generated extract script has `strings` without a full nix store path,
making it potentially impure.

The solution is to always pull `strings` from GNU toolchain, regardless
of the platform.

Note: this change should have no implications for darwin bootstrap
because `passthru.extractCmd` has very limited use in the tree,
basically only used when building Firefox, and is not evaluated
otherwise.

Note: previous attempt to resolve the issue was incorrect, effectively
doing nothing on Darwin, see #379014. (The
`targetPackages.gnuStdenv.cc.bintools.targetPrefix` was empty.)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
