### PR TITLE
[Backport release-25.11] kanidm: mark 1.7.x unsupported

### DIFF
--- a/nixos/tests/kanidm-provisioning.nix
+++ b/nixos/tests/kanidm-provisioning.nix
@@ -18,7 +18,7 @@ in
   name = "kanidm-provisioning-${kanidmPackage.version}";
   meta.maintainers = with pkgs.lib.maintainers; [ oddlama ];
 
-  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidmWithSecretProvisioning;
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidmWithSecretProvisioning_1_8;
 
   nodes.provision =
     { pkgs, lib, ... }:

--- a/nixos/tests/kanidm.nix
+++ b/nixos/tests/kanidm.nix
@@ -21,7 +21,7 @@ in
     oddlama
   ];
 
-  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidm;
+  _module.args.kanidmPackage = pkgs.lib.mkDefault pkgs.kanidm_1_8;
 
   nodes.server =
     { pkgs, ... }:

--- a/pkgs/servers/kanidm/1_7.nix
+++ b/pkgs/servers/kanidm/1_7.nix
@@ -2,5 +2,5 @@ import ./generic.nix {
   version = "1.7.4";
   hash = "sha256-nWwwcRmCfKJECYN/5w30W3sDu9BqIGonF4ke8F04x3E=";
   cargoHash = "sha256-h5jeQxvYzHRVfNYYh9qKukE4h4nhDyuRou2xuZq4AdM=";
-  eolDate = "2025-12-12";
+  unsupported = true;
 }

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -44,8 +44,8 @@
       # so users choosing to allow don't have to rebuild them every time.
       permittedInsecurePackages = [
         "olm-3.2.16" # see PR #347899
-        "kanidm_1_6-1.6.4"
-        "kanidmWithSecretProvisioning_1_6-1.6.4"
+        "kanidm_1_7-1.7.4"
+        "kanidmWithSecretProvisioning_1_7-1.7.4"
       ];
     };
 


### PR DESCRIPTION
(cherry picked from commit d584ab775ca431eef4510ea24f03e143f2422c37)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
