### PR TITLE
nixos/kde-pim: include akonadi-contacts for merkuro contacts widget

### DIFF
--- a/nixos/modules/programs/kde-pim.nix
+++ b/nixos/modules/programs/kde-pim.nix
@@ -40,6 +40,7 @@ in
         # Only needed when using the Merkuro Contacts widget in Plasma.
         ++ lib.optionals config.services.desktopManager.plasma6.enable [
           kcontacts
+          akonadi-contacts
         ]
       );
   };


### PR DESCRIPTION
With Merkuro on Plasma 6, the Contacts widget requires `kdePackages.akonadi-contacts` in order to fix the issue described in [#403952](https://github.com/NixOS/nixpkgs/issues/403952#issuecomment-2848832870), where the contacts show up as a list of URLs that crash plasmashell when interacted with. I'm not sure if the issue is something that only occurs while using a CardDAV server, but in any case, this fixes the issue and makes contacts show up as intended.

Also related to #406220.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
