### PR TITLE
ad: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/by-name/ad/ad/package.nix
+++ b/pkgs/by-name/ad/ad/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "ad";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "sminez";
     repo = "ad";
     tag = version;
-    sha256 = "0rd4krklpnvaimzblqx2ckab6lk4apkmvnqr618gnx8i5f4nyl6m";
+    hash = "sha256-t9zhNAmUkjjVabaBlP/dGMHY11lxC3qqg0N0HK4nz2I=";
   };
 
-  cargoHash = "sha256:12g3fcym8184py66fgwahpb9q05dm9r9rbhh4l50yd62gkmifc93";
+  cargoHash = "sha256-T1y7Xnyhet3a/Obb4RJ+iJE4wWpmQf0fnhxfTzM6dm0=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -25,6 +25,8 @@ rustPlatform.buildRustPackage rec {
     # both assume `/usr/bin/sh` exists
     "--skip=buffer::tests::try_expand_known_works::file_that_exists_abs_path"
     "--skip=buffer::tests::try_expand_known_works::file_that_exists_abs_path_with_addr"
+    # integration tests require filesystem and Unix socket access
+    "--skip=editor_scenarios::"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/ad/ad/package.nix
+++ b/pkgs/by-name/ad/ad/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ad";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "sminez";
     repo = "ad";
     tag = finalAttrs.version;
-    sha256 = "0rd4krklpnvaimzblqx2ckab6lk4apkmvnqr618gnx8i5f4nyl6m";
+    hash = "sha256-t9zhNAmUkjjVabaBlP/dGMHY11lxC3qqg0N0HK4nz2I=";
   };
 
-  cargoHash = "sha256:12g3fcym8184py66fgwahpb9q05dm9r9rbhh4l50yd62gkmifc93";
+  cargoHash = "sha256-T1y7Xnyhet3a/Obb4RJ+iJE4wWpmQf0fnhxfTzM6dm0=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -25,6 +25,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # both assume `/usr/bin/sh` exists
     "--skip=buffer::tests::try_expand_known_works::file_that_exists_abs_path"
     "--skip=buffer::tests::try_expand_known_works::file_that_exists_abs_path_with_addr"
+    # integration tests require filesystem and Unix socket access
+    "--skip=editor_scenarios::"
   ];
 
   postInstall = ''


### PR DESCRIPTION
This commit bumps ad to 0.4.0. It also skips the `editor_scenarios` integration tests as they require Unix socket access which is unavailable in the sandbox.

- Fixes #482856

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
