### PR TITLE
above: 2.8 -> 2.8.1

### DIFF
--- a/pkgs/by-name/ab/above/package.nix
+++ b/pkgs/by-name/ab/above/package.nix
@@ -6,14 +6,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "above";
-  version = "2.8";
+  version = "2.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "casterbyte";
     repo = "Above";
     tag = "v${version}";
-    hash = "sha256-kG+eaTT72jmeC9R9IKwfd/+9oLAzHLJoKfFJhJDJzDM=";
+    hash = "sha256-wyXWGfthzJeHZoJe4OKe9k2BIwLae/aOUtiJpT4SfHw=";
   };
 
   build-system = with python3.pkgs; [ setuptools ];
@@ -22,10 +22,6 @@ python3.pkgs.buildPythonApplication rec {
     colorama
     scapy
   ];
-
-  postFixup = ''
-    mv $out/bin/above.py $out/bin/$pname
-  '';
 
   # Project has no tests
   doCheck = false;

--- a/pkgs/by-name/ab/above/package.nix
+++ b/pkgs/by-name/ab/above/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "above";
   version = "2.8.1";
   pyproject = true;
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "casterbyte";
     repo = "Above";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-wyXWGfthzJeHZoJe4OKe9k2BIwLae/aOUtiJpT4SfHw=";
   };
 
@@ -29,9 +29,9 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "Invisible network protocol sniffer";
     homepage = "https://github.com/casterbyte/Above";
-    changelog = "https://github.com/casterbyte/Above/releases/tag/${src.tag}";
+    changelog = "https://github.com/casterbyte/Above/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "above";
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/casterbyte/Above/releases/tag/v2.8.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
