### PR TITLE
python3Packages.scikit-survival: use finalAttrs, skip failing test on aarch64-linux

### DIFF
--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -85,6 +85,10 @@ buildPythonPackage (finalAttrs: {
     "test_survival_svm"
     "test_tree"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+    # Flaky numerical assertion (AssertionError)
+    "test_baseline_predict"
+  ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
     # floating point mismatch on aarch64
     # 27079905.88052468 to far from 27079905.880496684

--- a/pkgs/development/python-modules/scikit-survival/default.nix
+++ b/pkgs/development/python-modules/scikit-survival/default.nix
@@ -25,7 +25,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "scikit-survival";
   version = "0.26.0";
   pyproject = true;
@@ -33,7 +33,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "sebp";
     repo = "scikit-survival";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-xtrGFNRHF8bL8Q82gIQLayuCSDFMrBBkQ63F+Nmbdes=";
   };
 
@@ -94,8 +94,8 @@ buildPythonPackage rec {
   meta = {
     description = "Survival analysis built on top of scikit-learn";
     homepage = "https://github.com/sebp/scikit-survival";
-    changelog = "https://github.com/sebp/scikit-survival/releases/tag/v${version}";
+    changelog = "https://github.com/sebp/scikit-survival/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.scikit-survival: use finalAttrs**
- **python3Packages.scikit-survival: skip failing test on aarch64-linux**

---

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
