### PR TITLE
nixos/{xserver,fonts}: fix eval break in nixos/modules/services/x11/xserver.nix and duplication in fonts

### DIFF
--- a/nixos/modules/config/fonts/fontdir.nix
+++ b/nixos/modules/config/fonts/fontdir.nix
@@ -21,7 +21,6 @@ let
         nativeBuildInputs = [
           gzip
           mkfontscale
-          mkfontscale
         ];
       }
       ''

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -877,7 +877,7 @@ in
           cfgPath = "X11/xorg.conf.d/10-evdev.conf";
         in
         {
-          ${cfgPath}.source = xf86-input-evdev.out + "/share/" + cfgPath;
+          ${cfgPath}.source = pkgs.xf86-input-evdev.out + "/share/" + cfgPath;
         }
       );
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -57,10 +57,10 @@ let
 
   # Map video driver names to driver packages. FIXME: move into card-specific modules.
   videoDrivers =
-    mapAttrs' (name: value: rec {
+    mapAttrs' (name: value: {
       name = removePrefix "xf86-video-" value.pname;
       value = {
-        modules = value;
+        modules = [ value ];
       };
     }) knownVideoDriverPackages
     // videoDriverAliases


### PR DESCRIPTION
apply suggestions from https://github.com/NixOS/nixpkgs/pull/482828#issuecomment-3800330914 that got posted after that pr was merged

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
