### PR TITLE
pass-git-helper,python3Packages.{hystack-ai,molecule}: Use /tmp as a temporary home directory

### DIFF
--- a/pkgs/by-name/pa/pass-git-helper/package.nix
+++ b/pkgs/by-name/pa/pass-git-helper/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -20,7 +21,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   dependencies = with python3Packages; [ pyxdg ];
 
-  env.HOME = "$TMPDIR";
+  nativeBuildInputs = [ writableTmpDirAsHomeHook ];
 
   pythonImportsCheck = [ "passgithelper" ];
 

--- a/pkgs/development/python-modules/haystack-ai/default.nix
+++ b/pkgs/development/python-modules/haystack-ai/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   hatchling,
+  writableTmpDirAsHomeHook,
   boilerpy3,
   events,
   httpx,
@@ -103,6 +104,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     hatchling
+    writableTmpDirAsHomeHook
   ];
 
   propagatedBuildInputs = [
@@ -130,8 +132,6 @@ buildPythonPackage rec {
     tqdm
     transformers
   ];
-
-  env.HOME = "$(mktemp -d)";
 
   optional-dependencies = {
     # all = [

--- a/pkgs/development/python-modules/molecule/default.nix
+++ b/pkgs/development/python-modules/molecule/default.nix
@@ -16,6 +16,7 @@
   testers,
   wcmatch,
   withPlugins ? true,
+  writableTmpDirAsHomeHook,
   molecule-plugins,
   yamllint,
 }:
@@ -61,7 +62,7 @@ buildPythonPackage rec {
     }).overrideAttrs
       (old: {
         # workaround the error: Permission denied: '/homeless-shelter'
-        HOME = "$(mktemp -d)";
+        nativeBuildInputs = old.nativeBuildInputs ++ [ writableTmpDirAsHomeHook ];
       });
 
   meta = {


### PR DESCRIPTION
I noticed a weird `~/.nix-profile/\$TMPDIR` directory and, using `realpath ~/.nix-profile/\$TMPDIR`, I identified `pass-git-helper` as the culprit. In particular, the value of `env.HOME` is not interpreted by bash as probably intended by the package author. Note that the tests of `pass-git-helper` fail if `$HOME` is unset. To fix this bug, I grepped for `env.HOME` to see how other packages provide a home directory for tests. During this search I noticed that `haystack-ai` suffers from a similar problem, although this is just a guess because it's currently marked as broken.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (only pass-git-helper, not haystack-ai)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
