### PR TITLE
workflows/periodic-merge: fix comment syntax

### DIFF
--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -65,5 +65,5 @@ jobs:
         with:
           issue-number: 105153
           body: |
-            Periodic merge from `${{ inputs.from }}` into `[${{ inputs.into }}](https://github.com/NixOS/nixpkgs/tree/${{ inputs.into }})` has [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).
+            Periodic merge from `${{ inputs.from }}` into [`${{ inputs.into }}`](https://github.com/NixOS/nixpkgs/tree/${{ inputs.into }}) has [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
[Oops!](https://github.com/NixOS/nixpkgs/pull/105153#issuecomment-3797029123)

Caused by me in #483198

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested by making the change to https://github.com/NixOS/nixpkgs/pull/105153#issuecomment-3797029123 and previewing (but not saving).
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
