### PR TITLE
ly & nixos/ly: add zacharyarnaise as maintainer

### DIFF
--- a/nixos/modules/services/display-managers/ly.nix
+++ b/nixos/modules/services/display-managers/ly.nix
@@ -166,5 +166,8 @@ in
     };
   };
 
-  meta.maintainers = with lib.maintainers; [ vonfry ];
+  meta.maintainers = with lib.maintainers; [
+    vonfry
+    zacharyarnaise
+  ];
 }

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -65,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.wtfpl;
     mainProgram = "ly";
     maintainers = with lib.maintainers; [
-      yiyu
       zacharyarnaise
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -64,7 +64,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://codeberg.org/fairyglade/ly";
     license = lib.licenses.wtfpl;
     mainProgram = "ly";
-    maintainers = with lib.maintainers; [ yiyu ];
+    maintainers = with lib.maintainers; [
+      yiyu
+      zacharyarnaise
+    ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
Having previously worked on ly module in https://github.com/NixOS/nixpkgs/pull/473013, I would like to help reviewing PRs and keep it up-to-date.
I'm also adding myself as an additional maintainer for the ly package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
