### PR TITLE
rustcast: init at 0.5.6

### DIFF
--- a/pkgs/by-name/ru/rustcast/package.nix
+++ b/pkgs/by-name/ru/rustcast/package.nix
@@ -1,0 +1,35 @@
+{
+  nix-update-script,
+  fetchFromGitHub,
+  rustPlatform,
+  apple-sdk,
+  lib,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rustcast";
+  version = "0.5.6";
+
+  src = fetchFromGitHub {
+    owner = "unsecretised";
+    repo = "rustcast";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-88vg+xdASskbYwLbEPGmHf8P1PL4PihJDXT1ua/cfCQ=";
+  };
+
+  nativeBuildInputs = [
+    apple-sdk
+  ];
+
+  cargoHash = "sha256-IvpvbsnWWI1I/1PmVfP6qXf8DzRknRBJjMixUp01xo8=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/unsecretised/rustcast/releases/tag/v${finalAttrs.version}";
+    description = "Modern Spotlight Alternative made opensource";
+    homepage = "https://github.com/unsecretised/rustcast";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+  };
+})


### PR DESCRIPTION
https://github.com/unsecretised/rustcast

It builds however there is an issue with running it. Leaving as draft till fixed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
