### PR TITLE
python3.setupHook: use replaceVars instead of substituteAllInPlace

### DIFF
--- a/pkgs/development/interpreters/python/setup-hook.nix
+++ b/pkgs/development/interpreters/python/setup-hook.nix
@@ -1,19 +1,19 @@
-{ runCommand }:
+{
+  runCommand,
+  replaceVars,
+}:
 
 sitePackages:
 
 let
-  hook = ./setup-hook.sh;
+  hook = replaceVars ./setup-hook.sh {
+    inherit sitePackages;
+  };
 in
 runCommand "python-setup-hook.sh"
   {
     strictDeps = true;
-    env = {
-      inherit sitePackages;
-    };
   }
   ''
-    cp ${hook} hook.sh
-    substituteAllInPlace hook.sh
-    mv hook.sh $out
+    cp ${hook} $out
   ''


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/237216

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
