### PR TITLE
deps-fnl: init at 0.2.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7755,6 +7755,13 @@
     githubId = 18535642;
     name = "Emily";
   };
+  emily-lavender = {
+    email = "emily@foggy.city";
+    github = "emily-lavender";
+    githubId = 253398252;
+    name = "Emily Lavender";
+    keys = [ { fingerprint = "3572 DE50 D71C 7DD7 1B48 8831 A7EF 615A 2AB9 1EE7"; } ];
+  };
   emilylange = {
     email = "nix@emilylange.de";
     github = "emilylange";

--- a/pkgs/by-name/de/deps-fnl/package.nix
+++ b/pkgs/by-name/de/deps-fnl/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  fetchFromGitLab,
+  stdenv,
+  luaPackages,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "deps.fnl";
+  version = "0.2.5";
+
+  src = fetchFromGitLab {
+    owner = "andreyorst";
+    repo = "deps.fnl";
+    tag = version;
+    hash = "sha256-gUqi0g7myWTbjILN4RQqbeeaSYcg0oVJYNO0Gv9XzNY=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    # deps requires argv0 to be fennel as an executable lua script
+    # skipping the luarocks wrapper is fine here
+    fennelLua=$(echo ${luaPackages.fennel}/fennel*/fennel/*/bin/fennel)
+    substitute deps $out/bin/deps \
+      --replace-fail '#!/usr/bin/env fennel' "#!$fennelLua"
+    chmod +x $out/bin/deps
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Dependency and PATH manager for Fennel";
+    homepage = "https://gitlab.com/andreyorst/deps.fnl";
+    license = lib.licenses.mit;
+    mainProgram = "deps";
+    maintainers = with lib.maintainers; [ emily-lavender ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Added `deps.fnl`, a dependency manager for the Fennel language. `luaPackages.fennel`, `fennel-ls`, and `fnlfmt` are already in nixpkgs, so this allows for a more complete Fennel dev environment. Since deps invokes its own argv0 to run fennel commands, the shebang needs to point directly to the fennel lua script rather than the luarocks wrapper. This is fine, since fennel is running as a standalone package.

https://gitlab.com/andreyorst/deps.fnl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
