### PR TITLE
python3Packages.fastmcp: 2.14.3 -> 2.14.4

### DIFF
--- a/pkgs/development/python-modules/fastmcp/default.nix
+++ b/pkgs/development/python-modules/fastmcp/default.nix
@@ -15,10 +15,12 @@
   cyclopts,
   exceptiongroup,
   httpx,
+  jsonref,
   jsonschema-path,
   mcp,
   openai,
   openapi-pydantic,
+  packaging,
   platformdirs,
   py-key-value-aio,
   pydantic,
@@ -39,20 +41,18 @@
   pytest-asyncio,
   pytest-httpx,
   pytestCheckHook,
-
-  pytest-timeout,
 }:
 
 buildPythonPackage (finalAttrs: {
   pname = "fastmcp";
-  version = "2.14.3";
+  version = "2.14.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jlowin";
     repo = "fastmcp";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vlwS4gpKMkmHh5Yr09ZMNFzpiEKjzJoJJNN3KxSBn3g=";
+    hash = "sha256-qJdOKLvxjenNCyya+XMrf3NGMaDL9LM9HsaQrhubXIY=";
   };
 
   build-system = [
@@ -65,9 +65,11 @@ buildPythonPackage (finalAttrs: {
     cyclopts
     exceptiongroup
     httpx
+    jsonref
     jsonschema-path
     mcp
     openapi-pydantic
+    packaging
     platformdirs
     py-key-value-aio
     pydantic
@@ -90,10 +92,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "fastmcp" ];
 
-  pytestFlags = [
-    "--timeout=30"
-  ];
-
   nativeCheckInputs = [
     dirty-equals
     email-validator
@@ -103,7 +101,6 @@ buildPythonPackage (finalAttrs: {
     psutil
     pytest-asyncio
     pytest-httpx
-    pytest-timeout
     pytestCheckHook
     writableTmpDirAsHomeHook
   ]


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/jlowin/fastmcp/compare/v2.14.3...v2.14.4
Changelog: https://github.com/jlowin/fastmcp/releases/tag/v2.14.4

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test