### PR TITLE
git: use Rust where possible

### DIFF
--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -51,7 +51,7 @@
   deterministic-host-uname, # trick Makefile into targeting the host platform when cross-compiling
   doInstallCheck ? !stdenv.hostPlatform.isDarwin, # extremely slow on darwin
   tests,
-  rustSupport ? false,
+  rustSupport ? lib.meta.availableOn stdenv.hostPlatform rustc,
   cargo,
   rustc,
 }:

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1147,6 +1147,7 @@ with pkgs;
     osxkeychainSupport = false;
     pythonSupport = false;
     perlSupport = false;
+    rustSupport = false; # Needed for bootstrap
     withpcre2 = false;
   };
 


### PR DESCRIPTION
Future versions of Git are going to require Rust, and Rust was added as a "test balloon" in v2.52.0 so downstream distributions -- such as ourselves -- can start ironing out the problems.  Support for this was added as an option in #476300 / 0869356f401a (git: add rust opt-in, 2025-12-31), but the default packaging wasn't changed at that time.

To get as much exposure for that as possible, default to enabling compilation with Rust where possible.  There are two exceptions that don't currently work:

- gitMinimal, which is currently required to build Rust, so cannot depend on it without creating a circular dependency.  Fixing that bootstrap issue is a future project.
- Platforms that don't have any support for Rust.  There's not much we can do about those, but add a warning when detecting Rust support so users affected are hopefully not caught *completely* off-guard when Git mandates Rust.

I've verified the full bootstrap works on aarch64-linux, including checking FODs can still be built correctly, by doing a bootstrap build of gitMinimal, git, gitSVN and gitFull:

1.  Create an empty directory with `mktemp -d --tmpdir nix-store-test.XXXXX`
2.  Build each package in turn with `nix-build -A <package> --no-substitute --store <test-store-dir>`

I have also – with the benefit of the public binary cache – run the full suite of tests in `git.passthru.tests`, which includes `tests.fetchgit` and `nixosTests.buildbot`.

I haven't included a release note, as this shouldn't be a breaking change and I don't think it counts as "major", but I'd be very happy to write one if others disagree.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
