### PR TITLE
saldo: 0.8.3 -> 0.8.4

### DIFF
--- a/pkgs/by-name/sa/saldo/package.nix
+++ b/pkgs/by-name/sa/saldo/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitLab,
   python3,
-  appstream-glib,
+  appstream,
   blueprint-compiler,
   desktop-file-utils,
   glib,
@@ -20,14 +20,14 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "saldo";
-  version = "0.8.3";
+  version = "0.8.4";
   pyproject = false;
 
   src = fetchFromGitLab {
     owner = "tabos";
     repo = "saldo";
     tag = version;
-    hash = "sha256-ItdEse9ab5spvxcWn1FTAl7ppfjohRr0CXI4ImiSe+g=";
+    hash = "sha256-QOhHDbXq+QHq6XV/ejt5+Si1bXRZZxLjsRlWVw7Zsuk=";
   };
 
   postPatch = ''
@@ -35,7 +35,7 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   nativeBuildInputs = [
-    appstream-glib # for appstream-util
+    appstream # for appstreamcli
     blueprint-compiler
     desktop-file-utils # for desktop-file-validate
     glib # for glib-compile-resources
@@ -65,6 +65,7 @@ python3.pkgs.buildPythonApplication rec {
   passthru.updateScript = gitUpdater { };
 
   meta = {
+    changelog = "https://gitlab.com/tabos/saldo/-/blob/${src.tag}/NEWS";
     description = "Banking application for small screens";
     homepage = "https://www.tabos.org/projects/saldo/";
     license = lib.licenses.gpl3Plus;


### PR DESCRIPTION
Diff: https://gitlab.com/tabos/saldo/-/compare/0.8.3...0.8.4

Changelog: https://gitlab.com/tabos/saldo/-/blob/0.8.4/NEWS


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
