### PR TITLE
python3Packages.triton-cuda.tests.axpy-cuda.gpuCheck: fix by making $HOME writable

### DIFF
--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -258,6 +258,11 @@ buildPythonPackage rec {
               ps.triton
               ps.torch-no-triton
             ];
+
+            gpuCheckArgs.nativeBuildInputs = [
+              # PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
+              writableTmpDirAsHomeHook
+            ];
           }
           ''
             # Adopted from Philippe Tillet https://triton-lang.org/main/getting-started/tutorials/01-vector-add.html


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
```
Traceback (most recent call last):
  File "/nix/store/3q2pzpmckwgdql2fljlf5cf6dic5f0kp-tester-cuda/bin/tester-cuda", line 41, in <module>
    output_triton = axpy(3.14, x, y)
  File "/nix/store/3q2pzpmckwgdql2fljlf5cf6dic5f0kp-tester-cuda/bin/tester-cuda", line 28, in axpy
    axpy_kernel[grid](n_elements, a, x, y, output, BLOCK_SIZE=1024)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/jit.py", line 419, in <lambda>
    return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
                                   ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/jit.py", line 713, in run
    device = driver.active.get_current_device()
             ^^^^^^^^^^^^^
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/driver.py", line 28, in active
    self._active = self.default
                   ^^^^^^^^^^^^
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/driver.py", line 22, in default
    self._default = _create_driver()
                    ~~~~~~~~~~~~~~^^
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/driver.py", line 10, in _create_driver
    return active_drivers[0]()
           ~~~~~~~~~~~~~~~~~^^
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/backends/nvidia/driver.py", line 723, in __init__
    self.utils = CudaUtils()  # TODO: make static
                 ~~~~~~~~~^^
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/backends/nvidia/driver.py", line 67, in __init__
    mod = compile_module_from_src(
        src=Path(os.path.join(dirname, "driver.c")).read_text(),
    ...<3 lines>...
        libraries=libraries,
    )
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/build.py", line 82, in compile_module_from_src
    cache = get_cache_manager(key)
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/cache.py", line 248, in get_cache_manager
    return cls(_base32(key))
  File "/nix/store/rsjl9pqmv9abj0wb2szpn33vhad4ymvd-python3-3.13.11-env/lib/python3.13/site-packages/triton/runtime/cache.py", line 55, in __init__
    os.makedirs(self.cache_dir, exist_ok=True)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 218, in makedirs
  File "<frozen os>", line 228, in makedirs
PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
