### PR TITLE
lazykube: init at 0.10.3

### DIFF
--- a/pkgs/by-name/la/lazykube/package.nix
+++ b/pkgs/by-name/la/lazykube/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "lazykube";
+  version = "0.10.3";
+
+  src = fetchFromGitHub {
+    owner = "TNK-Studio";
+    repo = "lazykube";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xfGzbjaH7dHeLWEaoRcYx5Gc3w4a4Kk1a1gG/EbXmSg=";
+  };
+
+  vendorHash = "sha256-3D+CElXHJv1WmBnO32hS4vW5VXXlNR3LwyGMtQJh3xs=";
+
+  subPackages = [ "cmd/lazykube" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Simple terminal UI for managing Kubernetes";
+    longDescription = ''
+      lazykube is a terminal-based UI for Kubernetes that provides an easy way to
+      browse and manage Kubernetes clusters with mouse and keyboard navigation.
+    '';
+    homepage = "https://github.com/TNK-Studio/lazykube";
+    changelog = "https://github.com/TNK-Studio/lazykube/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+    mainProgram = "lazykube";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adding lazykube, a terminal UI for Kubernetes cluster management.

Homepage: https://github.com/TNK-Studio/lazykube

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
