### PR TITLE
phpExtensions.datadog_trace: 0.97.0 -> 1.16.0

### DIFF
--- a/pkgs/development/php-packages/datadog_trace/default.nix
+++ b/pkgs/development/php-packages/datadog_trace/default.nix
@@ -9,27 +9,33 @@
   curl,
   pcre2,
   libiconv,
-  php,
 }:
 
 buildPecl rec {
   pname = "ddtrace";
-  version = "0.97.0";
+  version = "1.16.0";
 
   src = fetchFromGitHub {
     owner = "DataDog";
     repo = "dd-trace-php";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-Kx2HaWvRT+mFIs0LAAptx6nm9DQ83QEuyHNcEPEr7A4=";
+    hash = "sha256-o9g0PT/EbBlB9h2FGyYJsKoNUcJIhGR0hv3owztcvcw=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-cwhE6M8r8QnrIiNgEekI25GcKTByySrZsigPd9/Fq7o=";
+    hash = "sha256-vcM+iLpJiIxMqw/Xgq4E3hbY77+H1T1UkdJpUOO6dmo=";
   };
 
   env.NIX_CFLAGS_COMPILE = "-O2";
+
+  # Fix double slashes in Makefile paths to prevent impure path errors during
+  # linking. The Makefile has /$(builddir)/components-rs/... but builddir is
+  # already absolute (/build/source), creating //build/source/... paths.
+  postConfigure = ''
+    substituteInPlace Makefile --replace-fail '/$(builddir)/components-rs' '$(builddir)/components-rs'
+  '';
 
   nativeBuildInputs = [
     cargo
@@ -55,6 +61,5 @@ buildPecl rec {
       bsd3
     ];
     teams = [ lib.teams.php ];
-    broken = lib.versionAtLeast php.version "8.4";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
