### PR TITLE
dbqn: remove top-level override

### DIFF
--- a/pkgs/by-name/db/dbqn/package.nix
+++ b/pkgs/by-name/db/dbqn/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
-  jdk,
+  jre,
   makeWrapper,
   buildNativeImage ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "dbqn" + lib.optionalString buildNativeImage "-native";
   version = "0.2.2";
 
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    jdk
+    jre
     makeWrapper
   ];
 
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   ''
   + lib.optionalString buildNativeImage ''
     native-image --report-unsupported-elements-at-runtime \
-      -H:CLibraryPath=${lib.getLib jdk}/lib -J-Dfile.encoding=UTF-8 \
+      -H:CLibraryPath=${lib.getLib jre}/lib -J-Dfile.encoding=UTF-8 \
       -jar BQN.jar dbqn
   ''
   + ''
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
         mkdir -p $out/share/dbqn
         mv BQN.jar $out/share/dbqn/
 
-        makeWrapper "${lib.getBin jdk}/bin/java" "$out/bin/dbqn" \
+        makeWrapper "${lib.getBin jre}/bin/java" "$out/bin/dbqn" \
           --add-flags "-jar $out/share/dbqn/BQN.jar"
       ''
   )
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [
       sternenseemann
     ];
-    inherit (jdk.meta) platforms;
-    broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/dbqn-native.x86_64-darwin
+    inherit (jre.meta) platforms;
+    broken = stdenvNoCC.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/staging-next/dbqn-native.x86_64-darwin
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5200,14 +5200,9 @@ with pkgs;
     };
   };
 
-  dbqn = callPackage ../by-name/db/dbqn/package.nix {
-    jdk = jre;
-    stdenv = stdenvNoCC;
-  };
-
   dbqn-native = dbqn.override {
     buildNativeImage = true;
-    jdk = graalvmPackages.graalvm-ce;
+    jre = graalvmPackages.graalvm-ce;
   };
 
   clojupyter = callPackage ../applications/editors/jupyter-kernels/clojupyter {


### PR DESCRIPTION
Split from #474456.

This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
