### PR TITLE
lua-resty-hmac-ffi: init at 0.06-1

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -57,6 +57,7 @@ lua-iconv,,,,7.0.0,,
 lua-lsp,,,,,,
 lua-messagepack,,,,,,
 lua-protobuf,,,,,,lockejan
+lua-resty-hmac-ffi,https://raw.githubusercontent.com/jkeys089/lua-resty-hmac/master/rockspec/lua-resty-hmac-ffi-0.06-1.rockspec,,,,5.1,"de11n despsyched"
 lua-resty-http,,,,,,
 lua-resty-jwt,,,,,,
 lua-resty-openidc,,,,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1899,6 +1899,37 @@ final: prev: {
     }
   ) { };
 
+  lua-resty-hmac-ffi = callPackage (
+    {
+      buildLuarocksPackage,
+      fetchFromGitHub,
+      lua,
+    }:
+    buildLuarocksPackage {
+      pname = "lua-resty-hmac-ffi";
+      version = "0.06-1";
+
+      src = fetchFromGitHub {
+        owner = "jkeys089";
+        repo = "lua-resty-hmac";
+        rev = "0.06-1";
+        hash = "sha256-CdYps8gqJqa0UzvZ8CsesEyBIb3rr0ZD+ugCr5P96NM=";
+      };
+
+      disabled = lua.luaversion != "5.1";
+
+      meta = {
+        homepage = "https://github.com/jkeys089/lua-resty-hmac";
+        description = "HMAC functions for ngx_lua and LuaJIT";
+        maintainers = with lib.maintainers; [
+          de11n
+          despsyched
+        ];
+        license.fullName = "BSD-2-Clause License";
+      };
+    }
+  ) { };
+
   lua-resty-http = callPackage (
     {
       buildLuarocksPackage,


### PR DESCRIPTION
https://github.com/jkeys089/lua-resty-hmac

Note that this maybe depends on [`lua-resty-string`](https://github.com/openresty/lua-resty-string) but I think it vendors it. Is that acceptable? AFAIK other Lua Rocks packages do something similar.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
