### PR TITLE
bsh: 2.0b5 -> 2.1.1

### DIFF
--- a/pkgs/by-name/bs/bsh/package.nix
+++ b/pkgs/by-name/bs/bsh/package.nix
@@ -3,7 +3,7 @@
 fetchurl (finalAttrs: {
   name = "${finalAttrs.pname}-${finalAttrs.version}.jar";
   pname = "bsh";
-  version = "2.0b5";
-  url = "http://www.beanshell.org/bsh-${finalAttrs.version}.jar";
-  hash = "sha256-YjIZlWOAc1SzvLWs6z3BNlAvAixrDvdDmHqD9m/uWlw=";
+  version = "2.1.1";
+  url = "https://github.com/beanshell/beanshell/releases/download/${finalAttrs.version}/bsh-${finalAttrs.version}.jar";
+  hash = "sha256-cRksu+Seeiac/LoF3Fy5WcM7myba/NYmbKMoi0YfhqM=";
 })


### PR DESCRIPTION
Switch download location, homepage refers to the new one on GitHub

As suggested in #482980 

Checked that LibreOffice Still/Fresh build fine, and did a basic functionality test of Fresh.

Maybe will self-merge.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
