### PR TITLE
python3Packages.pycdio: disables tests that have problems with python…

### DIFF
--- a/pkgs/development/python-modules/pycdio/default.nix
+++ b/pkgs/development/python-modules/pycdio/default.nix
@@ -39,15 +39,18 @@ buildPythonPackage (finalAttrs: {
     libiconv
   ];
 
+  postPatch = ''
+    substituteInPlace {data,test}/isofs-m1.cue \
+      --replace-fail "ISOFS-M1.BIN" "isofs-m1.bin"
+  '';
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   enabledTestPaths = [ "test/test-*.py" ];
 
   disabledTests = [
     # Test are depending on image files that are not there
-    "test_fs"
     "test_bincue"
-    "test_read"
     "test_cdda"
   ];
 

--- a/pkgs/development/python-modules/pycdio/default.nix
+++ b/pkgs/development/python-modules/pycdio/default.nix
@@ -43,6 +43,14 @@ buildPythonPackage (finalAttrs: {
 
   enabledTestPaths = [ "test/test-*.py" ];
 
+  disabledTests = [
+    # Test are depending on image files that are not there
+    "test_fs"
+    "test_bincue"
+    "test_read"
+    "test_cdda"
+  ];
+
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];
   };


### PR DESCRIPTION
… 3.13 (#482857)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The package tests cant find some bin/img files through tests. Tried to fix via some links but it depends on img files which are not there and python 3.13 throws a OSError in that case. Disables this tests for now.

Built whipper with success.

## Things done

Diables specfic tests.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
