### PR TITLE
fetchPnpmDeps: Pass `--no-run-if-empty` to xargs to prevent running `chmod` without args

### DIFF
--- a/pkgs/build-support/node/fetch-pnpm-deps/default.nix
+++ b/pkgs/build-support/node/fetch-pnpm-deps/default.nix
@@ -157,9 +157,9 @@ in
             # See https://github.com/NixOS/nixpkgs/pull/350063
             # See https://github.com/NixOS/nixpkgs/issues/422889
             if [[ ${toString fetcherVersion} -ge 2 ]]; then
-              find $storePath -type f -name "*-exec" -print0 | xargs -0 chmod 555
-              find $storePath -type f -not -name "*-exec" -print0 | xargs -0 chmod 444
-              find $storePath -type d -print0 | xargs -0 chmod 555
+              find $storePath -type f -name "*-exec" -print0 | xargs --no-run-if-empty -0 chmod 555
+              find $storePath -type f -not -name "*-exec" -print0 | xargs --no-run-if-empty -0 chmod 444
+              find $storePath -type d -print0 | xargs --no-run-if-empty -0 chmod 555
             fi
 
             if [[ ${toString fetcherVersion} -ge 3 ]]; then


### PR DESCRIPTION
This PR updates `fetchPnpmDeps` to pass `--no-run-if-empty` to `xargs`. This prevents errors when `find` returns no results.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
