### PR TITLE
gtest: Add optional abseil-cpp support

### DIFF
--- a/pkgs/by-name/gt/gtest/package.nix
+++ b/pkgs/by-name/gt/gtest/package.nix
@@ -4,6 +4,9 @@
   fetchFromGitHub,
   cmake,
   ninja,
+  withAbseil ? false,
+  abseil-cpp,
+  re2,
   # Enable C++17 support
   #     https://github.com/google/googletest/issues/3081
   # Projects that require a higher standard can override this package.
@@ -47,6 +50,10 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     ninja
+  ]
+  ++ lib.optionals withAbseil [
+    abseil-cpp
+    re2
   ];
 
   cmakeFlags = [
@@ -54,7 +61,8 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals (cxx_standard != null) [
     "-DCMAKE_CXX_STANDARD=${cxx_standard}"
-  ];
+  ]
+  ++ lib.optional withAbseil "-DGTEST_HAS_ABSL=ON";
 
   meta = {
     description = "Google's framework for writing C++ tests";


### PR DESCRIPTION
or-tools 9.15 will require gtest built with abseil-cpp, but abseil-cpp itself requires gtest built without abseil-cpp to avoid infinite recursion, so make it configurable (defaulting to false to reduce rebuilds).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
