### PR TITLE
nixos/odoo: disable the database manager by default

### DIFF
--- a/nixos/modules/services/finance/odoo.nix
+++ b/nixos/modules/services/finance/odoo.nix
@@ -103,6 +103,9 @@ in
       services.odoo.settings.options = {
         data_dir = "/var/lib/private/odoo/data";
         proxy_mode = cfg.domain != null;
+        # Disable the database manager by default
+        # https://www.odoo.com/documentation/master/administration/on_premise/deploy.html#database-manager-security
+        list_db = lib.mkDefault false;
       }
       // (lib.optionalAttrs (cfg.addons != [ ]) {
         addons_path = lib.concatMapStringsSep "," lib.escapeShellArg cfg.addons;

--- a/nixos/tests/odoo.nix
+++ b/nixos/tests/odoo.nix
@@ -29,5 +29,6 @@
     server.wait_for_unit("odoo.service")
     server.wait_until_succeeds("curl -s http://localhost:8069/web/database/selector | grep '<title>Odoo</title>'")
     server.succeed("curl -s http://localhost/web/database/selector | grep '<title>Odoo</title>'")
+    server.succeed("curl http://localhost/web/database/manager | grep 'database manager has been disabled'")
   '';
 }


### PR DESCRIPTION
https://www.odoo.com/documentation/master/administration/on_premise/deploy.html#database-manager-security

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
