### PR TITLE
jitsi-meet-electron: 2025.2.0 -> 2026.5.0

### DIFF
--- a/pkgs/by-name/ji/jitsi-meet-electron/bump-node-abi.patch
+++ b/pkgs/by-name/ji/jitsi-meet-electron/bump-node-abi.patch
@@ -1,0 +1,32 @@
+diff --git a/package-lock.json b/package-lock.json
+index 6d9795b..c9370e2 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -12444,10 +12444,11 @@
+       "dev": true
+     },
+     "node_modules/node-abi": {
+-      "version": "3.74.0",
+-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
+-      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
++      "version": "3.87.0",
++      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
++      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+       "dev": true,
++      "license": "MIT",
+       "dependencies": {
+         "semver": "^7.3.5"
+       },
+@@ -26000,9 +26001,9 @@
+       }
+     },
+     "node-abi": {
+-      "version": "3.74.0",
+-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.74.0.tgz",
+-      "integrity": "sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==",
++      "version": "3.87.0",
++      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
++      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+       "dev": true,
+       "requires": {
+         "semver": "^7.3.5"

--- a/pkgs/by-name/ji/jitsi-meet-electron/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet-electron/package.nix
@@ -6,30 +6,41 @@
   copyDesktopItems,
   makeDesktopItem,
   makeWrapper,
+  xcbuild,
   libpng,
   libX11,
   libXi,
   libXtst,
   zlib,
-  electron,
+  electron_39,
 }:
 
+let
+  electron = electron_39;
+in
 buildNpmPackage rec {
   pname = "jitsi-meet-electron";
-  version = "2025.2.0";
+  version = "2025.10.0";
 
   src = fetchFromGitHub {
     owner = "jitsi";
     repo = "jitsi-meet-electron";
-    rev = "v${version}";
-    hash = "sha256-Pk62BpfXblRph3ktxy8eF9umRmPRZbZGjRWduy+3z+s=";
+    tag = "v${version}";
+    hash = "sha256-GKsTM/dDwt8JnV0TKe3kc9bcnPatJjX60/Ou/4aG4VA=";
   };
+
+  patches = [
+    ./bump-node-abi.patch # allow detecting the electron_39 ABI
+  ];
 
   nativeBuildInputs = [
     makeWrapper
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xcbuild
   ];
 
   # robotjs node-gyp dependencies
@@ -41,14 +52,13 @@ buildNpmPackage rec {
     zlib
   ];
 
-  npmDepsHash = "sha256-TckV91RJo06OKb8nIvxBCxu28qyHtA/ACDshOlaCQxA=";
+  npmDepsHash = "sha256-SjizHcD//yIwquJViiS6cIXLwhWeTrm5EJHMRDwbb6U=";
 
   makeCacheWritable = true;
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
-  # disable code signing on Darwin
-  env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
 
   preBuild = ''
     # remove some prebuilt binaries
@@ -56,48 +66,48 @@ buildNpmPackage rec {
 
     # don't force both darwin architectures together
     substituteInPlace node_modules/@jitsi/robotjs/binding.gyp \
-        --replace-fail "-arch x86_64" "" \
-        --replace-fail "-arch arm64" ""
+      --replace-fail "-arch x86_64" "" \
+      --replace-fail "-arch arm64" ""
   '';
 
   postBuild = ''
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
+    export npm_config_nodedir=${electron.headers}
+
     # npmRebuild is needed because robotjs won't be built on darwin otherwise
     # asarUnpack makes sure to unwrap binaries so that nix can see the RPATH
     npm exec electron-builder -- \
-        --dir \
-        -c.npmRebuild=true \
-        -c.asarUnpack="**/*.node" \
-        -c.electronDist=electron-dist \
-        -c.electronVersion=${electron.version}
+      --dir \
+      -c.mac.identity=null \
+      -c.npmRebuild=true \
+      -c.asarUnpack="**/*.node" \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version}
   '';
-
-  NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
 
   installPhase = ''
     runHook preInstall
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    mkdir -p $out/share/jitsi-meet-electron
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/jitsi-meet-electron
 
-    ${lib.optionalString stdenv.hostPlatform.isLinux ''
-      mkdir -p $out/share/jitsi-meet-electron
-      cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/jitsi-meet-electron
+    makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
+      --add-flags $out/share/jitsi-meet-electron/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --set-default ELECTRON_IS_DEV 0 \
+      --inherit-argv0
 
-      makeWrapper ${lib.getExe electron} $out/bin/jitsi-meet-electron \
-          --add-flags $out/share/jitsi-meet-electron/resources/app.asar \
-          --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
-          --set-default ELECTRON_IS_DEV 0 \
-          --inherit-argv0
-
-      install -Dm644 resources/icons/512x512.png $out/share/icons/hicolor/512x512/apps/jitsi-meet-electron.png
-    ''}
-
-    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
-      mkdir -p $out/Applications
-      cp -r dist/mac*/"Jitsi Meet.app" $out/Applications
-      makeWrapper "$out/Applications/Jitsi Meet.app/Contents/MacOS/Jitsi Meet" $out/bin/jitsi-meet-electron
-    ''}
-
+    install -Dm644 resources/icons/512x512.png $out/share/icons/hicolor/512x512/apps/jitsi-meet-electron.png
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/Applications
+    cp -r dist/mac*/"Jitsi Meet.app" $out/Applications
+    makeWrapper "$out/Applications/Jitsi Meet.app/Contents/MacOS/Jitsi Meet" $out/bin/jitsi-meet-electron
+  ''
+  + ''
     runHook postInstall
   '';
 
@@ -121,7 +131,7 @@ buildNpmPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/jitsi/jitsi-meet-electron/releases/tag/${src.rev}";
+    changelog = "https://github.com/jitsi/jitsi-meet-electron/releases/tag/${src.tag}";
     description = "Jitsi Meet desktop application powered by Electron";
     homepage = "https://github.com/jitsi/jitsi-meet-electron";
     license = lib.licenses.asl20;

--- a/pkgs/by-name/ji/jitsi-meet-electron/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet-electron/package.nix
@@ -1,28 +1,36 @@
 {
   lib,
   stdenv,
+
   buildNpmPackage,
   fetchFromGitHub,
-  copyDesktopItems,
   makeDesktopItem,
+
+  copyDesktopItems,
   makeWrapper,
+  xcbuild,
+
   libpng,
   libx11,
   libxi,
   libxtst,
   zlib,
-  electron,
+
+  electron_41,
 }:
 
+let
+  electron = electron_41;
+in
 buildNpmPackage rec {
   pname = "jitsi-meet-electron";
-  version = "2025.2.0";
+  version = "2026.5.0";
 
   src = fetchFromGitHub {
     owner = "jitsi";
     repo = "jitsi-meet-electron";
     rev = "v${version}";
-    hash = "sha256-Pk62BpfXblRph3ktxy8eF9umRmPRZbZGjRWduy+3z+s=";
+    hash = "sha256-yeYDft2d2RHNXYrmnHlBzsZ43bvBgwwsqxQr/Q+/AuQ=";
   };
 
   nativeBuildInputs = [
@@ -30,6 +38,9 @@ buildNpmPackage rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    xcbuild
   ];
 
   # robotjs node-gyp dependencies
@@ -41,14 +52,12 @@ buildNpmPackage rec {
     zlib
   ];
 
-  npmDepsHash = "sha256-TckV91RJo06OKb8nIvxBCxu28qyHtA/ACDshOlaCQxA=";
+  npmDepsHash = "sha256-5y7q6SnA9s85+HFOhqif1N8XRO7ekGJ4nfVbWZ/diuI=";
 
   makeCacheWritable = true;
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-    # disable code signing on Darwin
-    CSC_IDENTITY_AUTO_DISCOVERY = "false";
     NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
   };
 
@@ -66,6 +75,8 @@ buildNpmPackage rec {
     cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
+    export npm_config_nodedir=${electron.headers}
+
     # npmRebuild is needed because robotjs won't be built on darwin otherwise
     # asarUnpack makes sure to unwrap binaries so that nix can see the RPATH
     npm exec electron-builder -- \
@@ -73,7 +84,8 @@ buildNpmPackage rec {
         -c.npmRebuild=true \
         -c.asarUnpack="**/*.node" \
         -c.electronDist=electron-dist \
-        -c.electronVersion=${electron.version}
+        -c.electronVersion=${electron.version} \
+        -c.mac.identity=null
   '';
 
   installPhase = ''


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/452076

We are now correctly using `electron.headers` as the headers to compile native modules against.
Upstream updated to a version of `electron-rebuild` that depends on `node-abi` so we can no longer keep the electron version unpinned.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
