### PR TITLE
prek: 0.2.30 -> 0.3.0

### DIFF
--- a/pkgs/by-name/pr/prek/package.nix
+++ b/pkgs/by-name/pr/prek/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "prek";
-  version = "0.2.30";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "j178";
     repo = "prek";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-IqFUJNFs7a/M9IUNEwW40EZTAh+6a5Ov37xg5c9iwRc=";
+    hash = "sha256-J4onCCHZ6DT2CtZ8q0nrdOI74UGDJhVFG2nWj+p7moE=";
   };
 
-  cargoHash = "sha256-KOpQ3P9cmcWYT3bPKtKpzHPagX4b9hH0EiWGpt98NnE=";
+  cargoHash = "sha256-pR5NibzX5m8DcMxer0W1wowTJCesYaF852wpGiVboVg=";
 
   nativeCheckInputs = [
     git
@@ -81,6 +81,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "rust::remote_hooks_with_lib_deps"
         "unsupported::unsupported_language"
         "remote_hook_non_workspace"
+        "bun::additional_dependencies"
+        "bun::basic_bun"
         # "meta_hooks"
         "reuse_env"
         "docker::docker"
@@ -144,6 +146,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "no_commit_to_branch_hook_with_patterns"
         "check_executables_have_shebangs_various_cases"
         "check_executables_have_shebangs_hook"
+        "cache_gc_removes_unreferenced_entries"
         # does not properly use TMP
         "hook_impl"
         # problems with environment
@@ -162,6 +165,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
         # https://github.com/astral-sh/uv/issues/8635
         "alternate_config_file"
         "basic_discovery"
+        "cache_gc_keeps_local_hook_env"
         "color"
         "cookiecutter_template_directories_are_skipped"
         "empty_entry"


### PR DESCRIPTION
Changelog: https://github.com/j178/prek/releases/tag/v0.3.0
Diff: https://github.com/j178/prek/compare/v0.2.30...v0.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
