### PR TITLE
mpvScripts.uosc-danmaku: init at 2.0.0

### DIFF
--- a/pkgs/by-name/mp/mpv/scripts/uosc-danmaku.nix
+++ b/pkgs/by-name/mp/mpv/scripts/uosc-danmaku.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "uosc-danmaku";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "Tony15246";
+    repo = "uosc_danmaku";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-r4HcrDh4iW8ErfClfX1gkEWp7lVKbLE88fpj3tjYBAI=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 main.lua $out/share/mpv/scripts/uosc_danmaku/main.lua
+    cp -r modules apis dicts $out/share/mpv/scripts/uosc_danmaku/
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = gitUpdater { };
+    scriptName = "uosc_danmaku";
+  };
+
+  meta = {
+    description = "Load DanDanPlay danmaku in MPV player";
+    homepage = "https://github.com/Tony15246/uosc_danmaku";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ puiyq ];
+  };
+})


### PR DESCRIPTION
# Add `uosc-danmaku` MPV script

- **Description:** MPV script for loading DanDanPlay danmaku, based on the uosc UI framework.  
- **License:** MIT
- **Version:** v2.0.0 (ready for general use)
- **Upstream activity:** Actively maintained
- **Purpose:** Fills a gap in nixpkgs by providing a mpv script that supports the dandanplay API.  
- **Maintenance:** I use it daily and willing to maintain.  
- **Repository:** [https://github.com/Tony15246/uosc_danmaku](https://github.com/Tony15246/uosc_danmaku)



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
