### PR TITLE
_86Box{,-with-roms}: fix build

### DIFF
--- a/pkgs/by-name/_8/_86Box/package.nix
+++ b/pkgs/by-name/_8/_86Box/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   extra-cmake-modules,
   pkg-config,
@@ -49,7 +50,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-n68Ghhsv15TzpOMH4dBTNxa6AYwqN5s2C5pyO9VVaco=";
   };
 
-  patches = [ ./darwin.patch ];
+  patches = [
+    ./darwin.patch
+    # Fix build: Only make the fallthrough define available in C code
+    # https://github.com/86Box/86Box/issues/6607
+    (fetchpatch {
+      name = "fix-fallthrough-define-c-only.patch";
+      url = "https://github.com/86Box/86Box/commit/0092ce15de3efac108b961882f870a8c05e8c38f.patch";
+      hash = "sha256-DqjOtnyk6Zv9XHCLeuxD1wcLfvjGwGFvUWS0alXcchs=";
+    })
+  ];
 
   postPatch = ''
     substituteAllInPlace src/qt/qt_platform.cpp


### PR DESCRIPTION
The fix adds a patch from upstream that restricts the fallthrough macro definition to C code only (it was causing issues in C++ code). This addresses build failures reported in issue #484883

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
