### PR TITLE
bichon: init at 0.3.7

### DIFF
--- a/pkgs/by-name/bi/bichon/build-script-commit-hash.patch
+++ b/pkgs/by-name/bi/bichon/build-script-commit-hash.patch
@@ -1,0 +1,20 @@
+diff --git a/build.rs b/build.rs
+index ef46b47..eefbb17 100644
+--- a/build.rs
++++ b/build.rs
+@@ -1,14 +1,7 @@
+ use std::{io::Result, process::Command};
+ 
+ fn main() -> Result<()> {
+-    let output = Command::new("git")
+-        .args(&["rev-parse", "--short", "HEAD"])
+-        .output()
+-        .expect("Failed to get git commit hash");
+-    let git_hash = String::from_utf8(output.stdout)
+-        .expect("Invalid UTF-8")
+-        .trim()
+-        .to_string();
++    let git_hash = std::fs::read_to_string("COMMIT_HASH").unwrap();
+     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+     Ok(())
+ }

--- a/pkgs/by-name/bi/bichon/package.nix
+++ b/pkgs/by-name/bi/bichon/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenvNoCC,
+  rustPlatform,
+  openssl,
+  pkgconf,
+  git,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "bichon";
+  version = "0.3.7";
+
+  src = fetchFromGitHub {
+    owner = "rustmailer";
+    repo = "bichon";
+    tag = finalAttrs.version;
+    hash = "sha256-uJ2Ideu9phiHv8d7wSPu59tiH4wntDSGWL/sFUilD70=";
+    # Bichon insists on running retrieving the Git hash in its build script.
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse --short HEAD > $out/COMMIT_HASH
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
+  };
+
+  patches = [
+    ./build-script-commit-hash.patch
+  ];
+
+  cargoHash = "sha256-l11G3x7ZiInptez9KrGNf685eyxwjqePGbQiQxCkwNI=";
+
+  nativeBuildInputs = [
+    pkgconf
+    git
+  ];
+
+  buildInputs = [ openssl ];
+
+  bichon-web = stdenvNoCC.mkDerivation (finalAttrs': {
+    pname = "${finalAttrs.pname}-web";
+    inherit (finalAttrs) src version;
+
+    nativeBuildInputs = [
+      nodejs
+      pnpmConfigHook
+      pnpm_10
+    ];
+
+    sourceRoot = "${finalAttrs.src.name}/web";
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs')
+        pname
+        version
+        src
+        sourceRoot
+        ;
+      pnpm = pnpm_10;
+      fetcherVersion = 3;
+      hash = "sha256-T7Y9QLO6ruPQ6eRqTq7NeSPkp4oBOjgd/U3PXbYzRuk=";
+    };
+
+    postBuild = ''
+      pnpm build
+    '';
+
+    installPhase = ''
+      cp -r dist $out
+    '';
+  });
+
+  preBuild = ''
+    mkdir -p web/dist
+    cp -r ${finalAttrs.bichon-web}/* web/dist
+  '';
+
+  # As of 0.3.7, tests are failing due to upstream bugs (unrelated to nixpkgs)
+  doCheck = false;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/bichon";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "bichon-web"
+    ];
+  };
+
+  meta = {
+    description = "A lightweight, high-performance Rust email archiver with WebUI";
+    homepage = "https://github.com/rustmailer/bichon";
+    mainProgram = "bichon";
+    license = lib.licenses.agpl3Plus;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      tmarkus
+    ];
+  };
+})


### PR DESCRIPTION
Package bichon, a mail archiving server.
https://github.com/rustmailer/bichon

The subpackage design (bichon-web) is adapted from the qui package.

I have Bichon running locally using a NixOS module that needs a bit more polishing.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
