### PR TITLE
maintainers: Re-add OroraTech maintainers with new ownership approach

### DIFF
--- a/pkgs/development/python-modules/cobs/default.nix
+++ b/pkgs/development/python-modules/cobs/default.nix
@@ -36,5 +36,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://github.com/cmcqueen/cobs-python/";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kip93 ];
   };
 }

--- a/pkgs/development/python-modules/dronecan/default.nix
+++ b/pkgs/development/python-modules/dronecan/default.nix
@@ -27,5 +27,6 @@ buildPythonPackage rec {
     '';
     homepage = "https://dronecan.github.io/";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kip93 ];
   };
 }

--- a/pkgs/development/python-modules/libpcap/default.nix
+++ b/pkgs/development/python-modules/libpcap/default.nix
@@ -62,5 +62,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/karpierz/libpcap/";
     changelog = "https://github.com/karpierz/libpcap/blob/${version}/CHANGES.rst";
     license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ kip93 ];
   };
 }

--- a/pkgs/development/python-modules/pkg-about/default.nix
+++ b/pkgs/development/python-modules/pkg-about/default.nix
@@ -52,5 +52,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/karpierz/pkg_about/";
     changelog = "https://github.com/karpierz/pkg_about/blob/${version}/CHANGES.rst";
     license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ kip93 ];
   };
 }

--- a/pkgs/development/python-modules/pycyphal/default.nix
+++ b/pkgs/development/python-modules/pycyphal/default.nix
@@ -101,5 +101,6 @@ buildPythonPackage rec {
     homepage = "https://opencyphal.org/";
     changelog = "https://github.com/OpenCyphal/pycyphal/blob/${version}/CHANGELOG.rst";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kip93 ];
   };
 }

--- a/pkgs/development/tools/misc/yakut/default.nix
+++ b/pkgs/development/tools/misc/yakut/default.nix
@@ -55,5 +55,6 @@ buildPythonApplication rec {
     '';
     homepage = "https://github.com/OpenCyphal/yakut/";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kip93 ];
   };
 }


### PR DESCRIPTION
Follow up on https://github.com/NixOS/nixpkgs/pull/478835, re-adding maintainer-ship to some packages.

## Things done

Re-added myself and @victormeriqui, as well as @sbc64 as a new addition.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
