### PR TITLE
haskellPackages: fix pkgsStatic on aarch64-darwin

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -72,10 +72,13 @@
       stdenv.targetPlatform.isWindows
       || stdenv.targetPlatform.isGhcjs
       # Before <https://gitlab.haskell.org/ghc/ghc/-/merge_requests/13932>,
-      # we couldn't force hadrian to build terminfo for cross.
+      # we couldn't force hadrian to build terminfo for different triples.
       || (
         lib.versionOlder version "9.15.20250808"
-        && (stdenv.buildPlatform != stdenv.hostPlatform || stdenv.hostPlatform != stdenv.targetPlatform)
+        && (
+          stdenv.buildPlatform.config != stdenv.hostPlatform.config
+          || stdenv.hostPlatform.config != stdenv.targetPlatform.config
+        )
       )
     ),
 

--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -356,7 +356,9 @@ let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
   # TODO(@Ericson2314) Make unconditional
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+  targetPrefix = lib.optionalString (
+    targetPlatform.config != hostPlatform.config
+  ) "${targetPlatform.config}-";
 
   # TODO(@sternenseemann): there's no stage0:exe:haddock target by default,
   # so haddock isn't available for GHC cross-compilers. Can we fix that?


### PR DESCRIPTION
No clue why this was fine for `x86_64-linux`, but on `aarch64-darwin`, I got
```
$ nix-build -A pkgsStatic.haskell.packages.ghc910.ghc
configure: error: in `/nix/var/nix/builds/nix-16170-2790439639/ghc-9.10.3-source/_build/stage1/libraries/terminfo/build':
configure: error: curses library not found, so this package cannot be built
```
and after fixing that, in `installPhase`
```
# Fix the mode, in case umask is set
chmod 644 '/nix/store/07mbxqfbiim3chmrk5iy1qig8449rl1m-arm64-apple-darwin-ghc-9.10.3/lib/ghc-9.10.3/lib/package.conf.d/binary-0.8.9.3-3d56.conf'
'/nix/store/07mbxqfbiim3chmrk5iy1qig8449rl1m-arm64-apple-darwin-ghc-9.10.3/lib/ghc-9.10.3/bin/ghc-pkg' --global-package-db "/nix/store/07mbxqfbiim3chmrk5iy1qig8449rl1m-arm64-apple-darwin-ghc-9.10.3/lib/ghc-9.10.3/lib/package.conf.d" recache
if [ -d docs-utils ]; then \
	/nix/store/hf6y9njhfwvigr25kzrwmsvmv6jpni5n-coreutils-9.9/bin/install -c -m 755 -d "/nix/store/1503p0agvzgr8hcrgcv1f9cm344cxjfd-arm64-apple-darwin-ghc-9.10.3-doc/share/doc/arm64-apple-darwin-ghc/html/libraries/"; \
	/nix/store/hf6y9njhfwvigr25kzrwmsvmv6jpni5n-coreutils-9.9/bin/install -c -m 644 docs-utils/prologue.txt "/nix/store/1503p0agvzgr8hcrgcv1f9cm344cxjfd-arm64-apple-darwin-ghc-9.10.3-doc/share/doc/arm64-apple-darwin-ghc/html/libraries/"; \
	/nix/store/hf6y9njhfwvigr25kzrwmsvmv6jpni5n-coreutils-9.9/bin/install -c -m 755 docs-utils/gen_contents_index "/nix/store/1503p0agvzgr8hcrgcv1f9cm344cxjfd-arm64-apple-darwin-ghc-9.10.3-doc/share/doc/arm64-apple-darwin-ghc/html/libraries/"; \
fi
/nix/var/nix/builds/nix-51825-2701879890/ghc-9.10.3-source
ghc-settings-edit: /nix/store/07mbxqfbiim3chmrk5iy1qig8449rl1m-arm64-apple-darwin-ghc-9.10.3/lib/arm64-apple-darwin-ghc-9.10.3/lib/settings: openFile: does not exist (No such file or directory)
```
Notice the lines before the last refer to `lib/ghc-9.10.3/` while settings is searched for in `lib/arm64-apple-darwin-ghc-9.10.3`

These issues are due to the discrepancies pointed out in https://github.com/NixOS/nixpkgs/pull/383165/. 
We have at least 3 layers to think about regarding what counts as "native" builds:
1. `hostPlatform.canExecute targetPlatform` 
2. `hostPlatform.config == targetPlatform.config`
3. `hostPlatform == targetPlatform`

AFAICT, *3* implies *2* implies *1*. We've mostly looked at *3*, while ghc mostly looked at *2*.
We might need to re-think things some in general, but changing `common-hadrian.nix` to use *2* instead of *3* in these places seems to be an improvement as it fixes `pkgsStatic`. Was able to build and run `pkgsStatic.haskell.packages.ghc910.hello`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
