### PR TITLE
bash: Fix cross build

### DIFF
--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -75,7 +75,7 @@ lib.warnIf (withDocs != null)
       -DSSH_SOURCE_BASHRC
     ''
     # Bash's configure script assumes that CC and CC_FOR_BUILD have the
-    # same default -std=... flags. But at this moment, for FreeBSD, we
+    # same default -std=... flags. But at this moment, for Cross and FreeBSD, we
     # have CC_FOR_BUILD that defaults to c23, and a CC that default to
     # something older, perhaps c17. This breaks the build because of
     # bash's faulty assumptions.
@@ -83,13 +83,11 @@ lib.warnIf (withDocs != null)
     # To fix, we simply force the standard to be the higher for CC to
     # match CC_FOR_BUILD.
     #
-    # Once FreeBSD is built with a newer version of Clang, this hack
-    # should be removed.
-    +
-      lib.optionalString (stdenv.hostPlatform.isFreeBSD && stdenv.hostPlatform != stdenv.buildPlatform)
-        ''
-          -std=c23
-        '';
+    # Once FreeBSD and other contexts are built with a newer version of clang,
+    # this hack should be removed.
+    + lib.optionalString stdenv.cc.isClang ''
+      -std=c23
+    '';
 
     patchFlags = [ "-p0" ];
 


### PR DESCRIPTION
This fixes musl/llvm cross builds for me, maybe we should be doing this on all cross builds? 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
