### PR TITLE
hockeypuck: add NGI team

### DIFF
--- a/nixos/modules/services/security/hockeypuck.nix
+++ b/nixos/modules/services/security/hockeypuck.nix
@@ -10,7 +10,7 @@ let
   settingsFormat = pkgs.formats.toml { };
 in
 {
-  meta.maintainers = [ ];
+  meta.maintainers = lib.teams.ngi.members;
 
   options.services.hockeypuck = {
     enable = lib.mkEnableOption "Hockeypuck OpenPGP Key Server";

--- a/nixos/tests/hockeypuck.nix
+++ b/nixos/tests/hockeypuck.nix
@@ -25,7 +25,7 @@ let
 in
 {
   name = "hockeypuck";
-  meta.maintainers = [ ];
+  meta.maintainers = lib.teams.ngi.members;
 
   nodes.machine =
     { ... }:

--- a/pkgs/by-name/ho/hockeypuck-web/package.nix
+++ b/pkgs/by-name/ho/hockeypuck-web/package.nix
@@ -26,5 +26,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/hockeypuck/hockeypuck";
     license = lib.licenses.gpl3Plus;
     maintainers = [ ];
+    teams = with lib.teams; [ ngi ];
   };
 }

--- a/pkgs/by-name/ho/hockeypuck/package.nix
+++ b/pkgs/by-name/ho/hockeypuck/package.nix
@@ -7,13 +7,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "hockeypuck";
-  version = "2.1.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "hockeypuck";
     repo = "hockeypuck";
     rev = finalAttrs.version;
-    sha256 = "0da3ffbqck0dr7d89gy2yillp7g9a4ziyjlvrm8vgkkg2fs8dlb1";
+    sha256 = "sha256-ppWofGj1D2/tjtXt5LHzNcDPicKA4LKTxR1Mkl/oeHI=";
   };
 
   modRoot = "src/hockeypuck/";
@@ -27,5 +27,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/hockeypuck/hockeypuck";
     license = lib.licenses.agpl3Plus;
     maintainers = [ ];
+    teams = with lib.teams; [ ngi ];
   };
 })

--- a/pkgs/by-name/ho/hockeypuck/package.nix
+++ b/pkgs/by-name/ho/hockeypuck/package.nix
@@ -27,5 +27,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/hockeypuck/hockeypuck";
     license = lib.licenses.agpl3Plus;
     maintainers = [ ];
+    teams = with lib.teams; [ ngi ];
   };
 })


### PR DESCRIPTION
Adding the NGI team since this is an [NGI project](https://nlnet.nl/project/Hockeypuck/).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
