### PR TITLE
vanilla-dmz: add missing cursor symlinks, add amaanq to maintainers

### DIFF
--- a/pkgs/by-name/va/vanilla-dmz/package.nix
+++ b/pkgs/by-name/va/vanilla-dmz/package.nix
@@ -43,6 +43,19 @@ stdenvNoCC.mkDerivation rec {
     for theme in DMZ-{White,Black}; do
       mkdir -p $out/share/icons/$theme/cursors
       cp -a $theme/xcursors/* $out/share/icons/$theme/cursors/
+
+      pushd $out/share/icons/$theme/cursors
+      ln -s bottom_left_corner sw-resize
+      ln -s bottom_right_corner se-resize
+      ln -s bottom_side s-resize
+      ln -s left_ptr default
+      ln -s left_side w-resize
+      ln -s right_side e-resize
+      ln -s top_left_corner nw-resize
+      ln -s top_right_corner ne-resize
+      ln -s top_side n-resize
+      popd
+
       install -m644 $theme/index.theme $out/share/icons/$theme/index.theme
     done
 

--- a/pkgs/by-name/va/vanilla-dmz/package.nix
+++ b/pkgs/by-name/va/vanilla-dmz/package.nix
@@ -70,6 +70,6 @@ stdenvNoCC.mkDerivation rec {
     description = "Style neutral scalable cursor theme";
     platforms = lib.platforms.all;
     license = lib.licenses.cc-by-sa-30;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ amaanq ];
   };
 }


### PR DESCRIPTION
This PR adds symlinks for resize cursors and the default pointer, which
improves compatibility with GTK applications like Firefox and Thunderbird. I've also addedd myself as a maintainer of the package, as no one is maintaining it.

- Fixes #452489

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
