### PR TITLE
kanidm: refactor option organization and integrate ssh

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2205.section.md
+++ b/nixos/doc/manual/release-notes/rl-2205.section.md
@@ -105,7 +105,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
 - [K40-Whisperer](https://www.scorchworks.com/K40whisperer/k40whisperer.html), a program to control cheap Chinese laser cutters. Available as [programs.k40-whisperer.enable](#opt-programs.k40-whisperer.enable). Users must add themselves to the `k40` group to be able to access the device.
 
-- [kanidm](https://kanidm.github.io/kanidm/stable/), an identity management server written in Rust. Available as [services.kanidm](#opt-services.kanidm.enableServer)
+- [kanidm](https://kanidm.github.io/kanidm/stable/), an identity management server written in Rust. Available as [services.kanidm](#opt-services.kanidm.server.enable) (renamed to `services.kanidm.server.enable` in 26.05).
 
 - [Maddy](https://maddy.email/), a free an open source mail server. Available as [services.maddy](#opt-services.maddy.enable).
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -140,6 +140,11 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `services.slurm` now supports slurmrestd usage through the `services.slurm.rest` NixOS options.
 
+- `services.kanidm` options for server, client and unix were moved under dedicated namespaces.
+  For each component `enableComponent` and `componentSettings` are now `component.enable` and
+  `component.settings`. The unix module now supports using SSH keys from Kanidm via
+  `services.kanidm.unix.sshIntegration = true`.
+
 - `glibc` has been updated to version 2.42.
 
   This version no longer makes the stack executable when a shared library requires this. A symptom

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -772,7 +772,7 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.enablePam;
+                enable = config.services.kanidm.unix.enable;
                 control = "sufficient";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
                 settings = {
@@ -1139,7 +1139,7 @@ let
                 }
                 {
                   name = "kanidm";
-                  enable = config.services.kanidm.enablePam;
+                  enable = config.services.kanidm.unix.enable;
                   control = "sufficient";
                   modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
                   settings = {
@@ -1248,7 +1248,7 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.enablePam;
+                enable = config.services.kanidm.unix.enable;
                 control = "sufficient";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
               }
@@ -1412,7 +1412,7 @@ let
               }
               {
                 name = "kanidm";
-                enable = config.services.kanidm.enablePam;
+                enable = config.services.kanidm.unix.enable;
                 control = "optional";
                 modulePath = "${config.services.kanidm.package}/lib/pam_kanidm.so";
               }
@@ -2339,7 +2339,7 @@ in
       # Include the PAM modules in the system path mostly for the manpages.
       [ package ]
       ++ lib.optional config.users.ldap.enable pam_ldap
-      ++ lib.optional config.services.kanidm.enablePam config.services.kanidm.package
+      ++ lib.optional config.services.kanidm.unix.enable config.services.kanidm.package
       ++ lib.optional config.services.sssd.enable pkgs.sssd
       ++ lib.optionals config.security.pam.krb5.enable [
         pam_krb5

--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -25,21 +25,25 @@ in
     {
       services.kanidm = {
         package = kanidmPackage;
-        enableServer = true;
-        serverSettings = {
-          origin = "https://${serverDomain}";
-          domain = serverDomain;
-          bindaddress = "[::]:443";
-          ldapbindaddress = "[::1]:636";
-          tls_chain = "${certsPath}/snakeoil.crt";
-          tls_key = "${certsPath}/snakeoil.key";
+        server = {
+          enable = true;
+          settings = {
+            origin = "https://${serverDomain}";
+            domain = serverDomain;
+            bindaddress = "[::]:443";
+            ldapbindaddress = "[::1]:636";
+            tls_chain = "${certsPath}/snakeoil.crt";
+            tls_key = "${certsPath}/snakeoil.key";
+          };
         };
         # So we can check whether provisioning did what we wanted
-        enableClient = true;
-        clientSettings = {
-          uri = "https://${serverDomain}";
-          verify_ca = true;
-          verify_hostnames = true;
+        client = {
+          enable = true;
+          settings = {
+            uri = "https://${serverDomain}";
+            verify_ca = true;
+            verify_hostnames = true;
+          };
         };
       };
 
@@ -289,7 +293,7 @@ in
       # We need access to the config file in the test script.
       filteredConfig = pkgs.lib.converge (pkgs.lib.filterAttrsRecursive (
         _: v: v != null
-      )) nodes.provision.services.kanidm.serverSettings;
+      )) nodes.provision.services.kanidm.server.settings;
       serverConfigFile = (pkgs.formats.toml { }).generate "server.toml" filteredConfig;
 
       specialisations = "${nodes.provision.system.build.toplevel}/specialisation";

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -29,14 +29,16 @@ in
     {
       services.kanidm = {
         package = kanidmPackage;
-        enableServer = true;
-        serverSettings = {
-          origin = "https://${serverDomain}";
-          domain = serverDomain;
-          bindaddress = "[::]:443";
-          ldapbindaddress = "[::1]:636";
-          tls_chain = "${certsPath}/snakeoil.crt";
-          tls_key = "${certsPath}/snakeoil.key";
+        server = {
+          enable = true;
+          settings = {
+            origin = "https://${serverDomain}";
+            domain = serverDomain;
+            bindaddress = "[::]:443";
+            ldapbindaddress = "[::1]:636";
+            tls_chain = "${certsPath}/snakeoil.crt";
+            tls_key = "${certsPath}/snakeoil.key";
+          };
         };
       };
 
@@ -59,15 +61,17 @@ in
     {
       services.kanidm = {
         package = kanidmPackage;
-        enableClient = true;
-        clientSettings = {
-          uri = "https://${serverDomain}";
-          verify_ca = true;
-          verify_hostnames = true;
-        };
-        enablePam = true;
-        unixSettings = {
-          kanidm.pam_allowed_login_groups = [ "shell" ];
+        client = {
+          enable = true;
+          settings = {
+            uri = "https://${serverDomain}";
+            verify_ca = true;
+            verify_hostnames = true;
+          };
+          unix = {
+            enable = true;
+            kanidm.pam_allowed_login_groups = [ "shell" ];
+          };
         };
       };
 
@@ -86,7 +90,7 @@ in
       # We need access to the config file in the test script.
       filteredConfig = pkgs.lib.converge (pkgs.lib.filterAttrsRecursive (
         _: v: v != null
-      )) nodes.server.services.kanidm.serverSettings;
+      )) nodes.server.services.kanidm.server.settings;
       serverConfigFile = (pkgs.formats.toml { }).generate "server.toml" filteredConfig;
     in
     ''


### PR DESCRIPTION
Change option names to be consistent with other NixOS modules and option to integrate with Kanidm SSH keys when using the unix module.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
