### PR TITLE
ankiAddons.buildAnkiAddon: set passthru.updateScript by default

### DIFF
--- a/pkgs/by-name/an/anki/addons/adjust-sound-volume/default.nix
+++ b/pkgs/by-name/an/anki/addons/adjust-sound-volume/default.nix
@@ -2,7 +2,6 @@
   lib,
   anki-utils,
   fetchFromGitHub,
-  nix-update-script,
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "adjust-sound-volume";
@@ -13,7 +12,6 @@ anki-utils.buildAnkiAddon (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-6reIUz+tHKd4KQpuofLa/tIL5lCloj3yODZ8Cz29jFU=";
   };
-  passthru.updateScript = nix-update-script { };
   meta = {
     description = "Add a new menu item for adjusting the sound volume";
     homepage = "https://github.com/mnogu/adjust-sound-volume";

--- a/pkgs/by-name/an/anki/addons/ajt-card-management/default.nix
+++ b/pkgs/by-name/an/anki/addons/ajt-card-management/default.nix
@@ -2,7 +2,6 @@
   lib,
   anki-utils,
   fetchFromGitHub,
-  nix-update-script,
 }:
 
 anki-utils.buildAnkiAddon (finalAttrs: {
@@ -26,7 +25,6 @@ anki-utils.buildAnkiAddon (finalAttrs: {
         };
       });
   sourceRoot = "${finalAttrs.src.name}/card_management";
-  passthru.updateScript = nix-update-script { };
   meta = {
     description = "Reset, Learn, and Grade cards from the card browser";
     longDescription = ''

--- a/pkgs/by-name/an/anki/addons/anki-quizlet-importer-extended/default.nix
+++ b/pkgs/by-name/an/anki/addons/anki-quizlet-importer-extended/default.nix
@@ -2,7 +2,6 @@
   lib,
   anki-utils,
   fetchFromGitHub,
-  nix-update-script,
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "anki-quizlet-importer-extended";
@@ -13,7 +12,6 @@ anki-utils.buildAnkiAddon (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-BTddZColXM193x8xFa1axHeiWukjxXvwkXGpHxsLtR0=";
   };
-  passthru.updateScript = nix-update-script { };
   meta = {
     description = "Import Quizlet Decks into Anki";
     homepage = "https://ankiweb.net/shared/info/1362209126";

--- a/pkgs/by-name/an/anki/addons/anki-utils.nix
+++ b/pkgs/by-name/an/anki/addons/anki-utils.nix
@@ -5,6 +5,7 @@
   lndir,
   formats,
   runCommand,
+  nix-update-script,
 }:
 {
   buildAnkiAddon = lib.extendMkDerivation {
@@ -55,6 +56,7 @@
         '';
 
         passthru = {
+          updateScript = nix-update-script { };
           withConfig =
             {
               # JSON add-on config. The available options for an add-on are in its

--- a/pkgs/by-name/an/anki/addons/image-occlusion-enhanced/default.nix
+++ b/pkgs/by-name/an/anki/addons/image-occlusion-enhanced/default.nix
@@ -2,7 +2,6 @@
   lib,
   anki-utils,
   fetchFromGitHub,
-  nix-update-script,
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "image-occlusion-enhanced";
@@ -15,7 +14,6 @@ anki-utils.buildAnkiAddon (finalAttrs: {
     hash = "sha256-YR1hicBDb08J+1Qc+SDiJDXLo5FzLqCQGeVe7brbPME=";
   };
   sourceRoot = "${finalAttrs.src.name}/src/image_occlusion_enhanced";
-  passthru.updateScript = nix-update-script { };
   meta = {
     description = ''
       Adds extra features for creating image-based cloze-deletions

--- a/pkgs/by-name/an/anki/addons/passfail2/default.nix
+++ b/pkgs/by-name/an/anki/addons/passfail2/default.nix
@@ -2,7 +2,6 @@
   lib,
   anki-utils,
   fetchFromGitHub,
-  nix-update-script,
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "passfail2";
@@ -21,7 +20,6 @@ anki-utils.buildAnkiAddon (finalAttrs: {
 
     runHook postBuild
   '';
-  passthru.updateScript = nix-update-script { };
   meta = {
     description = ''
       Replaces the default Anki review buttons with only two options:

--- a/pkgs/by-name/an/anki/addons/puppy-reinforcement/default.nix
+++ b/pkgs/by-name/an/anki/addons/puppy-reinforcement/default.nix
@@ -2,7 +2,6 @@
   lib,
   anki-utils,
   fetchFromGitHub,
-  nix-update-script,
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "puppy-reinforcement";
@@ -14,7 +13,6 @@ anki-utils.buildAnkiAddon (finalAttrs: {
     hash = "sha256-y52AjmYrFTcTwd4QAcJzK5R9wwxUSlvnN3C2O/r5cHk=";
   };
   sourceRoot = "${finalAttrs.src.name}/src/puppy_reinforcement";
-  passthru.updateScript = nix-update-script { };
   meta = {
     description = "Encourage learners with pictures of cute puppies";
     longDescription = ''

--- a/pkgs/by-name/an/anki/addons/recolor/default.nix
+++ b/pkgs/by-name/an/anki/addons/recolor/default.nix
@@ -2,7 +2,6 @@
   lib,
   anki-utils,
   fetchFromGitHub,
-  nix-update-script,
 }:
 anki-utils.buildAnkiAddon (finalAttrs: {
   pname = "recolor";
@@ -24,8 +23,6 @@ anki-utils.buildAnkiAddon (finalAttrs: {
     # readonly with Nix.
     ./only-update-config-version-when-migration-happens.patch
   ];
-
-  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "ReColor your Anki desktop to whatever aesthetic you like";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
