### PR TITLE
nixos/mpd: allow to explicitly close firewall without a warning

### DIFF
--- a/nixos/modules/services/audio/mpd.nix
+++ b/nixos/modules/services/audio/mpd.nix
@@ -143,9 +143,13 @@ in
       };
 
       openFirewall = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Open ports in the firewall for mpd.";
+        type = lib.types.nullOr lib.types.bool;
+        default = null;
+        description = ''
+          Open ports in the firewall for mpd. If `null` (default), you might
+          get a warning asking you to set it explicitly to `true` or `false`,
+          depending upon the value of `services.mpd.settings.bind_to_address`.
+        '';
       };
 
       settings = lib.mkOption {
@@ -378,9 +382,9 @@ in
             ])
             || (lib.hasPrefix "/" cfg.settings.bind_to_address)
           )
-          && !cfg.openFirewall
+          && (isNull cfg.openFirewall)
         )
-        "Using '${cfg.settings.bind_to_address}' as services.mpd.settings.bind_to_address without enabling services.mpd.openFirewall, might prevent you from accessing MPD from other clients.";
+        "Using '${cfg.settings.bind_to_address}' as services.mpd.settings.bind_to_address without enabling services.mpd.openFirewall, might prevent you from accessing MPD from other clients. To suppress this warning, set services.mpd.openFirewall explicitly to `false`";
 
     # install mpd units
     systemd.packages = [ pkgs.mpd ];
@@ -438,7 +442,9 @@ in
       };
     };
 
-    networking.firewall.allowedTCPPorts = lib.optionals cfg.openFirewall [ cfg.settings.port ];
+    networking.firewall.allowedTCPPorts = lib.optionals (
+      builtins.isBool cfg.openFirewall && cfg.openFirewall
+    ) [ cfg.settings.port ];
 
     users.users = lib.optionalAttrs (cfg.user == name) {
       ${name} = {


### PR DESCRIPTION
## Things done

- [x] Fixes #484912
- [x] Addresses the comments here: https://github.com/NixOS/nixpkgs/pull/456989#discussion_r2642740944
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
