### PR TITLE
php8*Extensions.imagick: 3.8.0 -> 3.8.1

### DIFF
--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -11,8 +11,8 @@
 buildPecl {
   pname = "imagick";
 
-  version = "3.8.0";
-  sha256 = "sha256-vaZ0YchU8g1hBXgrdpxST8NziLddRIHZUWRNIWf/7sY=";
+  version = "3.8.1";
+  sha256 = "sha256-OjWHwKUkwX0NrZZzoWC5DNd26DaDhHThc7VJ7YZDUu4=";
 
   configureFlags = [ "--with-imagick=${imagemagick.dev}" ];
   nativeBuildInputs = [ pkg-config ];


### PR DESCRIPTION
ChangeLog: https://pecl.php.net/package-changelog.php?package=imagick&release=3.8.1

main motivation for the PR is that 8.3.1 fixes building with PHP-8.5 which was just merged (#481104)

## Things done

- Built on platform:
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
