### PR TITLE
notesnook: 3.3.5 -> 3.3.8

### DIFF
--- a/pkgs/by-name/no/notesnook/package.nix
+++ b/pkgs/by-name/no/notesnook/package.nix
@@ -35,6 +35,10 @@ let
       .${system} or throwSystem;
   };
 
+  passthru = {
+    updateScript = ./update.sh;
+  };
+
   appimageContents = appimageTools.extractType2 {
     inherit pname version src;
   };
@@ -67,6 +71,7 @@ let
       version
       src
       meta
+      passthru
       ;
 
     nativeBuildInputs = [ makeWrapper ];
@@ -91,6 +96,7 @@ let
       version
       src
       meta
+      passthru
       ;
 
     nativeBuildInputs = [ _7zz ];

--- a/pkgs/by-name/no/notesnook/package.nix
+++ b/pkgs/by-name/no/notesnook/package.nix
@@ -9,7 +9,7 @@
 
 let
   pname = "notesnook";
-  version = "3.3.5";
+  version = "3.3.8";
 
   inherit (stdenv.hostPlatform) system;
   throwSystem = throw "Unsupported system: ${system}";
@@ -27,10 +27,10 @@ let
     url = "https://github.com/streetwriters/notesnook/releases/download/v${version}/notesnook_${suffix}";
     hash =
       {
-        x86_64-linux = "sha256-jvQph74dMQgino3K1ZFLT/fsJVdTHVqMQaW0RQhfci0=";
-        aarch64-linux = "sha256-jrKmZmdx1T1wrlM0y195Z2MsI1XpFn0gyFyf7N/aUzo=";
-        x86_64-darwin = "sha256-bJ+sq6/lZcLcM7R2KAigemdpRDqSiExfcSunNQ7cGw0=";
-        aarch64-darwin = "sha256-DTY0gq62aXOanZvYletyXl5xmcs30vWTKE4nZujRCq0=";
+        x86_64-linux = "sha256-7gPCmC3uol5ukwu8OOhhqk9pBTgWjI14wYmM61nlg+A=";
+        aarch64-linux = "sha256-JmWt7yr/Ij01x7bTWUQ7UAwKcEf9i91fZZsHpEWRJYY=";
+        x86_64-darwin = "sha256-5Obl3YveMx38sdLIGRz3Lqi3mloruTyH/3MsNNX03TA=";
+        aarch64-darwin = "sha256-P1xqMFGAQQVq76O1RTp+3kZtzM1xGvSUpbki64KTji8=";
       }
       .${system} or throwSystem;
   };

--- a/pkgs/by-name/no/notesnook/update.sh
+++ b/pkgs/by-name/no/notesnook/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash curl jq common-updater-scripts
+
+set -xe
+
+latestTag=$(curl ${GITHUB_TOKEN:+-u":$GITHUB_TOKEN"} https://api.github.com/repos/streetwriters/notesnook/releases/latest | jq -r ".tag_name")
+latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; notesnook.version or (lib.getVersion notesnook)" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+for i in \
+  "x86_64-linux linux_x86_64.AppImage" \
+  "aarch64-linux linux_arm64.AppImage" \
+  "x86_64-darwin mac_x64.dmg" \
+  "aarch64-darwin mac_arm64.dmg"; do
+  set -- $i
+  hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "https://github.com/streetwriters/notesnook/releases/download/v$latestVersion/notesnook_$2")")
+  update-source-version notesnook $latestVersion $hash --system=$1 --ignore-same-version
+done


### PR DESCRIPTION
Expands on: #474857
Resolves: #484657
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
