### PR TITLE
ci/github-script/bot: only look at commit subject when deciding if a package is new/updated; refine regex

### DIFF
--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -332,13 +332,15 @@ module.exports = async ({ github, context, core, dry }) => {
         pull_number,
         per_page: 100,
       })
-      const commitMessages = prCommits.map((c) => c.commit.message)
+      const commitSubjects = prCommits.map(
+        (c) => c.commit.message.split('\n')[0],
+      )
 
       // Label new package PRs: "packagename: init at X.Y.Z"
       // Exclude NixOS module commits like "nixos/timekpr: init at 0.5.8"
       const newPackagePattern = /(?<!nixos\/\S+): init at\b/
       const hasNewPackages = changedPaths.attrdiff?.added?.length > 0
-      const commitsIndicateNewPackage = commitMessages.some((msg) =>
+      const commitsIndicateNewPackage = commitSubjects.some((msg) =>
         newPackagePattern.test(msg),
       )
       evalLabels['8.has: package (new)'] =
@@ -348,7 +350,7 @@ module.exports = async ({ github, context, core, dry }) => {
       // Matches versions like: 1.2.3, 0-unstable-2024-01-15, 1.3rc1, alpha, unstable
       // Exclude NixOS module commits like "nixos/ncps: types.str -> types.path"
       const updatePackagePattern = /(?<!nixos\/\S+): [\w.-]+ (->|→) [\w.-]+/
-      const commitsIndicateUpdate = commitMessages.some((msg) =>
+      const commitsIndicateUpdate = commitSubjects.some((msg) =>
         updatePackagePattern.test(msg),
       )
       evalLabels['8.has: package (update)'] = commitsIndicateUpdate

--- a/ci/github-script/bot.js
+++ b/ci/github-script/bot.js
@@ -338,7 +338,7 @@ module.exports = async ({ github, context, core, dry }) => {
 
       // Label new package PRs: "packagename: init at X.Y.Z"
       // Exclude NixOS module commits like "nixos/timekpr: init at 0.5.8"
-      const newPackagePattern = /(?<!nixos\/\S+): init at\b/
+      const newPackagePattern = /^(?<!nixos\/)\S+: init at\b/
       const hasNewPackages = changedPaths.attrdiff?.added?.length > 0
       const commitsIndicateNewPackage = commitSubjects.some((msg) =>
         newPackagePattern.test(msg),
@@ -349,7 +349,8 @@ module.exports = async ({ github, context, core, dry }) => {
       // Label package update PRs: "packagename: X.Y.Z -> A.B.C"
       // Matches versions like: 1.2.3, 0-unstable-2024-01-15, 1.3rc1, alpha, unstable
       // Exclude NixOS module commits like "nixos/ncps: types.str -> types.path"
-      const updatePackagePattern = /(?<!nixos\/\S+): [\w.-]+ (->|→) [\w.-]+/
+      const updatePackagePattern =
+        /^(?<!nixos\/)\S+: [\w.-]*\d[\w.-]* (->|→) [\w.-]*\d[\w.-]*$/
       const commitsIndicateUpdate = commitSubjects.some((msg) =>
         updatePackagePattern.test(msg),
       )


### PR DESCRIPTION
PR #483755 was labelled incorrectly, because the commit messages (but not the subjects) contained matching text.

The fix is to only look at the subject line.

Also, I missed that the regex for package update wasn't quite right: `(?<!nixos\/\S+): [\w.-]+ (->|→) [\w.-]+` matches "plfit: python -> withPython", but shouldn't. I fixed this too, and anchored both regexes to ensure they aren't matching on unintended portions of a line.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
