### PR TITLE
llama-cpp, stable-diffusion-cpp: split outputs to avoid conflict

### DIFF
--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -76,6 +76,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp";
   version = "7772";
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   src = fetchFromGitHub {
     owner = "ggml-org";
     repo = "llama.cpp";

--- a/pkgs/by-name/st/stable-diffusion-cpp/package.nix
+++ b/pkgs/by-name/st/stable-diffusion-cpp/package.nix
@@ -44,6 +44,11 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "stable-diffusion-cpp";
   version = "master-475-2efd199";
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   src = fetchFromGitHub {
     owner = "leejet";
     repo = "stable-diffusion.cpp";


### PR DESCRIPTION
```
pkgs.buildEnv error: two given paths contain a conflicting subpath:
`/nix/store/a9045qkcl65szaqihv7gc38r6dl7xb0d-stable-diffusion-cpp-master-475-2efd199/lib/cmake/ggml/ggml-config.cmake' and
`/nix/store/wi968p3hcvjhqqz0yr4hpdd3qabr2jh5-llama-cpp-7772/lib/cmake/ggml/ggml-config.cmake'
```

Probably it would be ideal to consume the separate ggml pkg instead of building vendored, but that would need more work and testing, and this change is reasonable anyway. However, it may also make sense to just remove these files from the output entirely since ggml is packaged already?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
