### PR TITLE
grasp-backend: init at 1.0.1

### DIFF
--- a/pkgs/by-name/gr/grasp-backend/package.nix
+++ b/pkgs/by-name/gr/grasp-backend/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "grasp-backend";
+  version = "1.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "karlicoss";
+    repo = "grasp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-4eHY58ulvLGkKHfEishRlWPI52juxWP2zzUDwRmTM/k=";
+  };
+
+  build-system = with python3Packages; [
+    hatch-vcs
+    hatchling
+  ];
+
+  pythonImportsCheck = [ "grasp_backend" ];
+
+  # Tests do not seem possible to run with pytest:
+  # RuntimeError: ("Couldn't determine path for ", PosixPath('/build/source/tests/webdriver_utils.py'))
+  doCheck = false;
+
+  meta = {
+    description = "Backend for grasp browser extension";
+    mainProgram = "grasp_backend";
+    maintainers = with lib.maintainers; [ hiro98 ];
+    homepage = "https://github.com/karlicoss/grasp/";
+    changelog = "https://github.com/karlicoss/grasp/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
