### PR TITLE
undetected-chromedriver: fix homepage metadata

### DIFF
--- a/pkgs/by-name/un/undetected-chromedriver/package.nix
+++ b/pkgs/by-name/un/undetected-chromedriver/package.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = chromedriver.meta // {
     description = "Custom Selenium ChromeDriver that passes all bot mitigation systems";
+    homepage = "https://github.com/ultrafunkamsterdam/undetected-chromedriver";
     mainProgram = "undetected-chromedriver";
     maintainers = [ ];
   };


### PR DESCRIPTION
## Summary

The package was inheriting `chromedriver.meta` without overriding `homepage`, causing it to point to Google's ChromeDriver documentation instead of the actual project repository.

## Changes

- Added `homepage = "https://github.com/ultrafunkamsterdam/undetected-chromedriver";` to the meta override block

## Test plan

- Verified the homepage URL is correct for the upstream project

cc @paveloom  @pbsds 