### PR TITLE
jetbrains.*-oss: updater: handle error on unreleased source versions

### DIFF
--- a/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/fetcher.py
+++ b/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/fetcher.py
@@ -1,3 +1,5 @@
+import sys
+
 import dataclasses
 from urllib import request
 from urllib.error import HTTPError
@@ -43,13 +45,17 @@ class VersionFetcher:
         self, ide: Ide, ignore_no_url_error=False
     ) -> VersionInfo | None:
         if ide.update_info is None:
-            print(f"[!] no update info for {ide.name} in `updateInfo.json` - skipping!")
+            print(
+                f"[!] no update info for {ide.name} in `updateInfo.json` - skipping!",
+                file=sys.stderr,
+            )
             return None
         channel_name = ide.update_info["channel"]
         channel = self.channels.get(channel_name)
         if channel is None:
             print(
-                f"[!] failed to find IDE channel {channel_name} - skipping! check {ide.name}'s `channel`!"
+                f"[!] failed to find IDE channel {channel_name} - skipping! check {ide.name}'s `channel`!",
+                file=sys.stderr,
             )
             return None
         try:
@@ -73,7 +79,8 @@ class VersionFetcher:
                 )
                 if not download_url and not ignore_no_url_error:
                     print(
-                        f"[!] no valid URL found for '{ide.name}' for '{system}'! make sure `updater/updateInfo.json` contains an entry and is correct."
+                        f"[!] no valid URL found for '{ide.name}' for '{system}'! make sure `updater/updateInfo.json` contains an entry and is correct.",
+                        file=sys.stderr,
                     )
                     download_urls[system] = None
                 else:
@@ -84,7 +91,10 @@ class VersionFetcher:
                 urls=download_urls,
             )
         except Exception as e:
-            print(f"[!] exception while trying to fetch version: {e} - skipping!")
+            print(
+                f"[!] exception while trying to fetch version: {e} - skipping!",
+                file=sys.stderr,
+            )
             return None
 
     @classmethod

--- a/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_bin.py
+++ b/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_bin.py
@@ -1,10 +1,12 @@
+import sys
+
 from jetbrains_nix_updater.config import UpdaterConfig
 from jetbrains_nix_updater.fetcher import VersionInfo
 from jetbrains_nix_updater.ides import Ide
 from jetbrains_nix_updater.util import replace_blocks, convert_hash_to_sri
 
 
-def run_bin_update(ide: Ide, info: VersionInfo, config: UpdaterConfig):
+def run_bin_update(ide: Ide, info: VersionInfo, config: UpdaterConfig) -> bool:
     urls_nix = ""
     for system, url in info.urls.items():
         urls_nix += f"""
@@ -33,5 +35,7 @@ def run_bin_update(ide: Ide, info: VersionInfo, config: UpdaterConfig):
                 ),
             ],
         )
+        return True
     except Exception as e:
-        print(f"[!] Writing update info to file failed: {e}")
+        print(f"[!] Writing update info to file failed: {e}", file=sys.stderr)
+        return False

--- a/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_src.py
+++ b/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_src.py
@@ -2,6 +2,7 @@ import json
 import re
 from pathlib import Path
 from xmltodict import parse
+from subprocess import CalledProcessError
 
 from jetbrains_nix_updater.config import UpdaterConfig
 from jetbrains_nix_updater.fetcher import VersionInfo
@@ -151,8 +152,17 @@ def maven_out_path(jb_root: Path, name: str) -> Path:
 
 def run_src_update(ide: Ide, info: VersionInfo, config: UpdaterConfig):
     variant = ide.name.removesuffix("-oss")
-    intellij_hash, intellij_outpath = prefetch_intellij_community(variant, info.version)
-    android_hash = prefetch_android(variant, info.version)
+    try:
+        intellij_hash, intellij_outpath = prefetch_intellij_community(variant, info.version)
+        android_hash = prefetch_android(variant, info.version)
+    except CalledProcessError:
+        print(
+            f"[!] Unable to fetch sources for version {info.version}. "
+            f"This probably means, that JetBrains has not published a source release yet for this version. "
+            f"Check: https://github.com/JetBrains/intellij-community/releases and https://github.com/JetBrains/android/tags"
+        )
+        print(f"[!] Skipping update of {ide.name}.")
+        return
     jps_hash = generate_jps_hash(config, intellij_outpath)
     restarter_hash = generate_restarter_hash(config, intellij_outpath)
     repositories = jar_repositories(intellij_outpath)

--- a/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_src.py
+++ b/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_src.py
@@ -1,3 +1,5 @@
+import sys
+
 import json
 import re
 from pathlib import Path
@@ -150,19 +152,22 @@ def maven_out_path(jb_root: Path, name: str) -> Path:
     return jb_root / "source" / f"{name}_maven_artefacts.json"
 
 
-def run_src_update(ide: Ide, info: VersionInfo, config: UpdaterConfig):
+def run_src_update(ide: Ide, info: VersionInfo, config: UpdaterConfig) -> bool:
     variant = ide.name.removesuffix("-oss")
     try:
-        intellij_hash, intellij_outpath = prefetch_intellij_community(variant, info.version)
+        intellij_hash, intellij_outpath = prefetch_intellij_community(
+            variant, info.version
+        )
         android_hash = prefetch_android(variant, info.version)
     except CalledProcessError:
         print(
             f"[!] Unable to fetch sources for version {info.version}. "
             f"This probably means, that JetBrains has not published a source release yet for this version. "
-            f"Check: https://github.com/JetBrains/intellij-community/releases and https://github.com/JetBrains/android/tags"
+            f"Check: https://github.com/JetBrains/intellij-community/releases and https://github.com/JetBrains/android/tags",
+            file=sys.stderr,
         )
-        print(f"[!] Skipping update of {ide.name}.")
-        return
+        print(f"[!] Skipping update of {ide.name}.", file=sys.stderr)
+        return False
     jps_hash = generate_jps_hash(config, intellij_outpath)
     restarter_hash = generate_restarter_hash(config, intellij_outpath)
     repositories = jar_repositories(intellij_outpath)
@@ -202,8 +207,8 @@ def run_src_update(ide: Ide, info: VersionInfo, config: UpdaterConfig):
             ],
         )
     except Exception as e:
-        print(f"[!] Writing update info to file failed: {e}")
-        return
+        print(f"[!] Writing update info to file failed: {e}", file=sys.stderr)
+        return False
 
     if not config.no_maven_deps:
         print("[*] Collecting maven hashes")
@@ -211,3 +216,4 @@ def run_src_update(ide: Ide, info: VersionInfo, config: UpdaterConfig):
         with open(maven_out_path(config.jetbrains_root, variant), "w") as f:
             json.dump(maven_hashes, f, indent=4)
             f.write("\n")
+    return True

--- a/pkgs/applications/editors/jetbrains/updater/main.py
+++ b/pkgs/applications/editors/jetbrains/updater/main.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i python3 -p python3 python3.pkgs.packaging python3.pkgs.xmltodict python3.pkgs.requests nurl
+import sys
+
 import argparse
 import json
 
@@ -54,12 +56,13 @@ def main():
     )
 
     print(f"[.] found IDEs to update: {', '.join(ide.name for ide in ides_to_run_for)}")
+    success = True
     for ide in ides_to_run_for:
         if ide.is_source and config.no_src:
-            print(f"[!] skipping {ide.name}, due to --no-src")
+            print(f"[!] skipping {ide.name}, due to --no-src", file=sys.stderr)
             continue
         if not ide.is_source and config.no_bin:
-            print(f"[!] skipping {ide.name}, due to --no-bin")
+            print(f"[!] skipping {ide.name}, due to --no-bin", file=sys.stderr)
             continue
 
         print(f"[@] updating IDE {ide.name}")
@@ -67,15 +70,18 @@ def main():
         info = version_fetcher.latest_version_info(
             ide, ignore_no_url_error=ide.is_source
         )
-        if info is not None:
+        if info is None:
+            success = False
+        else:
             if config.old_version == info.version:
                 print("[o] Version is the same, no update required")
                 return
 
             if ide.is_source:
-                run_src_update(ide, info, config)
+                success &= run_src_update(ide, info, config)
             else:
-                run_bin_update(ide, info, config)
+                success &= run_bin_update(ide, info, config)
+    exit(0 if success else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a small issue that happens right now, because the commercial PyCharm 2025.3.2 is already released but JetBrains hasn't released a source release of it yet via Git tag.

Before the script would output:

```
[i] running jetbrains updater with: UpdaterConfig(nixpkgs_root=PosixPath('/home/marco/dev/nixpkgs'), jetbrains_root=PosixPath('/home/marco/dev/nixpkgs/pkgs/applications/editors/jetbrains'), ide='pycharm-oss', old_version=None, no_bin=False, no_src=False, no_maven_deps=False)
[.] found IDEs to update: pycharm-oss
[@] updating IDE pycharm-oss
[-] Checking for updates from https://www.jetbrains.com/updates/updates.xml
[*] Prefetching IntelliJ community source code...
Traceback (most recent call last):
  File "/var/cache/nixpkgs-update/worker/worktree/jetbrains.pycharm-oss/pkgs/applications/editors/jetbrains/updater/main.py", line 82, in <module>
    main()
    ~~~~^^
  File "/var/cache/nixpkgs-update/worker/worktree/jetbrains.pycharm-oss/pkgs/applications/editors/jetbrains/updater/main.py", line 76, in main
    run_src_update(ide, info, config)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/var/cache/nixpkgs-update/worker/worktree/jetbrains.pycharm-oss/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_src.py", line 154, in run_src_update
    intellij_hash, intellij_outpath = prefetch_intellij_community(variant, info.version)
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/cache/nixpkgs-update/worker/worktree/jetbrains.pycharm-oss/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/update_src.py", line 75, in prefetch_intellij_community
    prefetch = run_command(
        [
    ...<8 lines>...
        ]
    )
  File "/var/cache/nixpkgs-update/worker/worktree/jetbrains.pycharm-oss/pkgs/applications/editors/jetbrains/updater/jetbrains_nix_updater/util.py", line 10, in run_command
    result = subprocess.run(cmd, capture_output=True, check=True, text=True, **kwargs)
  File "/nix/store/slhpx9glq7vl99bwi93bgrhn3syv98s1-python3-3.13.11/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['nix-prefetch-url', '--print-path', '--unpack', '--name', 'source', '--type', 'sha256', 'https://github.com/jetbrains/intellij-community/archive/pycharm/2025.3.2.tar.gz']' returned non-zero exit status 1.

```

Now it outputs a more clear error message (and just continues with the next IDE if you bulk update, instead of failing):

```
[i] running jetbrains updater with: UpdaterConfig(nixpkgs_root=PosixPath('/home/marco/dev/nixpkgs'), jetbrains_root=PosixPath('/home/marco/dev/nixpkgs/pkgs/applications/editors/jetbrains'), ide='pycharm-oss', old_version=None, no_bin=False, no_src=False, no_maven_deps=False)
[.] found IDEs to update: pycharm-oss
[@] updating IDE pycharm-oss
[-] Checking for updates from https://www.jetbrains.com/updates/updates.xml
[*] Prefetching IntelliJ community source code...
[!] Unable to fetch sources for version 2025.3.2. This probably means, that JetBrains has not published a source release yet for this version. Check: https://github.com/JetBrains/intellij-community/releases and https://github.com/JetBrains/android/tags
[!] Skipping update of pycharm-oss.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
