### PR TITLE
python3Packages.pyarrow: disable test_timezone_absent on Darwin

### DIFF
--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -111,6 +111,8 @@ buildPythonPackage rec {
     "pyarrow/tests/test_cpp_internals.py::test_pyarrow_include"
     # Searches for TZDATA in /usr.
     "pyarrow/tests/test_orc.py::test_example_using_json"
+    # TZDIR handling differs on Darwin; test assumes /usr/share/zoneinfo
+    "pyarrow/tests/test_orc.py::test_timezone_absent"
     # AssertionError: assert 'Europe/Monaco' == 'Europe/Paris'
     "pyarrow/tests/test_types.py::test_dateutil_tzinfo_to_string"
     # These fail with xxx_fixture not found.


### PR DESCRIPTION
TZDIR handling differs on Darwin; test assumes /usr/share/zoneinfo fallback which doesn't apply on macOS.

Disable `test_timezone_absent` test on Darwin.

The test sets `TZDIR` to an empty directory expecting pyarrow to fail when reading ORC files with
timezone info. On Darwin, the system falls back to other timezone sources
(`/var/db/timezone/zoneinfo/` or ICU), so no exception is raised:

FAILED pyarrow/tests/test_orc.py::test_timezone_absent
AssertionError: Should have raised exception

Fixes #483241 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
