### PR TITLE
amp-cli: 0.0.1769346334-gc7e300 -> 0.0.1769573834-gf25e1e

### DIFF
--- a/pkgs/by-name/am/amp-cli/package-lock.json
+++ b/pkgs/by-name/am/amp-cli/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@sourcegraph/amp": "^0.0.1769346334-gc7e300"
+        "@sourcegraph/amp": "^0.0.1769573834-gf25e1e"
       }
     },
     "node_modules/@napi-rs/keyring": {
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@sourcegraph/amp": {
-      "version": "0.0.1769346334-gc7e300",
-      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1769346334-gc7e300.tgz",
-      "integrity": "sha512-inYgc+ARJbXEXrDMQsG2kwQI9/tRHD/TPubNGv6XnQSd0MxCq9hr4KxiSryFnw5qIASWYn85RdSy6LM9dRFa7Q==",
+      "version": "0.0.1769573834-gf25e1e",
+      "resolved": "https://registry.npmjs.org/@sourcegraph/amp/-/amp-0.0.1769573834-gf25e1e.tgz",
+      "integrity": "sha512-CIUXmicZvkuekyDn5F9K7IozSG/FjnYM9gRS1KIWkeFBeQONRsnxuMaLswlNR4MIDd9nzco8wielehe6q6rnoA==",
       "license": "Amp Commercial License",
       "dependencies": {
         "@napi-rs/keyring": "1.1.9"

--- a/pkgs/by-name/am/amp-cli/package.nix
+++ b/pkgs/by-name/am/amp-cli/package.nix
@@ -9,11 +9,11 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "amp-cli";
-  version = "0.0.1769346334-gc7e300";
+  version = "0.0.1769573834-gf25e1e";
 
   src = fetchzip {
     url = "https://registry.npmjs.org/@sourcegraph/amp/-/amp-${finalAttrs.version}.tgz";
-    hash = "sha256-Y0ySMlYP/mvD+ydkGhqt03zYkFj6BmZpe2zLnAV5rDk=";
+    hash = "sha256-6iieN2hDbwUh9gU5oD53e/gpYTwV0uQ70KPQ1hgr1J0=";
   };
 
   postPatch = ''
@@ -45,7 +45,7 @@ buildNpmPackage (finalAttrs: {
     chmod +x bin/amp-wrapper.js
   '';
 
-  npmDepsHash = "sha256-2e0kJJqmIB3kAaSzATSaNojLvsCIq5MwTGK0y0OxfO4=";
+  npmDepsHash = "sha256-p2MzhZHblYFygEVmY3DkyeukLODRChOA802DowCugv0=";
 
   propagatedBuildInputs = [
     ripgrep


### PR DESCRIPTION
## Summary
- Update amp-cli from 0.0.1769346334-gc7e300 to 0.0.1769573834-gf25e1e
- Generated automatically using the package's `passthru.updateScript`

## Checklist
- [x] Package has been updated using its auto-updater
- [x] Package builds successfully (tested locally)
- [ ] Tested on NixOS/nix-darwin/other

## Notes
This PR was created using [nix-updater](https://github.com/deftdawg/nix-updater).