### PR TITLE
ladybugdb, python3Packages.real-ladybug: init at 0.14.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10156,6 +10156,12 @@
     githubId = 1742172;
     name = "Hamish Hutchings";
   };
+  hamidr = {
+    email = "hamidr.dev@gmail.com";
+    github = "hamidr";
+    githubId = 298427;
+    name = "Hamid Davoodi";
+  };
   hamzaremmal = {
     email = "hamza.remmal@epfl.ch";
     github = "hamzaremmal";

--- a/pkgs/by-name/la/ladybugdb/package.nix
+++ b/pkgs/by-name/la/ladybugdb/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  python3,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ladybugdb";
+  version = "0.14.1";
+
+  src = fetchFromGitHub {
+    owner = "LadybugDB";
+    repo = "ladybug";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Tq7a7XOKoxe0/cdZehNAEX4ENHIjMFdBBARNzZiuMM8=";
+  };
+
+  outputs = [
+    "out"
+    "lib"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/lbug";
+  doInstallCheck = true;
+
+  meta = {
+    changelog = "https://github.com/LadybugDB/ladybug/releases/tag/${finalAttrs.src.tag}";
+    description = "Embeddable property graph database management system (fork of Kuzu)";
+    homepage = "https://ladybugdb.com/";
+    license = lib.licenses.mit;
+    mainProgram = "lbug";
+    maintainers = with lib.maintainers; [ hamidr ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/real-ladybug/default.nix
+++ b/pkgs/development/python-modules/real-ladybug/default.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cmake,
+  ninja,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "real-ladybug";
+  version = "0.14.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LadybugDB";
+    repo = "ladybug";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Tq7a7XOKoxe0/cdZehNAEX4ENHIjMFdBBARNzZiuMM8=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/tools/python_api";
+
+  postUnpack = ''
+    chmod -R +w ${finalAttrs.src.name}
+  '';
+
+  postPatch = ''
+        substituteInPlace pyproject.toml \
+          --replace-fail 'version = "0.0.1"' 'version = "${finalAttrs.version}"'
+
+        cat >> pyproject.toml << 'TOML'
+
+    [tool.setuptools.package-data]
+    real_ladybug = ["*.so", "*.dylib", "*.pyd"]
+    TOML
+  '';
+
+  build-system = [ setuptools ];
+
+  # cmake and ninja are needed for preBuild which compiles the C++ engine
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  preBuild = ''
+    cmake -S ../.. -B ../../cmake-build -G Ninja \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_PYTHON=TRUE \
+      -DBUILD_SHELL=FALSE
+    cmake --build ../../cmake-build
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  enabledTestPaths = [
+    "test/"
+  ];
+
+  disabledTests = [
+    # Subprocess tests spawn new processes where build_dir may not resolve
+    "test_database_close"
+    "test_database_context_manager"
+  ];
+
+  disabledTestPaths = [
+    # Tests requiring dataset fixtures (conn_db_readonly/conn_db_readwrite)
+    # which fail due to path resolution issues in init_demo within the sandbox
+    "test/test_arrow.py"
+    "test/test_async_connection.py"
+    "test/test_connection.py"
+    "test/test_datatype.py"
+    "test/test_df.py"
+    "test/test_exception.py"
+    "test/test_get_header.py"
+    "test/test_issue.py"
+    "test/test_networkx.py"
+    "test/test_parameter.py"
+    "test/test_prepared_statement.py"
+    "test/test_query_result.py"
+    "test/test_timeout.py"
+    "test/test_udf.py"
+    # Tests requiring optional dependencies (pandas, polars, pyarrow, torch)
+    "test/test_scan_pandas.py"
+    "test/test_scan_pandas_pyarrow.py"
+    "test/test_scan_polars.py"
+    "test/test_scan_pyarrow.py"
+    "test/test_torch_geometric.py"
+    "test/test_torch_geometric_remote_backend.py"
+    # Subprocess tests that spawn new Python processes with build_dir
+    "test/test_query_result_close.py"
+    "test/test_wal.py"
+  ];
+
+  pythonImportsCheck = [ "real_ladybug" ];
+
+  meta = {
+    description = "Python bindings for LadybugDB, an embeddable property graph database management system (fork of Kuzu)";
+    homepage = "https://ladybugdb.com/";
+    changelog = "https://github.com/LadybugDB/ladybug/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hamidr ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16330,6 +16330,8 @@ self: super: with self; {
 
   readthedocs-sphinx-ext = callPackage ../development/python-modules/readthedocs-sphinx-ext { };
 
+  real-ladybug = callPackage ../development/python-modules/real-ladybug { };
+
   realtime = callPackage ../development/python-modules/realtime { };
 
   rebulk = callPackage ../development/python-modules/rebulk { };


### PR DESCRIPTION
Add LadybugDB, an embeddable property graph database (community fork of Kuzu).

  LadybugDB is a community-driven fork of [Kuzu](https://github.com/kuzudb/kuzu) after Kùzu Inc.
  discontinued active support. It continues development with a focus on object storage integration.

  Homepage: https://ladybugdb.com/

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [x] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.