### PR TITLE
python3Packages.python-otcextensions: init at 0.32.29

### DIFF
--- a/pkgs/development/python-modules/python-otcextensions/default.nix
+++ b/pkgs/development/python-modules/python-otcextensions/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  mock,
+  openstacksdk,
+  osc-lib,
+  oslo-config,
+  oslo-i18n,
+  oslotest,
+  pbr,
+  prometheus-client,
+  python-novaclient,
+  python-openstackclient,
+  requests-mock,
+  setuptools,
+  stestrCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "python-otcextensions";
+  version = "0.32.29";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "opentelekomcloud";
+    repo = "python-otcextensions";
+    tag = version;
+    hash = "sha256-hqxCnIfVJPnlwree0+kY9iXXjPMoGd06tVT+yT6rex8=";
+  };
+
+  env.PBR_VERSION = version;
+
+  build-system = [
+    pbr
+    setuptools
+  ];
+
+  dependencies = [
+    openstacksdk
+    osc-lib
+    oslo-config
+    oslo-i18n
+    python-novaclient
+    python-openstackclient
+  ];
+
+  nativeCheckInputs = [
+    mock
+    oslotest
+    prometheus-client
+    requests-mock
+    stestrCheckHook
+  ];
+
+  disabledTests = [
+    # Requires networking
+    "otcextensions.tests.unit.test_stats.TestNoStats.test_no_stats"
+    "otcextensions.tests.unit.test_stats.TestStats.test_list_projects"
+    "otcextensions.tests.unit.test_stats.TestStats.test_projects"
+    "otcextensions.tests.unit.test_stats.TestStats.test_servers_error"
+    "otcextensions.tests.unit.test_stats.TestStats.test_servers_no_detail"
+    "otcextensions.tests.unit.test_stats.TestStats.test_sfsturbo_share"
+    "otcextensions.tests.unit.test_stats.TestStats.test_timeout"
+  ];
+
+  pythonImportsCheck = [
+    "otcextensions"
+    "otcextensions.common"
+    "otcextensions.osclient"
+    "otcextensions.sdk"
+  ];
+
+  meta = {
+    description = "OpenStack SDK and client extensions for Open Telekom Cloud services";
+    homepage = "https://github.com/opentelekomcloud/python-otcextensions";
+    changelog = "https://github.com/opentelekomcloud/python-otcextensions/releases/tag/${version}";
+    license = lib.licenses.asl20;
+    teams = [ lib.teams.openstack ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15763,6 +15763,8 @@ self: super: with self; {
 
   python-otbr-api = callPackage ../development/python-modules/python-otbr-api { };
 
+  python-otcextensions = callPackage ../development/python-modules/python-otcextensions { };
+
   python-overseerr = callPackage ../development/python-modules/python-overseerr { };
 
   python-owasp-zap-v2-4 = callPackage ../development/python-modules/python-owasp-zap-v2-4 { };


### PR DESCRIPTION
OpenStack SDK and client extensions for Open Telekom Cloud services

https://github.com/opentelekomcloud/python-otcextensions


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
