### PR TITLE
maintainers: add willfish

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28298,6 +28298,7 @@
     name = "Will Cohen";
   };
   willfish = {
+    email = "willfish@pescado.mozmail.com";
     github = "willfish";
     githubId = 8156884;
     name = "William Fish";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28297,6 +28297,11 @@
     githubId = 5185341;
     name = "Will Cohen";
   };
+  willfish = {
+    github = "willfish";
+    githubId = 8156884;
+    name = "William Fish";
+  };
   willibutz = {
     email = "willibutz@posteo.de";
     github = "WilliButz";

--- a/pkgs/by-name/va/variety/package.nix
+++ b/pkgs/by-name/va/variety/package.nix
@@ -110,6 +110,7 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [
       p3psi
       zfnmxt
+      willfish
     ];
   };
 }


### PR DESCRIPTION
Adds `willfish` to `maintainers/maintainer-list.nix` and as a maintainer for the `variety` package.

Split out from a [`variety` version bump PR](https://github.com/NixOS/nixpkgs/pull/477721) to keep the maintainer addition as a separate, preceding change.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc