### PR TITLE
reindeer: add amaanq to maintainers

### DIFF
--- a/pkgs/by-name/re/reindeer/package.nix
+++ b/pkgs/by-name/re/reindeer/package.nix
@@ -31,6 +31,6 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "reindeer";
     homepage = "https://github.com/facebookincubator/reindeer";
     license = with lib.licenses; [ mit ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ amaanq ];
   };
 }


### PR DESCRIPTION
## Changes

- Closes #483713

This PR adds myself as a maintainer of `reindeer`, a tool that transforms Cargo deps to Buck build rules. Per the linked issue, Nick wanted to remove himself as a maintainer, and I volunteered to maintain it in his stead.