### PR TITLE
python3Packages.furo: 2025.07.19 -> 2025.12.19,  allow use of nodejs to be overridden

### DIFF
--- a/pkgs/development/python-modules/furo/default.nix
+++ b/pkgs/development/python-modules/furo/default.nix
@@ -14,6 +14,7 @@
   sphinx,
   sphinx-basic-ng,
   unzip,
+  useWebNative ? (lib.meta.availableOn stdenv.buildPlatform nodejs),
 }:
 
 let
@@ -76,7 +77,7 @@ let
     '';
   };
 
-  web = if (lib.meta.availableOn stdenv.buildPlatform nodejs) then web-native else web-bin;
+  web = if useWebNative then web-native else web-bin;
 in
 
 buildPythonPackage rec {

--- a/pkgs/development/python-modules/furo/default.nix
+++ b/pkgs/development/python-modules/furo/default.nix
@@ -18,7 +18,7 @@
 
 let
   pname = "furo";
-  version = "2025.07.19";
+  version = "2025.12.19";
   # version on pypi doesn't have month & day padded with 0
   pypiVersion =
     let
@@ -38,7 +38,7 @@ let
     owner = "pradyunsg";
     repo = "furo";
     tag = version;
-    hash = "sha256-pIF5zrh5YbkuSkrateEB/tDULSNbeVn2Qx+Fm3nOYGE=";
+    hash = "sha256-s9CQXmHI3PoXbB24e8rUd9ip02UZTjPHP4Ar6hV3mUc=";
   };
 
   web-bin =
@@ -49,7 +49,7 @@ let
         format = "wheel";
         dist = "py3";
         python = "py3";
-        hash = "sha256-veqGmCLf0rSU6oTAlzk3410Vda8Ii2chopx/eHityeM=";
+        hash = "sha256-uw6tUwn5UAEwZlomvuh2k8Qc5Nvf+GTb+2sNrkZz0k8=";
       };
     in
     runCommand "${pname}-web-bin"


### PR DESCRIPTION
It would be nice to be able to disable the use of `nodejs` more easily - the functionality is almost there already!

I'm not too sure yet what the best name of the added function argument would be.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
