### PR TITLE
treewide: fix cargoTestFlags/cargoBuildFlags for structuredAttrs

### DIFF
--- a/pkgs/by-name/bi/biome/package.nix
+++ b/pkgs/by-name/bi/biome/package.nix
@@ -33,8 +33,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoBuildFlags = [ "-p=biome_cli" ];
   cargoTestFlags = finalAttrs.cargoBuildFlags ++ [
+    "--"
     # fails due to cargo insta
-    "-- --skip=commands::check::print_json"
+    "--skip=commands::check::print_json"
     "--skip=commands::check::print_json_pretty"
     "--skip=commands::explain::explain_logs"
     "--skip=commands::format::print_json"

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -39,7 +39,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       zstd
     ];
 
-  cargoBuildFlags = [ "--package tauri-cli" ];
+  cargoBuildFlags = [
+    "--package"
+    "tauri-cli"
+  ];
   cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   env = lib.optionalAttrs stdenv.hostPlatform.isLinux {

--- a/pkgs/by-name/el/eludris/package.nix
+++ b/pkgs/by-name/el/eludris/package.nix
@@ -19,8 +19,14 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-JpXjnkZHz12YxgTSqTcWdQTkrMugP7ZGw48145BeBZk=";
 
-  cargoBuildFlags = [ "-p eludris" ];
-  cargoTestFlags = [ "-p eludris" ];
+  cargoBuildFlags = [
+    "--package"
+    "eludris"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "eludris"
+  ];
   buildInputs = [ openssl ];
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/fi/firecracker/package.nix
+++ b/pkgs/by-name/fi/firecracker/package.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-HG0HZes01shEtuVK7QCYmy/zsU0snbwsqCtev7u3/WI=";
 
   # For aws-lc-sys@0.22.0: use external bindgen.
-  AWS_LC_SYS_EXTERNAL_BINDGEN = "true";
+  env.AWS_LC_SYS_EXTERNAL_BINDGEN = "true";
 
   # For aws-lc-sys@0.22.0: fix gcc error:
   # In function 'memcpy',

--- a/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
+++ b/pkgs/by-name/fl/flutter_rust_bridge_codegen/package.nix
@@ -18,8 +18,14 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoHash = "sha256-pxEwcLiRB95UBfXb+JgS8duEXiZUApH/C8Exus5TkfU=";
-  cargoBuildFlags = "--package flutter_rust_bridge_codegen";
-  cargoTestFlags = "--package flutter_rust_bridge_codegen";
+  cargoBuildFlags = [
+    "--package"
+    "flutter_rust_bridge_codegen"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "flutter_rust_bridge_codegen"
+  ];
 
   # needed to get tests running
   nativeBuildInputs = [ cargo-expand ];

--- a/pkgs/by-name/ja/jarl/package.nix
+++ b/pkgs/by-name/ja/jarl/package.nix
@@ -31,7 +31,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoTestFlags = [
     "--lib"
     "--bins"
-    "--test integration"
+    "--test"
+    "integration"
     # "--test integration_tests"
   ];
 

--- a/pkgs/by-name/li/lighthouse/package.nix
+++ b/pkgs/by-name/li/lighthouse/package.nix
@@ -78,7 +78,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   cargoBuildFlags = [
-    "--package lighthouse"
+    "--package"
+    "lighthouse"
   ];
 
   __darwinAllowLocalNetworking = true;
@@ -88,15 +89,15 @@ rustPlatform.buildRustPackage rec {
   # All of these tests require network access and/or docker
   cargoTestFlags = [
     "--workspace"
-    "--exclude beacon_chain"
-    "--exclude beacon_node"
-    "--exclude http_api"
-    "--exclude lighthouse"
-    "--exclude lighthouse_network"
-    "--exclude network"
-    "--exclude slashing_protection"
-    "--exclude watch"
-    "--exclude web3signer_tests"
+    "--exclude=beacon_chain"
+    "--exclude=beacon_node"
+    "--exclude=http_api"
+    "--exclude=lighthouse"
+    "--exclude=lighthouse_network"
+    "--exclude=network"
+    "--exclude=slashing_protection"
+    "--exclude=watch"
+    "--exclude=web3signer_tests"
   ];
 
   # All of these tests require network access

--- a/pkgs/by-name/lu/lux-cli/package.nix
+++ b/pkgs/by-name/lu/lux-cli/package.nix
@@ -59,7 +59,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     LUX_SKIP_IMPURE_TESTS = 1; # Disable impure unit tests
   };
 
-  cargoTestFlags = "--lib"; # Disable impure integration tests
+  cargoTestFlags = [
+    "--lib" # Disable impure integration tests
+  ];
 
   nativeCheckInputs = [
     lua5_4

--- a/pkgs/by-name/ni/nickel/package.nix
+++ b/pkgs/by-name/ni/nickel/package.nix
@@ -26,8 +26,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-uCy/Qo92yZ4pjjgW64nWYH21EbdMMwGXP5522tl8MAE=";
 
   cargoBuildFlags = [
-    "-p nickel-lang-cli"
-    "-p nickel-lang-lsp"
+    "--package"
+    "nickel-lang-cli"
+    "--package"
+    "nickel-lang-lsp"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -58,10 +58,15 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-FrOo4+5S8JAlQSmDvH0omhOsG9PjZMvRejk9VHEucVY=";
 
   cargoBuildFlags = [
-    "--package rerun-cli"
-    "--package rerun_c"
+    "--package"
+    "rerun-cli"
+    "--package"
+    "rerun_c"
   ];
-  cargoTestFlags = [ "--package rerun-cli" ];
+  cargoTestFlags = [
+    "--package"
+    "rerun-cli"
+  ];
   buildNoDefaultFeatures = true;
   buildFeatures = [
     "native_viewer"

--- a/pkgs/by-name/ro/router/package.nix
+++ b/pkgs/by-name/ro/router/package.nix
@@ -37,10 +37,11 @@ rustPlatform.buildRustPackage rec {
 
   # The v8 package will try to download a `librusty_v8.a` release at build time to our read-only filesystem
   # To avoid this we pre-download the file and export it via RUSTY_V8_ARCHIVE
-  RUSTY_V8_ARCHIVE = callPackage ./librusty_v8.nix { };
+  env.RUSTY_V8_ARCHIVE = callPackage ./librusty_v8.nix { };
 
   cargoTestFlags = [
-    "-- --skip=query_planner::tests::missing_typename_and_fragments_in_requires"
+    "--"
+    "--skip=query_planner::tests::missing_typename_and_fragments_in_requires"
   ];
 
   passthru = {

--- a/pkgs/by-name/ro/rover/package.nix
+++ b/pkgs/by-name/ro/rover/package.nix
@@ -38,7 +38,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # valid by making a network call to the repo that houses their binaries; but, the
   # build env can't make network calls (impurity)
   cargoTestFlags = [
-    "-- --skip=latest_plugins_are_valid_versions"
+    "--"
+    "--skip=latest_plugins_are_valid_versions"
   ];
 
   # Some tests try to write configuration data to a location in the user's home

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -32,7 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoTestFlags = [
     # Prefer the "smoke" profile over "ci" to exclude flaky tests: https://github.com/rvben/rumdl/pull/341
-    "--profile smoke"
+    "--profile"
+    "smoke"
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/tp/tpnote/package.nix
+++ b/pkgs/by-name/tp/tpnote/package.nix
@@ -48,11 +48,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installManPage docs/build/man/man1/tpnote.1
   '';
 
-  RUSTONIG_SYSTEM_LIBONIG = true;
+  env.RUSTONIG_SYSTEM_LIBONIG = true;
 
   # The `tpnote` crate has no unit tests. All tests are in `tpnote-lib`.
   checkType = "debug";
-  cargoTestFlags = "--package tpnote-lib";
+  cargoTestFlags = [
+    "--package"
+    "tpnote-lib"
+  ];
   doCheck = true;
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/uk/ukmm/package.nix
+++ b/pkgs/by-name/uk/ukmm/package.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Force linking to libEGL, which is always dlopen()ed, and to
   # libwayland-client & libxkbcommon, which is dlopen()ed based on the
   # winit backend.
-  NIX_LDFLAGS = [
+  env.NIX_LDFLAGS = [
     "--push-state"
     "--no-as-needed"
     "-lEGL"

--- a/pkgs/by-name/vh/vhost-device-sound/package.nix
+++ b/pkgs/by-name/vh/vhost-device-sound/package.nix
@@ -29,8 +29,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pipewire
   ];
 
-  cargoBuildFlags = "-p vhost-device-sound";
-  cargoTestFlags = "-p vhost-device-sound";
+  cargoBuildFlags = [
+    "--package"
+    "vhost-device-sound"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "vhost-device-sound"
+  ];
 
   # Runs dbus-daemon, which tries to load config from /etc.
   doCheck = false;

--- a/pkgs/by-name/vi/viceroy/package.nix
+++ b/pkgs/by-name/vi/viceroy/package.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-PoexldRTp2cPu7iF7te//kO4Ph1P6A/jNZdMkYKERqM=";
 
   cargoTestFlags = [
-    "--package viceroy-lib"
+    "--package"
+    "viceroy-lib"
   ];
 
   meta = {

--- a/pkgs/by-name/xd/xdvdfs-cli/package.nix
+++ b/pkgs/by-name/xd/xdvdfs-cli/package.nix
@@ -19,8 +19,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-vNCqfXsPjb3mph28YuYKpWTs9VHbIcXs6GVn4XgQKtQ=";
 
-  cargoBuildFlags = [ "--package xdvdfs-cli" ];
-  cargoTestFlags = [ "--package xdvdfs-cli" ];
+  cargoBuildFlags = [
+    "--package"
+    "xdvdfs-cli"
+  ];
+  cargoTestFlags = [
+    "--package"
+    "xdvdfs-cli"
+  ];
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   versionCheckProgram = "${placeholder "out"}/bin/xdvdfs";

--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -80,7 +80,9 @@ toLuaModule (
       runHook postInstall
     '';
 
-    cargoTestFlags = "--lib"; # Disable impure integration tests
+    cargoTestFlags = [
+      "--lib" # Disable impure integration tests
+    ];
 
     meta = {
       description = "Lua API for the Lux package manager";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
