### PR TITLE
python3Packages.py-key-value-aio: drop pytest-xdist due to test crashes

### DIFF
--- a/pkgs/development/python-modules/py-key-value-aio/default.nix
+++ b/pkgs/development/python-modules/py-key-value-aio/default.nix
@@ -58,7 +58,6 @@
   inline-snapshot,
   py-key-value-shared-test,
   pytest-asyncio,
-  pytest-xdist,
   pytestCheckHook,
 }:
 
@@ -81,6 +80,18 @@ buildPythonPackage (finalAttrs: {
       --replace-fail \
         "uv_build>=0.8.2,<0.9.0" \
         "uv_build"
+  ''
+  # Tests fail when using pytest-xdist ('Worker crashes')
+  # https://github.com/strawgate/py-key-value/issues/266
+  + ''
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        '"-n=auto",' \
+        ""
+    substituteInPlace pyproject.toml \
+      --replace-fail \
+        '"--dist=loadfile",' \
+        ""
   '';
 
   build-system = [
@@ -160,7 +171,6 @@ buildPythonPackage (finalAttrs: {
     inline-snapshot
     py-key-value-shared-test
     pytest-asyncio
-    pytest-xdist
     pytestCheckHook
   ]
   ++ finalAttrs.passthru.optional-dependencies.disk
@@ -183,6 +193,10 @@ buildPythonPackage (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # keyring.errors.PasswordSetError: Can't store password on keychain: (-61, 'Unknown Error')
     "tests/stores/keyring/test_keyring.py"
+
+    # Worker crashes
+    # https://github.com/strawgate/py-key-value/issues/266
+    "tests/stores/rocksdb/test_rocksdb.py"
   ];
 
   meta = {


### PR DESCRIPTION
async tests crash randomly, see https://github.com/strawgate/py-key-value/issues/266

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
