### PR TITLE
kernel/modules-closure.sh: depmod fails on Linux 6.12+ due to missing modules.builtin.modinfo

### DIFF
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -107,9 +107,11 @@ fi
 # copy module ordering hints for depmod
 cp $kernel/lib/modules/"$version"/modules.order $out/lib/modules/"$version"/.
 cp $kernel/lib/modules/"$version"/modules.builtin $out/lib/modules/"$version"/.
+cp $kernel/lib/modules/"$version"/modules.builtin.modinfo $out/lib/modules/"$version"/.
 
 depmod -b $out -a $version
 
 # remove original hints from final derivation
 rm $out/lib/modules/"$version"/modules.order
 rm $out/lib/modules/"$version"/modules.builtin
+rm $out/lib/modules/"$version"/modules.builtin.modinfo


### PR DESCRIPTION

## Description
When building a NixOS system with `hardware.enableAllHardware = false;` (which triggers the creation of a shrunk kernel modules closure) using **Linux Kernel 6.12**, the build fails during the `depmod` step.

The error indicates that `depmod` cannot find `modules.builtin.modinfo`:

```
depmod: WARNING: could not open modules.builtin.modinfo at /nix/store/...-linux-6.12.67-modules-shrunk/lib/modules/6.12.67: No such file or directory
```

## Analysis
Starting with newer kernel versions (or newer kmod/depmod versions handling them), `depmod` requires `modules.builtin.modinfo` to be present alongside `modules.builtin` and `modules.order` when generating dependency maps.

The script `pkgs/build-support/kernel/modules-closure.sh` currently copies `modules.order` and `modules.builtin` from the original kernel build, but it misses `modules.builtin.modinfo`.

I verified that the original kernel derivation (`...-linux-6.12.67-modules`) **does** contain the `modules.builtin.modinfo` file, so it just needs to be copied over to the temporary build directory before `depmod` runs.

## Reproduction Steps
You can reproduce this issue using the following steps:

1. Clone the repository:
   ```bash
   git clone https://github.com/shaogme/nixos-images.git
   cd nixos-images
   ```

2. Modify `nix/iso/installer.nix`. Replace the `hardware.enableAllHardware = true;` line (around line 13) with the following configuration to trigger the `modules-shrunk` build:

   ```nix
     hardware.enableAllHardware = false;

     boot.initrd.availableKernelModules = [
       # Storage
       "nvme" "ahci" "xhci_pci" "ehci_pci" "usb_storage" "sd_mod" "sr_mod"
       # VirtIO
       "virtio_blk" "virtio_pci" "virtio_scsi"
       # Input
       "usbhid" "hid_generic"
     ];
   ```

3. Run the build:
   ```bash
   nix-build iso.nix
   ```

## Proposed Fix (Patch)
I have prepared a patch that checks for the existence of `modules.builtin.modinfo` and copies it if present, ensuring `depmod` succeeds.

```diff
diff --git a/pkgs/build-support/kernel/modules-closure.sh b/pkgs/build-support/kernel/modules-closure.sh
index 1234567..89abcdef 100755
--- a/pkgs/build-support/kernel/modules-closure.sh
+++ b/pkgs/build-support/kernel/modules-closure.sh
@@ -107,6 +107,9 @@ fi
 # copy module ordering hints for depmod
 cp $kernel/lib/modules/"$version"/modules.order $out/lib/modules/"$version"/.
 cp $kernel/lib/modules/"$version"/modules.builtin $out/lib/modules/"$version"/.
+if [ -f $kernel/lib/modules/"$version"/modules.builtin.modinfo ]; then
+    cp $kernel/lib/modules/"$version"/modules.builtin.modinfo $out/lib/modules/"$version"/.
+fi
 
 depmod -b $out -a $version
 
@@ -114,3 +117,4 @@ depmod -b $out -a $version
 # remove original hints from final derivation
 rm $out/lib/modules/"$version"/modules.order
 rm $out/lib/modules/"$version"/modules.builtin
+rm -f $out/lib/modules/"$version"/modules.builtin.modinfo
```

cc @NixOS/kernel
