### PR TITLE
microsoft-identity-broker: 2.0.1 -> 2.5.0

### DIFF
--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -3,95 +3,81 @@
   lib,
   fetchurl,
   dpkg,
-  openjdk11,
-  jnr-posix,
-  makeWrapper,
-  zip,
+  autoPatchelfHook,
   nixosTests,
-  bash,
+  dbus,
+  util-linux,
+  curl,
+  openssl,
+  libx11,
+  webkitgtk_4_1,
+  gtk3,
+  zlib,
+  pango,
+  harfbuzz,
+  atk,
+  cairo,
+  gdk-pixbuf,
+  libsoup_3,
   glib,
-  libxtst,
-  alsa-lib,
+  libsecret,
+  p11-kit,
 }:
 stdenv.mkDerivation rec {
   pname = "microsoft-identity-broker";
-  version = "2.0.1";
+  version = "2.5.0";
 
   src = fetchurl {
-    url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}_amd64.deb";
-    hash = "sha256-JheJnsu1ZxJbcpt0367FqfHVdwWWvPem2fm0i8s7MGE=";
+    url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}-noble_amd64.deb";
+    hash = "sha256-zid9kjjz3mBfJFfiYUoqlIyQSsR041JN3Ib+JFSSEbE=";
   };
 
   nativeBuildInputs = [
     dpkg
-    makeWrapper
-    openjdk11
-    zip
+    autoPatchelfHook
   ];
 
   buildInputs = [
+    dbus
+    util-linux
+    curl
+    openssl
+    libx11
+    webkitgtk_4_1
+    gtk3
+    zlib
+    pango
+    harfbuzz
+    atk
+    cairo
+    gdk-pixbuf
+    libsoup_3
     glib
-    libxtst
-    alsa-lib
+    libsecret
+    p11-kit
+    stdenv.cc.cc.lib
   ];
-
-  buildPhase = ''
-    runHook preBuild
-    rm opt/microsoft/identity-broker/lib/jnr-posix-3.1.4.jar
-    runHook postBuild
-  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/lib/microsoft-identity-broker
-    cp -a opt/microsoft/identity-broker/lib/* $out/lib/microsoft-identity-broker
-    cp -a usr/* $out
-    for jar in $out/lib/microsoft-identity-broker/*.jar; do
-      classpath="$classpath:$jar"
-    done
-    classpath="$classpath:${jnr-posix}/share/java/jnr-posix-${jnr-posix.version}.jar"
     mkdir -p $out/bin
-    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-broker \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
-      --add-flags "-classpath $classpath" \
-      --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
-      --add-flags "-verbose" \
-      --add-flags "-Djava.net.useSystemProxies=true" \
-      --add-flags "com.microsoft.identity.broker.service.IdentityBrokerService"
-
-    makeWrapper ${openjdk11}/bin/java $out/bin/microsoft-identity-device-broker \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}" \
-      --add-flags "-classpath $classpath" \
-      --add-flags "-Xmx256m -Xss256k -XX:+UseParallelGC -XX:ParallelGCThreads=1" \
-      --add-flags "-verbose" \
-      --add-flags "-Djava.net.useSystemProxies=true" \
-      --add-flags "com.microsoft.identity.broker.service.DeviceBrokerService"
+    cp -a opt/microsoft/identity-broker/bin/* $out/bin/
+    cp -a usr/* $out/
 
     runHook postInstall
   '';
 
   postInstall = ''
-    substituteInPlace \
-      $out/lib/systemd/user/microsoft-identity-broker.service \
-      $out/lib/systemd/system/microsoft-identity-device-broker.service \
-      $out/share/dbus-1/system-services/com.microsoft.identity.devicebroker1.service \
-      $out/share/dbus-1/services/com.microsoft.identity.broker1.service \
-      --replace \
-        ExecStartPre=sh \
-        ExecStartPre=${bash}/bin/sh \
-      --replace \
-        ExecStartPre=!sh \
-        ExecStartPre=!${bash}/bin/sh \
-      --replace \
-        /opt/microsoft/identity-broker/bin/microsoft-identity-broker \
-        $out/bin/microsoft-identity-broker \
-      --replace \
+    substituteInPlace $out/lib/systemd/system/microsoft-identity-device-broker.service \
+      --replace-fail \
         /opt/microsoft/identity-broker/bin/microsoft-identity-device-broker \
-        $out/bin/microsoft-identity-device-broker \
-      --replace \
-        /usr/lib/jvm/java-11-openjdk-amd64 \
-        ${openjdk11}
+        $out/bin/microsoft-identity-device-broker
+
+    substituteInPlace $out/share/dbus-1/services/com.microsoft.identity.broker1.service \
+      --replace-fail \
+        /opt/microsoft/identity-broker/bin/microsoft-identity-broker \
+        $out/bin/microsoft-identity-broker
   '';
 
   passthru = {


### PR DESCRIPTION
The update script stopped finding new versions because Microsoft no longer updates the `Packages.gz` index for Ubuntu 22.04. Meanwhile, version 2.5.0 shipped months ago.

The update script now scrapes the pool directory HTML directly instead of parsing `Packages.gz`. Also switches to Ubuntu 24.04 and handles the new filename format (versions now include a suffix like `2.5.0-noble`).

Version 2.5.0 of `microsoft-identity-broker` is a complete rewrite. Microsoft replaced the Java application with native binaries, so the package now uses `autoPatchelfHook` instead of wrapping Java JARs. I found the required libraries by running `patchelf --print-needed` on the extracted binary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
