### PR TITLE
swi-prolog: 9.2.9 -> 10.0.2

### DIFF
--- a/pkgs/by-name/sw/swi-prolog/package.nix
+++ b/pkgs/by-name/sw/swi-prolog/package.nix
@@ -10,9 +10,9 @@
   openssl,
   gmp,
   gperftools,
-  readline,
   libedit,
   libarchive,
+  libicns,
 
   # optional dependencies
   withDb ? true,
@@ -78,7 +78,7 @@
 
 let
   # minorVersion is even for stable, odd for unstable
-  version = "9.2.9";
+  version = "10.0.2";
 
   # This package provides several with* options, which replaces the old extraLibraries option.
   # This error should help users that still use this option find their way to these flags.
@@ -125,18 +125,25 @@ stdenv.mkDerivation {
     owner = "SWI-Prolog";
     repo = "swipl";
     tag = "V${version}";
-    hash = "sha256-M0stUwiD3Auz5OsmgVJFWg2RAswu42UUp8bafqZOC7A=";
+    hash = "sha256-w9BzcnXS2sqHsLXYEcfhZ1niKpifffiDtm8EcJ6cG9g=";
     fetchSubmodules = true;
   };
 
-  # Add the packInstall path to the swipl pack search path
   postPatch = ''
+    # Add the packInstall path to the swipl pack search path
     echo "user:file_search_path(pack, '$out/lib/swipl/extra-pack')." >> boot/init.pl
+
+    # iconutil is unavailable, replace with png2icns from libicns
+    substituteInPlace desktop/make_icns.sh \
+      --replace-fail 'iconutil -c icns "$ICONSET_DIR" -o "$OUTPUT"' 'png2icns "$OUTPUT" "$INPUT"'
   '';
 
   nativeBuildInputs = [
     cmake
     ninja
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    libicns
   ];
 
   buildInputs = [
@@ -146,7 +153,6 @@ stdenv.mkDerivation {
     openssl
     gperftools
     gmp
-    readline
     libedit
   ]
   ++ optionalDependencies;


### PR DESCRIPTION
Changelog: https://www.swi-prolog.org/ChangeLog?branch=stable&from=9.2.9&to=10.0.2

Depends on https://github.com/NixOS/nixpkgs/pull/489365

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
