### PR TITLE
various: migrate go modules to finalAttrs #1

### DIFF
--- a/pkgs/by-name/_1/_1fps/package.nix
+++ b/pkgs/by-name/_1/_1fps/package.nix
@@ -7,14 +7,14 @@
   libx11,
   stdenv,
 }:
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "1fps";
   version = "0.1.17";
 
   src = fetchFromGitHub {
     owner = "1fpsvideo";
     repo = "1fps";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-8dtcW/niwmhVXB2kZdR/RjNg2ArSClL1w4nGI5rP3+Y=";
   };
 
@@ -35,4 +35,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ renesat ];
     mainProgram = "1fps";
   };
-}
+})

--- a/pkgs/by-name/ad/adreaper/package.nix
+++ b/pkgs/by-name/ad/adreaper/package.nix
@@ -5,14 +5,14 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "adreaper";
   version = "1.1";
 
   src = fetchFromGitHub {
     owner = "AidenPearce369";
     repo = "ADReaper";
-    rev = "ADReaperv${version}";
+    rev = "ADReaperv${finalAttrs.version}";
     sha256 = "sha256-+FCb5TV9MUcRyex2M4rn2RhcIsXQFbtm1T4r7MpcRQs=";
   };
 
@@ -25,11 +25,11 @@ buildGoModule rec {
   meta = {
     description = "Enumeration tool for Windows Active Directories";
     homepage = "https://github.com/AidenPearce369/ADReaper";
-    changelog = "https://github.com/AidenPearce369/ADReaper/releases/tag/ADReaperv${version}";
+    changelog = "https://github.com/AidenPearce369/ADReaper/releases/tag/ADReaperv${finalAttrs.version}";
     # Upstream doesn't have a license yet
     # https://github.com/AidenPearce369/ADReaper/issues/2
     license = with lib.licenses; [ unfree ];
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "ADReaper";
   };
-}
+})

--- a/pkgs/by-name/ag/ags/package.nix
+++ b/pkgs/by-name/ag/ags/package.nix
@@ -19,14 +19,14 @@
 
   extraPackages ? [ ],
 }:
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "ags";
   version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "Aylur";
     repo = "ags";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-GLyNtU9A2VN22jNRHZ2OXuFfTJLh8uEVVt+ftsKUX0c=";
   };
 
@@ -62,7 +62,7 @@ buildGoModule rec {
       depsOf = pkg: [ (pkg.dev or pkg) ] ++ (map depsOf (pkg.propagatedBuildInputs or [ ]));
       girDirs = symlinkJoin {
         name = "gir-dirs";
-        paths = lib.flatten (map depsOf buildInputs);
+        paths = lib.flatten (map depsOf finalAttrs.buildInputs);
       };
     in
     ''
@@ -102,7 +102,7 @@ buildGoModule rec {
   meta = {
     description = "Scaffolding CLI for Astal widget system";
     homepage = "https://github.com/Aylur/ags";
-    changelog = "https://github.com/Aylur/ags/releases/tag/v${version}";
+    changelog = "https://github.com/Aylur/ags/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       PerchunPak
@@ -111,4 +111,4 @@ buildGoModule rec {
     mainProgram = "ags";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/al/alertmanager-webhook-logger/package.nix
+++ b/pkgs/by-name/al/alertmanager-webhook-logger/package.nix
@@ -5,13 +5,13 @@
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "alertmanager-webhook-logger";
   version = "1.0";
-  rev = "${version}";
+  rev = "${finalAttrs.version}";
 
   src = fetchFromGitHub {
-    inherit rev;
+    inherit (finalAttrs) rev;
     owner = "tomtom-international";
     repo = "alertmanager-webhook-logger";
     hash = "sha256-mJbpDiTwUsFm0lDKz8UE/YF6sBvcSSR6WWLrfKvtri4=";
@@ -30,4 +30,4 @@ buildGoModule rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jpds ];
   };
-}
+})

--- a/pkgs/by-name/al/algia/package.nix
+++ b/pkgs/by-name/al/algia/package.nix
@@ -5,14 +5,14 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "algia";
   version = "0.0.102";
 
   src = fetchFromGitHub {
     owner = "mattn";
     repo = "algia";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vpZL4UNDtcJRsBA0th6/YccE/3GG7kzHrgJ3RWpgSk8=";
   };
 
@@ -25,4 +25,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ haruki7049 ];
     mainProgram = "algia";
   };
-}
+})

--- a/pkgs/by-name/al/alice-lg/package.nix
+++ b/pkgs/by-name/al/alice-lg/package.nix
@@ -11,14 +11,14 @@
   fixup-yarn-lock,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "alice-lg";
   version = "6.2.0";
 
   src = fetchFromGitHub {
     owner = "alice-lg";
     repo = "alice-lg";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-DlmUurpu/bs/91fLsSQ3xJ8I8NWJweynMgV6Svkf0Uo=";
   };
 
@@ -26,11 +26,11 @@ buildGoModule rec {
 
   passthru.ui = stdenv.mkDerivation {
     pname = "alice-lg-ui";
-    src = "${src}/ui";
-    inherit version;
+    src = "${finalAttrs.src}/ui";
+    inherit (finalAttrs) version;
 
     yarnOfflineCache = fetchYarnDeps {
-      yarnLock = src + "/ui/yarn.lock";
+      yarnLock = finalAttrs.src + "/ui/yarn.lock";
       hash = "sha256-PwByNIegKYTOT8Yg3nDMDFZiLRVkbX07z99YaDiBsIY=";
     };
 
@@ -75,7 +75,7 @@ buildGoModule rec {
   };
 
   preBuild = ''
-    cp -R ${passthru.ui}/ ui/build/
+    cp -R ${finalAttrs.passthru.ui}/ ui/build/
   '';
 
   subPackages = [ "cmd/alice-lg" ];
@@ -94,4 +94,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ stv0g ];
     mainProgram = "alice-lg";
   };
-}
+})

--- a/pkgs/by-name/al/alp/package.nix
+++ b/pkgs/by-name/al/alp/package.nix
@@ -6,19 +6,19 @@
   alp,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "alp";
   version = "1.1.18";
 
   src = fetchFromGitHub {
     owner = "gernotfeichter";
     repo = "alp";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-tE8qKNXLKvFcnDULVkJJ/EJyEsvATCk/3YFkZCmpHSo=";
   };
   vendorHash = "sha256-AHPVhtm6La7HWuxJfpxTsS5wFTUZUJoVyebLGYhNKTg=";
 
-  sourceRoot = "${src.name}/linux";
+  sourceRoot = "${finalAttrs.src.name}/linux";
 
   # Executing Go commands directly in checkPhase and buildPhase below,
   # because the default testsuite runs all go tests, some of which require docker.
@@ -40,9 +40,9 @@ buildGoModule rec {
   '';
 
   passthru.tests = {
-    test-version = runCommand "${pname}-test" { } ''
+    test-version = runCommand "alp-test" { } ''
       ${alp}/bin/alp version > $out
-      cat $out | grep '${version}'
+      cat $out | grep '${finalAttrs.version}'
     '';
   };
 
@@ -53,4 +53,4 @@ buildGoModule rec {
     mainProgram = "alp";
     maintainers = with lib.maintainers; [ gernotfeichter ];
   };
-}
+})

--- a/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
+++ b/pkgs/by-name/am/amazon-cloudwatch-agent/package.nix
@@ -9,14 +9,14 @@
   versionCheckHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "amazon-cloudwatch-agent";
   version = "1.300064.0";
 
   src = fetchFromGitHub {
     owner = "aws";
     repo = "amazon-cloudwatch-agent";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-998kXLAwhSepDOrKGXRrOfrw9SU8tfxtYmPQNUQWhlI=";
   };
 
@@ -36,7 +36,7 @@ buildGoModule rec {
   #
   # Needed for "amazon-cloudwatch-agent -version" to not show "Unknown".
   postInstall = ''
-    echo v${version} > $out/bin/CWAGENT_VERSION
+    echo v${finalAttrs.version} > $out/bin/CWAGENT_VERSION
   '';
 
   doInstallCheck = true;
@@ -62,4 +62,4 @@ buildGoModule rec {
     mainProgram = "amazon-cloudwatch-agent";
     maintainers = with lib.maintainers; [ pmw ];
   };
-}
+})

--- a/pkgs/by-name/ap/apache-answer/package.nix
+++ b/pkgs/by-name/ap/apache-answer/package.nix
@@ -6,30 +6,29 @@
   pnpmConfigHook,
   pnpm,
   nodejs,
-  fetchpatch,
   stdenv,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "apache-answer";
   version = "1.7.1";
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "answer";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-QTm/6srSn4oF78795ADpW10bZmyEmqTNezB6JSkS2I4=";
   };
 
   webui = stdenv.mkDerivation {
-    pname = pname + "-webui";
-    inherit version src;
+    pname = "apache-answer" + "-webui";
+    inherit (finalAttrs) version src;
 
-    sourceRoot = "${src.name}/ui";
+    sourceRoot = "${finalAttrs.src.name}/ui";
 
     pnpmDeps = fetchPnpmDeps {
-      inherit src version pname;
-      sourceRoot = "${src.name}/ui";
+      inherit (finalAttrs) src version pname;
+      sourceRoot = "${finalAttrs.src.name}/ui";
       fetcherVersion = 1;
       hash = "sha256-6IeLOwsEqchCwe0GGj/4v9Q4/Hm16K+ve2X+8QHztQM=";
     };
@@ -63,12 +62,12 @@ buildGoModule rec {
   doCheck = false; # TODO checks are currently broken upstream
 
   ldflags = [
-    "-X main.Version=${version}"
-    "-X main.Commit=${version}"
+    "-X main.Version=${finalAttrs.version}"
+    "-X main.Commit=${finalAttrs.version}"
   ];
 
   preBuild = ''
-    cp -r ${webui}/* ui/build/
+    cp -r ${finalAttrs.webui}/* ui/build/
   '';
 
   meta = {
@@ -79,7 +78,7 @@ buildGoModule rec {
     ];
     platforms = lib.platforms.unix;
     mainProgram = "answer";
-    changelog = "https://github.com/apache/answer/releases/tag/v${version}";
+    changelog = "https://github.com/apache/answer/releases/tag/v${finalAttrs.version}";
     description = "Q&A platform software for teams at any scales";
   };
-}
+})

--- a/pkgs/by-name/ap/apx/package.nix
+++ b/pkgs/by-name/ap/apx/package.nix
@@ -12,7 +12,7 @@
   writeShellScript,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "apx";
   version = "2.4.5";
   versionConfig = "1.0.0";
@@ -20,7 +20,7 @@ buildGoModule rec {
   src = fetchFromGitHub {
     owner = "Vanilla-OS";
     repo = "apx";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0Rfj7hrH26R9GHOPPVdCaeb1bfAw9KnPpJYXyiei90U=";
   };
 
@@ -28,7 +28,7 @@ buildGoModule rec {
   configsSrc = fetchFromGitHub {
     owner = "Vanilla-OS";
     repo = "vanilla-apx-configs";
-    tag = "v${versionConfig}";
+    tag = "v${finalAttrs.versionConfig}";
     hash = "sha256-cCXmHkRjcWcpMtgPVtQF5Q76jr1Qt2RHSLtWLQdq+aE=";
   };
 
@@ -47,7 +47,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X 'main.Version=v${version}'"
+    "-X 'main.Version=v${finalAttrs.version}'"
   ];
 
   postPatch = ''
@@ -64,8 +64,8 @@ buildGoModule rec {
 
     # Install official Vanilla configs (same as install script)
     install -d $out/share/apx
-    cp -r ${configsSrc}/stacks $out/share/apx/
-    cp -r ${configsSrc}/package-managers $out/share/apx/
+    cp -r ${finalAttrs.configsSrc}/stacks $out/share/apx/
+    cp -r ${finalAttrs.configsSrc}/package-managers $out/share/apx/
 
     # Man pages, documentation, license
     installManPage man/man1/*
@@ -113,7 +113,7 @@ buildGoModule rec {
         environment.systemPackages = with pkgs; [ apx ];
     '';
     homepage = "https://github.com/Vanilla-OS/apx";
-    changelog = "https://github.com/Vanilla-OS/apx/releases/tag/v${version}";
+    changelog = "https://github.com/Vanilla-OS/apx/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       dit7ya
@@ -122,4 +122,4 @@ buildGoModule rec {
     ];
     mainProgram = "apx";
   };
-}
+})

--- a/pkgs/by-name/ar/argocd-autopilot/package.nix
+++ b/pkgs/by-name/ar/argocd-autopilot/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "argocd-autopilot";
   version = "0.4.20";
 
   src = fetchFromGitHub {
     owner = "argoproj-labs";
     repo = "argocd-autopilot";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-JLh41ZWiDcDrUtd8d+Ak5TFca4L6VHzUguS55P9lmj0=";
   };
 
@@ -26,19 +26,19 @@ buildGoModule rec {
     [
       "-s"
       "-w"
-      "-X ${package_url}.binaryName=${pname}"
-      "-X ${package_url}.version=${src.rev}"
+      "-X ${package_url}.binaryName=argocd-autopilot"
+      "-X ${package_url}.version=${finalAttrs.src.rev}"
       "-X ${package_url}.buildDate=unknown"
-      "-X ${package_url}.gitCommit=${src.rev}"
-      "-X ${package_url}.installationManifestsURL=github.com/argoproj-labs/argocd-autopilot/manifests/base?ref=${src.rev}"
-      "-X ${package_url}.installationManifestsNamespacedURL=github.com/argoproj-labs/argocd-autopilot/manifests/insecure?ref=${src.rev}"
+      "-X ${package_url}.gitCommit=${finalAttrs.src.rev}"
+      "-X ${package_url}.installationManifestsURL=github.com/argoproj-labs/argocd-autopilot/manifests/base?ref=${finalAttrs.src.rev}"
+      "-X ${package_url}.installationManifestsNamespacedURL=github.com/argoproj-labs/argocd-autopilot/manifests/insecure?ref=${finalAttrs.src.rev}"
     ];
 
   subPackages = [ "cmd" ];
 
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/argocd-autopilot version | grep ${src.rev} > /dev/null
+    $out/bin/argocd-autopilot version | grep ${finalAttrs.src.rev} > /dev/null
   '';
 
   installPhase = ''
@@ -60,4 +60,4 @@ buildGoModule rec {
       sagikazarmark
     ];
   };
-}
+})

--- a/pkgs/by-name/ar/argocd/package.nix
+++ b/pkgs/by-name/ar/argocd/package.nix
@@ -11,25 +11,25 @@
   nodejs,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "argocd";
   version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "argoproj";
     repo = "argo-cd";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-FvN4JCG/5SxpnmdEH9X1sMX5dNlp/x0ALNysv+LWroU=";
   };
 
   ui = stdenv.mkDerivation {
-    pname = "${pname}-ui";
-    inherit version;
-    src = src + "/ui";
+    pname = "argocd-ui";
+    inherit (finalAttrs) version;
+    src = finalAttrs.src + "/ui";
 
     offlineCache = fetchYarnDeps {
-      yarnLock = "${src}/ui/yarn.lock";
-      hash = "sha256-kqBolkQiwZUBic0f+Ek5HwYsOmro1+FStkDLXAre79o=";
+      yarnLock = "${finalAttrs.src}/ui/yarn.lock";
+      hash = "sha256-ekhSPWzIgFhwSw0bIlBqu8LTYk3vuJ9VM8eHc3mnHGM=";
     };
 
     nativeBuildInputs = [
@@ -58,17 +58,17 @@ buildGoModule rec {
     [
       "-s"
       "-w"
-      "-X ${packageUrl}.version=${version}"
+      "-X ${packageUrl}.version=${finalAttrs.version}"
       "-X ${packageUrl}.buildDate=unknown"
-      "-X ${packageUrl}.gitCommit=${src.rev}"
-      "-X ${packageUrl}.gitTag=${src.rev}"
+      "-X ${packageUrl}.gitCommit=${finalAttrs.src.rev}"
+      "-X ${packageUrl}.gitTag=${finalAttrs.src.rev}"
       "-X ${packageUrl}.gitTreeState=clean"
     ];
 
   nativeBuildInputs = [ installShellFiles ];
 
   preBuild = ''
-    cp -r ${ui}/dist ./ui
+    cp -r ${finalAttrs.ui}/dist ./ui
     stat ./ui/dist/app/index.html # Sanity check
   '';
 
@@ -88,7 +88,7 @@ buildGoModule rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    $out/bin/argocd version --client | grep ${src.rev} > /dev/null
+    $out/bin/argocd version --client | grep ${finalAttrs.src.rev} > /dev/null
   '';
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
@@ -112,4 +112,4 @@ buildGoModule rec {
       FKouhai
     ];
   };
-}
+})

--- a/pkgs/by-name/au/autobrr/package.nix
+++ b/pkgs/by-name/au/autobrr/package.nix
@@ -57,7 +57,7 @@ let
     '';
   };
 in
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   inherit
     autobrr-web
     pname
@@ -72,7 +72,7 @@ buildGoModule rec {
   '';
 
   ldflags = [
-    "-X main.version=${version}"
+    "-X main.version=${finalAttrs.version}"
     "-X main.commit=${src.tag}"
   ];
 
@@ -97,9 +97,9 @@ buildGoModule rec {
     description = "Modern, easy to use download automation for torrents and usenet";
     license = lib.licenses.gpl2Plus;
     homepage = "https://autobrr.com/";
-    changelog = "https://autobrr.com/release-notes/v${version}";
+    changelog = "https://autobrr.com/release-notes/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [ av-gal ];
     mainProgram = "autobrr";
     platforms = with lib.platforms; darwin ++ freebsd ++ linux;
   };
-}
+})


### PR DESCRIPTION
migrate go modules to finalAttrs pattern
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
