### PR TITLE
nixos: Fix modules meta.maintainers issues

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15729,7 +15729,7 @@
     github = "M0streng0";
     githubId = 85799811;
   };
-  m0ustache3 = {
+  M0ustach3 = {
     name = "M0ustach3";
     github = "M0ustach3";
     githubId = 37956764;

--- a/nixos/modules/programs/dsearch.nix
+++ b/nixos/modules/programs/dsearch.nix
@@ -49,5 +49,5 @@ in
     systemd.user.services.dsearch.wantedBy = mkIf cfg.systemd.enable [ cfg.systemd.target ];
   };
 
-  meta.maintainers = lib.teams.danklinux.maintainers;
+  meta.maintainers = lib.teams.danklinux.members;
 }

--- a/nixos/modules/programs/wayland/dms-shell.nix
+++ b/nixos/modules/programs/wayland/dms-shell.nix
@@ -226,5 +226,5 @@ in
     hardware.graphics.enable = lib.mkDefault true;
   };
 
-  meta.maintainers = lib.teams.danklinux.maintainers;
+  meta.maintainers = lib.teams.danklinux.members;
 }

--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -294,5 +294,5 @@ in
     services.libinput.enable = mkDefault true;
   };
 
-  meta.maintainers = lib.teams.danklinux.maintainers;
+  meta.maintainers = lib.teams.danklinux.members;
 }

--- a/nixos/modules/services/misc/memos.nix
+++ b/nixos/modules/services/misc/memos.nix
@@ -195,5 +195,5 @@ in
     };
   };
 
-  meta.maintainers = [ lib.maintainers.m0ustach3 ];
+  meta.maintainers = [ lib.maintainers.M0ustach3 ];
 }

--- a/nixos/modules/services/security/crowdsec.nix
+++ b/nixos/modules/services/security/crowdsec.nix
@@ -984,7 +984,7 @@ in
 
   meta = {
     maintainers = with lib.maintainers; [
-      m0ustach3
+      M0ustach3
       tornax
       jk
     ];


### PR DESCRIPTION
The rationale is simple: this should work:

```
nix-instantiate --strict --eval --json ./nixos --arg configuration '{}' --attr config.meta.maintainers
```

It does not.

```
error:
       … while evaluating the attribute 'value'
         at /.../nixos-unstable/lib/modules.nix:1118:7:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |       ^
         1119|       inherit (res.defsFinal') highestPrio;

       … while calling the 'addErrorContext' builtin
         at /.../nixos-unstable/lib/modules.nix:1118:15:
         1117|     // {
         1118|       value = addErrorContext "while evaluating the option `${showOption loc}':" value;
             |               ^
         1119|       inherit (res.defsFinal') highestPrio;

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: attribute 'maintainers' missing
       at /.../nixos-unstable/nixos/modules/services/display-managers/dms-greeter.nix:297:42:
          296|
          297|   meta.maintainers = lib.teams.danklinux.maintainers;
             |                                          ^
          298| }
```

~~The first commit adds a check to prevent this from happening again.~~ This became non-trivial, so this is pushed aside for a future PR.

The commits are fixing the issues encountered. The danklinux entries are self-evident, so no need to ping @LuckShiba about it I guess.

As for @M0ustach3, I took the liberty of using the casing from your GitHub username for your fixed maintainers-list entry, since `handle == github` is preferred. If that's not desirable, please tell me what to use instead.

* * *

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

> **NOTE**: Left everything other than the last item unchecked because this is purely eval-time, with apparently no current tests.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
