### PR TITLE
Added rustnet and myself as a maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -108,6 +108,12 @@
     githubId = 9675338;
     keys = [ { fingerprint = "F466 A548 AD3F C1F1 8C88  4576 8702 7528 B006 D66D"; } ];
   };
+  _0x545a = {
+    email = "theozuang@gmail.com";
+    name = "0x545a";
+    github = "0x545a";
+    githubId = "201163065";
+  };
   _0x5a4 = {
     email = "bej86nug@hhu.de";
     name = "0x5a4";

--- a/pkgs/applications/networking/rustnet/default.nix
+++ b/pkgs/applications/networking/rustnet/default.nix
@@ -27,6 +27,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "A cross-platform network monitoring terminal UI tool built with Rust.";
+    maintainers = [ "0x545a" ];
     license = lib.licenses.asl20;
     homepage = "https://github.com/domcyrus/rustnet";
     platforms = [ "x86_64-linux" ];

--- a/pkgs/applications/networking/rustnet/default.nix
+++ b/pkgs/applications/networking/rustnet/default.nix
@@ -1,0 +1,34 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.stdenv.mkDerivation rec {
+  pname = "rustnet";
+  version = "0.18.0";
+
+  src = pkgs.fetchurl {
+    url = "https://github.com/domcyrus/rustnet/releases/download/v${version}/rustnet-v${version}-x86_64-unknown-linux-musl.tar.gz";
+    hash = "sha256-yAjemn3Qi0GjTG5u7UEXHBJFTCd6ctVacV5UoAX7bWA=";
+  };
+
+  nativeBuildInputs = with pkgs; [ autoPatchelfHook libcap ];
+
+  buildInputs = with pkgs; [
+    libpcap
+    zlib
+  ];
+
+  sourceRoot = "rustnet-v${version}-x86_64-unknown-linux-musl";
+
+  installPhase = ''
+    runHook preInstall
+    # 1. Install the binary
+    install -m755 -D rustnet $out/bin/rustnet
+    runHook postInstall
+  '';
+
+  meta = with pkgs.lib; {
+    description = "A cross-platform network monitoring terminal UI tool built with Rust.";
+    license = lib.licenses.asl20;
+    homepage = "https://github.com/domcyrus/rustnet";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Rustnet is a cross-platform network monitoring TUI tool built with Rust.

It allows for connection status monitoring, process binding and stats gathering using eBPF.

Added myself as a maintainer of the package and in the maintainers list as well.

Homepage: https://github.com/domcyrus/rustnet

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
