### PR TITLE
mqtt-exporter: use patch rather than `substituteInPlace`

### DIFF
--- a/pkgs/by-name/mq/mqtt-exporter/package.nix
+++ b/pkgs/by-name/mq/mqtt-exporter/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   python3,
 }:
 
@@ -16,11 +17,13 @@ python3.pkgs.buildPythonApplication rec {
     hash = "sha256-z2y43sRlwgy3Bwhu8rvlTkf6HOT+v8kjo5FT3lo5CEA=";
   };
 
-  postPatch = ''
-    # https://github.com/kpetremann/mqtt-exporter/pull/117
-    substituteInPlace pyproject.toml \
-      --replace-fail  "mqtt_exporter.main:main" "mqtt_exporter.main:main_mqtt_exporter"
-  '';
+  patches = [
+    (fetchpatch {
+      name = "Fix `mqtt-exporter` script";
+      url = "https://github.com/kpetremann/mqtt-exporter/commit/53f5f31b28cb5aeec1c8d0bb7d1aea56f036082e.diff";
+      hash = "sha256-LS+kO6bHofNQxk9o+ExsJnaecwfY/40S0MIJwpJxCAI=";
+    })
+  ];
 
   build-system = with python3.pkgs; [ setuptools ];
 


### PR DESCRIPTION
The problem with this `substituteInPlace` is that it happily continues doing something once we're on a version of `mqtt-exporter` that has this bug fixed (which happened upstream in
<https://github.com/kpetremann/mqtt-exporter/commit/53f5f31b28cb5aeec1c8d0bb7d1aea56f036082e>).

Here's how it fails:

```console
$ mqtt-exporter
Traceback (most recent call last):
  File "/nix/store/apglhyifvx73d4ybmrcyic2fdp7dxq38-mqtt-exporter-1.9.0/bin/.mqtt-exporter-wrapped", line 6, in <module>
    from mqtt_exporter.main import main_mqtt_exporter_mqtt_exporter
ImportError: cannot import name 'main_mqtt_exporter_mqtt_exporter' from 'mqtt_exporter.main' (/nix/store/apglhyifvx73d4ybmrcyic2fdp7dxq38-mqtt-exporter-1.9.0/lib/python3.13/site-packages/mqtt_exporter/main.py)
```

The patch will do the correct thing and start to fail once it has already been applied.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
