### PR TITLE
various: add meta.identifier.cpeParts to a batch of packages

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -71,6 +71,7 @@ let
           vdemeester
           teutat3s
         ];
+        identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "docker" version;
       };
 
       docker-runc = runc.overrideAttrs {
@@ -248,6 +249,7 @@ let
           meta = docker-meta // {
             homepage = "https://mobyproject.org/";
             description = "Collaborative project for the container ecosystem to assemble container-based systems";
+            identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "mobyproject" version;
           };
         }
       );

--- a/pkgs/by-name/br/brotli/package.nix
+++ b/pkgs/by-name/br/brotli/package.nix
@@ -84,5 +84,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.all;
     mainProgram = "brotli";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "google" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/co/conntrack-tools/package.nix
+++ b/pkgs/by-name/co/conntrack-tools/package.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ fpletz ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "netfilter" version;
   };
 }

--- a/pkgs/by-name/cr/cryptsetup/package.nix
+++ b/pkgs/by-name/cr/cryptsetup/package.nix
@@ -116,5 +116,6 @@ stdenv.mkDerivation (finalAttrs: {
       raitobezarius
     ];
     platforms = with lib.platforms; linux;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "cryptsetup_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -290,5 +290,6 @@ stdenv.mkDerivation (finalAttrs: {
     broken = stdenv.hostPlatform.isStatic && (brotliSupport || gssSupport);
     pkgConfigModules = [ "libcurl" ];
     mainProgram = "curl";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "haxx" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -139,5 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus; # most is also under AFL-2.1
     teams = [ lib.teams.freedesktop ];
     platforms = lib.platforms.unix;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "freedesktop" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/el/elfutils/package.nix
+++ b/pkgs/by-name/el/elfutils/package.nix
@@ -155,5 +155,6 @@ stdenv.mkDerivation rec {
       gpl3Plus
     ];
     maintainers = with lib.maintainers; [ r-burns ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "elfutils_project" version;
   };
 }

--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -600,5 +600,6 @@ stdenv.mkDerivation (finalAttrs: {
       zivarah
     ];
     mainProgram = "git";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "git-scm" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/gn/gnutls/package.nix
+++ b/pkgs/by-name/gn/gnutls/package.nix
@@ -243,5 +243,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ vcunat ];
     platforms = lib.platforms.all;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;
   };
 }

--- a/pkgs/by-name/li/libarchive/package.nix
+++ b/pkgs/by-name/li/libarchive/package.nix
@@ -143,6 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     inherit (acl.meta) badPlatforms;
     pkgConfigModules = [ "libarchive" ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libarchive" finalAttrs.version;
   };
 
   passthru.tests = {

--- a/pkgs/by-name/li/libcap/package.nix
+++ b/pkgs/by-name/li/libcap/package.nix
@@ -143,5 +143,6 @@ stdenv.mkDerivation rec {
       "libcap"
       "libpsx"
     ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libcap_project" version;
   };
 }

--- a/pkgs/by-name/li/libgcrypt/package.nix
+++ b/pkgs/by-name/li/libgcrypt/package.nix
@@ -125,5 +125,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.lgpl2Plus;
     platforms = lib.platforms.all;
     maintainers = [ ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" version;
   };
 }

--- a/pkgs/by-name/li/libnl/package.nix
+++ b/pkgs/by-name/li/libnl/package.nix
@@ -72,5 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ fpletz ];
     platforms = lib.platforms.linux;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libnl_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/li/libressl/default.nix
+++ b/pkgs/by-name/li/libressl/default.nix
@@ -108,6 +108,7 @@ let
         badPlatforms = with lib.systems.inspect.patterns; [
           (lib.recursiveUpdate isPower64 isLittleEndian)
         ];
+        identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "openbsd" version;
       };
     };
   # https://github.com/libressl/portable/pull/1206

--- a/pkgs/by-name/li/libseccomp/package.nix
+++ b/pkgs/by-name/li/libseccomp/package.nix
@@ -92,5 +92,6 @@ stdenv.mkDerivation (finalAttrs: {
       "sparc64-linux"
     ];
     maintainers = with lib.maintainers; [ thoughtpolice ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libseccomp_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/li/libuv/package.nix
+++ b/pkgs/by-name/li/libuv/package.nix
@@ -210,6 +210,7 @@ stdenv.mkDerivation (finalAttrs: {
       bsd3
       cc-by-40
     ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libuv" finalAttrs.version;
   };
 
 })

--- a/pkgs/by-name/li/libxslt/package.nix
+++ b/pkgs/by-name/li/libxslt/package.nix
@@ -101,5 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ jtojnar ];
     broken = pythonSupport && !libxml2.pythonSupport; # see #73102 for why this is not an assert
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "xmlsoft" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -140,5 +140,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     license = lib.licenses.bsd3;
     badPlatforms = [ lib.systems.inspect.platformPatterns.isStatic ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "linux-pam" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/lz/lz4/package.nix
+++ b/pkgs/by-name/lz/lz4/package.nix
@@ -76,5 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     mainProgram = "lz4";
     maintainers = [ lib.maintainers.tobim ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "lz4_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/ne/networkmanager/package.nix
+++ b/pkgs/by-name/ne/networkmanager/package.nix
@@ -249,5 +249,6 @@ stdenv.mkDerivation (finalAttrs: {
       # Mandatory shared libraries.
       lib.systems.inspect.platformPatterns.isStatic
     ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnome" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/p1/p11-kit/package.nix
+++ b/pkgs/by-name/p1/p11-kit/package.nix
@@ -101,5 +101,6 @@ stdenv.mkDerivation rec {
     ];
     license = lib.licenses.bsd3;
     mainProgram = "p11-kit";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "p11-kit_project" version;
   };
 }

--- a/pkgs/development/interpreters/perl/interpreter.nix
+++ b/pkgs/development/interpreters/perl/interpreter.nix
@@ -363,6 +363,7 @@ stdenv.mkDerivation (
       platforms = lib.platforms.all;
       priority = 6; # in `buildEnv' (including the one inside `perl.withPackages') the library files will have priority over files in `perl`
       mainProgram = "perl";
+      identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "perl" finalAttrs.version;
     };
   }
   // lib.optionalAttrs crossCompiling rec {

--- a/pkgs/development/libraries/libidn2/default.nix
+++ b/pkgs/development/libraries/libidn2/default.nix
@@ -65,5 +65,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [ fpletz ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;
   };
 }

--- a/pkgs/development/libraries/libxml2/common.nix
+++ b/pkgs/development/libraries/libxml2/common.nix
@@ -159,6 +159,7 @@ stdenv'.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
     pkgConfigModules = [ "libxml-2.0" ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "xmlsoft" finalAttrs.version;
     # Python limits cross-compilation to an allowlist of host OSes.
     # https://github.com/python/cpython/blob/dfad678d7024ab86d265d84ed45999e031a03691/configure.ac#L534-L562
     broken =

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -276,6 +276,7 @@ stdenv.mkDerivation (finalAttrs: {
       in
       base ++ lib.optionals unicodeSupport (map (p: p + "w") base);
     platforms = lib.platforms.all;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "ncurses_project" finalAttrs.version;
   };
 
   passthru = {

--- a/pkgs/development/libraries/nettle/generic.nix
+++ b/pkgs/development/libraries/nettle/generic.nix
@@ -72,5 +72,6 @@ stdenv.mkDerivation {
 
     platforms = lib.platforms.all;
     maintainers = [ lib.maintainers.vcunat ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "nettle_project" version;
   };
 }

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -391,6 +391,7 @@ let
           "openssl"
         ];
         platforms = lib.platforms.all;
+        identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "openssl" finalAttrs.version;
       }
       // extraMeta;
     });

--- a/pkgs/development/libraries/pcre2/default.nix
+++ b/pkgs/development/libraries/pcre2/default.nix
@@ -53,5 +53,6 @@ stdenv.mkDerivation rec {
       "libpcre2-16"
       "libpcre2-32"
     ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "pcre" version;
   };
 }

--- a/pkgs/development/libraries/sqlite/default.nix
+++ b/pkgs/development/libraries/sqlite/default.nix
@@ -154,5 +154,6 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ np ];
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     pkgConfigModules = [ "sqlite3" ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "sqlite" version;
   };
 }

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -171,5 +171,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.zlib;
     platforms = lib.platforms.all;
     pkgConfigModules = [ "zlib" ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "zlib" finalAttrs.version;
   };
 })

--- a/pkgs/os-specific/linux/iptables/default.nix
+++ b/pkgs/os-specific/linux/iptables/default.nix
@@ -172,5 +172,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [ fpletz ];
     license = lib.licenses.gpl2Plus;
     downloadPage = "https://www.netfilter.org/projects/iptables/files/";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "netfilter" finalAttrs.version;
   };
 })

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -127,5 +127,6 @@ stdenv.mkDerivation rec {
     ]; # GPLv2+ for tools
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ artturin ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "kernel" version;
   };
 }

--- a/pkgs/os-specific/linux/libbpf/0.x.nix
+++ b/pkgs/os-specific/linux/libbpf/0.x.nix
@@ -65,5 +65,6 @@ stdenv.mkDerivation rec {
       martinetd
     ];
     platforms = lib.platforms.linux;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libbpf_project" version;
   };
 }

--- a/pkgs/os-specific/linux/libbpf/default.nix
+++ b/pkgs/os-specific/linux/libbpf/default.nix
@@ -75,5 +75,6 @@ stdenv.mkDerivation rec {
       martinetd
     ];
     platforms = lib.platforms.linux;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libbpf_project" version;
   };
 }

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1061,5 +1061,6 @@ stdenv.mkDerivation (finalAttrs: {
       # https://github.com/systemd/systemd/issues/20600#issuecomment-912338965
       lib.systems.inspect.platformPatterns.isStatic
     ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "systemd_project" finalAttrs.version;
   };
 })

--- a/pkgs/os-specific/linux/wpa_supplicant/default.nix
+++ b/pkgs/os-specific/linux/wpa_supplicant/default.nix
@@ -179,5 +179,6 @@ stdenv.mkDerivation rec {
       marcweber
     ];
     platforms = lib.platforms.linux;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "w1.fi" version;
   };
 }

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -100,5 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = lib.platforms.all;
     pkgConfigModules = [ "liblzma" ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "tukaani" finalAttrs.version;
   };
 })

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -267,5 +267,6 @@ stdenv.mkDerivation (finalAttrs: {
     ];
     platforms = with lib.platforms; unix ++ windows;
     priority = 10;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;
   };
 })

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -312,6 +312,7 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix ++ lib.platforms.windows;
     maintainers = extraMeta.maintainers or [ ];
     mainProgram = "ssh";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "openbsd" finalAttrs.version;
   }
   // extraMeta;
 })

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -216,5 +216,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.all;
     mainProgram = "gpg";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnupg" version;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds CPE identifiers to various packages using the new CPE tools added in https://github.com/NixOS/nixpkgs/pull/439074.

The idea is to test how well all this works and get at least some of these tags off the ground.

I started with a few packages that seemed central to me and went from there to also tag dependencies. I stopped at a round 40 files changed. 

I also used the [go-cpe-dictionary](https://github.com/vulsio/go-cpe-dictionary) project to download a local copy of the cpe database and compare these entries. I tried to start with software that seemed to have relatively recent entries/versions in the CPE database.

All of these were simple additions of vendor names.

These CPEs are added:

```
cpe:2.3:a:google:brotli:1.2.0:*:*:*:*:*:*:*
cpe:2.3:a:netfilter:conntrack-tools:1.4.8:*:*:*:*:*:*:*
cpe:2.3:a:cryptsetup_project:cryptsetup:2.8.3:*:*:*:*:*:*:*
cpe:2.3:a:haxx:curl:8.17.0:*:*:*:*:*:*:*
cpe:2.3:a:freedesktop:dbus:1.14.10:*:*:*:*:*:*:*
cpe:2.3:a:elfutils_project:elfutils:0.194:*:*:*:*:*:*:*
cpe:2.3:a:git-scm:git:2.52.0:*:*:*:*:*:*:*
cpe:2.3:a:gnu:gnutls:3.8.11:*:*:*:*:*:*:*
cpe:2.3:a:libarchive:libarchive:3.8.4:*:*:*:*:*:*:*
cpe:2.3:a:libcap_project:libcap:2.77:*:*:*:*:*:*:*
cpe:2.3:a:gnupg:libgcrypt:1.11.2:*:*:*:*:*:*:*
cpe:2.3:a:libnl_project:libnl:3.12.0:*:*:*:*:*:*:*
cpe:2.3:a:openbsd:libressl:4.2.1:*:*:*:*:*:*:*
cpe:2.3:a:libseccomp_project:libseccomp:2.6.0:*:*:*:*:*:*:*
cpe:2.3:a:libuv:libuv:1.51.0:*:*:*:*:*:*:*
cpe:2.3:a:xmlsoft:libxslt:1.1.45:*:*:*:*:*:*:*
cpe:2.3:a:linux-pam:linux-pam:1.7.1:*:*:*:*:*:*:*
cpe:2.3:a:lz4_project:lz4:1.10.0:*:*:*:*:*:*:*
cpe:2.3:a:gnome:networkmanager:1.54.3:*:*:*:*:*:*:*
cpe:2.3:a:p11-kit_project:p11-kit:0.25.10:*:*:*:*:*:*:*
cpe:2.3:a:perl:perl:5.42.0:*:*:*:*:*:*:*
cpe:2.3:a:gnu:libidn2:2.3.8:*:*:*:*:*:*:*
cpe:2.3:a:xmlsoft:libxml2:2.15.1:*:*:*:*:*:*:*
cpe:2.3:a:ncurses_project:ncurses:6.6:*:*:*:*:*:*:*
cpe:2.3:a:nettle_project:nettle:3.10.2:*:*:*:*:*:*:*
cpe:2.3:a:openssl:openssl:3.6.0:*:*:*:*:*:*:*
cpe:2.3:a:pcre:pcre2:10.46:*:*:*:*:*:*:*
cpe:2.3:a:sqlite:sqlite:3.51.2:*:*:*:*:*:*:*
cpe:2.3:a:zlib:zlib:1.3.1:*:*:*:*:*:*:*
cpe:2.3:a:netfilter:iptables:1.8.11:*:*:*:*:*:*:*
cpe:2.3:a:kernel:kmod:31:*:*:*:*:*:*:*
cpe:2.3:a:libbpf_project:libbpf:1.6.2:*:*:*:*:*:*:*
cpe:2.3:a:systemd_project:systemd:258.3:*:*:*:*:*:*:*
cpe:2.3:a:w1.fi:wpa_supplicant:2.11:*:*:*:*:*:*:*
cpe:2.3:a:tukaani:xz:5.8.2:*:*:*:*:*:*:*
cpe:2.3:a:gnu:coreutils:9.9:*:*:*:*:*:*:*
cpe:2.3:a:openbsd:openssh:10.2p1:*:*:*:*:*:*:*
cpe:2.3:a:gnupg:gnupg:2.4.8:*:*:*:*:*:*:*
cpe:2.3:a:docker:docker:29.1.5:*:*:*:*:*:*:*
cpe:2.3:a:mobyproject:moby:29.1.5:*:*:*:*:*:*:*
```

@YorikSar: I tried to use your shiny new tools for the first time. Maybe you're interested :).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
