### PR TITLE
adslib: unstable-2020-08-28 -> 0-unstable-2021-11-07

### DIFF
--- a/pkgs/by-name/ad/adslib/package.nix
+++ b/pkgs/by-name/ad/adslib/package.nix
@@ -7,13 +7,13 @@
 
 stdenv.mkDerivation {
   pname = "adslib";
-  version = "unstable-2020-08-28";
+  version = "0-unstable-2021-11-07";
 
   src = fetchFromGitHub {
     owner = "stlehmann";
     repo = "ADS";
-    rev = "c457b60d61d73325837ca50be2cc997c4792d481";
-    sha256 = "11r86xa8fr4z957hd0abn8x7182nz30a198d02y7gzpbhpi3z43k";
+    rev = "a894d4512a51f3ada026efbf9553e75ba9351e2e";
+    sha256 = "SEh4yneTM1dfbWRdWlb5gP/uSeoOeE3g7g/rJWSTba8=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/ad/adslib/package.nix
+++ b/pkgs/by-name/ad/adslib/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation {
@@ -19,6 +20,8 @@ stdenv.mkDerivation {
     mkdir -p $out/lib
     cp adslib.so $out/lib/adslib.so
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Beckhoff protocol to communicate with TwinCAT devices";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
