### PR TITLE
apachetomcatscanner: Remove urllib3 DEFAULT_CIPHERS to support urllib3 2.x & Fix mainProgram executable

### DIFF
--- a/pkgs/by-name/ap/apachetomcatscanner/package.nix
+++ b/pkgs/by-name/ap/apachetomcatscanner/package.nix
@@ -16,11 +16,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     hash = "sha256-9gaue/XfxtU+5URYfg+uYaNcx8G3Eu9DgVEpj/lk8TY=";
   };
 
-  # Posted a PR for discussion upstream that can be followed:
-  # https://github.com/p0dalirius/ApacheTomcatScanner/pull/32
-  postPatch = ''
-    sed -i '/apachetomcatscanner=apachetomcatscanner\.__main__:main/d' setup.py
-  '';
+  patches = [
+    # fix compatibility with urllib3 2.x
+    ./urllib3-default-ciphers-attributeerror.patch
+  ];
 
   pythonRelaxDeps = [
     "requests"
@@ -47,6 +46,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     changelog = "https://github.com/p0dalirius/ApacheTomcatScanner/releases/tag/${finalAttrs.version}";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ fab ];
-    mainProgram = "ApacheTomcatScanner";
+    mainProgram = "apachetomcatscanner";
   };
 })

--- a/pkgs/by-name/ap/apachetomcatscanner/urllib3-default-ciphers-attributeerror.patch
+++ b/pkgs/by-name/ap/apachetomcatscanner/urllib3-default-ciphers-attributeerror.patch
@@ -1,0 +1,24 @@
+diff --git a/apachetomcatscanner/utils/network.py b/apachetomcatscanner/utils/network.py
+index 0d8bd45..14fe83b 100644
+--- a/apachetomcatscanner/utils/network.py
++++ b/apachetomcatscanner/utils/network.py
+@@ -12,7 +12,6 @@ import requests
+ # Disable warnings of insecure connection for invalid certificates
+ requests.packages.urllib3.disable_warnings()
+ # Allow use of deprecated and weak cipher methods
+-requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ":HIGH:!DH:!aNULL"
+ try:
+     requests.packages.urllib3.contrib.pyopenssl.util.ssl_.DEFAULT_CIPHERS += (
+         ":HIGH:!DH:!aNULL"
+diff --git a/apachetomcatscanner/utils/scan.py b/apachetomcatscanner/utils/scan.py
+index bbd1c17..5a0f541 100644
+--- a/apachetomcatscanner/utils/scan.py
++++ b/apachetomcatscanner/utils/scan.py
+@@ -20,7 +20,6 @@ from apachetomcatscanner.utils.network import is_http_accessible, is_port_open
+ # Disable warnings of insecure connection for invalid certificates
+ requests.packages.urllib3.disable_warnings()
+ # Allow use of deprecated and weak cipher methods
+-requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ":HIGH:!DH:!aNULL"
+ try:
+     requests.packages.urllib3.contrib.pyopenssl.util.ssl_.DEFAULT_CIPHERS += (
+         ":HIGH:!DH:!aNULL"


### PR DESCRIPTION
Remove urllib3.util.ssl_.DEFAULT_CIPHERS so the CLI no longer crashes with urllib3 2.x.

## Things done
  - Built on platform:
      - [x] x86_64-linux
      - [ ] aarch64-linux
      - [ ] x86_64-darwin
      - [ ] aarch64-darwin
  - Tested, as applicable:
      - [ ] [NixOS tests] in [nixos/tests].
      - [ ] [Package tests] at passthru.tests.
      - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] Ran nixpkgs-review on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in ./result/bin/.
  - Nixpkgs Release Notes
      - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
      - [ ] Module addition: when adding a new NixOS module.
      - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## Checks done
  - `nix build .#apachetomcatscanner`
  - `./result/bin/apachetomcatscanner --help`
