### PR TITLE
nixos/osquery: add `package` option

### DIFF
--- a/nixos/tests/osquery.nix
+++ b/nixos/tests/osquery.nix
@@ -1,5 +1,5 @@
 import ./make-test-python.nix (
-  { lib, pkgs, ... }:
+  { lib, ... }:
 
   let
     config_refresh = "10";
@@ -13,19 +13,17 @@ import ./make-test-python.nix (
       lewo
     ];
 
-    nodes.machine =
-      { config, pkgs, ... }:
-      {
-        services.osquery = {
-          enable = true;
+    nodes.machine = _: {
+      services.osquery = {
+        enable = true;
 
-          settings.options = { inherit nullvalue utc; };
-          flags = {
-            inherit config_refresh;
-            nullvalue = "IGNORED";
-          };
+        settings.options = { inherit nullvalue utc; };
+        flags = {
+          inherit config_refresh;
+          nullvalue = "IGNORED";
         };
       };
+    };
 
     testScript =
       { nodes, ... }:


### PR DESCRIPTION
Added `package` option to `osquery` module.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
