### PR TITLE
cudaPackages: fix redistName for NVPL packages

### DIFF
--- a/pkgs/development/cuda-modules/packages/nvpl_blas.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_blas.nix
@@ -1,6 +1,6 @@
 { buildRedist }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_blas";
 
   outputs = [

--- a/pkgs/development/cuda-modules/packages/nvpl_common.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_common.nix
@@ -1,6 +1,6 @@
 { buildRedist }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_common";
 
   outputs = [

--- a/pkgs/development/cuda-modules/packages/nvpl_fft.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_fft.nix
@@ -1,6 +1,6 @@
 { buildRedist }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_fft";
 
   outputs = [

--- a/pkgs/development/cuda-modules/packages/nvpl_lapack.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_lapack.nix
@@ -1,6 +1,6 @@
 { buildRedist, nvpl_blas }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_lapack";
 
   outputs = [

--- a/pkgs/development/cuda-modules/packages/nvpl_rand.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_rand.nix
@@ -1,6 +1,6 @@
 { buildRedist }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_rand";
 
   outputs = [

--- a/pkgs/development/cuda-modules/packages/nvpl_scalapack.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_scalapack.nix
@@ -1,6 +1,6 @@
 { buildRedist }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_scalapack";
 
   outputs = [

--- a/pkgs/development/cuda-modules/packages/nvpl_sparse.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_sparse.nix
@@ -8,7 +8,6 @@ buildRedist {
     "dev"
     "include"
     "lib"
-    "static"
   ];
 
   meta = {

--- a/pkgs/development/cuda-modules/packages/nvpl_sparse.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_sparse.nix
@@ -1,6 +1,6 @@
 { buildRedist }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_sparse";
 
   outputs = [

--- a/pkgs/development/cuda-modules/packages/nvpl_tensor.nix
+++ b/pkgs/development/cuda-modules/packages/nvpl_tensor.nix
@@ -1,6 +1,6 @@
 { buildRedist, nvpl_blas }:
 buildRedist {
-  redistName = "cuda";
+  redistName = "nvpl";
   pname = "nvpl_tensor";
 
   outputs = [


### PR DESCRIPTION
Closes #485205.

Also removes non-existent static output for `nvpl_sparse`.

Verified by running

```console
nix-eval-jobs ./ci/redists.nix --arg supportedSystems '["aarch64-linux"]'  --argstr redistName "nvpl" --arg nixpkgs ../nixpkgs --force-recurse --select 'attrs: attrs.cudaPackages_12_6' --constituents | \
jq -cr '.constituents + [.drvPath] | .[] | select(.!=null) + "^*"' | \
nom build --keep-going --no-link --print-out-paths --stdin
```

using https://github.com/nixos-cuda/cuda-legacy/blob/86ad7e2c2e314f0234539cbbc66b5cd7746bcd32/ci/redists.nix.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
