### PR TITLE
wine: 10.0->11.0 and wine-staging: 10.20->11.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -147,6 +147,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- Wine has been updated to the 11.0 branch. Please check the [upstream announcement](https://gitlab.winehq.org/wine/wine/-/releases/wine-11.0) for more details.
+
 - Cinnamon has been updated to 6.6, please check the [upstream announcement](https://www.linuxmint.com/rel_zena_whatsnew.php) for more details.
 
 - Budgie has been updated to 10.10, please check the [upstream announcement](https://buddiesofbudgie.org/blog/budgie-10-10-released) for more details.

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -58,6 +58,8 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `opentrack`, `slushload`, `synthesia`, `vtfedit`, `winbox`, `wineasio`, and `yabridge` use wineWow64Packages instead of wineWowPackages as wine versions >= 11.0 have deprecated wineWowPackages. As such, the prefixes for these packages are NOT backwards compatible and need to be regenerated with potential for data loss.
+
 - `services.crabfit` was removed because its upstream packages are unmaintained and insecure.
 
 - `services.tandoor-recipes` now uses a sub-directory for media files by default starting with `26.05`. Existing setups should move media files out of the data directory and adjust `services.tandoor-recipes.extraConfig.MEDIA_ROOT` accordingly. See [Migrating media files for pre 26.05 installations](#module-services-tandoor-recipes-migrating-media).

--- a/nixos/tests/wine.nix
+++ b/nixos/tests/wine.nix
@@ -68,21 +68,12 @@ listToAttrs (
   map (makeWineTest "winePackages" [ hello32 ]) variants
   ++ optionals pkgs.stdenv.hostPlatform.is64bit (
     map
-      (makeWineTest "wineWowPackages" [
+      (makeWineTest "wineWow64Packages" [
         hello32
         hello64
       ])
       # This wayland combination times out after spending many hours.
       # https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.wine.wineWowPackages-wayland.x86_64-linux
       (pkgs.lib.remove "wayland" variants)
-    ++
-      map
-        (makeWineTest "wineWow64Packages" [
-          hello32
-          hello64
-        ])
-        # This wayland combination times out after spending many hours.
-        # https://hydra.nixos.org/job/nixos/trunk-combined/nixos.tests.wine.wineWowPackages-wayland.x86_64-linux
-        (pkgs.lib.remove "wayland" variants)
   )
 )

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -77,7 +77,7 @@ in
       "x86_64-linux"
       "x86_64-darwin"
     ];
-    mainProgram = "wine64";
+    mainProgram = "wine";
   };
   wineWow = callPackage ./base.nix {
     pname = "wine-wow";
@@ -112,7 +112,7 @@ in
       ];
     };
     platforms = [ "x86_64-linux" ];
-    mainProgram = "wine64";
+    mainProgram = "wine";
   };
   wineWow64 = callPackage ./base.nix {
     pname = "wine-wow64";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -142,9 +142,9 @@ rec {
 
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
-    version = "10.20";
-    url = "https://dl.winehq.org/wine/source/10.x/wine-${version}.tar.xz";
-    hash = "sha256-gbShU5WPYkf+UEHV32Xq3Lvuoba6jNok6349fOLR/jw=";
+    version = "11.1";
+    url = "https://dl.winehq.org/wine/source/11.x/wine-${version}.tar.xz";
+    hash = "sha256-v0x8j7XYwfZW8wor6pOHDIXxP/gxGrL2Hd75AOsoy48=";
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
@@ -154,7 +154,7 @@ rec {
     # see https://gitlab.winehq.org/wine/wine-staging
     staging = fetchFromGitLab {
       inherit version;
-      hash = "sha256-Ys0VNYj568qMHq56ZCprnsbpb/iqtiDlU3w0er8Ol5g=";
+      hash = "sha256-KBiESkLVEEWyUPzv1I7j8U9zjqfYdF+FL6wRCcIE290=";
       domain = "gitlab.winehq.org";
       owner = "wine";
       repo = "wine-staging";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -97,9 +97,9 @@ in
 rec {
 
   stable = fetchurl rec {
-    version = "10.0";
-    url = "https://dl.winehq.org/wine/source/10.0/wine-${version}.tar.xz";
-    hash = "sha256-xeCz9ffvr7MOnNTZxiS4XFgxcdM1SdkzzTQC80GsNgE=";
+    version = "11.0";
+    url = "https://dl.winehq.org/wine/source/11.0/wine-${version}.tar.xz";
+    hash = "sha256-wHpoV5M8H8YN/1RI1585ySSBwenbWqYo250DWERuBwE=";
 
     ## see http://wiki.winehq.org/Gecko
     gecko32 = fetchurl rec {
@@ -115,17 +115,15 @@ rec {
 
     ## see http://wiki.winehq.org/Mono
     mono = fetchurl rec {
-      version = "8.1.0";
+      version = "10.0.0";
       url = "https://dl.winehq.org/wine/wine-mono/${version}/wine-mono-${version}-x86.msi";
-      hash = "sha256-DtPsUzrvebLzEhVZMc97EIAAmsDFtMK8/rZ4rJSOCBA=";
+      hash = "sha256-26ynPl0J96OnwVetBCia+cpHw87XAS1GVEpgcEaQK4c=";
     };
 
     patches = [
       # Also look for root certificates at $NIX_SSL_CERT_FILE
       ./cert-path.patch
-    ]
-    ++ patches-binutils-2_44-fix-wine-older-than-10_2
-    ++ patches-add-truncf-to-the-import-library;
+    ];
 
     updateScript = writeShellScript "update-wine-stable" ''
       ${updateScriptPreamble}

--- a/pkgs/by-name/ai/airwave/package.nix
+++ b/pkgs/by-name/ai/airwave/package.nix
@@ -2,7 +2,7 @@
   lib,
   multiStdenv,
   fetchFromGitHub,
-  wineWowPackages,
+  wineWow64Packages,
   cmake,
   makeWrapper,
   file,
@@ -12,7 +12,7 @@
 }:
 
 let
-  wine-wow64 = wineWowPackages.stableFull;
+  wine-wow64 = wineWow64Packages.stableFull;
 in
 multiStdenv.mkDerivation (finalAttrs: {
   pname = "airwave";
@@ -65,7 +65,7 @@ multiStdenv.mkDerivation (finalAttrs: {
     mkdir $out/bin
     mv $out/libexec/airwave-manager $out/bin
     wrapProgram $out/libexec/airwave-host-32.exe --set WINELOADER ${lib.getExe' wine-wow64 "wine"}
-    wrapProgram $out/libexec/airwave-host-64.exe --set WINELOADER ${lib.getExe' wine-wow64 "wine64"}
+    wrapProgram $out/libexec/airwave-host-64.exe --set WINELOADER ${lib.getExe' wine-wow64 "wine"}
   '';
 
   meta = {

--- a/pkgs/by-name/cl/cloudflared/tests.nix
+++ b/pkgs/by-name/cl/cloudflared/tests.nix
@@ -56,7 +56,7 @@ in
       }
       ''
         export HOME="$(mktemp -d)"
-        wine64 $exe help
+        wine $exe help
         mkdir $out
       '';
 }

--- a/pkgs/by-name/dx/dxvk/setup_dxvk.sh
+++ b/pkgs/by-name/dx/dxvk/setup_dxvk.sh
@@ -145,7 +145,7 @@ export WINEDEBUG=-all
 export WINEDLLOVERRIDES="mscoree,mshtml="
 
 wine="wine"
-wine64="wine64"
+wine64="wine"
 wineboot="wineboot"
 
 # $PATH is the way for user to control where wine is located (including custom Wine versions).

--- a/pkgs/by-name/op/opentrack/package.nix
+++ b/pkgs/by-name/op/opentrack/package.nix
@@ -15,7 +15,7 @@
   libxdmcp,
   libevdev,
   makeDesktopItem,
-  wineWowPackages,
+  wineWow64Packages,
   onnxruntime,
   nix-update-script,
   withWine ? stdenv.targetPlatform.isx86_64,
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     qt6.wrapQtAppsHook
   ]
-  ++ lib.optionals withWine [ wineWowPackages.stable ];
+  ++ lib.optionals withWine [ wineWow64Packages.stable ];
 
   buildInputs = [
     finalAttrs.aruco

--- a/pkgs/by-name/sl/slushload/package.nix
+++ b/pkgs/by-name/sl/slushload/package.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchzip,
   makeWrapper,
-  wineWowPackages,
+  wineWow64Packages,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "slushload";
@@ -25,7 +25,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook preInstall
 
     mkdir -p $out/{bin,share}
-    makeWrapper ${wineWowPackages.base}/bin/wine $out/bin/slushload \
+    makeWrapper ${wineWow64Packages.stable}/bin/wine $out/bin/slushload \
       --set WINEDEBUG "-all" \
       --run "export WINEPREFIX=''${XDG_DATA_HOME:-\$HOME/.local/share}/slushload" \
       --add-flags $src/slushload_v3.exe
@@ -42,6 +42,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     mainProgram = "slushload";
+    platforms = wineWow64Packages.stable.meta.platforms;
     maintainers = with lib.maintainers; [ matthewcroughan ];
   };
 })

--- a/pkgs/by-name/sy/synthesia/package.nix
+++ b/pkgs/by-name/sy/synthesia/package.nix
@@ -5,7 +5,7 @@
   runtimeShell,
   copyDesktopItems,
   makeDesktopItem,
-  wineWowPackages,
+  wineWow64Packages,
 }:
 
 let
@@ -36,7 +36,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     copyDesktopItems
-    wineWowPackages.stable
+    wineWow64Packages.stable
   ];
 
   src = fetchurl {
@@ -53,7 +53,7 @@ stdenvNoCC.mkDerivation rec {
     mkdir -p $out/bin
     cat <<'EOF' > $out/bin/synthesia
     #!${runtimeShell}
-    export PATH=${wineWowPackages.stable}/bin:$PATH
+    export PATH=${wineWow64Packages.stable}/bin:$PATH
     export WINEARCH=win64
     export WINEPREFIX="''${SYNTHESIA_HOME:-"''${XDG_DATA_HOME:-"''${HOME}/.local/share"}/synthesia"}/wine"
     export WINEDLLOVERRIDES="mscoree=" # disable mono
@@ -75,6 +75,6 @@ stdenvNoCC.mkDerivation rec {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ ners ];
-    platforms = wineWowPackages.stable.meta.platforms;
+    platforms = wineWow64Packages.stable.meta.platforms;
   };
 }

--- a/pkgs/by-name/vt/vtfedit/package.nix
+++ b/pkgs/by-name/vt/vtfedit/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/vtfedit
 
     cp ${icon} $out/share/icons/hicolor/256x256/apps/vtfedit.png
-    cp -r ${if wine.meta.mainProgram == "wine64" then "x64" else "x86"}/* $out/share/lib
+    cp -r ${if builtins.elem "i686-linux" wine.meta.platforms then "x86" else "x64"}/* $out/share/lib
     cp ${./mimetype.xml} $out/share/mime/packages/vtfedit.xml
 
     runHook postInstall

--- a/pkgs/by-name/vt/vtfedit/package.nix
+++ b/pkgs/by-name/vt/vtfedit/package.nix
@@ -7,11 +7,11 @@
 
   copyDesktopItems,
   makeWrapper,
-  wineWowPackages,
+  wineWow64Packages,
   winetricks,
 }:
 let
-  wine = wineWowPackages.staging;
+  wine = wineWow64Packages.staging;
 in
 stdenv.mkDerivation rec {
   pname = "vtfedit";

--- a/pkgs/by-name/wi/winbox3/package.nix
+++ b/pkgs/by-name/wi/winbox3/package.nix
@@ -22,15 +22,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   version = "3.43";
 
   src = fetchurl (
-    if (wine.meta.mainProgram == "wine64") then
-      {
-        url = "https://download.mikrotik.com/routeros/winbox/${finalAttrs.version}/winbox64.exe";
-        hash = "sha256-W0HPUf2B6NCCaH9rUiFZz0q6IubfjtxIZyHU4JUHtuk=";
-      }
-    else
+    if (builtins.elem "i686-linux" wine.meta.platforms) then
       {
         url = "https://download.mikrotik.com/routeros/winbox/${finalAttrs.version}/winbox.exe";
         hash = "sha256-pAOOTgmjQoXI2o2MKTDuOOpb7q0rb/zWATDNyAMOLms=";
+      }
+    else
+      {
+        url = "https://download.mikrotik.com/routeros/winbox/${finalAttrs.version}/winbox64.exe";
+        hash = "sha256-W0HPUf2B6NCCaH9rUiFZz0q6IubfjtxIZyHU4JUHtuk=";
       }
   );
 

--- a/pkgs/by-name/wi/winbox3/package.nix
+++ b/pkgs/by-name/wi/winbox3/package.nix
@@ -5,11 +5,11 @@
   copyDesktopItems,
   makeDesktopItem,
   makeBinaryWrapper,
-  wineWowPackages,
+  wineWow64Packages,
 }:
 
 let
-  wine = wineWowPackages.stable;
+  wine = wineWow64Packages.stable;
   # The icon is also from the winbox AUR package (see above).
   icon = fetchurl {
     name = "winbox.png";

--- a/pkgs/by-name/wi/wineasio/package.nix
+++ b/pkgs/by-name/wi/wineasio/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   libjack2,
   pkg-config,
-  wineWowPackages,
+  wineWow64Packages,
   pkgsi686Linux,
   python3,
   python3Packages,
@@ -53,7 +53,7 @@ multiStdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    wineWowPackages.stable
+    wineWow64Packages.stable
   ];
 
   buildInputs = [
@@ -63,7 +63,7 @@ multiStdenv.mkDerivation rec {
 
   dontConfigure = true;
 
-  makeFlags = [ "PREFIX=${wineWowPackages.stable}" ];
+  makeFlags = [ "PREFIX=${wineWow64Packages.stable}" ];
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ya/yabridge/package.nix
+++ b/pkgs/by-name/ya/yabridge/package.nix
@@ -8,13 +8,13 @@
   meson,
   ninja,
   pkg-config,
-  wineWowPackages,
+  wineWow64Packages,
   libxcb,
   nix-update-script,
 }:
 
 let
-  wine = wineWowPackages.yabridge;
+  wine = wineWow64Packages.yabridge;
 
   # Derived from subprojects/asio.wrap
   asio = fetchFromGitHub {

--- a/pkgs/by-name/ya/yabridgectl/package.nix
+++ b/pkgs/by-name/ya/yabridgectl/package.nix
@@ -3,7 +3,7 @@
   rustPlatform,
   yabridge,
   makeWrapper,
-  wineWowPackages,
+  wineWow64Packages,
 }:
 
 rustPlatform.buildRustPackage {
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage {
     wrapProgram "$out/bin/yabridgectl" \
       --prefix PATH : ${
         lib.makeBinPath [
-          wineWowPackages.yabridge # winedump
+          wineWow64Packages.yabridge # winedump
         ]
       }
   '';

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1930,6 +1930,11 @@ mapAliases {
   win-pvdrivers = throw "'win-pvdrivers' has been removed as it was subject to the Xen build machine compromise (XSN-01) and has open security vulnerabilities (XSA-468)"; # Added 2025-08-29
   win-virtio = throw "'win-virtio' has been renamed to/replaced by 'virtio-win'"; # Converted to throw 2025-10-27
   wineWayland = throw "'wineWayland' has been renamed to/replaced by 'wine-wayland'"; # Converted to throw 2025-10-27
+  wineWowPackages =
+    warnAlias
+      "'wineWowPackages' is deprecated as it is no longer preferred by upstream. Use wineWow64Packages instead"
+      lib.recurseIntoAttrs
+      (winePackagesFor "wineWow");
   wingpanel-indicator-ayatana = throw "'wingpanel-indicator-ayatana' has been removed as it is archived upstream and doesn't work with pantheon 8 and onwards. Use wingpanel-indicator-namarupa instead"; # Added 2026-01-14
   winhelpcgi = throw "'winhelpcgi' has been removed as it was unmaintained upstream and broken with GCC 14"; # Added 2025-06-14
   wireshark-qt = warnAlias "'wireshark-qt' has been renamed to/replaced by 'wireshark'" wireshark; # Added 2026-01-23

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12851,7 +12851,6 @@ with pkgs;
 
   winePackages = recurseIntoAttrs (winePackagesFor (config.wine.build or "wine32"));
   wine64Packages = recurseIntoAttrs (winePackagesFor "wine64");
-  wineWowPackages = recurseIntoAttrs (winePackagesFor "wineWow");
   wineWow64Packages = recurseIntoAttrs (winePackagesFor "wineWow64");
 
   wine = winePackages.full;


### PR DESCRIPTION
updated the wine package sources, they build okay but i'm not sure what to do with this tidbit:

"The new WoW64 mode that was first introduced as experimental feature in
Wine 9.0 is considered fully supported, and essentially has feature parity
with the old WoW64 mode.

16-bit applications are supported in the new WoW64 mode.

It is possible to force an old WoW64 installation to run in new WoW64 mode
by setting the variable WINEARCH=wow64. This requires the prefix to have
been created as 64-bit (the default).

Pure 32-bit prefixes created with WINEARCH=win32 are deprecated, and are
not supported in new WoW64 mode.

The wine64 loader binary is removed, in favor of a single wine loader
that selects the correct mode based on the binary being executed. For
binaries that have both 32-bit and 64-bit versions installed, it defaults
to 64-bit. The 32-bit version can then be launched with an explicit path,
e.g. wine c:\\windows\\syswow64\\notepad.exe."

does this mean that we can get rid of wine64 and wine packages in favor of just wow64packages and wowpackages? 

closes https://github.com/NixOS/nixpkgs/issues/480828

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
