### PR TITLE
top-level/stage: assert no by-name overwrites

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -155,7 +155,11 @@ let
           overlays
           ;
       } res self super;
+
+      conflictingAttrs = lib.intersectAttrs res super;
     in
+    assert lib.assertMsg (conflictingAttrs == { })
+      "The following attributes were defined both in `pkgs/top-level/all-packages.nix` and elsewhere, most likely in `pkgs/by-name/`: ${lib.concatStringsSep ", " (lib.attrNames conflictingAttrs)}";
     res;
 
   aliases = self: super: lib.optionalAttrs config.allowAliases (import ./aliases.nix lib self super);


### PR DESCRIPTION
This asserts that no by-name packages are overwritten by definitions in all-packages.nix.

Resurrection of #454525

Remaining packages with overrides:
- [x] ArchiSteamFarm - #485695
- [x] aegisub - #483859
- [x] audacity - #485693
- [x] bitwuzla - #485692
- [x] cvc5 - #485691
- [x] darktable - #483859
- [x] dbeaver-bin - #484590
- [x] dbqn - #483861
- [x] element-web - #484588
- [x] factorio - #484585
- [x] firefox_decrypt - #499971
- [x] freedv - #485674
- [x] gfal2-util - #485694
- [x] glib - #485673
- [x] gopro-tool - #485675
- [x] heptagon - #493748
- [x] hugin - #485690
- [x] kitty - #484591
- [x] mkgmap (not actually required after rebase) - #485710
- [x] monado - #484592
- [x] mysql-workbench - #485676
- [x] neovim-unwrapped - #485677
- [x] odin - #483859
- [x] opaline - #485689 #497493
- [x] plausible - #485678
- [x] plfit - #483860
- [x] rabbitmq-server - #485679
- [x] renovate - #483859
- [x] rescript-language-server - #484594
- [x] rucio - #485702 
- [x] vanillatd - #484586
- [x] vtfedit - #484596
- [x] x2t - #485680
- [x] xcbuild - #485704

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test