### PR TITLE
balatro: add appsforartists as co-maintainer

### DIFF
--- a/pkgs/by-name/ba/balatro/package.nix
+++ b/pkgs/by-name/ba/balatro/package.nix
@@ -71,7 +71,10 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     license = lib.licenses.unfree;
     homepage = "https://store.steampowered.com/app/2379780/Balatro/";
-    maintainers = [ lib.maintainers.antipatico ];
+    maintainers = with lib.maintainers; [
+      antipatico
+      appsforartists
+    ];
     platforms = love.meta.platforms;
     mainProgram = "balatro";
   };


### PR DESCRIPTION
As I alluded to in #482912, I'd like to improve the Balatro derivation to work with other copies of the game (not only the ones from Steam).

Hoping to get input from @antipatico, but it seems he's not on GitHub much these days.