### PR TITLE
blast: 2.14.1 -> 2.17.0

### DIFF
--- a/pkgs/by-name/bl/blast/package.nix
+++ b/pkgs/by-name/bl/blast/package.nix
@@ -9,15 +9,17 @@
   cpio,
   gawk,
   coreutils,
+  curl,
+  sqlite,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "blast";
-  version = "2.14.1";
+  version = "2.17.0";
 
   src = fetchurl {
     url = "https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/${finalAttrs.version}/ncbi-blast-${finalAttrs.version}+-src.tar.gz";
-    sha256 = "sha256-cSwtvfD7E8wcLU9O9d0c5LBsO1fpbf6o8j5umfWxZQ4=";
+    sha256 = "sha256-UCBXqI6ZkONOYnWL4h6kdMwK1o1qY6LjeyNyrx5eoUc=";
   };
 
   sourceRoot = "ncbi-blast-${finalAttrs.version}+-src/c++";
@@ -28,6 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-flat-makefile"
     "--without-makefile-auto-update"
     "--with-dll" # build dynamic libraries (static are default)
+    "--with-sqlite3=${sqlite.dev}"
   ];
 
   makeFlags = [ "all_projects=app/" ];
@@ -100,6 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     gawk
     zlib
     bzip2
+    sqlite
   ];
 
   strictDeps = true;
@@ -109,6 +113,9 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     substituteInPlace $out/bin/get_species_taxids.sh \
         --replace-fail "/bin/rm" "${coreutils}/bin/rm"
+
+    substituteInPlace $out/bin/update_blastdb.pl \
+        --replace-fail 'qw(/usr/local/bin /usr/bin)' 'qw(${lib.getBin curl}/bin)'
   '';
   patches = [ ./no_slash_bin.patch ];
 


### PR DESCRIPTION
## Summary
**blast**: Update from 2.14.1 to 2.17.0

see: https://www.ncbi.nlm.nih.gov/books/NBK131777/

Changes:
  - Add sqlite for new build dependencies
  - Add curl path patch for update_blastdb.pl


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
