### PR TITLE
element-{web-unwrapped,desktop}: 1.12.8 -> 1.12.9

### DIFF
--- a/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
+++ b/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.12.8";
+  "version" = "1.12.9";
   "hashes" = {
-    "desktopSrcHash" = "sha256-J+ITqHLxbmhhjFnyfBlHFzxrPeIvsCv+iaxa8DiWorM=";
-    "desktopYarnHash" = "sha256-coa2AMNGLDtqcrQJDc/DDkcaWBCLa76VTKJLGlr7dpQ=";
+    "desktopSrcHash" = "sha256-VBlKFknwafXar05kEpwv0+9EwUPe9WQRMn8S8uhX2U8=";
+    "desktopYarnHash" = "sha256-tBO8rtz5/8OxmGsPmMEATqNVuBEcNp6L6lJCaJdPlNY=";
   };
 }

--- a/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
@@ -1,8 +1,8 @@
 {
-  "version" = "1.12.8";
+  "version" = "1.12.9";
   "hashes" = {
-    "webSrcHash" = "sha256-c1vrFEe0kEpCXs67oeZPv0xqmL3YaqAvD1nqoTQXlzk=";
-    "webYarnHash" = "sha256-Vo0SkCUPVQsVCgVILT+uvjbExDpYk4/DRfWdiisbf1o=";
-    "webSharedComponentsYarnHash" = "sha256-8wvjoanSd5KLDW6MbwY+3Ch9rzWpukeQEvYzMxXsbKA=";
+    "webSrcHash" = "sha256-txG91VN4b0ZtUnQp4IfN47YAn1WBI9UUxemReachcDo=";
+    "webYarnHash" = "sha256-Y2AvBlS7qdVUXalKet3Ud4a6MA4MKHM4ffRhB7Uq8Co=";
+    "webSharedComponentsYarnHash" = "sha256-yeFFVVMWyPN3BqOY46KAxPv7VRVrsFvPan5arTNd/GM";
   };
 }


### PR DESCRIPTION
Release notes: https://github.com/element-hq/element-web/releases/tag/v1.12.9
Full changelog: https://github.com/element-hq/element-web/compare/v1.12.8...v1.12.9
Release notes: https://github.com/element-hq/element-desktop/releases/tag/v1.12.9
Full changelog: https://github.com/element-hq/element-desktop/compare/v1.12.8...v1.12.9

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
