### PR TITLE
maintainers: remove nickgerace (including the "reindeer" package)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18729,11 +18729,6 @@
     github = "NickCao";
     githubId = 15247171;
   };
-  nickgerace = {
-    name = "Nick Gerace";
-    github = "nickgerace";
-    githubId = 39320683;
-  };
   nickhu = {
     email = "me@nickhu.co.uk";
     github = "NickHu";

--- a/pkgs/by-name/re/reindeer/package.nix
+++ b/pkgs/by-name/re/reindeer/package.nix
@@ -31,6 +31,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "reindeer";
     homepage = "https://github.com/facebookincubator/reindeer";
     license = with lib.licenses; [ mit ];
-    maintainers = with lib.maintainers; [ nickgerace ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
- Remove nickgerace as maintainer of the "reindeer" Rust CLI package (for use with buck2)
- Remove nickgerace from the maintainers list as there are no other packages being maintained by nickgerace

Related: #483713