### PR TITLE
auto-patchelf: Fix ignore-missing for dlopen with multiple sonames

### DIFF
--- a/pkgs/by-name/au/auto-patchelf/package.nix
+++ b/pkgs/by-name/au/auto-patchelf/package.nix
@@ -11,7 +11,7 @@ in
 # Note: Not using python3Packages.buildPythonApplication because of dependency propagation.
 stdenv.mkDerivation {
   pname = "auto-patchelf";
-  version = "0-unstable-2024-08-14";
+  version = "0-unstable-2026-01-29";
 
   buildInputs = [ pythonEnv ];
 

--- a/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
+++ b/pkgs/by-name/au/auto-patchelf/source/auto-patchelf.py
@@ -268,15 +268,28 @@ class IgnoredDependency:
 @dataclass
 class Dependency:
     file: Path                          # The file that contains the dependency
-    name: Path                          # The name of the dependency
-    found: bool = False                 # Whether it was found somewhere
+    candidates: list[Path]              # The list of possible dependency names
     location: Optional[Path] = None     # Where the dependency was found (if found)
 
+    def name(self) -> str:
+        if len(self.candidates) == 1:
+            return self.candidates[0].name
+        return f"any({", ".join(c.name for c in self.candidates)})"
+
+    def found(self) -> bool:
+        return self.location is not None
+
+    def matches(self, pattern: str) -> bool:
+        for candidate in self.candidates:
+            if fnmatch(candidate.name, pattern):
+                return True
+        return False
+
     def to_human_readable_str(self) -> str:
-        if self.found:
-            return f"    {self.name} -> found: {self.location}"
+        if self.found():
+            return f"    {self.name()} -> found: {self.location}"
         else:
-            return f"    {self.name} -> not found!"
+            return f"    {self.name()} -> not found!"
 
 
 @dataclass
@@ -361,9 +374,9 @@ def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], app
     # Be sure to get the output of all missing dependencies instead of
     # failing at the first one, because it's more useful when working
     # on a new package where you don't yet know the dependencies.
-    for dep in file_dependencies:
+    for candidates in file_dependencies:
         was_found = False
-        for candidate in dep:
+        for candidate in candidates:
 
             # This loop determines which candidate for a given
             # dependency can be found, and how. There may be multiple
@@ -402,7 +415,7 @@ def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], app
             elif found_dependency := find_dependency(candidate.name, file_arch, file_osabi):
                 origin_rpath_entry = find_first_matching_rpath_with_origin(path, found_dependency, existing_rpaths) if preserve_origin else None
                 rpath.append(origin_rpath_entry or found_dependency)
-                dep = Dependency(file=path, name=candidate, found=True, location=found_dependency)
+                dep = Dependency(file=path, candidates=candidates, location=found_dependency)
                 dependencies.append(dep)
                 logger.log(dep)
                 was_found = True
@@ -412,8 +425,7 @@ def auto_patchelf_file(logger: Logger, path: Path, runtime_deps: list[Path], app
                 break
 
         if not was_found:
-            dep_name = dep[0] if len(dep) == 1 else f"any({', '.join(map(str, dep))})"
-            dep = Dependency(file=path, name=dep_name, found=False, location=None)
+            dep = Dependency(file=path, candidates=candidates, location=None)
             dependencies.append(dep)
             logger.log(dep)
 
@@ -465,18 +477,18 @@ def auto_patchelf(
         if not path.is_symlink() and path.is_file():
             dependencies += auto_patchelf_file(logger, path, runtime_deps, append_rpaths, keep_libc, preserve_origin, extra_args)
 
-    missing = [dep for dep in dependencies if not dep.found]
+    missing = [dep for dep in dependencies if not dep.found()]
 
     # Print a summary of the missing dependencies at the end
     logger.debug(f"auto-patchelf: {len(missing)} dependencies could not be satisfied")
     failure = False
     for dep in missing:
         for pattern in ignore_missing:
-            if fnmatch(dep.name.name, pattern):
-                logger.log(IgnoredDependency(file=dep.file, name=dep.name, pattern=pattern))
+            if dep.matches(pattern):
+                logger.log(IgnoredDependency(file=dep.file, name=dep.name(), pattern=pattern))
                 break
         else:
-            logger.debug(f"error: auto-patchelf could not satisfy dependency {dep.name} wanted by {dep.file}")
+            logger.debug(f"error: auto-patchelf could not satisfy dependency {dep.name()} wanted by {dep.file}")
             failure = True
 
     if failure:


### PR DESCRIPTION
For context, I was trying to locally update the [terraria-server] package to 1.4.5.2 (the latest version). Turns out that the build of SDL3 in that pre-built binary switched to one that includes a `.note.dlopen` section for all the possible runtime dependencies (such as for X11, Wayland, Pulseaudio, etc.). This caused the `autoPatchelfHook` step to fail, since it didn't find the dependencies, but since this is for running a headless server, these dependencies don't end up being used, so I tried to add them to the ignore-missing list (`autoPatchelfIgnoreMissingDeps` in the nix config). This is when I encountered a bug in the script.

One of these missing dependencies gets printed as `any(libGL.so.1, libOpenGL.so.0)` in the console output, indicating that the note section lists both names as being valid. As soon as I put **anything** in the ignore-missing, the script throws an `AttributeError` when checking for an entry in `ignore-missing` that matches this dependency. This is because while both that check and the type annotation for `Dependency.name` expects the type `Path`, this case causes it to be set to a value of type `str`.

I was able to easily fix this by changing the type annotation to `str` and changing the cases where it's initialized to a `Path` value to instead assign it to the value of its `.name` attribute. This easily fixed the typing issue, and seems like a better fit for a "name" attribute. However, I also thought about how ignore-missing and these multi-soname entries should actually interact. Originally, I was thinking it would match the full "name" with the "any()" part (so something like `--ignore-missing "any(libGL.so.1, libOpenGL.so.0)"`. However, I realized that, with the way that the argument takes filenames with wildcards, it would be better to match against the individual names, and ignore it if any of the values in the ignore-missing list match any in the dependency's sonames list (so either `--ignore-missing "libGL.so.1"` or `--ignore-missing "libOpenGL.so.0"` would work). To facilitate this, I added another attribute to the `Dependency` class that contains a list of Paths that were either matched if `.found == True` (which always has a length of 1) or the list of all the candidates that could have matched but didn't if `.found == False`, with this being used for handling the ignore-missing list.

I also updated the version number in `package.nix` for this change. It looks like it hasn't been bumped for the past few changes, but I figure this is a change that *should* be done when the script is changed, so I did it here. Let me know if you'd rather I don't do that, and I can revert it.

[terraria-server]: https://github.com/NixOS/nixpkgs/blob/7d5ac2d0f8c739cfae8935e705914cf86e929c26/pkgs/by-name/te/terraria-server/package.nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
