### PR TITLE
dxvk_2: 2.6.1 -> 2.7.1

### DIFF
--- a/pkgs/by-name/dx/dxvk_2/package.nix
+++ b/pkgs/by-name/dx/dxvk_2/package.nix
@@ -11,6 +11,7 @@
   spirv-headers,
   vulkan-headers,
   SDL2,
+  sdl3,
   glfw,
   gitUpdater,
   sdl2Support ? (!stdenv.hostPlatform.isWindows),
@@ -37,13 +38,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dxvk";
-  version = "2.6.1";
+  version = "2.7.1";
 
   src = fetchFromGitHub {
     owner = "doitsujin";
     repo = "dxvk";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-edu9JQAKu8yUZLh+37RB1s1A3+s8xeUYQ5Oibdes9ZI=";
+    hash = "sha256-c4QlFCUH5SdXT4J3jTGQBAgFXFD8waTjvLUePLAdpFs=";
     fetchSubmodules = true; # Needed for the DirectX headers and libdisplay-info
   };
 
@@ -75,7 +76,10 @@ stdenv.mkDerivation (finalAttrs: {
     spirv-headers
     vulkan-headers
   ]
-  ++ lib.optionals sdl2Support [ SDL2 ]
+  ++ lib.optionals sdl2Support [
+    SDL2
+    sdl3
+  ]
   ++ lib.optionals glfwSupport [ glfw ]
   ++ lib.optionals hostPlatform.isWindows [ windows.pthreads ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://github.com/doitsujin/dxvk/releases/tag/v2.7.1
Additionally, add sdl3 to buildInputs so Meson can find the new SDL3 dependency.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
