### PR TITLE
buildFHSEnv: don't overwrite env vars to /usr prefix

### DIFF
--- a/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/buildFHSEnv.nix
@@ -125,15 +125,16 @@ let
       unset NIX_ENFORCE_PURITY
       export NIX_BINTOOLS_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt}=1
       export NIX_CC_WRAPPER_TARGET_HOST_${stdenv.cc.suffixSalt}=1
-      export NIX_CFLAGS_COMPILE='-idirafter /usr/include'
-      export NIX_CFLAGS_LINK='-L/usr/lib -L/usr/lib32'
-      export NIX_LDFLAGS='-L/usr/lib -L/usr/lib32'
-      export PKG_CONFIG_PATH=/usr/lib/pkgconfig
-      export ACLOCAL_PATH=/usr/share/aclocal
+      export NIX_CFLAGS_COMPILE="-idirafter /usr/include"''${NIX_CFLAGS_COMPILE:+" $NIX_CFLAGS_COMPILE"}
+      export NIX_CFLAGS_LINK="-L/usr/lib -L/usr/lib32"''${NIX_CFLAGS_LINK:+" $NIX_CFLAGS_LINK"}
+      export NIX_LDFLAGS="-L/usr/lib -L/usr/lib32"''${NIX_LDFLAGS:+" $NIX_LDFLAGS"}
+      export PKG_CONFIG_PATH=/usr/lib/pkgconfig''${PKG_CONFIG_PATH:+":$PKG_CONFIG_PATH"}
+      export ACLOCAL_PATH=/usr/share/aclocal''${ACLOCAL_PATH:+":$ACLOCAL_PATH"}
 
       # GStreamer searches for plugins relative to its real binary's location
       # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/commit/bd97973ce0f2c5495bcda5cccd4f7ef7dcb7febc
-      export GST_PLUGIN_SYSTEM_PATH_1_0=/usr/lib/gstreamer-1.0:/usr/lib32/gstreamer-1.0
+      export GST_PLUGIN_SYSTEM_PATH_1_0=/usr/lib/gstreamer-1.0:/usr/lib32/gstreamer-1.0''${GST_PLUGIN_SYSTEM_PATH_1_0:+":$GST_PLUGIN_SYSTEM_PATH_1_0"}
+
 
       ${profile}
     '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Overwriting needlessly breaks using buildFHSEnv programs inside other
derivations / build envs. Fix it by prepending the FHS paths instead.

(I think the FHS paths should have the lowest priority, by suffixing
them, but prefixing is a less disruptive change, so do that for now.)

Test setup:

```
$ NIXPKGS_ALLOW_UNFREE=1 nix-build -A quartus-prime-lite
```

Before:

```
$ NIX_CFLAGS_COMPILE="-I /path" NIX_CFLAGS_LINK="-L /path" NIX_LDFLAGS="-L /path" PKG_CONFIG_PATH=/path ACLOCAL_PATH=/path ./result/bin/quartus-prime-lite bash -c 'printf "NIX_CFLAGS_COMPILE=$NIX_CFLAGS_COMPILE\nNIX_CFLAGS_LINK=$NIX_CFLAGS_LINK\nNIX_LDFLAGS=$NIX_LDFLAGS\nPKG_CONFIG_PATH=$PKG_CONFIG_PATH\nACLOCAL_PATH=$ACLOCAL_PATH\n"'
NIX_CFLAGS_COMPILE=-idirafter /usr/include
NIX_CFLAGS_LINK=-L/usr/lib -L/usr/lib32
NIX_LDFLAGS=-L/usr/lib -L/usr/lib32
PKG_CONFIG_PATH=/usr/lib/pkgconfig
ACLOCAL_PATH=/usr/share/aclocal
```

After:

```
$ NIX_CFLAGS_COMPILE="-I /path" NIX_CFLAGS_LINK="-L /path" NIX_LDFLAGS="-L /path" PKG_CONFIG_PATH=/path ACLOCAL_PATH=/path ./result/bin/quartus-prime-lite bash -c 'printf "NIX_CFLAGS_COMPILE=$NIX_CFLAGS_COMPILE\nNIX_CFLAGS_LINK=$NIX_CFLAGS_LINK\nNIX_LDFLAGS=$NIX_LDFLAGS\nPKG_CONFIG_PATH=$PKG_CONFIG_PATH\nACLOCAL_PATH=$ACLOCAL_PATH\n"'
NIX_CFLAGS_COMPILE=-idirafter /usr/include -I /path
NIX_CFLAGS_LINK=-L/usr/lib -L/usr/lib32 -L /path
NIX_LDFLAGS=-L/usr/lib -L/usr/lib32 -L /path
PKG_CONFIG_PATH=/usr/lib/pkgconfig:/path
ACLOCAL_PATH=/usr/share/aclocal:/path
```

(I also included GST_PLUGIN_SYSTEM_PATH_1_0, although it's not a "build"
oriented variable.)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
