### PR TITLE
cudaPackages.cuda_nvcc: patch math_functions.h signatures

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -6,6 +6,7 @@
   cudaAtLeast,
   cudaOlder,
   cuda_cccl,
+  glibc,
   lib,
   libnvvm,
   makeBinaryWrapper,
@@ -162,6 +163,32 @@ buildRedist (finalAttrs: {
         wrapProgramBinary \
           "''${!outputBin:?}/bin/nvcc" \
           --prefix PATH : ${lib.makeBinPath [ backendStdenv.cc ]}
+      ''
+      # Fix compatibility with glibc 2.42:
+      # The cospi|sinpi|rsqrt function signatures in include/common/math_functions.h do not match
+      # glibc 2.42's.
+      # Indeed, there they are declared with noexcept(true) which is not the case in cuda_nvcc.
+      + lib.optionals (lib.versionAtLeast glibc.version "2.42") ''
+        nixLog "Patching math_functions.h signatures to match glibc's ones"
+        substituteInPlace "''${!outputInclude:?}/include/crt/math_functions.h" \
+          --replace-fail \
+            "sinpi(double x);" \
+            "sinpi(double x) noexcept (true);" \
+          --replace-fail \
+            "sinpif(float x);" \
+            "sinpif(float x) noexcept (true);" \
+          --replace-fail \
+            "cospi(double x);" \
+            "cospi(double x) noexcept (true);" \
+          --replace-fail \
+            "cospif(float x);" \
+            "cospif(float x) noexcept (true);" \
+          --replace-fail \
+            "rsqrt(double x);" \
+            "rsqrt(double x) noexcept (true);" \
+          --replace-fail \
+            "rsqrtf(float x);" \
+            "rsqrtf(float x) noexcept (true);"
       ''
     );
 


### PR DESCRIPTION
## Things done

Fix compatibility with glibc 2.42

The latest `glibc` (2.42) brought by [the latest `staging-next` iteration](https://github.com/NixOS/nixpkgs/pull/479279) does not play well with cuda 12.8.
This at least breaks `bitsandbytes` (https://github.com/NixOS/nixpkgs/pull/483507).

The `cospi|sinpi|rsqrt` function signatures in `include/common/math_functions.h` do not match glibc 2.42's.
Indeed, there they are declared with `noexcept(true)` which is not the case in `cuda_nvcc`.

This PR patches `math_functions.h` in `cuda_nvcc`'s output to fix the issue.

cc @NixOS/cuda-maintainers @kirillrdy 

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
