### PR TITLE
nixos/cocoon: init module; nixosTests.cocoon: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -42,6 +42,8 @@
 
 - [Dunst](https://github.com/dunst-project/dunst), a lightweight and customizable notification daemon. Available as [services.dunst](#opt-services.dunst.enable).
 
+- [cocoon](https://github.com/haileyok/cocoon), is a PDS (personal data server) that is a alternative to the bluesky pds. Available as [services.cocoon](#opt-services.cocoon.enable).
+
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
 
 - [Dawarich](https://dawarich.app/), a self-hostable location history tracker. Available as [services.dawarich](#opt-services.dawarich.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1598,6 +1598,7 @@
   ./services/web-apps/changedetection-io.nix
   ./services/web-apps/chhoto-url.nix
   ./services/web-apps/cloudlog.nix
+  ./services/web-apps/cocoon.nix
   ./services/web-apps/code-server.nix
   ./services/web-apps/coder.nix
   ./services/web-apps/collabora-online.nix

--- a/nixos/modules/services/web-apps/cocoon.nix
+++ b/nixos/modules/services/web-apps/cocoon.nix
@@ -1,0 +1,210 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.cocoon;
+
+  inherit (lib)
+    getExe
+    mkEnableOption
+    mkIf
+    mkOption
+    mkPackageOption
+    types
+    optional
+    ;
+in
+{
+  options.services.cocoon = {
+    enable = mkEnableOption "cocoon";
+
+    package = mkPackageOption pkgs "cocoon" { };
+
+    settings = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf (types.nullOr (types.either types.str types.path));
+
+        options = {
+          COCOON_ADDR = mkOption {
+            type = types.str;
+            default = ":8080";
+            example = ":3000";
+            description = "Address to bind the Cocoon instance to";
+          };
+
+          COCOON_DID = mkOption {
+            type = types.nullOr types.str;
+            example = "did:web:cocoon.example.com";
+            description = "DID web address for the Cocoon instance";
+          };
+
+          COCOON_HOSTNAME = mkOption {
+            type = types.nullOr types.str;
+            example = "cocoon.example.com";
+            description = "Hostname for the Cocoon instance";
+          };
+
+          COCOON_ROTATION_KEY_PATH = mkOption {
+            type = types.either types.path types.str;
+            default = "/var/lib/cocoon/rotation.key";
+            description = ''
+              Path to the rotation key file.
+
+              Generate it with:
+              ```
+              cocoon create-rotation-key --out /var/lib/cocoon/rotation.key
+              ```
+            '';
+          };
+
+          COCOON_JWK_PATH = mkOption {
+            type = types.either types.path types.str;
+            default = "/var/lib/cocoon/jwk.key";
+            description = ''
+              Path to the JWK key file
+
+              Generate it with:
+              ```
+              cocoon create-private-jwk --out /var/lib/cocoon/jwk.key
+              ```
+            '';
+          };
+
+          COCOON_CONTACT_EMAIL = mkOption {
+            type = types.str;
+            example = "me@example.com";
+            description = "Contact email for the Cocoon instance";
+          };
+
+          COCOON_RELAYS = mkOption {
+            type = types.str;
+            default = "https://bsky.network";
+            description = "Comma-separated list of Nostr relays to connect to";
+          };
+
+          COCOON_SESSION_COOKIE_KEY = mkOption {
+            type = types.str;
+            default = "session";
+            description = "Name of the session cookie";
+          };
+
+          COCOON_DB_TYPE = mkOption {
+            type = types.str;
+            default = "sqlite";
+            description = "Type of database to use (sqlite or postgres)";
+          };
+
+          COCOON_DB_NAME = mkOption {
+            type = types.str;
+            default = "/var/lib/cocoon/cocoon.db";
+            description = "Name of the SQLite database file (if using sqlite)";
+          };
+
+          COCOON_DATABASE_URL = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "postgres://cocoon:password@localhost:5432/cocoon?sslmode=disable";
+            description = "Database connection URL";
+          };
+        };
+      };
+
+      description = ''
+        Environment variables to set for the service. Secrets should be
+        specified using {option}`environmentFile`.
+
+        Refer to <https://github.com/haileyok/cocoon/blob/main/.env.example>
+        and <https://github.com/haileyok/cocoon/blob/main/README.md> for
+        available environment variables.
+      '';
+    };
+
+    environmentFiles = mkOption {
+      type = types.listOf types.path;
+      default = [ ];
+      description = ''
+        File to load environment variables from. Loaded variables override
+        values set in {option}`environment`.
+
+        Use it to set values of `COCOON_ADMIN_PASSWORD` and `COCOON_SESSION_SECRE`.
+
+        Generate `COCOON_ADMIN_PASSWORD` with
+        ```
+        openssl rand -hex 16
+        ```
+
+        Generate `COCOON_SESSION_SECRET` with
+        ```
+        openssl rand -hex 32
+        ```
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.cocoon = {
+      description = "cocoon";
+
+      after = [
+        "network-online.target"
+      ]
+      ++ optional (cfg.settings.COCOON_DB_TYPE == "postgres") "postgresql.service";
+      wants = [
+        "network-online.target"
+      ]
+      ++ optional (cfg.settings.COCOON_DB_TYPE == "postgres") "postgresql.service";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${getExe cfg.package} run";
+        Environment = lib.mapAttrsToList (k: v: "${k}=${if builtins.isInt v then toString v else v}") (
+          lib.filterAttrs (_: v: v != null) cfg.settings
+        );
+
+        EnvironmentFile = cfg.environmentFiles;
+        StateDirectory = "cocoon";
+        StateDirectoryMode = "0755";
+        Restart = "always";
+
+        # Hardening
+        RemoveIPC = true;
+        CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ];
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        ProtectClock = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        PrivateMounts = true;
+        SystemCallArchitectures = [ "native" ];
+        MemoryDenyWriteExecute = true;
+        RestrictNamespaces = true;
+        RestrictSUIDSGID = true;
+        ProtectHostname = true;
+        LockPersonality = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictRealtime = true;
+        DeviceAllow = [ "" ];
+        ProtectSystem = "strict";
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        ProtectHome = true;
+        PrivateUsers = true;
+        PrivateTmp = true;
+        UMask = "0077";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ isabelroses ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -382,6 +382,7 @@ in
   };
   cockpit = runTest ./cockpit.nix;
   cockroachdb = runTestOn [ "x86_64-linux" ] ./cockroachdb.nix;
+  cocoon = runTest ./cocoon.nix;
   code-server = runTest ./code-server.nix;
   coder = runTest ./coder.nix;
   collectd = runTest ./collectd.nix;

--- a/nixos/tests/cocoon.nix
+++ b/nixos/tests/cocoon.nix
@@ -1,0 +1,37 @@
+{ lib, ... }:
+{
+  name = "cocoon";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.cocoon = {
+        enable = true;
+        settings = {
+          COCOON_DID = "did:web:cocoon.example.com";
+          COCOON_HOSTNAME = "cocoon.example.com";
+          COCOON_CONTACT_EMAIL = "test@example.com";
+
+          # Snake oil testing credentials
+          COCOON_ADMIN_PASSWORD = "84f54c1229e02b662214e2af2df97cb6";
+          COCOON_SESSION_SECRET = "8ed099b41bb67939bf4e796fd4bd618add775a9265bcb32c63d00341a0f71b6c";
+          COCOON_ROTATION_KEY_PATH =
+            pkgs.runCommand "rotation-key" { nativeBuildInputs = [ pkgs.cocoon ]; }
+              ''
+                cocoon create-rotation-key --out $out
+              '';
+          COCOON_JWK_PATH = pkgs.runCommand "jwk-key" { nativeBuildInputs = [ pkgs.cocoon ]; } ''
+            cocoon create-private-jwk --out $out
+          '';
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("cocoon.service")
+    machine.wait_for_open_port(8080)
+    machine.succeed("curl --fail http://localhost:8080")
+  '';
+
+  meta.maintainers = [ lib.maintainers.isabelroses ];
+}

--- a/pkgs/by-name/co/cocoon/package.nix
+++ b/pkgs/by-name/co/cocoon/package.nix
@@ -2,6 +2,8 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nixosTests,
+  stdenvNoCC,
   nix-update-script,
 }:
 buildGoModule (finalAttrs: {
@@ -23,7 +25,10 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-bux3OfHT8f1FVpBAZUP23vo8M6h8nPTJbi/GTUzhdc4=";
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = lib.optionalAttrs stdenvNoCC.hostPlatform.isLinux { inherit (nixosTests) cocoon; };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "ATProtocol Personal Data Server written in Go with a SQLite block and blob store";


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
