### PR TITLE
nushellPlugins.clipboard: init at 0.110.0

### DIFF
--- a/pkgs/by-name/nu/nushell-plugin-clipboard/package.nix
+++ b/pkgs/by-name/nu/nushell-plugin-clipboard/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nu_plugin_clipboard";
+  version = "0.110.0";
+
+  src = fetchFromGitHub {
+    owner = "fmotalleb";
+    repo = "nu_plugin_clipboard";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9SFQJJun/7Ze3+P4zNJu+U5VOjQiM5VfPieu+2fNIXA=";
+  };
+
+  cargoHash = "sha256-tJ+xxrQHvX2tk1CMSn1wL7VrnqA4znzaaBuD3oyrzx4=";
+
+  passthru.update-script = nix-update-script { };
+
+  meta = {
+    description = "A nushell plugin to copy text into clipboard or get text from it. supports json<->object/table conversion out of box";
+    homepage = "https://github.com/fmotalleb/nu_plugin_clipboard";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "nu_plugin_clipboard";
+    platforms = lib.platforms.unix ++ lib.platforms.windows;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9162,6 +9162,7 @@ with pkgs;
       inherit dbus;
     };
     skim = callPackage ../by-name/nu/nushell-plugin-skim/package.nix { };
+    clipboard = callPackage ../by-name/nu/nushell-plugin-clipboard/package.nix { };
     semver = callPackage ../by-name/nu/nushell-plugin-semver/package.nix { };
     hcl = callPackage ../by-name/nu/nushell-plugin-hcl/package.nix { };
     desktop_notifications =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Added package for [nu_plugin_clipboard](https://github.com/fmotalleb/nu_plugin_clipboard)

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
