### PR TITLE
t-lang: init at 0.3.1

### DIFF
--- a/pkgs/by-name/t-/t-lang/package.nix
+++ b/pkgs/by-name/t-/t-lang/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "t-lang";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "alecthomas";
+    repo = "t";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J/lQ5x72Z6yv/F0+n9tMLsIP4ojrbZKuUajPlvMnBsU=";
+  };
+
+  cargoHash = "sha256-86T8rOKXx6agZw6xu10YVCgP+dyuodCW1ZZlimQFcFk=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Text processing language and utility";
+    longDescription = ''
+      T is a concise language for manipulating text, replacing common usage
+      patterns of Unix utilities like grep, sed, cut, awk, sort, and uniq.
+    '';
+    homepage = "https://github.com/alecthomas/t";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "t";
+  };
+})


### PR DESCRIPTION
init [`t`](https://github.com/alecthomas/t) as `t-lang`, a text processing language and utility.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
