### PR TITLE
dbus-broker: re-add expat to inputs to fix build

### DIFF
--- a/pkgs/by-name/db/dbus-broker/package.nix
+++ b/pkgs/by-name/db/dbus-broker/package.nix
@@ -10,6 +10,7 @@
   dbus,
   linuxHeaders,
   systemd,
+  expat,
 }:
 
 let
@@ -146,6 +147,7 @@ stdenv.mkDerivation (finalAttrs: {
     dbus
     linuxHeaders
     systemd
+    expat
   ];
 
   mesonFlags = [


### PR DESCRIPTION
Currently fails to build on staging with:
```
dbus-broker> Run-time dependency expat found: NO (tried pkgconfig)
dbus-broker> meson.build:76:20: ERROR: Dependency "expat" not found, tried pkgconfig
```

Prior to f82cda2388c1a47a72d4ea44ff04086d7b241d2d expat appeared as a propagated build input from dbus.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
