### PR TITLE
various: use stdenv.mkDerivation instead of qt5.mkDerivation

### DIFF
--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -1,9 +1,11 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   alsa-lib ? null,
   carla ? null,
   fftwFloat,
@@ -22,10 +24,9 @@
   qtx11extras,
   qttools,
   SDL ? null,
-  mkDerivation,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "lmms";
   version = "1.2.2";
 
@@ -41,6 +42,7 @@ mkDerivation rec {
     cmake
     qttools
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
   extra-cmake-modules,
+  wrapQtAppsHook,
   qtbase,
   qtquickcontrols2,
   SDL,
@@ -13,7 +14,7 @@
   nixosTests,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "sfxr-qt";
   version = "1.5.1";
 
@@ -35,6 +36,7 @@ mkDerivation rec {
         setuptools
       ]
     ))
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/editors/notepadqq/default.nix
+++ b/pkgs/applications/editors/notepadqq/default.nix
@@ -1,18 +1,19 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   pkg-config,
   which,
+  qttools,
+  wrapQtAppsHook,
   libuchardet,
   qtbase,
   qtsvg,
-  qttools,
   qtwebengine,
   qtwebsockets,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "notepadqq";
   # shipping a beta build as there's no proper release which supports qtwebengine
   version = "2.0.0-beta";
@@ -34,6 +35,7 @@ mkDerivation rec {
     pkg-config
     which
     qttools
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/editors/okteta/default.nix
+++ b/pkgs/applications/editors/okteta/default.nix
@@ -1,9 +1,10 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchurl,
   extra-cmake-modules,
   kdoctools,
+  wrapQtAppsHook,
   qtscript,
   kconfig,
   kinit,
@@ -17,7 +18,7 @@
   shared-mime-info,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "okteta";
   version = "0.26.24";
 
@@ -30,6 +31,7 @@ mkDerivation rec {
     qtscript
     extra-cmake-modules
     kdoctools
+    wrapQtAppsHook
   ];
   buildInputs = [ shared-mime-info ];
 

--- a/pkgs/applications/emulators/yabause/default.nix
+++ b/pkgs/applications/emulators/yabause/default.nix
@@ -1,9 +1,10 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchurl,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   qtbase,
   qt5,
   libGLU,
@@ -13,7 +14,7 @@
   SDL2 ? null,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "yabause";
   version = "0.9.15";
 
@@ -25,6 +26,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/applications/graphics/awesomebump/default.nix
+++ b/pkgs/applications/graphics/awesomebump/default.nix
@@ -1,6 +1,6 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchgit,
   qtbase,
   qmake,
@@ -8,6 +8,7 @@
   flex,
   bison,
   qtdeclarative,
+  wrapQtAppsHook,
 }:
 
 let
@@ -20,7 +21,7 @@ let
     fetchSubmodules = true;
   };
 
-  qtnproperty = mkDerivation {
+  qtnproperty = stdenv.mkDerivation {
     name = "qtnproperty";
     inherit src;
     sourceRoot = "${src.name}/Sources/utils/QtnProperty";
@@ -34,13 +35,14 @@ let
       qmake
       flex
       bison
+      wrapQtAppsHook
     ];
     postInstall = ''
       install -D bin-linux/QtnPEG $out/bin/QtnPEG
     '';
   };
 in
-mkDerivation {
+stdenv.mkDerivation {
   pname = "awesomebump";
   inherit version;
 
@@ -52,7 +54,10 @@ mkDerivation {
     qtdeclarative
   ];
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
 
   preBuild = ''
     ln -sf ${qtnproperty}/bin/QtnPEG Sources/utils/QtnProperty/bin-linux/QtnPEG

--- a/pkgs/applications/graphics/unigine-superposition/default.nix
+++ b/pkgs/applications/graphics/unigine-superposition/default.nix
@@ -20,7 +20,6 @@
   libXrender,
   autoPatchelfHook,
   makeWrapper,
-  mkDerivation,
   xkeyboard_config,
   fetchurl,
   buildFHSEnv,

--- a/pkgs/applications/misc/cask-server/default.nix
+++ b/pkgs/applications/misc/cask-server/default.nix
@@ -1,12 +1,13 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
   extra-cmake-modules,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "cask-server";
   version = "0.6.0";
 
@@ -20,6 +21,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    wrapQtAppsHook
   ];
 
   meta = {

--- a/pkgs/applications/misc/confclerk/default.nix
+++ b/pkgs/applications/misc/confclerk/default.nix
@@ -1,12 +1,13 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchurl,
   qtbase,
   qmake,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "confclerk";
   version = "0.7.2";
 
@@ -16,7 +17,11 @@ mkDerivation rec {
   };
 
   buildInputs = [ qtbase ];
-  nativeBuildInputs = [ qmake ];
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
 
   postInstall = ''
     mkdir -p $out/bin

--- a/pkgs/applications/misc/coolreader/default.nix
+++ b/pkgs/applications/misc/coolreader/default.nix
@@ -1,9 +1,9 @@
 {
   stdenv,
-  mkDerivation,
   fetchFromGitHub,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   lib,
   qttools,
   fribidi,
@@ -11,7 +11,7 @@
   zstd,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "coolreader";
   version = "3.2.58";
 
@@ -27,6 +27,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -1,9 +1,10 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   cmake,
   python3,
+  wrapQtAppsHook,
   qtbase,
   qtquickcontrols2,
   qtgraphicaleffects,
@@ -11,7 +12,7 @@
   plugins ? [ ],
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "cura";
   version = "4.13.1";
 
@@ -52,6 +53,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     python3.pkgs.wrapPython
+    wrapQtAppsHook
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/misc/ddcui/default.nix
+++ b/pkgs/applications/misc/ddcui/default.nix
@@ -1,15 +1,16 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   qtbase,
   qttools,
   ddcutil,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "ddcui";
   version = "0.6.0";
 
@@ -25,6 +26,7 @@ mkDerivation rec {
     # file is not currently written to support PREFIX installations.
     cmake
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/diffpdf/default.nix
+++ b/pkgs/applications/misc/diffpdf/default.nix
@@ -1,16 +1,16 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchurl,
   fetchpatch,
   qmake,
   qttools,
+  wrapQtAppsHook,
   qtbase,
   poppler,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "2.1.3";
   pname = "diffpdf";
 
@@ -30,6 +30,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     qttools
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/applications/misc/evtest-qt/default.nix
+++ b/pkgs/applications/misc/evtest-qt/default.nix
@@ -1,14 +1,15 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   qtbase,
   cmake,
+  wrapQtAppsHook,
   fetchFromGitHub,
   fetchpatch,
   unstableGitUpdater,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "evtest-qt";
   version = "0.2.0-unstable-2023-09-13";
 
@@ -30,7 +31,10 @@ mkDerivation {
     })
   ];
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
 
   buildInputs = [ qtbase ];
 

--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchurl,
   freetype,
   glib,
@@ -30,6 +29,7 @@
 
   xkeyboardconfig,
   autoPatchelfHook,
+  wrapQtAppsHook,
 }:
 let
   arch =
@@ -38,7 +38,7 @@ let
     else
       throw "Unsupported system ${stdenv.hostPlatform.system} ";
 in
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "googleearth-pro";
   version = "7.3.6.10201";
 
@@ -51,6 +51,7 @@ mkDerivation rec {
     dpkg
     makeWrapper
     autoPatchelfHook
+    wrapQtAppsHook
   ];
   propagatedBuildInputs = [ xkeyboardconfig ];
   buildInputs = [

--- a/pkgs/applications/misc/heimer/default.nix
+++ b/pkgs/applications/misc/heimer/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
   cmake,
+  wrapQtAppsHook,
   qttools,
   qtbase,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "heimer";
   version = "4.5.0";
 
@@ -35,6 +36,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/k4dirstat/default.nix
+++ b/pkgs/applications/misc/k4dirstat/default.nix
@@ -1,17 +1,18 @@
 {
-  mkDerivation,
-  extra-cmake-modules,
+  lib,
+  stdenv,
   fetchFromGitHub,
+  extra-cmake-modules,
+  wrapQtAppsHook,
   kiconthemes,
   kio,
   kjobwidgets,
   kxmlgui,
-  lib,
   testers,
   k4dirstat,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "k4dirstat";
   version = "3.4.3";
 
@@ -22,7 +23,11 @@ mkDerivation rec {
     hash = "sha256-TXMUtiPS7qRLm6cCy2ZntYrcNJ0fn6X+3o3P5u7oo08=";
   };
 
-  nativeBuildInputs = [ extra-cmake-modules ];
+  nativeBuildInputs = [
+    extra-cmake-modules
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
     kiconthemes
     kio

--- a/pkgs/applications/misc/klayout/default.nix
+++ b/pkgs/applications/misc/klayout/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   python3,
   ruby,
+  wrapQtAppsHook,
   qtbase,
   qtmultimedia,
   qttools,
@@ -11,10 +12,9 @@
   which,
   perl,
   libgit2,
-  stdenv,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "klayout";
   version = "0.30.4-1";
 
@@ -35,6 +35,7 @@ mkDerivation rec {
     perl
     python3
     ruby
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/ksmoothdock/default.nix
+++ b/pkgs/applications/misc/ksmoothdock/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
   extra-cmake-modules,
+  wrapQtAppsHook,
   kactivities,
   qtbase,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "KSmoothDock";
   version = "6.3";
 
@@ -28,6 +29,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/lyx/default.nix
+++ b/pkgs/applications/misc/lyx/default.nix
@@ -1,18 +1,19 @@
 {
   fetchurl,
   lib,
-  mkDerivation,
+  stdenv,
   pkg-config,
   python3,
   file,
   bc,
   qtbase,
+  wrapQtAppsHook,
   qtsvg,
   hunspell,
   makeWrapper, # , mythes, boost
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "2.4.4";
   pname = "lyx";
 
@@ -27,6 +28,7 @@ mkDerivation rec {
     makeWrapper
     python3
     qtbase
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/applications/misc/maliit-framework/default.nix
+++ b/pkgs/applications/misc/maliit-framework/default.nix
@@ -1,6 +1,6 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
 
@@ -24,9 +24,10 @@
   pkg-config,
   wayland-protocols,
   wayland-scanner,
+  wrapQtAppsHook,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "maliit-framework";
   version = "2.3.0-unstable-2024-06-24";
 
@@ -59,6 +60,7 @@ mkDerivation {
     pkg-config
     wayland-protocols
     wayland-scanner
+    wrapQtAppsHook
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/misc/maliit-keyboard/default.nix
+++ b/pkgs/applications/misc/maliit-keyboard/default.nix
@@ -1,6 +1,6 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
 
   anthy,
@@ -16,9 +16,10 @@
   cmake,
   pkg-config,
   wrapGAppsHook3,
+  wrapQtAppsHook,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "maliit-keyboard";
   version = "2.3.1-unstable-2024-09-04";
 
@@ -55,6 +56,7 @@ mkDerivation {
     cmake
     pkg-config
     wrapGAppsHook3
+    wrapQtAppsHook
   ];
 
   postInstall = ''

--- a/pkgs/applications/misc/michabo/default.nix
+++ b/pkgs/applications/misc/michabo/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   makeDesktopItem,
   fetchFromGitLab,
   qmake,
+  wrapQtAppsHook,
   # qt
   qtbase,
   qtwebsockets,
@@ -17,7 +18,7 @@ let
   };
 
 in
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "michabo";
   version = "0.1";
 
@@ -31,6 +32,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     qmake
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/applications/misc/moolticute/default.nix
+++ b/pkgs/applications/misc/moolticute/default.nix
@@ -1,16 +1,17 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   libusb1,
   pkg-config,
   qmake,
-  qtbase,
   qttools,
+  wrapQtAppsHook,
+  qtbase,
   qtwebsockets,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "moolticute";
   version = "1.03.0";
 
@@ -30,6 +31,7 @@ mkDerivation rec {
     pkg-config
     qmake
     qttools
+    wrapQtAppsHook
   ];
   buildInputs = [
     libusb1

--- a/pkgs/applications/misc/nixnote2/default.nix
+++ b/pkgs/applications/misc/nixnote2/default.nix
@@ -1,17 +1,18 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
+  qmake,
+  wrapQtAppsHook,
   boost,
   qtbase,
   qtwebkit,
   poppler,
-  qmake,
   hunspell,
   html-tidy,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "nixnote2";
   version = "2.0.2";
 
@@ -22,6 +23,11 @@ mkDerivation rec {
     sha256 = "0cfq95mxvcgby66r61gclm1a2c6zck5aln04xmg2q8kg6p9d31fr";
   };
 
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
     boost
     qtbase
@@ -29,8 +35,6 @@ mkDerivation rec {
     poppler
     hunspell
   ];
-
-  nativeBuildInputs = [ qmake ];
 
   postPatch = ''
     # Fix location of poppler-qt5.h

--- a/pkgs/applications/misc/openambit/default.nix
+++ b/pkgs/applications/misc/openambit/default.nix
@@ -1,17 +1,18 @@
 {
+  stdenv,
   cmake,
   fetchFromGitHub,
   fetchpatch,
   lib,
   libusb1,
-  mkDerivation,
   python3,
   qtbase,
   qttools,
+  wrapQtAppsHook,
   udev,
   zlib,
 }:
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "openambit";
   version = "0.5";
 
@@ -49,6 +50,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     qttools
+    wrapQtAppsHook
   ];
   buildInputs = [
     libusb1

--- a/pkgs/applications/misc/openbrf/default.nix
+++ b/pkgs/applications/misc/openbrf/default.nix
@@ -1,19 +1,19 @@
 {
-  mkDerivation,
   lib,
   stdenv,
   fetchFromGitHub,
   fetchpatch,
+  qmake,
+  wrapQtAppsHook,
   qtbase,
   vcg,
   glew,
-  qmake,
   libGLU,
   eigen,
   libGL,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "openbrf";
   version = "unstable-2016-01-09";
 
@@ -33,14 +33,17 @@ mkDerivation {
     })
   ];
 
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
     qtbase
     vcg
     glew
     eigen
   ];
-
-  nativeBuildInputs = [ qmake ];
 
   qmakeFlags = [ "openBrf.pro" ];
 

--- a/pkgs/applications/misc/opentx/default.nix
+++ b/pkgs/applications/misc/opentx/default.nix
@@ -1,21 +1,22 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
   gcc-arm-embedded,
   python3Packages,
+  qttools,
+  udevCheckHook,
+  wrapQtAppsHook,
   qtbase,
   qtmultimedia,
-  qttools,
   SDL,
   gtest,
   dfu-util,
   avrdude,
-  udevCheckHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "opentx";
   version = "2.3.15";
 
@@ -36,6 +37,7 @@ mkDerivation rec {
     python3Packages.pillow
     qttools
     udevCheckHook
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/pure-maps/default.nix
+++ b/pkgs/applications/misc/pure-maps/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
   qttools,
+  wrapQtAppsHook,
   kirigami2,
   qtquickcontrols2,
   qtlocation,
@@ -15,7 +16,7 @@
   pyotherside,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "pure-maps";
   version = "3.4.2";
 
@@ -32,6 +33,7 @@ mkDerivation rec {
     python3
     qttools
     python3.pkgs.wrapPython
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/qlcplus/default.nix
+++ b/pkgs/applications/misc/qlcplus/default.nix
@@ -1,9 +1,11 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qmake,
   pkg-config,
+  udevCheckHook,
+  wrapQtAppsHook,
   udev,
   qtmultimedia,
   qtscript,
@@ -15,10 +17,9 @@
   libusb-compat-0_1,
   libsndfile,
   libmad,
-  udevCheckHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qlcplus";
   version = "5.0.0";
 
@@ -33,6 +34,7 @@ mkDerivation rec {
     qmake
     pkg-config
     udevCheckHook
+    wrapQtAppsHook
   ];
   buildInputs = [
     udev

--- a/pkgs/applications/misc/qsudo/default.nix
+++ b/pkgs/applications/misc/qsudo/default.nix
@@ -1,13 +1,14 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qmake,
+  wrapQtAppsHook,
   qtbase,
   sudo,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qsudo";
   version = "2020.03.27";
 
@@ -22,6 +23,7 @@ mkDerivation rec {
 
   nativeBuildInputs = [
     qmake
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/misc/qsyncthingtray/default.nix
+++ b/pkgs/applications/misc/qsyncthingtray/default.nix
@@ -1,20 +1,20 @@
 {
-  mkDerivation,
   stdenv,
   lib,
   fetchFromGitHub,
   fetchpatch,
+  cmake,
+  wrapQtAppsHook,
   procps,
   qtbase,
   qtwebengine,
   qtwebkit,
-  cmake,
   syncthing,
   preferQWebView ? false,
   preferNative ? true,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "0.5.8";
   pname = "qsyncthingtray";
 
@@ -25,13 +25,16 @@ mkDerivation rec {
     sha256 = "1n9g4j7qznvg9zl6x163pi9f7wsc3x6q76i33psnm7x2v1i22x5w";
   };
 
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
     qtbase
     qtwebengine
   ]
   ++ lib.optional preferQWebView qtwebkit;
-
-  nativeBuildInputs = [ cmake ];
 
   cmakeFlags =
     [ ]

--- a/pkgs/applications/misc/qt-box-editor/default.nix
+++ b/pkgs/applications/misc/qt-box-editor/default.nix
@@ -1,15 +1,16 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
+  qmake,
+  wrapQtAppsHook,
   qtbase,
   qtsvg,
-  qmake,
   leptonica,
   tesseract4,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "qt-box-editor";
   version = "unstable-2019-07-14";
 
@@ -20,14 +21,17 @@ mkDerivation {
     hash = "sha256-3dWnAu0CLO3atjbC1zJEnL3vzsIEecDDDhW3INMfCv4=";
   };
 
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
     qtbase
     qtsvg
     leptonica
     tesseract4
   ];
-
-  nativeBuildInputs = [ qmake ];
 
   # https://github.com/zdenop/qt-box-editor/issues/87
   postPatch = ''

--- a/pkgs/applications/misc/rescuetime/default.nix
+++ b/pkgs/applications/misc/rescuetime/default.nix
@@ -3,12 +3,12 @@
   lib,
   fetchurl,
   dpkg,
+  wrapQtAppsHook,
   patchelf,
   qt5,
   libXtst,
   libXext,
   libX11,
-  mkDerivation,
   libXScrnSaver,
   writeScript,
   common-updater-scripts,
@@ -32,12 +32,15 @@ let
         sha256 = "09ng0yal66d533vzfv27k9l2va03rqbqmsni43qi3hgx7w9wx5ii";
       };
 in
-mkDerivation rec {
+stdenv.mkDerivation rec {
   # https://www.rescuetime.com/updates/linux_release_notes.html
   inherit version;
   pname = "rescuetime";
   inherit src;
-  nativeBuildInputs = [ dpkg ];
+  nativeBuildInputs = [
+    dpkg
+    wrapQtAppsHook
+  ];
   # avoid https://github.com/NixOS/patchelf/issues/99
   dontStrip = true;
 

--- a/pkgs/applications/misc/rsibreak/default.nix
+++ b/pkgs/applications/misc/rsibreak/default.nix
@@ -1,9 +1,10 @@
 {
-  mkDerivation,
   fetchurl,
   lib,
+  stdenv,
   extra-cmake-modules,
   kdoctools,
+  wrapQtAppsHook,
   knotifyconfig,
   kidletime,
   kwindowsystem,
@@ -11,7 +12,7 @@
   kcrash,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "rsibreak";
   version = "0.12.13";
 
@@ -23,6 +24,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     extra-cmake-modules
     kdoctools
+    wrapQtAppsHook
   ];
   propagatedBuildInputs = [
     knotifyconfig

--- a/pkgs/applications/misc/twmn/default.nix
+++ b/pkgs/applications/misc/twmn/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
-  qtbase,
   qmake,
   pkg-config,
+  wrapQtAppsHook,
+  qtbase,
   boost,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "twmn";
   version = "2025_10_23";
 
@@ -22,6 +23,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     qmake
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/applications/networking/datovka/default.nix
+++ b/pkgs/applications/networking/datovka/default.nix
@@ -1,17 +1,18 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchurl,
+  pkg-config,
+  wrapQtAppsHook,
   libxml2,
   libdatovka,
   qmake,
   qtbase,
   qtwebsockets,
   qtsvg,
-  pkg-config,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "datovka";
   version = "4.26.0";
 
@@ -19,6 +20,11 @@ mkDerivation rec {
     url = "https://gitlab.nic.cz/datovka/datovka/-/archive/v${version}/datovka-v${version}.tar.gz";
     sha256 = "sha256-pEdjh/c4vhirj2R9bYDdi2FL7N9x67kTOyfXiJDzMKE=";
   };
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     libdatovka
@@ -28,8 +34,6 @@ mkDerivation rec {
     libxml2
     qtwebsockets
   ];
-
-  nativeBuildInputs = [ pkg-config ];
 
   meta = {
     description = "Client application for operating Czech government-provided Databox infomation system";

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -64,11 +64,11 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     qttools
+    wrapQtAppsHook
   ]
   ++ lib.optionals enablePsiMedia [
     pkg-config
-  ]
-  ++ [ wrapQtAppsHook ];
+  ];
 
   buildInputs = [
     qtbase

--- a/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi-plus/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
+  wrapQtAppsHook,
   qtbase,
   qtmultimedia,
   qtimageformats,
@@ -43,7 +44,7 @@ assert builtins.elem (lib.toLower chatType) [
 
 assert enablePsiMedia -> enablePlugins;
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "psi-plus";
 
   version = "1.5.2115";
@@ -66,7 +67,8 @@ mkDerivation rec {
   ]
   ++ lib.optionals enablePsiMedia [
     pkg-config
-  ];
+  ]
+  ++ [ wrapQtAppsHook ];
 
   buildInputs = [
     qtbase

--- a/pkgs/applications/networking/instant-messengers/psi/default.nix
+++ b/pkgs/applications/networking/instant-messengers/psi/default.nix
@@ -1,9 +1,10 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
   qtbase,
+  wrapQtAppsHook,
   qtmultimedia,
   qtx11extras,
   qttools,
@@ -14,7 +15,7 @@
   hunspell,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "psi";
   version = "1.5";
   src = fetchFromGitHub {
@@ -30,6 +31,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     qttools
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/applications/networking/instant-messengers/ripcord/default.nix
+++ b/pkgs/applications/networking/instant-messengers/ripcord/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchurl,
   makeFontsConf,
   appimageTools,
@@ -9,6 +9,7 @@
   qtmultimedia,
   qtwebsockets,
   qtimageformats,
+  wrapQtAppsHook,
   autoPatchelfHook,
   desktop-file-utils,
   imagemagick,
@@ -20,7 +21,7 @@
   alsa-lib,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "ripcord";
   version = "0.4.29";
 
@@ -41,6 +42,7 @@ mkDerivation rec {
     autoPatchelfHook
     desktop-file-utils
     imagemagick
+    wrapQtAppsHook
   ];
   buildInputs = [
     libsodium

--- a/pkgs/applications/networking/instant-messengers/tensor/default.nix
+++ b/pkgs/applications/networking/instant-messengers/tensor/default.nix
@@ -1,18 +1,18 @@
 {
-  mkDerivation,
   lib,
   stdenv,
   fetchFromGitHub,
+  qmake,
+  wrapQtAppsHook,
   qtbase,
   qtquickcontrols,
-  qmake,
   makeDesktopItem,
 }:
 
 # we now have libqmatrixclient so a future version of tensor that supports it
 # should use that
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "tensor";
   version = "unstable-2017-02-21";
 
@@ -24,11 +24,15 @@ mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
     qtbase
     qtquickcontrols
   ];
-  nativeBuildInputs = [ qmake ];
 
   desktopItem = makeDesktopItem {
     name = "tensor";

--- a/pkgs/applications/networking/instant-messengers/twinkle/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twinkle/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   cmake,
   libxml2,
@@ -16,11 +17,11 @@
   alsa-lib,
   speex,
   ilbc,
-  mkDerivation,
   bcg729,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "twinkle";
   version = "unstable-2024-20-11";
 
@@ -51,6 +52,7 @@ mkDerivation rec {
     bison
     flex
     bcg729
+    wrapQtAppsHook
   ];
 
   cmakeFlags = [

--- a/pkgs/applications/networking/irc/kvirc/default.nix
+++ b/pkgs/applications/networking/irc/kvirc/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qtbase,
   qtmultimedia,
@@ -9,9 +9,10 @@
   pkg-config,
   cmake,
   gettext,
+  wrapQtAppsHook,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "kvirc";
   version = "2022-06-29";
 
@@ -33,6 +34,7 @@ mkDerivation {
     pkg-config
     cmake
     gettext
+    wrapQtAppsHook
   ];
 
   meta = {

--- a/pkgs/applications/networking/irc/quassel/default.nix
+++ b/pkgs/applications/networking/irc/quassel/default.nix
@@ -10,8 +10,8 @@
   fetchFromGitHub,
   cmake,
   makeWrapper,
+  wrapQtAppsHook,
   dconf,
-  mkDerivation,
   qtbase,
   boost,
   zlib,
@@ -45,7 +45,7 @@ let
   edf = flag: feature: [ ("-D" + feature + (if flag then "=ON" else "=OFF")) ];
 
 in
-(if !buildClient then stdenv.mkDerivation else mkDerivation) rec {
+stdenv.mkDerivation rec {
   pname = "quassel${tag}";
   version = "0.14.0";
 
@@ -62,7 +62,8 @@ in
   nativeBuildInputs = [
     cmake
     makeWrapper
-  ];
+  ]
+  ++ lib.optional buildClient wrapQtAppsHook;
   buildInputs = [
     qtbase
     boost

--- a/pkgs/applications/networking/ostinato/default.nix
+++ b/pkgs/applications/networking/ostinato/default.nix
@@ -1,9 +1,11 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   fetchurl,
   qmake,
+  copyDesktopItems,
+  wrapQtAppsHook,
   makeDesktopItem,
   qtbase,
   qtscript,
@@ -14,10 +16,9 @@
   diffutils,
   gawk,
   libnl,
-  copyDesktopItems,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "ostinato";
   version = "1.3.0";
 
@@ -44,6 +45,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     copyDesktopItems
     qmake
+    wrapQtAppsHook
   ];
 
   patches = [ ./drone_ini.patch ];

--- a/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
+++ b/pkgs/applications/networking/p2p/eiskaltdcpp/default.nix
@@ -5,9 +5,9 @@
   fetchpatch2,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   bzip2,
   libX11,
-  mkDerivation,
   qtbase,
   qttools,
   qtmultimedia,
@@ -22,7 +22,7 @@
   perl,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "eiskaltdcpp";
   version = "2.4.2";
 
@@ -43,6 +43,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/applications/networking/p2p/retroshare/default.nix
+++ b/pkgs/applications/networking/p2p/retroshare/default.nix
@@ -1,11 +1,12 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   fetchpatch2,
   qmake,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   miniupnpc,
   bzip2,
   speex,
@@ -21,7 +22,7 @@
   libgnome-keyring,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "retroshare";
   version = "0.6.7.2";
 
@@ -51,6 +52,7 @@ mkDerivation rec {
     pkg-config
     qmake
     cmake
+    wrapQtAppsHook
   ];
   buildInputs = [
     speex

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -56,7 +56,6 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
     makeWrapper
     wrapQtAppsHook
-    wrapQtAppsHook
   ];
   buildInputs = [
     minizip

--- a/pkgs/applications/networking/remote/teamviewer/default.nix
+++ b/pkgs/applications/networking/remote/teamviewer/default.nix
@@ -1,5 +1,4 @@
 {
-  mkDerivation,
   lib,
   stdenv,
   fetchurl,
@@ -23,7 +22,7 @@
   minizip,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "teamviewer";
   # teamviewer itself has not development files but the dev output removes propagated other dev outputs from runtime
   outputs = [
@@ -56,6 +55,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     autoPatchelfHook
     makeWrapper
+    wrapQtAppsHook
     wrapQtAppsHook
   ];
   buildInputs = [

--- a/pkgs/applications/office/mytetra/default.nix
+++ b/pkgs/applications/office/mytetra/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qmake,
   qtsvg,
   makeWrapper,
+  wrapQtAppsHook,
   xdg-utils,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "mytetra";
   version = "1.44.183";
 
@@ -22,6 +23,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     makeWrapper
+    wrapQtAppsHook
   ];
   buildInputs = [ qtsvg ];
 

--- a/pkgs/applications/office/qpdfview/default.nix
+++ b/pkgs/applications/office/qpdfview/default.nix
@@ -1,12 +1,13 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchurl,
   qmake,
-  qtbase,
   qttools,
-  qtsvg,
   pkg-config,
+  wrapQtAppsHook,
+  qtbase,
+  qtsvg,
   poppler,
   djvulibre,
   libspectre,
@@ -15,7 +16,7 @@
   ghostscript,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qpdfview";
   version = "0.5.0";
 
@@ -28,6 +29,7 @@ mkDerivation rec {
     qmake
     qttools
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/office/semantik/default.nix
+++ b/pkgs/applications/office/semantik/default.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitLab,
   wafHook,
   pkg-config,
   cmake,
+  wrapQtAppsHook,
   qtbase,
   python3,
   qtwebengine,
@@ -23,7 +24,7 @@
   kdelibs4support,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "semantik";
   version = "1.2.10";
 
@@ -66,6 +67,7 @@ mkDerivation rec {
     pkg-config
     wafHook
     cmake
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/radio/pothos/default.nix
+++ b/pkgs/applications/radio/pothos/default.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
     pkg-config
     doxygen
     wrapQtAppsHook
-    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/radio/pothos/default.nix
+++ b/pkgs/applications/radio/pothos/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
   cmake,
@@ -20,7 +20,7 @@
   python3,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "pothos";
   version = "0.7.1";
 
@@ -67,6 +67,7 @@ mkDerivation rec {
     cmake
     pkg-config
     doxygen
+    wrapQtAppsHook
     wrapQtAppsHook
   ];
 

--- a/pkgs/applications/radio/qsstv/default.nix
+++ b/pkgs/applications/radio/qsstv/default.nix
@@ -1,11 +1,12 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchurl,
   qtbase,
   qmake,
   openjpeg,
   pkg-config,
+  wrapQtAppsHook,
   fftw,
   libpulseaudio,
   alsa-lib,
@@ -14,7 +15,7 @@
   fftwFloat,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "9.5.8";
   pname = "qsstv";
 
@@ -26,6 +27,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/science/electronics/eagle/eagle.nix
+++ b/pkgs/applications/science/electronics/eagle/eagle.nix
@@ -1,8 +1,8 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchurl,
+  wrapQtAppsHook,
   makeDesktopItem,
   libXrender,
   libXrandr,
@@ -48,7 +48,7 @@ let
     qtwebengine
   ];
 in
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "eagle";
   version = "9.6.2";
 
@@ -68,6 +68,8 @@ mkDerivation rec {
     genericName = "Schematic editor";
     categories = [ "Development" ];
   };
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
 
   buildInputs = [
     libXrender

--- a/pkgs/applications/science/electronics/openhantek6022/default.nix
+++ b/pkgs/applications/science/electronics/openhantek6022/default.nix
@@ -1,9 +1,10 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   makeWrapper,
   cmake,
+  wrapQtAppsHook,
   qtbase,
   qttools,
   fftw,
@@ -11,7 +12,7 @@
   libglvnd,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "openhantek6022";
   version = "3.4.0";
 
@@ -25,6 +26,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     makeWrapper
+    wrapQtAppsHook
   ];
   buildInputs = [
     fftw

--- a/pkgs/applications/science/physics/xflr5/default.nix
+++ b/pkgs/applications/science/physics/xflr5/default.nix
@@ -1,11 +1,12 @@
 {
-  mkDerivation,
   lib,
-  qmake,
+  stdenv,
   fetchsvn,
+  qmake,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "xflr5";
   version = "6.61";
 
@@ -16,7 +17,10 @@ mkDerivation rec {
     sha256 = "sha256-Uj6R15OT5i5tAJEYWqyFyN5Z51Wz5RjO26mWC3Y6QAI=";
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
 
   meta = {
     description = "Analysis tool for airfoils, wings and planes";

--- a/pkgs/applications/science/robotics/apmplanner2/default.nix
+++ b/pkgs/applications/science/robotics/apmplanner2/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qmake,
+  wrapQtAppsHook,
   qtbase,
   qtscript,
   qtwebkit,
@@ -18,7 +19,7 @@
   SDL2,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "apmplanner2";
   version = "2.0.28";
 
@@ -28,6 +29,11 @@ mkDerivation rec {
     rev = version;
     sha256 = "0wvbfjnnf7sh6fpgw8gimh5hgzywj3nwrgr80r782f5gayd3v2l1";
   };
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     alsa-lib
@@ -44,8 +50,6 @@ mkDerivation rec {
     qtdeclarative
     qtquickcontrols2
   ];
-
-  nativeBuildInputs = [ qmake ];
 
   qmakeFlags = [ "apm_planner.pro" ];
 

--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -120,6 +120,7 @@ stdenv.mkDerivation rec {
     ninja
     pkg-config
     which
+    wrapQtAppsHook
   ]
   ++ lib.optionals withGui [
     qtbase
@@ -127,8 +128,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals withPython [
     python3Packages.setuptools
-  ]
-  ++ [ wrapQtAppsHook ];
+  ];
 
   buildInputs = [
     aspell

--- a/pkgs/applications/search/recoll/default.nix
+++ b/pkgs/applications/search/recoll/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   fetchurl,
   lib,
-  mkDerivation,
   antiword,
   aspell,
   bison,
@@ -32,6 +31,7 @@
   python3Packages,
   qtbase,
   qttools,
+  wrapQtAppsHook,
   unrtf,
   untex,
   unzip,
@@ -73,7 +73,7 @@ let
   useInotify = if stdenv.hostPlatform.isLinux then "true" else "false";
 in
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "recoll";
   version = "1.43.9";
 
@@ -127,7 +127,8 @@ mkDerivation rec {
   ]
   ++ lib.optionals withPython [
     python3Packages.setuptools
-  ];
+  ]
+  ++ [ wrapQtAppsHook ];
 
   buildInputs = [
     aspell

--- a/pkgs/applications/video/anilibria-winmaclinux/default.nix
+++ b/pkgs/applications/video/anilibria-winmaclinux/default.nix
@@ -68,7 +68,6 @@ stdenv.mkDerivation rec {
     pkg-config
     wrapQtAppsHook
     copyDesktopItems
-    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/anilibria-winmaclinux/default.nix
+++ b/pkgs/applications/video/anilibria-winmaclinux/default.nix
@@ -1,6 +1,6 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   qmake,
   pkg-config,
@@ -19,7 +19,7 @@
   mpv-unwrapped,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "anilibria-winmaclinux";
   version = "2.2.32";
 
@@ -68,6 +68,7 @@ mkDerivation rec {
     pkg-config
     wrapQtAppsHook
     copyDesktopItems
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/clipgrab/default.nix
+++ b/pkgs/applications/video/clipgrab/default.nix
@@ -1,11 +1,12 @@
 {
   lib,
+  stdenv,
   fetchurl,
   makeDesktopItem,
   ffmpeg,
   qmake,
   qttools,
-  mkDerivation,
+  wrapQtAppsHook,
   qtbase,
   qtdeclarative,
   qtlocation,
@@ -15,7 +16,7 @@
   yt-dlp,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "clipgrab";
   version = "3.9.7";
 
@@ -37,6 +38,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     qttools
+    wrapQtAppsHook
   ];
 
   patches = [

--- a/pkgs/applications/video/minitube/default.nix
+++ b/pkgs/applications/video/minitube/default.nix
@@ -1,13 +1,14 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
+  qmake,
+  qttools,
+  wrapQtAppsHook,
   phonon,
   phonon-backend-vlc,
   qtbase,
-  qmake,
   qtdeclarative,
-  qttools,
   qtx11extras,
   mpv,
 
@@ -15,7 +16,7 @@
   withAPIKey ? "AIzaSyBQvZXseEVvgu5Ega_DI-AIJ55v0OsHmVY",
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "minitube";
   version = "3.9.3";
 
@@ -36,6 +37,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     qttools
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/applications/video/mythtv/default.nix
+++ b/pkgs/applications/video/mythtv/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   which,
   qtbase,
@@ -33,6 +33,7 @@
   autoconf,
   automake,
   file,
+  wrapQtAppsHook,
   exiv2,
   linuxHeaders,
   soundtouch,
@@ -41,7 +42,7 @@
   withWebKit ? false,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "mythtv";
   version = "35.0";
 
@@ -98,6 +99,7 @@ mkDerivation rec {
     autoconf
     automake
     file
+    wrapQtAppsHook
   ];
 
   configureFlags = [ "--dvb-path=${linuxHeaders}/include" ];

--- a/pkgs/applications/video/qarte/default.nix
+++ b/pkgs/applications/video/qarte/default.nix
@@ -1,7 +1,8 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchbzr,
+  wrapQtAppsHook,
   python3,
   rtmpdump,
 }:
@@ -14,7 +15,7 @@ let
     ]
   );
 in
-mkDerivation {
+stdenv.mkDerivation {
   pname = "qarte";
   version = "5.5.0";
 
@@ -23,6 +24,8 @@ mkDerivation {
     rev = "88";
     sha256 = "sha256-+Ixe4bWKubH/XBESwmP2NWS8bH0jq611c3MZn7W87Jw=";
   };
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
 
   buildInputs = [ pythonEnv ];
 

--- a/pkgs/applications/video/qmediathekview/default.nix
+++ b/pkgs/applications/video/qmediathekview/default.nix
@@ -1,16 +1,16 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchFromGitHub,
   boost,
   qtbase,
   xz,
   qmake,
   pkg-config,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "QMediathekView";
   version = "0.2.1";
 
@@ -35,6 +35,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     pkg-config
+    wrapQtAppsHook
   ];
 
   installFlags = [ "INSTALL_ROOT=$(out)" ];

--- a/pkgs/applications/video/smtube/default.nix
+++ b/pkgs/applications/video/smtube/default.nix
@@ -1,13 +1,14 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchurl,
   qmake,
+  wrapQtAppsHook,
   qtscript,
   qtwebkit,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "21.10.0";
   pname = "smtube";
 
@@ -22,7 +23,10 @@ mkDerivation rec {
 
   dontUseQmakeConfigure = true;
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
   buildInputs = [
     qtscript
     qtwebkit

--- a/pkgs/applications/virtualization/qtemu/default.nix
+++ b/pkgs/applications/virtualization/qtemu/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitLab,
   pkg-config,
   qmake,
+  wrapQtAppsHook,
   qtbase,
   qemu,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qtemu";
   version = "2.1";
 
@@ -22,6 +23,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     qmake
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/co/cockatrice/package.nix
+++ b/pkgs/by-name/co/cockatrice/package.nix
@@ -23,7 +23,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     qt5.wrapQtAppsHook
-    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/co/cockatrice/package.nix
+++ b/pkgs/by-name/co/cockatrice/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   qt5,
   fetchFromGitHub,
   cmake,
@@ -8,7 +9,7 @@
 let
   protobuf = protobuf_21;
 in
-qt5.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "cockatrice";
   version = "2025-04-03-Release-2.10.2";
 
@@ -21,6 +22,7 @@ qt5.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    qt5.wrapQtAppsHook
     qt5.wrapQtAppsHook
   ];
 

--- a/pkgs/by-name/pe/pentobi/package.nix
+++ b/pkgs/by-name/pe/pentobi/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   qt5,
   appstream,
   fetchFromGitHub,
@@ -9,7 +10,7 @@
   docbook_xsl,
 }:
 
-qt5.mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "20.0";
   pname = "pentobi";
 
@@ -24,6 +25,7 @@ qt5.mkDerivation rec {
     cmake
     docbook_xsl
     qt5.qttools
+    qt5.wrapQtAppsHook
   ];
   buildInputs = [
     appstream

--- a/pkgs/by-name/po/pokerth/package.nix
+++ b/pkgs/by-name/po/pokerth/package.nix
@@ -63,7 +63,6 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     qt5.qmake
     qt5.wrapQtAppsHook
-    qt5.wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/by-name/po/pokerth/package.nix
+++ b/pkgs/by-name/po/pokerth/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   qt5,
   fetchFromGitHub,
   fetchpatch,
@@ -21,7 +22,7 @@ let
   protobuf = protobuf_21;
 in
 
-qt5.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "pokerth-${target}";
   version = "1.1.2";
 
@@ -61,6 +62,7 @@ qt5.mkDerivation rec {
 
   nativeBuildInputs = [
     qt5.qmake
+    qt5.wrapQtAppsHook
     qt5.wrapQtAppsHook
   ];
 

--- a/pkgs/by-name/va/vapoursynth/editor.nix
+++ b/pkgs/by-name/va/vapoursynth/editor.nix
@@ -1,19 +1,19 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchFromGitHub,
   makeWrapper,
   runCommand,
   python3,
   vapoursynth,
   qmake,
+  wrapQtAppsHook,
   qtbase,
   qtwebsockets,
 }:
 
 let
-  unwrapped = mkDerivation rec {
+  unwrapped = stdenv.mkDerivation rec {
     pname = "vapoursynth-editor";
     version = "R19-mod-4";
 
@@ -29,7 +29,11 @@ let
         --replace-fail "TARGET = vsedit-32bit" "TARGET = vsedit"
     '';
 
-    nativeBuildInputs = [ qmake ];
+    nativeBuildInputs = [
+      qmake
+      wrapQtAppsHook
+    ];
+
     buildInputs = [
       qtbase
       vapoursynth

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -68,8 +68,7 @@ stdenv.mkDerivation rec {
     qttools
     libsForQt5.wrapQtAppsHook
   ]
-  ++ lib.optionals useSCEL [ emacs ]
-  ++ [ libsForQt5.wrapQtAppsHook ];
+  ++ lib.optionals useSCEL [ emacs ];
 
   buildInputs = [
     gcc

--- a/pkgs/development/interpreters/supercollider/default.nix
+++ b/pkgs/development/interpreters/supercollider/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchpatch,
   fetchurl,
   cmake,
@@ -31,7 +30,7 @@
   withWebengine ? false, # vulnerable, so disabled by default
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "supercollider";
   version = "3.13.1";
 
@@ -69,7 +68,8 @@ mkDerivation rec {
     qttools
     libsForQt5.wrapQtAppsHook
   ]
-  ++ lib.optionals useSCEL [ emacs ];
+  ++ lib.optionals useSCEL [ emacs ]
+  ++ [ libsForQt5.wrapQtAppsHook ];
 
   buildInputs = [
     gcc

--- a/pkgs/development/libraries/g2o/default.nix
+++ b/pkgs/development/libraries/g2o/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchFromGitHub,
   cmake,
+  wrapQtAppsHook,
   eigen,
   suitesparse,
   blas,
@@ -14,7 +14,7 @@
   spdlog,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "g2o";
   version = "20241228";
 
@@ -34,7 +34,10 @@ mkDerivation rec {
   ];
   separateDebugInfo = true;
 
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [
+    cmake
+    wrapQtAppsHook
+  ];
   buildInputs = [
     eigen
     suitesparse

--- a/pkgs/development/libraries/herqq/default.nix
+++ b/pkgs/development/libraries/herqq/default.nix
@@ -1,17 +1,22 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qmake,
+  wrapQtAppsHook,
   qtmultimedia,
   qtbase,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   version = "unstable-20-06-26";
   pname = "herqq";
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
   buildInputs = [
     qtbase
     qtmultimedia

--- a/pkgs/development/libraries/libosmscout/default.nix
+++ b/pkgs/development/libraries/libosmscout/default.nix
@@ -1,16 +1,17 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   marisa,
   qttools,
   qtlocation,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "libosmscout";
   version = "2022.04.25";
 
@@ -36,6 +37,7 @@ mkDerivation {
   nativeBuildInputs = [
     cmake
     pkg-config
+    wrapQtAppsHook
   ];
   buildInputs = [
     marisa

--- a/pkgs/development/libraries/nemo-qml-plugin-dbus/default.nix
+++ b/pkgs/development/libraries/nemo-qml-plugin-dbus/default.nix
@@ -1,12 +1,13 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitLab,
   qmake,
+  wrapQtAppsHook,
   qtbase,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "nemo-qml-plugin-dbus";
   version = "2.1.24";
 
@@ -18,7 +19,10 @@ mkDerivation rec {
     sha256 = "1ilg929456d3k0xkvxa5r4k7i4kkw9i8kgah5xx1yq0d9wka0l77";
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
 
   postPatch = ''
     substituteInPlace dbus.pro --replace ' tests' ""

--- a/pkgs/development/tools/analysis/massif-visualizer/default.nix
+++ b/pkgs/development/tools/analysis/massif-visualizer/default.nix
@@ -1,9 +1,10 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchurl,
   extra-cmake-modules,
   shared-mime-info,
+  wrapQtAppsHook,
   qtsvg,
   qtxmlpatterns,
   karchive,
@@ -16,7 +17,7 @@
   kgraphviewer,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "massif-visualizer";
   version = "0.7.0";
 
@@ -30,6 +31,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     extra-cmake-modules
     shared-mime-info
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -1,6 +1,6 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
   cmake,
@@ -8,9 +8,10 @@
   capstone,
   bison,
   flex,
+  wrapQtAppsHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "boomerang";
   version = "0.5.2";
   # NOTE: When bumping version beyond 0.5.2, you likely need to remove
@@ -33,6 +34,7 @@ mkDerivation rec {
     cmake
     bison
     flex
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/development/tools/misc/gede/default.nix
+++ b/pkgs/development/tools/misc/gede/default.nix
@@ -1,17 +1,18 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   makeWrapper,
   python3,
   qtbase,
   qmake,
   qtserialport,
+  wrapQtAppsHook,
   ctags,
   gdb,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "gede";
   version = "2.22.1";
 
@@ -28,6 +29,7 @@ mkDerivation rec {
     python3
     qmake
     qtserialport
+    wrapQtAppsHook
   ];
 
   strictDeps = true;

--- a/pkgs/development/tools/ofono-phonesim/default.nix
+++ b/pkgs/development/tools/ofono-phonesim/default.nix
@@ -1,13 +1,14 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchzip,
   autoreconfHook,
   pkg-config,
+  wrapQtAppsHook,
   qtbase,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "ofono-phonesim";
   version = "unstable-2019-11-18";
 
@@ -19,6 +20,7 @@ mkDerivation {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -1,10 +1,12 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   cmake,
   extra-cmake-modules,
   makeWrapper,
+  qttools,
+  wrapQtAppsHook,
   boost,
   doxygen,
   openssl,
@@ -14,10 +16,9 @@
   loki,
   qscintilla,
   qtbase,
-  qttools,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "tora";
   version = "3.2.176";
 
@@ -33,6 +34,7 @@ mkDerivation {
     extra-cmake-modules
     makeWrapper
     qttools
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/os-specific/linux/wpa_supplicant/gui.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/gui.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   qtbase,
   qmake,
   inkscape,
   imagemagick,
+  wrapQtAppsHook,
   wpa_supplicant,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "wpa_gui";
   inherit (wpa_supplicant) version src patches;
 
@@ -17,6 +18,7 @@ mkDerivation {
     qmake
     inkscape
     imagemagick
+    wrapQtAppsHook
   ];
 
   postPatch = ''

--- a/pkgs/servers/pulseaudio/qpaeq.nix
+++ b/pkgs/servers/pulseaudio/qpaeq.nix
@@ -1,5 +1,6 @@
 {
-  mkDerivation,
+  stdenv,
+  wrapQtAppsHook,
   makeDesktopItem,
   python3,
   lib,
@@ -21,9 +22,11 @@ let
     startupNotify = false;
   };
 in
-mkDerivation {
+stdenv.mkDerivation {
   pname = "qpaeq";
   inherit (pulseaudio) version src;
+
+  nativeBuildInputs = [ wrapQtAppsHook ];
 
   buildInputs = [
 

--- a/pkgs/tools/filesystems/kio-fuse/default.nix
+++ b/pkgs/tools/filesystems/kio-fuse/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchgit,
   cmake,
   extra-cmake-modules,
+  wrapQtAppsHook,
   kio,
   fuse3,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "kio-fuse";
   version = "5.1.0";
 
@@ -21,6 +22,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/tools/graphics/gnuplot/default.nix
+++ b/pkgs/tools/graphics/gnuplot/default.nix
@@ -28,8 +28,8 @@
   gnused ? null,
   coreutils ? null,
   withQt ? false,
-  mkDerivation,
   qttools,
+  wrapQtAppsHook,
   qtbase,
   qtsvg,
 }:
@@ -38,7 +38,7 @@ assert libX11 != null -> (fontconfig != null && gnused != null && coreutils != n
 let
   withX = libX11 != null && !aquaterm && !stdenv.hostPlatform.isDarwin;
 in
-(if withQt then mkDerivation else stdenv.mkDerivation) rec {
+stdenv.mkDerivation rec {
   pname = "gnuplot";
   version = "6.0.4";
 
@@ -52,7 +52,10 @@ in
     pkg-config
     texinfo
   ]
-  ++ lib.optional withQt qttools;
+  ++ lib.optionals withQt [
+    qttools
+    wrapQtAppsHook
+  ];
 
   buildInputs = [
     cairo

--- a/pkgs/tools/graphics/pfstools/default.nix
+++ b/pkgs/tools/graphics/pfstools/default.nix
@@ -1,10 +1,10 @@
 {
   lib,
   stdenv,
-  mkDerivation,
   fetchurl,
   cmake,
   pkg-config,
+  wrapQtAppsHook,
   openexr,
   zlib,
   imagemagick6,
@@ -22,7 +22,7 @@
   opencv,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "pfstools";
   version = "2.2.0";
 
@@ -53,6 +53,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    wrapQtAppsHook
   ];
   buildInputs = [
     openexr

--- a/pkgs/tools/graphics/rocket/default.nix
+++ b/pkgs/tools/graphics/rocket/default.nix
@@ -1,12 +1,13 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   fetchFromGitHub,
   qmake,
+  wrapQtAppsHook,
   qtbase,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "rocket";
   version = "2018-06-09";
 
@@ -17,7 +18,10 @@ mkDerivation {
     sha256 = "13bdg2dc6ypk17sz39spqdlb3wai2y085bdb36pls2as2nf22drp";
   };
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
   buildInputs = [ qtbase ];
 
   dontConfigure = true;

--- a/pkgs/tools/misc/antimicrox/default.nix
+++ b/pkgs/tools/misc/antimicrox/default.nix
@@ -1,18 +1,19 @@
 {
-  mkDerivation,
   lib,
+  stdenv,
   cmake,
   extra-cmake-modules,
   pkg-config,
+  itstool,
+  udevCheckHook,
+  wrapQtAppsHook,
   SDL2,
   qttools,
   xorg,
   fetchFromGitHub,
-  itstool,
-  udevCheckHook,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "antimicrox";
   version = "3.5.1";
 
@@ -29,6 +30,7 @@ mkDerivation rec {
     pkg-config
     itstool
     udevCheckHook
+    wrapQtAppsHook
   ];
   buildInputs = [
     SDL2

--- a/pkgs/tools/misc/coreboot-configurator/default.nix
+++ b/pkgs/tools/misc/coreboot-configurator/default.nix
@@ -36,7 +36,6 @@ stdenv.mkDerivation {
     ninja
     pkg-config
     wrapQtAppsHook
-    wrapQtAppsHook
   ];
   buildInputs = [
     yaml-cpp

--- a/pkgs/tools/misc/coreboot-configurator/default.nix
+++ b/pkgs/tools/misc/coreboot-configurator/default.nix
@@ -1,9 +1,9 @@
 {
   lib,
+  stdenv,
   fetchFromGitHub,
   inkscape,
   meson,
-  mkDerivation,
   ninja,
   # We will resolve pkexec from the path because it has a setuid wrapper on
   # NixOS meaning that we cannot just use the path from the nix store.
@@ -19,7 +19,7 @@
   wrapQtAppsHook,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "coreboot-configurator";
   version = "unstable-2023-01-17";
 
@@ -35,6 +35,7 @@ mkDerivation {
     meson
     ninja
     pkg-config
+    wrapQtAppsHook
     wrapQtAppsHook
   ];
   buildInputs = [

--- a/pkgs/tools/misc/dialogbox/default.nix
+++ b/pkgs/tools/misc/dialogbox/default.nix
@@ -1,13 +1,13 @@
 {
   stdenv,
   lib,
-  mkDerivation,
   fetchFromGitHub,
   qmake,
+  wrapQtAppsHook,
   qtbase,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "dialogbox";
   version = "1.0+unstable=2020-11-16";
 
@@ -20,6 +20,7 @@ mkDerivation {
 
   nativeBuildInputs = [
     qmake
+    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/kronometer/default.nix
+++ b/pkgs/tools/misc/kronometer/default.nix
@@ -1,16 +1,17 @@
 {
-  mkDerivation,
   fetchurl,
+  stdenv,
   fetchpatch,
   lib,
   extra-cmake-modules,
   kdoctools,
+  wrapQtAppsHook,
   kconfig,
   kcrash,
   kinit,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "kronometer";
   version = "2.3.0";
 
@@ -36,6 +37,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     extra-cmake-modules
     kdoctools
+    wrapQtAppsHook
   ];
   propagatedBuildInputs = [
     kconfig

--- a/pkgs/tools/misc/qflipper/default.nix
+++ b/pkgs/tools/misc/qflipper/default.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation {
     qttools
     wrapGAppsHook3
     wrapQtAppsHook
-    wrapQtAppsHook
   ];
 
   buildInputs = [

--- a/pkgs/tools/misc/qflipper/default.nix
+++ b/pkgs/tools/misc/qflipper/default.nix
@@ -9,7 +9,6 @@
   qmake,
   wrapGAppsHook3,
   wrapQtAppsHook,
-  mkDerivation,
 
   qttools,
   qtbase,
@@ -31,7 +30,7 @@ let
   commit = "nix-${version}";
 
 in
-mkDerivation {
+stdenv.mkDerivation {
   inherit pname version;
 
   src = fetchFromGitHub {
@@ -47,6 +46,7 @@ mkDerivation {
     qmake
     qttools
     wrapGAppsHook3
+    wrapQtAppsHook
     wrapQtAppsHook
   ];
 

--- a/pkgs/tools/misc/qjoypad/default.nix
+++ b/pkgs/tools/misc/qjoypad/default.nix
@@ -1,16 +1,17 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   pkg-config,
   cmake,
+  qttools,
+  wrapQtAppsHook,
   libX11,
   libXtst,
   qtbase,
-  qttools,
   qtx11extras,
 }:
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qjoypad";
   version = "4.3.1";
 
@@ -30,6 +31,7 @@ mkDerivation rec {
     pkg-config
     cmake
     qttools
+    wrapQtAppsHook
   ];
   buildInputs = [
     libX11

--- a/pkgs/tools/misc/radeon-profile/default.nix
+++ b/pkgs/tools/misc/radeon-profile/default.nix
@@ -1,20 +1,24 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
+  qmake,
+  wrapQtAppsHook,
   qtbase,
   qtcharts,
-  qmake,
   libXrandr,
   libdrm,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
 
   pname = "radeon-profile";
   version = "20200824";
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
   buildInputs = [
     qtbase
     qtcharts

--- a/pkgs/tools/misc/ultrastar-creator/default.nix
+++ b/pkgs/tools/misc/ultrastar-creator/default.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qmake,
   qtbase,
   pkg-config,
+  wrapQtAppsHook,
   taglib,
   libbass,
   libbass_fx,
@@ -15,7 +16,7 @@
 # there’s a WIP branch here:
 # https://github.com/UltraStar-Deluxe/UltraStar-Creator/commits/BASS_removed
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "ultrastar-creator";
   version = "2019-04-23";
 
@@ -45,6 +46,7 @@ mkDerivation {
   nativeBuildInputs = [
     qmake
     pkg-config
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase

--- a/pkgs/tools/misc/ultrastar-manager/default.nix
+++ b/pkgs/tools/misc/ultrastar-manager/default.nix
@@ -1,8 +1,9 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   pkg-config,
+  wrapQtAppsHook,
   symlinkJoin,
   qmake,
   diffPlugins,
@@ -46,9 +47,11 @@ let
         inherit rev sha256;
       };
     in
-    mkDerivation {
+    stdenv.mkDerivation {
       name = "${src.name}-patched";
       inherit src;
+
+      nativeBuildInputs = [ wrapQtAppsHook ];
 
       dontInstall = true;
 
@@ -80,9 +83,11 @@ let
 
   buildPlugin =
     name:
-    mkDerivation {
+    stdenv.mkDerivation {
       name = "ultrastar-manager-${name}-plugin-${version}";
       src = patchedSrc;
+
+      nativeBuildInputs = [ wrapQtAppsHook ];
 
       buildInputs = [ qmake ] ++ buildInputs;
 
@@ -107,7 +112,7 @@ let
   };
 
 in
-mkDerivation {
+stdenv.mkDerivation {
   pname = "ultrastar-manager";
   inherit version;
   src = patchedSrc;
@@ -134,7 +139,11 @@ mkDerivation {
     make install
   '';
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    wrapQtAppsHook
+  ];
+
   inherit buildInputs;
 
   meta = {

--- a/pkgs/tools/security/chrome-token-signing/default.nix
+++ b/pkgs/tools/security/chrome-token-signing/default.nix
@@ -1,14 +1,15 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
+  pkg-config,
+  wrapQtAppsHook,
   qmake,
   pcsclite,
-  pkg-config,
   opensc,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "chrome-token-signing";
   version = "1.1.5";
 
@@ -19,7 +20,10 @@ mkDerivation rec {
     sha256 = "sha256-wKy/RVR7jx5AkMJgHXsuV+jlzyfH5nDRggcIUgh2ML4=";
   };
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    wrapQtAppsHook
+  ];
   buildInputs = [
     qmake
     pcsclite

--- a/pkgs/tools/security/kwalletcli/default.nix
+++ b/pkgs/tools/security/kwalletcli/default.nix
@@ -1,9 +1,10 @@
 {
-  mkDerivation,
   fetchFromGitHub,
   lib,
+  stdenv,
   makeWrapper,
   pkg-config,
+  wrapQtAppsHook,
   kcoreaddons,
   ki18n,
   kwallet,
@@ -11,7 +12,7 @@
   pinentry-qt,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "kwalletcli";
   version = "3.03";
 
@@ -42,6 +43,7 @@ mkDerivation rec {
   nativeBuildInputs = [
     makeWrapper
     pkg-config
+    wrapQtAppsHook
   ];
   # if using just kwallet, cmake will be added as a buildInput and fail the build
   propagatedBuildInputs = [

--- a/pkgs/tools/system/testdisk/default.nix
+++ b/pkgs/tools/system/testdisk/default.nix
@@ -1,11 +1,11 @@
 {
-  mkDerivation,
   lib,
   stdenv,
   fetchurl,
   ncurses,
   libuuid,
   pkg-config,
+  wrapQtAppsHook,
   libjpeg,
   zlib,
   libewf-legacy,
@@ -25,7 +25,7 @@ assert enableQt -> qtbase != null;
 assert enableQt -> qttools != null;
 assert enableQt -> qwt != null;
 
-(if enableQt then mkDerivation else stdenv.mkDerivation) rec {
+stdenv.mkDerivation rec {
   pname = "testdisk";
   version = "7.2";
   src = fetchurl {
@@ -55,7 +55,10 @@ assert enableQt -> qwt != null;
     qwt
   ];
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ lib.optional enableQt wrapQtAppsHook;
 
   env.NIX_CFLAGS_COMPILE = "-Wno-unused";
 

--- a/pkgs/tools/text/glogg/default.nix
+++ b/pkgs/tools/text/glogg/default.nix
@@ -1,13 +1,13 @@
 {
-  mkDerivation,
   lib,
   stdenv,
   fetchFromGitHub,
   qmake,
+  wrapQtAppsHook,
   boost,
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "glogg";
   version = "1.1.4";
 
@@ -23,7 +23,10 @@ mkDerivation rec {
       --replace "boost_program_options-mt" "boost_program_options"
   '';
 
-  nativeBuildInputs = [ qmake ];
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
   buildInputs = [ boost ];
 
   qmakeFlags = [ "VERSION=${version}" ];

--- a/pkgs/tools/typesetting/tikzit/default.nix
+++ b/pkgs/tools/typesetting/tikzit/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   qmake,
   qttools,
@@ -8,9 +8,10 @@
   poppler,
   flex,
   bison,
+  wrapQtAppsHook,
 }:
 
-mkDerivation {
+stdenv.mkDerivation {
   pname = "tikzit";
   version = "2.1.6";
 
@@ -26,6 +27,7 @@ mkDerivation {
     qttools
     flex
     bison
+    wrapQtAppsHook
   ];
   buildInputs = [
     qtbase


### PR DESCRIPTION
the first commit doesn't create any rebuilds
the second, due to deduplication of wrapQtAppsHook, does however
the third as well

ref https://github.com/NixOS/nixpkgs/issues/180841

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
