### PR TITLE
rimage: init at 0.12.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7244,6 +7244,11 @@
     githubId = 4987132;
     keys = [ { fingerprint = "1021 2207 286B F15B 0CF1  C5EA D70C C9F5 CEF4 EEB8"; } ];
   };
+  dustypomerleau = {
+    name = "Dusty Pomerleau";
+    github = "dustypomerleau";
+    githubId = 6304651;
+  };
   DutchGerman = {
     name = "Stefan Visser";
     email = "stefan.visser@apm-ecampus.de";

--- a/pkgs/by-name/ri/rimage/libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
+++ b/pkgs/by-name/ri/rimage/libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
@@ -1,0 +1,21 @@
+--- a/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
++++ b/libaom-sys-0.17.2+libaom.3.11.0/vendor/build/cmake/aom_optimization.cmake
+@@ -212,7 +212,7 @@ endfunction()
+ # Currently checks only for presence of required object formats and support for
+ # the -Ox argument (multipass optimization).
+ function(test_nasm)
+-  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
++  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hO
+                   OUTPUT_VARIABLE nasm_helptext)
+ 
+   if(NOT "${nasm_helptext}" MATCHES "-Ox")
+@@ -220,6 +220,9 @@ function(test_nasm)
+       FATAL_ERROR "Unsupported nasm: multipass optimization not supported.")
+   endif()
+ 
++  execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -hf
++                  OUTPUT_VARIABLE nasm_helptext)
++
+   if("${AOM_TARGET_CPU}" STREQUAL "x86")
+     if("${AOM_TARGET_SYSTEM}" STREQUAL "Darwin")
+       if(NOT "${nasm_helptext}" MATCHES "macho32")

--- a/pkgs/by-name/ri/rimage/package.nix
+++ b/pkgs/by-name/ri/rimage/package.nix
@@ -1,0 +1,66 @@
+{
+  cmake,
+  fetchFromGitHub,
+  lib,
+  nasm,
+  perl,
+  qemu,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rimage";
+  version = "0.12.3";
+
+  src = fetchFromGitHub {
+    owner = "SalOne22";
+    repo = "rimage";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-I7nOvxRORdZeolBABt5u94Ij0PI/AiLi4wbN+C02haQ=";
+  };
+
+  auditable = false;
+
+  cargoHash = "sha256-kfOzzVkxHDqVrhX6vZF18f9hAXK9SKwezJphH0QGE4E=";
+
+  nativeBuildInputs = [
+    cmake
+    nasm
+    perl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    qemu
+  ];
+
+  cargoBuildFlags = [ "--bin=rimage" ];
+
+  buildFeatures = [
+    "build-binary"
+    "icc"
+  ];
+
+  patches = [
+    # The below patch is needed to fix this build, until the upstream dependency (libavif-rs) fixes the problem.
+    # The explicit `patchFlags` can also be removed when this patch becomes obsolete.
+    # <https://github.com/njaard/libavif-rs/issues/122>
+    ./libaom-sys-0.17.2+libaom.3.11.0-cmake-nasm-fix.patch
+  ];
+
+  patchFlags = [
+    "-p1"
+    "--directory=../rimage-${finalAttrs.version}-vendor"
+  ];
+
+  meta = {
+    description = "Rust image optimization CLI tool inspired by squoosh";
+    homepage = "https://github.com/SalOne22/rimage";
+    changelog = "https://github.com/SalOne22/rimage/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ dustypomerleau ];
+    mainProgram = "rimage";
+  };
+})


### PR DESCRIPTION
[rimage](https://github.com/SalOne22/rimage) is a CLI for image conversion and optimization.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
