### PR TITLE
tailscale.gui: init at 1.94.1; move from tailscale-gui

### DIFF
--- a/pkgs/by-name/ta/tailscale/gui.nix
+++ b/pkgs/by-name/ta/tailscale/gui.nix
@@ -5,15 +5,16 @@
   xar,
   cpio,
   pbzx,
+  version,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "tailscale-gui";
-  version = "1.92.3";
+  inherit version;
 
   src = fetchurl {
     url = "https://pkgs.tailscale.com/stable/Tailscale-${finalAttrs.version}-macos.pkg";
-    hash = "sha256-K5tJHyFhqnxV4KHzr7YOHRoH33vk+dq+EVWyUo88nuI=";
+    hash = "sha256-MPS6OA6+0SN0IZjPPcV1fE6VS7BdzXZE+z5HkfoA31M=";
   };
 
   dontUnpack = true;
@@ -40,7 +41,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   meta = {
-    description = "Tailscale GUI client for macOS";
+    description = "Standalone Tailscale GUI client for macOS";
     homepage = "https://tailscale.com";
     changelog = "https://tailscale.com/changelog#client";
     license = lib.licenses.unfree;

--- a/pkgs/by-name/ta/tailscale/package.nix
+++ b/pkgs/by-name/ta/tailscale/package.nix
@@ -20,6 +20,9 @@
 
   nixosTests,
   tailscale-nginx-auth,
+
+  # for passthru.gui
+  callPackage,
 }:
 
 buildGoModule (finalAttrs: {
@@ -218,10 +221,13 @@ buildGoModule (finalAttrs: {
       --zsh <($out/bin/tailscale completion zsh)
   '';
 
-  passthru.tests = {
-    inherit (nixosTests) headscale;
-    inherit tailscale-nginx-auth;
-    tests = finalAttrs.finalPackage.overrideAttrs { doCheck = true; };
+  passthru = {
+    tests = {
+      inherit (nixosTests) headscale;
+      inherit tailscale-nginx-auth;
+      tests = finalAttrs.finalPackage.overrideAttrs { doCheck = true; };
+    };
+    gui = callPackage ./gui.nix { inherit (finalAttrs) version; };
   };
 
   meta = {
@@ -237,6 +243,7 @@ buildGoModule (finalAttrs: {
       philiptaron
       pyrox0
       ryan4yin
+      anish
     ];
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1700,6 +1700,7 @@ mapAliases {
   synth = throw "'synth' has been removed because it is unmaintained"; # Added 2025-11-15
   system = warnAlias "'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'" stdenv.hostPlatform.system; # Converted to warning 2025-10-28
   t1lib = throw "'t1lib' has been removed as it was broken and unmaintained upstream."; # Added 2025-06-11
+  tailscale-gui = warnAlias "'tailscale-gui' has been renamed to/replaced by 'tailscale.gui'" tailscale.gui; # Added 2026-01-28
   tamgamp.lv2 = tamgamp-lv2; # Added 2025-09-27
   taplo-cli = throw "'taplo-cli' has been renamed to/replaced by 'taplo'"; # Converted to throw 2025-10-27
   taplo-lsp = throw "'taplo-lsp' has been renamed to/replaced by 'taplo'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
Moves `tailscale-gui` into `tailscale.gui` to ensure version synchronization. The GUI and CLI must be the same version to avoid mismatch warnings when both are used together. On Mac, users who want Tailscale SSH need both packages:

- `tailscale.gui` for the menu bar interface
- `services.tailscale.enable` to run the open-source daemon with SSH support, since the GUI's system extension doesn't support SSH (it reports "sandboxed" regardless of build type).

`tailscale-gui` is aliased to `tailscale.gui` for backwards compatibility.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
