### PR TITLE
k8sgpt: 0.4.8 -> 0.4.28

### DIFF
--- a/pkgs/by-name/k8/k8sgpt/package.nix
+++ b/pkgs/by-name/k8/k8sgpt/package.nix
@@ -1,24 +1,34 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
+  installShellFiles,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "k8sgpt";
-  version = "0.4.8";
+  version = "0.4.28";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   src = fetchFromGitHub {
     owner = "k8sgpt-ai";
     repo = "k8sgpt";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-TaJBGU+nLMVOL1uiHPan8p2DfuAWTr57Lt2BtfNq6dA=";
+    hash = "sha256-hY1gyKy37SIASyhlWD+2aAeyfgfFpoBtm2XXIwCrh/Y=";
   };
 
-  vendorHash = "sha256-960gfOCpqY2gCbHR+fYFeV9UjztWMRVQKHIg/n3ELxk=";
+  vendorHash = "sha256-6RgcIGGhtgxWR90gQWxXYxID6L5bZLrLLH0S+MSIO2w=";
 
   # https://nixos.org/manual/nixpkgs/stable/#var-go-CGO_ENABLED
   env.CGO_ENABLED = 0;
+
+  preCheck = ''
+    export HOME=$TMPDIR
+  '';
 
   # https://nixos.org/manual/nixpkgs/stable/#ssec-skip-go-tests
   ldflags = [
@@ -28,6 +38,13 @@ buildGoModule (finalAttrs: {
     "-X main.commit=${finalAttrs.src.rev}"
     "-X main.date=1970-01-01-00:00:01"
   ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd k8sgpt \
+      --bash <($out/bin/k8sgpt completion bash) \
+      --zsh <($out/bin/k8sgpt completion zsh) \
+      --fish <($out/bin/k8sgpt completion fish)
+  '';
 
   meta = {
     description = "Giving Kubernetes Superpowers to everyone";


### PR DESCRIPTION
- Update k8sgpt to latest release.
- Fix tests not passing
- Add shell completion

Many things were added in the past year. Here is a git changelog https://github.com/k8sgpt-ai/k8sgpt/compare/v0.4.8...v0.4.27

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
