### PR TITLE
mozc: make ibus dependency optional (opt-in)

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -76,6 +76,8 @@
 
 - `mercure` has been update to `0.21.4` (or later). Version [0.21.0](https://github.com/dunglas/mercure/releases/v0.21.0) and [0.21.2](https://github.com/dunglas/mercure/releases/tag/v0.21.2) introduce breaking changes to the package.
 
+- `mozc` and `mozc-ut` no longer contains the IBus front-end, which are now provided by `ibus-engines.mozc` and `ibus-engines.mozc-ut`.
+
 - `n8n` has been updated to version 2. You can find the breaking changes here: https://docs.n8n.io/2-0-breaking-changes/.
 
 - `gurk-rs` has been updated from `0.6.4` to `0.8.0`. Version `0.8.0` includes breaking changes. For more information read the [release notes for 0.8.0](https://github.com/boxdot/gurk-rs/releases/tag/v0.8.0).

--- a/pkgs/by-name/mo/mozc-ut/package.nix
+++ b/pkgs/by-name/mo/mozc-ut/package.nix
@@ -8,8 +8,10 @@
   mozcdic-ut-place-names,
   mozcdic-ut-skk-jisyo,
   mozcdic-ut-sudachidict,
+  withIbus ? false,
 }:
 mozc.override {
+  inherit withIbus;
   dictionaries = [
     mozcdic-ut-alt-cannadic
     mozcdic-ut-edict2

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2236,7 +2236,8 @@ with pkgs;
 
     m17n = callPackage ../tools/inputmethods/ibus-engines/ibus-m17n { };
 
-    inherit mozc mozc-ut;
+    mozc = mozc.override { withIbus = true; };
+    mozc-ut = mozc-ut.override { withIbus = true; };
 
     openbangla-keyboard = libsForQt5.callPackage ../applications/misc/openbangla-keyboard {
       withIbusSupport = true;


### PR DESCRIPTION
**Things done**
Added option `withIbus` to enable/disable ibus integration of `mozc`. Exposing a near-minimal mozc package (with emacs frontend).

**Implications**
- This can be helpful for non-users of ibus in reducing their build size by removing the `ibus` dependency. The package `mozc` now builds the mozc server and the emacs frontend, without the ibus component (as opposed to`ibus-engines.mozc` which build with ibus integration).
 - `fcitx5-mozc` would depends on the variant without `ibus`, which seems also more reasonable than the current behavior.
 - Users configuring their system using `(pkgs.)mozc` would obtain a non-ibus version, possibly breaking configurations. As the [NixOS Packages Search](https://search.nixos.org/packages) turns up `ibus-engines.mozc` alone, I expect this scenario to be uncommon.

**Minor changes**
 - Ibus icons are now symlinks to `share/icons/mozc/*`

**Alternative approaches**
- Make `ibus-engines.mozc` solely the `ibus` component, while `mozc` contains mozc and the emacs helper.

---
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.