### PR TITLE
python313Packages.aioguardian: 2025.02.0 -> 2026.01.0

### DIFF
--- a/pkgs/development/python-modules/aioguardian/default.nix
+++ b/pkgs/development/python-modules/aioguardian/default.nix
@@ -16,7 +16,7 @@
   yarl,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aioguardian";
   version = "2026.01.0";
   pyproject = true;
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "bachya";
     repo = "aioguardian";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-p0rSN00CxTJsoo5iD3jsnTPUIl3G/fDc6tMjj0H0MuE=";
   };
 
@@ -71,8 +71,8 @@ buildPythonPackage rec {
       Guardian line of water valves and sensors from Elexa.
     '';
     homepage = "https://github.com/bachya/aioguardian";
-    changelog = "https://github.com/bachya/aioguardian/releases/tag/${version}";
-    license = with lib.licenses; [ mit ];
+    changelog = "https://github.com/bachya/aioguardian/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/aioguardian/default.nix
+++ b/pkgs/development/python-modules/aioguardian/default.nix
@@ -18,7 +18,7 @@
 
 buildPythonPackage rec {
   pname = "aioguardian";
-  version = "2025.02.0";
+  version = "2026.01.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     owner = "bachya";
     repo = "aioguardian";
     tag = version;
-    hash = "sha256-RoVD2O/OAk4l96kYEq7ZM/2QuckcPxDluf1MT4HdKc4=";
+    hash = "sha256-p0rSN00CxTJsoo5iD3jsnTPUIl3G/fDc6tMjj0H0MuE=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/bachya/aioguardian/compare/2025.02.0...2026.01.0

Changelog: https://github.com/bachya/aioguardian/releases/tag/2026.01.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
