### PR TITLE
plfit: python -> withPython

### DIFF
--- a/pkgs/by-name/pl/plfit/package.nix
+++ b/pkgs/by-name/pl/plfit/package.nix
@@ -3,10 +3,13 @@
   fetchFromGitHub,
   lib,
   llvmPackages,
+  withPython ? false,
   python ? null,
   stdenv,
   swig,
 }:
+
+assert withPython -> python != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "plfit";
@@ -19,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-0JrPAq/4yzr7XbxvcnFj8CKmMyZT05PkSdGprNdAsJA=";
   };
 
-  postPatch = lib.optionalString (python != null) ''
+  postPatch = lib.optionalString withPython ''
     substituteInPlace src/CMakeLists.txt \
       --replace-fail ' ''${Python3_SITEARCH}' ' ${placeholder "out"}/${python.sitePackages}' \
       --replace-fail ' ''${Python3_SITELIB}' ' ${placeholder "out"}/${python.sitePackages}'
@@ -28,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
   ]
-  ++ lib.optionals (python != null) [
+  ++ lib.optionals withPython [
     python
     swig
   ];
@@ -36,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DPLFIT_USE_OPENMP=ON"
   ]
-  ++ lib.optionals (python != null) [
+  ++ lib.optionals withPython [
     "-DPLFIT_COMPILE_PYTHON_MODULE=ON"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3453,10 +3453,6 @@ with pkgs;
 
   tautulli = python3Packages.callPackage ../servers/tautulli { };
 
-  plfit = callPackage ../by-name/pl/plfit/package.nix {
-    python = null;
-  };
-
   inherit (callPackage ../development/tools/pnpm { })
     pnpm_8
     pnpm_9

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12340,7 +12340,12 @@ self: super: with self; {
 
   plexwebsocket = callPackage ../development/python-modules/plexwebsocket { };
 
-  plfit = toPythonModule (pkgs.plfit.override { inherit (self) python; });
+  plfit = toPythonModule (
+    pkgs.plfit.override {
+      withPython = true;
+      inherit (self) python;
+    }
+  );
 
   plink = callPackage ../development/python-modules/plink { };
 


### PR DESCRIPTION
Improves the override interface, because `withPython` does not conflict
with the old `python` package.

Split from #474456.

This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
