### PR TITLE
tldr: 3.3.0 -> 3.4.3

### DIFF
--- a/pkgs/by-name/tl/tldr/package.nix
+++ b/pkgs/by-name/tl/tldr/package.nix
@@ -6,26 +6,24 @@
   python3Packages,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "tldr";
-  version = "3.3.0";
+  version = "3.4.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tldr-pages";
     repo = "tldr-python-client";
-    tag = version;
-    hash = "sha256-lc0Jen8vW4BNg784td1AZa2GTYvXC1d83FnAe5RZqpY=";
+    tag = finalAttrs.version;
+    hash = "sha256-YdVmgV7N67XswcGlUN1hhXpRXGMHhY34VBxfr7i/MBs=";
   };
 
   build-system = with python3Packages; [
-    setuptools
-    wheel
+    hatchling
   ];
 
   dependencies = with python3Packages; [
     termcolor
-    colorama
     shtab
   ];
 
@@ -56,7 +54,7 @@ python3Packages.buildPythonApplication rec {
       through a man page for the correct flags.
     '';
     homepage = "https://tldr.sh";
-    changelog = "https://github.com/tldr-pages/tldr-python-client/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/tldr-pages/tldr-python-client/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       taeer
@@ -65,4 +63,4 @@ python3Packages.buildPythonApplication rec {
     ];
     mainProgram = "tldr";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
changes: [https://github.com/tldr-pages/tldr-python-client/releases/tag/3.4.3](https://github.com/tldr-pages/tldr-python-client/releases/tag/3.4.3)
diff: [https://github.com/tldr-pages/tldr-python-client/compare/3.3.0...3.4.3](https://github.com/tldr-pages/tldr-python-client/compare/3.3.0...3.4.3)
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
