### PR TITLE
nixos/transmission: convert test to runTest and replace activationScript by systemd service

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1630,7 +1630,7 @@ in
   traefik = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./traefik.nix;
   trafficserver = runTest ./trafficserver.nix;
   transfer-sh = runTest ./transfer-sh.nix;
-  transmission_4 = handleTest ./transmission.nix { };
+  transmission_4 = runTest ./transmission.nix;
   trezord = runTest ./trezord.nix;
   trickster = runTest ./trickster.nix;
   trilium-server = runTestOn [ "x86_64-linux" ] ./trilium-server.nix;

--- a/nixos/tests/transmission.nix
+++ b/nixos/tests/transmission.nix
@@ -1,27 +1,28 @@
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  {
-    name = "transmission";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [ coconnor ];
+{ pkgs, ... }:
+{
+  name = "transmission";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ coconnor ];
+  };
+
+  nodes.machine =
+    { ... }:
+    {
+      imports = [ ../modules/profiles/minimal.nix ];
+
+      networking.firewall.allowedTCPPorts = [ 9091 ];
+
+      security.apparmor.enable = true;
+
+      services.transmission.enable = true;
     };
 
-    nodes.machine =
-      { ... }:
-      {
-        imports = [ ../modules/profiles/minimal.nix ];
-
-        networking.firewall.allowedTCPPorts = [ 9091 ];
-
-        security.apparmor.enable = true;
-
-        services.transmission.enable = true;
-      };
-
-    testScript = ''
+  testScript =
+    { nodes, ... }:
+    #python
+    ''
       start_all()
       machine.wait_for_unit("transmission")
       machine.shutdown()
     '';
-  }
-)
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- **nixos/tests/transmission: convert to runTest** (see https://github.com/NixOS/nixpkgs/issues/386873)
- **nixos/transmission: replace activationScript by a systemd unit** (see https://github.com/NixOS/nixpkgs/issues/475305)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
