### PR TITLE
nixhist: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ni/nixhist/package.nix
+++ b/pkgs/by-name/ni/nixhist/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     description = "A TUI for viewing, comparing, and managing NixOS generations";
     homepage = "https://github.com/daskladas/nixhist";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = [ ];
     mainProgram = "nixhist";
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/ni/nixhist/package.nix
+++ b/pkgs/by-name/ni/nixhist/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  xorg,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nixhist";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "daskladas";
+    repo = "nixhist";
+    rev = "v${version}";
+    hash = "sha256-Y7GisoFi96I9JeuNw4aKZpfcEZp13A8NfS5vzfsR9Mk=";
+  };
+
+  cargoHash = "sha256-/7JHIU0REuEaPWPSAM5QsW0d6dZz+cCfhlX1ytUH5Lc=";
+  doCheck = false;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    xorg.libxcb
+  ];
+
+  meta = {
+    description = "A TUI for viewing, comparing, and managing NixOS generations";
+    homepage = "https://github.com/daskladas/nixhist";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "nixhist";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Description

Add nixhist, a TUI for viewing, comparing, and managing NixOS generations.

**Features:**
- View system and home-manager generations
- Compare generations with detailed package diffs
- Restore, delete, or pin generations
- Built-in themes (Gruvbox, Nord, Transparent)

**Homepage:** https://github.com/daskladas/nixhist

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested via `nix-build -A nixhist`
- [ ] Tested compilation of all packages that depend on this change using `nix-build -A nixhist`
- [x] Verified that all tests pass (`doCheck = false` - some tests require environment not available in sandbox)
- [x] Ensured that commit message follows [nixpkgs guidelines](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)