### PR TITLE
mcp-hub: init at v4.2.1

### DIFF
--- a/pkgs/by-name/mc/mcp-hub/package.nix
+++ b/pkgs/by-name/mc/mcp-hub/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+buildNpmPackage (finalAttrs: rec {
+  pname = "mcp-hub";
+  version = "4.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ravitemer";
+    repo = "mcp-hub";
+    rev = "v${version}";
+    hash = "sha256-KakvXZf0vjdqzyT+LsAKHEr4GLICGXPmxl1hZ3tI7Yg=";
+  };
+
+  npmDepsHash = "sha256-nyenuxsKRAL0PU/UPSJsz8ftHIF+LBTGdygTqxti38g=";
+
+  meta = {
+    description = "A centralized manager for Model Context Protocol (MCP) servers with dynamic server management and monitoring";
+    homepage = "https://github.com/ravitemer/mcp-hub";
+    changelog = "https://github.com/ravitemer/mcp-hub/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lampros ];
+    mainProgram = "mcp-hub";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION


Initialize `mcp-hub`

> A centralized manager for Model Context Protocol (MCP) servers with dynamic server management and monitoring

https://github.com/ravitemer/mcp-hub



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
