### PR TITLE
[Backport release-25.11] nixos/qui: init service 

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -12,6 +12,8 @@
 
 - [knot-resolver](https://www.knot-resolver.cz/) in version 6. Available as `services.knot-resolver`. A module for knot-resolver 5 was already available as `services.kresd`.
 
+- [qui](https://github.com/autobrr/qui), a modern alternative webUI for qBittorrent, with multi-instance support. Written in Go/React. Available as [services.qui](#opt-services.qui.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1539,6 +1539,7 @@
   ./services/torrent/opentracker.nix
   ./services/torrent/peerflix.nix
   ./services/torrent/qbittorrent.nix
+  ./services/torrent/qui.nix
   ./services/torrent/rqbit.nix
   ./services/torrent/rtorrent.nix
   ./services/torrent/torrentstream.nix

--- a/nixos/modules/services/torrent/qui.nix
+++ b/nixos/modules/services/torrent/qui.nix
@@ -1,0 +1,191 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    getExe
+    maintainers
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    ;
+  inherit (lib.types)
+    bool
+    path
+    port
+    str
+    submodule
+    ;
+  cfg = config.services.qui;
+
+  stateDir = "/var/lib/qui";
+  configFormat = pkgs.formats.toml { };
+  configFile = configFormat.generate "qui.toml" cfg.settings;
+in
+{
+  options = {
+    services.qui = {
+      enable = mkEnableOption "qui";
+
+      package = mkPackageOption pkgs "qui" { };
+
+      user = mkOption {
+        type = str;
+        default = "qui";
+        description = "User to run qui as.";
+      };
+
+      group = mkOption {
+        type = str;
+        default = "qui";
+        example = "torrents";
+        description = "Group to run qui as.";
+      };
+
+      openFirewall = mkOption {
+        type = bool;
+        default = false;
+        description = "Whether or not to open ports in the firewall for qui.";
+      };
+
+      secretFile = mkOption {
+        type = path;
+        example = "/run/secrets/qui-session.txt";
+        description = ''
+          Path to a file that contains the session secret. The session secret
+          can be generated with `openssl rand -hex 32`.
+        '';
+      };
+
+      settings = mkOption {
+        default = { };
+        example = {
+          port = 7777;
+          logLevel = "DEBUG";
+          metricsEnabled = true;
+        };
+        type = submodule {
+          freeformType = configFormat.type;
+          options = {
+            host = mkOption {
+              type = str;
+              default = "127.0.0.1";
+              description = "The host address qui listens on.";
+            };
+
+            port = mkOption {
+              type = port;
+              default = 7476;
+              description = "The port qui listens on.";
+            };
+          };
+        };
+        description = ''
+          qui configuration options.
+
+          Refer to the [template config](https://github.com/autobrr/qui/blob/main/internal/config/config.go)
+          in the source code for the available options.
+          The documentation contains the available [environment variables](https://getqui.com/docs/configuration/environment/),
+          this can be used to get an overview.
+        '';
+      };
+
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !(cfg.settings ? sessionSecret);
+        message = ''
+          Session secrets should not be passed via settings, as
+          these are stored in the world-readable nix store.
+
+          Use the secretFile option instead.'';
+      }
+    ];
+
+    systemd.services.qui = {
+      description = "qui: alternative qBittorrent webUI";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+
+        LoadCredential = "sessionSecret:${cfg.secretFile}";
+        Environment = [ "QUI__SESSION_SECRET_FILE=%d/sessionSecret" ];
+        StateDirectory = "qui";
+
+        ExecStartPre = ''
+          ${pkgs.coreutils}/bin/install -m 600 '${configFile}' '%S/qui/config.toml'
+        '';
+        ExecStart = "${getExe cfg.package} serve --config-dir %S/qui";
+        Restart = "on-failure";
+
+        # Based on qbittorrent and nemorosa hardening settings
+        # Similar to what systemd hardening helper suggests
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateNetwork = false;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = "yes";
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        # This should allow for hardlinking to torrent client files
+        ProtectSystem = "full";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [ "@system-service" ];
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.settings.port ];
+    };
+
+    users = {
+      users = mkIf (cfg.user == "qui") {
+        qui = {
+          group = cfg.group;
+          description = "qui user";
+          isSystemUser = true;
+          home = stateDir;
+        };
+      };
+
+      groups = mkIf (cfg.group == "qui") {
+        qui = { };
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ undefined-landmark ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1321,6 +1321,7 @@ in
   qtile = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./qtile/default.nix;
   qtile-extras = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./qtile-extras/default.nix;
   quake3 = runTest ./quake3.nix;
+  qui = runTest ./qui.nix;
   quicktun = runTest ./quicktun.nix;
   quickwit = runTest ./quickwit.nix;
   rabbitmq = runTest ./rabbitmq.nix;

--- a/nixos/tests/qui.nix
+++ b/nixos/tests/qui.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+
+{
+  name = "qui";
+  meta.maintainers = with lib.maintainers; [ undefined-landmark ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      # We create this secret in the Nix store (making it readable by everyone).
+      # DO NOT DO THIS OUTSIDE OF TESTS!!
+      testSecretFile = pkgs.writeText "session_secret" "not-secret";
+    in
+    {
+      services.qui = {
+        enable = true;
+        secretFile = testSecretFile;
+      };
+
+      # Use port other than default to test if settings options work.
+      specialisation.settingsPort.configuration = {
+        services.qui = {
+          enable = true;
+          secretFile = testSecretFile;
+          settings.port = 7777;
+        };
+      };
+    };
+
+  testScript =
+    { nodes, ... }:
+    let
+      settingsPort = "${nodes.machine.system.build.toplevel}/specialisation/settingsPort";
+    in
+    # python
+    ''
+      def test_webui(port):
+        machine.wait_for_unit("qui.service")
+        machine.wait_for_open_port(port)
+        machine.wait_until_succeeds(f"curl --fail http://localhost:{port}")
+
+      test_webui(7476)
+
+      machine.succeed("${settingsPort}/bin/switch-to-configuration test")
+      test_webui(7777)
+    '';
+}

--- a/pkgs/by-name/qu/qui/package.nix
+++ b/pkgs/by-name/qu/qui/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   stdenvNoCC,
+  nixosTests,
   nix-update-script,
   nodejs,
   pnpm_9,
@@ -72,11 +73,14 @@ buildGoModule (finalAttrs: {
   versionCheckProgramArg = "version";
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--subpackage"
-      "qui-web"
-    ];
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--subpackage"
+        "qui-web"
+      ];
+    };
+    tests.testService = nixosTests.qui;
   };
 
   meta = {


### PR DESCRIPTION
Automatic backport of #472934 failed because of a merge conflict in the release notes. This PR cherry picks the commits from the original PR and fixes the merge conflict. 

Additionally, the default cherry pick doesn't put qui in the right place in the module list. This is also fixed. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
