### PR TITLE
thc-ipv6: `fix gcc-15` build

### DIFF
--- a/pkgs/by-name/th/thc-ipv6/package.nix
+++ b/pkgs/by-name/th/thc-ipv6/package.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     "PREFIX=$(out)"
   ];
 
+  enableParallelBuilding = true;
+
   meta = {
     description = "IPv6 attack toolkit";
     homepage = "https://github.com/vanhauser-thc/thc-ipv6";

--- a/pkgs/by-name/th/thc-ipv6/package.nix
+++ b/pkgs/by-name/th/thc-ipv6/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   libpcap,
   openssl,
   libnetfilter_queue,
@@ -17,6 +18,16 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "07kwika1zdq62s5p5z94xznm77dxjxdg8k0hrg7wygz50151nzmx";
   };
+
+  patches = [
+    # Fix gcc-15 build failure:
+    #   https://github.com/vanhauser-thc/thc-ipv6/pull/53
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://github.com/vanhauser-thc/thc-ipv6/commit/c9617d5638196bd88336225a6abdfd45c3df0bcf.patch";
+      hash = "sha256-4+LmRsDInzzNFHvj8WK+r1fKeoLggQW7yrahC1d6WCs=";
+    })
+  ];
 
   buildInputs = [
     libpcap


### PR DESCRIPTION
Without the chnage the build fails on `master` as
https://hydra.nixos.org/build/320117087:

    thc-ipv6-lib.c: In function 'thc_pcap_function':
    thc-ipv6-lib.c:127:36: error: too many arguments to function 'thc_open_ipv6'; expected 0, have 1
      127 |   if (thc_socket < 0) thc_socket = thc_open_ipv6(interface);
          |                                    ^~~~~~~~~~~~~ ~~~~~~~~~
    In file included from thc-ipv6-lib.c:75:
    thc-ipv6.h:211:23: note: declared here
      211 | extern int            thc_open_ipv6();
          |                       ^~~~~~~~~~~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
