### PR TITLE
protobuf: 33.4 -> 33.5

### DIFF
--- a/pkgs/development/libraries/protobuf/33.nix
+++ b/pkgs/development/libraries/protobuf/33.nix
@@ -2,8 +2,8 @@
 
 callPackage ./generic.nix (
   {
-    version = "33.4";
-    hash = "sha256-/mdniUtu6+tj2W8zYeV5xvEzMMfzKkGVk7Lc37p1+dE=";
+    version = "33.5";
+    hash = "sha256-bn8wMZSAqukZyo+fLT4O044ld53FvIfCdajr2WwM93E=";
   }
   // args
 )

--- a/pkgs/development/python-modules/protobuf/6.nix
+++ b/pkgs/development/python-modules/protobuf/6.nix
@@ -7,14 +7,14 @@
   protobuf,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "protobuf";
-  version = "6.33.4";
+  version = "6.33.5";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-3C5hvKOxBHDBkS0Wb+CvZ7/CDrVZcdzvjfpIzhTw7ZE=";
+    inherit (finalAttrs) pname version;
+    hash = "sha256-bdysKggfi3uWQsCUBrxqQpASj85fRxzd0WWWC7kRnlw=";
   };
 
   build-system = [ setuptools ];
@@ -26,7 +26,7 @@ buildPythonPackage rec {
   doCheck =
     # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
     # The non-python protobuf provides the protoc binary which must not be newer.
-    assert lib.versionAtLeast version ("6." + protobuf.version);
+    assert lib.versionAtLeast finalAttrs.version ("6." + protobuf.version);
     # the pypi source archive does not ship tests
     false;
 
@@ -50,9 +50,9 @@ buildPythonPackage rec {
     description = "Protocol Buffers are Google's data interchange format";
     homepage = "https://developers.google.com/protocol-buffers/";
     changelog = "https://github.com/protocolbuffers/protobuf/releases/v${
-      builtins.substring 2 (-1) version
+      builtins.substring 2 (-1) finalAttrs.version
     }";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ GaetanLepage ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/protocolbuffers/protobuf/compare/v33.4...v33.5
Changelog: https://github.com/protocolbuffers/protobuf/releases/tag/v33.5

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
