### PR TITLE
yaziPlugins.yatline: 25.5.31-unstable-2026-01-21 -> 25.12.29-unstable-2026-01-27

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline.yazi";
-  version = "25.5.31-unstable-2026-01-21";
+  version = "25.12.29-unstable-2026-01-27";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline.yazi";
-    rev = "3227a30b21f69b68df513754b5a00d6e75cece57";
-    hash = "sha256-yhptHABQ0alVab2i367D5grJyG7SrfHH8H4JuGeYFyk=";
+    rev = "c5d4b487d6277dd68ea9d3c6537641bf4ae9cf8e";
+    hash = "sha256-HjTRAfUHs6vlEWKruQWeA2wT/Mcd+WEHM90egFTYcWQ=";
   };
 
   meta = {


### PR DESCRIPTION
Update yatline plugin from 25.5.31-unstable-2026-01-21 to 25.12.29-unstable-2026-01-27.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

---

Add a 👍 [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to [issues you find important](https://github.com/NixOS/nixpkgs/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc).