### PR TITLE
cups-brother-dcpl2620dw: init at 4.1.0-1

### DIFF
--- a/pkgs/by-name/cu/cups-brother-dcpl2620dw/fix-perm.patch
+++ b/pkgs/by-name/cu/cups-brother-dcpl2620dw/fix-perm.patch
@@ -1,0 +1,10 @@
+--- a/opt/brother/Printers/DCPL2620DW/cupswrapper/lpdwrapper
++++ b/opt/brother/Printers/DCPL2620DW/cupswrapper/lpdwrapper
+@@ -387,6 +387,7 @@ my $temprch;
+ close $temprch;
+ 
+ `cp  $basedir/inf/br${PRINTER}rc  $TEMPRC`;
++`chmod 666  $TEMPRC`;
+ $ENV{BRPRINTERRCFILE} = $TEMPRC;
+ 
+ logprint( 0 , "TEMPRC    = $TEMPRC\n");

--- a/pkgs/by-name/cu/cups-brother-dcpl2620dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpl2620dw/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  perl,
+  gnused,
+  ghostscript,
+  file,
+  coreutils,
+  gnugrep,
+  which,
+}:
+
+let
+  arches = [
+    "x86_64"
+    "i686"
+  ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-dcpl2620dw";
+  version = "4.1.0-1";
+  model = "DCPL2620DW";
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [ perl ];
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf106010/dcpl2620dwpdrv-${version}.i386.deb";
+    hash = "sha256-jl+Fh6wDzdHp768WivHEG1/KsIzly1c8bMLsYZgc8yo=";
+  };
+
+  patches = [
+    # The brother lpdwrapper uses a temporary file to convey the printer settings.
+    # The original settings file will be copied with "400" permissions and the "brprintconflsr3"
+    # binary cannot alter the temporary file later on. This fixes the permissions so the can be modified.
+    # Since this is all in briefly in the temporary directory of systemd-cups and not accessible by others,
+    # it shouldn't be a security concern.
+    ./fix-perm.patch
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -ar opt $out/opt
+    # delete unnecessary files for the current architecture
+  ''
+  + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/${model}/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches)
+  + ''
+    # bundled scripts don't understand the arch subdirectories for some reason
+    ln -s \
+      "$out/opt/brother/Printers/${model}/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+      "$out/opt/brother/Printers/${model}/lpd/"
+
+    # Fix global references and replace auto discovery mechanism with hardcoded values
+    substituteInPlace $out/opt/brother/Printers/${model}/lpd/lpdfilter \
+      --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/${model}\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+    substituteInPlace $out/opt/brother/Printers/${model}/cupswrapper/lpdwrapper \
+      --replace "my \$basedir = C" "my \$basedir = \"$out/opt/brother/Printers/${model}\" ; #" \
+      --replace "PRINTER =~" "PRINTER = \"${model}\"; #"
+
+    # Make sure all executables have the necessary runtime dependencies available
+    find "$out" -executable -and -type f | while read file; do
+      wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+    done
+
+    # Symlink filter and ppd into a location where CUPS will discover it
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+    mkdir -p $out/etc/opt/brother/Printers/${model}/inf
+
+    ln -s $out/opt/brother/Printers/${model}/inf/br${model}rc \
+          $out/etc/opt/brother/Printers/${model}/inf/br${model}rc
+    ln -s \
+      $out/opt/brother/Printers/${model}/cupswrapper/lpdwrapper \
+      $out/lib/cups/filter/brother_lpdwrapper_${model}
+    ln -s \
+      $out/opt/brother/Printers/${model}/cupswrapper/brother-${model}-cups-en.ppd \
+      $out/share/cups/model/
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother ${model} printer driver";
+    license = lib.licenses.unfree;
+    platforms = map (arch: "${arch}-linux") arches;
+    maintainers = with lib.maintainers; [ husjon ];
+  };
+}


### PR DESCRIPTION
Based on the `cups-brother-hll2375dw` drivers as they were the closest.
Added model variable to reduce repetition.

Currently in use in my own flake using my branch as an overlay https://codeberg.org/husjon/nixos-config/src/branch/main/configuration/default.nix#L102-L104 (overlay defined in `flake.nix`)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
