### PR TITLE
clipse: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/by-name/cl/clipse/package.nix
+++ b/pkgs/by-name/cl/clipse/package.nix
@@ -2,20 +2,41 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  stdenv,
+  enableWayland ? stdenv.hostPlatform.isLinux,
+  enableX11 ? false,
 }:
 
+assert lib.assertMsg (
+  stdenv.hostPlatform.isLinux -> (lib.xor enableX11 enableWayland)
+) "Exactly one of enableWayland, enableX11 must be true";
+
 buildGoModule (finalAttrs: {
-  pname = "clipse";
-  version = "1.1.0";
+  pname = "clipse${lib.optionalString enableX11 "-x11"}";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "savedra1";
     repo = "clipse";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-yUkHT7SZT7Eudvk1n43V+WGWqUKtXaV+p4ySMK/XzQw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iDMHEhYuxspBYG54WivnVj2GfMxAc5dcrjNxtAMhsck=";
   };
 
-  vendorHash = "sha256-+9uoB/1g4qucdM8RJRs+fSc5hpcgaCK0GrUOFgHWeKo=";
+  vendorHash = "sha256-rq+2UhT/kAcYMdla+Z/11ofNv2n4FLvpVgHZDe0HqX4=";
+
+  tags =
+    if stdenv.hostPlatform.isDarwin then
+      [ "darwin" ]
+    else if enableWayland then
+      [ "wayland" ]
+    else if enableX11 then
+      [ "linux" ]
+    else
+      [ ];
+
+  env = {
+    CGO_ENABLED = if enableX11 || stdenv.hostPlatform.isDarwin then "1" else "0";
+  };
 
   meta = {
     description = "Useful clipboard manager TUI for Unix";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12449,4 +12449,9 @@ with pkgs;
   gpac-unstable = callPackage ../by-name/gp/gpac/package.nix {
     releaseChannel = "unstable";
   };
+
+  clipse-x11 = callPackage ../by-name/cl/clipse/package.nix {
+    enableWayland = false;
+    enableX11 = true;
+  };
 }


### PR DESCRIPTION
In this new version of clipse, the Go build now requires different tags and CGO availability depending on the display server used by the host OS.  

E.g.

* Wayland: `CGO_ENABLED=0 go build -tags wayland -o clipse`
* X11: `go build -tags linux -o clipse`
* Darwin: `go build -tags darwin -o clipse`

The package has been updated to handle this, using the `stdenv` library to check for a Darwin host, and defaulting to Wayland unless `clipse-x11` is used for the package name (overriding as  X11).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
