### PR TITLE
go-task: 3.45.5 -> 3.48.0

### DIFF
--- a/pkgs/by-name/go/go-task/package.nix
+++ b/pkgs/by-name/go/go-task/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "go-task";
-  version = "3.45.5";
+  version = "3.48.0";
 
   src = fetchFromGitHub {
     owner = "go-task";
     repo = "task";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-YIsFADsGDgBR8TYrvhyz1DR1q6wZXDhjSsWi8DeijFA=";
+    hash = "sha256-t6u2SSPDh+zj8M5aJfP3mYgSgBMNDEMNhMWEkr86M0U=";
   };
 
-  vendorHash = "sha256-DQqz/GwV8SIsQsyF39Rzw+ojzhVw6Ih2j5utILEomV4=";
+  vendorHash = "sha256-v8OY4JkDaY8Xl20JvU8JbAXD43BaGrM5UmiJHnHaxek=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
## Summary
Updates go-task from version 3.45.5 to 3.48.0

## Changes
- Updated version to 3.48.0
- Updated source hash
- Updated vendorHash for Go dependencies

## Test plan
- Built package successfully with `nix-build -A go-task`
- Verified version output: `3.48.0`