### PR TITLE
tabby: 0.28.0 -> 0.32.0

### DIFF
--- a/pkgs/by-name/ta/tabby/package.nix
+++ b/pkgs/by-name/ta/tabby/package.nix
@@ -3,6 +3,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  fetchurl,
   nix-update-script,
   stdenv,
 
@@ -32,7 +33,12 @@ let
   # https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/ollama/default.nix
 
   pname = "tabby";
-  version = "0.28.0";
+  version = "0.32.0";
+
+  swaggerUiSrc = fetchurl {
+    url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip";
+    hash = "sha256-SBJE0IEgl7Efuu73n3HZQrFxYX+cn5UU5jrL4T5xzNw=";
+  };
 
   availableAccelerations = flatten [
     (optional cudaSupport "cuda")
@@ -118,15 +124,21 @@ rustPlatform.buildRustPackage {
   inherit pname version;
   inherit featureDevice;
 
+  VERGEN_IDEMPOTENT = "true";
+  VERGEN_GIT_DESCRIBE = "v${version}";
+  VERGEN_GIT_SHA = "nix-package";
+  VERGEN_BUILD_TIMESTAMP = "1970-01-01T00:00:00Z";
+  VERGEN_GIT_SEMVER = "v${version}";
+
   src = fetchFromGitHub {
     owner = "TabbyML";
     repo = "tabby";
     tag = "v${version}";
-    hash = "sha256-cdY1/k7zZ4am6JP9ghnnJFHop/ZcnC/9alzd2MS8xqc=";
+    hash = "sha256-qcp0QKiF5Fldbc8SI3q0TWdbizVA5tppDfmM4OL7vh8=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-yEns0QAARmuV697/na08K8uwJWZihY3pMyCZcERDlFM=";
+  cargoHash = "sha256-/qo2MbtkIe4dXsvQPUT5n5O94/oAlQwAmR75tIEDnv8=";
 
   # Don't need to build llama-cpp-server (included in default build)
   # We also don't add CUDA features here since we're using the overridden llama-cpp package
@@ -142,6 +154,10 @@ rustPlatform.buildRustPackage {
     versionCheckHook
   ];
   doInstallCheck = true;
+
+  preBuild = ''
+    export SWAGGER_UI_DOWNLOAD_URL="file://${swaggerUiSrc}"
+  '';
 
   nativeBuildInputs = [
     git


### PR DESCRIPTION
Description
Update tabby from 0.28.0 to 0.32.0.

This update addresses several build issues and brings the package up to date with the latest features.

Changes
Update version and hashes: Bump to 0.32.0.

Fix sandbox build: The utoipa-swagger-ui crate attempts to download assets during build, which fails in the Nix sandbox. I've added fetchurl for these assets and injected the path via SWAGGER_UI_DOWNLOAD_URL.

Fix version metadata: Injected VERGEN_GIT_* environment variables to ensure tabby --version reports the correct version instead of a generic idempotent placeholder.

Changelog: https://github.com/TabbyML/tabby/releases/tag/v0.32.0

Hi @ghthor, I've updated the package and fixed the build issues in the sandbox environment. Could you please take a look when you have a moment? Thanks!

Things done
Built on platform:

[x] x86_64-linux

Tested, as applicable:

[x] Tested basic functionality of all binary files, usually in ./result/bin/.

Verified tabby --version returns 0.32.0.

Verified tabby serve starts correctly with CUDA support.

Nixpkgs Release Notes

[x] Package update: when the change is major or breaking.

[x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.