### PR TITLE
umple: init at 1.37.0

### DIFF
--- a/pkgs/by-name/um/umple/2DShapes.ump
+++ b/pkgs/by-name/um/umple/2DShapes.ump
@@ -1,0 +1,62 @@
+// Taken from https://github.com/umple/Umple/wiki/examples
+
+// 2D Shapes class hierarchy - sample UML class
+// diagram in Umple
+// From Book by Lethbridge and Laganiere, McGraw Hill 2004
+// Object-Oriented Software Engineering:
+//   Practical Software Engineering using UML and Java
+// See https://www.site.uottawa.ca/school/research/lloseng/
+
+//Namespace for core of the system.
+namespace Shapes.core;
+
+class Shape2D {
+ center;
+}
+//Abstract
+class EllipticalShape {
+ isA Shape2D;
+ semiMajorAxis;
+}
+//Abstract
+class Polygon {
+ isA Shape2D;
+}
+class Circle {
+ isA EllipticalShape;
+}
+class Ellipse{
+ isA EllipticalShape;
+}
+class SimplePolygon {
+ orientation;
+ isA Polygon;
+}
+class ArbitraryPolygon {
+ points;
+ isA Polygon;
+}
+class Rectangle {
+ isA SimplePolygon;
+ height;
+ width;
+}
+class RegularPolygon {
+ numPoints;
+ radius;
+ isA SimplePolygon;
+}
+
+class Shape2D {
+  public static void main(String [] argc) Java {
+    Shape2D s = new
+      RegularPolygon("0,0","0","3","100");
+    System.out.println(s);
+  }
+
+  public static void main(String [] argc) Python{
+    import RegularPolygon
+    s = RegularPolygon.RegularPolygon("0,0","0","3","100")
+    print(str(s))
+  }
+}

--- a/pkgs/by-name/um/umple/deps.json
+++ b/pkgs/by-name/um/umple/deps.json
@@ -1,0 +1,616 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://plugins.gradle.org/m2": {
+  "com/bmuschko#gradle-docker-plugin/3.2.1": {
+   "jar": "sha256-BfgdS5EdMR7nrEhJ6/eLMD4HdDQY1OiaVZVCK/OAIxQ=",
+   "pom": "sha256-slOHkvEGJnUa9sjeAgdH/1E4kntOKfL69KjtOsFKzSE="
+  },
+  "com/github/luben#zstd-jni/1.5.6-3": {
+   "jar": "sha256-9y7eGzklj6+BJ33FjeMMccuuQlNzJVjSzhC1PYtXY9U=",
+   "pom": "sha256-39L6ex0jk5IWkC+ET6XoannN+5IJdg5MBCQrWljUlJA="
+  },
+  "com/netflix/nebula#gradle-ospackage-plugin/12.3.0": {
+   "jar": "sha256-G31BgIxAfGFKaH53ytCTsGRe/axv/3VaYfqsycGx0Tk=",
+   "module": "sha256-48jwwoAZ8Lp9rUUjg+VPZBr2c4OqEOyWeRRcA6fcajQ=",
+   "pom": "sha256-O9fcqwynS7fY3nSxxN4ekJBKIwghlDCxfi9V+pe45/8="
+  },
+  "com/netflix/nebula/ospackage#com.netflix.nebula.ospackage.gradle.plugin/12.3.0": {
+   "pom": "sha256-NbRAjb4z1OaaXaHzN77BhG9M+BiakQi7RXh9BpL/FR8="
+  },
+  "commons-codec#commons-codec/1.17.0": {
+   "jar": "sha256-9wDegKwnDQNE/ep0aCAdi5yAXlxkgzHDYZ8u4GfM/Fk=",
+   "pom": "sha256-wBxM2l5Aj0HtHYPkoKFwz1OAG2M4q6SfD5BHhrwSFPw="
+  },
+  "commons-io#commons-io/2.16.1": {
+   "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
+   "pom": "sha256-V3fSkiUceJXASkxXAVaD7Ds1OhJIbJs+cXjpsLPDj/8="
+  },
+  "de/undercouch#gradle-download-task/4.1.1": {
+   "jar": "sha256-6wi1cOQI1GRnBecKlJYU1DnqKxFFXxZSqwMw3olU2rk=",
+   "pom": "sha256-EQnx9xpUJU1ZAzfYudRD+d/AhyjJwdgzVlXMHcyIwLk="
+  },
+  "io/airlift#airbase/112": {
+   "pom": "sha256-GMzRBMvZfrRL1XtowEerf/gfvIAJh/gtgVxorEwjBM4="
+  },
+  "io/airlift#aircompressor/0.27": {
+   "jar": "sha256-/b7zE3oo9juwy5NIeAMIDt50ak7D1CHjbG8MMFw15eQ=",
+   "pom": "sha256-Wqzaib44VjvfO/rHkzNhbAgCymFwcN6ma6ZJUHyZREE="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/30": {
+   "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  },
+  "org/apache/ant#ant-launcher/1.10.15": {
+   "jar": "sha256-XIVRmQMHoDIzbZjdrtVJo5ponwfU1Ma5UGAb8is9ahs=",
+   "pom": "sha256-ea+EKil53F/gAivAc8SYgQ7q2DvGKD7t803E3+MNrJU="
+  },
+  "org/apache/ant#ant-parent/1.10.11": {
+   "pom": "sha256-V6BTJoLzD6MHQWoiWSnVcQrNpy17Je4IyvmNyCzTXbY="
+  },
+  "org/apache/ant#ant-parent/1.10.15": {
+   "pom": "sha256-SYhPGHPFEHzCN/QoXER3R5uwgEvwc3OUgBsI114rvrA="
+  },
+  "org/apache/ant#ant/1.10.11": {
+   "pom": "sha256-wiiU2ctGq/XOv27rK8z+TXjhju6jEaDqat3VnftLH+M="
+  },
+  "org/apache/ant#ant/1.10.15": {
+   "jar": "sha256-djrNpKaViMnqiBepUoUf8ML8S/+h0IHCVl3EB/KdV5Q=",
+   "pom": "sha256-R4DmHoeBbu4fIdGE7Jl7Zfk9tfS5BCwXitsp4j50JdY="
+  },
+  "org/apache/commons#commons-compress/1.21": {
+   "pom": "sha256-Z1uwI8m+7d4yMpSZebl0Kl/qlGKApVobRi1Mp4AQiM0="
+  },
+  "org/apache/commons#commons-compress/1.26.2": {
+   "jar": "sha256-kWigMUHY/H7aIaI2DYPMBBK8ux1iBNmSvUjCVzyzxrg=",
+   "pom": "sha256-FChxmJXNCpE67jPiQkuagEsQ8Rl+XTWpzpnPKhF0yw4="
+  },
+  "org/apache/commons#commons-lang3/3.14.0": {
+   "jar": "sha256-e5a/PuaJSau1vEZVWawnDgVRWW+jRSP934kOxBjd4Tw=",
+   "pom": "sha256-EQQ4hjutN8KPkGv4cBbjjHqMdYujIeCdEdxaI2Oo554="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/64": {
+   "pom": "sha256-bxljiZToNXtO1zRpb5kgV++q+hI1ZzmYEzKZeY4szds="
+  },
+  "org/apache/commons#commons-parent/69": {
+   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/maven#maven-archiver/3.6.3": {
+   "jar": "sha256-g1ZhKYmMejhL/6oRinakBmfVRpSEYLQ+64Vj+hdjWEg=",
+   "pom": "sha256-vBMCWcXhCHonDqjPP4GC/syQv5MROiB01kChpn8QLsQ="
+  },
+  "org/apache/maven#maven-parent/43": {
+   "pom": "sha256-RooSYumqpf6/nWBOKDYmf4FTUfK0Ug8o+xf1PHHjNVQ="
+  },
+  "org/apache/maven/shared#maven-shared-components/43": {
+   "pom": "sha256-YHLdEDvboxmVhMW3PtRbAFZ80+qRjiFgsQvHQ3yegYE="
+  },
+  "org/bouncycastle#bcpg-jdk15on/1.69": {
+   "jar": "sha256-o5hP9/2VGNAAlONPPT5xSkgj8lBa2hwZs1wSnib2OTQ=",
+   "pom": "sha256-2iKA/jlan+d4adxcwAqpvuiPaUx8R4XqEHOXIrafrU8="
+  },
+  "org/bouncycastle#bcprov-jdk15on/1.69": {
+   "jar": "sha256-5Gm9Ofk2mZ8lYAJjEAP/AioilR2p1b2Xicer+pdjopI=",
+   "pom": "sha256-/YHicUSVvOeeauazAp2s0kzyz/NAJB2lgQVYlae6eN4="
+  },
+  "org/codehaus/plexus#plexus-archiver/4.10.0": {
+   "jar": "sha256-TAeBT/SjkZmZmugruh44qk8lY3Rn/KxqZu1jp2U1eZo=",
+   "pom": "sha256-k8oAH9M9pT04t09trxnnG8lzbtYUMJH/kAPNTAWs5sk="
+  },
+  "org/codehaus/plexus#plexus-interpolation/1.27": {
+   "jar": "sha256-P7T7YUP9+WQCTDy3OFUVJLnqhOXCEc1mDFWa0HA+UjA=",
+   "pom": "sha256-1U+8vEOZ41IyKHSkEoudKP6f4Vg/iew2HeJC6jjTP5s="
+  },
+  "org/codehaus/plexus#plexus-io/3.5.0": {
+   "jar": "sha256-ll7SiRLPGuTGKBEsQAngwZgZvETtXbivVO5e2iEDaj4=",
+   "pom": "sha256-9bhs0iOgv0umSd4Z5+jk4fFDRP9jb4sAJMicRtKMydg="
+  },
+  "org/codehaus/plexus#plexus/16": {
+   "pom": "sha256-aNTu1lo9u8NC7YDdE4++nGfLf7TCq8T1IBzbW59kWGg="
+  },
+  "org/codehaus/plexus#plexus/18": {
+   "pom": "sha256-tD7onIiQueW8SNB5/LTETwgrUTklM1bcRVgGozw92P0="
+  },
+  "org/junit#junit-bom/5.10.0": {
+   "module": "sha256-6z7mEnYIAQaUqJgFbnQH0RcpYAOrpfXbgB30MLmIf88=",
+   "pom": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
+  },
+  "org/junit#junit-bom/5.10.1": {
+   "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
+   "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
+  },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.10.3": {
+   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
+   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
+  },
+  "org/junit#junit-bom/5.8.0-M1": {
+   "module": "sha256-vgUUcTA6UD9MIkZwdbJ0kEE3fd1tWoywc53tZ9kW2C0=",
+   "pom": "sha256-dxREMv/Gi9mKeQqxBpYZ2RAyz8Dk4TwIFjqgPaNv1uI="
+  },
+  "org/redline-rpm#redline/1.2.10": {
+   "jar": "sha256-LgdOe9QhdOrqyYzrx4Lw17zI3CpBYXkyrJx51WvIbs0=",
+   "pom": "sha256-B6tuIriDJfDPdNQuiaZjQY5Vb+pXmMZnjSY8+YJuxC4="
+  },
+  "org/slf4j#slf4j-api/1.7.36": {
+   "jar": "sha256-0+9XXj5JeWeNwBvx3M5RAhSTtNEft/G+itmCh3wWocA=",
+   "pom": "sha256-+wRqnCKUN5KLsRwtJ8i113PriiXmDL0lPZhSEN7cJoQ="
+  },
+  "org/slf4j#slf4j-api/1.7.5": {
+   "pom": "sha256-r6+OdAGbIw0/Vv3XyT+xBwwNyjTz0tWrXeqfxha9XKQ="
+  },
+  "org/slf4j#slf4j-parent/1.7.36": {
+   "pom": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
+  },
+  "org/slf4j#slf4j-parent/1.7.5": {
+   "pom": "sha256-xDvFoCLb/Z3oK+Iy3/5GIIy8feEsFDhbXagk4zHlNbs="
+  },
+  "org/sonatype/forge#forge-parent/4": {
+   "pom": "sha256-GDjRMkeQBbS3RZt5jp2ZFVFQkMKICC/c2G2wsQmDokw="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/sonatype/plexus#plexus-cipher/1.4": {
+   "jar": "sha256-WhX9uiJmng/dBuENzOYyCHnh9zmPvJEM0Gd7UGcqeMQ=",
+   "pom": "sha256-pjouI5iMyn+sbJOIbW8FBv0m2I1+jMDLibnG4NbJlK0="
+  },
+  "org/sonatype/plexus#plexus-sec-dispatcher/1.4": {
+   "jar": "sha256-2nPjK1gTLmTa8SJp/Z0BHAswPyNIQPF5kIclpjK2tXw=",
+   "pom": "sha256-tNbx4rkXL7dRDhixSupMpaBkb8izotcKLr/6b+SHh9w="
+  },
+  "org/sonatype/spice#spice-parent/12": {
+   "pom": "sha256-IaGbJtvlw43bURTPTq2/XMtBG8axKP3VlJscyxLzaD4="
+  },
+  "org/tukaani#xz/1.4": {
+   "pom": "sha256-/kqLT1R/okQ0L7r0pOgPDEg3HYXMQBtYUViRKENiWJI="
+  },
+  "org/tukaani#xz/1.9": {
+   "jar": "sha256-IRswbPxE+Plt86Cj3a91uoxSie7XfWDXL4ibuFX1NeU=",
+   "pom": "sha256-CTvhsDMxvOKTLWglw36YJy12Ieap6fuTKJoAJRi43Vo="
+  },
+  "org/vafer#jdeb/1.14": {
+   "jar": "sha256-K5maQLdp9syj+zgbjxEY/DRLiKvi84uhstUyV/ifNgI=",
+   "pom": "sha256-UhZkuBz7sPxlYawUMG105wkNjrgh1De0de9jwlxaoIc="
+  },
+  "org/yaml#snakeyaml/1.19": {
+   "jar": "sha256-CnsQY/yuuAa0C3KNAbk2HTjh7Y3rk/lFmU/sfBdh2tE=",
+   "pom": "sha256-LPLw3zc1cHbH8clmIV6L5urKSM670TZHjaZ0mpjjomE="
+  }
+ },
+ "https://repo1.maven.org/maven2": {
+  "aopalliance#aopalliance/1.0": {
+   "jar": "sha256-Ct3sZw/tzT8RPFyAkdeDKA0j9146y4QbYanNsHk3agg=",
+   "pom": "sha256-JugjMBV9a4RLZ6gGSUXiBlgedyl3GD4+Mf7GBYqppZs="
+  },
+  "com/google#google/5": {
+   "pom": "sha256-4J00XnPKP7yn8+BfMN63Tp053Wt5qT/ujFEfI0F7aCg="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.4": {
+   "jar": "sha256-uvfW6pfOYGxT4RtoVLpfLOfvXCTd3wr6GNEmC9JbACw=",
+   "pom": "sha256-EyZziktPfMrPYHuGahH7hRk+9g9qWUYRh85yZfm+W+0="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.4": {
+   "pom": "sha256-QElbQ3pg0jmPD9/AVLidnDlKgjR6J0oHIcLpUKQwIYY="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#guava-parent/14.0.1": {
+   "pom": "sha256-5aUl7Ttdf/8qjalkHgy5hcf9uEfjCB4qNz2vLnADm2M="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/30.1-jre": {
+   "pom": "sha256-4q+3R+vE/iMo1qkPqIxdioO7HjIGG7mxD/Q+LEetbnM="
+  },
+  "com/google/guava#guava/14.0.1": {
+   "pom": "sha256-PdSpktU+tSShxlRqJLhTszKyZSB1XiayXTgQATFCS3s="
+  },
+  "com/google/guava#guava/30.1-jre": {
+   "jar": "sha256-5t0HL50/4CpGAGiDgL1CK9rBhMr2/iQYz90JNPCUMqo=",
+   "pom": "sha256-lkbUzVAJTUq+UH5VXT921340pMVWayL7Ew71XU676Sc="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/guava/guava/maven-metadata": {
+   "xml": {
+    "groupId": "com.google.guava",
+    "lastUpdated": "20260414193116",
+    "release": "33.6.0-jre"
+   }
+  },
+  "com/google/inject#guice-parent/3.0": {
+   "pom": "sha256-XG44w1mE5VAzSY/CLRUZslAcNqvwif1EUIFJH2/M6Ro="
+  },
+  "com/google/inject#guice/3.0": {
+   "jar": "sha256-GlnQQh/9NVzAtwtC3xwumvdEyKLQyS2jefX8ovB/HSI=",
+   "pom": "sha256-IogoDGRaFuamSRGbP0PrysKmmCFrgFssbw7uo5GR7cA="
+  },
+  "com/google/j2objc#j2objc-annotations/1.3": {
+   "jar": "sha256-Ia8wySJnvWEiwOC00gzMtmQaN+r5VsZUDsRx1YTmSns=",
+   "pom": "sha256-X6yoJLoRW+5FhzAzff2y/OpGui/XdNQwTtvzD6aj8FU="
+  },
+  "com/ibm/icu#icu4j/52.1": {
+   "pom": "sha256-9fXj+DzEgf4xtKcZAY0/tWpTa5pkGyvcN4kBYkSYhkY="
+  },
+  "io/github/classgraph#classgraph/4.8.35": {
+   "jar": "sha256-S+jLCgnY0HfSfyj6J/KnwQuEYwxj4cD2IH1EvfLO78g=",
+   "pom": "sha256-gzF7P8oJQDa082OVdOs94t8QKub80+Yr3PaF9lkg/ak="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "log4j#log4j/1.2.15": {
+   "pom": "sha256-SkgVA4q+8Kdy2zj/BvmFx9I9wxCb+Hf12DMpQm3afa8="
+  },
+  "log4j#log4j/1.2.16": {
+   "pom": "sha256-Kx6fEFXPC0pGWar0dLZehC1cHcWAtcTgI472NHDREP0="
+  },
+  "log4j#log4j/1.2.17": {
+   "jar": "sha256-HTFpZEVpdyBScJF1Q2kIKmZRvUl4G2AF3rlOVnU0Bvk=",
+   "pom": "sha256-O5Wj083TqkuRqzJ921ob/gPYHic3lONqoUQEcdXXDl4="
+  },
+  "net/java/dev/jna#jna-platform/5.18.1": {
+   "jar": "sha256-rRTBsexPQ9OWIxIZ36Y16/go9zjqyfiQ6hvAd5WJLZo=",
+   "pom": "sha256-OdU4qVmaRHR3CDiGXtQs+j5rPRMIbLHld7i7QxSNGmU="
+  },
+  "net/java/dev/jna#jna/5.18.1": {
+   "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",
+   "pom": "sha256-mLYq5v8oDXR/s1n8QuSP7RE9Rbw3Kagj3DC4MIqAZkU="
+  },
+  "net/sf/jopt-simple#jopt-simple/4.4": {
+   "jar": "sha256-PKo+nzO/XYuMCu/qjPFmp/RomIBCHESkLZzqDTrG4u0=",
+   "pom": "sha256-grxfPGJDqK9v7dC7tLUQvUNQOYrRqH1CBcuB6ltMkXQ="
+  },
+  "org/antlr#antlr-master/3.2": {
+   "pom": "sha256-fRkllZP6jp3uFclxr/qZy/4mP4mAhXSwLzxkntc9GjU="
+  },
+  "org/antlr#antlr-runtime/3.2": {
+   "jar": "sha256-bZ+ZcgLMAtTU+j1OhObS0946Gx+VHpoag7QNAnmlA4k=",
+   "pom": "sha256-7LFOJegtITLWPHQuMMML0qWxiVQfmPGaVAaLVvHz1o8="
+  },
+  "org/apache/ant#ant-launcher/1.9.15": {
+   "jar": "sha256-O2x8C7wGSm1AA5+ZX23Dm8O3mjs18+lH7VRcS2Yb2Us=",
+   "pom": "sha256-g2t7bhQDQxWvlcxFLrUnz2kS4vo/hOxRQAYIc3zaBT8="
+  },
+  "org/apache/ant#ant-parent/1.9.15": {
+   "pom": "sha256-PS+Wc7hr27MK3bdcWdnP/BKDOVfX6t1SSZuOpBMW9DQ="
+  },
+  "org/apache/ant#ant/1.9.15": {
+   "jar": "sha256-VZh4OBCCR0ZVx0DoNzosmZD+Sph6pMJvOccizvXELMw=",
+   "pom": "sha256-0VF8gmrVqm32WpXqw6h+Zult7Qf/YiR3bbhKZb6rpTs="
+  },
+  "org/checkerframework#checker-qual/3.5.0": {
+   "jar": "sha256-cpmQs/GKlWBvwlc4NraVi820TLUr+9G3qpwznP81paQ=",
+   "pom": "sha256-KDazuKeO2zGhgDWS5g/HZ7IfLRkHZGMbpu+gg3uzVyE="
+  },
+  "org/eclipse/emf#org.eclipse.emf.common/2.17.0": {
+   "jar": "sha256-W4qj/X71SsaVqnPGv+opmpviz3Ry7WuKn6hN/QAL3LM=",
+   "pom": "sha256-zYf3dhgsAKnai7KIbXx7rLvoMjJsKw4sQ3rrs7fvAVg="
+  },
+  "org/eclipse/emf#org.eclipse.emf.common/2.45.0": {
+   "pom": "sha256-Momjqyn/zL6YIl3+lfnffSiuQz6xrNNUZkZQfzXtqwc="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore.xmi/2.16.0": {
+   "jar": "sha256-2NoRRs2DZ19dVBf92R/Inyr0tD5KMBEGYTJplNxxF20=",
+   "pom": "sha256-McYAPeGYu++mcsQ9ixI5b+K0DnXH8M+N6pvOkGZix18="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore.xmi/2.40.0": {
+   "pom": "sha256-Vo7z0mmi/HE1/EBvXJ5JbdQjQ6CB3xufaaMj9fHuSzE="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore/2.20.0": {
+   "jar": "sha256-nuU5o8UO88/LqjqF808EHupoKtRZ0+lW33dp9rKZGzY=",
+   "pom": "sha256-6aoQO2xLlRT1Par3jX/y2/B6zexP7uKVCb4I6hvsOSw="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore/2.42.0": {
+   "pom": "sha256-9J8c6yPnlQi1R0TqD5Ii8y97jTTpQq2rDrmKwv6JvtY="
+  },
+  "org/eclipse/emf/org.eclipse.emf.common/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.emf",
+    "lastUpdated": "20260224162236",
+    "release": "2.45.0"
+   }
+  },
+  "org/eclipse/emf/org.eclipse.emf.ecore.xmi/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.emf",
+    "lastUpdated": "20260224162235",
+    "release": "2.40.0"
+   }
+  },
+  "org/eclipse/emf/org.eclipse.emf.ecore/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.emf",
+    "lastUpdated": "20260224162245",
+    "release": "2.42.0"
+   }
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.compiler.apt/1.3.1100": {
+   "jar": "sha256-zJqUAyG8X/IdsjBRdcPGYBYYoeosDbr65NGJBX5fVsI=",
+   "pom": "sha256-96v/7G1ehU+ora9ZJyT7rFFM8gKsaO9Q6ZTBzx9Dyjg="
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.compiler.tool/1.2.1000": {
+   "jar": "sha256-XVB7Co4RPPyccS9TBuzp0ON3VEfIEfyl+EkMNhWnVLQ=",
+   "pom": "sha256-qryopLNthGmhzCQ4AnWupz5YZqvAl8spXubpXK9Lpwk="
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.core/3.17.0": {
+   "pom": "sha256-F04xhLHTa8gqBjdPLhcacmXRXgjCDDXqtL8y4OGdG48="
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.core/3.23.0": {
+   "jar": "sha256-sf7D5ZoMCcXisipnc3pUFithF/FQA3iya+SQgWw0Q8I=",
+   "pom": "sha256-IHpNbAWKRyIzp/n11ufbRdIG1szT9c6jTgQHuoQm0yU="
+  },
+  "org/eclipse/platform#org.eclipse.core.commands/3.12.500": {
+   "jar": "sha256-RHEzYuVe0o5ttdLDG/Z1JP7wh2RaRNwyOdrGDs4BfLk=",
+   "pom": "sha256-yD+4t0dc62ANfijxwyfGjhzSaFHeyEEKthn/9W17SoI="
+  },
+  "org/eclipse/platform#org.eclipse.core.contenttype/3.9.800": {
+   "jar": "sha256-4MLblmANUZzjanX5t8lxr9KHDS0Fnu5L8kNtmzOqC40=",
+   "pom": "sha256-vZ20X3R3JIQpxxz4RlcC2r+xUgzoU0+dwl1BeOu1iXs="
+  },
+  "org/eclipse/platform#org.eclipse.core.expressions/3.9.500": {
+   "jar": "sha256-hES13pDJtKtSjI6lw0HH6HLQ2+gkGreQhVUQhtlufJ4=",
+   "pom": "sha256-1Ks7hbJUOHlXRXwfRrcAG1qQqJjFIixQIKB5DlFhalA="
+  },
+  "org/eclipse/platform#org.eclipse.core.filesystem/1.11.400": {
+   "jar": "sha256-b3C5XRS5DsV7lMXj26fh0YlnnPmkvEUm6ckb7tfWoO8=",
+   "pom": "sha256-sQA8+u8BN+YzwThrzFfbCl5Yelm1Fx5We6Uwz6u/jMU="
+  },
+  "org/eclipse/platform#org.eclipse.core.jobs/3.15.700": {
+   "jar": "sha256-NwFReae5uQ0Wy5L0sb5gg6Gm2tJUKPqPa4libwzC2nk=",
+   "pom": "sha256-OUVAotjHPjVRHz1f8J2fNkdm4P4steb4V8Tfqwl9Ot8="
+  },
+  "org/eclipse/platform#org.eclipse.core.resources/3.23.200": {
+   "jar": "sha256-d5PgetR4AfYqqnBPCkbWD4wK6AdeAPAucg1phiv+N7w=",
+   "pom": "sha256-CPZTnfSlOMqg0Hsde2tHJsDpck6GWH6qMXKx0RAH8fg="
+  },
+  "org/eclipse/platform#org.eclipse.core.runtime/3.19.0": {
+   "pom": "sha256-5d9UsnVbbVg/aoJOpuRLwYBQKfaaF6M8GISSOPCCMnQ="
+  },
+  "org/eclipse/platform#org.eclipse.core.runtime/3.34.200": {
+   "jar": "sha256-tPNqCssI8D0LPbVLIfxWOMggxEdEakELpJalBw+jQ2M=",
+   "pom": "sha256-VUfhQDP4BRrlX0qDhwRsdAk7UgNs3DVu9p6lGOrn5uw="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.app/1.7.600": {
+   "jar": "sha256-/TUzmINRB2CPVUd5pukYkXJe+5Tg9XVZ0Ks86kthVsc=",
+   "pom": "sha256-cZhnUaan5uJyMJs6ZqySGUPplQlqXIgI1C6aDMJR1eg="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.common/3.13.0": {
+   "pom": "sha256-+3O5zurY3z4CrkYhA323gKKaURHCIDHszq+BXLmw35A="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.common/3.20.300": {
+   "jar": "sha256-hV0jmvKd2x0iSNN4aXwJW+Yu+5pbPBuybTH3uXqOFq4=",
+   "pom": "sha256-ALs//vT1/wr/lXaIGYlvxY1kxitKkEc60niE6P0viFI="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.preferences/3.12.100": {
+   "jar": "sha256-/QToGiirMra7BzKG6yk8RLdgF2/PHjXvFWFNYt+CD4Y=",
+   "pom": "sha256-IYxiWoWw5QQU6dGRKFYUtrL+qf9/0TITKm4PkyQzMZY="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.registry/3.12.600": {
+   "jar": "sha256-T4zXJoFEa1mDkKjCTum5mW9uTF+r7QIrUL0m9vWgv2w=",
+   "pom": "sha256-Kwg3b6gZu5Q3vHDKJM6w8NtE3gE/63F9vmmaKU+2MSc="
+  },
+  "org/eclipse/platform#org.eclipse.osgi/3.23.100": {
+   "pom": "sha256-gph5O0PkohKzeJ6c/dpZEqEGTCkPTgr4pUrLSNB5TuQ="
+  },
+  "org/eclipse/platform#org.eclipse.osgi/3.24.100": {
+   "jar": "sha256-0g+JIDBZb7wsJdoArNvSdQ93zv1oE2wzo+J5uJSYZ6g=",
+   "pom": "sha256-+U4i9QNmKcxz7AM41+C5wFx2g70TZ4wWa8p/fIfm+oE="
+  },
+  "org/eclipse/platform#org.eclipse.text/3.14.600": {
+   "jar": "sha256-1nW4pgPmL0PLqcHyS+ysEYKzKHwDPEL7gQYmjafTLXE=",
+   "pom": "sha256-ej/wQTbv0Vn8pN0QEk2idD+fSFUN7shfR4TTDxZIQx0="
+  },
+  "org/eclipse/platform/org.eclipse.core.contenttype/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072734",
+    "release": "3.9.800"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.core.filesystem/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072743",
+    "release": "1.11.400"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.core.jobs/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20250906152133",
+    "release": "3.15.700"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.core.resources/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260309141945",
+    "release": "3.23.200"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.equinox.app/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260309141957",
+    "release": "1.7.600"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.equinox.preferences/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072801",
+    "release": "3.12.100"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.equinox.registry/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072814",
+    "release": "3.12.600"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.osgi/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260309142004",
+    "release": "3.24.100"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.text/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260309142023",
+    "release": "3.14.600"
+   }
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.core/2.26.0.M1": {
+   "jar": "sha256-cSJpnGjNwDzHCD+416m8Fu9X81Zs+VHb8iAu59hBPP4=",
+   "pom": "sha256-gAUnNNtYJj1M81i7Xnts2YM8SOpYrrEz6OU7HJh6bnk="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib.macro/2.26.0.M1": {
+   "jar": "sha256-0JD3xc6lbz4fU5zR7DBJF9vcW0CatfhJH+fRKweHaqc=",
+   "pom": "sha256-noRJeVGBYI2AALRM4yFw2UzP1JaN1V2KgGNyqYnrPj8="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib.macro/2.9.0.beta3": {
+   "pom": "sha256-mrnejeg674gkxdP7ejRO4ucqCkFKvjRaU9fQu3QMK/8="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib/2.26.0.M1": {
+   "jar": "sha256-WDcavdMrnHaEcXE9KbTTOVE0Mhxu1u6sMDT2H6DO868=",
+   "pom": "sha256-cdrQr0y9l+9VG/GjtdISVz6Wm8Ahcqvn24VOLLr3on8="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib/2.9.0.beta3": {
+   "pom": "sha256-tvTav1nQs3hAJpu5l9g8blJklfs3PgS/4gyUkro7WrY="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.common.types/2.26.0.M1": {
+   "jar": "sha256-J4CbsOaZyXIjvMqgWb5gUsgm7cjOTWjk4a8c8OA8WpI=",
+   "pom": "sha256-KBblpXkaPCgF70MCp2FD5bosfgHNRWSYJmKi6NBNzG4="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.parent/2.9.0.beta3": {
+   "pom": "sha256-iitPMtKIuMIpKhznz1PSniKrUJLrQJCGHk7fWH5dxXE="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.tycho.parent/2.9.0.beta3": {
+   "pom": "sha256-aw4ohgIotMlzzRlMG75OAWJ3Z9eFa8IPLXhJdsqM3Hc="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.ui/2.9.0.beta3": {
+   "jar": "sha256-LdJ4gAHfV5Tdh3PcoWTLVf9loRXq2KyoTxcQIv1YXEk=",
+   "pom": "sha256-ijONMPrjEGreQAPcjqK4D4UYWks2MIvqLmXwNet5xao="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.util/2.26.0.M1": {
+   "jar": "sha256-GjUOUkVY9wqbaPoU1CpkzfSHJZSIMmbVHVM6XtHe87k=",
+   "pom": "sha256-PiFttra2eWhlgERIshGKlnMU088VE07lShOxcmNCcls="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.util/2.9.0.beta3": {
+   "pom": "sha256-Av48mI0vXSEvRU1Dd6sW87+kuCmmriSDjmW5mKXfXkM="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.xbase.lib/2.26.0.M1": {
+   "jar": "sha256-6t00qIDs00kIirnsc8/esHRlaL8lhACb0CUt5EgNjZM=",
+   "pom": "sha256-RQGK9XRXRnva6chBnh86GlIXMPixtWsV9vFihq2YW7M="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.xbase.lib/2.9.0.beta3": {
+   "pom": "sha256-PdmWaS7jFJPKsPuHXR8dH/TYVJR9w9h7/v4wXwn+ICM="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.xbase/2.26.0.M1": {
+   "jar": "sha256-jk8M2/NovIVnk1V6qrrBiRUwTMv6thT0GfAkY+w+Z/o=",
+   "pom": "sha256-WwQhe/Y1tnJ+6AvbD7ou1Zc6mcznyJuAqCO932xde5o="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext/2.26.0.M1": {
+   "jar": "sha256-AJqnshwnSwjN0HYZLCYrSTwfRsk4O1Uzo0HvnAr/Uro=",
+   "pom": "sha256-bVw1Q8nsT1RgOUbQWaMwYnWDRJTMXnBHMTuf4gTgqkk="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext/2.9.0.beta3": {
+   "pom": "sha256-sdYgpLPTQpjRnvmniZuQG4ujVrWmWsBikJHChbNOQRs="
+  },
+  "org/eclipse/xtext#xtext-dev-bom/2.26.0.M1": {
+   "pom": "sha256-rS44hS+MKr4hxk2eMIfDDiqruej4VkLEjYK+CUTf4hY="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/osgi#org.osgi.service.prefs/1.1.2": {
+   "jar": "sha256-Q8fIcHEONjQF1CLaZTzODXmKRTf3bkkw95vOrdOlU0U=",
+   "pom": "sha256-bqSDzqF36RMQmExkUuaUqiCAGVG1AfF8uboRQyjCzCY="
+  },
+  "org/osgi#osgi.annotation/8.0.1": {
+   "jar": "sha256-oOikw2K9NgCBLzew6kX7qWbHvASdAf7Vagnsx0CCdZ4=",
+   "pom": "sha256-iC0Hao4lypIH95ywk4DEcvazxBUIFivSuqBpF74d7XM="
+  },
+  "org/ow2#ow2/1.5": {
+   "pom": "sha256-D4obEW52C4/mOJxRuE5LB6cPwRCC1Pk25FO1g91QtDs="
+  },
+  "org/ow2/asm#asm-analysis/9.1": {
+   "jar": "sha256-gaiAQbG4vtpaiplkYJgEbEhwlTgnDEne9oq/8lrDvjQ=",
+   "pom": "sha256-rFRUwRsDQxypUd9x+06GyMTIDfaXn5W3V8rtOrD0cVY="
+  },
+  "org/ow2/asm#asm-commons/9.1": {
+   "jar": "sha256-r8sm3B/BLAxKma2mcJCN2C4Y38SIyvXuklRplrRwwAw=",
+   "pom": "sha256-oPZRsnuK/pwOYS16Ambqy197HHh7xLWsgkXz16EYG38="
+  },
+  "org/ow2/asm#asm-tree/9.1": {
+   "jar": "sha256-/QCvpJ6VlddkYgWwnOy0p3ao/wugby1ZuPe/nHBLSnM=",
+   "pom": "sha256-tqANkgfANUYPgcfXDtQSU/DSFmUr7UX6GjBS/81QuUw="
+  },
+  "org/ow2/asm#asm/9.1": {
+   "jar": "sha256-zaTeRV+rSP8Ly3xItGOUR9TehZp6/DCglKmG8JNr66I=",
+   "pom": "sha256-xoOpDdaPKxeIy9/EZH6pQF71kls3HBmfj9OdRNPO3o0="
+  },
+  "org/sonatype/forge#forge-parent/6": {
+   "pom": "sha256-nF981SJqyMN5jLH4AMAx997cFgbcUNwpVnh3yCJEWac="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/sonatype/sisu/inject#cglib/2.2.1-v20090111": {
+   "pom": "sha256-SvNVR7tds+Sft1CGWvDjM6/cgubm19itvRwUEd+tYIE="
+  }
+ },
+ "https://repository.jboss.org": {
+  "nexus/content/groups/public-jboss/com/google/guava/guava/maven-metadata": {
+   "xml": {
+    "groupId": "com.google.guava",
+    "lastUpdated": "20160429131712",
+    "release": "20.0-hal"
+   }
+  }
+ }
+}

--- a/pkgs/by-name/um/umple/deps.json
+++ b/pkgs/by-name/um/umple/deps.json
@@ -1,0 +1,622 @@
+{
+ "!comment": "This is a nixpkgs Gradle dependency lockfile. For more details, refer to the Gradle section in the nixpkgs manual.",
+ "!version": 1,
+ "https://plugins.gradle.org/m2": {
+  "com/bmuschko#gradle-docker-plugin/3.2.1": {
+   "jar": "sha256-BfgdS5EdMR7nrEhJ6/eLMD4HdDQY1OiaVZVCK/OAIxQ=",
+   "pom": "sha256-slOHkvEGJnUa9sjeAgdH/1E4kntOKfL69KjtOsFKzSE="
+  },
+  "com/github/luben#zstd-jni/1.5.6-3": {
+   "jar": "sha256-9y7eGzklj6+BJ33FjeMMccuuQlNzJVjSzhC1PYtXY9U=",
+   "pom": "sha256-39L6ex0jk5IWkC+ET6XoannN+5IJdg5MBCQrWljUlJA="
+  },
+  "com/netflix/nebula#gradle-ospackage-plugin/12.3.0": {
+   "jar": "sha256-G31BgIxAfGFKaH53ytCTsGRe/axv/3VaYfqsycGx0Tk=",
+   "module": "sha256-48jwwoAZ8Lp9rUUjg+VPZBr2c4OqEOyWeRRcA6fcajQ=",
+   "pom": "sha256-O9fcqwynS7fY3nSxxN4ekJBKIwghlDCxfi9V+pe45/8="
+  },
+  "com/netflix/nebula/ospackage#com.netflix.nebula.ospackage.gradle.plugin/12.3.0": {
+   "pom": "sha256-NbRAjb4z1OaaXaHzN77BhG9M+BiakQi7RXh9BpL/FR8="
+  },
+  "commons-codec#commons-codec/1.17.0": {
+   "jar": "sha256-9wDegKwnDQNE/ep0aCAdi5yAXlxkgzHDYZ8u4GfM/Fk=",
+   "pom": "sha256-wBxM2l5Aj0HtHYPkoKFwz1OAG2M4q6SfD5BHhrwSFPw="
+  },
+  "commons-io#commons-io/2.16.1": {
+   "jar": "sha256-9B97qs1xaJZEes6XWGIfYsHGsKkdiazuSI2ib8R3yE8=",
+   "pom": "sha256-V3fSkiUceJXASkxXAVaD7Ds1OhJIbJs+cXjpsLPDj/8="
+  },
+  "de/undercouch#gradle-download-task/4.1.1": {
+   "jar": "sha256-6wi1cOQI1GRnBecKlJYU1DnqKxFFXxZSqwMw3olU2rk=",
+   "pom": "sha256-EQnx9xpUJU1ZAzfYudRD+d/AhyjJwdgzVlXMHcyIwLk="
+  },
+  "io/airlift#airbase/112": {
+   "pom": "sha256-GMzRBMvZfrRL1XtowEerf/gfvIAJh/gtgVxorEwjBM4="
+  },
+  "io/airlift#aircompressor/0.27": {
+   "jar": "sha256-/b7zE3oo9juwy5NIeAMIDt50ak7D1CHjbG8MMFw15eQ=",
+   "pom": "sha256-Wqzaib44VjvfO/rHkzNhbAgCymFwcN6ma6ZJUHyZREE="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
+  },
+  "org/apache#apache/23": {
+   "pom": "sha256-vBBiTgYj82V3+sVjnKKTbTJA7RUvttjVM6tNJwVDSRw="
+  },
+  "org/apache#apache/30": {
+   "pom": "sha256-Y91KOTqcDfyzFO/oOHGkHSQ7yNIAy8fy0ZfzDaeCOdg="
+  },
+  "org/apache#apache/31": {
+   "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
+  },
+  "org/apache#apache/33": {
+   "pom": "sha256-14vYUkxfg4ChkKZSVoZimpXf5RLfIRETg6bYwJI6RBU="
+  },
+  "org/apache/ant#ant-launcher/1.10.15": {
+   "jar": "sha256-XIVRmQMHoDIzbZjdrtVJo5ponwfU1Ma5UGAb8is9ahs=",
+   "pom": "sha256-ea+EKil53F/gAivAc8SYgQ7q2DvGKD7t803E3+MNrJU="
+  },
+  "org/apache/ant#ant-parent/1.10.11": {
+   "pom": "sha256-V6BTJoLzD6MHQWoiWSnVcQrNpy17Je4IyvmNyCzTXbY="
+  },
+  "org/apache/ant#ant-parent/1.10.15": {
+   "pom": "sha256-SYhPGHPFEHzCN/QoXER3R5uwgEvwc3OUgBsI114rvrA="
+  },
+  "org/apache/ant#ant/1.10.11": {
+   "pom": "sha256-wiiU2ctGq/XOv27rK8z+TXjhju6jEaDqat3VnftLH+M="
+  },
+  "org/apache/ant#ant/1.10.15": {
+   "jar": "sha256-djrNpKaViMnqiBepUoUf8ML8S/+h0IHCVl3EB/KdV5Q=",
+   "pom": "sha256-R4DmHoeBbu4fIdGE7Jl7Zfk9tfS5BCwXitsp4j50JdY="
+  },
+  "org/apache/commons#commons-compress/1.21": {
+   "pom": "sha256-Z1uwI8m+7d4yMpSZebl0Kl/qlGKApVobRi1Mp4AQiM0="
+  },
+  "org/apache/commons#commons-compress/1.26.2": {
+   "jar": "sha256-kWigMUHY/H7aIaI2DYPMBBK8ux1iBNmSvUjCVzyzxrg=",
+   "pom": "sha256-FChxmJXNCpE67jPiQkuagEsQ8Rl+XTWpzpnPKhF0yw4="
+  },
+  "org/apache/commons#commons-lang3/3.14.0": {
+   "jar": "sha256-e5a/PuaJSau1vEZVWawnDgVRWW+jRSP934kOxBjd4Tw=",
+   "pom": "sha256-EQQ4hjutN8KPkGv4cBbjjHqMdYujIeCdEdxaI2Oo554="
+  },
+  "org/apache/commons#commons-parent/52": {
+   "pom": "sha256-ddvo806Y5MP/QtquSi+etMvNO18QR9VEYKzpBtu0UC4="
+  },
+  "org/apache/commons#commons-parent/64": {
+   "pom": "sha256-bxljiZToNXtO1zRpb5kgV++q+hI1ZzmYEzKZeY4szds="
+  },
+  "org/apache/commons#commons-parent/69": {
+   "pom": "sha256-1Q2pw5vcqCPWGNG0oDtz8ZZJf8uGFv0NpyfIYjWSqbs="
+  },
+  "org/apache/maven#maven-archiver/3.6.3": {
+   "jar": "sha256-g1ZhKYmMejhL/6oRinakBmfVRpSEYLQ+64Vj+hdjWEg=",
+   "pom": "sha256-vBMCWcXhCHonDqjPP4GC/syQv5MROiB01kChpn8QLsQ="
+  },
+  "org/apache/maven#maven-parent/43": {
+   "pom": "sha256-RooSYumqpf6/nWBOKDYmf4FTUfK0Ug8o+xf1PHHjNVQ="
+  },
+  "org/apache/maven/shared#maven-shared-components/43": {
+   "pom": "sha256-YHLdEDvboxmVhMW3PtRbAFZ80+qRjiFgsQvHQ3yegYE="
+  },
+  "org/bouncycastle#bcpg-jdk15on/1.69": {
+   "jar": "sha256-o5hP9/2VGNAAlONPPT5xSkgj8lBa2hwZs1wSnib2OTQ=",
+   "pom": "sha256-2iKA/jlan+d4adxcwAqpvuiPaUx8R4XqEHOXIrafrU8="
+  },
+  "org/bouncycastle#bcprov-jdk15on/1.69": {
+   "jar": "sha256-5Gm9Ofk2mZ8lYAJjEAP/AioilR2p1b2Xicer+pdjopI=",
+   "pom": "sha256-/YHicUSVvOeeauazAp2s0kzyz/NAJB2lgQVYlae6eN4="
+  },
+  "org/codehaus/plexus#plexus-archiver/4.10.0": {
+   "jar": "sha256-TAeBT/SjkZmZmugruh44qk8lY3Rn/KxqZu1jp2U1eZo=",
+   "pom": "sha256-k8oAH9M9pT04t09trxnnG8lzbtYUMJH/kAPNTAWs5sk="
+  },
+  "org/codehaus/plexus#plexus-interpolation/1.27": {
+   "jar": "sha256-P7T7YUP9+WQCTDy3OFUVJLnqhOXCEc1mDFWa0HA+UjA=",
+   "pom": "sha256-1U+8vEOZ41IyKHSkEoudKP6f4Vg/iew2HeJC6jjTP5s="
+  },
+  "org/codehaus/plexus#plexus-io/3.5.0": {
+   "jar": "sha256-ll7SiRLPGuTGKBEsQAngwZgZvETtXbivVO5e2iEDaj4=",
+   "pom": "sha256-9bhs0iOgv0umSd4Z5+jk4fFDRP9jb4sAJMicRtKMydg="
+  },
+  "org/codehaus/plexus#plexus/16": {
+   "pom": "sha256-aNTu1lo9u8NC7YDdE4++nGfLf7TCq8T1IBzbW59kWGg="
+  },
+  "org/codehaus/plexus#plexus/18": {
+   "pom": "sha256-tD7onIiQueW8SNB5/LTETwgrUTklM1bcRVgGozw92P0="
+  },
+  "org/junit#junit-bom/5.10.0": {
+   "module": "sha256-6z7mEnYIAQaUqJgFbnQH0RcpYAOrpfXbgB30MLmIf88=",
+   "pom": "sha256-4AbdiJT5/Ht1/DK7Ev5e2L5lZn1bRU+Z4uC4xbuNMLM="
+  },
+  "org/junit#junit-bom/5.10.1": {
+   "module": "sha256-IbCvz//i7LN3D16wCuehn+rulOdx+jkYFzhQ2ueAZ7c=",
+   "pom": "sha256-IcSwKG9LIAaVd/9LIJeKhcEArIpGtvHIZy+6qzN7w/I="
+  },
+  "org/junit#junit-bom/5.10.2": {
+   "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
+   "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
+  },
+  "org/junit#junit-bom/5.10.3": {
+   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
+   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
+  },
+  "org/junit#junit-bom/5.8.0-M1": {
+   "module": "sha256-vgUUcTA6UD9MIkZwdbJ0kEE3fd1tWoywc53tZ9kW2C0=",
+   "pom": "sha256-dxREMv/Gi9mKeQqxBpYZ2RAyz8Dk4TwIFjqgPaNv1uI="
+  },
+  "org/redline-rpm#redline/1.2.10": {
+   "jar": "sha256-LgdOe9QhdOrqyYzrx4Lw17zI3CpBYXkyrJx51WvIbs0=",
+   "pom": "sha256-B6tuIriDJfDPdNQuiaZjQY5Vb+pXmMZnjSY8+YJuxC4="
+  },
+  "org/slf4j#slf4j-api/1.7.36": {
+   "jar": "sha256-0+9XXj5JeWeNwBvx3M5RAhSTtNEft/G+itmCh3wWocA=",
+   "pom": "sha256-+wRqnCKUN5KLsRwtJ8i113PriiXmDL0lPZhSEN7cJoQ="
+  },
+  "org/slf4j#slf4j-api/1.7.5": {
+   "pom": "sha256-r6+OdAGbIw0/Vv3XyT+xBwwNyjTz0tWrXeqfxha9XKQ="
+  },
+  "org/slf4j#slf4j-parent/1.7.36": {
+   "pom": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
+  },
+  "org/slf4j#slf4j-parent/1.7.5": {
+   "pom": "sha256-xDvFoCLb/Z3oK+Iy3/5GIIy8feEsFDhbXagk4zHlNbs="
+  },
+  "org/sonatype/forge#forge-parent/4": {
+   "pom": "sha256-GDjRMkeQBbS3RZt5jp2ZFVFQkMKICC/c2G2wsQmDokw="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/sonatype/plexus#plexus-cipher/1.4": {
+   "jar": "sha256-WhX9uiJmng/dBuENzOYyCHnh9zmPvJEM0Gd7UGcqeMQ=",
+   "pom": "sha256-pjouI5iMyn+sbJOIbW8FBv0m2I1+jMDLibnG4NbJlK0="
+  },
+  "org/sonatype/plexus#plexus-sec-dispatcher/1.4": {
+   "jar": "sha256-2nPjK1gTLmTa8SJp/Z0BHAswPyNIQPF5kIclpjK2tXw=",
+   "pom": "sha256-tNbx4rkXL7dRDhixSupMpaBkb8izotcKLr/6b+SHh9w="
+  },
+  "org/sonatype/spice#spice-parent/12": {
+   "pom": "sha256-IaGbJtvlw43bURTPTq2/XMtBG8axKP3VlJscyxLzaD4="
+  },
+  "org/tukaani#xz/1.4": {
+   "pom": "sha256-/kqLT1R/okQ0L7r0pOgPDEg3HYXMQBtYUViRKENiWJI="
+  },
+  "org/tukaani#xz/1.9": {
+   "jar": "sha256-IRswbPxE+Plt86Cj3a91uoxSie7XfWDXL4ibuFX1NeU=",
+   "pom": "sha256-CTvhsDMxvOKTLWglw36YJy12Ieap6fuTKJoAJRi43Vo="
+  },
+  "org/vafer#jdeb/1.14": {
+   "jar": "sha256-K5maQLdp9syj+zgbjxEY/DRLiKvi84uhstUyV/ifNgI=",
+   "pom": "sha256-UhZkuBz7sPxlYawUMG105wkNjrgh1De0de9jwlxaoIc="
+  },
+  "org/yaml#snakeyaml/1.19": {
+   "jar": "sha256-CnsQY/yuuAa0C3KNAbk2HTjh7Y3rk/lFmU/sfBdh2tE=",
+   "pom": "sha256-LPLw3zc1cHbH8clmIV6L5urKSM670TZHjaZ0mpjjomE="
+  }
+ },
+ "https://repo1.maven.org/maven2": {
+  "aopalliance#aopalliance/1.0": {
+   "jar": "sha256-Ct3sZw/tzT8RPFyAkdeDKA0j9146y4QbYanNsHk3agg=",
+   "pom": "sha256-JugjMBV9a4RLZ6gGSUXiBlgedyl3GD4+Mf7GBYqppZs="
+  },
+  "com/google#google/5": {
+   "pom": "sha256-4J00XnPKP7yn8+BfMN63Tp053Wt5qT/ujFEfI0F7aCg="
+  },
+  "com/google/code/findbugs#jsr305/3.0.2": {
+   "jar": "sha256-dmrSoHg/JoeWLIrXTO7MOKKLn3Ki0IXuQ4t4E+ko0Mc=",
+   "pom": "sha256-GYidvfGyVLJgGl7mRbgUepdGRIgil2hMeYr+XWPXjf4="
+  },
+  "com/google/errorprone#error_prone_annotations/2.3.4": {
+   "jar": "sha256-uvfW6pfOYGxT4RtoVLpfLOfvXCTd3wr6GNEmC9JbACw=",
+   "pom": "sha256-EyZziktPfMrPYHuGahH7hRk+9g9qWUYRh85yZfm+W+0="
+  },
+  "com/google/errorprone#error_prone_parent/2.3.4": {
+   "pom": "sha256-QElbQ3pg0jmPD9/AVLidnDlKgjR6J0oHIcLpUKQwIYY="
+  },
+  "com/google/guava#failureaccess/1.0.1": {
+   "jar": "sha256-oXHuTHNN0tqDfksWvp30Zhr6typBra8x64Tf2vk2yiY=",
+   "pom": "sha256-6WBCznj+y6DaK+lkUilHyHtAopG1/TzWcqQ0kkEDxLk="
+  },
+  "com/google/guava#guava-parent/14.0.1": {
+   "pom": "sha256-5aUl7Ttdf/8qjalkHgy5hcf9uEfjCB4qNz2vLnADm2M="
+  },
+  "com/google/guava#guava-parent/26.0-android": {
+   "pom": "sha256-+GmKtGypls6InBr8jKTyXrisawNNyJjUWDdCNgAWzAQ="
+  },
+  "com/google/guava#guava-parent/30.1-jre": {
+   "pom": "sha256-4q+3R+vE/iMo1qkPqIxdioO7HjIGG7mxD/Q+LEetbnM="
+  },
+  "com/google/guava#guava/14.0.1": {
+   "pom": "sha256-PdSpktU+tSShxlRqJLhTszKyZSB1XiayXTgQATFCS3s="
+  },
+  "com/google/guava#guava/30.1-jre": {
+   "jar": "sha256-5t0HL50/4CpGAGiDgL1CK9rBhMr2/iQYz90JNPCUMqo=",
+   "pom": "sha256-lkbUzVAJTUq+UH5VXT921340pMVWayL7Ew71XU676Sc="
+  },
+  "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
+   "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
+   "pom": "sha256-GNSx2yYVPU5VB5zh92ux/gXNuGLvmVSojLzE/zi4Z5s="
+  },
+  "com/google/guava/guava/maven-metadata": {
+   "xml": {
+    "groupId": "com.google.guava",
+    "lastUpdated": "20260414193116",
+    "release": "33.6.0-jre"
+   }
+  },
+  "com/google/inject#guice-parent/3.0": {
+   "pom": "sha256-XG44w1mE5VAzSY/CLRUZslAcNqvwif1EUIFJH2/M6Ro="
+  },
+  "com/google/inject#guice/3.0": {
+   "jar": "sha256-GlnQQh/9NVzAtwtC3xwumvdEyKLQyS2jefX8ovB/HSI=",
+   "pom": "sha256-IogoDGRaFuamSRGbP0PrysKmmCFrgFssbw7uo5GR7cA="
+  },
+  "com/google/j2objc#j2objc-annotations/1.3": {
+   "jar": "sha256-Ia8wySJnvWEiwOC00gzMtmQaN+r5VsZUDsRx1YTmSns=",
+   "pom": "sha256-X6yoJLoRW+5FhzAzff2y/OpGui/XdNQwTtvzD6aj8FU="
+  },
+  "com/ibm/icu#icu4j/52.1": {
+   "pom": "sha256-9fXj+DzEgf4xtKcZAY0/tWpTa5pkGyvcN4kBYkSYhkY="
+  },
+  "io/github/classgraph#classgraph/4.8.35": {
+   "jar": "sha256-S+jLCgnY0HfSfyj6J/KnwQuEYwxj4cD2IH1EvfLO78g=",
+   "pom": "sha256-gzF7P8oJQDa082OVdOs94t8QKub80+Yr3PaF9lkg/ak="
+  },
+  "javax/inject#javax.inject/1": {
+   "jar": "sha256-kcdwRKUMSBY2wy2Rb9ickRinIZU5BFLIEGUID5V95/8=",
+   "pom": "sha256-lD4SsQBieARjj6KFgFoKt4imgCZlMeZQkh6/5GIai/o="
+  },
+  "junit#junit/4.13.2": {
+   "jar": "sha256-jklbY0Rp1k+4rPo0laBly6zIoP/1XOHjEAe+TBbcV9M=",
+   "pom": "sha256-Vptpd+5GA8llwcRsMFj6bpaSkbAWDraWTdCSzYnq3ZQ="
+  },
+  "log4j#log4j/1.2.15": {
+   "pom": "sha256-SkgVA4q+8Kdy2zj/BvmFx9I9wxCb+Hf12DMpQm3afa8="
+  },
+  "log4j#log4j/1.2.16": {
+   "pom": "sha256-Kx6fEFXPC0pGWar0dLZehC1cHcWAtcTgI472NHDREP0="
+  },
+  "log4j#log4j/1.2.17": {
+   "jar": "sha256-HTFpZEVpdyBScJF1Q2kIKmZRvUl4G2AF3rlOVnU0Bvk=",
+   "pom": "sha256-O5Wj083TqkuRqzJ921ob/gPYHic3lONqoUQEcdXXDl4="
+  },
+  "net/java/dev/jna#jna-platform/5.18.1": {
+   "jar": "sha256-rRTBsexPQ9OWIxIZ36Y16/go9zjqyfiQ6hvAd5WJLZo=",
+   "pom": "sha256-OdU4qVmaRHR3CDiGXtQs+j5rPRMIbLHld7i7QxSNGmU="
+  },
+  "net/java/dev/jna#jna/5.18.1": {
+   "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",
+   "pom": "sha256-mLYq5v8oDXR/s1n8QuSP7RE9Rbw3Kagj3DC4MIqAZkU="
+  },
+  "net/sf/jopt-simple#jopt-simple/4.4": {
+   "jar": "sha256-PKo+nzO/XYuMCu/qjPFmp/RomIBCHESkLZzqDTrG4u0=",
+   "pom": "sha256-grxfPGJDqK9v7dC7tLUQvUNQOYrRqH1CBcuB6ltMkXQ="
+  },
+  "org/antlr#antlr-master/3.2": {
+   "pom": "sha256-fRkllZP6jp3uFclxr/qZy/4mP4mAhXSwLzxkntc9GjU="
+  },
+  "org/antlr#antlr-runtime/3.2": {
+   "jar": "sha256-bZ+ZcgLMAtTU+j1OhObS0946Gx+VHpoag7QNAnmlA4k=",
+   "pom": "sha256-7LFOJegtITLWPHQuMMML0qWxiVQfmPGaVAaLVvHz1o8="
+  },
+  "org/apache/ant#ant-launcher/1.9.15": {
+   "jar": "sha256-O2x8C7wGSm1AA5+ZX23Dm8O3mjs18+lH7VRcS2Yb2Us=",
+   "pom": "sha256-g2t7bhQDQxWvlcxFLrUnz2kS4vo/hOxRQAYIc3zaBT8="
+  },
+  "org/apache/ant#ant-parent/1.9.15": {
+   "pom": "sha256-PS+Wc7hr27MK3bdcWdnP/BKDOVfX6t1SSZuOpBMW9DQ="
+  },
+  "org/apache/ant#ant/1.9.15": {
+   "jar": "sha256-VZh4OBCCR0ZVx0DoNzosmZD+Sph6pMJvOccizvXELMw=",
+   "pom": "sha256-0VF8gmrVqm32WpXqw6h+Zult7Qf/YiR3bbhKZb6rpTs="
+  },
+  "org/checkerframework#checker-qual/3.5.0": {
+   "jar": "sha256-cpmQs/GKlWBvwlc4NraVi820TLUr+9G3qpwznP81paQ=",
+   "pom": "sha256-KDazuKeO2zGhgDWS5g/HZ7IfLRkHZGMbpu+gg3uzVyE="
+  },
+  "org/eclipse/emf#org.eclipse.emf.common/2.17.0": {
+   "jar": "sha256-W4qj/X71SsaVqnPGv+opmpviz3Ry7WuKn6hN/QAL3LM=",
+   "pom": "sha256-zYf3dhgsAKnai7KIbXx7rLvoMjJsKw4sQ3rrs7fvAVg="
+  },
+  "org/eclipse/emf#org.eclipse.emf.common/2.45.0": {
+   "pom": "sha256-Momjqyn/zL6YIl3+lfnffSiuQz6xrNNUZkZQfzXtqwc="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore.xmi/2.16.0": {
+   "jar": "sha256-2NoRRs2DZ19dVBf92R/Inyr0tD5KMBEGYTJplNxxF20=",
+   "pom": "sha256-McYAPeGYu++mcsQ9ixI5b+K0DnXH8M+N6pvOkGZix18="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore.xmi/2.40.0": {
+   "pom": "sha256-Vo7z0mmi/HE1/EBvXJ5JbdQjQ6CB3xufaaMj9fHuSzE="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore/2.20.0": {
+   "jar": "sha256-nuU5o8UO88/LqjqF808EHupoKtRZ0+lW33dp9rKZGzY=",
+   "pom": "sha256-6aoQO2xLlRT1Par3jX/y2/B6zexP7uKVCb4I6hvsOSw="
+  },
+  "org/eclipse/emf#org.eclipse.emf.ecore/2.42.0": {
+   "pom": "sha256-9J8c6yPnlQi1R0TqD5Ii8y97jTTpQq2rDrmKwv6JvtY="
+  },
+  "org/eclipse/emf/org.eclipse.emf.common/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.emf",
+    "lastUpdated": "20260224162236",
+    "release": "2.45.0"
+   }
+  },
+  "org/eclipse/emf/org.eclipse.emf.ecore.xmi/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.emf",
+    "lastUpdated": "20260224162235",
+    "release": "2.40.0"
+   }
+  },
+  "org/eclipse/emf/org.eclipse.emf.ecore/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.emf",
+    "lastUpdated": "20260224162245",
+    "release": "2.42.0"
+   }
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.compiler.apt/1.3.1100": {
+   "jar": "sha256-zJqUAyG8X/IdsjBRdcPGYBYYoeosDbr65NGJBX5fVsI=",
+   "pom": "sha256-96v/7G1ehU+ora9ZJyT7rFFM8gKsaO9Q6ZTBzx9Dyjg="
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.compiler.tool/1.2.1000": {
+   "jar": "sha256-XVB7Co4RPPyccS9TBuzp0ON3VEfIEfyl+EkMNhWnVLQ=",
+   "pom": "sha256-qryopLNthGmhzCQ4AnWupz5YZqvAl8spXubpXK9Lpwk="
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.core/3.17.0": {
+   "pom": "sha256-F04xhLHTa8gqBjdPLhcacmXRXgjCDDXqtL8y4OGdG48="
+  },
+  "org/eclipse/jdt#org.eclipse.jdt.core/3.23.0": {
+   "jar": "sha256-sf7D5ZoMCcXisipnc3pUFithF/FQA3iya+SQgWw0Q8I=",
+   "pom": "sha256-IHpNbAWKRyIzp/n11ufbRdIG1szT9c6jTgQHuoQm0yU="
+  },
+  "org/eclipse/platform#org.eclipse.core.commands/3.12.500": {
+   "jar": "sha256-RHEzYuVe0o5ttdLDG/Z1JP7wh2RaRNwyOdrGDs4BfLk=",
+   "pom": "sha256-yD+4t0dc62ANfijxwyfGjhzSaFHeyEEKthn/9W17SoI="
+  },
+  "org/eclipse/platform#org.eclipse.core.contenttype/3.9.800": {
+   "jar": "sha256-4MLblmANUZzjanX5t8lxr9KHDS0Fnu5L8kNtmzOqC40=",
+   "pom": "sha256-vZ20X3R3JIQpxxz4RlcC2r+xUgzoU0+dwl1BeOu1iXs="
+  },
+  "org/eclipse/platform#org.eclipse.core.expressions/3.9.600": {
+   "jar": "sha256-7/hM/I8g4jVEjDpk+kwvpl+X4O0I0mMC8zG2d9/3emY=",
+   "pom": "sha256-LoubbvcTC0GLfGQY7X7mTAo7nd806z3Va/qLIzr2qtI="
+  },
+  "org/eclipse/platform#org.eclipse.core.filesystem/1.11.400": {
+   "jar": "sha256-b3C5XRS5DsV7lMXj26fh0YlnnPmkvEUm6ckb7tfWoO8=",
+   "pom": "sha256-sQA8+u8BN+YzwThrzFfbCl5Yelm1Fx5We6Uwz6u/jMU="
+  },
+  "org/eclipse/platform#org.eclipse.core.jobs/3.15.700": {
+   "jar": "sha256-NwFReae5uQ0Wy5L0sb5gg6Gm2tJUKPqPa4libwzC2nk=",
+   "pom": "sha256-OUVAotjHPjVRHz1f8J2fNkdm4P4steb4V8Tfqwl9Ot8="
+  },
+  "org/eclipse/platform#org.eclipse.core.jobs/3.15.800": {
+   "pom": "sha256-4BqLscYYZjcJv4yyFznslhvc6MVVXQTn+3VzvjD2jWY="
+  },
+  "org/eclipse/platform#org.eclipse.core.resources/3.24.0": {
+   "jar": "sha256-4mcC2BfWwm6D5Nbn5v9HYaU3dEh6JHsfr3yXXTlWg/4=",
+   "pom": "sha256-2LzuUCsfE1UK/R4pjZCLeh4cbNveVUj2joroopFNShE="
+  },
+  "org/eclipse/platform#org.eclipse.core.runtime/3.19.0": {
+   "pom": "sha256-5d9UsnVbbVg/aoJOpuRLwYBQKfaaF6M8GISSOPCCMnQ="
+  },
+  "org/eclipse/platform#org.eclipse.core.runtime/3.34.200": {
+   "jar": "sha256-tPNqCssI8D0LPbVLIfxWOMggxEdEakELpJalBw+jQ2M=",
+   "pom": "sha256-VUfhQDP4BRrlX0qDhwRsdAk7UgNs3DVu9p6lGOrn5uw="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.app/1.7.600": {
+   "jar": "sha256-/TUzmINRB2CPVUd5pukYkXJe+5Tg9XVZ0Ks86kthVsc=",
+   "pom": "sha256-cZhnUaan5uJyMJs6ZqySGUPplQlqXIgI1C6aDMJR1eg="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.common/3.13.0": {
+   "pom": "sha256-+3O5zurY3z4CrkYhA323gKKaURHCIDHszq+BXLmw35A="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.common/3.20.300": {
+   "pom": "sha256-ALs//vT1/wr/lXaIGYlvxY1kxitKkEc60niE6P0viFI="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.common/3.20.400": {
+   "jar": "sha256-QjtYYTpOm7vm7CI5aQ/zKfE9aeuyhAal+dcFFqZkOiQ=",
+   "pom": "sha256-uGupfIVGTB0QapWYJrNFQkoubQ1bCI/Sf/8FGW/xS+8="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.preferences/3.12.100": {
+   "jar": "sha256-/QToGiirMra7BzKG6yk8RLdgF2/PHjXvFWFNYt+CD4Y=",
+   "pom": "sha256-IYxiWoWw5QQU6dGRKFYUtrL+qf9/0TITKm4PkyQzMZY="
+  },
+  "org/eclipse/platform#org.eclipse.equinox.registry/3.12.600": {
+   "jar": "sha256-T4zXJoFEa1mDkKjCTum5mW9uTF+r7QIrUL0m9vWgv2w=",
+   "pom": "sha256-Kwg3b6gZu5Q3vHDKJM6w8NtE3gE/63F9vmmaKU+2MSc="
+  },
+  "org/eclipse/platform#org.eclipse.osgi/3.23.100": {
+   "pom": "sha256-gph5O0PkohKzeJ6c/dpZEqEGTCkPTgr4pUrLSNB5TuQ="
+  },
+  "org/eclipse/platform#org.eclipse.osgi/3.24.200": {
+   "jar": "sha256-v+g/zR+gNOuamGs8tuXisY27rLZ+q9qtLaMoBOzYxlo=",
+   "pom": "sha256-sMVs+qxqcAh+RUJXzABLfTb7uYk9vu5N64fGISWGERY="
+  },
+  "org/eclipse/platform#org.eclipse.text/3.14.700": {
+   "jar": "sha256-QHX3qjoZ8s5v/R9VXrwIhOBlzEC1n3HXdNoJKMFCNVU=",
+   "pom": "sha256-CUpEEYG78vzd7jYOoXXKFPO/NfAVtPlNpV6CTltDM+0="
+  },
+  "org/eclipse/platform/org.eclipse.core.contenttype/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072734",
+    "release": "3.9.800"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.core.filesystem/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072743",
+    "release": "1.11.400"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.core.jobs/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260608064403",
+    "release": "3.15.800"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.core.resources/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260608064402",
+    "release": "3.24.0"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.equinox.app/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260309141957",
+    "release": "1.7.600"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.equinox.preferences/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072801",
+    "release": "3.12.100"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.equinox.registry/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20251208072814",
+    "release": "3.12.600"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.osgi/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260608064445",
+    "release": "3.24.200"
+   }
+  },
+  "org/eclipse/platform/org.eclipse.text/maven-metadata": {
+   "xml": {
+    "groupId": "org.eclipse.platform",
+    "lastUpdated": "20260608064456",
+    "release": "3.14.700"
+   }
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.core/2.26.0.M1": {
+   "jar": "sha256-cSJpnGjNwDzHCD+416m8Fu9X81Zs+VHb8iAu59hBPP4=",
+   "pom": "sha256-gAUnNNtYJj1M81i7Xnts2YM8SOpYrrEz6OU7HJh6bnk="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib.macro/2.26.0.M1": {
+   "jar": "sha256-0JD3xc6lbz4fU5zR7DBJF9vcW0CatfhJH+fRKweHaqc=",
+   "pom": "sha256-noRJeVGBYI2AALRM4yFw2UzP1JaN1V2KgGNyqYnrPj8="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib.macro/2.9.0.beta3": {
+   "pom": "sha256-mrnejeg674gkxdP7ejRO4ucqCkFKvjRaU9fQu3QMK/8="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib/2.26.0.M1": {
+   "jar": "sha256-WDcavdMrnHaEcXE9KbTTOVE0Mhxu1u6sMDT2H6DO868=",
+   "pom": "sha256-cdrQr0y9l+9VG/GjtdISVz6Wm8Ahcqvn24VOLLr3on8="
+  },
+  "org/eclipse/xtend#org.eclipse.xtend.lib/2.9.0.beta3": {
+   "pom": "sha256-tvTav1nQs3hAJpu5l9g8blJklfs3PgS/4gyUkro7WrY="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.common.types/2.26.0.M1": {
+   "jar": "sha256-J4CbsOaZyXIjvMqgWb5gUsgm7cjOTWjk4a8c8OA8WpI=",
+   "pom": "sha256-KBblpXkaPCgF70MCp2FD5bosfgHNRWSYJmKi6NBNzG4="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.parent/2.9.0.beta3": {
+   "pom": "sha256-iitPMtKIuMIpKhznz1PSniKrUJLrQJCGHk7fWH5dxXE="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.tycho.parent/2.9.0.beta3": {
+   "pom": "sha256-aw4ohgIotMlzzRlMG75OAWJ3Z9eFa8IPLXhJdsqM3Hc="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.ui/2.9.0.beta3": {
+   "jar": "sha256-LdJ4gAHfV5Tdh3PcoWTLVf9loRXq2KyoTxcQIv1YXEk=",
+   "pom": "sha256-ijONMPrjEGreQAPcjqK4D4UYWks2MIvqLmXwNet5xao="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.util/2.26.0.M1": {
+   "jar": "sha256-GjUOUkVY9wqbaPoU1CpkzfSHJZSIMmbVHVM6XtHe87k=",
+   "pom": "sha256-PiFttra2eWhlgERIshGKlnMU088VE07lShOxcmNCcls="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.util/2.9.0.beta3": {
+   "pom": "sha256-Av48mI0vXSEvRU1Dd6sW87+kuCmmriSDjmW5mKXfXkM="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.xbase.lib/2.26.0.M1": {
+   "jar": "sha256-6t00qIDs00kIirnsc8/esHRlaL8lhACb0CUt5EgNjZM=",
+   "pom": "sha256-RQGK9XRXRnva6chBnh86GlIXMPixtWsV9vFihq2YW7M="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.xbase.lib/2.9.0.beta3": {
+   "pom": "sha256-PdmWaS7jFJPKsPuHXR8dH/TYVJR9w9h7/v4wXwn+ICM="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext.xbase/2.26.0.M1": {
+   "jar": "sha256-jk8M2/NovIVnk1V6qrrBiRUwTMv6thT0GfAkY+w+Z/o=",
+   "pom": "sha256-WwQhe/Y1tnJ+6AvbD7ou1Zc6mcznyJuAqCO932xde5o="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext/2.26.0.M1": {
+   "jar": "sha256-AJqnshwnSwjN0HYZLCYrSTwfRsk4O1Uzo0HvnAr/Uro=",
+   "pom": "sha256-bVw1Q8nsT1RgOUbQWaMwYnWDRJTMXnBHMTuf4gTgqkk="
+  },
+  "org/eclipse/xtext#org.eclipse.xtext/2.9.0.beta3": {
+   "pom": "sha256-sdYgpLPTQpjRnvmniZuQG4ujVrWmWsBikJHChbNOQRs="
+  },
+  "org/eclipse/xtext#xtext-dev-bom/2.26.0.M1": {
+   "pom": "sha256-rS44hS+MKr4hxk2eMIfDDiqruej4VkLEjYK+CUTf4hY="
+  },
+  "org/hamcrest#hamcrest-core/1.3": {
+   "jar": "sha256-Zv3vkelzk0jfeglqo4SlaF9Oh1WEzOiThqekclHE2Ok=",
+   "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
+  },
+  "org/hamcrest#hamcrest-parent/1.3": {
+   "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
+  },
+  "org/osgi#org.osgi.service.prefs/1.1.2": {
+   "jar": "sha256-Q8fIcHEONjQF1CLaZTzODXmKRTf3bkkw95vOrdOlU0U=",
+   "pom": "sha256-bqSDzqF36RMQmExkUuaUqiCAGVG1AfF8uboRQyjCzCY="
+  },
+  "org/osgi#osgi.annotation/8.0.1": {
+   "jar": "sha256-oOikw2K9NgCBLzew6kX7qWbHvASdAf7Vagnsx0CCdZ4=",
+   "pom": "sha256-iC0Hao4lypIH95ywk4DEcvazxBUIFivSuqBpF74d7XM="
+  },
+  "org/ow2#ow2/1.5": {
+   "pom": "sha256-D4obEW52C4/mOJxRuE5LB6cPwRCC1Pk25FO1g91QtDs="
+  },
+  "org/ow2/asm#asm-analysis/9.1": {
+   "jar": "sha256-gaiAQbG4vtpaiplkYJgEbEhwlTgnDEne9oq/8lrDvjQ=",
+   "pom": "sha256-rFRUwRsDQxypUd9x+06GyMTIDfaXn5W3V8rtOrD0cVY="
+  },
+  "org/ow2/asm#asm-commons/9.1": {
+   "jar": "sha256-r8sm3B/BLAxKma2mcJCN2C4Y38SIyvXuklRplrRwwAw=",
+   "pom": "sha256-oPZRsnuK/pwOYS16Ambqy197HHh7xLWsgkXz16EYG38="
+  },
+  "org/ow2/asm#asm-tree/9.1": {
+   "jar": "sha256-/QCvpJ6VlddkYgWwnOy0p3ao/wugby1ZuPe/nHBLSnM=",
+   "pom": "sha256-tqANkgfANUYPgcfXDtQSU/DSFmUr7UX6GjBS/81QuUw="
+  },
+  "org/ow2/asm#asm/9.1": {
+   "jar": "sha256-zaTeRV+rSP8Ly3xItGOUR9TehZp6/DCglKmG8JNr66I=",
+   "pom": "sha256-xoOpDdaPKxeIy9/EZH6pQF71kls3HBmfj9OdRNPO3o0="
+  },
+  "org/sonatype/forge#forge-parent/6": {
+   "pom": "sha256-nF981SJqyMN5jLH4AMAx997cFgbcUNwpVnh3yCJEWac="
+  },
+  "org/sonatype/oss#oss-parent/7": {
+   "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
+  },
+  "org/sonatype/oss#oss-parent/9": {
+   "pom": "sha256-+0AmX5glSCEv+C42LllzKyGH7G8NgBgohcFO8fmCgno="
+  },
+  "org/sonatype/sisu/inject#cglib/2.2.1-v20090111": {
+   "pom": "sha256-SvNVR7tds+Sft1CGWvDjM6/cgubm19itvRwUEd+tYIE="
+  }
+ },
+ "https://repository.jboss.org": {
+  "nexus/content/groups/public-jboss/com/google/guava/guava/maven-metadata": {
+   "xml": {
+    "groupId": "com.google.guava",
+    "lastUpdated": "20160429131712",
+    "release": "20.0-hal"
+   }
+  }
+ }
+}

--- a/pkgs/by-name/um/umple/fix-manpage.patch
+++ b/pkgs/by-name/um/umple/fix-manpage.patch
@@ -1,0 +1,13 @@
+--- a/build.gradle
++++ b/build.gradle
+@@ -605,8 +605,8 @@ task packageAllJars {
+ 
+ // Generate options text from help message
+ task genOptions(type:Exec) {
+-  workingDir "${rootProject.projectDir.toString()}/dist/"
+-  commandLine 'java', '-jar', 'umple.jar', '-help'
++  workingDir "${rootProject.projectDir.toString()}/dist/gradle/libs/"
++  commandLine 'java', '-jar', '@UMPLE_OUT_JAR@', '-help'
+   standardOutput = new ByteArrayOutputStream()
+   doLast {
+     def strings = standardOutput.toString().split('-----------')

--- a/pkgs/by-name/um/umple/gradle-8-compat.patch
+++ b/pkgs/by-name/um/umple/gradle-8-compat.patch
@@ -1,0 +1,48 @@
+diff --git a/build.gradle b/build.gradle
+index 897ab9d0a..ff84824f9 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -10,7 +10,7 @@ buildscript {
+ }
+ 
+ plugins {
+-  id 'nebula.ospackage' version '9.1.1'
++  id 'com.netflix.nebula.ospackage' version '12.3.0'
+ }
+ 
+ String runGit(List<String> args, String fallback) {
+@@ -376,7 +376,6 @@ sourceSets {
+             ]
+             exclude '**/*.ump', '**/.git*'
+         }
+-        java.outputDir = file(rootProject.ext.classfileOutputDir)
+     }
+     test {
+         compileClasspath = files(
+@@ -394,10 +393,16 @@ sourceSets {
+             ]
+             exclude '**/*.ump', '**/.git*'
+         }
+-        java.outputDir = file(rootProject.ext.testClassfileOutputDir)
+     }
+ }
+ 
++tasks.named("compileJava") {
++    destinationDirectory.set(file(rootProject.ext.classfileOutputDir))
++}
++
++tasks.named("compileTestJava") {
++    destinationDirectory.set(file(rootProject.ext.testClassfileOutputDir))
++}
+ 
+ // ===============
+ //  Jar packaging
+@@ -2011,7 +2016,7 @@ task executeDocJar (type: JavaExec){
+     def drop = fileTree ("${rootProject.ext.umpleoscripts}/dropbox") {
+       include '*.js'
+     }
+-   files = files (
++   files = project.files (
+      'umpleonline/scripts/prototype.js',
+      'umpleonline/scripts/dom.js',
+      'umpleonline/scripts/ajax.js', 

--- a/pkgs/by-name/um/umple/package.nix
+++ b/pkgs/by-name/um/umple/package.nix
@@ -1,0 +1,174 @@
+{
+  lib,
+  stdenvNoCC,
+  runCommand,
+  fetchurl,
+  fetchFromGitHub,
+  gradle_8, # incompatible with gradle 9+
+  installShellFiles,
+  makeWrapper,
+  nix-update-script,
+  opentxl,
+  jre,
+}:
+let
+  # Required for bootstrapping
+  umpleJar = fetchurl {
+    url = "https://github.com/umple/umple/releases/download/v1.36.0/umple-1.36.0.8088.f0fbd82bc.jar";
+    hash = "sha256-vCnGCkv2USAJcpXzR6sgCFsL43ZmHWd5+NOA8+lHBhg=";
+  };
+
+  # Not managed through Gradle
+  joptSimple = fetchFromGitHub {
+    owner = "jopt-simple";
+    repo = "jopt-simple";
+    tag = "jopt-simple-4.4";
+    hash = "sha256-sOQaEq2qzvEwJzwZIcMQus3tetzA6O2VPl8XUJAtupM=";
+  };
+
+  version = "1.37.0-unstable-2026-04-25";
+  numericVersion = lib.head (lib.splitString "-" version);
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "umple";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "umple";
+    repo = "umple";
+    rev = "98d4c08c5bbb171c94abf60fec92214448eb5a6d";
+    hash = "sha256-MLhICAjwXUkDwqIDxMz2+VnRC36ckmIVkOivZTpxWPE=";
+    deepClone = true;
+
+    # Store Git info used to generate Umple unstable version
+    postFetch = ''
+      cd $out
+      git rev-parse --short HEAD > COMMIT
+      git rev-list --count HEAD > COMMIT_COUNT
+      rm -rf .git
+      cd -
+    '';
+  };
+
+  patches = [
+    # The upstream project uses some deprecated Gradle 7 features and old dependencies
+    ./gradle-8-compat.patch
+    # Replaces the logic to determine the current version (requires Git at runtime)
+    ./replace-version.patch
+    # Fixes broken working directory + updates Jar paths for manpage generation task
+    ./fix-manpage.patch
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    gradle_8
+    gradle_8.jdk
+    installShellFiles
+    makeWrapper
+    opentxl
+  ];
+
+  postPatch = ''
+    gitCommit=$(<COMMIT)
+    gitCommitCount=$(<COMMIT_COUNT)
+    umpleVersion="${numericVersion}.$gitCommitCount.$gitCommit"
+
+    # Set variables from patches + use Nix store paths
+    substituteInPlace build.gradle \
+      --replace-fail @UMPLE_VERSION@ "$umpleVersion" \
+      --replace-fail @UMPLE_OUT_JAR@ "umple-$umpleVersion.jar" \
+      --replace-fail '${"$"}{rootProject.projectDir.toString()}/libs/umple-latest.jar' '${umpleJar}' \
+      --replace-fail '${"$"}{rootProject.projectDir.toString()}/dist/gradle/libs/vendors/jopt-simple-jopt-simple-4.4/src/main/java/joptsimple' '${joptSimple}/src/main/java/joptsimple'
+
+    # Replace outdated version in manpage
+    substituteInPlace build/package-files/template.1 \
+      --replace-warn 1.31.1 "$umpleVersion"
+
+    # Replace @UMPLE_VERSION@ template in original source code with actual version.
+    # This ensures that emitted files include comments indicating the proper version,
+    # e.g. "Generated with Umple x.y.z"
+    find . -type f \( -name '*.java' -o -name '*.ump' \) -exec sed -i "s/@UMPLE_VERSION@/$umpleVersion/g" {} +
+  '';
+
+  mitmCache = gradle_8.fetchDeps {
+    inherit (finalAttrs) pname;
+    data = ./deps.json;
+  };
+
+  __darwinAllowLocalNetworking = true;
+
+  gradleBuildTask = "quickbuild";
+
+  gradleFlags = [
+    # Network-dependent tasks
+    "--exclude-task=downloadUmpleJar"
+    "--exclude-task=downloadJOptSimpleVendorZip"
+    "--exclude-task=downloadAndUnzipJOptSimpleVendor"
+    "--exclude-task=prepareJOptSimpleVendor"
+    # Tasks that try to modify readonly files
+    "--exclude-task=cleanUpUmple"
+  ];
+
+  postBuild = ''
+    gradle --no-daemon genManpage
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/java}
+    cp dist/gradle/libs/umple*.jar $out/share/java
+    installManPage build/package-files/umple.1
+
+    pushd $out/share/java
+    # Strip version suffix from filenames
+    for file in *.jar; do
+      mv "$file" "''${file%-$umpleVersion.jar}.jar"
+    done
+    # Create wrappers
+    for file in *.jar; do
+      makeWrapper ${lib.getExe jre} "$out/bin/''${file%.jar}" \
+        --add-flags "-jar $out/share/java/$file"
+    done
+    popd
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  passthru.tests."2dshapes" =
+    runCommand "umple-test"
+      {
+        nativeBuildInputs = [
+          finalAttrs.finalPackage
+          gradle_8.jdk
+        ];
+        src = ./2DShapes.ump;
+      }
+      ''
+        set -euo pipefail
+        cp $src .
+        umple $(basename $src)
+        javac -d bin Shapes/core/*.java
+        java -cp bin Shapes.core.Shape2D
+        touch $out
+      '';
+
+  meta = {
+    description = "Model-oriented programming language and modelling tool for integrating UML constructs into high-level languages";
+    mainProgram = "umple";
+    homepage = "https://github.com/umple/umple";
+    downloadPage = "https://github.com/umple/umple/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+    maintainers = with lib.maintainers; [ MysteryBlokHed ];
+  };
+})

--- a/pkgs/by-name/um/umple/package.nix
+++ b/pkgs/by-name/um/umple/package.nix
@@ -1,0 +1,159 @@
+{
+  lib,
+  stdenvNoCC,
+  runCommand,
+  fetchurl,
+  fetchFromGitHub,
+  gradle_8, # incompatible with gradle 9+
+  installShellFiles,
+  makeBinaryWrapper,
+  opentxl,
+  jre,
+}:
+let
+  versions = lib.importJSON ./versions.json;
+  inherit (versions.umple) version longVersion;
+
+  # Required for bootstrapping
+  umpleJar = fetchurl versions.umpleJar;
+
+  # Not managed through Gradle
+  joptSimple = fetchFromGitHub {
+    owner = "jopt-simple";
+    repo = "jopt-simple";
+    tag = "jopt-simple-4.4";
+    hash = "sha256-sOQaEq2qzvEwJzwZIcMQus3tetzA6O2VPl8XUJAtupM=";
+  };
+
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "umple";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "umple";
+    repo = "umple";
+    tag = "v${version}";
+    hash = "sha256-BPy1L3bzvKoywM0srv36SXVe8psaY/m0bljy30z5dr8=";
+  };
+
+  patches = [
+    # The upstream project uses some deprecated Gradle 7 features and old dependencies
+    ./gradle-8-compat.patch
+    # Replaces the logic to determine the current version (requires Git at runtime)
+    ./replace-version.patch
+    # Fixes broken working directory + updates Jar paths for manpage generation task
+    ./fix-manpage.patch
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  nativeBuildInputs = [
+    gradle_8
+    gradle_8.jdk
+    installShellFiles
+    makeBinaryWrapper
+    opentxl
+  ];
+
+  postPatch = ''
+    # Set variables from patches + use Nix store paths
+    substituteInPlace build.gradle \
+      --replace-fail @UMPLE_VERSION@ "${longVersion}" \
+      --replace-fail @UMPLE_OUT_JAR@ "umple-${longVersion}.jar" \
+      --replace-fail '${"$"}{rootProject.projectDir.toString()}/libs/umple-latest.jar' '${umpleJar}' \
+      --replace-fail '${"$"}{rootProject.projectDir.toString()}/dist/gradle/libs/vendors/jopt-simple-jopt-simple-4.4/src/main/java/joptsimple' '${joptSimple}/src/main/java/joptsimple'
+
+    # Replace outdated version in manpage
+    substituteInPlace build/package-files/template.1 \
+      --replace-warn 1.31.1 "${longVersion}"
+
+    # Replace @UMPLE_VERSION@ template in original source code with actual version.
+    # This ensures that emitted files include comments indicating the proper version,
+    # e.g. "Generated with Umple x.y.z"
+    find . -type f \( -name '*.java' -o -name '*.ump' \) -exec sed -i "s/@UMPLE_VERSION@/${longVersion}/g" {} +
+  '';
+
+  mitmCache = gradle_8.fetchDeps {
+    inherit (finalAttrs) pname;
+    data = ./deps.json;
+  };
+
+  __darwinAllowLocalNetworking = true;
+
+  gradleBuildTask = "quickbuild";
+
+  gradleFlags = [
+    # Network-dependent tasks
+    "--exclude-task=downloadUmpleJar"
+    "--exclude-task=downloadJOptSimpleVendorZip"
+    "--exclude-task=downloadAndUnzipJOptSimpleVendor"
+    "--exclude-task=prepareJOptSimpleVendor"
+    # Tasks that try to modify readonly files
+    "--exclude-task=cleanUpUmple"
+  ];
+
+  postBuild = ''
+    gradle --no-daemon genManpage
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/java}
+    cp dist/gradle/libs/umple*.jar $out/share/java
+    installManPage build/package-files/umple.1
+
+    pushd $out/share/java
+    # Strip version suffix from filenames
+    for file in *.jar; do
+      mv "$file" "''${file%-${longVersion}.jar}.jar"
+    done
+    # Create wrappers
+    for file in *.jar; do
+      makeWrapper ${lib.getExe jre} "$out/bin/''${file%.jar}" \
+        --add-flags "-jar $out/share/java/$file"
+    done
+    popd
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = ./update.sh;
+
+    bootstrap = umpleJar;
+
+    tests."2dshapes" =
+      runCommand "umple-test"
+        {
+          nativeBuildInputs = [
+            finalAttrs.finalPackage
+            gradle_8.jdk
+          ];
+          src = ./2DShapes.ump;
+        }
+        ''
+          set -euo pipefail
+          cp $src .
+          umple $(basename $src)
+          javac -d bin Shapes/core/*.java
+          java -cp bin Shapes.core.Shape2D
+          touch $out
+        '';
+  };
+
+  meta = {
+    description = "Model-oriented programming language and modelling tool for integrating UML constructs into high-level languages";
+    mainProgram = "umple";
+    homepage = "https://github.com/umple/umple";
+    downloadPage = "https://github.com/umple/umple/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryBytecode
+    ];
+    maintainers = with lib.maintainers; [ MysteryBlokHed ];
+  };
+})

--- a/pkgs/by-name/um/umple/replace-version.patch
+++ b/pkgs/by-name/um/umple/replace-version.patch
@@ -1,0 +1,11 @@
+--- a/build.gradle
++++ b/build.gradle
+@@ -32,7 +32,7 @@ ext {
+     umpleMajorVersionFile = new File("${rootProject.projectDir.toString()}/build/umpleversion.txt")
+     umpleLastVersion = new org.yaml.snakeyaml.Yaml().load(rootProject.ext.umpleLastVersionFile.newInputStream()).version
+     umpleMajorVersion = new org.yaml.snakeyaml.Yaml().load(rootProject.ext.umpleMajorVersionFile.newInputStream()).version
+-    umpleCurrentVersion = "${rootProject.ext.umpleMajorVersion}.${runGit(['rev-list', '--count', 'master'], 'x')}.${runGit(['rev-parse', '--short', 'master'], 'dev')}"
++    umpleCurrentVersion = "@UMPLE_VERSION@"
+     umpleCurrentJarBase = "umple-${rootProject.ext.umpleCurrentVersion}"
+     umpleCurrentJar = "${rootProject.projectDir.toString()}/dist/gradle/libs/${rootProject.ext.umpleCurrentJarBase}.jar"
+     umpleJarRemoteSource = "https://cruise.umple.org/umpleonline/scripts/umple.jar"

--- a/pkgs/by-name/um/umple/update.sh
+++ b/pkgs/by-name/um/umple/update.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl git jq nix-update
+set -euo pipefail
+
+release=$(curl -s ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} https://api.github.com/repos/umple/umple/releases/latest)
+latestTag=$(echo "$release" | jq -r '.tag_name')
+latestVersion="${latestTag#v}"
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; umple.version or (lib.getVersion umple)" | tr -d '"')
+echo "Current version: $currentVersion"
+echo "Latest version: $latestVersion"
+
+if [[ "$currentVersion" = "$latestVersion" ]]; then
+  echo "Up-to-date."
+  exit
+fi
+
+echo "Updating to $latestVersion"
+
+location="$(dirname -- "${BASH_SOURCE[0]}")"
+
+# Get commit count and hash from upstream repository tag
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+pushd "$tmpdir"
+git clone --branch "$latestVersion" --single-branch https://github.com/umple/umple.git .
+revision=$(git rev-parse --short HEAD)
+commitCount=$(git rev-list --count HEAD)
+longVersion="$latestVersion.$commitCount.$revision"
+popd
+
+# Find the filename and hash of the latest stable Umple JAR for bootstrapping.
+# The best way to do this is to just check the prefix of release assets,
+# since the commit count + hash used don't match the release tag, for some reason.
+umpleName=$(echo "$release" | jq -r 'first(.assets[] | select(.name | startswith("umple-")) | .name)')
+if [[ -z "$umpleName" ]]; then
+  echo "Could not find Umple JAR in GitHub release assets."
+  exit 1
+fi
+
+umpleUrl="https://github.com/umple/umple/releases/download/$latestTag/$umpleName"
+umpleHash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 \
+  "$(nix-prefetch-url "$umpleUrl")")
+
+# Save version info
+jq -n \
+  --arg version "$latestVersion" \
+  --arg longVersion "$longVersion" \
+  --arg revision "$revision" \
+  --arg commitCount "$commitCount" \
+  --arg umpleUrl "$umpleUrl" \
+  --arg umpleHash "$umpleHash" \
+  '{
+    "umple": {
+      "version": $version,
+      "longVersion": $longVersion,
+      "revision": $revision,
+      "commitCount": $commitCount
+    },
+    "umpleJar": {
+      "url": $umpleUrl,
+      "hash": $umpleHash
+    }
+  }' > "$location/versions.json"
+
+# Version update is done; use nix-update for hashes and Gradle deps
+nix-update umple --version=skip

--- a/pkgs/by-name/um/umple/versions.json
+++ b/pkgs/by-name/um/umple/versions.json
@@ -1,0 +1,12 @@
+{
+  "umple": {
+    "version": "1.37.0",
+    "longVersion": "1.37.0.8543.1593c2b83",
+    "revision": "1593c2b83",
+    "commitCount": "8543"
+  },
+  "umpleJar": {
+    "url": "https://github.com/umple/umple/releases/download/v1.37.0/umple-1.37.0.8542.3a8c87689.jar",
+    "hash": "sha256-pBHHbURbe7B5A11tShvHGlSO4XMJPcdM7Iy+ph3PxAE="
+  }
+}


### PR DESCRIPTION
Adds a package for [Umple](https://github.com/umple/umple), a programming language and modelling tool for integrating UML constructs into high-level languages. It's used for a handful of courses in the University of Ottawa curriculum, so it would be convenient to have access through nixpkgs rather than manually fetching the release jarfiles. It will also allow for packaging the language server in the future.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
