### PR TITLE
viennarna: 2.7.0 -> 2.7.2

### DIFF
--- a/pkgs/by-name/vi/viennarna/package.nix
+++ b/pkgs/by-name/vi/viennarna/package.nix
@@ -2,20 +2,20 @@
   lib,
   stdenv,
   fetchurl,
+  pkg-config,
   dlib,
   gsl,
   mpfr,
   perl,
   python3,
 }:
-
 stdenv.mkDerivation rec {
   pname = "viennarna";
-  version = "2.7.0";
+  version = "2.7.2";
 
   src = fetchurl {
     url = "https://www.tbi.univie.ac.at/RNA/download/sourcecode/2_7_x/ViennaRNA-${version}.tar.gz";
-    hash = "sha256-mpn9aO04CJTe+01eaooocWKScAKM338W8KBdpujHFHM=";
+    hash = "sha256-GrX0pPdvyFoiQ1RgiORfXYXy16VsxlbpabAFzOm/q18=";
   };
 
   # use nixpkgs dlib sources instead of bundled ones
@@ -25,6 +25,10 @@ stdenv.mkDerivation rec {
     cp -a ${dlib.src} ./src/dlib-19.24
     find ./src/dlib-19.24 -type d -exec chmod +w {} \;
   '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
 
   buildInputs = [
     gsl


### PR DESCRIPTION
 Fixes build failure with GCC 14 due to K&R style function declarations.
 
- Update 2.7.0 → 2.7.2
- Add `pkg-config` to `nativeBuildInputs` (newly required in 2.7.2)

ViennaRNA 2.7.0 fails to build with GCC 14 because of conflicting function types:

lists.h:58: void lst_kill (LIST * l, void (*freeNode) ());
lists.c:99: void lst_kill(LIST l, void ()(void *))

GCC 14 treats K&R style `()` and prototype style `(void *)` as incompatible types.
This is fixed upstream in 2.7.2.

Changelog: https://github.com/ViennaRNA/ViennaRNA/releases/tag/v2.7.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
