### PR TITLE
workflows/eval: Un-parallelize misc, fixing check, and add modules meta check

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -453,10 +453,9 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@4e002c8ec80594ecd40e759629461e26c8abed15 # v31
 
-      - name: Run misc eval tasks in parallel
+      - name: Ensure flake outputs on all systems still evaluate
+        run: nix flake check --all-systems --no-build './nixpkgs/untrusted?shallow=1'
+
+      - name: Query nixpkgs with aliases enabled to check for basic syntax errors
         run: |
-          # Ensure flake outputs on all systems still evaluate
-          nix flake check --all-systems --no-build './nixpkgs/untrusted?shallow=1' &
-          # Query nixpkgs with aliases enabled to check for basic syntax errors
-          nix-env -I ./nixpkgs/untrusted -f ./nixpkgs/untrusted -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null &
-          wait
+          time nix-env -I ./nixpkgs/untrusted -f ./nixpkgs/untrusted -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -459,3 +459,7 @@ jobs:
       - name: Query nixpkgs with aliases enabled to check for basic syntax errors
         run: |
           time nix-env -I ./nixpkgs/untrusted -f ./nixpkgs/untrusted -qa '*' --option restrict-eval true --option allow-import-from-derivation false >/dev/null
+
+      - name: Ensure NixOS modules meta is valid
+        run: |
+          time nix-instantiate -I ./nixpkgs/untrusted --strict --eval --json ./nixpkgs/untrusted/nixos --arg configuration '{}' --attr config.meta --option restrict-eval true --option allow-import-from-derivation false


### PR DESCRIPTION
This change is two-fold:

 - Quickly fix the “misc” check that was broken by #436171.

> In https://github.com/samueldr-at-cyberus/nixpkgs/commit/3d9cb9f3553b74d5fbbaa467dc96c6994daf95d0 (https://github.com/NixOS/nixpkgs/pull/436171), the two check
> commands were combined in the same step, and backgrounded, `wait`ing on
> their completion.
> 
> `help wait` states the following:
> 
> > If ID is not given, waits for all currently active child processes,
> > and the return status is zero.
> 
> The result was that this check's misc check results were accidentally
> thrown away. Oops.

 - Add a “misc” check for NixOS modules `meta` data.

* * *

I would have preferred to keep the misc checks parallelized, but the implementation got kinda hairy, and I don't want to be the one pinged for the follow-up breakage. So the simple solution is to revert the breakage.

Then, on top of that, while working on tooling to [check that third-party modules are actually no-ops](https://github.com/cyberus-ctrl-os/ctrl-os-modules/blob/cbfd630f8817bc258b8fb4f88df60476def6d5fb/lib/check-modules-no-ops.nix), I noticed that evaluation errors slipped into the NixOS modules `meta` data. The issues are resolved in #436171.

I opened this as a separate PR as I am *very unfamiliar* with how the checks are actually implemented, what with the `nixpkgs/untrusted` checkout, ~~and apparently this check being ran from the target branch, rather than the PR branch?~~ and apparently my "fix" I tried quickly must have been wrong, because this failed as expected. ~~I do not know how to properly verify that this is appropriate, and didn't want to needlessly block on the fix to be merged~~.

Unless an alternative is done quickly and correctly, I believe the revert should be merged ASAP, and the re-parallelization done with due care.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

> **NOTE:** Everything else left unchecked since this is a CI change.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
