### PR TITLE
ly: cleanup

### DIFF
--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -1,16 +1,20 @@
 {
-  stdenv,
-  lib,
-  fetchFromGitea,
-  linux-pam,
-  libxcb,
-  makeBinaryWrapper,
-  zig_0_15,
   callPackage,
+  fetchFromGitea,
+  lib,
+  libxcb,
+  linux-pam,
+  makeBinaryWrapper,
   nixosTests,
+  stdenv,
+  versionCheckHook,
   x11Support ? true,
+  zig_0_15,
 }:
 
+let
+  zig = zig_0_15;
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "ly";
   version = "1.3.1";
@@ -25,8 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     makeBinaryWrapper
-    zig_0_15
+    zig
   ];
+
   buildInputs = [
     linux-pam
   ]
@@ -35,22 +40,31 @@ stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     ln -s ${
       callPackage ./deps.nix {
-        zig = zig_0_15;
+        inherit zig;
       }
     } $ZIG_GLOBAL_CACHE_DIR/p
   '';
+
   zigBuildFlags = [
     "-Denable_x11_support=${lib.boolToString x11Support}"
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   passthru.tests = { inherit (nixosTests) ly; };
 
   meta = {
     description = "TUI display manager";
-    license = lib.licenses.wtfpl;
+    longDescription = ''
+      Ly is a lightweight TUI (ncurses-like) display manager for Linux
+      and BSD, designed with portability in mind (e.g. it does not
+      require systemd to run).
+    '';
     homepage = "https://codeberg.org/fairyglade/ly";
-    maintainers = [ ];
-    platforms = lib.platforms.linux;
+    license = lib.licenses.wtfpl;
     mainProgram = "ly";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://codeberg.org/fairyglade/ly";
     license = lib.licenses.wtfpl;
     mainProgram = "ly";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ yiyu ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
