### PR TITLE
memtier-benchmark: adds Darwin/macOS support

### DIFF
--- a/pkgs/by-name/me/memtier-benchmark/package.nix
+++ b/pkgs/by-name/me/memtier-benchmark/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     description = "Redis and Memcached traffic generation and benchmarking tool";
     homepage = "https://github.com/redislabs/memtier_benchmark";
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ thoughtpolice ];
     mainProgram = "memtier_benchmark";
   };


### PR DESCRIPTION
The upstream github repo for memtier-benchmark supports building for Darwin/macOS and all of the dependencies included in this flake also support it.

Example link to prebuilt binaries in the upstream repo: https://github.com/redis/memtier_benchmark/releases/tag/2.2.1 


