### PR TITLE
ncps: fix ncps --version

### DIFF
--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -42,16 +42,13 @@ let
       hash = "sha256-qc6h1gnU7dFyb0GiBq++E2yf49K7mO86Vwdf8y3817U=";
     };
 
+    vendorHash = "sha256-nnt4HIG4Fs7RhHjVb7mYJ39UgvFKc46Cu42cURMmr1s=";
+
     ldflags = [
       "-X github.com/kalbasit/ncps/cmd.Version=v${finalAttrs.version}"
     ];
 
-    vendorHash = "sha256-nnt4HIG4Fs7RhHjVb7mYJ39UgvFKc46Cu42cURMmr1s=";
-
     subPackages = [ "." ];
-
-    doCheck = true;
-    checkFlags = [ "-race" ];
 
     nativeBuildInputs = [
       curl # used for checking MinIO health check
@@ -65,6 +62,20 @@ let
       redis # Redis for distributed locking integration tests
       makeWrapper # For wrapping dbmate.
     ];
+
+    postInstall = ''
+      mkdir -p $out/share/ncps
+      cp -r db $out/share/ncps/db
+
+      makeWrapper ${dbmate-wrapper}/bin/dbmate-wrapper \
+        $out/bin/dbmate-ncps \
+        --prefix PATH : ${dbmate-real}/bin \
+        --set NCPS_DB_MIGRATIONS_DIR $out/share/ncps/db/migrations
+    '';
+
+    doCheck = true;
+
+    checkFlags = [ "-race" ];
 
     # pre and post checks
     preCheck = ''
@@ -81,16 +92,6 @@ let
       source $src/nix/packages/ncps/pre-check-mysql.sh
       source $src/nix/packages/ncps/pre-check-postgres.sh
       source $src/nix/packages/ncps/pre-check-redis.sh
-    '';
-
-    postInstall = ''
-      mkdir -p $out/share/ncps
-      cp -r db $out/share/ncps/db
-
-      makeWrapper ${dbmate-wrapper}/bin/dbmate-wrapper \
-        $out/bin/dbmate-ncps \
-        --prefix PATH : ${dbmate-real}/bin \
-        --set NCPS_DB_MIGRATIONS_DIR $out/share/ncps/db/migrations
     '';
 
     meta = {

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -45,7 +45,7 @@ let
     vendorHash = "sha256-nnt4HIG4Fs7RhHjVb7mYJ39UgvFKc46Cu42cURMmr1s=";
 
     ldflags = [
-      "-X github.com/kalbasit/ncps/cmd.Version=v${finalAttrs.version}"
+      "-X github.com/kalbasit/ncps/pkg/ncps.Version=v${finalAttrs.version}"
     ];
 
     subPackages = [ "." ];


### PR DESCRIPTION
Upstream I refactored the cmd package into pkg/ncps so the version no longer worked.

```
❯ nix build .#ncps -L
❯ ./result/bin/ncps --version
ncps version v0.7.2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
