### PR TITLE
systemctl-tui: 0.4.1 -> 0.5.0

### DIFF
--- a/pkgs/by-name/sy/systemctl-tui/package.nix
+++ b/pkgs/by-name/sy/systemctl-tui/package.nix
@@ -8,17 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "systemctl-tui";
-  version = "0.4.1";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "rgwood";
     repo = "systemctl-tui";
-    # https://github.com/rgwood/systemctl-tui/issues/68#issuecomment-3735677971
-    tag = "v${finalAttrs.version}-take2";
-    hash = "sha256-6SN8c8gDVsvFFyrcFjdO70pJpVxWG/AbdB6V4mM5Q5Y=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qm5CcBry1Cls/neZz4Q4jdNjN3vr3pdV0X7KWW0qP70=";
   };
 
-  cargoHash = "sha256-4VlKJUxmxC1dIZYsUMLhNzOJTYacpddlKZUSwjKlzJ8=";
+  cargoHash = "sha256-0wR8AaGfIlsQbYzwCI4xEGZ+tu1ETHRJ8VlLT5shkOk=";
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/rgwood/systemctl-tui/compare/v0.4.1...v0.5.0
Changelog: https://github.com/rgwood/systemctl-tui/releases/tag/v0.5.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
