### PR TITLE
qdb: init at 1.2

### DIFF
--- a/pkgs/by-name/qd/qdb/package.nix
+++ b/pkgs/by-name/qd/qdb/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Quick and dirty brainfuck interpreter";
     mainProgram = "qdb";
-    homepage = "https://brainfuck.com/qdb.c";
+    homepage = "https://brainfuck.org/qdb.c";
 
     # Make any use you like of this software. I can't stop you anyway. :)
     license = lib.licenses.publicDomain;

--- a/pkgs/by-name/qd/qdb/package.nix
+++ b/pkgs/by-name/qd/qdb/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+}:
+
+stdenv.mkDerivation {
+  pname = "qdb";
+  version = "1.2";
+
+  src = fetchurl {
+    url = "https://brainfuck.org/qdb.c";
+    hash = "sha256-5GPsZ2F7bNxoCzWGbh2Xg/H+e3IcsVpQ1UtSD3yHTMw=";
+  };
+  unpackPhase = "cp $src qdb.c";
+
+  buildPhase = ''
+    cc qdb.c -o qdb
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp qdb $out/bin/
+  '';
+
+  meta = {
+    description = "Quick and dirty brainfuck interpreter";
+    mainProgram = "qdb";
+
+    # Make any use you like of this software. I can't stop you anyway. :)
+    license = lib.licenses.publicDomain;
+  };
+}

--- a/pkgs/by-name/qd/qdb/package.nix
+++ b/pkgs/by-name/qd/qdb/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Quick and dirty brainfuck interpreter";
     mainProgram = "qdb";
+    homepage = "https://brainfuck.com/qdb.c";
 
     # Make any use you like of this software. I can't stop you anyway. :)
     license = lib.licenses.publicDomain;


### PR DESCRIPTION
There seems to be a lack of C brainfuck interpreters in nixpkgs, this is a simple, yet working one from [brainfuck.org](https://brainfuck.org/qdb.c)

This software hasn't been updated in at least 5 years (that's the `Last-Modified` date the web server reports), but it doesn't have to be, as it's feature complete.

I didn't add myself as a maintainer, because there isn't really anything to maintain here. I'd be surprised if this package ever breaks.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux (though not as part of nixpkgs)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
