### PR TITLE
nixtamal: init at 0.1.1-beta

### DIFF
--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  fetchdarcs,
+  python3Packages,
+  ocamlPackages,
+  makeBinaryWrapper,
+  coreutils,
+  nix-prefetch-darcs,
+  nix-prefetch-git,
+  nix-prefetch-pijul,
+  testers,
+  nixtamal,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "nixtamal";
+  version = "0.1.1-beta";
+  release_year = 2026;
+
+  minimalOCamlVersion = "5.3";
+
+  src = fetchdarcs {
+    url = "https://darcs.toastal.in.th/nixtamal/stable/";
+    mirrors = [ "https://smeder.ee/~toastal/nixtamal.darcs" ];
+    rev = finalAttrs.version;
+    hash = "sha256-8HrW7VH2LAcTyduGfToC3+oqU7apILdvgd76c8r8NIw=";
+  };
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    # For manpages
+    python3Packages.docutils
+    python3Packages.pygments
+  ];
+
+  buildInputs = with ocamlPackages; [
+    camomile
+    cmdliner
+    eio
+    eio_main
+    fmt
+    jingoo
+    (jsont.override {
+      withBrr = false;
+      withBytesrw = true;
+    })
+    kdl
+    logs
+    ppx_deriving
+    ppx_deriving_qcheck
+    saturn
+    stdint
+    uri
+  ];
+
+  checkInputs = with ocamlPackages; [
+    alcotest
+    qcheck
+    qcheck-alcotest
+  ];
+
+  postPatch = ''
+    substituteInPlace bin/main.ml --subst-var version
+    substituteInPlace lib/lock_loader.ml --subst-var release_year
+  '';
+
+  doCheck = true;
+
+  postInstall = ''
+    wrapProgram "$out/bin/nixtamal" --prefix PATH : ${
+      lib.makeBinPath [
+        coreutils
+        nix-prefetch-darcs
+        nix-prefetch-git
+        nix-prefetch-pijul
+      ]
+    }
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = nixtamal;
+    command = "${nixtamal.meta.mainProgram} --version";
+  };
+
+  meta = {
+    license = with lib.licenses; [ gpl3Plus ];
+    platforms = lib.platforms.unix;
+    mainProgram = "nixtamal";
+    homepage = "https://nixtamal.toast.al";
+    changelog = "https://nixtamal.toast.al/changelog/";
+    description = "Fulfilling, pure input pinning for Nix";
+    longDescription = ''
+      Nixtamal’s keys features
+
+      • Automate the manual work of input pinning, allowing to lock & refresh inputs
+      • Declaritive KDL manifest file over imperative CLI flags
+      • Host, forge, VCS-agnostic
+      • Fetchers from Nixpkgs not supported by the builtins (currently Darcs, Pijul)
+      • Supports mirrors
+      • Override hash algorithm on a per-project & per-input basis — including BLAKE3 support
+      • Custom freshness commands
+      • No experimental Nix features required
+    '';
+    maintainers = with lib.maintainers; [ toastal ];
+  };
+})


### PR DESCRIPTION
New package

<!--
^ Please summarize the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
