### PR TITLE
prefetch-npm-deps: support file: scheme for dependencies

### DIFF
--- a/pkgs/build-support/node/prefetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/prefetch-npm-deps/default.nix
@@ -195,6 +195,28 @@
 
           hash = "sha256-QGObVDd9qVtf/U78+ayP6RHVWsU+HXhg70BFblQ1PZs=";
         };
+
+        # Test lockfiles with file: dependencies
+        fileDependenciesV1 = makeTest {
+          name = "file-dependencies-lockfile-v1";
+
+          src = fetchurl {
+            url = "https://raw.githubusercontent.com/elbywan/wretch/970b19e0fcc3dd219b9f3fc247d8f34cc01979c6/package-lock.json";
+            hash = "sha256-3vTMxc9M2TeiclUFYbG5eTzavSAXjAzz6N5v/1VM4Bc=";
+          };
+
+          hash = "sha256-4wTohTVWF49iQvdaUxNhwplfTVb53yFnAaUVA2xIXrc=";
+        };
+        fileDependenciesV3 = makeTest {
+          name = "file-dependencies-lockfile-v3";
+
+          src = fetchurl {
+            url = "https://raw.githubusercontent.com/alam00000/bentopdf/146e3f07d4111e309d0b29bb949e78e44454be3b/package-lock.json";
+            hash = "sha256-9Ea5ctJYbClxStYNhSfSpsO/P99/4CQK58PLK5e6PoQ=";
+          };
+
+          hash = "sha256-1xWkzAzZXd9f4sY9xFHLfj482ZCs2oKFJ79C+Iy7RFY=";
+        };
       };
 
     meta = {

--- a/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/main.rs
@@ -238,6 +238,7 @@ fn fixup_lockfile(
                 .values_mut()
             {
                 if let Some(Value::String(resolved)) = package.get("resolved")
+                    && !resolved.starts_with("file:")
                     && let Some(Value::String(integrity)) = package.get("integrity")
                 {
                     if resolved.starts_with("git+") {
@@ -286,6 +287,7 @@ fn fixup_v1_deps(
             .as_object()
             .expect("v1 dep must be object")
             .get("resolved")
+            && !resolved.starts_with("file:")
             && let Some(Value::String(integrity)) = dep
                 .as_object()
                 .expect("v1 dep must be object")
@@ -509,6 +511,10 @@ mod tests {
                     "resolved": "git+ssh://git@github.com/NixOS/nixpkgs.git",
                     "integrity": "sha512-aaa"
                 },
+                "baz": {
+                    "resolved": "file:baz.tar.gz",
+                    "integrity": "sha512-bbb"
+                },
                 "foo-bad": {
                     "resolved": "foo",
                     "integrity": "sha1-foo"
@@ -533,6 +539,10 @@ mod tests {
                 },
                 "bar": {
                     "resolved": "git+ssh://git@github.com/NixOS/nixpkgs.git",
+                },
+                "baz": {
+                    "resolved": "file:baz.tar.gz",
+                    "integrity": "sha512-bbb"
                 },
                 "foo-bad": {
                     "resolved": "foo",

--- a/pkgs/build-support/node/prefetch-npm-deps/src/parse/mod.rs
+++ b/pkgs/build-support/node/prefetch-npm-deps/src/parse/mod.rs
@@ -25,10 +25,10 @@ pub fn lockfile(
     let mut packages = lock::packages(content)
         .context("failed to extract packages from lockfile")?
         .into_par_iter()
-        .map(|p| {
+        .filter_map(|p| {
             let n = p.name.clone().unwrap();
 
-            Package::from_lock(p).with_context(|| format!("failed to parse data for {n}"))
+            Package::from_lock(p).with_context(|| format!("failed to parse data for {n}")).transpose()
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
@@ -124,7 +124,7 @@ enum Specifics {
 }
 
 impl Package {
-    fn from_lock(pkg: lock::Package) -> anyhow::Result<Package> {
+    fn from_lock(pkg: lock::Package) -> anyhow::Result<Option<Package>> {
         let mut resolved = match pkg
             .resolved
             .expect("at this point, packages should have URLs")
@@ -132,6 +132,10 @@ impl Package {
             UrlOrString::Url(u) => u,
             UrlOrString::String(_) => panic!("at this point, all packages should have URLs"),
         };
+
+        if resolved.scheme() == "file" {
+            return Ok(None);
+        }
 
         let specifics = match get_hosted_git_url(&resolved)? {
             Some(hosted) => {
@@ -174,12 +178,12 @@ impl Package {
             },
         };
 
-        Ok(Package {
+        Ok(Some(Package {
             name: pkg.name.unwrap(),
             version: pkg.version,
             url: resolved,
             specifics,
-        })
+        }))
     }
 
     pub fn tarball(&self) -> anyhow::Result<Vec<u8>> {


### PR DESCRIPTION
Fixes #484067, with the caveat that `makeCacheWritable` needs to be enabled for `file:` dependencies to work.

This just makes `prefetch-npm-deps` ignore all `file:` dependencies, since they don't need to be downloaded from anywhere.

I'm not sure this is the best approach, so feedback is appreciated.
~~I might have to target staging instead depending on the amount of rebuilds.~~ Yep

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
