### PR TITLE
python314Packages.appthreat-vulnerability-db: 6.5.1 -> 6.6.0

### DIFF
--- a/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
+++ b/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
@@ -7,11 +7,13 @@
   fetchFromGitHub,
   httpx,
   msgpack,
+  oras,
   orjson,
   packageurl-python,
   pydantic,
-  pytestCheckHook,
   pytest-cov-stub,
+  pytestCheckHook,
+  pyyaml,
   rich,
   semver,
   setuptools,
@@ -21,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "appthreat-vulnerability-db";
-  version = "6.5.1";
+  version = "6.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "AppThreat";
     repo = "vulnerability-db";
     tag = "v${version}";
-    hash = "sha256-SyUTDWi9t37Gw8qn7vCpW+l5jBAXFH5b/VACrFhgsRU=";
+    hash = "sha256-/tcfHEvTdk0B/vfcqqkTn9kGT3QIPLWW4l01fjnrhqE=";
   };
 
   pythonRelaxDeps = [
@@ -51,13 +53,24 @@ buildPythonPackage rec {
     semver
     tabulate
   ]
-  ++ httpx.optional-dependencies.http2;
+  ++ httpx.optional-dependencies.http2
+  ++ pydantic.optional-dependencies.email;
+
+  optional-dependencies = {
+    all = [
+      oras
+      pyyaml
+    ];
+    custom = [ pyyaml ];
+    oras = [ oras ];
+  };
 
   nativeCheckInputs = [
     pytest-cov-stub
     pytestCheckHook
     writableTmpDirAsHomeHook
-  ];
+  ]
+  ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   disabledTests = [
     # Tests require network access

--- a/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
+++ b/pkgs/development/python-modules/appthreat-vulnerability-db/default.nix
@@ -21,7 +21,7 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "appthreat-vulnerability-db";
   version = "6.6.0";
   pyproject = true;
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "AppThreat";
     repo = "vulnerability-db";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-/tcfHEvTdk0B/vfcqqkTn9kGT3QIPLWW4l01fjnrhqE=";
   };
 
@@ -70,7 +70,7 @@ buildPythonPackage rec {
     pytestCheckHook
     writableTmpDirAsHomeHook
   ]
-  ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   disabledTests = [
     # Tests require network access
@@ -84,9 +84,9 @@ buildPythonPackage rec {
   meta = {
     description = "Vulnerability database and package search for sources such as OSV, NVD, GitHub and npm";
     homepage = "https://github.com/appthreat/vulnerability-db";
-    changelog = "https://github.com/AppThreat/vulnerability-db/releases/tag/${src.tag}";
+    changelog = "https://github.com/AppThreat/vulnerability-db/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "vdb";
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/AppThreat/vulnerability-db/releases/tag/v6.6.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
