### PR TITLE
librewolf-unwrapped: 147.0.1-3 -> 147.0.3-2

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "147.0.1-3",
+  "packageVersion": "147.0.3-2",
   "source": {
-    "rev": "147.0.1-3",
-    "hash": "sha256-0BeC3zlL5cvnpTaPnKn26lT1XlvqBQuMc4rauNbeIIk="
+    "rev": "147.0.3-2",
+    "hash": "sha256-Gnsk+dY0B0j/0npy//y/UItKvPrI9HELrH86x0QklBk="
   },
   "firefox": {
-    "version": "147.0.1",
-    "hash": "sha512-8eG8SGRRJU8zsAD7RRP9lIpaboSEGYDudnxC0ybhhW9EqEN8j9v/LLNNF3/qKxkH/Nct0zvOw/Bt242IFRhTqA=="
+    "version": "147.0.3",
+    "hash": "sha512-N+OcR9aU7M3Ku32KCkz+GwKGCpf2BGU/Nkxg9OmHlv/H8carUSJrLlA0pLSAXMxuw5g/DYMMnzZpLfLsJhJz2Q=="
   }
 }


### PR DESCRIPTION
Diff: https://codeberg.org/librewolf/source/compare/147.0.1-3...147.0.3-2

~~Changes haven't been tested yet.~~
Changes have been tested now. Patches seem to get applied successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
