### PR TITLE
python3Packages.papis: cleanup, skip failing test on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/isbnlib/default.nix
+++ b/pkgs/development/python-modules/isbnlib/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -15,6 +16,9 @@ buildPythonPackage (finalAttrs: {
   pname = "isbnlib";
   version = "3.10.14";
   pyproject = true;
+
+  # Several tests fail and suggest that the package is incompatible with python >= 3.14
+  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "xlcnd";

--- a/pkgs/development/python-modules/isbnlib/default.nix
+++ b/pkgs/development/python-modules/isbnlib/default.nix
@@ -2,12 +2,16 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # tests
   pytestCheckHook,
   pytest-cov-stub,
-  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "isbnlib";
   version = "3.10.14";
   pyproject = true;
@@ -15,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "xlcnd";
     repo = "isbnlib";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-d6p0wv7kj+NOZJRE2rzQgb7PXv+E3tASIibYCjzCdx8=";
   };
 
@@ -32,8 +36,8 @@ buildPythonPackage rec {
 
   enabledTestPaths = [ "isbnlib/test/" ];
 
-  # All disabled tests require a network connection
   disabledTests = [
+    # Require a network connection
     "test_cache"
     "test_editions_any"
     "test_editions_merge"
@@ -66,8 +70,8 @@ buildPythonPackage rec {
   meta = {
     description = "Extract, clean, transform, hyphenate and metadata for ISBNs";
     homepage = "https://github.com/xlcnd/isbnlib";
-    changelog = "https://github.com/xlcnd/isbnlib/blob/v${version}/CHANGES.txt";
+    changelog = "https://github.com/xlcnd/isbnlib/blob/${finalAttrs.src.tag}/CHANGES.txt";
     license = lib.licenses.lgpl3Plus;
     maintainers = with lib.maintainers; [ dotlambda ];
   };
-}
+})

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -45,16 +45,26 @@
   pytest-cov-stub,
   sphinx,
   sphinx-click,
+  writableTmpDirAsHomeHook,
 }:
-buildPythonPackage rec {
+
+buildPythonPackage (finalAttrs: {
   pname = "papis";
   version = "0.14.1";
   pyproject = true;
 
+  patches = [
+    (fetchpatch2 {
+      name = "fix-support-new-click-in-papisrunner.patch";
+      url = "https://github.com/papis/papis/commit/0e3ffff4bd1b62cdf0a9fdc7f54d6a2e2ab90082.patch?full_index=1";
+      hash = "sha256-KUw5U5izTTWqXHzGWLibtqHWAsVxla6SA8x6SJ07/zU=";
+    })
+  ];
+
   src = fetchFromGitHub {
     owner = "papis";
     repo = "papis";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-V4YswLNYwfBYe/Td0PEeDG++ClZoF08yxXjUXuyppPI=";
   };
 
@@ -81,7 +91,7 @@ buildPythonPackage rec {
     requests
     stevedore
   ]
-  ++ lib.optionals withOptDeps optional-dependencies.complete;
+  ++ lib.optionals withOptDeps finalAttrs.passthru.optional-dependencies.complete;
 
   optional-dependencies = {
     complete = [
@@ -102,11 +112,8 @@ buildPythonPackage rec {
     pytest-cov-stub
     sphinx
     sphinx-click
+    writableTmpDirAsHomeHook
   ];
-
-  preCheck = ''
-    export HOME=$(mktemp -d);
-  '';
 
   enabledTestPaths = [
     "papis"
@@ -126,23 +133,15 @@ buildPythonPackage rec {
     "test_git_cli"
   ];
 
-  patches = [
-    (fetchpatch2 {
-      name = "fix-support-new-click-in-papisrunner.patch";
-      url = "https://github.com/papis/papis/commit/0e3ffff4bd1b62cdf0a9fdc7f54d6a2e2ab90082.patch?full_index=1";
-      hash = "sha256-KUw5U5izTTWqXHzGWLibtqHWAsVxla6SA8x6SJ07/zU=";
-    })
-  ];
-
   meta = {
     description = "Powerful command-line document and bibliography manager";
     mainProgram = "papis";
     homepage = "https://papis.readthedocs.io/";
-    changelog = "https://github.com/papis/papis/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/papis/papis/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       nico202
       teto
     ];
   };
-}
+})

--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch2,
+  pythonAtLeast,
 
   # build-system
   hatchling,


### PR DESCRIPTION
## Things done

- **python3Packages.papis: cleanup**
- **python3Packages.papis: disable on python>=3.14**
- **python3Packages.isbnlib: cleanup**
- **python3Packages.isbnlib: skip failing test on python>=3.14**

cc @nico202 @teto

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
