### PR TITLE
supercell-wx: fix build with gcc14 pin

### DIFF
--- a/pkgs/by-name/su/supercell-wx/package.nix
+++ b/pkgs/by-name/su/supercell-wx/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   replaceVars,
   tracy,
@@ -33,6 +34,8 @@
   zlib,
 }:
 let
+  buildStdenv = if stdenv.cc.isGNU then gcc14Stdenv else stdenv;
+
   gtestSkip = [
     # Skip tests requiring network access
     "AwsLevel*DataProvider.FindKeyFixed"
@@ -54,7 +57,7 @@ let
     "MarkerModelTest.*"
   ];
 in
-stdenv.mkDerivation (finalAttrs: {
+buildStdenv.mkDerivation (finalAttrs: {
   pname = "supercell-wx";
   version = "0.5.3";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes build of `supercell-wx` which was broken by `stdenv` defaulting to GCC 15. For now, pinning it to GCC 14.

Related: #475479

First found in: #476455

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
