### PR TITLE
{vscode-extensions.sourcery.sourcery,sourcery}: 1.37.0 -> 1.43.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/sourcery.sourcery/default.nix
@@ -6,13 +6,31 @@
   zlib,
 }:
 
-vscode-utils.buildVscodeMarketplaceExtension {
+let
+  inherit (stdenv.hostPlatform) system;
+in
+vscode-utils.buildVscodeMarketplaceExtension (finalAttrs: {
+  passthru.platformTable = {
+    "x86_64-linux" = {
+      arch = "linux-x64";
+      hash = "sha256-Oz4Buraof4yXIxGeKXIsDkvEQQ0Gzf/b5mdses1nHlo=";
+    };
+    "x86_64-darwin" = {
+      arch = "darwin-x64";
+      hash = "sha256-Iqe4KZXQHenKAypXK/qzG2BCXbk2cZ0i/0xhWhlfQxo=";
+    };
+    "aarch64-darwin" = {
+      arch = "darwin-arm64";
+      hash = "sha256-vMDB5zmdBNt3R5AkeuCYhxzW/rSGwM+wtU5K4v3ZU/U=";
+    };
+  };
+
   mktplcRef = {
     name = "sourcery";
     publisher = "sourcery";
-    version = "1.37.0";
-    hash = "sha256-ovCxcr1m3GmRu45hr5DG781xkQdANbQYLvV2gFhG4eQ=";
-  };
+    version = "1.43.0";
+  }
+  // finalAttrs.passthru.platformTable.${system} or (throw "Unsupported platform ${system}");
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
@@ -28,9 +46,6 @@ vscode-utils.buildVscodeMarketplaceExtension {
     homepage = "https://github.com/sourcery-ai/sourcery-vscode";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [ tomasajt ];
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-    ];
+    platforms = lib.attrNames finalAttrs.passthru.platformTable;
   };
-}
+})


### PR DESCRIPTION
Supersedes https://github.com/NixOS/nixpkgs/pull/453174

r-ryantm has been updating the vscode extension automatically, so I didn't notice that the previously combined vscode extension source, which had all files for all platforms, was split up into multiple separate sources.
Because of this, only one architecture was being fetched.
 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
