### PR TITLE
lua5_5: build `linux` target

### DIFF
--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -31,10 +31,10 @@ stdenv.mkDerivation (
     luaversion = lib.versions.majorMinor finalAttrs.version;
 
     plat =
-      if (stdenv.hostPlatform.isLinux && lib.versionOlder self.luaversion "5.4") then
-        "linux"
-      else if (stdenv.hostPlatform.isLinux && self.luaversion == "5.4") then
+      if (stdenv.hostPlatform.isLinux && self.luaversion == "5.4") then
         "linux-readline"
+      else if stdenv.hostPlatform.isLinux then
+        "linux"
       else if stdenv.hostPlatform.isDarwin then
         "macosx"
       else if stdenv.hostPlatform.isMinGW then


### PR DESCRIPTION
The platform/lua version check falls back to the `generic` target for Lua 5.5.

This results in errors when trying to load Lua packages written in C:

```
Lua 5.5.0  Copyright (C) 1994-2025 Lua.org, PUC-Rio
> require('lfs')
error loading module 'lfs' from file '/nix/store/v1vzcy780zpsdahjq1fj6khb46jnxwm5-lua-5.5.0-env/lib/lua/5.5/lfs.so':
        dynamic libraries not enabled; check your Lua installation
```

See also: https://github.com/NixOS/nixpkgs/pull/484662#issuecomment-3820851482

Note: There is no `linux-readline` target in the Lua 5.5 Makefile, so we just build the `linux` target.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
