### PR TITLE
glibc: fix darwin-cross-build.patch for glibc 2.42

### DIFF
--- a/pkgs/development/libraries/glibc/darwin-cross-build.patch
+++ b/pkgs/development/libraries/glibc/darwin-cross-build.patch
@@ -3,9 +3,10 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
 * use host version of ar, which is given by environment variable
 * build system uses stamp.os and stamp.oS files, which only differ in case;
   this fails on macOS, so replace .oS with .o_S
---- glibc-2.32/Makefile.in	2018-02-01 17:17:18.000000000 +0100
-+++ glibc-2.32/Makefile.in	2020-12-27 18:21:30.000000000 +0100
-@@ -6,9 +6,11 @@
+
+--- a/Makefile.in	2026-01-26 09:08:32.283335000 +0100
++++ b/Makefile.in	2026-01-26 09:08:44.281448649 +0100
+@@ -17,10 +17,12 @@
  .PHONY: all install bench
  
  all .DEFAULT:
@@ -13,14 +14,27 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
 +	ulimit -n 1024; \
 +	$(MAKE) -r AR=$$AR PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
  
+ check xcheck test:
+-	$(MAKE) -r PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) \
++	ulimit -n 1024; \
++	$(MAKE) -r AR=$$AR PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) \
+ 		CC="$(TEST_CC)" CXX="$(TEST_CXX)" \
+ 		cc-option-wimplicit-fallthrough="$(test-cc-option-wimplicit-fallthrough)" \
+ 		config-cflags-mprefer-vector-width="$(test-config-cflags-mprefer-vector-width)" \
+@@ -33,8 +35,9 @@
+ 		objdir=`pwd` $@
+ 
  install:
 +	ulimit -n 1024; \
  	LC_ALL=C; export LC_ALL; \
- 	$(MAKE) -r PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
+-	$(MAKE) -r PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
++	$(MAKE) -r AR=$$AR PARALLELMFLAGS="$(PARALLELMFLAGS)" -C $(srcdir) objdir=`pwd` $@
  
---- glibc-2.32/Makerules	2018-02-01 17:17:18.000000000 +0100
-+++ glibc-2.32/Makerules	2020-12-27 18:21:30.000000000 +0100
-@@ -847,8 +847,8 @@
+ bench bench-clean bench-build:
+ 	$(MAKE) -C $(srcdir)/benchtests $(PARALLELMFLAGS) objdir=`pwd` $@
+--- a/Makerules	2026-01-26 09:08:32.283426000 +0100
++++ b/Makerules	2026-01-26 09:09:20.363730545 +0100
+@@ -804,8 +804,8 @@
  ifndef objects
  
  # Create the stamp$o files to keep the parent makefile happy.
@@ -31,7 +45,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  	$(make-target-directory)
  	rm -f $@; > $@
  else
-@@ -859,7 +859,7 @@
+@@ -816,7 +816,7 @@
  # The parent will then actually add them all to the archive in the
  # archive rule, below.
  define o-iterator-doit
@@ -40,7 +54,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  endef
  define do-stamp
  $(make-target-directory)
-@@ -875,14 +875,14 @@
+@@ -832,14 +832,14 @@
  # on the stamp files built above.
  define o-iterator-doit
  $(common-objpfx)$(patsubst %,$(libtype$o),c): \
@@ -57,7 +71,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  ifndef subdir
  $(subdirs-stamps): subdir_lib;
  endif
-@@ -893,7 +893,7 @@
+@@ -850,7 +850,7 @@
  # This makes all the object files.
  .PHONY: objects objs libobjs extra-objs
  objects objs: libobjs extra-objs
@@ -66,7 +80,7 @@ enable cross-compilation of glibc on Darwin (build=Darwin, host=Linux)
  extra-objs: $(addprefix $(objpfx),$(extra-objs))
  
  # Canned sequence for building an extra library archive.
-@@ -1499,7 +1499,7 @@
+@@ -1366,7 +1366,7 @@
  	$(rmobjs)
  define rmobjs
  $(foreach o,$(object-suffixes-for-libc),


### PR DESCRIPTION
The darwin-cross-build.patch failed to apply when cross-compiling glibc.

Regenerate the patch against glibc 2.42 sources. Also extend the patch to cover the 'check xcheck test' target which was previously unpatched but needs the same ulimit and AR fixes for consistency.

Tested: nix build --file . pkgsCross.aarch64-multiplatform.glibc
Tested: nix build --file . pkgsCross.gnu64.glibc


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
