### PR TITLE
greenbone-feed-sync: init at 25.2.0

### DIFF
--- a/pkgs/by-name/gr/greenbone-feed-sync/package.nix
+++ b/pkgs/by-name/gr/greenbone-feed-sync/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  pkgs,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "greenbone-feed-sync";
+  version = "25.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "greenbone";
+    repo = "greenbone-feed-sync";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-lpbbAODk/uLg1nbSPj9Ico5/8klM5Fm5tyXeRQao7N8=";
+  };
+
+  build-system = with python3.pkgs; [ poetry-core ];
+
+  dependencies = with python3.pkgs; [
+    rich
+    shtab
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pkgs.rsync
+    pontos
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "greenbone.feed.sync" ];
+
+  meta = {
+    description = "Tool for downloading the Greenbone Community Feed";
+    homepage = "https://github.com/greenbone/greenbone-feed-sync";
+    changelog = "https://github.com/greenbone/greenbone-feed-sync/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "greenbone-feed-sync";
+  };
+})


### PR DESCRIPTION
Tool for downloading the Greenbone Community Feed

https://github.com/greenbone/greenbone-feed-sync


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
