### PR TITLE
offlineimap: 8.0.0 -> 8.0.1

### DIFF
--- a/pkgs/by-name/of/offlineimap/package.nix
+++ b/pkgs/by-name/of/offlineimap/package.nix
@@ -55,7 +55,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   dependencies = with python3.pkgs; [
     certifi
     distro
+    gssapi
     imaplib2
+    keyring
+    portalocker
     pysocks
     rfc6555
     urllib3

--- a/pkgs/by-name/of/offlineimap/package.nix
+++ b/pkgs/by-name/of/offlineimap/package.nix
@@ -15,33 +15,22 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "offlineimap";
-  version = "8.0.0";
+  version = "8.0.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "OfflineIMAP";
     repo = "offlineimap3";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XLxKqO5OCXsFu8S3lMp2Ke5hp6uer9npZ3ujmL6Kb3g=";
+    hash = "sha256-Aigh2B4MTAOeUprtcK9kOx+aG4yCmGZoWTLmYYhrfXA=";
   };
 
   patches = [
     (fetchpatch {
-      name = "sqlite-version-aware-threadsafety-check.patch";
-      url = "https://github.com/OfflineIMAP/offlineimap3/pull/139/commits/7cd32cf834b34a3d4675b29bebcd32dc1e5ef128.patch";
-      hash = "sha256-xNq4jFHMf9XZaa9BFF1lOzZrEGa5BEU8Dr+gMOBkJE4=";
-    })
-    (fetchpatch {
-      # https://github.com/OfflineIMAP/offlineimap3/pull/120
-      name = "python312-comaptibility.patch";
-      url = "https://github.com/OfflineIMAP/offlineimap3/commit/a1951559299b297492b8454850fcfe6eb9822a38.patch";
-      hash = "sha256-CBGMHi+ZzOBJt3TxBf6elrTRMIQ+8wr3JgptL2etkoA=";
-    })
-    (fetchpatch {
-      # https://github.com/OfflineIMAP/offlineimap3/pull/161
-      name = "python312-compatibility.patch";
-      url = "https://github.com/OfflineIMAP/offlineimap3/commit/3dd8ebc931e3f3716a90072bd34e50ac1df629fa.patch";
-      hash = "sha256-2IJ0yzESt+zk+r+Z+9js3oKhFF0+xok0xK8Jd3G/gYY=";
+      # https://github.com/OfflineIMAP/offlineimap3/pull/225
+      name = "duplicate-bin.patch";
+      url = "https://github.com/OfflineIMAP/offlineimap3/commit/64557d2251f0d911c215eb743f6bfe8de8dfc042.patch";
+      hash = "sha256-Agy38fLt2k9AwPmGBoQxUD7+FD3qJzj89A13SQr0/nU=";
     })
   ];
 
@@ -70,6 +59,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     pysocks
     rfc6555
     urllib3
+  ];
+
+  # https://github.com/OfflineIMAP/offlineimap3/pull/232
+  pythonRelaxDeps = [
+    "urllib3"
   ];
 
   postInstall = ''

--- a/pkgs/by-name/of/offlineimap/package.nix
+++ b/pkgs/by-name/of/offlineimap/package.nix
@@ -70,6 +70,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     make -C docs man
     installManPage docs/offlineimap.1
     installManPage docs/offlineimapui.7
+    install -Dm644 offlineimap.conf -T $out/share/offlineimap/offlineimap.conf
+    install -Dm644 offlineimap.conf.minimal -T $out/share/offlineimap/offlineimap.conf.minimal
   '';
 
   # Test requires credentials


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Since we use installer in `pypaInstallPhase`, we run into https://github.com/OfflineIMAP/offlineimap3/pull/225 and the fix applies verbatim.

For the `urllib3` dependency, although upstream [pins](https://github.com/OfflineIMAP/offlineimap3/blob/bcf2238db5ae6bbd241b05b2fb8efc1072b07193/pyproject.toml#L6) it to `urllib3~=1.25.9`, it's not actually used anywhere except this [contrib file](https://github.com/OfflineIMAP/offlineimap3/blob/master/contrib/internet-urllib3.py) so it's safe to relax. See https://github.com/OfflineIMAP/offlineimap3/pull/232.

We're currently adding `certifi` from `testinternet` and `pysocks` for the optional proxy feature. I don't see any reason not to add the other [optional dependencies](https://github.com/OfflineIMAP/offlineimap3/blob/bcf2238db5ae6bbd241b05b2fb8efc1072b07193/pyproject.toml#L49-L53) (`keyring`, `portalocker`, `gssapi`).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test