### PR TITLE
kanidm: remove unversioned alias and old versions

### DIFF
--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -238,8 +238,8 @@ in
     enablePam = mkEnableOption "the Kanidm PAM and NSS integration";
 
     package = mkPackageOption pkgs "kanidm" {
-      example = "kanidm_1_4";
-      extraDescription = "If not set will receive a specific version based on stateVersion. Set to `pkgs.kanidm` to always receive the latest version, with the understanding that this could introduce breaking changes.";
+      example = "kanidm_1_8";
+      extraDescription = "Must be set to an explicit version.";
     };
 
     serverSettings = mkOption {
@@ -873,16 +873,6 @@ in
           )
         )
       );
-
-    services.kanidm.package =
-      let
-        pkg =
-          if lib.versionAtLeast config.system.stateVersion "24.11" then
-            pkgs.kanidm_1_4
-          else
-            lib.warn "No default kanidm package found for stateVersion = '${config.system.stateVersion}'. Using unpinned version. Consider setting `services.kanidm.package = pkgs.kanidm_1_x` to avoid upgrades introducing breaking changes." pkgs.kanidm;
-      in
-      lib.mkDefault pkg;
 
     environment.systemPackages = mkIf cfg.enableClient [ cfg.package ];
 

--- a/nixos/modules/services/security/kanidm.nix
+++ b/nixos/modules/services/security/kanidm.nix
@@ -1070,6 +1070,7 @@ in
   };
 
   meta.maintainers = with lib.maintainers; [
+    adamcstephens
     Flakebi
     oddlama
   ];

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -18,7 +18,7 @@ in
   name = "kanidm-provisioning-${kanidmPackage.version}";
   meta.maintainers = with pkgs.lib.maintainers; [ oddlama ];
 
-  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidmWithSecretProvisioning_1_7;
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidmWithSecretProvisioning_1_8;
 
   nodes.provision =
     { pkgs, lib, ... }:

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -17,6 +17,7 @@ in
 {
   name = "kanidm-${kanidmPackage.version}";
   meta.maintainers = with pkgs.lib.maintainers; [
+    adamcstephens
     Flakebi
     oddlama
   ];

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -21,7 +21,7 @@ in
     oddlama
   ];
 
-  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidm_1_7;
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidm_1_8;
 
   nodes.server =
     { pkgs, ... }:

--- a/pkgs/servers/kanidm/1_5.nix
+++ b/pkgs/servers/kanidm/1_5.nix
@@ -1,6 +1,0 @@
-import ./generic.nix {
-  version = "1.5.0";
-  hash = "sha256-swrqyjA7Wgq17vd+753LDFcXrSFixVNLhTvj1bhG3DU=";
-  cargoHash = "sha256-72IwS8Nk1y6xDH9y8JW2LpbhFWaq0tpORx7JQSCF5/M=";
-  unsupported = true;
-}

--- a/pkgs/servers/kanidm/1_6.nix
+++ b/pkgs/servers/kanidm/1_6.nix
@@ -1,6 +1,0 @@
-import ./generic.nix {
-  version = "1.6.4";
-  hash = "sha256-ui3w1HDHXHARsjQ3WtJfZbM7Xgg3ODnUneXJMQwaOMw=";
-  cargoHash = "sha256-KJGELBzScwsLd6g3GR9Vk0nfDU2EjZBfXwlXJ+bZb1k=";
-  unsupported = true;
-}

--- a/pkgs/servers/kanidm/1_7.nix
+++ b/pkgs/servers/kanidm/1_7.nix
@@ -2,5 +2,5 @@ import ./generic.nix {
   version = "1.7.4";
   hash = "sha256-nWwwcRmCfKJECYN/5w30W3sDu9BqIGonF4ke8F04x3E=";
   cargoHash = "sha256-h5jeQxvYzHRVfNYYh9qKukE4h4nhDyuRou2xuZq4AdM=";
-  eolDate = "2025-12-12";
+  unsupported = true;
 }

--- a/pkgs/servers/kanidm/README.md
+++ b/pkgs/servers/kanidm/README.md
@@ -20,12 +20,8 @@ For example, when upgrading from 1.4 -> 1.5
 1. Update `1_5.nix` hashes/paths, and as needed for upstream changes, `generic.nix`
 1. Update `all-packages.nix` to add `kanidm_1_5` and `kanidmWithSecretProvisioning_1_5`, leave default
 1. Update the previous release, e.g. `1_4.nix` and set `eolDate = "YYYY-MM-DD"` where the date is 30 days from release of 1.5.
+1. Update default in `nixos/tests/kanidm.nix` and `nixos/tests/kanidm-provisioning.nix`
 1. Create commit, `kanidm_1_5: init at 1.5.0` - this is the only commit that will be backported
-
-### Update default
-
-1. Update kanidm aliases in `aliases.nix`. Should remove completely after 25.11 branch off.
-1. Create commit `kanidm: update default to 1.5.0`
 
 ### Backport to stable
 
@@ -41,5 +37,5 @@ Kanidm versions are supported for 30 days after the release of new versions. Fol
 
 1. Remove the third oldest release from `all-packages.nix`, e.g. 1.3.x continuing the example. Remove `kanidm_1_3` and `kanidmWithSecretProvisioning_1_3`
 1. Update `pkgs/top-level/release.nix` and remove `kanidm_1_3*` from `permittedInsecurePackages`
-1. Update `pkgs/top-level/aliases.nix` and add `kanidm_1_4` and `kanidmWithSecretProvisioning_1_4-1.4.6`
+1. Update `pkgs/top-level/aliases.nix` and add `kanidm_1_4` and `kanidmWithSecretProvisioning_1_4`
 1. Remove `pkgs/by-name/ka/kanidm/1_3.nix`

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -884,10 +884,14 @@ mapAliases {
   k3s_1_30 = throw "'k3s_1_30' has been removed from nixpkgs as it has reached end of life"; # Added 2025-09-01
   k3s_1_31 = throw "'k3s_1_31' has been removed from nixpkgs as it has reached end of life"; # Added 2025-12-08
   kak-lsp = throw "'kak-lsp' has been renamed to/replaced by 'kakoune-lsp'"; # Converted to throw 2025-10-27
-  kanidm = warnAlias "'kanidm' will be removed before 26.05. You must use a versioned package, e.g. 'kanidm_1_x'." kanidm_1_7; # Added 2025-09-01
+  kanidm = throw "'kanidm' alias has been removed. You must use a versioned package, e.g. 'kanidm_1_x'."; # Added 2026-01-29
   kanidm_1_4 = throw "'kanidm_1_4' has been removed as it has reached end of life"; # Added 2025-06-18
+  kanidm_1_5 = throw "'kanidm_1_5' has been removed as it has reached end of life"; # Added 2026-01-29
+  kanidm_1_6 = throw "'kanidm_1_6' has been removed as it has reached end of life"; # Added 2026-01-29
   kanidmWithSecretProvisioning = warnAlias "'kanidmWithSecretProvisioning' will be removed before 26.05. You must use a versioned package, e.g. 'kanidmWithSecretProvisioning_1_x'." kanidmWithSecretProvisioning_1_7; # Added 2025-09-01
   kanidmWithSecretProvisioning_1_4 = throw "'kanidmWithSecretProvisioning_1_4' has been removed as it has reached end of life"; # Added 2025-06-18
+  kanidmWithSecretProvisioning_1_5 = throw "'kanidmWithSecretProvisioning_1_5' has been removed as it has reached end of life"; # Added 2026-01-29
+  kanidmWithSecretProvisioning_1_6 = throw "'kanidmWithSecretProvisioning_1_6' has been removed as it has reached end of life"; # Added 2026-01-29
   kapitano = throw "'kapitano' has been removed, as it is unmaintained upstream"; # Added 2025-10-29
   kbibtex = throw "'kbibtex' has been removed, as it is unmaintained upstream"; # Added 2025-08-30
   kcli = throw "kcli has been removed because it has been marked as broken since at least November 2024."; # Added 2025-09-28

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8542,12 +8542,6 @@ with pkgs;
 
   inherit
     ({
-      kanidm_1_5 = callPackage ../servers/kanidm/1_5.nix {
-        kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_5;
-      };
-      kanidm_1_6 = callPackage ../servers/kanidm/1_6.nix {
-        kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_6;
-      };
       kanidm_1_7 = callPackage ../servers/kanidm/1_7.nix {
         kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_7;
       };
@@ -8555,17 +8549,11 @@ with pkgs;
         kanidmWithSecretProvisioning = kanidmWithSecretProvisioning_1_8;
       };
 
-      kanidmWithSecretProvisioning_1_5 = kanidm_1_5.override { enableSecretProvisioning = true; };
-      kanidmWithSecretProvisioning_1_6 = kanidm_1_6.override { enableSecretProvisioning = true; };
       kanidmWithSecretProvisioning_1_7 = kanidm_1_7.override { enableSecretProvisioning = true; };
       kanidmWithSecretProvisioning_1_8 = kanidm_1_8.override { enableSecretProvisioning = true; };
     })
-    kanidm_1_5
-    kanidm_1_6
     kanidm_1_7
     kanidm_1_8
-    kanidmWithSecretProvisioning_1_5
-    kanidmWithSecretProvisioning_1_6
     kanidmWithSecretProvisioning_1_7
     kanidmWithSecretProvisioning_1_8
     ;

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -44,8 +44,8 @@
       # so users choosing to allow don't have to rebuild them every time.
       permittedInsecurePackages = [
         "olm-3.2.16" # see PR #347899
-        "kanidm_1_6-1.6.4"
-        "kanidmWithSecretProvisioning_1_6-1.6.4"
+        "kanidm_1_7-1.7.4"
+        "kanidmWithSecretProvisioning_1_7-1.7.4"
       ];
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Removed unversioned alias, 1.5.x, 1.6.x
- Marked 1.7.x unsupported
- Explicitly force users to set package for the module, as opposed to the implicit unavailable version.

Closes #476894

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
