### PR TITLE
entt: 3.14.0 -> 3.16.0

### DIFF
--- a/pkgs/by-name/en/entt/package.nix
+++ b/pkgs/by-name/en/entt/package.nix
@@ -6,16 +6,18 @@
 }:
 stdenv.mkDerivation rec {
   pname = "entt";
-  version = "3.14.0";
+  version = "3.16.0";
 
   src = fetchFromGitHub {
     owner = "skypjack";
     repo = "entt";
     rev = "v${version}";
-    hash = "sha256-IPAM7fr/tvSOMKWUbXbloNAnlp5t7J0ynSsTMZ2jKYs=";
+    hash = "sha256-i4K7NigYPYAOsVLhtjQJFmm9LoWiTg39F8SIBRuv4Vg=";
   };
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DENTT_INSTALL=ON" ];
 
   meta = {
     homepage = "https://github.com/skypjack/entt";

--- a/pkgs/by-name/en/entt/package.nix
+++ b/pkgs/by-name/en/entt/package.nix
@@ -6,16 +6,18 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "entt";
-  version = "3.14.0";
+  version = "3.16.0";
 
   src = fetchFromGitHub {
     owner = "skypjack";
     repo = "entt";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-IPAM7fr/tvSOMKWUbXbloNAnlp5t7J0ynSsTMZ2jKYs=";
+    hash = "sha256-i4K7NigYPYAOsVLhtjQJFmm9LoWiTg39F8SIBRuv4Vg=";
   };
 
   nativeBuildInputs = [ cmake ];
+
+  cmakeFlags = [ "-DENTT_INSTALL=ON" ];
 
   meta = {
     homepage = "https://github.com/skypjack/entt";


### PR DESCRIPTION
This commits bumps entt to 3.16.0, Additionally, upstream changed the install target to be opt-in via the `ENTT_INSTALL` flag, so we set that to `ON`.

- Fixes #479163

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
