### PR TITLE
medusa: refresh source hash for GCC 15 fix

### DIFF
--- a/pkgs/by-name/me/medusa/package.nix
+++ b/pkgs/by-name/me/medusa/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "jmk-foofus";
     repo = "medusa";
     tag = finalAttrs.version;
-    hash = "sha256-devirQMmS8mtxT5H5XafRRvCyfcvwoWxtTp0V1SJeSM=";
+    hash = "sha256-ftn5RBE3NYfjXLq8Gm92sbFW+M925BDuL/VmwfPYXpo=";
   };
 
   outputs = [


### PR DESCRIPTION
The 2.3 tag appears to have been updated (force-pushed?) after nixpkgs originally packaged it (nixpkgs commit e02b2d8 on March 7, 2025 predates the official 2.3 release on May 14, 2025). The current tag includes GCC 15 fixes from upstream (PR 76, 82) that were merged after the nixpkgs tag.

This commit updates the hash to fetch the corrected source with proper function pointer types that are compatible with GCC 15's stricter checking.

- Fixes #481545

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
