### PR TITLE
installFonts: init hook (also migrate fonts as proof of concept)

### DIFF
--- a/pkgs/build-support/setup-hooks/install-fonts.sh
+++ b/pkgs/build-support/setup-hooks/install-fonts.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+
+# Setup hook that installs font files to their respective locations.
+#
+# Example usage in a derivation:
+#
+#   { …, installFonts, … }:
+#
+#   stdenvNoCC.mkDerivation {
+#     …
+#     outputs = [
+#       "out"
+#       "webfont" # If .woff or .woff2 output is desired
+#     ];
+#
+#     nativeBuildInputs = [ installFonts ];
+#     …
+#   }
+#
+# This hook also provides an `installFont` function that can be used to install
+# additional fonts of a particular extension into their respective folder.
+#
+postInstallHooks+=(installFonts)
+
+installFont() {
+  if (($# != 2)); then
+    nixErrorLog "expected 2 arguments!"
+    nixErrorLog "usage: installFont fontExt outDir"
+    exit 1
+  fi
+
+  find -iname "*.$1" -print0 | xargs -0 -r install -m644 -D -t "$2"
+}
+
+installFonts() {
+  if [ "${dontInstallFonts-}" == 1 ]; then return; fi
+
+  installFont 'ttf' "$out/share/fonts/truetype"
+  installFont 'ttc' "$out/share/fonts/truetype"
+  installFont 'otf' "$out/share/fonts/opentype"
+  installFont 'bdf' "$out/share/fonts/misc"
+  installFont 'otb' "$out/share/fonts/misc"
+  installFont 'psf' "$out/share/consolefonts"
+
+  if [ -n "${webfont-}" ]; then
+    installFont 'woff' "$webfont/share/fonts/woff"
+    installFont 'woff2' "$webfont/share/fonts/woff2"
+  fi
+
+}

--- a/pkgs/by-name/ba/barlow/package.nix
+++ b/pkgs/by-name/ba/barlow/package.nix
@@ -2,30 +2,26 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  installFonts,
 }:
 
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "barlow";
   version = "1.422";
+
+  outputs = [
+    "out"
+    "webfont"
+  ];
 
   src = fetchFromGitHub {
     owner = "jpt";
     repo = "barlow";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-FG68o6qN/296RhSNDHFXYXbkhlXSZJgGhVjzlJqsksY=";
   };
 
-  installPhase = ''
-    runHook preInstall
-
-    install -Dm644 fonts/otf/*.otf -t $out/share/fonts/opentype
-    install -Dm644 fonts/ttf/*.ttf fonts/gx/*.ttf -t $out/share/fonts/truetype
-    install -Dm644 fonts/eot/*.eot -t $out/share/fonts/eot
-    install -Dm644 fonts/woff/*.woff -t $out/share/fonts/woff
-    install -Dm644 fonts/woff2/*.woff2 -t $out/share/fonts/woff2
-
-    runHook postInstall
-  '';
+  nativeBuildInputs = [ installFonts ];
 
   meta = {
     description = "Grotesk variable font superfamily";
@@ -34,4 +30,4 @@ stdenvNoCC.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -710,6 +710,10 @@ with pkgs;
 
   makeDesktopItem = callPackage ../build-support/make-desktopitem { };
 
+  installFonts = makeSetupHook {
+    name = "install-fonts-hook";
+  } ../build-support/setup-hooks/install-fonts.sh;
+
   copyPkgconfigItems = makeSetupHook {
     name = "copy-pkg-config-items-hook";
   } ../build-support/setup-hooks/copy-pkgconfig-items.sh;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This will supercede #483493 if we decide that a builder is a bad idea. This was actually REALLY easy, yay! I thought this would be really confusing but it's not that bad :smile: It's also nice because now we have a nice helper for installing any additional formats in postInstall or whatever.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
