### PR TITLE
dell-530cdn: set pname and version instead of name

### DIFF
--- a/pkgs/by-name/de/dell-530cdn/package.nix
+++ b/pkgs/by-name/de/dell-530cdn/package.nix
@@ -12,9 +12,14 @@ let
     sha256 = "0pj32sj6jcdnpa5v75af0hnvx4z0ky0m1k2522cfdx4cb1r2lna9";
   };
 in
-runCommand "Dell-5130cdn-Color-Laser-1.3-1" { } ''
-  mkdir -p usr/share/cups/model
-  ${rpm}/bin/rpm2cpio ${src} | ${cpio}/bin/cpio -i
-  mkdir -p $out/share/ppd
-  mv usr/share/cups/model/Dell $out/share/ppd
-''
+runCommand "Dell-5130cdn-Color-Laser-${version}"
+  {
+    pname = "dell-5130cdn-color-laser";
+    inherit version;
+  }
+  ''
+    mkdir -p usr/share/cups/model
+    ${rpm}/bin/rpm2cpio ${src} | ${cpio}/bin/cpio -i
+    mkdir -p $out/share/ppd
+    mv usr/share/cups/model/Dell $out/share/ppd
+  ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
