### PR TITLE
yaziPlugins.yatline-githead: 0-unstable-2025-05-31 -> 0-unstable-2026-01-30

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/yatline-githead/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline-githead/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline-githead.yazi";
-  version = "0-unstable-2025-05-31";
+  version = "0-unstable-2026-01-30";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline-githead.yazi";
-    rev = "f8f969e84c39ad4215334ea5012183a2a5a6160b";
-    hash = "sha256-Cs8zSYtUfdCmKwIkJwQGyQNeSOmmpPvObCMnGm+32zg=";
+    rev = "25a068d78838e463a7c34f3674a6f3b986756968";
+    hash = "sha256-1BrqMwFff3wH+RntYSQkeuRZiBMdgK5v1c9h+QQ8XF8=";
   };
 
   meta = {


### PR DESCRIPTION
Compare: https://github.com/imsi32/yatline-githead.yazi/compare/f8f969e84c39ad4215334ea5012183a2a5a6160b...25a068d78838e463a7c34f3674a6f3b986756968


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Fixes some api deprecation
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
