### PR TITLE
Add firewarden

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3875,6 +3875,12 @@
     name = "Joseph Madden";
     keys = [ { fingerprint = "3CF8 E983 2219 AB4B 0E19  158E 6112 1921 C9F8 117C"; } ];
   };
+  brett = {
+    email = "brett@librum.org";
+    github = "brett";
+    githubId = 523;
+    name = "Brett Eisenberg";
+  };
   brettlyons = {
     email = "blyons@fastmail.com";
     github = "brettlyons";

--- a/pkgs/by-name/fi/firewarden/package.nix
+++ b/pkgs/by-name/fi/firewarden/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeWrapper,
+  firejail,
+  networkmanager,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "firewarden";
+  version = "1.1.5";
+
+  src = fetchFromGitHub {
+    owner = "pigmonkey";
+    repo = "firewarden";
+    tag = version;
+    hash = "sha256-Nq3SIZsw68FI3VkK5QdqdIHkV8tgz/eK5YvsIn0yxaU=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 firewarden $out/bin/firewarden
+
+    wrapProgram $out/bin/firewarden \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          firejail
+          networkmanager
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open a program within a private Firejail sandbox";
+    longDescription = ''
+      Firewarden is a bash script that wraps application launches with Firejail
+      sandboxing, creating isolated environments with temporary filesystems.
+      It is particularly useful for mitigating harm caused by opening potentially
+      malicious files, such as PDFs and images.
+    '';
+    homepage = "https://github.com/pigmonkey/firewarden";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.brett ];
+    platforms = lib.platforms.linux;
+    mainProgram = "firewarden";
+  };
+}


### PR DESCRIPTION
## Description

Firewarden is a bash script that wraps application launches with Firejail sandboxing, creating isolated environments with temporary filesystems. It is particularly useful for mitigating harm caused by opening potentially malicious files, such as PDFs and images.

## Metadata

- **Upstream**: https://github.com/pigmonkey/firewarden
- **License**: Unlicense (Public Domain)
- **Version**: 1.1.5
- **Platforms**: Linux only (requires firejail)

## Testing

Built and tested locally:
- [x] Package builds successfully
- [x] Binary is executable
- [x] Runtime dependencies (firejail) are correctly wrapped
- [x] Metadata is complete

## Checklist

- [x] Built on Linux
- [ ] Built on Darwin (N/A - Linux only)
- [x] Formatted with nixfmt-rfc-style
- [x] Added myself to maintainer-list.nix
- [x] No hash placeholders
