### PR TITLE
nixos/git: support system-wide gitattributes

### DIFF
--- a/nixos/modules/programs/git.nix
+++ b/nixos/modules/programs/git.nix
@@ -84,6 +84,20 @@ in
 
         enablePureSSHTransfer = lib.mkEnableOption "Enable pure SSH transfer in server side by adding git-lfs-transfer to environment.systemPackages";
       };
+
+      attributes = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        example = "*.pdf diff=pdf";
+        description = ''
+          Assign git attributes to files (one pattern per line):
+
+              PATTERN1 ATTR1 ATTR2 ...
+
+          Blank lines and lines beginning with # are ignored. See
+          {manpage}`gitattributes(5)` for more information.
+        '';
+      };
     };
   };
 
@@ -92,6 +106,10 @@ in
       environment.systemPackages = [ cfg.package ];
       environment.etc.gitconfig = lib.mkIf (cfg.config != [ ]) {
         text = lib.concatMapStringsSep "\n" lib.generators.toGitINI cfg.config;
+      };
+
+      environment.etc.gitattributes = lib.mkIf (cfg.attributes != "") {
+        text = cfg.attributes + "\n";
       };
     })
     (lib.mkIf (cfg.enable && cfg.lfs.enable) {


### PR DESCRIPTION
This makes it possible to configure system-wide diff, merge, etc. strategies.

Unfortunately, there's no equivalent for gitignore (without clobbering `core.excludesFile`) .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test