### PR TITLE
lttoolbox: 3.7.6 -> 3.8.2

### DIFF
--- a/pkgs/by-name/lt/lttoolbox/package.nix
+++ b/pkgs/by-name/lt/lttoolbox/package.nix
@@ -2,10 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
-  autoreconfHook,
-  autoconf,
-  automake,
+  cmake,
   pkg-config,
   utf8cpp,
   libtool,
@@ -16,19 +13,17 @@
 
 stdenv.mkDerivation rec {
   pname = "lttoolbox";
-  version = "3.7.6";
+  version = "3.8.2";
 
   src = fetchFromGitHub {
     owner = "apertium";
     repo = "lttoolbox";
     tag = "v${version}";
-    hash = "sha256-T92TEhrWwPYW8e49rc0jfM0C3dmNYtuexhO/l5s+tQ0=";
+    hash = "sha256-g9mWHd9MzVKg/6zF7Fh7owFM3uX9vOQzX0IkrEzr5LY=";
   };
 
   nativeBuildInputs = [
-    autoreconfHook
-    autoconf
-    automake
+    cmake
     pkg-config
     utf8cpp
     libtool
@@ -40,12 +35,19 @@ stdenv.mkDerivation rec {
   buildFlags = [
     "CPPFLAGS=-I${utf8cpp}/include/utf8cpp"
   ];
+  cmakeFlags = [
+  ];
+
+  # Workaround based on
+  # https://github.com/NixOS/nixpkgs/issues/144170#issuecomment-1423195220
+  # for https://github.com/apertium/lttoolbox/issues/207
+  preInstall = ''
+    sed -i.tmp 's,[$$]{\(exec_\)*prefix}//nix/store,/nix/store,' ./lttoolbox.pc
+    rm ./lttoolbox.pc.tmp
+  '';
 
   nativeCheckInputs = [ python3 ];
   doCheck = true;
-  checkPhase = ''
-    python3 tests/run_tests.py
-  '';
 
   meta = {
     description = "Finite state compiler, processor and helper tools used by apertium";


### PR DESCRIPTION
Upgrade to newest release; autoconf was replaced with cmake in upstream lttoolbox.

Minor preInstall patch for https://github.com/NixOS/nixpkgs/issues/144170

`checkPhase` no longer needed, as default `make test` runs the package tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
