### PR TITLE
ankiAddons.auto-sync: init at version 1.1.2-unstable-2023-11-20

### DIFF
--- a/pkgs/by-name/an/anki/addons/auto-sync/default.nix
+++ b/pkgs/by-name/an/anki/addons/auto-sync/default.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  anki-utils,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+anki-utils.buildAnkiAddon (finalAttrs: {
+  pname = "auto-sync";
+  version = "1.1.2-unstable-2023-11-20";
+  src = fetchFromGitHub {
+    owner = "Robin-Haupt-1";
+    repo = "Auto-Sync-Anki-Addon";
+    rev = "30d09d8b48c97cd66ef68ae73815b1cb29bcbc55";
+    hash = "sha256-dBEWyHLN6lwWEsrKULYnACqexjVsvZUpXWOLJy9vwkA=";
+  };
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = ''
+      Auto-sync your collection while Anki is idle
+    '';
+    homepage = "https://github.com/Robin-Haupt-1/Auto-Sync-Anki-Addon";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ dastarruer ];
+  };
+})

--- a/pkgs/by-name/an/anki/addons/default.nix
+++ b/pkgs/by-name/an/anki/addons/default.nix
@@ -8,6 +8,8 @@
 
   anki-quizlet-importer-extended = callPackage ./anki-quizlet-importer-extended { };
 
+  auto-sync = callPackage ./auto-sync { };
+
   image-occlusion-enhanced = callPackage ./image-occlusion-enhanced { };
 
   local-audio-yomichan = callPackage ./local-audio-yomichan { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
@euank @JuneStepp @oxij 
Add the auto-sync Anki addon, which will periodically sync your Anki cards while the app is open and idle.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
