### PR TITLE
idescriptor: init at 0.1.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -237,6 +237,7 @@
   ./programs/htop.nix
   ./programs/i3lock.nix
   ./programs/iay.nix
+  ./programs/idescriptor.nix
   ./programs/iftop.nix
   ./programs/iio-hyprland.nix
   ./programs/immersed.nix

--- a/nixos/modules/programs/idescriptor.nix
+++ b/nixos/modules/programs/idescriptor.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.idescriptor;
+in
+{
+  options.programs.idescriptor = {
+    enable = lib.mkEnableOption "iDescriptor, a cross-platform iDevice management tool";
+
+    package = lib.mkPackageOption pkgs "idescriptor" { };
+
+    users = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [ ];
+      description = "Users to be added to the idevice group.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services = {
+      udev.packages = [ cfg.package ];
+
+      usbmuxd.enable = true;
+    };
+
+    users.groups.idevice = {
+      members = cfg.users;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ amadejkastelic ];
+}

--- a/pkgs/by-name/id/idescriptor/99-idevice.rules
+++ b/pkgs/by-name/id/idescriptor/99-idevice.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", MODE="0666", GROUP="idevice"

--- a/pkgs/by-name/id/idescriptor/package.nix
+++ b/pkgs/by-name/id/idescriptor/package.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildGoModule,
+  copyDesktopItems,
+  makeDesktopItem,
+  cmake,
+  pkg-config,
+  avahi-compat,
+  ffmpeg,
+  libheif,
+  libimobiledevice,
+  libimobiledevice-glue,
+  libplist,
+  go,
+  qrencode,
+  libssh,
+  libtatsu,
+  libusbmuxd,
+  libusb1,
+  libzip,
+  openssl,
+  pugixml,
+  qt6,
+  lxqt,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "idescriptor";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "iDescriptor";
+    repo = "iDescriptor";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pj/8PCZUTPu28MQd3zL8ceDsQy4+55348ZOCpiQaiEo=";
+    fetchSubmodules = true;
+  };
+
+  ipatool-go-modules =
+    (buildGoModule {
+      pname = "ipatool-go";
+      inherit (finalAttrs) version src;
+      modRoot = "lib/ipatool-go";
+      vendorHash = "sha256-4ZCNgLAcZtEd7zDbIu3kyP/Cyp6TaBM9gyZEohgzCk8=";
+      proxyVendor = true;
+      doCheck = false;
+      env.GOWORK = "off";
+    }).goModules;
+
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    pkg-config
+    go
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    avahi-compat
+    ffmpeg
+    libheif
+    libimobiledevice
+    libimobiledevice-glue
+    libplist
+    qrencode
+    libssh
+    libtatsu
+    libusbmuxd
+    libusb1
+    libzip
+    openssl
+    pugixml
+    qt6.qtbase
+    qt6.qtlocation
+    qt6.qtmultimedia
+    qt6.qtpositioning
+    qt6.qtserialport
+    qt6.qtsvg
+    qt6.qttools
+    qt6.qtwayland
+    lxqt.qtermwidget
+  ];
+
+  cmakeFlags = [
+    "-DPACKAGE_MANAGER_MANAGED=ON"
+    "-DPACKAGE_MANAGER_HINT=nixpkgs"
+  ];
+
+  preConfigure = ''
+    export GOCACHE=$TMPDIR/go-cache
+    export GOPATH=$TMPDIR/go
+    export GOPROXY=file://${finalAttrs.ipatool-go-modules}
+    export GOSUMDB=off
+  '';
+
+  postInstall = ''
+    install -Dm644 -t $out/lib/udev/rules.d ${./99-idevice.rules}
+
+    install -Dm644 $src/resources/icons/app-icon/icon.png \
+      $out/share/icons/hicolor/256x256/apps/idescriptor.png
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "iDescriptor";
+      exec = "iDescriptor";
+      icon = "idescriptor";
+      desktopName = "iDescriptor";
+      comment = "Cross-platform iDevice management tool";
+      categories = [
+        "System"
+        "Utility"
+      ];
+    })
+  ];
+
+  meta = {
+    homepage = "https://github.com/iDescriptor/iDescriptor";
+    changelog = "https://github.com/iDescriptor/iDescriptor/releases/tag/v${finalAttrs.version}";
+    description = "A cross-platform iDevice management tool";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ amadejkastelic ];
+    mainProgram = "iDescriptor";
+  };
+})


### PR DESCRIPTION
https://github.com/iDescriptor/iDescriptor

iDescriptor is a program that allows you to interact with you ios device via USB.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
