### PR TITLE
python3Packages.onnxscript: disable flaky cuda tests

### DIFF
--- a/pkgs/development/python-modules/onnxscript/default.nix
+++ b/pkgs/development/python-modules/onnxscript/default.nix
@@ -257,59 +257,71 @@ buildPythonPackage (finalAttrs: {
     requiredSystemFeatures = [ "cuda" ];
 
     # Skip all tests that are failing independantly of the GPU availability
-    disabledTests = disabledTests ++ [
-      # AssertionError: Tensor-likes are not close!
-      "test_output_match_opinfo__cumsum_cuda_float16"
-      "test_output_match_opinfo__nn_functional_conv1d_cuda_float32"
-      "test_output_match_opinfo__nn_functional_embedding_cuda_float16"
-      "test_output_match_opinfo__nn_functional_embedding_cuda_float32"
-      "test_output_match_opinfo__ops_aten_conv3d_cuda_float32"
-      "test_output_match_opinfo__ops_aten_convolution_cuda_float32"
-      "test_output_match_opinfo__ops_aten_embedding_bag_cuda_float32"
-      "test_output_match_opinfo__ops_aten_embedding_renorm_cuda_float16"
-      "test_output_match_opinfo__ops_aten_embedding_renorm_cuda_float32"
+    disabledTests =
+      disabledTests
+      ++ [
+        # AssertionError: Tensor-likes are not close!
+        "test_output_match_opinfo__cumsum_cuda_float16"
+        "test_output_match_opinfo__nn_functional_conv1d_cuda_float32"
+        "test_output_match_opinfo__nn_functional_embedding_cuda_float16"
+        "test_output_match_opinfo__nn_functional_embedding_cuda_float32"
+        "test_output_match_opinfo__ops_aten_conv3d_cuda_float32"
+        "test_output_match_opinfo__ops_aten_convolution_cuda_float32"
+        "test_output_match_opinfo__ops_aten_embedding_bag_cuda_float32"
+        "test_output_match_opinfo__ops_aten_embedding_renorm_cuda_float16"
+        "test_output_match_opinfo__ops_aten_embedding_renorm_cuda_float32"
 
-      # AssertionError: Scalars are not equal!
-      "test_output_match_opinfo__equal_cuda_bool"
-      "test_output_match_opinfo__ops_aten_embedding_bag_padding_idx_cuda_float16"
-      "test_output_match_opinfo__ops_aten_embedding_bag_padding_idx_cuda_float32"
+        # AssertionError: Scalars are not equal!
+        "test_output_match_opinfo__equal_cuda_bool"
+        "test_output_match_opinfo__ops_aten_embedding_bag_padding_idx_cuda_float16"
+        "test_output_match_opinfo__ops_aten_embedding_bag_padding_idx_cuda_float32"
 
-      # TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
-      "test_output_match_opinfo__index_put_cuda_float16"
-      "test_output_match_opinfo__index_put_cuda_float32"
-      "test_output_match_opinfo__index_put_cuda_int32"
-      "test_output_match_opinfo__index_put_cuda_int64"
+        # AssertionError: Not equal to tolerance rtol=0, atol=0
+        "test_fuse_pad_into_conv_4"
+        "test_fuse_pad_into_conv_5"
+        "test_fuse_pad_into_conv_6"
+        "test_fuse_pad_into_conv_7"
 
-      # RuntimeError: ONNX Runtime failed to evaluate
-      # onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 :
-      # INVALID_ARGUMENT : Non-zero status code returned while running LayerNormalization node.
-      # Name:'node_LayerNormalization_0' Status Message: Size of X.shape[axis:] must be larger than 1, got 1
-      "test_output_match_opinfo__native_layer_norm_cuda_float16"
-      # onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented: [ONNXRuntimeError] : 9 :
-      # NOT_IMPLEMENTED : Could not find an implementation for SplitToSequence(11) node with name '_inlfunc_aten_split_n0'
-      "test_output_match_opinfo__split_cuda_bool"
-      "test_output_match_opinfo__split_list_args_cuda_bool"
-      # onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented: [ONNXRuntimeError] : 9 :
-      # NOT_IMPLEMENTED : Could not find an implementation for SplitToSequence(11) node with name '_inlfunc_aten_split_with_sizes_n0'
-      "test_output_match_opinfo__split_with_sizes_cuda_bool"
+        # TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
+        "test_output_match_opinfo__index_put_cuda_float16"
+        "test_output_match_opinfo__index_put_cuda_float32"
+        "test_output_match_opinfo__index_put_cuda_int32"
+        "test_output_match_opinfo__index_put_cuda_int64"
 
-      # AssertionError: ONNX model is invalid
-      # onnx.onnx_cpp2py_export.shape_inference.InferenceError: [ShapeInferenceError] Inference error(s):
-      # (op_type:ConstantOfShape, node name: node_ConstantOfShape_67):
-      # [TypeInferenceError] Inferred elem type differs from existing elem type: (FLOAT) vs (INT64)
-      "test_output_match_opinfo__ops_aten__scaled_dot_product_efficient_attention_cuda_float32"
+        # RuntimeError: ONNX Runtime failed to evaluate
+        # onnxruntime.capi.onnxruntime_pybind11_state.InvalidArgument: [ONNXRuntimeError] : 2 :
+        # INVALID_ARGUMENT : Non-zero status code returned while running LayerNormalization node.
+        # Name:'node_LayerNormalization_0' Status Message: Size of X.shape[axis:] must be larger than 1, got 1
+        "test_output_match_opinfo__native_layer_norm_cuda_float16"
+        # onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented: [ONNXRuntimeError] : 9 :
+        # NOT_IMPLEMENTED : Could not find an implementation for SplitToSequence(11) node with name '_inlfunc_aten_split_n0'
+        "test_output_match_opinfo__split_cuda_bool"
+        "test_output_match_opinfo__split_list_args_cuda_bool"
+        # onnxruntime.capi.onnxruntime_pybind11_state.NotImplemented: [ONNXRuntimeError] : 9 :
+        # NOT_IMPLEMENTED : Could not find an implementation for SplitToSequence(11) node with name '_inlfunc_aten_split_with_sizes_n0'
+        "test_output_match_opinfo__split_with_sizes_cuda_bool"
 
-      # RuntimeError: FlashAttention only support fp16 and bf16 data type
-      "test_output_match_opinfo__ops_aten__scaled_dot_product_flash_attention_cuda_float32"
+        # AssertionError: ONNX model is invalid
+        # onnx.onnx_cpp2py_export.shape_inference.InferenceError: [ShapeInferenceError] Inference error(s):
+        # (op_type:ConstantOfShape, node name: node_ConstantOfShape_67):
+        # [TypeInferenceError] Inferred elem type differs from existing elem type: (FLOAT) vs (INT64)
+        "test_output_match_opinfo__ops_aten__scaled_dot_product_efficient_attention_cuda_float32"
 
-      # Unexpected success
-      "test_output_match_opinfo__ops_aten_col2im_cuda_float16"
-      "test_output_match_opinfo__sort_cuda_float16"
+        # RuntimeError: FlashAttention only support fp16 and bf16 data type
+        "test_output_match_opinfo__ops_aten__scaled_dot_product_flash_attention_cuda_float32"
 
-      # RuntimeError: expected scalar type Int but found Float
-      "test_output_match_opinfo__ops_aten_fake_quantize_per_tensor_affine_cuda_float16"
-      "test_output_match_opinfo__ops_aten_fake_quantize_per_tensor_affine_cuda_float32"
-    ];
+        # Unexpected success
+        "test_output_match_opinfo__ops_aten_col2im_cuda_float16"
+        "test_output_match_opinfo__sort_cuda_float16"
+
+        # RuntimeError: expected scalar type Int but found Float
+        "test_output_match_opinfo__ops_aten_fake_quantize_per_tensor_affine_cuda_float16"
+        "test_output_match_opinfo__ops_aten_fake_quantize_per_tensor_affine_cuda_float32"
+      ]
+      ++ lib.optionals (pythonAtLeast "3.14") [
+        # TypeError: Expecting a type not f<class 'typing.Union'> for typeinfo
+        "TestOutputConsistencyFullGraphCUDA"
+      ];
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
FAILED onnxscript/rewriter/rules/common/_fuse_pad_into_conv_test.py::FuseConvPadTest::test_fuse_pad_into_conv_4 - AssertionError:
Not equal to tolerance rtol=0, atol=0

Mismatched elements: 2043 / 2520 (81.1%)
Max absolute difference among violations: 3.8146973e-06
Max relative difference among violations: 0.00052819
 ACTUAL: array([[[[[ 1.049978,  2.382957,  3.18309 , ...,  0.109219, -0.705735,
           -1.020914],
          [ 0.727048,  4.678765,  4.825941, ...,  4.942149,  5.020426,...
 DESIRED: array([[[[[ 1.049977,  2.382957,  3.18309 , ...,  0.109219, -0.705735,
           -1.020914],
          [ 0.727048,  4.678766,  4.825942, ...,  4.942148,  5.020427,...
FAILED onnxscript/rewriter/rules/common/_fuse_pad_into_conv_test.py::FuseConvPadTest::test_fuse_pad_into_conv_5 - AssertionError:
Not equal to tolerance rtol=0, atol=0

Mismatched elements: 2043 / 2520 (81.1%)
Max absolute difference among violations: 3.8146973e-06
Max relative difference among violations: 0.00052819
 ACTUAL: array([[[[[ 1.049978,  2.382957,  3.18309 , ...,  0.109219, -0.705735,
           -1.020914],
          [ 0.727048,  4.678765,  4.825941, ...,  4.942149,  5.020426,...
 DESIRED: array([[[[[ 1.049977,  2.382957,  3.18309 , ...,  0.109219, -0.705735,
           -1.020914],
          [ 0.727048,  4.678766,  4.825942, ...,  4.942148,  5.020427,...
FAILED onnxscript/rewriter/rules/common/_fuse_pad_into_conv_test.py::FuseConvPadTest::test_fuse_pad_into_conv_6 - AssertionError:
Not equal to tolerance rtol=0, atol=0

Mismatched elements: 2560 / 2880 (88.9%)
Max absolute difference among violations: 0.00281596
Max relative difference among violations: 0.6178971
 ACTUAL: array([[[[[ 0.000000e+00,  0.000000e+00,  0.000000e+00, ...,
            0.000000e+00,  0.000000e+00,  0.000000e+00],
          [ 4.267471e+00,  2.317511e+00,  2.724599e+00, ...,...
 DESIRED: array([[[[[ 0.000000e+00,  0.000000e+00,  0.000000e+00, ...,
            0.000000e+00,  0.000000e+00,  0.000000e+00],
          [ 4.267610e+00,  2.317051e+00,  2.724379e+00, ...,...
FAILED onnxscript/rewriter/rules/common/_fuse_pad_into_conv_test.py::FuseConvPadTest::test_fuse_pad_into_conv_7 - AssertionError:
Not equal to tolerance rtol=0, atol=0

Mismatched elements: 2560 / 2880 (88.9%)
Max absolute difference among violations: 0.00281596
Max relative difference among violations: 0.6178971
 ACTUAL: array([[[[[ 0.000000e+00,  0.000000e+00,  0.000000e+00, ...,
            0.000000e+00,  0.000000e+00,  0.000000e+00],
          [ 4.267471e+00,  2.317511e+00,  2.724599e+00, ...,...
 DESIRED: array([[[[[ 0.000000e+00,  0.000000e+00,  0.000000e+00, ...,
            0.000000e+00,  0.000000e+00,  0.000000e+00],
          [ 4.267610e+00,  2.317051e+00,  2.724379e+00, ...,...
= 4 failed, 4027 passed, 1862 skipped, 34 deselected, 213 xfailed, 21389 warnings in 555.90s (0:09:15) =
```

https://hydra.nixos-cuda.org/build/137915

cc @SomeoneSerge

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
