### PR TITLE
python3Packages.mlx: remove gguf-tools and pybind11 from buildInputs; enable for x86_64-darwin; use nlohmann_json from nixpkgs

### DIFF
--- a/pkgs/by-name/ra/ramalama/package.nix
+++ b/pkgs/by-name/ra/ramalama/package.nix
@@ -56,13 +56,10 @@ python3Packages.buildPythonApplication rec {
             llama-cpp-vulkan
             podman
           ]
-          ++ (
-            with python3Packages;
-            [
-              huggingface-hub
-            ]
-            ++ lib.optional (lib.meta.availableOn stdenv.hostPlatform mlx-lm) mlx-lm
-          )
+          ++ (with python3Packages; [
+            huggingface-hub
+            mlx-lm
+          ])
         )
       }
   '';

--- a/pkgs/development/python-modules/mlx-lm/default.nix
+++ b/pkgs/development/python-modules/mlx-lm/default.nix
@@ -84,9 +84,5 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/ml-explore/mlx-lm";
     changelog = "https://github.com/ml-explore/mlx-lm/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    badPlatforms = [
-      # Building for x86_64 on macOS is not supported by mlx (dependency)
-      "x86_64-darwin"
-    ];
   };
 })

--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -15,7 +15,6 @@
   apple-sdk,
   fmt,
   nlohmann_json,
-  pybind11,
   # linux-only
   openblas,
 
@@ -105,7 +104,6 @@ buildPythonPackage (finalAttrs: {
   buildInputs = [
     fmt
     nlohmann_json
-    pybind11
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     openblas

--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -80,19 +80,24 @@ buildPythonPackage (finalAttrs: {
 
   env = {
     PYPI_RELEASE = 1;
-    CMAKE_ARGS = toString [
-      # NOTE The `metal` command-line utility used to build the Metal kernels is not open-source.
-      # To build mlx with Metal support in Nix, you'd need to use one of the sandbox escape
-      # hatches which let you interact with a native install of Xcode, such as `composeXcodeWrapper`
-      # or by changing the upstream (e.g., https://github.com/zed-industries/zed/discussions/7016).
-      (lib.cmakeBool "MLX_BUILD_METAL" false)
-      (lib.cmakeBool "USE_SYSTEM_FMT" true)
-      (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_GGUFLIB" "${gguf-tools}")
-      (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-I${lib.getDev nlohmann_json}/include/nlohmann")
+    CMAKE_ARGS = toString (
+      [
+        # NOTE The `metal` command-line utility used to build the Metal kernels is not open-source.
+        # To build mlx with Metal support in Nix, you'd need to use one of the sandbox escape
+        # hatches which let you interact with a native install of Xcode, such as `composeXcodeWrapper`
+        # or by changing the upstream (e.g., https://github.com/zed-industries/zed/discussions/7016).
+        (lib.cmakeBool "MLX_BUILD_METAL" false)
+        (lib.cmakeBool "USE_SYSTEM_FMT" true)
+        (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_GGUFLIB" "${gguf-tools}")
+        (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-I${lib.getDev nlohmann_json}/include/nlohmann")
 
-      # Cmake cannot find nanobind-config.cmake by itself
-      (lib.cmakeFeature "nanobind_DIR" "${nanobind}/${python.sitePackages}/nanobind/cmake")
-    ];
+        # Cmake cannot find nanobind-config.cmake by itself
+        (lib.cmakeFeature "nanobind_DIR" "${nanobind}/${python.sitePackages}/nanobind/cmake")
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+        (lib.cmakeBool "MLX_ENABLE_X64_MAC" true)
+      ]
+    );
   };
 
   build-system = [
@@ -177,10 +182,6 @@ buildPythonPackage (finalAttrs: {
       booxter
       cameronyule
       viraptor
-    ];
-    badPlatforms = [
-      # Building for x86_64 on macOS is not supported
-      "x86_64-darwin"
     ];
   };
 })

--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -52,8 +52,9 @@ buildPythonPackage (finalAttrs: {
   };
 
   patches = [
-    # Use system nanobind instead of fetching its sources
+    # Use nix packages instead of fetching their sources
     ./dont-fetch-nanobind.patch
+    ./dont-fetch-json.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (replaceVars ./darwin-build-fixes.patch {
@@ -88,7 +89,7 @@ buildPythonPackage (finalAttrs: {
       (lib.cmakeBool "MLX_BUILD_METAL" false)
       (lib.cmakeBool "USE_SYSTEM_FMT" true)
       (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_GGUFLIB" "${gguf-tools}")
-      (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_JSON" "${nlohmann_json.src}")
+      (lib.cmakeFeature "CMAKE_CXX_FLAGS" "-I${lib.getDev nlohmann_json}/include/nlohmann")
 
       # Cmake cannot find nanobind-config.cmake by itself
       (lib.cmakeFeature "nanobind_DIR" "${nanobind}/${python.sitePackages}/nanobind/cmake")

--- a/pkgs/development/python-modules/mlx/default.nix
+++ b/pkgs/development/python-modules/mlx/default.nix
@@ -104,7 +104,6 @@ buildPythonPackage (finalAttrs: {
 
   buildInputs = [
     fmt
-    gguf-tools
     nlohmann_json
     pybind11
   ]

--- a/pkgs/development/python-modules/mlx/dont-fetch-json.patch
+++ b/pkgs/development/python-modules/mlx/dont-fetch-json.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 2451aa65..f88d4889 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -241,14 +241,6 @@ else()
+   set(MLX_BUILD_ACCELERATE OFF)
+ endif()
+ 
+-message(STATUS "Downloading json")
+-FetchContent_Declare(
+-  json
+-  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+-FetchContent_MakeAvailable(json)
+-target_include_directories(
+-  mlx PRIVATE $<BUILD_INTERFACE:${json_SOURCE_DIR}/single_include/nlohmann>)
+-
+ add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/mlx)
+ 
+ target_include_directories(
+


### PR DESCRIPTION
- **python3Packages.mlx: use nlohmann_json from nixpkgs**
- **python3Packages.mlx: remove gguf-tools source checkout from buildInputs**
- **python3Packages.mlx: remove pybind11 from buildInputs**
- **python3Packages.mlx: enable for x86_64-darwin**
- **ramalama: remove explicit check of mlx-lm availability**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
