### PR TITLE
 libbluray: use minimal jdk 

### DIFF
--- a/pkgs/by-name/li/libbluray/package.nix
+++ b/pkgs/by-name/li/libbluray/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  callPackage,
   stdenv,
   fetchurl,
   pkg-config,
@@ -71,18 +70,18 @@ stdenv.mkDerivation rec {
     ++ lib.optional (!withMetadata) "-dlibxml2=disabled"
     ++ lib.optional (!withFonts) "-Dfreetype=disabled";
 
+  passthru = {
+    tests = {
+      # Verify the "full" package when verifying changes to this package
+      inherit libbluray-full;
+    };
+  };
+
   meta = {
     homepage = "http://www.videolan.org/developers/libbluray.html";
     description = "Library to access Blu-Ray disks for video playback";
     license = lib.licenses.lgpl21;
     maintainers = [ lib.maintainers.amarshall ];
     platforms = lib.platforms.unix;
-  };
-
-  passthru = {
-    tests = {
-      # Verify the "full" package when verifying changes to this package
-      inherit libbluray-full;
-    };
   };
 }

--- a/pkgs/by-name/li/libbluray/package.nix
+++ b/pkgs/by-name/li/libbluray/package.nix
@@ -7,7 +7,8 @@
   meson,
   ninja,
   withJava ? false,
-  jdk21, # Newer JDK's depend on a release with a fix for https://code.videolan.org/videolan/libbluray/-/issues/46
+  jdk21_headless,
+  jre21_minimal, # Newer JDK's depend on a release with a fix for https://code.videolan.org/videolan/libbluray/-/issues/46
   ant,
   stripJavaArchivesHook,
   withAACS ? false,
@@ -24,6 +25,18 @@
 # Info on how to use:
 # https://wiki.archlinux.org/index.php/BluRay
 
+let
+  jre = jre21_minimal.override {
+    modules = [
+      "java.base"
+      "java.datatransfer"
+      "java.desktop"
+      "java.rmi"
+      "java.xml"
+    ];
+    jdk = jdk21_headless;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "libbluray";
   version = "1.4.0";
@@ -47,7 +60,7 @@ stdenv.mkDerivation rec {
     pkg-config
   ]
   ++ lib.optionals withJava [
-    jdk21
+    jdk21_headless
     ant
     stripJavaArchivesHook
   ];
@@ -66,7 +79,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags =
     lib.optional (!withJava) "-Dbdj_jar=disabled"
-    ++ lib.optional withJava "-Djdk_home=${jdk21.home}"
+    ++ lib.optional withJava "-Djdk_home=${jre.home}"
     ++ lib.optional (!withMetadata) "-dlibxml2=disabled"
     ++ lib.optional (!withFonts) "-Dfreetype=disabled";
 


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
