### PR TITLE
python3Packages.pymitsubishi: 0.4.2 -> 0.5.0, home-assistant-custom-components.mitsubishi: 0.4.3 -> 0.5.3

### DIFF
--- a/pkgs/development/python-modules/pymitsubishi/default.nix
+++ b/pkgs/development/python-modules/pymitsubishi/default.nix
@@ -11,14 +11,14 @@
 
 buildPythonPackage rec {
   pname = "pymitsubishi";
-  version = "0.4.2";
+  version = "0.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pymitsubishi";
     repo = "pymitsubishi";
     tag = "v${version}";
-    hash = "sha256-frqyAXAP2O8TZzXx5ephcLSLJA9p0P74KJrPoSKPYYo=";
+    hash = "sha256-Y+peVtaPWuvgM+2x7bIuwCicscv6xkZHzqpFSyiJQWQ=";
   };
 
   postPatch = ''

--- a/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/mitsubishi/package.nix
@@ -11,20 +11,18 @@
 buildHomeAssistantComponent rec {
   owner = "pymitsubishi";
   domain = "mitsubishi";
-  version = "0.4.3";
+  version = "0.5.3";
 
   src = fetchFromGitHub {
     owner = "pymitsubishi";
     repo = "homeassistant-mitsubishi";
     tag = "v${version}";
-    hash = "sha256-jhcclDealb1T84zNse2tpT3MDvDaOqhTMGrBhiUXHPc=";
+    hash = "sha256-yVj3QPH00u7WEvhK3pHKmrNx6o9ybK9LgRhq51OvjAc=";
   };
 
   dependencies = [
     pymitsubishi
   ];
-
-  doCheck = false; # TODO: remove in the next release after 0.4.0
 
   nativeCheckInputs = [
     pytest-cov-stub


### PR DESCRIPTION
Supersedes #484664

python3Packages.pymitsubishi: 0.4.2 -> 0.5.0
Changelog: https://github.com/pymitsubishi/pymitsubishi/compare/v0.4.2...v0.5.0

home-assistant-custom-components.mitsubishi: 0.4.3 -> 0.5.3
Changelog: https://github.com/pymitsubishi/homeassistant-mitsubishi/compare/v0.4.3...v0.5.3


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
