### PR TITLE
signal-desktop-bin: 7.86.0 -> 7.88.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
@@ -1,7 +1,7 @@
 { callPackage, commandLineArgs }:
 callPackage ./generic.nix { inherit commandLineArgs; } {
   pname = "signal-desktop-bin";
-  version = "7.86.0";
+  version = "7.88.0";
 
   libdir = "usr/lib64/signal-desktop";
   bindir = "usr/bin";
@@ -10,6 +10,6 @@ callPackage ./generic.nix { inherit commandLineArgs; } {
     bsdtar -xf $downloadedFile -C "$out"
   '';
 
-  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-43-aarch64/10043047-signal-desktop/signal-desktop-7.86.0-1.fc43.aarch64.rpm";
-  hash = "sha256-gInim9c3RBsMH2K9v0ELj9zQ/IxcwlISCajwBq142Js=";
+  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/10095387-signal-desktop/signal-desktop-7.88.0-1.fc42.aarch64.rpm";
+  hash = "sha256-lrBOsvwOIPcgGMraW3cmC6gaRfYY/ml7dmbLnZQ5mNE=";
 }

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-darwin.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-darwin.nix
@@ -6,11 +6,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "signal-desktop-bin";
-  version = "7.86.0";
+  version = "7.88.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/signal-desktop-mac-universal-${finalAttrs.version}.dmg";
-    hash = "sha256-Wk5fkJiKWsronC5gjAzpwPQt4bGURb8bU3/XUbI+kBU=";
+    hash = "sha256-ymNFy0LT+sLihldmxnRzADr2kHFd7yHclpMSjd8HkPM=";
   };
   sourceRoot = ".";
 

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
@@ -1,12 +1,12 @@
 { callPackage, commandLineArgs }:
 callPackage ./generic.nix { inherit commandLineArgs; } rec {
   pname = "signal-desktop-bin";
-  version = "7.86.0";
+  version = "7.88.0";
 
   libdir = "opt/Signal";
   bindir = libdir;
   extractPkg = "dpkg-deb -x $downloadedFile $out";
 
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-  hash = "sha256-OOnaOnrAWAw3EJS31Wzf83ekWiJab0EvY68UTEOTMjA=";
+  hash = "sha256-5pj4ylQCuMa2xKL9iNvU4+vZzzaJYQUfp5RklhXFT6w=";
 }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
