### PR TITLE
mpvScripts.thumbfast-vanilla-osc: init at 0-unstable-2025-02-04

### DIFF
--- a/pkgs/by-name/mp/mpv/scripts/thumbfast-vanilla-osc.nix
+++ b/pkgs/by-name/mp/mpv/scripts/thumbfast-vanilla-osc.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  fetchFromGitHub,
+  unstableGitUpdater,
+  buildLua,
+}:
+
+buildLua {
+  pname = "thumbfast-vanilla-osc";
+  version = "0-unstable-2025-02-04";
+
+  src = fetchFromGitHub {
+    owner = "po5";
+    repo = "thumbfast";
+    rev = "9d78edc167553ccea6290832982d0bc15838b4ac";
+    hash = "sha256-AG3w5B8lBcSXV4cbvX3nQ9hri/895xDbTsdaqF+RL64=";
+  };
+  passthru.updateScript = unstableGitUpdater { branch = "vanilla-osc"; };
+
+  scriptPath = "player/lua/osc.lua";
+
+  meta = {
+    description = "Modified version of the vanilla UI with thumbfast support";
+    homepage = "https://github.com/po5/thumbfast";
+    # License not stated explicitly, but is a derivative of https://github.com/mpv-player/mpv/blob/master/player/lua/osc.lua
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ coca ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Currently users of `mpvScripts.thumbfast` have to pull in this script from a separate branch in thumbfast if they want to use the vanilla UI. License is not specified in the branch, but its only minor modifications of the [LGPL licensed](https://github.com/mpv-player/mpv/blob/master/Copyright#L5-L7) [osc.lua](https://github.com/mpv-player/mpv/blob/master/player/lua/osc.lua).

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
