### PR TITLE
teamtype: 0.9.0 -> 0.9.1; vscode-extensions.teamtype.teamtype: 0.8.0 -> 0.8.2

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/teamtype.teamtype/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/teamtype.teamtype/default.nix
@@ -7,8 +7,8 @@ vscode-utils.buildVscodeMarketplaceExtension {
   mktplcRef = {
     publisher = "teamtype";
     name = "teamtype";
-    version = "0.8.0";
-    hash = "sha256-p9bynTMmCn6pu7SVEABeSawv9VjWpE8KecQOeIsE/LE=";
+    version = "0.8.2";
+    hash = "sha256-qVZf+fOrdnDJzRUVA3GhTUDLhdJrH2tPRgvYW+ymVGw=";
   };
 
   meta = {

--- a/pkgs/by-name/te/teamtype/package.nix
+++ b/pkgs/by-name/te/teamtype/package.nix
@@ -9,18 +9,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "teamtype";
-  version = "0.9.0";
+  version = "0.9.1";
 
   src = fetchFromGitHub {
     owner = "teamtype";
     repo = "teamtype";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-B/4xR16cEG90fK12XQqjlpWzd6tyUVYXOBXK0j5fvNU=";
+    hash = "sha256-74MufpLTACkPevzOyaXw2Rr7S7VvaFEYHEyTQYwKVT8=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/daemon";
 
-  cargoHash = "sha256-yuAk4SqYzNK1gD6lqVVDOyAJNq/NIf44DWdZ3aM/Q8s=";
+  cargoHash = "sha256-OIOffnCC9PlT/SXPOuTnKx3feZnkHP+jzbQIJWX0tzk=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Changelog: https://github.com/teamtype/teamtype/releases/tag/v0.9.1
Diff: https://github.com/teamtype/teamtype/compare/v0.9.0...v0.9.1

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
