### PR TITLE
joycond: unstable-2021-07-30 -> 0-unstable-2026-03-02

### DIFF
--- a/pkgs/by-name/jo/joycond/package.nix
+++ b/pkgs/by-name/jo/joycond/package.nix
@@ -8,17 +8,18 @@
   udev,
   udevCheckHook,
   acl,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation {
   pname = "joycond";
-  version = "unstable-2021-07-30";
+  version = "0-unstable-2026-03-02";
 
   src = fetchFromGitHub {
     owner = "DanielOgorchock";
     repo = "joycond";
-    rev = "f9a66914622514c13997c2bf7ec20fa98e9dfc1d";
-    sha256 = "sha256-quw7yBHDDZk1+6uHthsfMCej7g5uP0nIAqzvI6436B8=";
+    rev = "0df025ac5dc284b1f31172b6b252321ba788c4de";
+    sha256 = "sha256-2rHSQFQvpNZWZJQenZxPEVkbUFQvhRz1Om1AnnIio4M=";
   };
 
   nativeBuildInputs = [
@@ -48,6 +49,8 @@ stdenv.mkDerivation {
     substituteInPlace $out/etc/udev/rules.d/89-joycond.rules --replace \
       "/bin/setfacl"  "${acl}/bin/setfacl"
   '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     homepage = "https://github.com/DanielOgorchock/joycond";

--- a/pkgs/by-name/jo/joycond/package.nix
+++ b/pkgs/by-name/jo/joycond/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
     description = "Userspace daemon to combine joy-cons from the hid-nintendo kernel driver";
     mainProgram = "joycond";
     license = lib.licenses.gpl3Only;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ claymorwan ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
