### PR TITLE
protonvpn-gui: 4.13.1 -> 4.14.0

### DIFF
--- a/pkgs/by-name/pr/protonvpn-gui/package.nix
+++ b/pkgs/by-name/pr/protonvpn-gui/package.nix
@@ -6,26 +6,26 @@
   libappindicator-gtk3,
   libayatana-appindicator,
   libnotify,
-  wrapGAppsHook3,
+  wrapGAppsHook4,
   withIndicator ? true,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "protonvpn-gui";
-  version = "4.13.1";
+  version = "4.14.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";
     repo = "proton-vpn-gtk-app";
     tag = "v${version}";
-    hash = "sha256-pfk7ttQp7nWpGWqBWny9VdSktpB7RoBJIcF/pF6gAfA=";
+    hash = "sha256-zmtx7lua1VsjRjtGYlkuT+u2rCJt7RQk8JRgVrLWVaM=";
   };
 
   nativeBuildInputs = [
     # Needed for the NM namespace
     gobject-introspection
-    wrapGAppsHook3
+    wrapGAppsHook4
   ];
 
   buildInputs = [


### PR DESCRIPTION
Diff: https://github.com/ProtonVPN/proton-vpn-gtk-app/compare/v4.13.1...v4.14.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
