### PR TITLE
styx-cli: init at 1.0.1

### DIFF
--- a/pkgs/by-name/st/styx-cli/package.nix
+++ b/pkgs/by-name/st/styx-cli/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "styx-cli";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "bearcove";
+    repo = "styx";
+    tag = "styx-cli-v${finalAttrs.version}";
+    hash = "sha256-1XS1voPdqr2GJSsOdm93alknS5vwdoFi1WF9bzMCf0o=";
+  };
+
+  cargoHash = "sha256-7eqw0Qjj2VV2KYGSOVoLl8nyuMCTMpLte2lVL7MQPpI=";
+
+  cargoBuildFlags = [
+    "--package"
+    "styx-cli"
+  ];
+
+  checkFlags = [
+    # These tests don't like nix's build environment
+    "--skip=error::tests::test_missing_field_diagnostic"
+    "--skip=error::tests::test_unknown_field_diagnostic"
+    "--skip=error::tests::test_ariadne_config_respects_no_color_env"
+    "--skip=error::tests::test_invalid_scalar_diagnostic"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--use-github-releases"
+      "--version-regex"
+      "styx-cli-v(.*)"
+    ];
+  };
+
+  meta = {
+    changelog = "https://github.com/bearcove/styx/releases/tag/styx-cli-v${finalAttrs.version}";
+    description = "Document language for mortals";
+    downloadPage = "https://github.com/bearcove/styx";
+    homepage = "https://styx.bearcove.eu/";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = [ lib.maintainers.pyrox0 ];
+    mainProgram = "styx";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
