### PR TITLE
mpd-mpris: apply upstream fix

### DIFF
--- a/pkgs/by-name/mp/mpd-mpris/package.nix
+++ b/pkgs/by-name/mp/mpd-mpris/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  fetchpatch,
 }:
 
 buildGoModule (finalAttrs: {
@@ -18,6 +19,13 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-ugJEw02jSsfObljDaup31zoQlf2HvwDRUljD7lp7Ys4=";
 
   subPackages = [ "cmd/mpd-mpris" ];
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/natsukagami/mpd-mpris/commit/1591f15548aed0f9741d723f24fb505cb24fafe8.patch";
+      hash = "sha256-6ZqR4woKiIjwLxyafmidTM8eBXtvBzKNXZvtS1+KKKI=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace services/mpd-mpris.service --replace-fail "ExecStart=" "ExecStart=$out/bin/"


### PR DESCRIPTION
Applies https://github.com/natsukagami/mpd-mpris/pull/76, which fixes a difficult-to-diagnose bug where mpd skips the last half-second or so of every track.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
