### PR TITLE
linuxPackages.*: Drop unneeded NIX_CFLAGS_COMPILE usage

### DIFF
--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -22,9 +22,6 @@ stdenv.mkDerivation {
     sed 's/depmod /true /' -i Makefile
   '';
 
-  # Fix build on Linux kernel >= 5.18
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=implicit-fallthrough" ];
-
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
   makeFlags = kernelModuleMakeFlags ++ [

--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -21,8 +21,6 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-
   makeFlags = kernelModuleMakeFlags ++ [
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=${placeholder "out"}"

--- a/pkgs/os-specific/linux/nvidia-x11/open.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/open.nix
@@ -10,52 +10,50 @@
   broken ? false,
 }:
 
-stdenv.mkDerivation (
-  {
-    pname = "nvidia-open";
-    version = "${kernel.version}-${nvidia_x11.version}";
+stdenv.mkDerivation {
+  pname = "nvidia-open";
+  version = "${kernel.version}-${nvidia_x11.version}";
 
-    src = fetchFromGitHub {
-      owner = "NVIDIA";
-      repo = "open-gpu-kernel-modules";
-      rev = nvidia_x11.version;
-      inherit hash;
-    };
+  src = fetchFromGitHub {
+    owner = "NVIDIA";
+    repo = "open-gpu-kernel-modules";
+    rev = nvidia_x11.version;
+    inherit hash;
+  };
 
-    inherit patches;
+  inherit patches;
 
-    nativeBuildInputs = kernel.moduleBuildDependencies;
+  nativeBuildInputs = kernel.moduleBuildDependencies;
 
-    makeFlags =
-      kernelModuleMakeFlags
-      ++ [
-        "IGNORE_PREEMPT_RT_PRESENCE=1"
-        "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
-        "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-        "MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"
-        "DATE="
-        "TARGET_ARCH=${stdenv.hostPlatform.parsed.cpu.name}"
-      ]
-      ++ lib.optionals stdenv.cc.isClang [
-        "C_INCLUDE_PATH=${lib.getLib stdenv.cc.cc}/lib/clang/${lib.versions.major stdenv.cc.cc.version}/include"
-      ];
+  makeFlags =
+    kernelModuleMakeFlags
+    ++ [
+      "IGNORE_PREEMPT_RT_PRESENCE=1"
+      "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+      "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      "MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"
+      "DATE="
+      "TARGET_ARCH=${stdenv.hostPlatform.parsed.cpu.name}"
+    ]
+    ++ lib.optionals stdenv.cc.isClang [
+      "C_INCLUDE_PATH=${lib.getLib stdenv.cc.cc}/lib/clang/${lib.versions.major stdenv.cc.cc.version}/include"
+    ];
 
-    installTargets = [ "modules_install" ];
-    enableParallelBuilding = true;
+  installTargets = [ "modules_install" ];
+  enableParallelBuilding = true;
 
-    meta = {
-      description = "NVIDIA Linux Open GPU Kernel Module";
-      homepage = "https://github.com/NVIDIA/open-gpu-kernel-modules";
-      license = with lib.licenses; [
-        gpl2Plus
-        mit
-      ];
-      platforms = [
-        "x86_64-linux"
-        "aarch64-linux"
-      ];
-      maintainers = with lib.maintainers; [ nickcao ];
-      inherit broken;
-    };
-  }
-)
+  meta = {
+    description = "NVIDIA Linux Open GPU Kernel Module";
+    homepage = "https://github.com/NVIDIA/open-gpu-kernel-modules";
+    license = with lib.licenses; [
+      gpl2Plus
+      mit
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ nickcao ];
+    inherit broken;
+  };
+}

--- a/pkgs/os-specific/linux/nvidia-x11/open.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/open.nix
@@ -58,7 +58,4 @@ stdenv.mkDerivation (
       inherit broken;
     };
   }
-  // lib.optionalAttrs stdenv.hostPlatform.isAarch64 {
-    env.NIX_CFLAGS_COMPILE = "-fno-stack-protector";
-  }
 )

--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -22,8 +22,6 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "pic" ];
 
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
-
   prePatch = ''
     substituteInPlace ./Makefile \
       --replace /lib/modules/ "${kernel.dev}/lib/modules/" \


### PR DESCRIPTION
Due to #484935, the `NIX_CFLAGS_COMPILE` affordance in Nixpkgs does not work when combined with `kernelModuleMakeFlags`.

See: https://github.com/NixOS/nixpkgs/blame/f86e9fe549f551d6bb738a1d01efa7d61b2da3e7/pkgs/os-specific/linux/kernel/common-flags.nix#L10-L11

The `CC` variable ends-up clobbered with the unwrapped compiler, and the `NIX_CFLAGS_COMPILE` magic happens entirely in the wrapper.

Thankfully(?) this broke nothing(?), since apparently(?) all the modules using both `kernelModuleMakeFlags` and `NIX_CFLAGS_COMPILE` appears to be vestigial in all cases.

All cases but one are trivially shown to not be needed. Putting nonsense in `NIX_CFLAGS_COMPILE` leads to successful builds.

The `nvidia_*_open` situation is a tad different. There is still the `CXX` compiler that ends-up resolving to the *wrapped* variant. In turn, this means that ***the C++ compiler and C compiler invocations may use different flags***. Whether or not the flag (`-fno-stack-protector`) really is needed, having different flags is not good.

I believe the flag is not needed, as going back to its introduction in 2023 shows that removing it makes the build fail. Here, removing it and building it (via cross `pkgsCross.aarch64-multiplatform.linuxPackages.nvidia_x11_stable_open`) is still successful.

 - cc @NickCao for the NVIDIA driver
 - cc @bjornfor for lttng
 - cc @Lassulus for rtl8814au
 - cc @PuercoPop for digimend

> **NOTE**: Let's not discuss the underlying bug here. We're kinda lucky and can take this opportunity to drop those proven-vestigial `CFLAGS`.

Candidates for (non(?))-breakage were found using:

```
 $ grep -l 'NIX_CFLAGS_COMPILE' $(grep -RIil 'kernelModuleMakeFlags' *)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - [x] cross aarch64-linux for `nvidia_open` 
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
