### PR TITLE
redis: set config group for service user

### DIFF
--- a/nixos/modules/services/databases/redis.nix
+++ b/nixos/modules/services/databases/redis.nix
@@ -477,7 +477,7 @@ in
       lib.nameValuePair (redisName name) {
         description = "System user for the redis-server instance ${name}";
         isSystemUser = true;
-        group = redisName name;
+        group = conf.group;
       }
     ) (lib.filterAttrs (name: conf: conf.user == redisName name) enabledServers);
     users.groups = lib.mapAttrs' (


### PR DESCRIPTION
Avoids trying to set the primary group of the redis user to a group that doesn't exist.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- ~~[ ] Tested basic functionality of all binary files, usually in `./result/bin/`.~~ Does not apply.
- Nixpkgs Release Notes
  - ~~[ ] Package update: when the change is major or breaking.~~ Does not apply.
- NixOS Release Notes
  - ~~[ ] Module addition: when adding a new NixOS module.~~ Does not apply.
  - ~~[ ] Module update: when the change is significant.~~ Bugfix. Not significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
