### PR TITLE
treewide: expand pythonPath bash array for structuredAttrs for buildPythonPath

### DIFF
--- a/pkgs/applications/misc/pure-maps/default.nix
+++ b/pkgs/applications/misc/pure-maps/default.nix
@@ -50,7 +50,7 @@ mkDerivation rec {
   pythonPath = with python3.pkgs; [ gpxpy ];
 
   preInstall = ''
-    buildPythonPath "$pythonPath"
+    buildPythonPath "''${pythonPath[*]}"
     qtWrapperArgs+=(--prefix PYTHONPATH : "$program_PYTHONPATH")
   '';
 

--- a/pkgs/applications/networking/mailreaders/astroid/default.nix
+++ b/pkgs/applications/networking/mailreaders/astroid/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pythonPath = with python3.pkgs; requiredPythonModules extraPythonPackages;
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "$program_PYTHONPATH"
     )

--- a/pkgs/applications/system/coolercontrol/coolercontrold.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrold.nix
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage {
   postFixup = ''
     addDriverRunpath "$out/bin/coolercontrold"
 
-    buildPythonPath "$pythonPath"
+    buildPythonPath "''${pythonPath[*]}"
     wrapProgram "$out/bin/coolercontrold" \
       --prefix PATH : $program_PATH \
       --prefix PYTHONPATH : $program_PYTHONPATH

--- a/pkgs/by-name/bl/blender/package.nix
+++ b/pkgs/by-name/bl/blender/package.nix
@@ -345,7 +345,7 @@ stdenv'.mkDerivation (finalAttrs: {
       mv $out/Blender.app $out/Applications
     ''
     + ''
-      buildPythonPath "$pythonPath"
+      buildPythonPath "''${pythonPath[*]}"
       wrapProgram $blenderExecutable \
         --prefix PATH : $program_PATH \
         --prefix PYTHONPATH : "$program_PYTHONPATH" \

--- a/pkgs/by-name/bl/blender/wrapper.nix
+++ b/pkgs/by-name/bl/blender/wrapper.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r $src/share/doc $out/share
     cp -r $src/share/icons $out/share
 
-    buildPythonPath "$pythonPath"
+    buildPythonPath "''${pythonPath[*]}"
 
     makeWrapper ${blender}/bin/blender $out/bin/${finalAttrs.finalPackage.pname} \
       --prefix PATH : $program_PATH \

--- a/pkgs/by-name/bu/budgie-media-player-applet/package.nix
+++ b/pkgs/by-name/bu/budgie-media-player-applet/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   postFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
     patchPythonScript "$out/lib/budgie-desktop/plugins/budgie-media-player-applet/applet.py"
   '';
 

--- a/pkgs/by-name/cl/clapper-enhancers/package.nix
+++ b/pkgs/by-name/cl/clapper-enhancers/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
     for yt_plugin in $out/lib/clapper-enhancers/plugins/yt-dlp/*.py; do
       patchPythonScript $yt_plugin
     done

--- a/pkgs/by-name/ge/geis/package.nix
+++ b/pkgs/by-name/ge/geis/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
     gappsWrapperArgs+=(--set PYTHONPATH "$program_PYTHONPATH")
   '';
 

--- a/pkgs/by-name/hp/hplip/package.nix
+++ b/pkgs/by-name/hp/hplip/package.nix
@@ -306,7 +306,7 @@ python3Packages.buildPythonApplication {
   dontWrapGApps = true;
   dontWrapQtApps = true;
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
 
     for bin in $out/bin/*; do
       py=$(readlink -m $bin)

--- a/pkgs/by-name/hy/hypnotix/package.nix
+++ b/pkgs/by-name/hy/hypnotix/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
 
     # yt-dlp is needed for mpv to play YouTube channels.
     wrapProgram $out/bin/hypnotix \

--- a/pkgs/by-name/ju/jumpnbump/package.nix
+++ b/pkgs/by-name/ju/jumpnbump/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation {
     pillow
   ];
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
   '';
   postFixup = ''
     wrapPythonPrograms

--- a/pkgs/by-name/ki/kicad/package.nix
+++ b/pkgs/by-name/ki/kicad/package.nix
@@ -283,7 +283,7 @@ stdenv.mkDerivation rec {
     (concatStringsSep "\n" (flatten [
       "runHook preInstall"
 
-      (optionalString withScripting "buildPythonPath \"${base} $pythonPath\" \n")
+      (optionalString withScripting ''buildPythonPath "${base} ''${pythonPath[*]}"'')
 
       # wrap each of the directly usable tools
       (map (

--- a/pkgs/by-name/li/lightdm-slick-greeter/package.nix
+++ b/pkgs/by-name/li/lightdm-slick-greeter/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   '';
 
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "$program_PYTHONPATH"
       --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ xapp-symbolic-icons ]}"

--- a/pkgs/by-name/si/siglo/package.nix
+++ b/pkgs/by-name/si/siglo/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation rec {
   ];
 
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
     gappsWrapperArgs+=(--prefix PYTHONPATH : "$program_PYTHONPATH")
   '';
 

--- a/pkgs/by-name/st/sticky/package.nix
+++ b/pkgs/by-name/st/sticky/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
   ];
 
   preFixup = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
 
     gappsWrapperArgs+=(
       --prefix PYTHONPATH : "$program_PYTHONPATH"

--- a/pkgs/desktops/mate/pluma/default.nix
+++ b/pkgs/desktops/mate/pluma/default.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postFixup = ''
-    buildPythonPath "$pythonPath"
+    buildPythonPath "''${pythonPath[*]}"
     patchPythonScript $out/lib/pluma/plugins/snippets/Snippet.py
   '';
 

--- a/pkgs/tools/misc/system-config-printer/default.nix
+++ b/pkgs/tools/misc/system-config-printer/default.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
 
   postInstall = ''
-    buildPythonPath "$out $pythonPath"
+    buildPythonPath "$out ''${pythonPath[*]}"
     gappsWrapperArgs+=(
       --prefix PATH : "$program_PATH"
       --set CUPS_DATADIR "${libcupsfilters}/share/cups"


### PR DESCRIPTION
Followup to https://github.com/NixOS/nixpkgs/pull/483072 and https://github.com/NixOS/nixpkgs/pull/471986


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
