### PR TITLE
openssl_1_1: fix build after 3.0.19 patch update

### DIFF
--- a/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs-darwin.patch
+++ b/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs-darwin.patch
@@ -1,0 +1,13 @@
+diff --git a/include/internal/cryptlib.h b/include/internal/cryptlib.h
+index 329ef62..9a8df64 100644
+--- a/include/internal/cryptlib.h
++++ b/include/internal/cryptlib.h
+@@ -56,7 +56,7 @@ DEFINE_LHASH_OF(MEM);
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+ #  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_FILE          "/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
+ # else

--- a/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs.patch
+++ b/pkgs/development/libraries/openssl/1.1/use-etc-ssl-certs.patch
@@ -1,0 +1,13 @@
+diff --git a/include/internal/cryptlib.h b/include/internal/cryptlib.h
+index 329ef62..9a8df64 100644
+--- a/include/internal/cryptlib.h
++++ b/include/internal/cryptlib.h
+@@ -56,7 +56,7 @@ DEFINE_LHASH_OF(MEM);
+ # ifndef OPENSSL_SYS_VMS
+ #  define X509_CERT_AREA          OPENSSLDIR
+ #  define X509_CERT_DIR           OPENSSLDIR "/certs"
+-#  define X509_CERT_FILE          OPENSSLDIR "/cert.pem"
++#  define X509_CERT_FILE          "/etc/ssl/certs/ca-certificates.crt"
+ #  define X509_PRIVATE_DIR        OPENSSLDIR "/private"
+ #  define CTLOG_FILE              OPENSSLDIR "/ct_log_list.cnf"
+ # else

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -411,7 +411,7 @@ in
       ./1.1/nix-ssl-cert-file.patch
 
       (
-        if stdenv.hostPlatform.isDarwin then ./use-etc-ssl-certs-darwin.patch else ./use-etc-ssl-certs.patch
+        if stdenv.hostPlatform.isDarwin then ./1.1/use-etc-ssl-certs-darwin.patch else ./1.1/use-etc-ssl-certs.patch
       )
     ];
     withDocs = true;


### PR DESCRIPTION
**This is essentially a backport of https://github.com/NixOS/nixpkgs/pull/485055.**

## Things done

Restored working `openssl_1_1` that broke due to whitespace changes in patch. The patches are unchanged from the original ones (same blob hash), just in a different folder and no longer shared between OpenSSL 1.1 and 3.0.

Fails:

```
env NIXPKGS_ALLOW_INSECURE=1 nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-25.11.tar.gz -p openssl_1_1
```

Works (Tested on Linux and Mac OS):

```
env NIXPKGS_ALLOW_INSECURE=1 nix-shell -I nixpkgs=https://github.com/mbr/nixpkgs/archive/openssl_1_1-post-jan-27th-fix.tar.gz -p openssl_1_1
```

Closes #485027.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
