### PR TITLE
[python-updates] haskell.compiler.*: fix user's guide build with Sphinx 9

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -308,6 +308,9 @@
         ./ghc-define-undefined-elf-st-visibility.patch
       ]
 
+      # Fix docs build with Sphinx >= 9 https://gitlab.haskell.org/ghc/ghc/-/issues/26810
+      ++ [ ./ghc-9.6-or-later-docs-sphinx-9.patch ]
+
       ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; });
 
     stdenv = stdenvNoCC;

--- a/pkgs/development/compilers/ghc/common-make-native-bignum.nix
+++ b/pkgs/development/compilers/ghc/common-make-native-bignum.nix
@@ -305,6 +305,9 @@ stdenv.mkDerivation (
       # Fix docs build with Sphinx >= 7 https://gitlab.haskell.org/ghc/ghc/-/issues/24129 krank:ignore-line
       ./docs-sphinx-7.patch
 
+      # Fix docs build with Sphinx >= 9 https://gitlab.haskell.org/ghc/ghc/-/issues/26810
+      ./ghc-9.4-docs-sphinx-9.patch
+
       # Correctly record libnuma's library and include directories in the
       # package db. This fixes linking whenever stdenv and propagation won't
       # quite pass the correct -L flags to the linker, e.g. when using GHC

--- a/pkgs/development/compilers/ghc/ghc-9.4-docs-sphinx-9.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.4-docs-sphinx-9.patch
@@ -1,0 +1,31 @@
+From db33b15c27e607cd66b85d0a2a6868c7b718a96b Mon Sep 17 00:00:00 2001
+From: sterni <sternenseemann@systemli.org>
+Date: Wed, 28 Jan 2026 00:09:54 +0100
+Subject: [PATCH] users_guide: fix runtime error during build with Sphinx 9.1.0
+
+Appears that pathto is stricter about what it accepts now.
+Tested Sphinx 8.2.3 and 9.1.0 on the ghc-9.10 branch.
+
+Resolves #26810.
+
+Co-authored-by: Martin Weinelt <hexa@darmstadt.ccc.de>
+---
+ docs/users_guide/rtd-theme/layout.html | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/docs/users_guide/rtd-theme/layout.html b/docs/users_guide/rtd-theme/layout.html
+index 2a61142514..4b3c1befba 100644
+--- a/docs/users_guide/rtd-theme/layout.html
++++ b/docs/users_guide/rtd-theme/layout.html
+@@ -70,7 +70,7 @@
+     {%- if css|attr("rel") %}
+   <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
+     {%- else %}
+-  <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
++  <link rel="stylesheet" href="{{ pathto(css.filename, 1) }}" type="text/css" />
+     {%- endif %}
+   {%- endfor %}
+ 
+-- 
+2.52.0
+

--- a/pkgs/development/compilers/ghc/ghc-9.6-or-later-docs-sphinx-9.patch
+++ b/pkgs/development/compilers/ghc/ghc-9.6-or-later-docs-sphinx-9.patch
@@ -1,0 +1,30 @@
+From 9653a2b9a9e3a756b287b0a59204860511e4abce Mon Sep 17 00:00:00 2001
+From: sterni <sternenseemann@systemli.org>
+Date: Wed, 28 Jan 2026 00:09:54 +0100
+Subject: [PATCH] users_guide: fix runtime error during build with Sphinx 9.1.0
+
+Appears that pathto is stricter about what it accepts now.
+Tested Sphinx 8.2.3 and 9.1.0 on the ghc-9.10 branch.
+
+Resolves #26810.
+
+Co-authored-by: Martin Weinelt <hexa@darmstadt.ccc.de>
+---
+ docs/users_guide/rtd-theme/layout.html | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/docs/users_guide/rtd-theme/layout.html b/docs/users_guide/rtd-theme/layout.html
+index 94a40cc1c3..f2441378a8 100644
+--- a/docs/users_guide/rtd-theme/layout.html
++++ b/docs/users_guide/rtd-theme/layout.html
+@@ -32,7 +32,7 @@
+     {%- if css|attr("rel") %}
+       <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
+     {%- else %}
+-      <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
++      <link rel="stylesheet" href="{{ pathto(css.filename, 1) }}" type="text/css" />
+     {%- endif %}
+   {%- endfor %}
+ 
+-- 
+2.52.0


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Only checked doc build for 9.10 and that the patch applies. The rest, we'll have to see…

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
