### PR TITLE
rumdl: 0.1.2 -> 0.1.8

### DIFF
--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -2,26 +2,32 @@
   lib,
   fetchFromGitHub,
   rustPlatform,
+  installShellFiles,
   gitMinimal,
+  stdenvNoCC,
   versionCheckHook,
   nix-update-script,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.1.2";
+  version = "0.1.6";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8K+jZL/yo7ur5WD+5+L+ZHhFkhYo83brgD6Gg1Xo6js=";
+    hash = "sha256-n8rGccgwf0ybttAsYt6OrmFz/aH3TOHksLZMc/AqSv0=";
   };
 
-  cargoHash = "sha256-dpHV5+DJLsjwvLkxtXOS7CYUNKXW57o0O541pO8vN5U=";
+  cargoHash = "sha256-haRjTd7cp0eJnK4CUUVsZZumZ+SVS+TaR1PpkdOoNb4=";
 
   cargoBuildFlags = [
     "--bin=rumdl"
+  ];
+
+  nativeBuildInputs = [
+    installShellFiles
   ];
 
   nativeCheckInputs = [
@@ -34,6 +40,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # Prefer the "smoke" profile over "ci" to exclude flaky tests: https://github.com/rvben/rumdl/pull/341
     "--profile smoke"
   ];
+
+  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+    installShellCompletion --cmd rumdl \
+      --bash <("$out/bin/rumdl" completions bash) \
+      --fish <("$out/bin/rumdl" completions fish) \
+      --zsh <("$out/bin/rumdl" completions zsh)
+  '';
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.1.7";
+  version = "0.1.8";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zTdhXUc221G1kXHu7dXnF14b85tnvsqosDSUlRG1vpI=";
+    hash = "sha256-W6+4InVhfROlH0IwtmPanxc0OAl4rooiuz8lKAFRRoI=";
   };
 
-  cargoHash = "sha256-P0QIsTcqmO4f7DeKQe66suemnUI6ztD1hvfKAN4ttJE=";
+  cargoHash = "sha256-ATODqtHCNEZcYm2CdvrHz8L1c+AcKfXkUGhVbUyW9Wg=";
 
   cargoBuildFlags = [
     "--bin=rumdl"

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.1.6";
+  version = "0.1.7";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-n8rGccgwf0ybttAsYt6OrmFz/aH3TOHksLZMc/AqSv0=";
+    hash = "sha256-zTdhXUc221G1kXHu7dXnF14b85tnvsqosDSUlRG1vpI=";
   };
 
-  cargoHash = "sha256-haRjTd7cp0eJnK4CUUVsZZumZ+SVS+TaR1PpkdOoNb4=";
+  cargoHash = "sha256-P0QIsTcqmO4f7DeKQe66suemnUI6ztD1hvfKAN4ttJE=";
 
   cargoBuildFlags = [
     "--bin=rumdl"

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -4,7 +4,7 @@
   rustPlatform,
   installShellFiles,
   gitMinimal,
-  stdenvNoCC,
+  stdenv,
   versionCheckHook,
   nix-update-script,
 }:
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--profile smoke"
   ];
 
-  postInstall = lib.optionalString (stdenvNoCC.buildPlatform.canExecute stdenvNoCC.hostPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd rumdl \
       --bash <("$out/bin/rumdl" completions bash) \
       --fish <("$out/bin/rumdl" completions fish) \


### PR DESCRIPTION
Diff: https://github.com/rvben/rumdl/compare/v0.1.2...v0.1.6

Releases:
- https://github.com/rvben/rumdl/releases/tag/v0.1.6
- https://github.com/rvben/rumdl/releases/tag/v0.1.5
- https://github.com/rvben/rumdl/releases/tag/v0.1.4
- https://github.com/rvben/rumdl/releases/tag/v0.1.3

Shell completions were [added](https://github.com/rvben/rumdl/pull/333) in v0.1.6.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

cc: @Hasnep