### PR TITLE
ci/github-script/reviews: detect reviews belonging to commits.js

### DIFF
--- a/ci/github-script/reviews.js
+++ b/ci/github-script/reviews.js
@@ -66,7 +66,13 @@ async function dismissReviews({ github, context, core, dry, reviewKey }) {
     changesRequestedReviews.every(
       (review) =>
         commentResolvedRegex.test(review.body) ||
-        (reviewKey && reviewKeyRegex.test(review.body)),
+        (reviewKey && reviewKeyRegex.test(review.body)) ||
+        // If we are called by check-commits and the review body is clearly
+        // from `commits.js`, then we can safely dismiss the review.
+        // This helps with pre-existing reviews (before the comments were added).
+        (reviewKey &&
+          reviewKey === 'check-commits' &&
+          review.body.includes('PR / Check / cherry-pick')),
     )
   ) {
     reviewsToDismiss = changesRequestedReviews


### PR DESCRIPTION
See comment, but TLDR this is for backwards-compatibility.

(See #479628, where it failed to dismiss after I had fixed the cherry-pick, at least until I manually added the needed comment.)

We don't bother detecting `prepare.js` because it always errors when leaving reviews (and so should never be dismissed).

Because there are so few, I have simply added the needed comments to each of `check-target-branch.js`'s pre-existing reviews instead of trying to detect them.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
