### PR TITLE
winetricks: 20250102 -> 20260125

### DIFF
--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -254,8 +254,8 @@ rec {
 
   winetricks = fetchFromGitHub rec {
     # https://github.com/Winetricks/winetricks/releases
-    version = "20250102";
-    hash = "sha256-Km2vVTYsLs091cjmNTW8Kqku3vdsEA0imTtZfqZWDQo=";
+    version = "20260125";
+    hash = "sha256-uIBVESebsH7rXnxWd/qlrZxcG7Y486PctHzcLz29HDk=";
     owner = "Winetricks";
     repo = "winetricks";
     rev = version;

--- a/pkgs/applications/emulators/wine/winetricks.nix
+++ b/pkgs/applications/emulators/wine/winetricks.nix
@@ -11,13 +11,13 @@
   gnugrep,
   gnused,
   gnutar,
-  unrar-free,
   gzip,
   p7zip,
   perl,
   unzip,
   which,
   zenity,
+  unrar-free,
   versionCheckHook,
 }:
 
@@ -33,28 +33,12 @@ stdenv.mkDerivation rec {
     makeWrapper
   ];
 
-  # coreutils is for sha1sum
-  pathAdd = lib.makeBinPath [
-    perl
-    which
-    coreutils
-    zenity
-    curl
-    cabextract
-    unzip
-    p7zip
-    gnused
-    gnugrep
-    bash
-    gawk
-    gnutar
-    gzip
-    unrar-free
-  ];
-
   makeFlags = [ "PREFIX=$(out)" ];
 
   doCheck = false; # requires "bashate"
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   postPatch = ''
     patchShebangs src/winetricks


### PR DESCRIPTION
updated winetricks to 20260125, released yesterday

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
