### PR TITLE
camset: patch to work with numpy >=2.3

### DIFF
--- a/pkgs/by-name/ca/camset/fix-numpy-2.3.patch
+++ b/pkgs/by-name/ca/camset/fix-numpy-2.3.patch
@@ -1,0 +1,22 @@
+From 61e500c661cc6f2d5095a380be719c10c0f77c61 Mon Sep 17 00:00:00 2001
+From: limes007 <39467727+limes007@users.noreply.github.com>
+Date: Wed, 17 Sep 2025 11:02:57 +0200
+Subject: [PATCH] bugfix for numpy >2.3
+
+---
+ camset/cam_window.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/camset/cam_window.py b/camset/cam_window.py
+index 7eac4ae..f709634 100644
+--- a/camset/cam_window.py
++++ b/camset/cam_window.py
+@@ -68,7 +68,7 @@ def show_frame(self):
+             # TODO: resizing video and window this way is very cpu intensive for large resolutions, should be improved or removed
+             frame = cv2.resize(frame, dim, interpolation = cv2.INTER_CUBIC)
+             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB) # needed for proper color representation in gtk
+-            pixbuf = GdkPixbuf.Pixbuf.new_from_data(frame.tostring(),
++            pixbuf = GdkPixbuf.Pixbuf.new_from_data(frame.tobytes(),
+                                                 GdkPixbuf.Colorspace.RGB,
+                                                 False,
+                                                 8,

--- a/pkgs/by-name/ca/camset/package.nix
+++ b/pkgs/by-name/ca/camset/package.nix
@@ -7,6 +7,7 @@
   v4l-utils,
   wrapGAppsHook3,
   lib,
+  fetchpatch,
 }:
 
 python3Packages.buildPythonApplication {
@@ -20,6 +21,14 @@ python3Packages.buildPythonApplication {
     rev = "b813ba9b1d29f2d46fad268df67bf3615a324f3e";
     hash = "sha256-vTF3MJQi9fZZDlbEj5800H22GGWOte3+KZCpSnsSTaQ=";
   };
+  patches = [
+    # remove when https://github.com/azeam/camset/pull/30 merged
+    (fetchpatch {
+      url = "https://github.com/azeam/camset/commit/61e500c661cc6f2d5095a380be719c10c0f77c61.patch";
+      name = "fix-numpy-2.3";
+      hash = "sha256-FEoxwJSAV/pxtMkCuzdRLjrdbsp7ZNXiMlBtEAK9IJs=";
+    })
+  ];
 
   build-system = with python3Packages; [ setuptools ];
 

--- a/pkgs/by-name/ca/camset/package.nix
+++ b/pkgs/by-name/ca/camset/package.nix
@@ -7,7 +7,6 @@
   v4l-utils,
   wrapGAppsHook3,
   lib,
-  fetchpatch,
 }:
 
 python3Packages.buildPythonApplication {
@@ -23,11 +22,7 @@ python3Packages.buildPythonApplication {
   };
   patches = [
     # remove when https://github.com/azeam/camset/pull/30 merged
-    (fetchpatch {
-      url = "https://github.com/azeam/camset/commit/61e500c661cc6f2d5095a380be719c10c0f77c61.patch";
-      name = "fix-numpy-2.3";
-      hash = "sha256-FEoxwJSAV/pxtMkCuzdRLjrdbsp7ZNXiMlBtEAK9IJs=";
-    })
+    ./fix-numpy-2.3.patch
   ];
 
   build-system = with python3Packages; [ setuptools ];


### PR DESCRIPTION
Addresses runtime error:

Unable to detect what device /dev/media0 is, exiting. Traceback (most recent call last):
  File "/nix/store/vwv84rg90w91dwbim8bajz37rlvwwisf-camset-0-unstable-2023-05-20/lib/python3.13/site-packages/camset/cam_window.py", line 71, in show_frame
    pixbuf = GdkPixbuf.Pixbuf.new_from_data(frame.tostring(),
                                            ^^^^^^^^^^^^^^
AttributeError: 'numpy.ndarray' object has no attribute 'tostring'


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
