### PR TITLE
aliyunpan: init at 0.3.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28731,6 +28731,12 @@
     github = "peterablehmann";
     githubId = 36541313;
   };
+  xiangpingjiang = {
+    email = "xiangpingjiang1998@gmail.com";
+    github = "xiangpingjiang";
+    githubId = 45722758;
+    name = "xiangpingjiang";
+  };
   xiaoxiangmoe = {
     name = "ZHAO JinXiang";
     email = "xiaoxiangmoe@gmail.com";

--- a/pkgs/by-name/al/aliyunpan/package.nix
+++ b/pkgs/by-name/al/aliyunpan/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "aliyunpan";
+  version = "0.3.7";
+
+  src = fetchFromGitHub {
+    owner = "tickstep";
+    repo = "aliyunpan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9sbAKv2SOZPKnP56vL0rfMEDhTpIV524s9sIvlWAM6o=";
+  };
+
+  vendorHash = "sha256-tNUXB+pU/0gJL3oG9rdk6J+SvO5ASqkuO+gVZiRdaVg=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=v${finalAttrs.version}"
+  ];
+
+  # skip test
+  checkFlags =
+    let
+      skippedTests = [
+        # require network access
+        "TestGetQRCodeLoginResult"
+        # depend specific local file
+        "TestBoltUltraFiles"
+        "TestLocalSyncDb"
+        "TestLocalGet"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  postInstall = ''
+    mkdir -p "$out/share/doc/aliyunpan"
+    cp README.md "$out/share/doc/aliyunpan/"
+    cp docs/manual.md "$out/share/doc/aliyunpan/"
+    cp docs/plugin_manual.md "$out/share/doc/aliyunpan/"
+  '';
+
+  meta = {
+    description = "Command line client for Aliyun Drive";
+    homepage = "https://github.com/tickstep/aliyunpan";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ xiangpingjiang ];
+    mainProgram = "aliyunpan";
+  };
+})


### PR DESCRIPTION
Adding [aliyunpan](https://github.com/tickstep/aliyunpan)  Golang cli.  Aliyunpan cli client. 



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
