### PR TITLE
nushellPlugins.bson: init at 26.1100.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20642,6 +20642,12 @@
     github = "philipwilk";
     githubId = 50517631;
   };
+  philocalyst = {
+    name = "Myles Wirth";
+    email = "milestheperson@posteo.net";
+    github = "philocalyst";
+    githubId = 114884788;
+  };
   philtaken = {
     email = "philipp.herzog@protonmail.com";
     github = "philtaken";

--- a/pkgs/by-name/nu/nushell-plugin-bson/package.nix
+++ b/pkgs/by-name/nu/nushell-plugin-bson/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  llvmPackages,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nu_plugin_bson";
+  version = "26.1100.0";
+
+  src = fetchFromGitHub {
+    owner = "Kissaki";
+    repo = "nu_plugin_bson";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3Uu2YF5fnNvRP4+9GpLYjzZt7lg0kCbBl4bk4l5rEuY=";
+  };
+
+  cargoHash = "sha256-iORPlIP9kDLlJkm09SZn2lO3bWcj/Q/g+dBd2CPWiOg=";
+
+  nativeBuildInputs = [
+    llvmPackages.libclang
+  ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  passthru.update-script = nix-update-script { };
+  meta = {
+    description = " Nushell plugin for BSON (Binary JSON) format `from bson` and `to bson`";
+    homepage = "https://github.com/Kissaki/nu_plugin_bson";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "nu_plugin_bson";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9192,6 +9192,7 @@ with pkgs;
 
   nushellPlugins = recurseIntoAttrs {
     gstat = callPackage ../by-name/nu/nushell-plugin-gstat/package.nix { };
+    bson = callPackage ../by-name/nu/nushell-plugin-bson/package.nix { };
     formats = callPackage ../by-name/nu/nushell-plugin-formats/package.nix { };
     polars = callPackage ../by-name/nu/nushell-plugin-polars/package.nix { };
     query = callPackage ../by-name/nu/nushell-plugin-query/package.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Added package for [nu_plugin_bson](https://github.com/Kissaki/nu_plugin_bson?rgh-link-date=2026-01-28T19%3A48%3A55Z)

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
