### PR TITLE
mistral-vibe: 1.3.5 -> 2.0.0

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mistral-vibe";
-  version = "1.3.5";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mistralai";
     repo = "mistral-vibe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-R+sh8xQpLDIKqQwE1JjguP4NwE2Jz7tuXNK1+EsHnrA=";
+    hash = "sha256-2waDKL1TWVw2BXl0oqV9+kH86w7dWpz1j61VQSxJW5Q=";
   };
 
   build-system = with python3Packages; [
@@ -37,7 +37,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
   dependencies = with python3Packages; [
     agent-client-protocol
-    aiofiles
+    anyio
     httpx
     mcp
     mistralai
@@ -70,20 +70,15 @@ python3Packages.buildPythonApplication (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
   versionCheckKeepEnvironment = [ "HOME" ];
-  pytestFlags = [ "tests/cli/test_clipboard.py" ];
 
-  disabledTests = [
-    # AssertionError: assert '/nix/store/00000000000000000000000000000000-bash-5.3p3/bin/sh:
-    # warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8): No such file or directory\n' == ''
-    "test_decodes_non_utf8_bytes"
-    "test_runs_echo_successfully"
-    "test_truncates_output_to_max_bytes"
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    # AssertionError: assert 3 == 4
-    "test_get_copy_fns_with_wl_copy"
-    "test_get_copy_fns_with_both_system_tools"
-    "test_get_copy_fns_with_xclip"
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # AssertionError
+    "test_rebuilds_index_when_mass_change_threshold_is_exceeded"
+    "test_updates_index_incrementally_by_default"
+    "test_updates_index_on_file_creation"
+    "test_updates_index_on_file_deletion"
+    "test_updates_index_on_file_rename"
+    "test_updates_index_on_folder_rename"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/mistralai/mistral-vibe/compare/v1.3.5...v2.0.0
Changelog: https://github.com/mistralai/mistral-vibe/blob/v2.0.0/CHANGELOG.md

cc @shikanime @mana-byte

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test