### PR TITLE
xen: fix finalSection detection when using a debug build

### DIFF
--- a/nixos/modules/virtualisation/xen-boot-builder.sh
+++ b/nixos/modules/virtualisation/xen-boot-builder.sh
@@ -91,7 +91,7 @@ EOF
         # https://xenbits.xenproject.org/docs/unstable/misc/efi.html.
         [ "$1" = "debug" ] && echo -e "\e[1;34mxenBootBuilder:\e[0m making Xen UKI..."
         xenEfi=$(jq -re ".\"org.xenproject.bootspec.v2\".efiPath" "$bootspecFile")
-        finalSection=$(objdump --header --wide "$xenEfi" | tail -n +6 | sort --key="4,4" | tail -n 1 | grep -Eo '\.[a-z]*')
+        finalSection=$(objdump --header --wide "$xenEfi" | tail -n +6 | sort --key="4,4" | tail -n 1 | grep -Eo '\.[a-z_]*')
         padding=$(objdump --header --section="$finalSection" "$xenEfi" | awk -v section="$finalSection" '$0 ~ section { printf("0x%016x\n", and(strtonum("0x"$3) + strtonum("0x"$4) + 0xfff, compl(0xfff)))};')
         [ "$1" = "debug" ] && echo "               - padding: $padding"
         objcopy \


### PR DESCRIPTION
When using a debug build of xen the section will look like this:
```bash
Sections:
Idx Name              Size      VMA               LMA               File off  Algn  Flags
  0 .text             0018e07b  ffff82d040200000  ffff82d040200000  00000440  2**4  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .rodata           00060648  ffff82d040400000  ffff82d040400000  0018e4c0  2**2  CONTENTS, ALLOC, LOAD, DATA
  2 .buildid          00000035  ffff82d040460648  ffff82d040460648  001eeb20  2**2  CONTENTS, ALLOC, LOAD, READONLY, DATA
  3 .init             000ac528  ffff82d040600000  ffff82d040600000  001eeb60  2**2  CONTENTS, ALLOC, LOAD, CODE, DATA
  4 .data.read_mostly 00009ed0  ffff82d040800000  ffff82d040800000  0029b0a0  2**4  CONTENTS, ALLOC, LOAD, DATA
  5 .data             0000c46c  ffff82d04080a000  ffff82d04080a000  002a4f80  2**4  CONTENTS, ALLOC, LOAD, DATA
  6 .bss              001312c8  ffff82d040817000  ffff82d040817000  00000000  2**4  ALLOC
  7 .reloc            00001598  ffff82d0409482c8  ffff82d0409482c8  002b1400  2**2  CONTENTS, ALLOC, LOAD, READONLY, DATA
  8 .debug_abbrev     000a46d6  ffff82d040949860  ffff82d040949860  002b29a0  2**0  CONTENTS, READONLY, DEBUGGING
  9 .debug_info       00d538aa  ffff82d0409edf36  ffff82d0409edf36  00357080  2**0  CONTENTS, READONLY, DEBUGGING
 10 .debug_str        00600083  ffff82d0417417e0  ffff82d0417417e0  010aa940  2**0  CONTENTS, READONLY, DEBUGGING
 11 .debug_line       00254e06  ffff82d041d41864  ffff82d041d41864  016aa9e0  2**0  CONTENTS, READONLY, DEBUGGING
 12 .debug_line_str   0004b714  ffff82d041f9666a  ffff82d041f9666a  018ff800  2**0  CONTENTS, READONLY, DEBUGGING
 13 .debug_frame      00043778  ffff82d041fe1d80  ffff82d041fe1d80  0194af20  2**0  CONTENTS, READONLY, DEBUGGING
 14 .debug_loclists   002dc9a3  ffff82d0420254f8  ffff82d0420254f8  0198e6a0  2**0  CONTENTS, READONLY, DEBUGGING
 15 .debug_rnglists   00090974  ffff82d042301ea0  ffff82d042301ea0  01c6b060  2**0  CONTENTS, READONLY, DEBUGGING
 16 .debug_aranges    000168f8  ffff82d042392818  ffff82d042392818  01cfb9e0  2**0  CONTENTS, READONLY, DEBUGGING
```

The current detection of the final section incorrectly reports the final section as `.debug`, which this PR fixes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
