### PR TITLE
services/xserver: add missing prefix for xf86-input-evdev

### DIFF
--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -58,7 +58,7 @@ let
   # Map video driver names to driver packages. FIXME: move into card-specific modules.
   videoDrivers =
     mapAttrs' (name: value: rec {
-      name = removePrefix "xf86-video-" builtins.trace value value.pname;
+      name = removePrefix "xf86-video-" (builtins.trace value value.pname);
       value = {
         modules = value;
       };

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -877,7 +877,7 @@ in
           cfgPath = "X11/xorg.conf.d/10-evdev.conf";
         in
         {
-          ${cfgPath}.source = xf86-input-evdev.out + "/share/" + cfgPath;
+          ${cfgPath}.source = pkgs.xf86-input-evdev.out + "/share/" + cfgPath;
         }
       );
 

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -58,7 +58,7 @@ let
   # Map video driver names to driver packages. FIXME: move into card-specific modules.
   videoDrivers =
     mapAttrs' (name: value: rec {
-      name = removePrefix "xf86-video-" value.pname;
+      name = removePrefix "xf86-video-" builtins.trace value value.pname;
       value = {
         modules = value;
       };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

(I'm still working on the fix)

The refactoring done in #482828 did not include the `pkgs.` prefix correctly, resulting in an evaluation error. The patch I'm proposing does fix this and allows configurations to be built.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test



----


Initial state:

```bash
~> nixos-rebuild --flake . build
building the system configuration...
warning: Git tree '/home/fumesover/dev/nix-config' is dirty
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nixos-system-fixme-nixos-26.05.20260126.d7eb1c6'
         whose name attribute is located at /nix/store/vgdbp53078qphi810jh5kvyqw19217gl-source/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'buildCommand' of derivation 'nixos-system-fixme-nixos-26.05.20260126.d7eb1c6'
         at /nix/store/vgdbp53078qphi810jh5kvyqw19217gl-source/nixos/modules/system/activation/top-level.nix:69:7:
           68|       passAsFile = [ "extraDependencies" ];
           69|       buildCommand = systemBuilder;
             |       ^
           70|

       … while evaluating the option `environment.etc."X11/xorg.conf.d/10-evdev.conf".source':

       … while evaluating definitions from `/nix/store/vgdbp53078qphi810jh5kvyqw19217gl-source/nixos/modules/services/x11/xserver.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: undefined variable 'xf86-input-evdev'
       at /nix/store/vgdbp53078qphi810jh5kvyqw19217gl-source/nixos/modules/services/x11/xserver.nix:880:31:
          879|         {
          880|           ${cfgPath}.source = xf86-input-evdev.out + "/share/" + cfgPath;
             |                               ^
          881|         }
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '.#nixosConfigurations."fixme-nixos".config.system.build.toplevel'' returned non-zero exit status 1.
```

after first commit:
```bash
~> nixos-rebuild --flake . build
building the system configuration...
warning: Git tree '/home/fumesover/dev/nix-config' is dirty
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nixos-system-fixme-nixos-26.05.20260126.bbdedaf'
         whose name attribute is located at /nix/store/jlx6nwf2ph5f9d6zfr485ikd0sj0zs0b-source/pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'buildCommand' of derivation 'nixos-system-fixme-nixos-26.05.20260126.bbdedaf'
         at /nix/store/jlx6nwf2ph5f9d6zfr485ikd0sj0zs0b-source/nixos/modules/system/activation/top-level.nix:69:7:
           68|       passAsFile = [ "extraDependencies" ];
           69|       buildCommand = systemBuilder;
             |       ^
           70|

       … while evaluating the option `environment.etc."lightdm/lightdm.conf".source':

       … while evaluating definitions from `/nix/store/jlx6nwf2ph5f9d6zfr485ikd0sj0zs0b-source/nixos/modules/services/x11/display-managers/lightdm.nix':

       … while evaluating the option `services.xserver.displayManager.xserverArgs':

       … while evaluating definitions from `/nix/store/jlx6nwf2ph5f9d6zfr485ikd0sj0zs0b-source/nixos/modules/services/x11/xserver.nix':

       … while evaluating the option `services.xserver.modules':

       … while evaluating definitions from `/nix/store/jlx6nwf2ph5f9d6zfr485ikd0sj0zs0b-source/nixos/modules/services/x11/xserver.nix':

       … while evaluating the option `services.xserver.drivers':

       … while evaluating definitions from `/nix/store/jlx6nwf2ph5f9d6zfr485ikd0sj0zs0b-source/nixos/modules/services/x11/xserver.nix':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'pname' missing
       at /nix/store/jlx6nwf2ph5f9d6zfr485ikd0sj0zs0b-source/nixos/modules/services/x11/xserver.nix:61:41:
           60|     mapAttrs' (name: value: rec {
           61|       name = removePrefix "xf86-video-" value.pname;
             |                                         ^
           62|       value = {
Command 'nix --extra-experimental-features 'nix-command flakes' build --print-out-paths '.#nixosConfigurations."fixme-nixos".config.system.build.toplevel'' returned non-zero exit status 1.

```
