### PR TITLE
elephant: init at 2.19.2, nixos/elephant: init service

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -36,6 +36,8 @@
 
 - [dsearch](https://github.com/AvengeMedia/danksearch), a fast filesystem search service with fuzzy matching. Available as [programs.dsearch](#opt-programs.dsearch.enable).
 
+- [Elephant](https://github.com/abenz1267/elephant), a data provider service and backend for building custom application launchers. Available as [services.elephant](#opt-services.elephant.enable).
+
 - [Dunst](https://github.com/dunst-project/dunst), a lightweight and customizable notification daemon. Available as [services.dunst](#opt-services.dunst.enable).
 
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -843,6 +843,7 @@
   ./services/misc/dump1090-fa.nix
   ./services/misc/dwm-status.nix
   ./services/misc/dysnomia.nix
+  ./services/misc/elephant.nix
   ./services/misc/errbot.nix
   ./services/misc/ersatztv.nix
   ./services/misc/etebase-server.nix

--- a/nixos/modules/services/misc/elephant.nix
+++ b/nixos/modules/services/misc/elephant.nix
@@ -1,0 +1,37 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.elephant;
+in
+{
+  options.services.elephant = {
+    enable = lib.mkEnableOption "Elephant application launcher backend";
+
+    package = lib.mkPackageOption pkgs "elephant" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.elephant = {
+      description = "Elephant application launcher backend";
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      serviceConfig = {
+        Restart = "always";
+        RestartSec = 10;
+        ExecStart = "${cfg.package}/bin/elephant";
+      };
+    };
+
+    environment.systemPackages = [ cfg.package ];
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    saadndm
+  ];
+}

--- a/pkgs/by-name/el/elephant/package.nix
+++ b/pkgs/by-name/el/elephant/package.nix
@@ -1,0 +1,131 @@
+{
+  enableArchLinuxPkgs ? false,
+  enableDnfPackages ? false,
+  enable1password ? false,
+  enableBitwarden ? true,
+  enableBluetooth ? true,
+  enableBookmarks ? true,
+  enableCalc ? true,
+  enableClipboard ? true,
+  enableDesktopApplications ? true,
+  enableFiles ? true,
+  enableMenus ? true,
+  enableNiriActions ? true,
+  enableNiriSessions ? true,
+  enableProviderList ? true,
+  enableRunner ? true,
+  enableSnippets ? true,
+  enableSymbols ? true,
+  enableTodo ? true,
+  enableUnicode ? true,
+  enableWebsearch ? true,
+  enableWindows ? true,
+
+  bluez,
+  buildGoModule,
+  fd,
+  fetchFromGitHub,
+  imagemagick,
+  lib,
+  libqalculate,
+  makeWrapper,
+  nix-update-script,
+  protobuf,
+  protoc-gen-go,
+  wl-clipboard,
+}:
+let
+  providerMap = {
+    "1password" = enable1password;
+    "archlinuxpkgs" = enableArchLinuxPkgs;
+    "bitwarden" = enableBitwarden;
+    "bluetooth" = enableBluetooth;
+    "bookmarks" = enableBookmarks;
+    "calc" = enableCalc;
+    "clipboard" = enableClipboard;
+    "desktopapplications" = enableDesktopApplications;
+    "dnfpackages" = enableDnfPackages;
+    "files" = enableFiles;
+    "menus" = enableMenus;
+    "niriactions" = enableNiriActions;
+    "nirisessions" = enableNiriSessions;
+    "providerlist" = enableProviderList;
+    "runner" = enableRunner;
+    "snippets" = enableSnippets;
+    "symbols" = enableSymbols;
+    "todo" = enableTodo;
+    "unicode" = enableUnicode;
+    "websearch" = enableWebsearch;
+    "windows" = enableWindows;
+  };
+
+  enabledProviders = lib.filterAttrs (_: enabled: enabled) providerMap;
+  enabledProvidersList = lib.concatStringsSep " " (lib.attrNames enabledProviders);
+
+  runtimeDeps =
+    lib.optionals enableFiles [ fd ]
+    ++ lib.optionals enableBluetooth [ bluez ]
+    ++ lib.optionals enableCalc [ libqalculate ]
+    ++ lib.optionals enableClipboard [
+      wl-clipboard
+      imagemagick
+    ];
+
+in
+buildGoModule (finalAttrs: {
+  pname = "elephant";
+  version = "2.19.2";
+
+  src = fetchFromGitHub {
+    owner = "abenz1267";
+    repo = "elephant";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-hs1Re7ltWYFBsiwDsK3Qb3/KgZ4E2HY7cFB/M8JWSu4=";
+  };
+
+  vendorHash = "sha256-tO+5x2FIY1UBvWl9x3ZSpHwTWUlw1VNDTi9+2uY7xdU=";
+
+  buildInputs = [ protobuf ];
+  nativeBuildInputs = [
+    makeWrapper
+    protoc-gen-go
+  ];
+
+  subPackages = [ "cmd/elephant" ];
+
+  postBuild = ''
+    echo "Building providers: ${enabledProvidersList}"
+
+    mkdir -p $out/lib/elephant/providers
+    for provider in ${enabledProvidersList}; do
+      [ -z "$provider" ] && continue
+      if [ -d "internal/providers/$provider" ]; then
+        echo "Building provider: $provider"
+        go build -buildmode=plugin -o "$out/lib/elephant/providers/$provider.so" ./internal/providers/"$provider" || exit 1
+      fi
+    done
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/elephant \
+      --prefix PATH : ${lib.makeBinPath runtimeDeps} \
+      --set ELEPHANT_PROVIDER_DIR "$out/lib/elephant/providers"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Data provider service and backend for building custom application launchers";
+    changelog = "https://github.com/abenz1267/elephant/releases/tag/v${finalAttrs.version}";
+    homepage = "https://github.com/abenz1267/elephant";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      adamcstephens
+      saadndm
+    ];
+    mainProgram = "elephant";
+  };
+})


### PR DESCRIPTION
Add elephant, a data provider service and backend for building custom application launchers, such as https://github.com/abenz1267/walker.

Homepage: https://github.com/abenz1267/elephant

The package supports configurable providers go plugin providers (bluetooth, clipboard, calculator, etc.), with runtime dependencies conditionally included based on enabled providers.

Closes #450973
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
