### PR TITLE
quickjs{,-ng}: react to CVE-2026-1144 and CVE-2026-1145

### DIFF
--- a/pkgs/by-name/qu/quickjs-ng/package.nix
+++ b/pkgs/by-name/qu/quickjs-ng/package.nix
@@ -2,6 +2,7 @@
   lib,
   cmake,
   fetchFromGitHub,
+  fetchpatch,
   stdenv,
   testers,
   texinfo,
@@ -17,6 +18,24 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-Mb0YyxTWU6a8HFTVBmlJ5yGEDmjKXHqTSszAvb8Y01U=";
   };
+
+  patches = [
+    # CVE-2026-1145: Fix heap buffer overflow in js_typed_array_constructor_ta
+    # https://github.com/quickjs-ng/quickjs/issues/1305
+    (fetchpatch {
+      name = "CVE-2026-1145.patch";
+      url = "https://github.com/quickjs-ng/quickjs/commit/53aebe66170d545bb6265906fe4324e4477de8b4.patch";
+      hash = "sha256-PObMEqIush07mQ7YcoFUJ3rXitOlEU0tCsgVi6P2zW0=";
+    })
+    # CVE-2026-1144: Fix OOB access in atomic ops
+    # https://github.com/quickjs-ng/quickjs/issues/1301
+    # https://github.com/quickjs-ng/quickjs/issues/1302
+    (fetchpatch {
+      name = "CVE-2026-1144.patch";
+      url = "https://github.com/quickjs-ng/quickjs/commit/ea3e9d77454e8fc9cb3ef3c504e9c16af5a80141.patch";
+      hash = "sha256-ph6U+Mz7gxR4RWEtc+XU5fO6qjApQTqqW5dzwnOqTdc=";
+    })
+  ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/qu/quickjs/package.nix
+++ b/pkgs/by-name/qu/quickjs/package.nix
@@ -121,5 +121,10 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ ];
     mainProgram = "qjs";
     platforms = lib.platforms.all;
+    # Pending upstream fix: https://github.com/bellard/quickjs/pull/483
+    knownVulnerabilities = [
+      "CVE-2026-1144"
+      "CVE-2026-1145"
+    ];
   };
 })


### PR DESCRIPTION
## Summary

Marks `quickjs` as vulnerable, and pulls two commits from upstream `quickjs-ng` fixing these issues.

Closes #482190
Closes #482191

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
