### PR TITLE
tree-wide: use allowUnfreePackages where applicable

### DIFF
--- a/nixos/modules/hardware/facter/virtualisation.nix
+++ b/nixos/modules/hardware/facter/virtualisation.nix
@@ -105,7 +105,7 @@ in
     # parallels
     hardware.parallels.enable = lib.mkIf cfg.parallels.enable (lib.mkDefault true);
     nixpkgs.config = lib.mkIf (!options.nixpkgs.pkgs.isDefined && cfg.parallels.enable) {
-      allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "prl-tools" ];
+      allowUnfreePackages = [ "prl-tools" ];
     };
   };
 }

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -300,7 +300,7 @@ if ($virt eq "oracle") {
 # It is blocked by https://github.com/systemd/systemd/pull/23859
 if ($virt eq "parallels") {
     push @attrs, "hardware.parallels.enable = true;";
-    push @attrs, "nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ \"prl-tools\" ];";
+    push @attrs, "nixpkgs.config.allowUnfreePackages = [ \"prl-tools\" ];";
 }
 
 # Likewise for QEMU.

--- a/nixos/tests/sabnzbd-module.nix
+++ b/nixos/tests/sabnzbd-module.nix
@@ -60,7 +60,7 @@
       ];
 
       # unrar is unfree
-      nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "unrar" ];
+      nixpkgs.config.allowUnfreePackages = [ "unrar" ];
     };
 
   testScript = ''

--- a/pkgs/applications/networking/cluster/k3s/docs/examples/NVIDIA.md
+++ b/pkgs/applications/networking/cluster/k3s/docs/examples/NVIDIA.md
@@ -17,7 +17,7 @@ services.xserver = {
   videoDrivers = [ "nvidia" ];
 };
 
-nixpkgs.config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+nixpkgs.config.allowUnfreePackages = [
   "nvidia-x11"
   "nvidia-settings"
 ];

--- a/pkgs/by-name/jo/joypixels/package.nix
+++ b/pkgs/by-name/jo/joypixels/package.nix
@@ -47,14 +47,13 @@ let
     unfree licenses.
 
     configuration.nix:
-      nixpkgs.config.allowUnfreePredicate = pkg:
-        builtins.elem (lib.getName pkg) [
-          "joypixels"
-        ];
+      nixpkgs.config.allowUnfreePackages = [
+        "joypixels"
+      ];
       nixpkgs.config.joypixels.acceptLicense = true;
 
     config.nix:
-      allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [
+      allowUnfreePackages = [
         "joypixels"
       ];
       joypixels.acceptLicense = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
