### PR TITLE
Rocq platform 9.0 update

### DIFF
--- a/pkgs/development/coq-modules/LibHyps/default.nix
+++ b/pkgs/development/coq-modules/LibHyps/default.nix
@@ -2,6 +2,7 @@
   lib,
   mkCoqDerivation,
   coq,
+  stdlib,
   version ? null,
 }:
 
@@ -9,12 +10,14 @@ mkCoqDerivation {
   pname = "LibHyps";
   owner = "Matafou";
   inherit version;
-  defaultVersion = if (lib.versions.range "8.11" "8.20") coq.version then "2.0.8" else null;
+  defaultVersion = if (lib.versions.range "8.11" "9.0") coq.version then "2.0.8" else null;
   release = {
     "2.0.8".sha256 = "sha256-u8T7ZWfgYNFBsIPss0uUS0oBvdlwPp3t5yYIMjYzfLc=";
   };
 
   configureScript = "./configure.sh";
+
+  propagatedBuildInputs = [ stdlib ];
 
   releaseRev = (v: "libhyps-${v}");
 

--- a/pkgs/development/coq-modules/aac-tactics/default.nix
+++ b/pkgs/development/coq-modules/aac-tactics/default.nix
@@ -11,6 +11,7 @@ mkCoqDerivation {
 
   releaseRev = v: "v${v}";
 
+  release."9.0.0".sha256 = "sha256-mln1182EOeXZCa1NzjAiovK93Xm+5JMZpGqJVrM67Jo=";
   release."8.20.0".sha256 = "sha256-VQzeINIZAfP3Qyh29uPqcNVlNJfIzzRLtN0Cm4EuGCk=";
   release."8.19.1".sha256 = "sha256-W/V57h+rjb3m0ktCG83PquMHfXiv6H1Nhvw9sVEPLqM=";
   release."8.19.0".sha256 = "sha256-IeCBd8gcu4bAXH5I/XIT7neQIILi+EWR6qqAA4GzQD0=";
@@ -34,6 +35,10 @@ mkCoqDerivation {
   defaultVersion =
 
     lib.switch coq.coq-version [
+      {
+        case = "9.0";
+        out = "9.0.0";
+      }
       {
         case = "8.20";
         out = "8.20.0";

--- a/pkgs/development/coq-modules/mtac2/default.nix
+++ b/pkgs/development/coq-modules/mtac2/default.nix
@@ -2,6 +2,7 @@
   lib,
   mkCoqDerivation,
   coq,
+  stdlib,
   unicoq,
   version ? null,
 }:
@@ -14,14 +15,19 @@ mkCoqDerivation {
     with lib.versions;
     lib.switch coq.version [
       {
-        case = range "8.19" "8.19";
+        case = range "8.19" "9.0";
         out = "1.4-coq${coq.coq-version}";
       }
     ] null;
+  release."1.4-coq9.0".sha256 = "sha256-pAPBRCW7M46UZPJ+v/0xAT8mpQURN8czMmlrfYz/MVU=";
+  release."1.4-coq8.20".sha256 = "sha256-3nu/8zDvdnl6WzGtw46mVcdqgkRgc6Xy8/I+lUOrSIY=";
   release."1.4-coq8.19".sha256 = "sha256-G9eK0eLyECdT20/yf8yyz7M8Xq2WnHHaHpxVGP0yTtU=";
   releaseRev = v: "v${v}";
   mlPlugin = true;
-  propagatedBuildInputs = [ unicoq ];
+  propagatedBuildInputs = [
+    stdlib
+    unicoq
+  ];
   meta = {
     description = "Typed tactic language for Coq";
     license = lib.licenses.mit;

--- a/pkgs/development/coq-modules/paramcoq/default.nix
+++ b/pkgs/development/coq-modules/paramcoq/default.nix
@@ -12,7 +12,7 @@ mkCoqDerivation {
     with lib.versions;
     lib.switch coq.version [
       {
-        case = range "8.10" "8.20";
+        case = range "8.10" "9.0";
         out = "1.1.3+coq${coq.coq-version}";
       }
       {
@@ -23,6 +23,7 @@ mkCoqDerivation {
   displayVersion = {
     paramcoq = "...";
   };
+  release."1.1.3+coq9.0".sha256 = "sha256-zibQ9nBadSElpyI8iMTDRW/mqtxmxClaVb24o5W6ajE=";
   release."1.1.3+coq8.20".sha256 = "sha256-34xDOz/2xO39fnQW6Zb9CI2EKFuJZjrAdOpMEmwuzY0=";
   release."1.1.3+coq8.19".sha256 = "sha256-5NVsdLXaoz6qrr5ra5YfoHeuK4pEf8JX/X9+SZA0U+U=";
   release."1.1.3+coq8.18".sha256 = "sha256-hNBaj9hB+OzwXsOX+TOXtDLjA5oP4EmEgseLwxFxW+I=";

--- a/pkgs/development/coq-modules/rewriter/default.nix
+++ b/pkgs/development/coq-modules/rewriter/default.nix
@@ -16,12 +16,12 @@ mkCoqDerivation {
     in
     lib.switch coq.coq-version [
       {
-        case = range "8.17" "8.19";
-        out = "0.0.11";
+        case = range "8.17" "9.0";
+        out = "0.0.15";
       }
     ] null;
   release = {
-    "0.0.11".sha256 = "sha256-aYoO08nwItlOoE5BnKRGib2Zk4Fz4Ni/L4QaqkObPow=";
+    "0.0.15".sha256 = "sha256-zxNIMppFXUKShOXLbdZphy0Je5ii6cjcWUUcQMTcaHk=";
   };
   releaseRev = v: "v${v}";
 

--- a/pkgs/development/coq-modules/unicoq/default.nix
+++ b/pkgs/development/coq-modules/unicoq/default.nix
@@ -13,10 +13,15 @@ mkCoqDerivation {
     with lib.versions;
     lib.switch coq.version [
       {
+        case = range "8.20" "9.0";
+        out = "1.6-8.20";
+      }
+      {
         case = range "8.19" "8.19";
-        out = "1.6-${coq.coq-version}";
+        out = "1.6-8.19";
       }
     ] null;
+  release."1.6-8.20".sha256 = "sha256-zne9LB0lGdqUfrBe8cDK8fwuxfBDFU4PqNlt9nl7rNI=";
   release."1.6-8.19".sha256 = "sha256-fDk60B8AzJwiemxHGgWjNu6PTu6NcJoI9uK7Ww2AT14=";
   releaseRev = v: "v${v}";
   mlPlugin = true;

--- a/pkgs/development/rocq-modules/relation-algebra/default.nix
+++ b/pkgs/development/rocq-modules/relation-algebra/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  mkRocqDerivation,
+  rocq-core,
+  stdlib,
+  version ? null,
+}:
+
+mkRocqDerivation {
+  pname = "relation-algebra";
+  owner = "damien-pous";
+
+  inherit version;
+  defaultVersion =
+    lib.switch
+      [ rocq-core.rocq-version ]
+      [
+        {
+          cases = [ (lib.versions.isEq "9.0") ];
+          out = "1.8.0";
+        }
+      ]
+      null;
+
+  releaseRev = v: "v${v}";
+
+  release."1.8.0".sha256 = "sha256-RnY+a57KnStACteaT5dKQoCCH0qp7/W+4qoaApIilj0=";
+
+  propagatedBuildInputs = [
+    stdlib
+  ];
+
+  dontConfigure = true;
+
+  mlPlugin = true;
+
+  meta = {
+    description = "Relation algebra library for Rocq";
+    maintainers = with lib.maintainers; [ siraben ];
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/rocq-packages.nix
+++ b/pkgs/top-level/rocq-packages.nix
@@ -46,6 +46,7 @@ let
       mathcomp-field = self.mathcomp.field;
       mathcomp-character = self.mathcomp.character;
       parseque = callPackage ../development/rocq-modules/parseque { };
+      relation-algebra = callPackage ../development/rocq-modules/relation-algebra { };
       rocq-elpi = callPackage ../development/rocq-modules/rocq-elpi { };
       stdlib = callPackage ../development/rocq-modules/stdlib { };
       vsrocq-language-server = callPackage ../development/rocq-modules/vsrocq-language-server { };


### PR DESCRIPTION
Update Rocq packages for Rocq 9.0 compatibility based on the contents of the Rocq Platform.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
