### PR TITLE
abseil-cpp: Rename to abseil-cpp_202508

### DIFF
--- a/pkgs/by-name/ab/abseil-cpp/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp/package.nix
@@ -1,50 +1,8 @@
-{
-  lib,
-  stdenv,
-  fetchFromGitHub,
-  cmake,
-  gtest,
-  static ? stdenv.hostPlatform.isStatic,
-  cxxStandard ? null,
-}:
+# Some packages, such as or-tools, strictly require a specific LTS
+# branch of abseil-cpp, and will be broken by arbitrary upgrades.  See
+# also https://abseil.io/about/compatibility, which confirms “Each LTS
+# release should be considered to be a new major version of the
+# library.”  Therefore, we keep packages `abseil-cpp_YYYYMM` for each
+# required LTS branch, leaving `abseil-cpp` as an alias.
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "abseil-cpp";
-  version = "20250814.1";
-
-  src = fetchFromGitHub {
-    owner = "abseil";
-    repo = "abseil-cpp";
-    tag = finalAttrs.version;
-    hash = "sha256-SCQDORhmJmTb0CYm15zjEa7dkwc+lpW2s1d4DsMRovI=";
-  };
-
-  outputs = [
-    "out"
-    "dev"
-  ];
-
-  cmakeFlags = [
-    (lib.cmakeBool "ABSL_BUILD_TEST_HELPERS" true)
-    (lib.cmakeBool "ABSL_USE_EXTERNAL_GOOGLETEST" true)
-    (lib.cmakeBool "BUILD_SHARED_LIBS" (!static))
-  ]
-  ++ lib.optionals (cxxStandard != null) [
-    (lib.cmakeFeature "CMAKE_CXX_STANDARD" cxxStandard)
-  ];
-
-  strictDeps = true;
-
-  nativeBuildInputs = [ cmake ];
-
-  buildInputs = [ gtest ];
-
-  meta = {
-    description = "Open-source collection of C++ code designed to augment the C++ standard library";
-    homepage = "https://abseil.io/";
-    changelog = "https://github.com/abseil/abseil-cpp/releases/tag/${finalAttrs.version}";
-    license = lib.licenses.asl20;
-    platforms = lib.platforms.all;
-    maintainers = [ lib.maintainers.GaetanLepage ];
-  };
-})
+{ abseil-cpp_202508 }: abseil-cpp_202508

--- a/pkgs/by-name/ab/abseil-cpp_202508/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp_202508/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gtest,
+  static ? stdenv.hostPlatform.isStatic,
+  cxxStandard ? null,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "abseil-cpp";
+  version = "20250814.1";
+
+  src = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    tag = finalAttrs.version;
+    hash = "sha256-SCQDORhmJmTb0CYm15zjEa7dkwc+lpW2s1d4DsMRovI=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ABSL_BUILD_TEST_HELPERS" true)
+    (lib.cmakeBool "ABSL_USE_EXTERNAL_GOOGLETEST" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!static))
+  ]
+  ++ lib.optionals (cxxStandard != null) [
+    (lib.cmakeFeature "CMAKE_CXX_STANDARD" cxxStandard)
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gtest ];
+
+  meta = {
+    description = "Open-source collection of C++ code designed to augment the C++ standard library";
+    homepage = "https://abseil.io/";
+    changelog = "https://github.com/abseil/abseil-cpp/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.GaetanLepage ];
+  };
+})


### PR DESCRIPTION
Some packages, such as or-tools, strictly require a specific LTS branch of abseil-cpp, and will be broken by arbitrary upgrades. See also https://abseil.io/about/compatibility, which confirms “Each LTS release should be considered to be a new major version of the library.”

(or-tools 9.14 currently uses abseil-cpp_202505 but the 9.15 upgrade will need abseil-cpp_202508.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
