### PR TITLE
yaziPlugins: update on 2026-01-28; yaziPlugins.githead: init at 0-unstable-2026-01-26

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/dupes/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/dupes/default.nix
@@ -7,13 +7,13 @@
 }:
 mkYaziPlugin {
   pname = "dupes.yazi";
-  version = "0-unstable-2025-10-23";
+  version = "0-unstable-2026-01-29";
 
   src = fetchFromGitHub {
     owner = "mshnwq";
     repo = "dupes.yazi";
-    rev = "18a9395d38f42e406805b92834154fc7ad15a7b8";
-    hash = "sha256-hBpUoMKGZgKrgxAOYZQ9CU4BKPSiYpYVWyuHYXHZ/Pc=";
+    rev = "1edf7a406410d5d18b4fbda7b3540e35ab3ad5d6";
+    hash = "sha256-7x8N1heASHlYaLzzzdO4jm6IrTgqFbybp+I9EdF7c3M=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ya/yazi/plugins/git/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/git/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "git.yazi";
-  version = "25.12.29-unstable-2026-01-02";
+  version = "25.12.29-unstable-2026-01-26";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "03cdd4b5b15341b3c0d0f4c850d633fadd05a45f";
-    hash = "sha256-5dMAJ6W/L66XuH4CCwRRFpKSLy0ZDFIABAYleFX0AsQ=";
+    rev = "e07bf41442a7f6fdd003069f380e1ae469a86211";
+    hash = "sha256-aC8DUZpzNHEf9MW3tX3XcDYY/mWClAHkw+nZaxDQHp8=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/githead/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/githead/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "githead.yazi";
+  version = "0-unstable-2026-01-26";
+
+  src = fetchFromGitHub {
+    owner = "llanosrocas";
+    repo = "githead.yazi";
+    rev = "317d09f728928943f0af72ff6ce31ea335351202";
+    hash = "sha256-o2EnQYOxp5bWn0eLn0sCUXcbtu6tbO9pdUdoquFCTVw=";
+  };
+
+  meta = {
+    description = "Git status header for yazi inspired by powerlevel10k ";
+    homepage = "https://github.com/llanosrocas/githead.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ khaneliman ];
+  };
+}

--- a/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mediainfo/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mediainfo.yazi";
-  version = "25.5.31-unstable-2026-01-24";
+  version = "25.5.31-unstable-2026-01-27";
 
   src = fetchFromGitHub {
     owner = "boydaihungst";
     repo = "mediainfo.yazi";
-    rev = "ae2a1f18feb55ea9148032ce247109f2303ddbfd";
-    hash = "sha256-QH1vvPjPYGbf47kSgxV97pxZrdSFcqAEyXtQbJhusLg=";
+    rev = "dc61636816e3f44bacacd6f2936f2588980d75fe";
+    hash = "sha256-sNr5eW1K2r4NFvheEJ8UuYhVqCBqrXQQvRe1dBbAwas=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "25.12.29-unstable-2025-12-29";
+  version = "25.12.29-unstable-2026-01-26";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "517619af126f25f3da096ff156ce46b561b54be3";
-    hash = "sha256-j7fsUmx2nK4Tyj5KCamcCmfs99K6duV+okf8NvzccsI=";
+    rev = "0c95a0dac882e652f70c6fbc79655658c0cb6e74";
+    hash = "sha256-DwHTpEIuING9cajq+O61OmHR93/tpKqgU+cM0//5TZ8=";
   };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- dupes: 0-unstable-2025-10-23 → 0-unstable-2026-01-29
  Compare: https://github.com/Mshnwq/dupes.yazi/compare/18a9395d38f42e406805b92834154fc7ad15a7b8...1edf7a406410d5d18b4fbda7b3540e35ab3ad5d6
- git: 25.12.29-unstable-2026-01-02 → 25.12.29-unstable-2026-01-26
  Compare: https://github.com/yazi-rs/plugins/compare/03cdd4b5b15341b3c0d0f4c850d633fadd05a45f...e07bf41442a7f6fdd003069f380e1ae469a86211
- mediainfo: 25.5.31-unstable-2026-01-24 → 25.5.31-unstable-2026-01-27
  Compare: https://github.com/boydaihungst/mediainfo.yazi/compare/ae2a1f18feb55ea9148032ce247109f2303ddbfd...dc61636816e3f44bacacd6f2936f2588980d75fe
- mount: 25.12.29-unstable-2025-12-29 → 25.12.29-unstable-2026-01-26
  Compare: https://github.com/yazi-rs/plugins/compare/517619af126f25f3da096ff156ce46b561b54be3...0c95a0dac882e652f70c6fbc79655658c0cb6e74

Adding githead since `yatline-githead` has been acting up lately and slow to respond to PRs. 
https://github.com/llanosrocas/githead.yazi
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
