### PR TITLE
impacket: enable OpenSSL legacy provider in wrappers

### DIFF
--- a/pkgs/development/python-modules/impacket/default.nix
+++ b/pkgs/development/python-modules/impacket/default.nix
@@ -11,11 +11,31 @@
   pyasn1-modules,
   pycryptodomex,
   pyopenssl,
+  python,
   setuptools,
   pytestCheckHook,
   six,
+  writeText,
 }:
 
+let
+  opensslConf = writeText "openssl.conf" ''
+    openssl_conf = openssl_init
+
+    [openssl_init]
+    providers = provider_sect
+
+    [provider_sect]
+    default = default_sect
+    legacy = legacy_sect
+
+    [default_sect]
+    activate = 1
+
+    [legacy_sect]
+    activate = 1
+  '';
+in
 buildPythonPackage rec {
   pname = "impacket";
   version = "0.13.0";
@@ -46,7 +66,12 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  pythonImportsCheck = [ "impacket" ];
+  makeWrapperArgs = [ "--set-default OPENSSL_CONF ${opensslConf}" ];
+
+  pythonImportsCheck = [
+    "impacket"
+    "impacket.msada_guids"
+  ];
 
   disabledTestPaths = [
     # Skip all RPC related tests

--- a/pkgs/development/python-modules/impacket/default.nix
+++ b/pkgs/development/python-modules/impacket/default.nix
@@ -11,7 +11,6 @@
   pyasn1-modules,
   pycryptodomex,
   pyopenssl,
-  python,
   setuptools,
   pytestCheckHook,
   six,


### PR DESCRIPTION
Closes #255563

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  If you want to add a “Checks done” section (optional), you can append:

  ## Checks done
  - `nix build .#python3Packages.impacket`
  - `./result/bin/dacledit.py --help`