### PR TITLE
wild-unwrapped: add `ld.wild` symlink

### DIFF
--- a/pkgs/by-name/wi/wild-unwrapped/package.nix
+++ b/pkgs/by-name/wi/wild-unwrapped/package.nix
@@ -33,6 +33,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env.ZSTD_SYS_USE_PKG_CONFIG = true;
 
+  postInstall = ''
+    ln -s wild $out/bin/ld.wild
+  '';
+
   doCheck = false; # Tests are ran in passthru tests
 
   doInstallCheck = true;


### PR DESCRIPTION
This commit allows using wild with `-fuse-ld=wild` in clang and rustc. Upstream [documents](https://github.com/davidlattimore/wild#using-as-your-default-linker) that this symlink is required for the flag to work.

- Fixes #481471

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
