### PR TITLE
node-glob: maintenance, move to new binary repository

### DIFF
--- a/pkgs/by-name/no/node-glob/package.nix
+++ b/pkgs/by-name/no/node-glob/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "glob";
-  version = "10.3.3";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "isaacs";
-    repo = "node-glob";
+    repo = "glob-bin";
     rev = "v${version}";
-    hash = "sha256-oLlNhQOnu/hlKjNWa5vjqslz1EarZJOpUEXUB+vGQvc=";
+    hash = "sha256-PW2XzV+vT9NlHAwE3JriEYqoZjsuJFXFk0SlfA/7dIw=";
   };
 
-  npmDepsHash = "sha256-78oODw+CBCk5JRJbDqLqVmzTVImP7Z7o6jRIimDxZDQ=";
+  npmDepsHash = "sha256-BJVDfld/EmeRxHlmPByaQ3BO3PyoeHhklEjztcHFTvg=";
 
   dontNpmBuild = true;
 
@@ -23,8 +23,8 @@ buildNpmPackage rec {
     changelog = "https://github.com/isaacs/node-glob/blob/${src.rev}/changelog.md";
     description = "Little globber for Node.js";
     homepage = "https://github.com/isaacs/node-glob";
-    license = lib.licenses.isc;
-    mainProgram = "glob";
+    license = lib.licenses.blueOak100;
+    mainProgram = "glob-bin";
     maintainers = [ ];
   };
 }

--- a/pkgs/by-name/no/node-glob/package.nix
+++ b/pkgs/by-name/no/node-glob/package.nix
@@ -25,6 +25,6 @@ buildNpmPackage rec {
     homepage = "https://github.com/isaacs/node-glob";
     license = lib.licenses.blueOak100;
     mainProgram = "glob-bin";
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.kashw2 ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The version of this package currently available in nixpkgs is over two years old at this point. This updates it to a release from 2 months ago.

The upstream maintainer of node-glob also as of version 13 split the library and binary distributions of this package. The binary is now only packaged under the glob-bin repository but the source is still located under node-glob which is why I've chosen to not update their changelogs or home pages.

I've also updated the package after the upstream moved to the blueoak100 license
https://github.com/isaacs/glob-bin/blob/main/LICENSE.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
