### PR TITLE
heroic{,-unwrapped}: adopt, bump to electron_39

### DIFF
--- a/pkgs/by-name/he/heroic-unwrapped/bump-node-abi.patch
+++ b/pkgs/by-name/he/heroic-unwrapped/bump-node-abi.patch
@@ -1,0 +1,53 @@
+diff --git a/package.json b/package.json
+index 80ff4d3..4c54077 100644
+--- a/package.json
++++ b/package.json
+@@ -159,6 +159,7 @@
+     "vite-plugin-svgr": "^4.3.0"
+   },
+   "resolutions": {
++    "node-abi": "3.87.0",
+     "ts-morph": "17.0.1"
+   }
+ }
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index a9e85b9..11d677c 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -6,6 +6,7 @@ settings:
+ 
+ overrides:
+   ts-morph: 17.0.1
++  node-abi: 3.87.0
+ 
+ patchedDependencies:
+   '@types/node@22.15.18':
+@@ -4469,8 +4471,8 @@ packages:
+   no-case@3.0.4:
+     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
+ 
+-  node-abi@3.75.0:
+-    resolution: {integrity: sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==}
++  node-abi@3.87.0:
++    resolution: {integrity: sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==}
+     engines: {node: '>=10'}
+ 
+   node-addon-api@1.7.2:
+@@ -6376,7 +6380,7 @@ snapshots:
+       detect-libc: 2.0.4
+       fs-extra: 10.1.0
+       got: 11.8.6
+-      node-abi: 3.75.0
++      node-abi: 3.87.0
+       node-api-version: 0.2.1
+       ora: 5.4.1
+       read-binary-file-arch: 1.0.6
+@@ -11110,7 +11114,7 @@ snapshots:
+       lower-case: 2.0.2
+       tslib: 2.8.1
+ 
+-  node-abi@3.75.0:
++  node-abi@3.87.0:
+     dependencies:
+       semver: 7.7.2
+ 

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -10,8 +10,9 @@
   nodejs,
   python3,
   makeWrapper,
-  # Electron updates frequently break Heroic, so pin same version as upstream, or newest non-EOL.
-  electron_37,
+  # Electron updates can break Heroic, so try to use same version as upstream.
+  # If the used electron version is higher than upstream's then the node-abi package might need to be updated
+  electron_39,
   vulkan-helper,
   gogdl,
   nile,
@@ -20,10 +21,12 @@
 }:
 
 let
+  pnpm = pnpm_10;
+  electron = electron_39;
+
   legendary = callPackage ./legendary.nix { };
   epic-integration = callPackage ./epic-integration.nix { };
   comet-gog = comet-gog_heroic;
-  electron = electron_37;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "heroic-unwrapped";
@@ -37,16 +40,21 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    pnpm = pnpm_10;
-    fetcherVersion = 1;
-    hash = "sha256-F8H0eYltIJ0S8AX+2S3cR+v8dvePw09VWToVOLM8qII=";
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "sha256-+NNX4Mq0LY2vFI6GOYccWSX4TI+tJR+WokT0dAjbgm4=";
   };
 
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
-    pnpm_10
+    pnpm
     python3
     makeWrapper
   ];
@@ -56,6 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./fix-non-steam-shortcuts.patch
     # Fixes incorrect path to GalaxyCommunication.exe
     ./pr-4885.patch
+    # Add support for compiling with electron_39 headers
+    ./bump-node-abi.patch
   ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -128,7 +128,12 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher";
     changelog = "https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      tomasajt
+      keenanweaver
+      DieracDelta
+      baksa
+    ];
     # Heroic may work on nix-darwin, but it needs a dedicated maintainer for the platform.
     # It may also work on other Linux targets, but all the game stores only
     # support x86 Linux, so it would require extra hacking to run games via QEMU


### PR DESCRIPTION
Tracking: https://github.com/NixOS/nixpkgs/issues/483957
Supersedes: https://github.com/NixOS/nixpkgs/pull/483958

At the time of creating this PR heroic seems to be close to making an actual release supporting electron_39, but there was no release made yet.
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/pull/5162
https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/commit/d8764447f170ba347fc41ef14cff46a4f15a9e26

I don't know whether I will be backporting that update yet.

But I *will* backport this one, since it's (hopefully) not actually changing anything about the app itself.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
