### PR TITLE
codechecker: fix clang-tidy path resolution

### DIFF
--- a/pkgs/by-name/co/codechecker/package.nix
+++ b/pkgs/by-name/co/codechecker/package.nix
@@ -99,15 +99,17 @@ python3Packages.buildPythonApplication rec {
   ];
 
   postInstall = ''
-    wrapProgram "$out/bin/CodeChecker" --prefix PATH : ${
-      lib.makeBinPath (
-        [ ]
-        ++ lib.optional withClang clang
-        ++ lib.optional withClangTools clang-tools
-        ++ lib.optional withCppcheck cppcheck
-        ++ lib.optional withGcc gcc
-      )
-    }
+    wrapProgram "$out/bin/CodeChecker" \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [ ]
+          ++ lib.optional withClang clang
+          ++ lib.optional withClangTools clang-tools
+          ++ lib.optional withCppcheck cppcheck
+          ++ lib.optional withGcc gcc
+        )
+      } \
+      ${lib.optionalString withClangTools "--set CC_ANALYZER_BIN clang-tidy:${lib.getExe' clang-tools "clang-tidy"}"}
   '';
 
   meta = {


### PR DESCRIPTION
CodeChecker fails to execute clang-tidy because it resolves symlinks, which causes it to invoke the wrong tool (clangd).

In the clang-tools package, all tools are symlinked to the `clangd` wrapper script:

```
$ ls -la /nix/store/95a688lk14i0y5y70fwh9qhjd84490yd-clang-tools-21.1.7/bin/
...
lrwxrwxrwx clang-tidy -> clangd
.r-xr-xr-x clangd
```

The [clang-tools wrapper script](https://github.com/NixOS/nixpkgs/blob/9ad3f463385b34cccc3a91b9597d5cf1a05abae6/pkgs/development/compilers/llvm/common/clang-tools/wrapper#L40) then determines which tool to invoke based on `basename $0`. 

CodeChecker [resolves these symlinks](https://github.com/Ericsson/codechecker/blob/703c32044a90bca06d5238b2a3ed059b29de062e/analyzer/codechecker_analyzer/analyzers/clangtidy/analyzer.py#L149-L150) when detecting analyzers, which results in pointing to `clangd` instead of `clang-tidy`:

```
$ result/bin/CodeChecker analyzers
...
clang-tidy /nix/store/95a688lk14i0y5y70fwh9qhjd84490yd-clang-tools-21.1.7/bin/clangd 21.1.7
...
```

Since CodeChecker resolved the symlink to `clangd`, all subsequent clang-tidy invocations fail.

In this fix we set `CC_ANALYZER_BIN` to provide the direct path to `clang-tidy`, preventing CodeChecker from resolving the symlink and ensuring the correct tool is invoked.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
