### PR TITLE
build-support/rustc-wrapper: use explicit substitution instead of substituteAll

### DIFF
--- a/pkgs/build-support/rust/rustc-wrapper/default.nix
+++ b/pkgs/build-support/rust/rustc-wrapper/default.nix
@@ -3,37 +3,37 @@
   runCommand,
   rustc-unwrapped,
   sysroot ? null,
+  stdenvNoCC,
+  shell ? stdenvNoCC.shell,
 }:
+let
+  sysrootFlag = lib.optionalString (sysroot != null) "--sysroot ${sysroot}";
 
+  # Upstream rustc still assumes that musl = static[1].  The fix for
+  # this is to disable crt-static by default for non-static musl
+  # targets.
+  #
+  # Even though Cargo will build build.rs files for the build platform,
+  # cross-compiling _from_ musl appears to work fine, so we only need
+  # to do this when rustc's target platform is dynamically linked musl.
+  #
+  # [1]: https://github.com/rust-lang/compiler-team/issues/422
+  #
+  # WARNING: using defaultArgs is dangerous, as it will apply to all
+  # targets used by this compiler (host and target).  This means
+  # that it can't be used to set arguments that should only be
+  # applied to the target.  It's fine to do this for -crt-static,
+  # because rustc does not support +crt-static host platforms
+  # anyway.
+  defaultArgs = lib.optionalString (
+    with rustc-unwrapped.stdenv.targetPlatform; isMusl && !isStatic
+  ) "-C target-feature=-crt-static";
+in
 runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}"
   {
     preferLocalBuild = true;
     strictDeps = true;
     inherit (rustc-unwrapped) outputs;
-
-    env = {
-      sysroot = lib.optionalString (sysroot != null) "--sysroot ${sysroot}";
-
-      # Upstream rustc still assumes that musl = static[1].  The fix for
-      # this is to disable crt-static by default for non-static musl
-      # targets.
-      #
-      # Even though Cargo will build build.rs files for the build platform,
-      # cross-compiling _from_ musl appears to work fine, so we only need
-      # to do this when rustc's target platform is dynamically linked musl.
-      #
-      # [1]: https://github.com/rust-lang/compiler-team/issues/422
-      #
-      # WARNING: using defaultArgs is dangerous, as it will apply to all
-      # targets used by this compiler (host and target).  This means
-      # that it can't be used to set arguments that should only be
-      # applied to the target.  It's fine to do this for -crt-static,
-      # because rustc does not support +crt-static host platforms
-      # anyway.
-      defaultArgs = lib.optionalString (
-        with rustc-unwrapped.stdenv.targetPlatform; isMusl && !isStatic
-      ) "-C target-feature=-crt-static";
-    };
 
     passthru = {
       inherit (rustc-unwrapped)
@@ -58,10 +58,18 @@ runCommand "${rustc-unwrapped.pname}-wrapper-${rustc-unwrapped.version}"
     mkdir -p $out/bin
     ln -s ${rustc-unwrapped}/bin/* $out/bin
     rm $out/bin/{rustc,rustdoc}
-    prog=${rustc-unwrapped}/bin/rustc extraFlagsVar=NIX_RUSTFLAGS \
-        substituteAll ${./rustc-wrapper.sh} $out/bin/rustc
-    prog=${rustc-unwrapped}/bin/rustdoc extraFlagsVar=NIX_RUSTDOCFLAGS \
-        substituteAll ${./rustc-wrapper.sh} $out/bin/rustdoc
+    substitute ${./rustc-wrapper.sh} $out/bin/rustc \
+      --replace-fail "@shell@" ${lib.escapeShellArg shell} \
+      --replace-fail "@sysrootFlag@" ${lib.escapeShellArg sysrootFlag} \
+      --replace-fail "@defaultArgs@" ${lib.escapeShellArg defaultArgs} \
+      --replace-fail "@prog@" ${lib.escapeShellArg rustc-unwrapped}/bin/rustc \
+      --replace-fail "@extraFlagsVar@" "NIX_RUSTFLAGS"
+    substitute ${./rustc-wrapper.sh} $out/bin/rustdoc \
+      --replace-fail "@shell@" ${lib.escapeShellArg shell} \
+      --replace-fail "@sysrootFlag@" ${lib.escapeShellArg sysrootFlag} \
+      --replace-fail "@defaultArgs@" ${lib.escapeShellArg defaultArgs} \
+      --replace-fail "@prog@" ${lib.escapeShellArg rustc-unwrapped}/bin/rustdoc \
+      --replace-fail "@extraFlagsVar@" "NIX_RUSTDOCFLAGS"
     chmod +x $out/bin/{rustc,rustdoc}
     ${lib.concatMapStrings (output: "ln -s ${rustc-unwrapped.${output}} \$${output}\n") (
       lib.remove "out" rustc-unwrapped.outputs

--- a/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
+++ b/pkgs/build-support/rust/rustc-wrapper/rustc-wrapper.sh
@@ -1,6 +1,6 @@
 #!@shell@
 
-defaultSysroot=(@sysroot@)
+defaultSysroot=(@sysrootFlag@)
 
 for arg; do
     case "$arg" in


### PR DESCRIPTION
The use of `substituteAll` [is to be avoided](https://github.com/NixOS/nixpkgs/issues/237216) and this fixes the wrapper when `structuredAttrs` are enabled.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
