### PR TITLE
coredns: fix externalPlugins by 'go mod vendor' after 'go generate'

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -407,6 +407,7 @@ in
   containers-tmpfs = runTest ./containers-tmpfs.nix;
   containers-unified-hierarchy = runTest ./containers-unified-hierarchy.nix;
   convos = runTest ./convos.nix;
+  coredns = runTest ./coredns.nix;
   corerad = runTest ./corerad.nix;
   corteza = runTest ./corteza.nix;
   cosmic = runTest {

--- a/nixos/tests/coredns.nix
+++ b/nixos/tests/coredns.nix
@@ -1,0 +1,42 @@
+{ pkgs, ... }:
+{
+  name = "coredns";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ johanot ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.dnsutils ];
+      services.coredns = {
+        enable = true;
+        config = ''
+          .:10053 {
+                ipecho {
+                  domain test.nixos.org
+                  ttl 2629800
+                }
+              }
+        '';
+        package = pkgs.coredns.override {
+          externalPlugins = [
+            {
+              name = "ipecho";
+              repo = "github.com/Eun/coredns-ipecho";
+              version = "224170ebca45cc59c6b071d280a18f42d1ff130c";
+              position = "start-of-file";
+            }
+          ];
+          vendorHash = "sha256-dNxHpXkiqz7B/JhZdxfZluIHFVXILlSm3XtB+v/EoMY=";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("coredns.service")
+    machine.wait_for_open_port(10053)
+    machine.succeed("dig @127.0.0.1 -p 10053 127.0.0.2.test.nixos.org A +short | grep 127.0.0.2")
+  '';
+}

--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -78,6 +78,7 @@ buildGoModule (finalAttrs: {
     for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
     go mod vendor
     CC= GOOS= GOARCH= go generate
+    go mod vendor
     go mod tidy
   '';
 
@@ -134,6 +135,7 @@ buildGoModule (finalAttrs: {
   '';
 
   passthru.tests = {
+    coredns-external-plugins = nixosTests.coredns;
     kubernetes-single-node = nixosTests.kubernetes.dns-single-node;
     kubernetes-multi-node = nixosTests.kubernetes.dns-multi-node;
   };


### PR DESCRIPTION
This PR fixes external plugins that I accidentally broke during the coredns update (#480354).
I also added a passthru test that touches "external plugins".

see: https://github.com/NixOS/nixpkgs/pull/480354#issuecomment-3796730517

cc @adriansalamon

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
