### PR TITLE
sonarr: add packaging info and fix install dir

### DIFF
--- a/pkgs/by-name/so/sonarr/package.nix
+++ b/pkgs/by-name/so/sonarr/package.nix
@@ -62,6 +62,8 @@ buildDotnetModule {
   pname = "sonarr";
   inherit version src;
 
+  # Upstream expects to be ran from a "bin" directory
+  installPath = "${placeholder "out"}/lib/sonarr/bin";
   strictDeps = true;
   nativeBuildInputs = [
     nodejs
@@ -87,12 +89,18 @@ buildDotnetModule {
     yarn --offline run build --env production
   '';
   postInstall =
+    let
+      packageInfo = writers.writeText "package_info" ''
+        PackageVersion=${version}
+        PackageAuthor=[NixOS](https://nixos.org)
+      '';
+    in
     lib.optionalString withFFmpeg ''
-      rm -- "$out/lib/sonarr/ffprobe"
-      ln -s -- "$ffprobe" "$out/lib/sonarr/ffprobe"
+      ln -sf -- "$ffprobe" "$out/lib/sonarr/bin/ffprobe"
     ''
     + ''
-      cp -a -- _output/UI "$out/lib/sonarr/UI"
+      cp -a -- _output/UI "$out/lib/sonarr/bin/UI"
+      ln -s ${packageInfo} $out/lib/sonarr/package_info
     '';
   # Add an alias for compatibility with Sonarr v3 package.
   postFixup = ''


### PR DESCRIPTION
Upstream provides `PackageAuthor` and `PackageVersion` for packagers, docker images, etc. This is presumably to help with debugging, and considering how much this package has diverged from upstream, we should provide this info.

In addition, there are some assumptions in code that Sonarr is always running from a directory called "bin", this was not the case with this package, so the output has been moved one level deeper.

### Screenshot: System -> Status

<img width="378" height="164" alt="image" src="https://github.com/user-attachments/assets/4279a795-7f22-4f59-ab8d-0786dca61343" />

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

/cc @fadenb @purcell @tie @niklaskorz