### PR TITLE
dbus: fix build by adding `libcap_ng` for `libaudit` support

### DIFF
--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -7,6 +7,7 @@
   enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
   systemdMinimal,
   audit,
+  libcap_ng,
   libapparmor,
   dbus,
   docbook_xml_dtd_44,
@@ -81,6 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     audit
     libapparmor
+    libcap_ng
   ];
   # ToDo: optional selinux?
 


### PR DESCRIPTION
The dbus meson.build requires both libaudit and libcap-ng when libaudit support is enabled:

    have_libaudit = libaudit_ok and cap_ng_ok

While the audit package itself depends on libcap_ng, that dependency doesn't make libcap_ng available in dbus's build environment. Adding it explicitly fixes the build failure:

    Library cap-ng found: NO
    meson.build:556:8: ERROR: Problem encountered: libaudit support requested but not found

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
