### PR TITLE
python313Packages.tkinter: fix nix-shell usage

### DIFF
--- a/pkgs/development/python-modules/tkinter/default.nix
+++ b/pkgs/development/python-modules/tkinter/default.nix
@@ -20,12 +20,14 @@ buildPythonPackage {
   src = python.src;
 
   prePatch = ''
-    mkdir $NIX_BUILD_TOP/tkinter
+    python_src=$PWD
+    tkinter_src=$PWD/../tkinter
+    mkdir -p "$tkinter_src"
 
     # copy the module bits and pieces from the python source
-    cp -v  Modules/{_tkinter.c,tkinter.h} ../tkinter/
-    cp -rv Modules/clinic ../tkinter/
-    cp -rv Lib/tkinter ../tkinter/
+    cp -v  Modules/{_tkinter.c,tkinter.h} "$tkinter_src"
+    cp -rv Modules/clinic "$tkinter_src"
+    cp -rv Lib/tkinter "$tkinter_src"
 
     # install our custom pyproject.toml
     cp ${
@@ -33,11 +35,11 @@ buildPythonPackage {
         python_version = python.version;
         python_internal_dir = "${python}/include/${python.libPrefix}/internal";
       }
-    } $NIX_BUILD_TOP/tkinter/pyproject.toml
+    } "$tkinter_src"/pyproject.toml
 
   ''
   + lib.optionalString (pythonOlder "3.13") ''
-    substituteInPlace "$NIX_BUILD_TOP/tkinter/tkinter/tix.py" --replace-fail \
+    substituteInPlace "$tkinter_src/tkinter/tix.py" --replace-fail \
       "os.environ.get('TIX_LIBRARY')" \
       "os.environ.get('TIX_LIBRARY') or '${tclPackages.tix}/lib'"
   '';
@@ -46,7 +48,7 @@ buildPythonPackage {
   patches = lib.optional (pythonOlder "3.12") ./fix-ttk-notebook-test.patch;
 
   preConfigure = ''
-    pushd $NIX_BUILD_TOP/tkinter
+    cd "$tkinter_src"
   '';
 
   build-system = [ setuptools ];
@@ -72,7 +74,7 @@ buildPythonPackage {
   nativeCheckInputs = lib.optional stdenv.hostPlatform.isLinux xvfb-run;
 
   preCheck = ''
-    cd $NIX_BUILD_TOP/Python-*/Lib
+    cd "$python_src"/Lib
     export HOME=$TMPDIR
   '';
 


### PR DESCRIPTION
$NIX_BUILD_TOP was used inconsistently and the name of the Python source directory was assumed to have a certain pattern. These changes make the build work better in a nix-shell.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
