### PR TITLE
exo: 1.0.65 -> 1.0.67

### DIFF
--- a/pkgs/by-name/ex/exo/package.nix
+++ b/pkgs/by-name/ex/exo/package.nix
@@ -18,13 +18,13 @@
   nix-update-script,
 }:
 let
-  version = "1.0.65";
+  version = "1.0.67";
   src = fetchFromGitHub {
     name = "exo";
     owner = "exo-explore";
     repo = "exo";
     tag = "v${version}";
-    hash = "sha256-Zj174EySIILdj7+QJVT6ZGYvjO+jXHj+GizVsve2lFk=";
+    hash = "sha256-hipCiAqCkkyrVcQXEZKbGoVbgjM3hykUcazNPEbT+q8=";
   };
 
   pyo3-bindings = python3Packages.buildPythonPackage (finalAttrs: {
@@ -55,6 +55,10 @@ let
     enabledTestPaths = [
       "rust/exo_pyo3_bindings/tests/"
     ];
+
+    # RuntimeError
+    # Attempted to create a NULL object
+    doCheck = !stdenv.hostPlatform.isDarwin;
   });
 
   dashboard = buildNpmPackage (finalAttrs: {
@@ -72,6 +76,19 @@ let
         ;
       fetcherVersion = 2;
       hash = "sha256-3ZgE1ysb1OeB4BNszvlrnYcc7gOo7coPfOEQmMHC6E0=";
+    };
+  });
+
+  # exo requires building mlx-lm from its main branch to use the kimi-k2.5 model
+  mlx-lm-unstable = python3Packages.mlx-lm.overridePythonAttrs (old: {
+    version = "0.30.4-unstable-2026-01-27";
+    src = old.src.override {
+      rev = "96699e6dadb13b82b28285bb131a0741997d19ae";
+      tag = null;
+      hash = "sha256-L1ws8XA8VhR18pRuRGbVal/yEfJaFNW8QzS16C1dFpE=";
+    };
+    meta = old.meta // {
+      changelog = "https://github.com/ml-explore/mlx-lm/releases/tag/v0.30.5";
     };
   });
 in
@@ -134,7 +151,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
       loguru
       mflux
       mlx
-      mlx-lm
+      mlx-lm-unstable
       nvidia-ml-py
       openai
       openai-harmony


### PR DESCRIPTION
## Things done

Diff: https://github.com/exo-explore/exo/compare/v1.0.65...v1.0.67
Changelogs:
- https://github.com/exo-explore/exo/releases/tag/v1.0.66
- https://github.com/exo-explore/exo/releases/tag/v1.0.67

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test