### PR TITLE
ptouch-print: 1.5-unstable-2024-02-11 -> 1.7-unstable-2026-01-23

### DIFF
--- a/pkgs/by-name/pt/ptouch-print/package.nix
+++ b/pkgs/by-name/pt/ptouch-print/package.nix
@@ -15,12 +15,12 @@
 
 stdenv.mkDerivation {
   pname = "ptouch-print";
-  version = "1.5-unstable-2024-02-11";
+  version = "1.7-unstable-2026-01-23";
 
   src = fetchgit {
     url = "https://git.familie-radermacher.ch/linux/ptouch-print.git";
-    rev = "8aaeecd84b619587dc3885dd4fea4b7310c82fd4";
-    hash = "sha256-IIq3SmMfsgwSYbgG1w/wrBnFtb6xdFK2lkK27Qqk6mw=";
+    rev = "3e026ef26b48dda338bb983132494935d6aeb626";
+    hash = "sha256-LpBgZWpbOiEf+yA/fDNwsSPxkgMVLnOsrE65Q3lvhwg";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update package ptouch-print from 1.5 to 1.7

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
