### PR TITLE
magic-vlsi: Fix hash

### DIFF
--- a/pkgs/by-name/ma/magic-vlsi/package.nix
+++ b/pkgs/by-name/ma/magic-vlsi/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "RTimothyEdwards";
     repo = "magic";
     tag = finalAttrs.version;
-    hash = "sha256-5Mh2KUvtBOSab3s/Co/hWjKU4SQmY5UxWfrqqDz3q6c=";
+    hash = "sha256-o9x29CDOtSQpQvTach6RaTJxRd2iTjyYi94ZjffUxVI=";
     leaveDotGit = true;
   };
 


### PR DESCRIPTION
Somehow a wrong hash value slipped through.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
