### PR TITLE
turbo-unwrapped: 2.7.6 -> 2.8.12

### DIFF
--- a/pkgs/by-name/tu/turbo-unwrapped/package.nix
+++ b/pkgs/by-name/tu/turbo-unwrapped/package.nix
@@ -18,16 +18,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "turbo-unwrapped";
-  version = "2.7.6";
+  version = "2.8.12";
 
   src = fetchFromGitHub {
     owner = "vercel";
     repo = "turborepo";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-skpTDC27F2S+rKB+24+I1OxgDX6AmdI9QwnUAr0Ps4o=";
+    hash = "sha256-qVkKv3Odpx2KRVPztGhr+8AhxpYRmCF5XRCew957yJA=";
   };
 
-  cargoHash = "sha256-47ATXzlArTT+QsQvCQ7AfnFOXxTbPfXqmMS3zIimkEc=";
+  cargoHash = "sha256-P6lujI0NCfmcJfa1Lw4xyzbP5jzQD5Ghyjhp8s3JpjY=";
 
   nativeBuildInputs = [
     capnproto


### PR DESCRIPTION
Closes: #494026

Changelogs: 
- https://github.com/vercel/turborepo/releases/tag/v2.8.0
- https://github.com/vercel/turborepo/releases/tag/v2.8.1
- https://github.com/vercel/turborepo/releases/tag/v2.8.2
- https://github.com/vercel/turborepo/releases/tag/v2.8.3
- https://github.com/vercel/turborepo/releases/tag/v2.8.4
- https://github.com/vercel/turborepo/releases/tag/v2.8.5
- https://github.com/vercel/turborepo/releases/tag/v2.8.6
- https://github.com/vercel/turborepo/releases/tag/v2.8.7
- https://github.com/vercel/turborepo/releases/tag/v2.8.8
- https://github.com/vercel/turborepo/releases/tag/v2.8.9
- https://github.com/vercel/turborepo/releases/tag/v2.8.10
- https://github.com/vercel/turborepo/releases/tag/v2.8.11
- https://github.com/vercel/turborepo/releases/tag/v2.8.12

Diff: https://github.com/vercel/turborepo/compare/v2.7.6...v2.8.12

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
