### PR TITLE
cups-brother-hll2310d: init at 4.0.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12443,6 +12443,13 @@
     githubId = 2377;
     name = "Jonathan del Strother";
   };
+  jderrac = {
+    email = "jeremy@derrac.fr";
+    github = "jderrac";
+    githubId = 1788613;
+    name = "Jérémy Derrac";
+    keys = [ { fingerprint = "7B18 DA58 169F AEB8 6826  D1D6 BED4 91C6 40AB 31DD"; } ];
+  };
   jdev082 = {
     email = "jdev0894@gmail.com";
     github = "jdev082";

--- a/pkgs/by-name/cu/cups-brother-hll2310d/package.nix
+++ b/pkgs/by-name/cu/cups-brother-hll2310d/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  perl,
+  gnused,
+  ghostscript,
+  file,
+  coreutils,
+  gnugrep,
+  which,
+}:
+
+let
+  arches = [
+    "x86_64"
+    "i686"
+    "armv7l"
+  ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cups-brother-hll2310d";
+  version = "4.0.0-1";
+  strictDeps = true;
+  __structuredAttrs = true;
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  src = fetchurl {
+    url = "https://download.brother.com/pub/com/linux/linux/packages/hll2310dpdrv-${finalAttrs.version}.i386.deb";
+    hash = "sha256-g+ny6rTqiBXIPWEUnHqdXdXpRd4V8Ibs3VLmfsx1QbQ=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    # delete unnecessary files for the current architecture
+  ''
+  + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/HLL2310D/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches)
+  + ''
+
+    # bundled scripts don't understand the arch subdirectories for some reason
+    ln -s \
+      "$out/opt/brother/Printers/HLL2310D/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+      "$out/opt/brother/Printers/HLL2310D/lpd/"
+
+    # Fix global references and replace auto discovery mechanism with hardcoded values
+    substituteInPlace $out/opt/brother/Printers/HLL2310D/lpd/lpdfilter \
+      --replace /opt "$out/opt" \
+      --replace "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/HLL2310D\"; #" \
+      --replace "PRINTER =~" "PRINTER = \"HLL2310D\"; #"
+
+    # Make sure all executables have the necessary runtime dependencies available
+    find "$out" -executable -and -type f | while read file; do
+      wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+    done
+
+    # Symlink filter and ppd into a location where CUPS will discover it
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln -s \
+      $out/opt/brother/Printers/HLL2310D/lpd/lpdfilter \
+      $out/lib/cups/filter/brother_lpdwrapper_HLL2310D
+
+    ln -s \
+      $out/opt/brother/Printers/HLL2310D/cupswrapper/brother-HLL2310D-cups-en.ppd \
+      $out/share/cups/model/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother HL-L2310D printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = map (arch: "${arch}-linux") arches;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=fr&lang=fr&prod=hll2310d_us_eu_as&os=128";
+    maintainers = [ lib.maintainers.jderrac ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I wanted to use the official driver for my printer (Brother HL-L2310D) and decided to reuse the existing approach for hll2350dw [package.nix](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/cu/cups-brother-hll2350dw/package.nix) 

- I've pulled the deb source from the latest brother install script
- Changed the hll2350dw references to hll2310d
- Tested printing on my system with it

This is copy-pasta from another package updated to fit my printer. Maybe it should be generalized as the approach could fit multiple cups-brother-... drivers (hll2350dw, mfcl2750dw, ...)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
