### PR TITLE
linuxPackages.btf: init

### DIFF
--- a/pkgs/os-specific/linux/btf/default.nix
+++ b/pkgs/os-specific/linux/btf/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  stdenv,
+  kernel,
+  bpftools,
+}:
+
+stdenv.mkDerivation {
+  pname = "btf";
+  inherit (kernel) version;
+
+  nativeBuildInputs = [ bpftools ];
+
+  dontUnpack = true;
+
+  buildPhase = ''
+    objcopy --dump-section .BTF=btf ${lib.getDev kernel}/vmlinux /dev/null
+    mkdir -p $out/include
+    bpftool btf dump file btf format c > $out/include/vmlinux.h
+  '';
+
+  meta = {
+    description = "Kernel headers generated from embedded BTF";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ artemist ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -371,6 +371,8 @@ in
         # unreleased changes to the module build process.
         bcachefs = callPackage pkgs.bcachefs-tools.kernelModule { };
 
+        btf = callPackage ../os-specific/linux/btf { };
+
         ch9344 = callPackage ../os-specific/linux/ch9344 { };
 
         chipsec = callPackage ../by-name/ch/chipsec/package.nix {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add a new `linuxPackages.btf` package that includes the given kernel's btf-generated `vmlinux.h`. Some packages, such as systemd, require a kernel's data structures and functions generated from btf for full functionality.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
