### PR TITLE
tor: 0.4.8.21 -> 0.4.8.22

### DIFF
--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -46,11 +46,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tor";
-  version = "0.4.8.21";
+  version = "0.4.8.22";
 
   src = fetchurl {
     url = "https://dist.torproject.org/tor-${finalAttrs.version}.tar.gz";
-    hash = "sha256-6vb1tzCRuVV2lF6t6YgW3f980AW+/k2UcYpvdmuECQM=";
+    hash = "sha256-yIYg2SeKJ549In/2CXW4SqQTWSEfjs/2hgGZI7mSkzI=";
   };
 
   outputs = [


### PR DESCRIPTION
Release notes: https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.8.22/ReleaseNotes

This release contains one security fix, which has a corresponding low severity TROVE entry: https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE.

Tested by:
- Operating a relay (aarch64-linux)
- Basic usage via `torsocks` and `curl` to access clearnet sites and onion services (x86_64-linux)
- Using Tor Browser with `tor` as a standalone proxy (command: `TOR_PROVIDER=none TOR_SOCKS_PORT=9050 tor-browser`) (x86_64-linux)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 484829`
Commit: `3696d101eb7ee5588f14c5c6654c4d06c2d50453`

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 18 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>briar-desktop</li>
    <li>carburetor</li>
    <li>cwtch-ui</li>
    <li>cwtch-ui.debug</li>
    <li>cwtch-ui.pubcache</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>

### `aarch64-linux`
<details>
  <summary>:white_check_mark: 14 packages built:</summary>
  <ul>
    <li>bisq2</li>
    <li>carburetor</li>
    <li>feather</li>
    <li>onionshare</li>
    <li>onionshare-gui</li>
    <li>onionshare-gui.dist</li>
    <li>onionshare.dist</li>
    <li>sparrow</li>
    <li>tor</li>
    <li>tor.geoip</li>
    <li>tractor</li>
    <li>tractor.dist</li>
    <li>trezor-suite</li>
    <li>wahay</li>
  </ul>
</details>
