### PR TITLE
pantheon.switchboard-with-plugs: enable strictDeps

### DIFF
--- a/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard/wrapper.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     glib
+    lndir
     wrapGAppsHook4
   ];
 
@@ -47,11 +48,12 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
   allowSubstitutes = false;
+  strictDeps = true;
 
   installPhase = ''
     mkdir -p $out
     for i in $(cat $pathsPath); do
-      ${lndir}/bin/lndir -silent $i $out
+      lndir -silent $i $out
     done
 
     dbus_file="share/dbus-1/services/io.elementary.settings.service"


### PR DESCRIPTION
motivated by https://github.com/NixOS/nixpkgs/issues/178468

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
