### PR TITLE
bitlbee-mastodon: fix `gcc-15` build

### DIFF
--- a/pkgs/by-name/bi/bitlbee-mastodon/gcc-15.patch
+++ b/pkgs/by-name/bi/bitlbee-mastodon/gcc-15.patch
@@ -1,0 +1,17 @@
+https://github.com/kensanata/bitlbee-mastodon/pull/61
+
+FIx gcc-15 build (`bool` collision).
+--- a/src/mastodon-lib.c
++++ b/src/mastodon-lib.c
+@@ -2093,9 +2093,9 @@ static char *indent(int n)
+ /**
+  * Return a static yes or no string. No deallocation needed.
+  */
+-static char *yes_or_no(int bool)
++static char *yes_or_no(int b)
+ {
+-	return bool ? "yes" : "no";
++	return b ? "yes" : "no";
+ }
+ 
+ /**

--- a/pkgs/by-name/bi/bitlbee-mastodon/package.nix
+++ b/pkgs/by-name/bi/bitlbee-mastodon/package.nix
@@ -17,6 +17,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-8vmq/YstuBYUxe00P4NrxD/eMYI++R9uvn1sCcMTr7I=";
   };
 
+  patches = [
+    # gcc-15 build fix: https://github.com/kensanata/bitlbee-mastodon/pull/61
+    ./gcc-15.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config


### PR DESCRIPTION
Without the change the build fails on `master` as
https://hydra.nixos.org/build/319885265:

    mastodon-lib.c:2096:28: error: 'bool' cannot be used here
     2096 | static char *yes_or_no(int bool)
          |                            ^~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
