### PR TITLE
sso-mib: init at 0.7.0

### DIFF
--- a/pkgs/by-name/ss/sso-mib/package.nix
+++ b/pkgs/by-name/ss/sso-mib/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  libjwt,
+  libuuid,
+  glib,
+  json-glib,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sso-mib";
+  version = "0.7.0";
+
+  src = fetchFromGitHub {
+    owner = "siemens";
+    repo = "sso-mib";
+    rev = "v${version}";
+    hash = "sha256-C5Gaes8mAQMNAY51tJu4U26AyQ3Thy6mpXg4ewgMRP8=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "bin"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    libjwt
+    libuuid
+    glib
+    json-glib
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  enableParallelBuilding = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/siemens/sso-mib";
+    description = "C library to interact with a locally running microsoft-identity-broker to get various authentication tokens via DBus.";
+    maintainers = [ maintainers.michaeladler ];
+    platforms = platforms.all;
+    license = [
+      licenses.gpl2Only
+      licenses.lgpl21Only
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[sso-mib](https://github.com/siemens/sso-mib/) is a lightweight C library and CLI tool for interacting with a Microsoft Identity Broker to obtain authentication tokens via DBus. For example, FreeRDP can optionally use sso-mib (see https://github.com/FreeRDP/FreeRDP/pull/11600) to enable passwordless login to remote machines. Packaging sso-mib in nixpkgs would allow users to enable this functionality in FreeRDP and other applications that support sso-mib.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
