### PR TITLE
python3Packages.rapidocr-onnruntime: disable checks on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/rapidocr-onnxruntime/default.nix
+++ b/pkgs/development/python-modules/rapidocr-onnxruntime/default.nix
@@ -25,15 +25,6 @@
   rapidocr-onnxruntime,
 }:
 let
-  version = "1.4.4";
-
-  src = fetchFromGitHub {
-    owner = "RapidAI";
-    repo = "RapidOCR";
-    tag = "v${version}";
-    hash = "sha256-x0VELDKOffxbV3v0aDFJFuDC4YfsGM548XWgINmRc3M=";
-  };
-
   models =
     fetchzip {
       url = "https://github.com/RapidAI/RapidOCR/releases/download/v1.1.0/required_for_whl_v1.3.0.zip";
@@ -42,12 +33,19 @@ let
     }
     + "/required_for_whl_v1.3.0/resources/models";
 in
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "rapidocr-onnxruntime";
-  inherit version src;
+  version = "1.4.4";
   pyproject = true;
 
-  sourceRoot = "${src.name}/python";
+  src = fetchFromGitHub {
+    owner = "RapidAI";
+    repo = "RapidOCR";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-x0VELDKOffxbV3v0aDFJFuDC4YfsGM548XWgINmRc3M=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/python";
 
   # HACK:
   # Upstream uses a very unconventional structure to organize the packages, and we have to coax the
@@ -61,7 +59,7 @@ buildPythonPackage {
   # hence we patch that out and get the version from the build environment directly.
   patches = [
     (replaceVars ./setup-py-override-version-checking.patch {
-      inherit version;
+      inherit (finalAttrs) version;
     })
   ];
 
@@ -141,11 +139,11 @@ buildPythonPackage {
   });
 
   meta = {
-    changelog = "https://github.com/RapidAI/RapidOCR/releases/tag/${src.tag}";
+    changelog = "https://github.com/RapidAI/RapidOCR/releases/tag/${finalAttrs.src.tag}";
     description = "Cross platform OCR Library based on OnnxRuntime";
     homepage = "https://github.com/RapidAI/RapidOCR";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ wrvsrx ];
     mainProgram = "rapidocr_onnxruntime";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.rapidocr-onnxruntime: use finalAttrs**
- **python3Packages.rapidocr-onnruntime: disable checks on aarch64-linux**
  See https://github.com/NixOS/nixpkgs/pull/481039 for more context.

cc @wrvsrx

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
