### PR TITLE
gnu-config: enable strictDeps

### DIFF
--- a/pkgs/by-name/gn/gnu-config/package.nix
+++ b/pkgs/by-name/gn/gnu-config/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  runtimeShell,
 }:
 
 # Note: this package is used for bootstrapping fetchurl, and thus
@@ -52,6 +53,19 @@ stdenv.mkDerivation {
     install -Dm755 ./config.sub $out/config.sub
     runHook postInstall
   '';
+
+  fixupPhase = ''
+    runHook preFixup
+    if [[ -z "''${dontPatchShebangs-}" ]]; then
+      substituteInPlace $out/config.guess \
+        --replace-fail '#! /bin/sh' '#!${runtimeShell}'
+      substituteInPlace $out/config.sub \
+        --replace-fail '#! /bin/sh' '#!${runtimeShell}'
+    fi
+    runHook postFixup
+  '';
+
+  strictDeps = true;
 
   meta = {
     description = "Attempt to guess a canonical system name";

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -1069,7 +1069,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           )
           ++ lib.optionals localSystem.isAarch64 [
             prevStage.updateAutotoolsGnuConfigScriptsHook
-            prevStage.gnu-config
+            prevStage.updateAutotoolsGnuConfigScriptsHook.gnu_config
           ]
           ++ lib.optionals localSystem.isx86_64 [ prevStage.darwin.Csu ]
           ++ (with prevStage.darwin; [

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -875,7 +875,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
           ++ lib.optionals (localSystem.libc == "musl") [ fortify-headers ]
           ++ [
             prevStage.updateAutotoolsGnuConfigScriptsHook
-            prevStage.gnu-config
+            prevStage.updateAutotoolsGnuConfigScriptsHook.gnu_config
           ]
           ++ [
             gcc-unwrapped.gmp

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -287,7 +287,9 @@ with pkgs;
   updateAutotoolsGnuConfigScriptsHook = makeSetupHook {
     name = "update-autotools-gnu-config-scripts-hook";
     substitutions = {
-      gnu_config = gnu-config;
+      gnu_config = gnu-config.override {
+        runtimeShell = targetPackages.stdenv.shell;
+      };
     };
   } ../build-support/setup-hooks/update-autotools-gnu-config-scripts.sh;
 


### PR DESCRIPTION
motivated by https://github.com/NixOS/nixpkgs/issues/178468

it would be as simple as setting `strictDeps = true` and `buildInputs = [ bashNonInteractive ]` except this package is used during the bootstrap of `stdenv`: this method of manually patching seems to be the least complex way to get correct behavior while avoiding cyclic references when deriving `stdenv` itself.

successfully built the following, from x86_64-linux:
- `gnu-config`
- `pkgsCross.aarch64-multiplatform.buildPackages.gnu-config` (equivalent)
- `pkgsCross.aarch64-multiplatform.gnu-config`
- `pkgsCross.musl32.gnu-config`
- `pkgsMusl.gnu-config`
- `pkgsStatic.gnu-config`
- `pkgsi686Linux.gnu-config`

successfully eval'd `gnu-config` for the following systems:
- `aarch64-darwin`
- `aarch64-freebsd`
- `aarch64-linux-musl`
- `aarch64-linux`
- `x86_64-cygwin`
- `x86_64-darwin`
- `x86_64-freebsd`
- `x86_64-linux-musl`
- `x86_64-linux`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test