### PR TITLE
reqable: add wrapGAppsHook3 to fix GSettings runtime error

### DIFF
--- a/pkgs/by-name/re/reqable/package.nix
+++ b/pkgs/by-name/re/reqable/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   dpkg,
   autoPatchelfHook,
-  makeBinaryWrapper,
+  wrapGAppsHook3,
   fontconfig,
   atk,
   cairo,
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     dpkg
     autoPatchelfHook
-    makeBinaryWrapper
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -72,11 +72,12 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  dontWrapGApps = true;
+
   preFixup = ''
-    mkdir $out/bin
     makeWrapper $out/share/reqable/reqable $out/bin/reqable \
-      --prefix LD_LIBRARY_PATH : $out/share/reqable/lib \
-      --set GIO_MODULE_DIR "${glib.out}/lib/gio/modules"
+     --prefix LD_LIBRARY_PATH : $out/share/reqable/lib \
+     ''${gappsWrapperArgs[@]}
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/re/reqable/package.nix
+++ b/pkgs/by-name/re/reqable/package.nix
@@ -76,8 +76,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup = ''
     makeWrapper $out/share/reqable/reqable $out/bin/reqable \
-     --prefix LD_LIBRARY_PATH : $out/share/reqable/lib \
-     ''${gappsWrapperArgs[@]}
+      --prefix LD_LIBRARY_PATH : $out/share/reqable/lib \
+      ''${gappsWrapperArgs[@]}
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
This fixes a runtime crash in reqable caused by missing GSettings schemas.

Without wrapping the application, reqable crashes at runtime with: `GLib-GIO-ERROR: No GSettings schemas are installed on the system`, for example when exporting CA certificates from the UI.

Adding `wrapGAppsHook3` ensures the required GTK/GSettings environment variables are set correctly, making the application usable on NixOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
