### PR TITLE
wire-desktop: linux 3.40.3718 -> 3.40.3882, macos 3.40.5285 -> 3.40.5442

### DIFF
--- a/pkgs/by-name/wi/wire-desktop/package.nix
+++ b/pkgs/by-name/wi/wire-desktop/package.nix
@@ -76,6 +76,9 @@ let
       ./update.sh
       ./.
     ];
+    # R-ryantm does not respect the commit feature, leading to inaccurate
+    # commit messages because it only sees the Linux version numbers.
+    # nixpkgs-update: no auto update
     supportedFeatures = [ "commit" ];
   };
 

--- a/pkgs/by-name/wi/wire-desktop/versions.json
+++ b/pkgs/by-name/wi/wire-desktop/versions.json
@@ -1,10 +1,10 @@
 {
   "linux": {
-    "version": "3.40.3718",
-    "hash": "sha256-1jBhF+Rnys8C3DaVbCKHDiylox2WG1qRvwnDbQrp1Mk="
+    "version": "3.40.3882",
+    "hash": "sha256-8cZGbOngQ0LcUdCcalexkF2nEDb+u3I0zqEbRf/sRiw="
   },
   "macos": {
-    "version": "3.40.5285",
-    "hash": "sha256-pcWB3irdPyDj55dWmNyc+oThVGgHtIu//EAk1k/56is="
+    "version": "3.40.5442",
+    "hash": "sha256-BxGkAbkl5kgeHq4dgITYsU1fXFY8XDWEOfwjHnk6XtQ="
   }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Disabled auto updates and ran the updateScript.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
