### PR TITLE
clickable: Skip test that expects /tmp to never be symlink

### DIFF
--- a/pkgs/by-name/cl/clickable/package.nix
+++ b/pkgs/by-name/cl/clickable/package.nix
@@ -21,6 +21,8 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-W6NPZ5uP7wGjgyA+Nv2vpmshKWny2CCSrn/Gaoi7Pr4=";
   };
 
+  __structuredAttrs = true;
+
   build-system = [ python3Packages.setuptools ];
 
   dependencies = with python3Packages; [
@@ -40,14 +42,18 @@ python3Packages.buildPythonApplication rec {
   ];
 
   disabledTests =
-    # Tests require running docker daemon
     [
+      # Require running docker daemon
       "test_cpp_plugin"
       "test_godot_plugin"
       "test_html"
       "test_python"
       "test_qml_only"
       "test_rust"
+
+      # Expects /tmp to exist and not be a symlink
+      # https://gitlab.com/clickable/clickable/-/issues/479
+      "TestReviewCommand and test_run and not test_run_with_path_arg"
     ]
     # Tests do not work on non-amd64 platforms
     ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [

--- a/pkgs/by-name/cl/clickable/package.nix
+++ b/pkgs/by-name/cl/clickable/package.nix
@@ -50,9 +50,20 @@ python3Packages.buildPythonApplication rec {
     "TestReviewCommand and test_run and not test_run_with_path_arg"
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [
-    # hardcode amd64
-    "TestArchitectures and test_arch and not test_arch_agnostic"
-    "TestArchitectures and test_restricted_arch and not test_restricted_arch_env"
+    # pytest's lack of exact nodeid matching or deselecting makes it impossible to nicely disable just
+    # test_architectures.py::TestArchitectures::test_arch (infix matching makes test_arch match test_architectures.py).
+    # Have to `or` for every other TestArchitectures test and then `not` that.
+    # What we want to disable: test_arch & test_restricted_arch
+    # Reason: they hardcode amd64
+    "TestArchitectures and not (${
+      lib.strings.concatStringsSep " or " [
+        "test_arch_agnostic"
+        "test_default_arch"
+        "test_fail_arch_agnostic"
+        "test_fail_in_restricted_arch"
+        "test_restricted_arch_env"
+      ]
+    })"
 
     # no -ide images on non-x86_64
     # https://gitlab.com/clickable/clickable/-/issues/478

--- a/pkgs/by-name/cl/clickable/package.nix
+++ b/pkgs/by-name/cl/clickable/package.nix
@@ -41,37 +41,27 @@ python3Packages.buildPythonApplication rec {
     which
   ];
 
-  disabledTests =
-    [
-      # Require running docker daemon
-      "test_cpp_plugin"
-      "test_godot_plugin"
-      "test_html"
-      "test_python"
-      "test_qml_only"
-      "test_rust"
+  disabledTests = [
+    # Requires running docker daemon
+    "TestTemplates"
 
-      # Expects /tmp to exist and not be a symlink
-      # https://gitlab.com/clickable/clickable/-/issues/479
-      "TestReviewCommand and test_run and not test_run_with_path_arg"
-    ]
-    # Tests do not work on non-amd64 platforms
-    ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [
-      # hardcode amd64
-      "test_arch"
-      "test_restricted_arch"
+    # Expects /tmp to exist and not be a symlink
+    # https://gitlab.com/clickable/clickable/-/issues/479
+    "TestReviewCommand and test_run and not test_run_with_path_arg"
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isx86_64) [
+    # hardcode amd64
+    "TestArchitectures and test_arch and not test_arch_agnostic"
+    "TestArchitectures and test_restricted_arch and not test_restricted_arch_env"
 
-      # no -ide images on arm64
-      # https://gitlab.com/clickable/clickable/-/issues/478
-      "test_command_overrided"
-      "test_init_cmake_project"
-      "test_init_cmake_project_exe_as_var"
-      "test_init_cmake_project_no_exe"
-      "test_init_cmake_project_no_to_prompt"
-      "test_initialize_qtcreator_conf"
-      "test_project_pre_configured"
-      "test_recurse_replace"
-    ];
+    # no -ide images on non-x86_64
+    # https://gitlab.com/clickable/clickable/-/issues/478
+    "TestIdeQtCreatorCommand and test_command_overrided"
+    "TestIdeQtCreatorCommand and test_init_cmake_project"
+    "TestIdeQtCreatorCommand and test_initialize_qtcreator_conf"
+    "TestIdeQtCreatorCommand and test_project_pre_configured"
+    "TestIdeQtCreatorCommand and test_recurse_replace"
+  ];
 
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 


### PR DESCRIPTION
Follow-up to #482861

Darwin is currently failing, due to `/tmp` there being a symlink: https://hydra.nixos.org/build/320456109
Situation reported upstream: https://gitlab.com/clickable/clickable/-/issues/479

Enabled `__structuredAttrs` so we can disable just the failing test. This also lets us be more precise with the other tests that we disable, so I threw that in here as well.

Tested locally on aarch64-linux. pytest's options for disabling tests kinda suck upon closer inspection, so disabling *just* the failing tests got messy…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
