### PR TITLE
omnom: 0.7.0 -> 0.9.0; nixos/omnom: add `base_url` option

### DIFF
--- a/nixos/modules/services/misc/omnom.nix
+++ b/nixos/modules/services/misc/omnom.nix
@@ -92,6 +92,18 @@ in
                   "127.0.0.1:''${config.services.omnom.port}"
                 '';
               };
+              # NOTE: this can't be empty, because it will be overwritten by
+              # Omnom's internal default config.
+              base_url = lib.mkOption {
+                type = lib.types.str;
+                internal = true;
+                default = "http://127.0.0.1:${toString cfg.port}/";
+                description = "Full server URL.";
+                example = "https://local.omnom/xy/";
+                defaultText = lib.literalExpression ''
+                  "http://''${config.services.omnom.settings.server.address}/"
+                '';
+              };
               secure_cookie = lib.mkOption {
                 type = lib.types.bool;
                 default = true;

--- a/nixos/tests/omnom/default.nix
+++ b/nixos/tests/omnom/default.nix
@@ -28,18 +28,18 @@
 
       def open_omnom():
         # Add-ons Manager
-        server.succeed("xdotool mousemove --sync 960 90 click 1")
+        server.succeed("xdotool mousemove --sync 1221 83 click 1")
         server.sleep(10)
         # omnom
-        server.succeed("xdotool mousemove --sync 700 190 click 1")
+        server.succeed("xdotool mousemove --sync 877 184 click 1")
         server.sleep(10)
 
 
-      service_url = "http://127.0.0.1:${toString port}"
+      service_url = "http://127.0.0.1:${port}/"
 
       server.start()
       server.wait_for_unit("omnom.service")
-      server.wait_for_open_port(${toString port})
+      server.wait_for_open_port(${port})
       server.succeed(f"curl -sf '{service_url}'")
 
       output = server.succeed("omnom create-user user user@example.com")
@@ -59,23 +59,23 @@
       open_omnom()
 
       # token
-      server.succeed("xdotool mousemove --sync 700 350 click 1")
+      server.succeed("xdotool mousemove --sync 943 345 click 1")
       server.succeed(f"xdotool type {token}")
       server.sleep(10)
 
       # url
-      server.succeed("xdotool mousemove --sync 700 470 click 1")
+      server.succeed("xdotool mousemove --sync 943 452 click 1")
       server.succeed(f"xdotool type '{service_url}'")
       server.sleep(10)
 
       # submit
-      server.succeed("xdotool mousemove --sync 900 520 click 1")
+      server.succeed("xdotool mousemove --sync 1156 485 click 1")
       server.sleep(10)
 
       open_omnom()
 
       # save
-      server.succeed("xdotool mousemove --sync 900 520 click 1")
+      server.succeed("xdotool mousemove --sync 1151 459 click 1")
       server.sleep(10)
 
       # refresh
@@ -85,19 +85,19 @@
       server.screenshot("home.png")
 
       # view bookmarks
-      server.succeed("xdotool mousemove --sync 300 130 click 1")
+      server.succeed("xdotool mousemove --sync 377 133 click 1")
       server.sleep(10)
 
       # view snapshot
-      server.succeed("xdotool mousemove --sync 970 230 click 1")
+      server.succeed("xdotool mousemove --sync 414 307 click 1")
       server.sleep(10)
-      server.succeed("xdotool mousemove --sync 160 340 click 1")
+      server.succeed("xdotool mousemove --sync 993 510 click 1")
       server.sleep(10)
 
       server.screenshot("screenshot.png")
 
       # view details
-      server.succeed("xdotool mousemove --sync 290 200 click 1")
+      server.succeed("xdotool mousemove --sync 400 230 click 1")
       server.sleep(10)
 
       server.screenshot("snapshot_details.png")

--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -85,7 +85,9 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Webpage bookmarking and snapshotting service";
-    homepage = "https://github.com/asciimoo/omnom";
+    homepage = "https://omnom.zone/";
+    downloadPage = "https://github.com/asciimoo/omnom";
+    changelog = "https://github.com/asciimoo/omnom/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.agpl3Only;
     teams = [ lib.teams.ngi ];
     mainProgram = "omnom";

--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -13,17 +13,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "omnom";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "asciimoo";
     repo = "omnom";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-auujlRG3RKJYYTi/iptx0Y3Yzqmt6i9AlfjVcqn5YPc=";
+    hash = "sha256-Txqla3fivQdM8oQYGlyaYhSQhBLJRykWkftdmkHxlu8=";
     fetchSubmodules = true;
   };
 
-  vendorHash = "sha256-0usbfvGz+9chLGyHHUUStUh7x91ZGfr/+gAXXVA5iNc=";
+  vendorHash = "sha256-meToyr93nmKLZ//h8Gc0rp2hc4vOV9ULU+FbBXmbDv8=";
 
   passthru.updateScript = nix-update-script { };
 
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
       pname = "omnom-addons";
       inherit (finalAttrs) version src;
 
-      npmDepsHash = "sha256-sUn5IvcHWJ/yaqeGz9SGvGx9HHAlrcnS0lJxIxUVS6M=";
+      npmDepsHash = "sha256-CIzp6/mBTuSaEFv0lk3d/GZyq1VRDvCSoqrujz4AG/E=";
       sourceRoot = "${finalAttrs'.src.name}/ext";
       npmPackFlags = [ "--ignore-scripts" ];
 

--- a/pkgs/by-name/om/omnom/package.nix
+++ b/pkgs/by-name/om/omnom/package.nix
@@ -13,13 +13,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "omnom";
-  version = "0.8.0";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "asciimoo";
     repo = "omnom";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Txqla3fivQdM8oQYGlyaYhSQhBLJRykWkftdmkHxlu8=";
+    hash = "sha256-cG+cAsarbDqi3BLrIiSnH4VQS0fdfyMgkvbQvzKUXNw=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/480400

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
