### PR TITLE
apacheHttpdPackages.mod_auth{nz_external,z_unixgroup}: init

### DIFF
--- a/pkgs/servers/http/apache-modules/mod-authnz-external/default.nix
+++ b/pkgs/servers/http/apache-modules/mod-authnz-external/default.nix
@@ -1,0 +1,55 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+
+  apacheHttpd,
+  apr,
+  aprutil,
+  autoPatchelfHook,
+  openldap,
+  openssl,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mod-authnz-external";
+  version = "3.3.3";
+
+  src = fetchFromGitHub {
+    owner = "phokz";
+    repo = "mod-auth-external";
+    tag = "mod_authnz_external-${finalAttrs.version}";
+    hash = "sha256-6khXrkZMR4a94W9/HGF3XGM3JyhGiFp6Actj6UqO0Ak=";
+  };
+
+  configureFlags = [ "--with-apxs2=${lib.getDev apacheHttpd}/bin/apxs" ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pkg-config
+  ];
+  buildInputs = [
+    apacheHttpd
+    apr
+    aprutil
+    openldap
+    openssl
+  ];
+
+  installPhase = ''
+    mkdir -p $out/modules
+    cp ./.libs/* $out/modules
+  '';
+
+  meta = {
+    description = "External Authentication Module for Apache HTTP Server";
+    homepage = "https://github.com/phokz/mod-auth-external";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/servers/http/apache-modules/mod-authz-unixgroup/default.nix
+++ b/pkgs/servers/http/apache-modules/mod-authz-unixgroup/default.nix
@@ -1,0 +1,57 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+
+  apacheHttpd,
+  apr,
+  aprutil,
+  autoPatchelfHook,
+  libbsd,
+  openldap,
+  openssl,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mod-authz-unixgroup";
+  version = "1.2.0";
+
+  src = fetchFromGitHub {
+    owner = "phokz";
+    repo = "mod-auth-external";
+    tag = "mod_authz_unixgroup-${finalAttrs.version}";
+    hash = "sha256-hX7ovar83rnNd4UoEzlBwvEyD7jB8oj1TPVlMWurmbo=";
+  };
+
+  configureFlags = [ "--with-apxs2=${lib.getDev apacheHttpd}/bin/apxs" ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pkg-config
+  ];
+  buildInputs = [
+    apacheHttpd
+    apr
+    aprutil
+    libbsd
+    openldap
+    openssl
+  ];
+
+  installPhase = ''
+    mkdir -p $out/modules
+    cp ./.libs/* $out/modules
+  '';
+
+  meta = {
+    description = "Unix group access control modules for Apache";
+    homepage = "https://github.com/phokz/mod-auth-external";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      de11n
+      despsyched
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8406,6 +8406,7 @@ with pkgs;
     {
       inherit apacheHttpd;
       mod_auth_mellon = callPackage ../servers/http/apache-modules/mod_auth_mellon { };
+      mod_authnz_external = callPackage ../servers/http/apache-modules/mod-authnz-external { };
       mod_ca = callPackage ../servers/http/apache-modules/mod_ca { };
       mod_crl = callPackage ../servers/http/apache-modules/mod_crl { };
       mod_cspnonce = callPackage ../servers/http/apache-modules/mod_cspnonce { };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8407,6 +8407,7 @@ with pkgs;
       inherit apacheHttpd;
       mod_auth_mellon = callPackage ../servers/http/apache-modules/mod_auth_mellon { };
       mod_authnz_external = callPackage ../servers/http/apache-modules/mod-authnz-external { };
+      mod_authz_unixgroup = callPackage ../servers/http/apache-modules/mod-authz-unixgroup { };
       mod_ca = callPackage ../servers/http/apache-modules/mod_ca { };
       mod_crl = callPackage ../servers/http/apache-modules/mod_crl { };
       mod_cspnonce = callPackage ../servers/http/apache-modules/mod_cspnonce { };


### PR DESCRIPTION
https://github.com/phokz/mod-auth-external

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
