### PR TITLE
codex: 0.89.0 -> 0.92.0

### DIFF
--- a/pkgs/by-name/co/codex/package.nix
+++ b/pkgs/by-name/co/codex/package.nix
@@ -4,6 +4,10 @@
   rustPlatform,
   fetchFromGitHub,
   installShellFiles,
+  clang,
+  cmake,
+  gitMinimal,
+  libclang,
   makeBinaryWrapper,
   nix-update-script,
   pkg-config,
@@ -14,26 +18,48 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "codex";
-  version = "0.89.0";
+  version = "0.92.0";
 
   src = fetchFromGitHub {
     owner = "openai";
     repo = "codex";
     tag = "rust-v${finalAttrs.version}";
-    hash = "sha256-VFbtxGOqX80qWqVo+BG+BnUr8DiLCfcJCrN9fwy7utY=";
+    hash = "sha256-m/g+5wdehyaHDw6i5vik4HXiisY/iWFtPX0gKjCFPNY=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/codex-rs";
 
-  cargoHash = "sha256-gg7KPEMO2aiBcIN8TllaDQeTLyw+WLfmMrXBKV/L53M=";
+  cargoHash = "sha256-fuT8vPb9/7fZam129nR6y+r+3j46WBhlf73Htkcjpzc=";
 
   nativeBuildInputs = [
+    clang
+    cmake
+    gitMinimal
     installShellFiles
     makeBinaryWrapper
     pkg-config
+    rustPlatform.bindgenHook
   ];
 
-  buildInputs = [ openssl ];
+  buildInputs = [
+    libclang.lib
+    openssl
+  ];
+
+  # rama-boring-sys builds BoringSSL from source via cmake
+  # Disable GCC's stringop-overflow warning-as-error which can trigger
+  # false positives in BoringSSL's a_bitstr.cc on some systems
+  env = {
+    LIBCLANG_PATH = "${libclang.lib}/lib";
+    NIX_CFLAGS_COMPILE = toString (
+      lib.optionals stdenv.cc.isGNU [
+        "-Wno-error=stringop-overflow"
+      ]
+      ++ lib.optionals stdenv.cc.isClang [
+        "-Wno-error=character-conversion"
+      ]
+    );
+  };
 
   # NOTE: part of the test suite requires access to networking, local shells,
   # apple system configuration, etc. since this is a very fast moving target


### PR DESCRIPTION
## Summary

Update codex from 0.89.0 to 0.92.0.

### Changes
- Add build dependencies for `rama-boring-sys` which builds BoringSSL from source: `clang`, `cmake`, `gitMinimal`, `libclang`, `rustPlatform.bindgenHook`
- Add `NIX_CFLAGS_COMPILE` to suppress GCC `stringop-overflow` false positives in BoringSSL's `a_bitstr.cc`
- Add clang `character-conversion` warning suppression for darwin

### Testing
- [x] Built on x86_64-linux
- [x] Verified `codex --version` outputs `codex-cli 0.92.0`

### Related
- Supersedes/addresses issues in #483705

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

🤖 Generated with [Claude Code](https://claude.ai/code)