### PR TITLE
terraria-server: 1.4.5.0 -> 1.4.5.3

### DIFF
--- a/pkgs/by-name/te/terraria-server/package.nix
+++ b/pkgs/by-name/te/terraria-server/package.nix
@@ -10,12 +10,12 @@
 
 stdenv.mkDerivation rec {
   pname = "terraria-server";
-  version = "1.4.5.0";
+  version = "1.4.5.3";
   urlVersion = lib.replaceStrings [ "." ] [ "" ] version;
 
   src = fetchurl {
     url = "https://terraria.org/api/download/pc-dedicated-server/terraria-server-${urlVersion}.zip";
-    hash = "sha256-PRA7cCFL2WJlT5Bat24PSgs9rhLu4C2mu5zWbut3kdQ=";
+    hash = "sha256-5W6XpGaWQTs9lSy1UJq60YR6mfvb3LTts9ppK05XNCg=";
   };
 
   nativeBuildInputs = [
@@ -37,6 +37,45 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  # Starting with 1.4.5.1, the included build of SDL3 includes a .note.dlopen section,
+  # which lists all the possible runtime dependencies. Since this is a headless server,
+  # it doesn't actually need access to any of these libraries, but by default,
+  # autoPatchelfHook will result in a build error if it doesn't find them.
+  # This simply tells autoPatchelfHook to ignore these missing unused dependencies.
+  autoPatchelfIgnoreMissingDeps = [
+    "libusb-1.0.so.0"
+    "libGLESv1_CM.so.1"
+    "libGLES_CM.so.1"
+    "libGLESv2.so.2"
+    "libEGL.so.1"
+    "libGL.so.1"
+    "libasound.so.2"
+    "libjack.so.0"
+    "libpipewire-0.3.so.0"
+    "libpulse.so.0"
+    "libXtst.so.6"
+    "libXss.so.1"
+    "libXrandr.so.2"
+    "libXfixes.so.3"
+    "libXi.so.6"
+    "libXcursor.so.1"
+    "libXext.so.6"
+    "libX11.so.6"
+    "libX11-xcb.so.1"
+    "libvulkan.so.1"
+    "libdrm.so.2"
+    "libdecor-0.so.0"
+    "libxkbcommon.so.0"
+    "libwayland-cursor.so.0"
+    "libwayland-egl.so.1"
+    "libwayland-client.so.0"
+    "libfribidi.so.0"
+    "libthai.so.0"
+    "libdbus-1.so.3"
+    "libudev.so.1"
+    "libsteam_api.so"
+  ];
 
   meta = {
     homepage = "https://terraria.org";


### PR DESCRIPTION
This PR does not work as is, as it currently depends on another PR. The game is also getting a lot of rapid hotfixes, so it would probably be a good idea to wait for the updates to slow down before updating the package in nixpkgs. I'm making this PR now mostly for reference.

Starting with version 1.4.5.1, the builds changed the build of SDL3 included to one that includes a `.note.dlopen` section that lists all the potential runtime dependencies (such as for X11, Wayland, Pulseaudio, etc.), which causes build errors when `autoPatchelfHook` can't find the libraries. This *would* be a simple use-case for `autoPatchelfIgnoreMissingDeps`, but currently `auto-patchelf` has a bug that prevents that from working with dependencies with multiple potential names, which some of the entries in this SDL3 build has (such as for the OpenGL so). This PR assumes that the changes from #485011 are present, which fixes this bug.

If we want to get this working without that PR (eg. if we want to backport this, but not the script change, or if the other PR gets blocked from merging), then really the only options would be to either strip the `.note.dlopen` section from the so or replace the so entirely before the `autoPatchelfHook` runs. I'm not 100% sure which method would be best to go about that if we want to go that route, so I'd appreciate any advice on how to approach that if we want to go that route.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
