### PR TITLE
python3Packages.syrupy: 5.0.0 -> 5.1.0

### DIFF
--- a/pkgs/development/python-modules/syrupy/default.nix
+++ b/pkgs/development/python-modules/syrupy/default.nix
@@ -1,8 +1,10 @@
 {
   lib,
+  attrs,
   buildPythonPackage,
   fetchFromGitHub,
   poetry-core,
+  pydantic,
   pytest,
   pytest-xdist,
   invoke,
@@ -10,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "syrupy";
-  version = "5.0.0";
+  version = "5.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "syrupy-project";
     repo = "syrupy";
     tag = "v${version}";
-    hash = "sha256-TRwU9+2RvZB2gbVm82DzLge8QoDflxjavcRdYZUgVfs=";
+    hash = "sha256-oogH5Q+0leZsfu/7r3tZmB2rxjcUOmGAsn4Z50oSlH8=";
   };
 
   build-system = [ poetry-core ];
@@ -25,7 +27,9 @@ buildPythonPackage rec {
   buildInputs = [ pytest ];
 
   nativeCheckInputs = [
+    attrs
     invoke
+    pydantic
     pytest
     pytest-xdist
   ];


### PR DESCRIPTION
Diff: https://github.com/syrupy-project/syrupy/compare/v5.0.0...v5.1.0

Changelog: https://github.com/syrupy-project/syrupy/blob/v5.1.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
