### PR TITLE
grub2: pull in more xfs patches

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -136,6 +136,12 @@ let
           conflicts = [ "shutdown.target" ];
           wantedBy = [ "multi-user.target" ] ++ optional hasDefaultGatewaySet "network-online.target";
 
+          # Stop+starting the network can break
+          # switch-to-configuration on NFS clients by reloading the
+          # systemd config when the NFS server is unreachable. Do an
+          # in-place restart after systemd has reloaded instead.
+          stopIfChanged = false;
+
           unitConfig.ConditionCapability = "CAP_NET_ADMIN";
 
           path = [ pkgs.iproute2 ];

--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -97,31 +97,19 @@ let
 
         deviceDependency =
           dev:
-          # Use systemd service if we manage device creation, else
-          # trust udev when not in a container
-          if (dev == null || dev == "lo") then
+          if (dev == null || dev == "lo" || config.boot.isContainer) then
             [ ]
-          else if
-            (hasAttr dev (filterAttrs (k: v: v.virtual) cfg.interfaces))
-            || (hasAttr dev cfg.bridges)
-            || (hasAttr dev cfg.bonds)
-            || (hasAttr dev cfg.macvlans)
-            || (hasAttr dev cfg.sits)
-            || (hasAttr dev cfg.ipips)
-            || (hasAttr dev cfg.vlans)
-            || (hasAttr dev cfg.greTunnels)
-            || (hasAttr dev cfg.vswitches)
-          then
-            [ "${dev}-netdev.service" ]
           else
-            optional (!config.boot.isContainer) (subsystemDevice dev);
+            [ "${dev}-netdev.service" ];
 
         hasDefaultGatewaySet =
           (cfg.defaultGateway != null && cfg.defaultGateway.address != "")
           || (cfg.enableIPv6 && cfg.defaultGateway6 != null && cfg.defaultGateway6.address != "");
 
-        needNetworkSetup =
-          cfg.resolvconf.enable || cfg.defaultGateway != null || cfg.defaultGateway6 != null;
+        # XXX we explicitly rely on network-setup.service being
+        # unconditionally present for triggering dependencies on
+        # interface units.
+        needNetworkSetup = true;
 
         networkLocalCommands = lib.mkIf needNetworkSetup {
           after = [ "network-setup.service" ];
@@ -131,14 +119,18 @@ let
         networkSetup = lib.mkIf needNetworkSetup {
           description = "Networking Setup";
 
-          after = [ "network-pre.target" ];
+          after = [
+            "network-pre.target"
+            "systemd-udevd.service"
+            "systemd-sysctl.service"
+          ];
           before = [
             "network.target"
             "shutdown.target"
           ];
           wants = [ "network.target" ];
-          # exclude bridges from the partOf relationship to fix container networking bug #47210
-          partOf = map (i: "network-addresses-${i.name}.service") (
+          # exclude bridges from the requires relationship to fix container networking bug #47210
+          requiredBy = map (i: "network-addresses-${i.name}.service") (
             filter (i: !(hasAttr i.name cfg.bridges)) interfaces
           );
           conflicts = [ "shutdown.target" ];
@@ -225,10 +217,12 @@ let
             wantedBy = [
               "network-setup.service"
               "network.target"
+              "multi-user.target"
             ];
             # order before network-setup because the routes that are configured
             # there may need ip addresses configured
             before = [ "network-setup.service" ];
+            requires = [ "network-setup.service" ];
             bindsTo = deviceDependency i.name;
             after = [ "network-pre.target" ] ++ (deviceDependency i.name);
             serviceConfig.Type = "oneshot";
@@ -315,6 +309,7 @@ let
               "network-setup.service"
               (subsystemDevice i.name)
             ];
+            requires = [ "network-setup.service" ];
             before = [ "network-setup.service" ];
             path = [ pkgs.iproute2 ];
             serviceConfig = {
@@ -343,7 +338,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps ++ optional v.rstp "mstpd.service";
-              partOf = [ "network-setup.service" ] ++ optional v.rstp "mstpd.service";
+              requires = [ "network-setup.service" ] ++ optional v.rstp "mstpd.service";
               after = [
                 "network-pre.target"
               ]
@@ -452,7 +447,7 @@ let
               # should work without internalConfigs dependencies because address/link configuration depends
               # on the device, which is created by ovs-vswitchd with type=internal, but it does not...
               before = [ "network-setup.service" ] ++ internalConfigs;
-              partOf = [ "network-setup.service" ]; # shutdown the bridge when network is shutdown
+              requires = [ "network-setup.service" ]; # shutdown the bridge when network is shutdown
               bindsTo = [ "ovs-vswitchd.service" ]; # requires ovs-vswitchd to be alive at all times
               after = [
                 "network-pre.target"
@@ -521,6 +516,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps ++ map (i: "network-addresses-${i}.service") v.interfaces;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -570,6 +566,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -614,6 +611,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -644,6 +642,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -735,6 +734,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";
@@ -770,7 +770,7 @@ let
                 (subsystemDevice n)
               ];
               bindsTo = deps;
-              partOf = [ "network-setup.service" ];
+              requires = [ "network-setup.service" ];
               after = [ "network-pre.target" ] ++ deps;
               before = [ "network-setup.service" ];
               serviceConfig.Type = "oneshot";

--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -249,6 +249,50 @@ let
     to ~/.config/nixpkgs/config.nix.
   '';
 
+  remediate_unfree = attrs: ''
+    You can install it anyway by allowing this package, using one of the
+    following methods:
+
+    a) if this happened while building a NixOS config, e.g. by
+       running `fc-manage switch`, you can add ‘${lib.getName attrs}’
+       to `flyingcircus.allowedUnfreePackageNames`, like this:
+
+         {
+           flyingcircus.allowedUnfreePackageNames = [
+             "${lib.getName attrs}"
+           ];
+         }
+
+    b) when using our channel tarballs (e.g. a tarball from the FCIO Hydra or
+       `import <fc> {}`), you can the following declarations to the `import` argument:
+
+         {
+           config.allowedUnfreePackageNames = [
+             "${lib.getName attrs}"
+           ];
+         }
+
+    c) when using nixpkgs directly (e.g. via `import <nixpkgs> {}`), you can add
+       the following declarations to the `import` argument:
+
+         {
+           # to allow ANY unfree package
+           config.allowUnfree = true;
+
+           # to allow ONLY THIS unfree package
+           config.allowUnfreePredicate = pkg: builtins.elem (pkg.pname or (builtins.parseDrvName pkg).name) [
+             "${lib.getName attrs}"
+           ];
+         }
+
+    d) temporarily allowing any unfree package can be enabled via
+
+         $ export NIXPKGS_ALLOW_UNFREE=1
+
+       Please note that this only advisable for interactive use, e.g. for `nix-shell`
+       and should NOT be used for NixOS configurations or user envs.
+  '';
+
   remediate_insecure =
     attrs:
     ''
@@ -258,34 +302,36 @@ let
     + (concatStrings (map (issue: " - ${issue}\n") attrs.meta.knownVulnerabilities))
     + ''
 
-      You can install it anyway by allowing this package, using the
+      You can install it anyway by allowing this package, using one of the
       following methods:
 
-      a) To temporarily allow all insecure packages, you can use an environment
-         variable for a single invocation of the nix tools:
+      a) if this happened while building a NixOS config, e.g. by
+         running `fc-manage switch`, you can add ‘${getNameWithVersion attrs}’
+         to `flyingcircus.permittedInsecurePackages`, like this:
+
+           {
+             flyingcircus.permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+      b) when using nixpkgs directly, you can set `permittedInsecurePackages` like this:
+
+           {
+             config.permittedInsecurePackages = [
+               "${getNameWithVersion attrs}"
+             ];
+           }
+
+         This is relevant when importing a channel tarball from Hydra
+         or the machine's nixpkgs (i.e. `import <nixpkgs>`), e.g. in a user env.
+
+      c) temporarily allowing any insecure package can be enabled via
 
            $ export NIXPKGS_ALLOW_INSECURE=1
-           ${flakeNote}
-      b) for `nixos-rebuild` you can add ‘${getNameWithVersion attrs}’ to
-         `nixpkgs.config.permittedInsecurePackages` in the configuration.nix,
-         like so:
 
-           {
-             nixpkgs.config.permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
-      c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
-         ‘${getNameWithVersion attrs}’ to `permittedInsecurePackages` in
-         ~/.config/nixpkgs/config.nix, like so:
-
-           {
-             permittedInsecurePackages = [
-               "${getNameWithVersion attrs}"
-             ];
-           }
-
+         Please note that this only advisable for interactive use, e.g. for `nix-shell`
+         and should NOT be used for NixOS configurations or user envs.
     '';
 
   remediateOutputsToInstall =
@@ -473,7 +519,7 @@ let
       {
         reason = "unfree";
         errormsg = "has an unfree license (‘${showLicense attrs.meta.license}’)";
-        remediation = remediate_allowlist "Unfree" (remediate_predicate "allowUnfreePredicate" attrs);
+        remediation = remediate_unfree attrs;
       }
     else if hasBlocklistedLicense attrs then
       {

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -583,6 +583,26 @@ stdenv.mkDerivation rec {
       url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=ac1512b872af8567b408518a7efa01607a0219ae";
       hash = "sha256-deyp6Yatlgv86bYMt7WcWhKg8J6StDPUEy4UPHqJYIc=";
     })
+    (fetchpatch {
+      name = "xfs-non-continuous-data-blocks.patch";
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=68dd65cfdaad08b1f8ec01b84949b0bf88bc0d8c";
+      hash = "sha256-KWdOJhsWmUIOj66SrIYhZvpnshDSpfzaEKZOSXjIs1E=";
+    })
+    (fetchpatch {
+      name = "xfs-superblock.patch";
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=1ed2628b560cedac7fd1a696985ab85b24541a8e";
+      hash = "sha256-ijeEzqHhrPU12iWF4Os8S3paCAR0gQ+W4JAIV5dH0jw=";
+    })
+    (fetchpatch {
+      name = "xfs-iterate-dir.patch";
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=f209887381a56dea79152ab26ffb485718e3218e";
+      hash = "sha256-3qWfGxQg7pndeseIcQn3uPj23cGJWyuP5dG4eDQearU=";
+    })
+    (fetchpatch {
+      name = "xfs-large-extent.patch";
+      url = "https://git.savannah.gnu.org/cgit/grub.git/patch/?id=4abac0ad5a7914dd3cdfff08aaac06588bf98d80";
+      hash = "sha256-SActYcUgGRNoAtmpUOSas2JRdWtg7sLovh4BtZRmFUc=";
+    })
   ];
 
   postPatch =

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -109,7 +109,7 @@ assert lib.asserts.assertMsg (
 
 stdenv.mkDerivation rec {
   pname = "grub";
-  version = "2.12";
+  version = "2.12.1";
 
   src = fetchgit {
     url = "https://git.savannah.gnu.org/git/grub.git";


### PR DESCRIPTION
Pull in missing XFS patches for grub2 that fix boot issues with XFS file systems.
Bumping the patch release number of grub ensures that the bootloader files are actually installed.

FC-51697 PL-135139

I only tested that this builds, the rest can be left to our regular pre-release QA pipeline.