### PR TITLE
tailscale-gui: init at 1.92.3

### DIFF
--- a/pkgs/by-name/ta/tailscale-gui/package.nix
+++ b/pkgs/by-name/ta/tailscale-gui/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  xar,
+  cpio,
+  pbzx,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "tailscale-gui";
+  version = "1.92.3";
+
+  src = fetchurl {
+    url = "https://pkgs.tailscale.com/stable/Tailscale-${finalAttrs.version}-macos.pkg";
+    hash = "sha256-K5tJHyFhqnxV4KHzr7YOHRoH33vk+dq+EVWyUo88nuI=";
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    xar
+    cpio
+    pbzx
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    xar -xf $src
+    cd Distribution.pkg
+    pbzx -n Payload | cpio -i
+
+    mkdir -p $out/Applications/Tailscale.app
+    mkdir -p $out/bin
+
+    cp -R Contents $out/Applications/Tailscale.app/
+    ln -s "$out/Applications/Tailscale.app/Contents/MacOS/Tailscale" "$out/bin/tailscale"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Tailscale GUI client for macOS";
+    homepage = "https://tailscale.com";
+    changelog = "https://tailscale.com/changelog#client";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ anish ];
+    platforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Adds the Tailscale GUI client for macOS. This provides the menu bar application with system extension management, which is the [recommended way](https://tailscale.com/kb/1065/macos-variants) to use Tailscale on macOS.

Like _1password-gui (see #254944), this app must be run from /Applications to function correctly. I made a companion PR (https://github.com/nix-darwin/nix-darwin/pull/1683) adding a `programs.tailscale-gui` module that handles copying the app to `/Applications`, following the same pattern as `programs._1password-gui` (see https://github.com/nix-darwin/nix-darwin/pull/1438).

For standalone usage, you need to copy the app manually:

```bash
sudo cp -R $(nix-build -A tailscale-gui)/Applications/Tailscale.app /Applications/
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
