### PR TITLE
oxipng: 10.0.0 -> 10.1.0

### DIFF
--- a/pkgs/by-name/ox/oxipng/package.nix
+++ b/pkgs/by-name/ox/oxipng/package.nix
@@ -5,7 +5,7 @@
 }:
 
 rustPlatform.buildRustPackage rec {
-  version = "10.0.0";
+  version = "10.1.0";
   pname = "oxipng";
 
   # do not use fetchCrate (only repository includes tests)
@@ -13,10 +13,10 @@ rustPlatform.buildRustPackage rec {
     owner = "shssoichiro";
     repo = "oxipng";
     tag = "v${version}";
-    hash = "sha256-c8NNTO+6GuFb5BBPpdyDSHbtmojq+9ceOic54Zq3nwE=";
+    hash = "sha256-fPzdko8qcg9zcr79SrEakLqTFj9hDCakl6hTVpW9al8=";
   };
 
-  cargoHash = "sha256-YStZ2j2gjC5uVUnHaQIk6xtSbnPm0IoNONRr/nFOOUg=";
+  cargoHash = "sha256-P8PT75TwdYeS9xJ7EEdIhlgHfd0VlIPUaLkM0SfRPq0=";
 
   # don't require qemu for aarch64-linux tests
   # error: linker `aarch64-linux-gnu-gcc` not found


### PR DESCRIPTION
https://github.com/oxipng/oxipng/releases/tag/v10.1.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
