### PR TITLE
dpkg: fix musl build

### DIFF
--- a/pkgs/by-name/dp/dpkg/package.nix
+++ b/pkgs/by-name/dp/dpkg/package.nix
@@ -15,7 +15,7 @@
   pkg-config,
   diffutils,
   versionCheckHook,
-  glibc ? !stdenv.hostPlatform.isDarwin,
+  glibc,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -91,10 +91,20 @@ stdenv.mkDerivation (finalAttrs: {
     # which makes some tests fail.
     sed -i '/opts normalize/a AT_SKIP_IF([true])' src/at/chdir.at
   ''
-  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
-    substituteInPlace src/main/help.c \
-       --replace-fail '"ldconfig"' \"${glibc.bin}/bin/ldconfig\"
-  '';
+  +
+    lib.optionalString
+      (
+        stdenv.hostPlatform.libc == "glibc"
+        || stdenv.hostPlatform.libc == "uclibc"
+        || stdenv.hostPlatform.isFreeBSD
+        || stdenv.hostPlatform.isOpenBSD
+        || stdenv.hostPlatform.isNetBSD
+      )
+      ''
+        # See <https://github.com/guillemj/dpkg/blob/1.22.21/src/main/help.c#L93>
+        substituteInPlace src/main/help.c \
+           --replace-fail '"ldconfig"' \"${glibc.bin}/bin/ldconfig\"
+      '';
 
   buildInputs = [
     perl


### PR DESCRIPTION
fixes `nix-build -A pkgsMusl.dpkg` from x86_64-linux builder.

`pkgsCross.x86_64-darwin.stdenv.hostPlatform.libc` et al show "libSystem" so this new condition should not change darwin behavior.

the condition is derived from upstream, e.g.
- <https://github.com/guillemj/dpkg/blob/1.22.21/src/main/help.c#L93>
- or <https://git.launchpad.net/ubuntu/+source/dpkg/tree/src/main/help.c> (currently offline)

`glibc ? !stdenv.hostPlatform.isDarwin` call arg was nonsense so delete it: `pkgs.glibc` always exists and it would have been an eval error to actually override it with a bool value.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
