### PR TITLE
rerun: 0.28.2 -> 0.29.0

### DIFF
--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -35,7 +35,7 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rerun";
-  version = "0.28.2";
+  version = "0.29.0";
 
   outputs = [
     "out"
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "rerun-io";
     repo = "rerun";
     tag = finalAttrs.version;
-    hash = "sha256-4zijWVLXnNQLqEMWnO1o/fnCoBjESDbn14CQyCP2o2s=";
+    hash = "sha256-15wYH+MhrAaW7MPl7Kkh7u5SzxIGXTj2HkhJGZ38kMo=";
   };
 
   # The path in `build.rs` is wrong for some reason, so we patch it to make the passthru tests work
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --replace-fail '"rerun_sdk/rerun_cli/rerun"' '"rerun_sdk/rerun"'
   '';
 
-  cargoHash = "sha256-FrOo4+5S8JAlQSmDvH0omhOsG9PjZMvRejk9VHEucVY=";
+  cargoHash = "sha256-TVsPS1jzDzRSY9b636Tv30WupCnyfADeA+8pYn8STIs=";
 
   cargoBuildFlags = [
     "--package rerun-cli"

--- a/pkgs/development/python-modules/rerun-sdk/default.nix
+++ b/pkgs/development/python-modules/rerun-sdk/default.nix
@@ -36,8 +36,22 @@ buildPythonPackage {
     src
     version
     cargoDeps
-    postPatch
     ;
+
+  postPatch =
+    (rerun.postPatch or "")
+
+    # error: failed to parse contents of PYO3_CONFIG_FILE
+    #
+    # The pyo3 config file is supposed to be generated beforehand by invoking pixi.
+    # As the only goal of this file is to enhance build caching, it is not worth bothering with it.
+    # See https://github.com/rerun-io/rerun/blob/0.29.0/BUILD.md#pythonpyo3-configuration-important
+    + ''
+      substituteInPlace .cargo/config.toml \
+        --replace-fail \
+          "PYO3_CONFIG_FILE" \
+          "# PYO3_CONFIG_FILE"
+    '';
 
   nativeBuildInputs = [
     pkgs.protobuf # for protoc


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/rerun-io/rerun/compare/0.28.2...0.29.0
Changelog: https://github.com/rerun-io/rerun/releases/tag/0.29.0

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
