### PR TITLE
python313Packages.logurich: init at 0.7.1, python313Packages.cyvest: init at 5.1.4

### DIFF
--- a/pkgs/development/python-modules/cyvest/default.nix
+++ b/pkgs/development/python-modules/cyvest/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  logurich,
+  pydantic,
+  pytest-cov-stub,
+  pytestCheckHook,
+  pyvis,
+  rich,
+  typing-extensions,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "cyvest";
+  version = "5.1.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "PakitoSec";
+    repo = "cyvest";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OvAnhasc4iZtfi8olQ4rLaokcaC/b5rYdPPMn2pVYTA=";
+  };
+
+  pythonRelaxDeps = [ "pydantic" ];
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    click
+    logurich
+    pydantic
+    rich
+    typing-extensions
+  ];
+
+  optional-dependencies = {
+    visualization = [
+      pyvis
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "cyvest" ];
+
+  meta = {
+    description = "Cybersecurity Investigation Model";
+    homepage = "https://github.com/PakitoSec/cyvest";
+    changelog = "https://github.com/PakitoSec/cyvest/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/development/python-modules/logurich/default.nix
+++ b/pkgs/development/python-modules/logurich/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  loguru,
+  pytestCheckHook,
+  rich,
+  uv-build,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "logurich";
+  version = "0.7.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "PakitoSec";
+    repo = "logurich";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+Ez1tS/kDguq8mQImiu2/h64YsBCTVv4b4sT/tJaD7E=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.9.20,<0.10.0" "uv_build"
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    loguru
+    rich
+  ];
+
+  optional-dependencies = {
+    click = [
+      click
+    ];
+  };
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "logurich" ];
+
+  meta = {
+    description = "Logger that combine loguru and rich";
+    homepage = "https://github.com/PakitoSec/logurich";
+    changelog = "https://github.com/PakitoSec/logurich/releases/tag/v${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3456,6 +3456,8 @@ self: super: with self; {
 
   cytoolz = callPackage ../development/python-modules/cytoolz { };
 
+  cyvest = callPackage ../development/python-modules/cyvest { };
+
   dacite = callPackage ../development/python-modules/dacite { };
 
   daemonize = callPackage ../development/python-modules/daemonize { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9122,6 +9122,8 @@ self: super: with self; {
 
   logster = callPackage ../development/python-modules/logster { };
 
+  logurich = callPackage ../development/python-modules/logurich { };
+
   loguru = callPackage ../development/python-modules/loguru { };
 
   loguru-logging-intercept = callPackage ../development/python-modules/loguru-logging-intercept { };


### PR DESCRIPTION
Cybersecurity Investigation Model

https://github.com/PakitoSec/cyvest

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
