### PR TITLE
cocom-tool-set: fix build on darwin

### DIFF
--- a/pkgs/by-name/co/cocom-tool-set/package.nix
+++ b/pkgs/by-name/co/cocom-tool-set/package.nix
@@ -16,11 +16,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   env = {
     RANLIB = "${stdenv.cc.targetPrefix}gcc-ranlib";
-    NIX_CFLAGS_COMPILE = toString [
-      "-Wno-error=implicit-int"
-      "-Wno-error=implicit-function-declaration"
-      "-std=gnu17"
-    ];
+    NIX_CFLAGS_COMPILE = toString (
+      [
+        "-Wno-error=implicit-int"
+        "-Wno-error=implicit-function-declaration"
+      ]
+      ++ lib.optional stdenv.cc.isGNU "-std=gnu17"
+    );
   };
 
   autoreconfFlags = "REGEX";


### PR DESCRIPTION
Using -std=gnu17 on clang++ is fatal, but only a warning on g++.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
