### PR TITLE
hyprshutdown: 0-unstable-2026-01-27 -> 0.1.0

### DIFF
--- a/pkgs/by-name/hy/hyprshutdown/package.nix
+++ b/pkgs/by-name/hy/hyprshutdown/package.nix
@@ -13,17 +13,17 @@
   hyprgraphics,
   cairo,
   nix-update-script,
-  testers,
+  versionCheckHook,
 }:
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprshutdown";
-  version = "0-unstable-2026-01-27";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprshutdown";
-    rev = "9f18be9c4e1a484c65b22dd53280815dc79a5a56";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dp5lyZzKsjdqJLfwr0S4ILets8eu1kLfBB2y/LxspsU=";
   };
 
@@ -43,20 +43,12 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     (glaze.override { enableSSL = false; })
   ];
 
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--help";
+
   passthru = {
-    updateScript = nix-update-script {
-      # TODO: remove when stable release available
-      extraArgs = [ "--version=branch" ];
-    };
-    tests = {
-      help = testers.runCommand {
-        name = "${finalAttrs.pname}-help-test";
-        nativeBuildInputs = [ finalAttrs.finalPackage ];
-        script = ''
-          '${finalAttrs.meta.mainProgram}' --help && touch "$out"
-        '';
-      };
-    };
+    updateScript = nix-update-script { };
   };
 
   meta = {


### PR DESCRIPTION
This is possible now that v0.1.0 has been released. Note that this PR does not include any actual updates.

It may be in our interest to add a passthrough test to check the version, but there isn't an easy way to get that right now (requires parsing `--help`), so I haven't bothered to do it yet.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
