### PR TITLE
haskell-modules/generic-stack-builder.nix: move env variables into env for structuredAttrs

### DIFF
--- a/pkgs/development/haskell-modules/generic-stack-builder.nix
+++ b/pkgs/development/haskell-modules/generic-stack-builder.nix
@@ -47,19 +47,21 @@ stdenv.mkDerivation (
       stackHook
     ];
 
-    STACK_PLATFORM_VARIANT = "nix";
-    STACK_IN_NIX_SHELL = 1;
-    STACK_IN_NIX_EXTRA_ARGS = extraArgs;
+    env = {
+      STACK_PLATFORM_VARIANT = "nix";
+      STACK_IN_NIX_SHELL = 1;
+      STACK_IN_NIX_EXTRA_ARGS = extraArgs;
 
-    # XXX: workaround for https://ghc.haskell.org/trac/ghc/ticket/11042.
-    LD_LIBRARY_PATH = lib.makeLibraryPath (LD_LIBRARY_PATH ++ buildInputs);
-    # ^^^ Internally uses `getOutput "lib"` (equiv. to getLib)
+      # XXX: workaround for https://ghc.haskell.org/trac/ghc/ticket/11042.
+      LD_LIBRARY_PATH = lib.makeLibraryPath (LD_LIBRARY_PATH ++ buildInputs);
+      # ^^^ Internally uses `getOutput "lib"` (equiv. to getLib)
 
-    # Non-NixOS git needs cert
-    GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+      # Non-NixOS git needs cert
+      GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-    # Fixes https://github.com/commercialhaskell/stack/issues/2358 krank:ignore-line
-    LANG = "en_US.UTF-8";
+      # Fixes https://github.com/commercialhaskell/stack/issues/2358 krank:ignore-line
+      LANG = "en_US.UTF-8";
+    };
 
     preferLocalBuild = true;
 


### PR DESCRIPTION
This doesn't seem to have any in-tree uses, but moving the env variables seems like a safe improvement?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
