### PR TITLE
openssl_3: 3.0.18 -> 3.0.19

### DIFF
--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -429,8 +429,8 @@ in
   };
 
   openssl_3 = common {
-    version = "3.0.18";
-    hash = "sha256-2Aw09c+QLczx8bXfXruG0DkuNwSeXXPfGzq65y5P/os=";
+    version = "3.0.19";
+    hash = "sha256-+lpBQ7iq4YvlPvLzyvKaLgdHQwuLx00y2IM1uUq2MHI=";
 
     patches = [
       # Support for NIX_SSL_CERT_FILE, motivation:

--- a/pkgs/development/libraries/openssl/use-etc-ssl-certs-darwin.patch
+++ b/pkgs/development/libraries/openssl/use-etc-ssl-certs-darwin.patch
@@ -3,11 +3,11 @@ index 329ef62..9a8df64 100644
 --- a/include/internal/cryptlib.h
 +++ b/include/internal/cryptlib.h
 @@ -56,7 +56,7 @@ DEFINE_LHASH_OF(MEM);
- # ifndef OPENSSL_SYS_VMS
- #  define X509_CERT_AREA          OPENSSLDIR
- #  define X509_CERT_DIR           OPENSSLDIR "/certs"
--#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
-+#  define X509_CERT_FILE          "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
- #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
- #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
- # else
+ #ifndef OPENSSL_SYS_VMS
+ #define X509_CERT_AREA OPENSSLDIR
+ #define X509_CERT_DIR OPENSSLDIR "/certs"
+-#define X509_CERT_FILE OPENSSLDIR "/cert.pem"
++#define X509_CERT_FILE "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+ #define X509_PRIVATE_DIR OPENSSLDIR "/private"
+ #define CTLOG_FILE OPENSSLDIR "/ct_log_list.cnf"
+ #else

--- a/pkgs/development/libraries/openssl/use-etc-ssl-certs.patch
+++ b/pkgs/development/libraries/openssl/use-etc-ssl-certs.patch
@@ -3,11 +3,11 @@ index 329ef62..9a8df64 100644
 --- a/include/internal/cryptlib.h
 +++ b/include/internal/cryptlib.h
 @@ -56,7 +56,7 @@ DEFINE_LHASH_OF(MEM);
- # ifndef OPENSSL_SYS_VMS
- #  define X509_CERT_AREA          OPENSSLDIR
- #  define X509_CERT_DIR           OPENSSLDIR "/certs"
--#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
-+#  define X509_CERT_FILE          "/etc/ssl/certs/ca-certificates.crt"
- #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
- #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
- # else
+ #ifndef OPENSSL_SYS_VMS
+ #define X509_CERT_AREA OPENSSLDIR
+ #define X509_CERT_DIR OPENSSLDIR "/certs"
+-#define X509_CERT_FILE OPENSSLDIR "/cert.pem"
++#define X509_CERT_FILE "/etc/ssl/certs/ca-certificates.crt"
+ #define X509_PRIVATE_DIR OPENSSLDIR "/private"
+ #define CTLOG_FILE OPENSSLDIR "/ct_log_list.cnf"
+ #else


### PR DESCRIPTION
The second item (severity: High) has possible unauthenticated RCE:
https://www.openwall.com/lists/oss-security/2026/01/27/5
https://github.com/openssl/openssl/blob/openssl-3.0.19/CHANGES.md#openssl-30

The patches differ in whitespace only, as that's what upstream changed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
