### PR TITLE
[25.11] maintainer-list: Fix M0ustach3 maintainer entry

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15683,7 +15683,7 @@
     github = "M0streng0";
     githubId = 85799811;
   };
-  m0ustache3 = {
+  M0ustach3 = {
     name = "M0ustach3";
     github = "M0ustach3";
     githubId = 37956764;

--- a/nixos/modules/services/misc/memos.nix
+++ b/nixos/modules/services/misc/memos.nix
@@ -195,5 +195,5 @@ in
     };
   };
 
-  meta.maintainers = [ lib.maintainers.m0ustach3 ];
+  meta.maintainers = [ lib.maintainers.M0ustach3 ];
 }

--- a/nixos/modules/services/security/crowdsec.nix
+++ b/nixos/modules/services/security/crowdsec.nix
@@ -984,7 +984,7 @@ in
 
   meta = {
     maintainers = with lib.maintainers; [
-      m0ustach3
+      M0ustach3
       tornax
       jk
     ];


### PR DESCRIPTION
## Summary

Backport of #484155 to release-25.11.

Only the second commit (M0ustach3 maintainer entry fix) was applicable to this release branch. The first commit (danklinux team members reference fix) could not be cherry-picked because the affected modules (`dsearch.nix`, `dms-shell.nix`, `dms-greeter.nix`) do not exist on release-25.11.

This fixes evaluation errors when accessing `meta.maintainers` in the `memos` and `crowdsec` NixOS modules, where the maintainer attribute name had typos that didn't match the maintainer-list entry.

## Original PR

- #484155