### PR TITLE
procps-ng: fix build on non-Linux

### DIFF
--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch2,
   fetchurl,
   ncurses,
   pkg-config,
@@ -31,6 +32,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-wubRk8x4+EzW3bcqr21capFi8EcOWZIJIFf1/1GFYvo=";
   };
 
+  patches = [
+    # Fix build on Darwin. This patch can be dropped once 4.0.6 is released.
+    (fetchpatch2 {
+      url = "https://gitlab.com/procps-ng/procps/-/commit/2dc340e47669e0b0df7f71ff082e05ac5fa36615.diff";
+      hash = "sha256-4eu0MdHsCeUPiQBTdvYHlUAtSVbgputTqPRmSvh9iVs=";
+    })
+  ];
+
   buildInputs = [ ncurses ] ++ lib.optionals withSystemd [ systemdLibs ];
   nativeBuildInputs = [
     pkg-config
@@ -47,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-watch8bit"
   ]
   ++ lib.optionals withSystemd [ "--with-systemd" ]
+  ++ lib.optionals (!stdenv.hostPlatform.isLinux) [ "--disable-pidwait" ] # Requires (Linux-only) `pidfd_open`
   ++ lib.optionals stdenv.hostPlatform.isMusl [ "--disable-w" ]
   ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"


### PR DESCRIPTION
- Disable `pidwait`, which fails to build on Darwin due to requiring `pidof_open`; and
- Apply patch from upstream to avoid using `SIGPOLL` on Darwin.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
