### PR TITLE
unrar-free: 0.3.1-unstable-2024-09-19 -> 0.3.3

### DIFF
--- a/pkgs/by-name/un/unrar-free/package.nix
+++ b/pkgs/by-name/un/unrar-free/package.nix
@@ -5,17 +5,18 @@
   autoreconfHook,
   libarchive,
   pkg-config,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unrar-free";
-  version = "0.3.1-unstable-2024-09-19";
+  version = "0.3.3";
 
   src = fetchFromGitLab {
     owner = "bgermann";
     repo = "unrar-free";
-    rev = "a7f9a157276ae68987fb44fe5ccf4f4255eb0a5e";
-    hash = "sha256-aCO1vklG5MneEiqS/IBvC09YrvWa+OndfvCblDFKA1E=";
+    tag = finalAttrs.version;
+    hash = "sha256-3eI8vWc6E+gj+LwBG6jG1l8h8EXXcAQ44W0ALzwOOFg=";
   };
 
   nativeBuildInputs = [
@@ -26,6 +27,9 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ libarchive ];
 
   setupHook = ./setup-hook.sh;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
 
   meta = {
     description = "Free utility to extract files from RAR archives";

--- a/pkgs/by-name/un/unrar-free/package.nix
+++ b/pkgs/by-name/un/unrar-free/package.nix
@@ -45,7 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://gitlab.com/bgermann/unrar-free";
     license = lib.licenses.gpl2Plus;
     mainProgram = "unrar-free";
-    maintainers = with lib.maintainers; [ thiagokokada ];
+    maintainers = with lib.maintainers; [
+      anthonyroussel
+      thiagokokada
+    ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };


### PR DESCRIPTION
Diff: https://gitlab.com/bgermann/unrar-free/-/compare/a7f9a157276ae68987fb44fe5ccf4f4255eb0a5e...0.3.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
