### PR TITLE
bentopdf: init at 1.11.2, nixos/bentopdf: init, nixosTests.bentopdf: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -30,6 +30,8 @@
 
 - [nohang](https://github.com/hakavlad/nohang), a daemon for Linux that prevents out of memory (OOM) situations from affecting system responsiveness. Available as [services.nohang](#opt-services.nohang.enable)
 
+- [bentopdf](https://github.com/alam00000/bentopdf), a privacy-first PDF toolkit running completely in-browser. Available as [services.bentopdf](#opt-services.bentopdf.enable).
+
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).
 
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1586,6 +1586,7 @@
   ./services/web-apps/artalk.nix
   ./services/web-apps/audiobookshelf.nix
   ./services/web-apps/baikal.nix
+  ./services/web-apps/bentopdf.nix
   ./services/web-apps/bluemap.nix
   ./services/web-apps/bluesky-pds.nix
   ./services/web-apps/bookstack.nix

--- a/nixos/modules/services/web-apps/bentopdf.nix
+++ b/nixos/modules/services/web-apps/bentopdf.nix
@@ -1,0 +1,112 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.bentopdf;
+in
+{
+  options.services.bentopdf = {
+    enable = lib.mkEnableOption "bentopdf Privacy First PDF Toolkit";
+
+    package = lib.mkPackageOption pkgs "bentopdf" {
+      extraDescription = ''
+        To use the "normal mode" variant of bentopdf, which includes all socials, marketing and explanatory texts, set this option to `pkgs.bentopdf.override { simpleMode = false; }`.
+      '';
+    };
+
+    domain = lib.mkOption {
+      description = "Domain to use for the virtual host.";
+      type = lib.types.str;
+    };
+
+    nginx = {
+      enable = lib.mkEnableOption "a virtualhost to serve bentopdf through nginx";
+
+      virtualHost = lib.mkOption {
+        type = lib.types.submodule (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
+        default = { };
+        example = lib.literalExpression ''
+          {
+            serverAliases = [ "bentopdf.''${config.networking.domain}" ];
+          }
+        '';
+        description = "Extra configuration for the nginx virtual host of bentopdf.";
+      };
+    };
+
+    caddy = {
+      enable = lib.mkEnableOption "a virtualhost to serve bentopdf through caddy";
+
+      virtualHost = lib.mkOption {
+        type = lib.types.submodule (
+          import ../web-servers/caddy/vhost-options.nix { cfg = config.services.caddy; }
+        );
+        default = { };
+        example = lib.literalExpression ''
+          {
+            serverAliases = [ "bentopdf.''${config.networking.domain}" ];
+          }
+        '';
+        description = "Extra configuration for the caddy virtual host of bentopdf.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.nginx = lib.mkIf cfg.nginx.enable {
+      enable = lib.mkDefault true;
+      virtualHosts."${cfg.domain}" = lib.mkMerge [
+        cfg.nginx.virtualHost
+        {
+          root = lib.mkForce "${cfg.package}";
+
+          locations."/" = {
+            index = "index.html";
+            extraConfig = ''
+              try_files $uri $uri/ /index.html;
+            '';
+          };
+
+          locations."~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$".extraConfig = ''
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+          '';
+        }
+      ];
+    };
+
+    services.caddy = lib.mkIf cfg.caddy.enable {
+      enable = lib.mkDefault true;
+      virtualHosts."${cfg.domain}" = lib.mkMerge [
+        cfg.caddy.virtualHost
+        {
+          hostName = lib.mkForce cfg.domain;
+          extraConfig = ''
+            root * ${cfg.package}
+            try_files {path} /index.html
+            file_server
+
+            @static {
+              path_regexp static \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$
+            }
+            handle @static {
+              header {
+                Cache-Control "public, immutable"
+              }
+              header Cache-Control max-age=31536000
+            }
+          '';
+        }
+      ];
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [
+    charludo
+    stunkymonkey
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -274,6 +274,7 @@ in
   beanstalkd = runTest ./beanstalkd.nix;
   bees = runTest ./bees.nix;
   benchexec = runTest ./benchexec.nix;
+  bentopdf = handleTest ./bentopdf { };
   beszel = runTest ./beszel.nix;
   binary-cache = runTest {
     imports = [ ./binary-cache.nix ];

--- a/nixos/tests/bentopdf/caddy.nix
+++ b/nixos/tests/bentopdf/caddy.nix
@@ -1,0 +1,28 @@
+import ../make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "bentopdf-caddy";
+    meta.maintainers = with lib.maintainers; [ stunkymonkey ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.bentopdf = {
+          enable = true;
+          domain = "localhost:80";
+          caddy.enable = true;
+          caddy.virtualHost.extraConfig = "tls internal";
+        };
+        # disable letsencrypt cert fetching
+        services.caddy.globalConfig = "auto_https disable_certs";
+      };
+
+    testScript = ''
+      machine.wait_for_unit("caddy.service")
+      machine.wait_for_open_port(80)
+      machine.succeed("curl -vvv --fail --show-error --silent --location --insecure http://localhost/")
+      assert "<title>BentoPDF - The Privacy First PDF Toolkit</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost/")
+    '';
+  }
+)

--- a/nixos/tests/bentopdf/default.nix
+++ b/nixos/tests/bentopdf/default.nix
@@ -1,0 +1,6 @@
+{ system, pkgs, ... }:
+
+{
+  caddy = import ./caddy.nix { inherit system pkgs; };
+  nginx = import ./nginx.nix { inherit system pkgs; };
+}

--- a/nixos/tests/bentopdf/nginx.nix
+++ b/nixos/tests/bentopdf/nginx.nix
@@ -1,0 +1,24 @@
+import ../make-test-python.nix (
+  { lib, ... }:
+
+  {
+    name = "bentopdf-nginx";
+    meta.maintainers = with lib.maintainers; [ stunkymonkey ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.bentopdf = {
+          enable = true;
+          domain = "localhost";
+          nginx.enable = true;
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("nginx.service")
+      machine.wait_for_open_port(80)
+      assert "<title>BentoPDF - The Privacy First PDF Toolkit</title>" in machine.succeed("curl --fail --show-error --silent --location --insecure http://localhost:80/")
+    '';
+  }
+)

--- a/pkgs/by-name/be/bentopdf/package.nix
+++ b/pkgs/by-name/be/bentopdf/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  simpleMode ? true,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "bentopdf";
+  # We intentionally don't update the version, due to:
+  # https://github.com/NixOS/nixpkgs/issues/484067
+  # nixpkgs-update: no auto update
+  version = "1.11.2";
+
+  src = fetchFromGitHub {
+    owner = "alam00000";
+    repo = "bentopdf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-br4My0Q4zoA+ZIrXM4o4oQjZ7IpSdwg+iKiAUdc2B/s=";
+  };
+  npmDepsHash = "sha256-UNNNYO7e7qdumI0/ka2ieFZzKURPl1V3981vHCPcVfY=";
+
+  npmBuildFlags = [
+    "--"
+    "--mode"
+    "production"
+  ];
+
+  env.SIMPLE_MODE = lib.boolToString simpleMode;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r dist/* $out/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Privacy-first PDF toolkit";
+    homepage = "https://bentopdf.com";
+    changelog = "https://github.com/alam00000/bentopdf/releases";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      charludo
+      stunkymonkey
+    ];
+  };
+})

--- a/pkgs/by-name/be/bentopdf/package.nix
+++ b/pkgs/by-name/be/bentopdf/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nixosTests,
   simpleMode ? true,
 }:
 buildNpmPackage (finalAttrs: {
@@ -35,6 +36,10 @@ buildNpmPackage (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    inherit (nixosTests.bentopdf) caddy nginx;
+  };
 
   meta = {
     description = "Privacy-first PDF toolkit";


### PR DESCRIPTION
follow up of #454213

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
