### PR TITLE
age-plugin-tpm: fix version

### DIFF
--- a/pkgs/by-name/ag/age-plugin-tpm/package.nix
+++ b/pkgs/by-name/ag/age-plugin-tpm/package.nix
@@ -7,6 +7,7 @@
   swtpm,
   openssl,
   age,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
@@ -28,6 +29,7 @@ buildGoModule rec {
     age
     swtpm
   ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   buildInputs = [
     openssl

--- a/pkgs/by-name/ag/age-plugin-tpm/package.nix
+++ b/pkgs/by-name/ag/age-plugin-tpm/package.nix
@@ -36,6 +36,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
+    "-X main.version=${version}"
   ];
 
   passthru.tests = {


### PR DESCRIPTION
age-plugin-tpm v1.0.1 added --version cli flag.
Currently, version is reported as `dev` in nixkpgs. This fixes it and reports 1.0.1.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
