### PR TITLE
Improve clang-tools wrapper

### DIFF
--- a/pkgs/development/compilers/llvm/common/clang-tools/wrapper
+++ b/pkgs/development/compilers/llvm/common/clang-tools/wrapper
@@ -4,6 +4,24 @@ buildcpath() {
   local path after
   while (( $# )); do
     case $1 in
+        -isystem)
+            shift
+            path=$path${path:+':'}$1
+            ;;
+        -idirafter)
+            shift
+            after=$after${after:+':'}$1
+            ;;
+    esac
+    shift
+  done
+  echo $path${after:+':'}$after
+}
+
+buildcpluspath() {
+  local path after
+  while (( $# )); do
+    case $1 in
         -isystem|-cxx-isystem)
             shift
             path=$path${path:+':'}$1
@@ -32,9 +50,9 @@ if [ "$extendcpath" = true ]; then
   export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
                                                  $(<@clang@/nix-support/libc-cflags))
 
-  export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
-                                                                                        $(<@clang@/nix-support/libcxx-cxxflags) \
-                                                                                        $(<@clang@/nix-support/libc-cflags))
+  export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpluspath ${NIX_CFLAGS_COMPILE} \
+                                                                                            $(<@clang@/nix-support/libcxx-cxxflags) \
+                                                                                            $(<@clang@/nix-support/libc-cflags))
 fi
 
 @out@/bin/$(basename $0)-unwrapped "$@"

--- a/pkgs/development/compilers/llvm/common/clang-tools/wrapper
+++ b/pkgs/development/compilers/llvm/common/clang-tools/wrapper
@@ -47,8 +47,8 @@ for arg in "$@"; do
 done
 
 if [ "$extendcpath" = true ]; then
-  export CPATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
-                                                 $(<@clang@/nix-support/libc-cflags))
+  export C_INCLUDE_PATH=${CPATH}${CPATH:+':'}$(buildcpath ${NIX_CFLAGS_COMPILE} \
+                                                          $(<@clang@/nix-support/libc-cflags))
 
   export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}${CPLUS_INCLUDE_PATH:+':'}$(buildcpluspath ${NIX_CFLAGS_COMPILE} \
                                                                                             $(<@clang@/nix-support/libcxx-cxxflags) \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

PR #462747 (staging) and  #475078 (master) added handling of `-cxx-isystem` to `buildcpath`, but that's not strictly correct. Since `-cxx-isystem` is meant for C++ headers. This could cause wrong headers to be included.

The other problem is that, the current wrapper uses `$CPATH`, which is actually the [wrong environment variable to use](https://github.com/llvm/llvm-project/issues/154015#issuecomment-3235237574)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
