### PR TITLE
nemo-with-extensions: Fix open with root with polkit 127

### DIFF
--- a/pkgs/by-name/ne/nemo-with-extensions/package.nix
+++ b/pkgs/by-name/ne/nemo-with-extensions/package.nix
@@ -46,7 +46,8 @@ symlinkJoin {
 
     # Point to wrapped binary in all service files
     for file in "share/dbus-1/services/nemo.FileManager1.service" \
-      "share/dbus-1/services/nemo.service"
+      "share/dbus-1/services/nemo.service" \
+      "share/polkit-1/actions/org.nemo.root.policy"
     do
       rm "$out/$file"
       substitute "${nemo}/$file" "$out/$file" \

--- a/pkgs/by-name/ne/nemo/package.nix
+++ b/pkgs/by-name/ne/nemo/package.nix
@@ -87,13 +87,6 @@ stdenv.mkDerivation rec {
     "--localedir=${cinnamon-translations}/share/locale"
   ];
 
-  postInstall = ''
-    # This fixes open as root and handles nemo-with-extensions well.
-    # https://github.com/NixOS/nixpkgs/issues/297570
-    substituteInPlace $out/share/polkit-1/actions/org.nemo.root.policy \
-      --replace-fail "$out/bin/nemo" "/run/current-system/sw/bin/nemo"
-  '';
-
   preFixup = ''
     gappsWrapperArgs+=(
        --prefix XDG_DATA_DIRS : "${


### PR DESCRIPTION
https://github.com/polkit-org/polkit/commit/9aa43e089d870a8ee695e625237c5b731b250678

Similar to #485180

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
