### PR TITLE
nixos/n8n: add custom nodes option

### DIFF
--- a/nixos/tests/n8n.nix
+++ b/nixos/tests/n8n.nix
@@ -15,6 +15,7 @@ in
     {
       services.n8n = {
         enable = true;
+        customNodes = [ pkgs.n8n-nodes-carbonejs ];
         environment = {
           WEBHOOK_URL = webhookUrl;
           N8N_TEMPLATES_ENABLED = false;
@@ -41,5 +42,11 @@ in
     # Test _FILE environment variables
     machine.succeed("grep -qF 'LoadCredential=n8n_encryption_key_file:${secretFile}' /etc/systemd/system/n8n.service")
     machine.succeed("grep -qF 'N8N_ENCRYPTION_KEY_FILE=%d/n8n_encryption_key_file' /etc/systemd/system/n8n.service")
+
+    # Test custom nodes
+    machine.succeed("grep -qF 'N8N_CUSTOM_EXTENSIONS=' /etc/systemd/system/n8n.service")
+    custom_extensions_dir = machine.succeed("grep -oP 'N8N_CUSTOM_EXTENSIONS=\\K[^\"]+' /etc/systemd/system/n8n.service").strip()
+    machine.succeed(f"test -L {custom_extensions_dir}/n8n-nodes-carbonejs")
+    machine.succeed(f"test -f {custom_extensions_dir}/n8n-nodes-carbonejs/package.json")
   '';
 }

--- a/pkgs/by-name/n8/n8n-nodes-carbonejs/package.nix
+++ b/pkgs/by-name/n8/n8n-nodes-carbonejs/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "n8n-nodes-carbonejs";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jreyesr";
+    repo = "n8n-nodes-carbonejs";
+    tag = "v${version}";
+    hash = "sha256-Dvl+Kc04i+hQ8rciT7n3oS4rtgke+HEqUszJnQa7UA0=";
+  };
+
+  npmDepsHash = "sha256-3VwejuSFGvJWNsitLKfVVpB8GnkTrrf/LLobNCpy8gU=";
+
+  meta = {
+    description = "n8n community node for rendering Word templates using Carbone.js";
+    homepage = "https://github.com/jreyesr/n8n-nodes-carbonejs";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sweenu ];
+  };
+}

--- a/pkgs/by-name/n8/n8n-nodes-carbonejs/package.nix
+++ b/pkgs/by-name/n8/n8n-nodes-carbonejs/package.nix
@@ -2,25 +2,31 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  nix-update-script,
+  n8n,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "n8n-nodes-carbonejs";
   version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "jreyesr";
     repo = "n8n-nodes-carbonejs";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Dvl+Kc04i+hQ8rciT7n3oS4rtgke+HEqUszJnQa7UA0=";
   };
 
   npmDepsHash = "sha256-3VwejuSFGvJWNsitLKfVVpB8GnkTrrf/LLobNCpy8gU=";
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
+    inherit (n8n.meta) platforms;
     description = "n8n community node for rendering Word templates using Carbone.js";
     homepage = "https://github.com/jreyesr/n8n-nodes-carbonejs";
+    changelog = "https://github.com/jreyesr/n8n-nodes-carbonejs/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sweenu ];
   };
-}
+})


### PR DESCRIPTION
Adds an option to the n8n module for custom nodes.
Also added a first custom node: n8n-nodes-carbonejs

I wonder if the custom node packages should be built in the n8n directory rather than their own?

Fixes https://github.com/NixOS/nixpkgs/issues/435198

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
