### PR TITLE
python3Packages.verilogae: disable on python 3.14

### DIFF
--- a/pkgs/development/python-modules/verilogae/default.nix
+++ b/pkgs/development/python-modules/verilogae/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
   nix-update-script,
   setuptools-rust,
   rustPlatform,
@@ -25,6 +26,9 @@ buildPythonPackage.override { stdenv = llvmPackages.stdenv; } rec {
     rev = "d878f5519b1767b64c6ebeb4d67e29e7cd46e60b";
     hash = "sha256-TDE2Ewokhm2KSKe+sunUbV8KD3kaTSd5dB3CLCWGJ9U=";
   };
+
+  # segfault in pythonImportsCheckPhase
+  disabled = pythonAtLeast "3.14";
 
   postPatch = ''
     substituteInPlace openvaf/osdi/build.rs \
@@ -66,6 +70,7 @@ buildPythonPackage.override { stdenv = llvmPackages.stdenv; } rec {
   meta = {
     description = "Verilog-A tool useful for compact model parameter extraction";
     homepage = "https://man.sr.ht/~dspom/openvaf_doc/verilogae/";
+    downloadPage = "https://github.com/OpenVAF/OpenVAF-Reloaded";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       jasonodoom


### PR DESCRIPTION
Segfaults in dependencies check

Tracking #475732

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
