### PR TITLE
micro: use versionCheckHook

### DIFF
--- a/pkgs/by-name/mi/micro/package.nix
+++ b/pkgs/by-name/mi/micro/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   installShellFiles,
   stdenv,
+  versionCheckHook,
   # Deprecated options
   # Remove them as soon as possible
   withXclip ? null,
@@ -68,6 +69,9 @@ let
       };
       wrapper = callPackage ./wrapper.nix { micro = self; };
     };
+
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
 
     meta = {
       homepage = "https://micro-editor.github.io";

--- a/pkgs/by-name/mi/micro/tests/version.nix
+++ b/pkgs/by-name/mi/micro/tests/version.nix
@@ -1,6 +1,0 @@
-{ micro, testers }:
-
-testers.testVersion {
-  package = micro;
-  command = "micro -version";
-}


### PR DESCRIPTION
Enable the versionCheckHook for the micro package, to help avoid update issues in the future

Seems to be working okay (buildlog):
```
Running phase: installCheckPhase
Executing versionCheckPhase
Successfully managed to find version 2.0.15 in the output of the command /nix/store/jqqfwq155z39lz3ncvnssb2ykjrr066d-micro-2.0.15/bin/micro --version
Version: 2.0.15
Commit hash: v2.0.15
Compiled on Unknown
Finished versionCheckPhase
no Makefile or custom installCheckPhase, doing nothing
```

CC: @pbsds (maintainer)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
