### PR TITLE
vtsls: 0.2.9 -> 0.3.0 

### DIFF
--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -9,6 +9,8 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
+  vtsls,
+  runCommand,
 }:
 let
   pnpm' = pnpm_10.override { nodejs = nodejs_22; };
@@ -94,6 +96,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+
+    tests.smoke =
+      runCommand "vtsls-smoke-test"
+        {
+        }
+        ''
+          INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":"file:///tmp","workspaceFolders":[{"uri":"file:///tmp","name":"test"}],"capabilities":{}}}'
+          CONTENT_LENGTH=''${#INIT_REQUEST}
+
+          RESPONSE=$(
+            {
+              printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST"
+              sleep 1
+            } | timeout 3  ${lib.getExe vtsls} --stdio 2>&1 | head -c 1000
+          ) || true
+
+          echo "$RESPONSE" | grep -q '"capabilities"'
+          touch $out
+        '';
   };
 
   meta = {

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -5,23 +5,23 @@
   nodejs_22,
   gitMinimal,
   gitSetupHook,
-  pnpm_8,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
 }:
 let
-  pnpm' = pnpm_8.override { nodejs = nodejs_22; };
+  pnpm' = pnpm_10.override { nodejs = nodejs_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vtsls";
-  version = "0.2.9";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "yioneko";
     repo = "vtsls";
     tag = "server-v${finalAttrs.version}";
-    hash = "sha256-vlw84nigvQqRB9OQBxOmrR9CClU9M4dNgF/nrvGN+sk=";
+    hash = "sha256-RuxaT3u9OOUMbDN6A2biIeUC+Z4leELF3OhKXxmCqbM=";
     fetchSubmodules = true;
   };
 
@@ -36,7 +36,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ nodejs_22 ];
 
-  pnpmWorkspaces = [ "@vtsls/language-server" ];
+  pnpmWorkspaces = [
+    "@vtsls/language-server"
+    "@vtsls/language-service"
+    "@vtsls/vscode-fuzzy"
+  ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -46,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
       version
       ;
     pnpm = pnpm';
-    fetcherVersion = 1;
-    hash = "sha256-SdqeTYRH60CyU522+nBo0uCDnzxDP48eWBAtGTL/pqg=";
+    fetcherVersion = 3;
+    hash = "sha256-CWTI8uGfrUFgry3NZ9wPgmdg3yYz4SBu7wvVnR+kS6I=";
   };
 
   # Patches to get submodule sha from file instead of 'git submodule status'

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -9,6 +9,8 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
+  vtsls,
+  runCommand,
 }:
 let
   pnpm' = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
@@ -94,6 +96,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     updateScript = nix-update-script { };
+
+    tests.smoke =
+      runCommand "vtsls-smoke-test"
+        {
+        }
+        ''
+          INIT_REQUEST='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"processId":null,"rootUri":"file:///tmp","workspaceFolders":[{"uri":"file:///tmp","name":"test"}],"capabilities":{}}}'
+          CONTENT_LENGTH=''${#INIT_REQUEST}
+
+          RESPONSE=$(
+            {
+              printf "Content-Length: %d\r\n\r\n%s" "$CONTENT_LENGTH" "$INIT_REQUEST"
+              sleep 1
+            } | timeout 3  ${lib.getExe vtsls} --stdio 2>&1 | head -c 1000
+          ) || true
+
+          echo "$RESPONSE" | grep -q '"capabilities"'
+          touch $out
+        '';
   };
 
   meta = {

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -5,23 +5,23 @@
   nodejs-slim_22,
   gitMinimal,
   gitSetupHook,
-  pnpm_8,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   nix-update-script,
 }:
 let
-  pnpm' = pnpm_8.override { nodejs-slim = nodejs-slim_22; };
+  pnpm' = pnpm_11.override { nodejs-slim = nodejs-slim_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "vtsls";
-  version = "0.2.9";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "yioneko";
     repo = "vtsls";
     tag = "server-v${finalAttrs.version}";
-    hash = "sha256-vlw84nigvQqRB9OQBxOmrR9CClU9M4dNgF/nrvGN+sk=";
+    hash = "sha256-RuxaT3u9OOUMbDN6A2biIeUC+Z4leELF3OhKXxmCqbM=";
     fetchSubmodules = true;
   };
 
@@ -36,7 +36,11 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ nodejs-slim_22 ];
 
-  pnpmWorkspaces = [ "@vtsls/language-server" ];
+  pnpmWorkspaces = [
+    "@vtsls/language-server"
+    "@vtsls/language-service"
+    "@vtsls/vscode-fuzzy"
+  ];
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs)
@@ -46,8 +50,8 @@ stdenv.mkDerivation (finalAttrs: {
       version
       ;
     pnpm = pnpm';
-    fetcherVersion = 3;
-    hash = "sha256-1P2ph8ZX6/KptkLP4wk0dZzuvnYCLOWorM1b9+otKsE=";
+    fetcherVersion = 4;
+    hash = "sha256-jYh79MtcfW/p6twuDM1JDwukSnn2/TJQYvHBlut0QnE=";
   };
 
   # Patches to get submodule sha from file instead of 'git submodule status'


### PR DESCRIPTION
Update to latest version and enable building 0.3.0.

Add smoke test to verify LSP initialization works.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
