### PR TITLE
Skaware updates January 2026

### DIFF
--- a/pkgs/development/skaware-packages/execline/default.nix
+++ b/pkgs/development/skaware-packages/execline/default.nix
@@ -7,14 +7,14 @@
 }:
 
 let
-  version = "2.9.7.0";
+  version = "2.9.8.1";
 in
 skawarePackages.buildPackage {
   inherit version;
 
   pname = "execline";
   # ATTN: also check whether there is a new manpages version
-  sha256 = "sha256-c8kWDvyZQHjY6lSA+RYb/Rs88LYff6q3BKsYmFF9Agc=";
+  sha256 = "sha256-IzUNEHl5CWNgYFImB1kctKIRgyjLWMXmX7GaLA1HJk4=";
 
   # Maintainer of manpages uses following versioning scheme: for every
   # upstream $version he tags manpages release as ${version}.1, and,

--- a/pkgs/development/skaware-packages/mdevd/default.nix
+++ b/pkgs/development/skaware-packages/mdevd/default.nix
@@ -6,8 +6,8 @@
 
 skawarePackages.buildPackage {
   pname = "mdevd";
-  version = "0.1.7.0";
-  sha256 = "sha256-7JZu7DmHnzPHhTQzcwIcRPiHyDagj8rx1jQS472/yjI=";
+  version = "0.1.8.1";
+  sha256 = "sha256-k9K7pymf87G58kmSjC6E4jpa89gp69lnfqRFNcWFqoI=";
 
   description = "mdev-compatible Linux hotplug manager daemon";
   platforms = lib.platforms.linux;

--- a/pkgs/development/skaware-packages/nsss/default.nix
+++ b/pkgs/development/skaware-packages/nsss/default.nix
@@ -2,8 +2,8 @@
 
 skawarePackages.buildPackage {
   pname = "nsss";
-  version = "0.2.1.0";
-  sha256 = "sha256-8iGjHBzuiB6ZKobf4pYzIlPHqfxl9g2IgpzI6JSEIPQ=";
+  version = "0.2.1.1";
+  sha256 = "sha256-pff2y8Gdey3ALVjiupwJ0I+iRZ/j3xh3815jnA8rEpI=";
 
   description = "Implementation of a subset of the pwd.h, group.h and shadow.h family of functions";
 

--- a/pkgs/development/skaware-packages/s6-dns/default.nix
+++ b/pkgs/development/skaware-packages/s6-dns/default.nix
@@ -2,8 +2,8 @@
 
 skawarePackages.buildPackage {
   pname = "s6-dns";
-  version = "2.4.1.0";
-  sha256 = "sha256-tjCFGfEJpnRpxKqvqd8fAJrQlh+nmP/Dj4lVh+aTVyk=";
+  version = "2.4.1.1";
+  sha256 = "sha256-JkPP9JmgeOoXDl+mqH2GxNcjtl89FICnE318xJlHQzg=";
 
   description = "Suite of DNS client programs and libraries for Unix systems";
 

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -10,8 +10,8 @@
 
 skawarePackages.buildPackage {
   pname = "s6-linux-init";
-  version = "1.1.3.0";
-  sha256 = "sha256-0RtZa3GawTT3frGUUJB9H+bYS0rcNtRO90jb5VSHs+0=";
+  version = "1.2.0.0";
+  sha256 = "sha256-82cImDHGlI/evomW2khKuP0Uhclek8HlsDe4hxGN6dk=";
 
   description = "Set of minimalistic tools used to create a s6-based init system, including a /sbin/init binary, on a Linux kernel";
   platforms = lib.platforms.linux;

--- a/pkgs/development/skaware-packages/s6-linux-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-utils/default.nix
@@ -2,12 +2,13 @@
   lib,
   skawarePackages,
   skalibs,
+  execline,
 }:
 
 skawarePackages.buildPackage {
   pname = "s6-linux-utils";
-  version = "2.6.3.0";
-  sha256 = "sha256-fiScNsc7mev8H5qaTDGL52tGHrxT05Ut6QZMz6tABzk=";
+  version = "2.6.4.0";
+  sha256 = "sha256-zHJ/cNXoeAQzpJest8sxAGVrMSZYmrAunSBCAGx5TPI=";
 
   description = "Set of minimalistic Linux-specific system utilities";
   platforms = lib.platforms.linux;
@@ -25,13 +26,16 @@ skawarePackages.buildPackage {
     "--includedir=\${dev}/include"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
+    "--with-include=${execline.dev}/include"
     "--with-lib=${skalibs.lib}/lib"
+    "--with-lib=${execline.lib}/lib"
     "--with-dynlib=${skalibs.lib}/lib"
+    "--with-dynlib=${execline.lib}/lib"
   ];
 
   postInstall = ''
     # remove all s6 executables from build directory
-    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable) rngseed
+    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable) fstab2s6rc rngseed
     rm libs6ps.a.xyzzy
 
     mv doc $doc/share/doc/s6-linux-utils/html

--- a/pkgs/development/skaware-packages/s6-networking/default.nix
+++ b/pkgs/development/skaware-packages/s6-networking/default.nix
@@ -25,8 +25,8 @@ assert sslSupportEnabled -> sslLibs ? ${sslSupport};
 
 skawarePackages.buildPackage {
   pname = "s6-networking";
-  version = "2.7.1.0";
-  sha256 = "sha256-p7M0l+cpIaWdTB/GfOXMdL0GXgkQW/Gnnx/HPPmgZZI=";
+  version = "2.7.2.1";
+  sha256 = "sha256-Z5+GUthb40PawfB2SXzTbKjFZACUh4D4XcZONAVeLBs=";
 
   manpages = skawarePackages.buildManPages {
     pname = "s6-networking-man-pages";
@@ -76,7 +76,7 @@ skawarePackages.buildPackage {
 
   postInstall = ''
     # remove all s6 executables from build directory
-    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable)
+    rm $(find -name "s6-*" -type f -mindepth 1 -maxdepth 1 -executable) proxy-server
     rm libs6net.* libstls.* libs6tls.* libsbearssl.*
 
     mv doc $doc/share/doc/s6-networking/html

--- a/pkgs/development/skaware-packages/s6-portable-utils/default.nix
+++ b/pkgs/development/skaware-packages/s6-portable-utils/default.nix
@@ -6,8 +6,8 @@
 
 skawarePackages.buildPackage {
   pname = "s6-portable-utils";
-  version = "2.3.1.0";
-  sha256 = "sha256-BCRKqHrixBLUmZdptec8tCivugwuiqkhWzo2574qgPk=";
+  version = "2.3.1.1";
+  sha256 = "sha256-zwjXGWPA6hcIzdgr1ArTARVLzMWbaO77Qoqnm0InMkI=";
 
   manpages = skawarePackages.buildManPages {
     pname = "s6-portable-utils-man-pages";

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -10,8 +10,8 @@
 
 skawarePackages.buildPackage {
   pname = "s6-rc";
-  version = "0.5.6.0";
-  sha256 = "sha256-gSd/aAXo2ZmtKVv5FAqQmUO2h//Ptao8Tv2EsaV0WG4=";
+  version = "0.6.0.0";
+  sha256 = "sha256-RtSmKVnvFgl7hNz7DDsxpv9JqkdtSu7Jxbe94c5oSQE=";
 
   manpages = skawarePackages.buildManPages {
     pname = "s6-rc-man-pages";
@@ -25,18 +25,17 @@ skawarePackages.buildPackage {
   platforms = lib.platforms.unix;
 
   outputs = [
-    "bin"
-    "lib"
+    # "bin" "lib"
+    "out"
     "dev"
     "doc"
-    "out"
   ];
 
   configureFlags = [
-    "--libdir=\${lib}/lib"
-    "--libexecdir=\${lib}/libexec"
-    "--dynlibdir=\${lib}/lib"
-    "--bindir=\${bin}/bin"
+    "--libdir=\${out}/lib"
+    "--libexecdir=\${out}/libexec"
+    "--dynlibdir=\${out}/lib"
+    "--bindir=\${out}/bin"
     "--includedir=\${dev}/include"
     "--with-sysdeps=${skalibs.lib}/lib/skalibs/sysdeps"
     "--with-include=${skalibs.dev}/include"
@@ -72,7 +71,7 @@ skawarePackages.buildPackage {
   postInstall = ''
     # remove all s6 executables from build directory
     rm $(find -name "s6-rc-*" -type f -mindepth 1 -maxdepth 1 -executable)
-    rm s6-rc libs6rc.*
+    rm s6-rc libs6rc*
 
     mv doc $doc/share/doc/s6-rc/html
     mv examples $doc/share/doc/s6-rc/examples

--- a/pkgs/development/skaware-packages/s6/default.nix
+++ b/pkgs/development/skaware-packages/s6/default.nix
@@ -7,8 +7,8 @@
 
 skawarePackages.buildPackage {
   pname = "s6";
-  version = "2.13.2.0";
-  sha256 = "sha256-xRFLgEJxa7cGkUBpMayw4nltg7Qcv7XIBo3OegL5mkU=";
+  version = "2.14.0.1";
+  sha256 = "sha256-wlr+gXy8P1lO/FBQNR+LkQG6eGFtDOkVZY83Dn7i4lg=";
 
   manpages = skawarePackages.buildManPages {
     pname = "s6-man-pages";

--- a/pkgs/development/skaware-packages/skalibs/default.nix
+++ b/pkgs/development/skaware-packages/skalibs/default.nix
@@ -7,8 +7,8 @@
 
 skawarePackages.buildPackage {
   pname = "skalibs";
-  version = "2.14.4.0";
-  sha256 = "sha256-DmJiYYSMySBzj5L9UKJMFLIeMDBt/tl7hDU2n0uuAKU=";
+  version = "2.14.5.1";
+  sha256 = "sha256-+jWccEObSAQAoKLvaAJqJzazFQJanZXfadNGAfuTjw8=";
 
   description = "Set of general-purpose C programming libraries";
 

--- a/pkgs/development/skaware-packages/tipidee/default.nix
+++ b/pkgs/development/skaware-packages/tipidee/default.nix
@@ -6,8 +6,8 @@
 
 skawarePackages.buildPackage {
   pname = "tipidee";
-  version = "0.0.6.0";
-  sha256 = "sha256-4q3YvhCJAi43kCQbk6xKWj5Y2tZF9dkZ+MunRM1KFwI=";
+  version = "0.0.7.1";
+  sha256 = "sha256-ah5JwvCvWqRNuO3sK5KUxPXPaLg6eDGatJkE+KUv63M=";
 
   description = "HTTP 1.1 webserver, serving static files and CGI/NPH";
 

--- a/pkgs/development/skaware-packages/utmps/default.nix
+++ b/pkgs/development/skaware-packages/utmps/default.nix
@@ -2,8 +2,8 @@
 
 skawarePackages.buildPackage {
   pname = "utmps";
-  version = "0.1.3.1";
-  sha256 = "sha256-HEwTerNm9txrgdOlcsmXUUtk14S9Uuf5UU5vbz8chbk=";
+  version = "0.1.3.2";
+  sha256 = "sha256-sRTVauysicBctMDtM8Y4igIRSwnenM44Srm4qTRphmg=";
 
   description = "Secure utmpx and wtmp implementation";
 


### PR DESCRIPTION
This includes the Christmas 2025 and January 2026 releases. Everything seems to be working on my s6(-rc) based systems.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
