### PR TITLE
yaziPlugins.wl-clipboard: fix broken emit function call

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/wl-clipboard/0001-Fix-emit-function-call.patch
+++ b/pkgs/by-name/ya/yazi/plugins/wl-clipboard/0001-Fix-emit-function-call.patch
@@ -1,0 +1,22 @@
+From bb6caca50f67dbe93983c8e0bf8d6c75f48b2d21 Mon Sep 17 00:00:00 2001
+From: Luminar Leaf <80571430+LuminarLeaf@users.noreply.github.com>
+Date: Tue, 20 Jan 2026 16:49:29 +0530
+Subject: [PATCH] Fix emit function call
+
+Upstream function name changed
+---
+ main.lua | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/main.lua b/main.lua
+index 1c737b2..87be707 100644
+--- a/main.lua
++++ b/main.lua
+@@ -13,7 +13,7 @@ end)
+
+ return {
+ 	entry = function()
+-		ya.manager_emit("escape", { visual = true })
++		ya.emit("escape", { visual = true })
+
+ 		local urls = selected_or_hovered()

--- a/pkgs/by-name/ya/yazi/plugins/wl-clipboard/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/wl-clipboard/default.nix
@@ -22,6 +22,8 @@ mkYaziPlugin {
     hash = "sha256-3PRQl4TvuOe5DwVi1gmtmfTOEVZWRayijIbnPgaR3L8=";
   };
 
+  patches = [ ./0001-Fix-emit-function-call.patch ];
+
   meta = {
     description = "Wayland implementation of a simple system clipboard for yazi file manager";
     homepage = "https://github.com/grappas/wl-clipboard.yazi";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added a patch to fix a broken emit function call in `yaziPlugins.wl-clipboard`.

Original error message:
```
runtime error: [string "wl-clipboard"]:16: attempt to call a nil value (field 'manager_emit')
stack traceback:
	[string "wl-clipboard"]:16: in function <[string "wl-clipboard"]:15>
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
