### PR TITLE
nixos/mpv: import from home-manager

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -128,6 +128,8 @@
 
 - [cocoon](https://github.com/haileyok/cocoon), a PDS (personal data server) that is an alternative to the Bluesky PDS. Available as [services.cocoon](#opt-services.cocoon.enable).
 
+- [mpv](https://mpv.io/), a general-purpose media player. Available as [programs.mpv](#opt-programs.mpv.enable).
+
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
 
 - [linkding](https://linkding.link/), a self-hosted bookmark manager designed to be minimal, fast, and easy to set up. Available as [services.linkding](#opt-services.linkding.enable).

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -128,8 +128,6 @@
 
 - [cocoon](https://github.com/haileyok/cocoon), a PDS (personal data server) that is an alternative to the Bluesky PDS. Available as [services.cocoon](#opt-services.cocoon.enable).
 
-- [mpv](https://mpv.io/), a general-purpose media player. Available as [programs.mpv](#opt-programs.mpv.enable).
-
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
 
 - [linkding](https://linkding.link/), a self-hosted bookmark manager designed to be minimal, fast, and easy to set up. Available as [services.linkding](#opt-services.linkding.enable).

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -18,6 +18,8 @@
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
+- [mpv](https://mpv.io/), a general-purpose media player. Available as [programs.mpv](#opt-programs.mpv.enable).
+
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).
 
 - [FlapAlerted](https://github.com/Kioubit/FlapAlerted), detects BGP flapping events and provides statistics based on BGP update messages. Available as [services.flap-alerted](#opt-services.flap-alerted.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -269,6 +269,7 @@
   ./programs/miriway.nix
   ./programs/mosh.nix
   ./programs/mouse-actions.nix
+  ./programs/mpv.nix
   ./programs/msmtp.nix
   ./programs/mtr.nix
   ./programs/nano.nix

--- a/nixos/modules/programs/mpv.nix
+++ b/nixos/modules/programs/mpv.nix
@@ -1,0 +1,265 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    generators
+    literalExpression
+    mkIf
+    mkOption
+    types
+    ;
+  inherit (builtins) typeOf stringLength;
+
+  cfg = config.programs.mpv;
+
+  mpvOption =
+    with types;
+    oneOf [
+      str
+      int
+      bool
+      float
+    ];
+  mpvOptionDup = types.either mpvOption (types.listOf mpvOption);
+  mpvOptions = types.attrsOf mpvOptionDup;
+  mpvProfiles = types.attrsOf mpvOptions;
+  mpvBindings = types.attrsOf types.str;
+  mpvDefaultProfiles = types.listOf types.str;
+
+  renderOption =
+    option:
+    rec {
+      int = toString option;
+      float = int;
+      bool = lib.boolToYesNo option;
+      string = option;
+    }
+    .${typeOf option};
+
+  renderOptionValue =
+    value:
+    let
+      rendered = renderOption value;
+      length = toString (stringLength rendered);
+    in
+    "%${length}%${rendered}";
+
+  renderOptions = generators.toKeyValue {
+    mkKeyValue = generators.mkKeyValueDefault { mkValueString = renderOptionValue; } "=";
+    listsAsDuplicateKeys = true;
+  };
+
+  renderScriptOptions = generators.toKeyValue {
+    mkKeyValue = generators.mkKeyValueDefault { mkValueString = renderOption; } "=";
+    listsAsDuplicateKeys = true;
+  };
+
+  renderProfiles = generators.toINI {
+    mkKeyValue = generators.mkKeyValueDefault { mkValueString = renderOptionValue; } "=";
+    listsAsDuplicateKeys = true;
+  };
+
+  renderBindings =
+    bindings: lib.concatStringsSep "\n" (lib.mapAttrsToList (name: value: "${name} ${value}") bindings);
+
+  renderDefaultProfiles = profiles: renderOptions { profile = lib.concatStringsSep "," profiles; };
+
+in
+{
+  options = {
+    programs.mpv = {
+      enable = lib.mkEnableOption "mpv";
+
+      package = lib.mkPackageOption pkgs "mpv" {
+        example = ''
+          pkgs.mpv.override (prev: {
+            mpv-unwrapped = prev.mpv-unwrapped.override {
+              vapoursynthSupport = true;
+            };
+            youtubeSupport = true;
+          })
+        '';
+      };
+
+      finalPackage = mkOption {
+        type = types.package;
+        readOnly = true;
+        visible = false;
+        description = ''
+          Resulting mpv package.
+        '';
+      };
+
+      scripts = mkOption {
+        type = types.listOf types.package;
+        default = [ ];
+        example = literalExpression "[ pkgs.mpvScripts.mpris ]";
+        description = ''
+          List of scripts to use with mpv.
+        '';
+      };
+
+      scriptOpts = mkOption {
+        description = ''
+          Script options added to
+          {file}`/etc/mpv/script-opts/`. See
+          {manpage}`mpv(1)`
+          for the full list of options of builtin scripts.
+        '';
+        type = types.attrsOf mpvOptions;
+        default = { };
+        example = {
+          osc = {
+            scalewindowed = 2.0;
+            vidscale = false;
+            visibility = "always";
+          };
+        };
+      };
+
+      config = mkOption {
+        description = ''
+          Configuration written to
+          {file}`/etc/mpv/mpv.conf`. See
+          {manpage}`mpv(1)`
+          for the full list of options.
+        '';
+        type = mpvOptions;
+        default = { };
+        example = literalExpression ''
+          {
+            profile = "gpu-hq";
+            force-window = true;
+            ytdl-format = "bestvideo+bestaudio";
+            cache-default = 4000000;
+          }
+        '';
+      };
+
+      includes = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        example = literalExpression ''
+          [
+            "/path/to/config.inc";
+            "/path/to/conditional.inc";
+          ]
+        '';
+        description = "List of configuration files to include at the end of mpv.conf.";
+      };
+
+      profiles = mkOption {
+        description = ''
+          Sub-configuration options for specific profiles written to
+          {file}`/etc/mpv/mpv.conf`. See
+          {option}`programs.mpv.config` for more information.
+        '';
+        type = mpvProfiles;
+        default = { };
+        example = literalExpression ''
+          {
+            fast = {
+              vo = "vdpau";
+            };
+            "protocol.dvd" = {
+              profile-desc = "profile for dvd:// streams";
+              alang = "en";
+            };
+          }
+        '';
+      };
+
+      defaultProfiles = mkOption {
+        description = ''
+          Profiles to be applied by default. Options set by them are overridden
+          by options set in [](#opt-programs.mpv.config).
+        '';
+        type = mpvDefaultProfiles;
+        default = [ ];
+        example = [ "gpu-hq" ];
+      };
+
+      bindings = mkOption {
+        description = ''
+          Input configuration written to
+          {file}`/etc/mpv/input.conf`. See
+          {manpage}`mpv(1)`
+          for the full list of options.
+        '';
+        type = mpvBindings;
+        default = { };
+        example = literalExpression ''
+          {
+            WHEEL_UP = "seek 10";
+            WHEEL_DOWN = "seek -10";
+            "Alt+0" = "set window-scale 0.5";
+          }
+        '';
+      };
+
+      extraInput = mkOption {
+        description = ''
+          Additional lines that are appended to {file}`/etc/mpv/input.conf`.
+           See {manpage}`mpv(1)` for the full list of options.
+        '';
+        type = types.lines;
+        default = "";
+        example = ''
+          esc         quit                        #! Quit
+          #           script-binding uosc/video   #! Video tracks
+          # additional comments
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.finalPackage ];
+        programs.mpv.finalPackage =
+          if cfg.scripts == [ ] then
+            cfg.package
+          else
+            cfg.package.override (prev: {
+              scripts = (prev.scripts or [ ]) ++ cfg.scripts;
+            });
+      }
+
+      (mkIf (cfg.includes != [ ]) {
+        environment.etc."mpv/mpv.conf" = {
+          text = lib.mkAfter (lib.concatMapStringsSep "\n" (x: "include=${x}") cfg.includes);
+        };
+      })
+
+      (mkIf (cfg.config != { } || cfg.profiles != { }) {
+        environment.etc."mpv/mpv.conf".text = ''
+          ${lib.optionalString (cfg.defaultProfiles != [ ]) (renderDefaultProfiles cfg.defaultProfiles)}
+          ${lib.optionalString (cfg.config != { }) (renderOptions cfg.config)}
+          ${lib.optionalString (cfg.profiles != { }) (renderProfiles cfg.profiles)}
+        '';
+      })
+      (mkIf (cfg.bindings != { } || cfg.extraInput != "") {
+        environment.etc."mpv/input.conf".text = lib.mkMerge [
+          (mkIf (cfg.bindings != { }) (renderBindings cfg.bindings))
+          (mkIf (cfg.extraInput != "") cfg.extraInput)
+        ];
+      })
+      {
+        environment.etc = lib.mapAttrs' (
+          name: value:
+          lib.nameValuePair "mpv/script-opts/${name}.conf" {
+            text = renderScriptOptions value;
+          }
+        ) cfg.scriptOpts;
+      }
+    ]
+  );
+  meta.maintainers = with lib.maintainers; [
+    Stebalien
+  ];
+}

--- a/pkgs/by-name/mp/mpv/package.nix
+++ b/pkgs/by-name/mp/mpv/package.nix
@@ -117,6 +117,12 @@ symlinkJoin {
   passthru.tests.mpv-scripts-should-not-collide = buildEnv {
     name = "mpv-scripts-env";
     paths = lib.pipe mpvScripts [
+      (lib.flip lib.removeAttrs [
+        # Deprecated (intentionally throws when evaluating)
+        "youtube-quality"
+        # Collides with modernx
+        "modernx-zydezu"
+      ])
       # filters "override" "overrideDerivation" "recurseForDerivations"
       (lib.filterAttrs (key: script: lib.isDerivation script))
       # replaces unfree and meta.broken scripts with decent placeholders


### PR DESCRIPTION
This adapts the programs.mpv module from home-manager to apply the configuration options globally. However, it makes a few changes:

1. Some stylistic changes as suggested in review.
2. The `package` option may now be combined with the `scripts` option.
3. The `extraMakeWrapperArgs` option has been removed. This option was added to the home-manager module because that module doesn't allow one to both set the `package` option AND customize the `scripts` option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
