### PR TITLE
pgdog: init at 0.1.28

### DIFF
--- a/pkgs/by-name/pg/pgdog/package.nix
+++ b/pkgs/by-name/pg/pgdog/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  useMoldLinker,
+  versionCheckHook,
+  withMold ? with clangStdenv.hostPlatform; isUnix && !isDarwin,
+}:
+let
+  stdenv = if withMold then useMoldLinker clangStdenv else clangStdenv;
+in
+rustPlatform.buildRustPackage.override { inherit stdenv; } (finalAttrs: {
+  pname = "pgdog";
+  version = "0.1.28";
+
+  src = fetchFromGitHub {
+    owner = "pgdogdev";
+    repo = "pgdog";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3TRpjLlyS9XKqBPCUqW0ilwaMiAXRzg1RdF9x3GYnxY=";
+  };
+
+  cargoHash = "sha256-iqUB9m2MXbl4rgwTH2TYF6lqbpkMFng5pUAzUXzhhJs=";
+
+  # Hardcoded paths for C compiler and linker
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  cargoBuildFlags = [
+    "--package"
+    "pgdog"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  strictDeps = true;
+
+  # Several tests rely on networking
+  doCheck = false;
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "PostgreSQL connection pooler, load balancer, and database sharder";
+    homepage = "https://pgdog.dev/";
+    changelog = "https://github.com/pgdogdev/pgdog/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "pgdog";
+    maintainers = with lib.maintainers; [ EpicEric ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
PgDog is a sharder, connection pooler and load balancer for PostgreSQL written in Rust. An alternative to PgBouncer.

https://pgdog.dev/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
