### PR TITLE
vkmark: fix build with vulkan-headers >= 1.4.333

### DIFF
--- a/pkgs/by-name/vk/vkmark/fix-build-with-newer-vulkan-headers.patch
+++ b/pkgs/by-name/vk/vkmark/fix-build-with-newer-vulkan-headers.patch
@@ -1,0 +1,73 @@
+From abc5fc8495692df968636c29f44719e0999a73b5 Mon Sep 17 00:00:00 2001
+From: Philipp Zabel <p.zabel@pengutronix.de>
+Date: Wed, 10 Dec 2025 10:59:49 +0100
+Subject: [PATCH 1/2] core: Register custom dispatcher with isDispatchLoader
+
+Since Vulkan 1.4.333, custom dispatch loaders must be registered
+with isDispatchLoader to be recognized.
+---
+ src/vulkan_state.cpp | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/src/vulkan_state.cpp b/src/vulkan_state.cpp
+index a36b2994dbba3e74cb1fb378e4dbb054157ae516..847095147bf5e050e558065623921ac3f06eb7e7 100644
+--- a/src/vulkan_state.cpp
++++ b/src/vulkan_state.cpp
+@@ -65,6 +65,18 @@ class DebugUtilsDispatcher
+ 
+ }
+ 
++#if VK_HEADER_VERSION >= 333
++namespace vk::detail {
++
++template <>
++struct isDispatchLoader<::DebugUtilsDispatcher>
++{
++    static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
++};
++
++}
++#endif
++
+ VulkanState::VulkanState(VulkanWSI& vulkan_wsi, ChoosePhysicalDeviceStrategy const& pd_strategy, bool debug)
+     : debug_enabled(debug)
+ {
+
+From ab3f3d709e2f93859b528b1ace56423675940290 Mon Sep 17 00:00:00 2001
+From: Philipp Zabel <p.zabel@pengutronix.de>
+Date: Wed, 10 Dec 2025 10:59:49 +0100
+Subject: [PATCH 2/2] kms: Register custom dispatcher with isDispatchLoader
+
+Since Vulkan 1.4.333, custom dispatch loaders must be registered
+with isDispatchLoader to be recognized.
+---
+ src/ws/kms_window_system.cpp | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/src/ws/kms_window_system.cpp b/src/ws/kms_window_system.cpp
+index 4bf7838cee0512925ef084b641de3c2a11389c6d..1bc04581eee233f33ad3ea7a719ec4c3894b1104 100644
+--- a/src/ws/kms_window_system.cpp
++++ b/src/ws/kms_window_system.cpp
+@@ -474,6 +474,22 @@ class GetFormatProperties2Dispatcher
+     PFN_vkGetPhysicalDeviceFormatProperties2KHR vkGetPhysicalDeviceFormatProperties2KHR;
+ };
+ 
++}
++
++#if VK_HEADER_VERSION >= 333
++namespace vk::detail {
++
++template <>
++struct isDispatchLoader<::GetFormatProperties2Dispatcher>
++{
++    static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
++};
++
++}
++#endif
++
++namespace {
++
+ std::vector<uint64_t> vk_get_supported_mods_for_format(VulkanState& vulkan,
+                                                        vk::Format format)
+ {

--- a/pkgs/by-name/vk/vkmark/package.nix
+++ b/pkgs/by-name/vk/vkmark/package.nix
@@ -28,6 +28,12 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-Rjpjqe7htwlhDdwELm74MvSzHzXLhRD/P8IES7nz/VY=";
   };
 
+  patches = [
+    # Fix build with vulkan-headers >= 1.4.333
+    # Remove once https://github.com/vkmark/vkmark/pull/80 is included in a release
+    ./fix-build-with-newer-vulkan-headers.patch
+  ];
+
   postPatch = ''
     substituteInPlace src/meson.build \
       --replace-fail "vulkan_dep.get_pkgconfig_variable('prefix')" "'${vulkan-headers}'"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

fixes https://github.com/NixOS/nixpkgs/issues/483387

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
