### PR TITLE
poezio: 0.14 -> 0.15.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22292,7 +22292,7 @@
     name = "Rexx Larsson";
   };
   reylak = {
-    name = "Joaquin Lopez";
+    name = "Reylak";
     email = "elreylak@proton.me";
     github = "Reylak-dev";
     githubId = 178049808;

--- a/pkgs/by-name/po/poezio/package.nix
+++ b/pkgs/by-name/po/poezio/package.nix
@@ -1,21 +1,20 @@
 {
   lib,
-  fetchFromGitea,
+  fetchFromCodeberg,
   pkg-config,
   python3,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finallAttrs {
   pname = "poezio";
-  version = "0.14";
+  version = "0.15.1";
   pyproject = true;
 
-  src = fetchFromGitea {
-    domain = "codeberg.org";
+  src = fetchFromCodeberg {
     owner = "poezio";
     repo = "poezio";
-    rev = "v${version}";
-    hash = "sha256-sk+8r+a0CcoB0RidqnE7hJUgt/xvN/MCJMkxiquvdJc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-v9PpPghHf0Yi5JpK98+i2EAmohSXOhUyhY+duhICtnY=";
   };
 
   nativeBuildInputs = [ pkg-config ];
@@ -23,16 +22,13 @@ python3.pkgs.buildPythonApplication rec {
 
   dependencies = with python3.pkgs; [
     aiodns
-    cffi
-    mpd2
-    potr
     pyasn1
     pyasn1-modules
     pycares
     pyinotify
     setuptools
     slixmpp
-    typing-extensions
+    sphinx
   ];
 
   nativeCheckInputs = with python3.pkgs; [
@@ -51,7 +47,8 @@ python3.pkgs.buildPythonApplication rec {
   meta = {
     description = "Free console XMPP client";
     homepage = "https://poez.io";
-    changelog = "https://codeberg.org/poezio/poezio/src/tag/v${version}/CHANGELOG";
+    changelog = "https://codeberg.org/poezio/poezio/src/tag/${src.tag}/CHANGELOG";
     license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ reylak ];
   };
-}
+})


### PR DESCRIPTION
Updated poezio from the v0.14 to 0.15.1
also i plan to add an override to install the omemo plugin

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
