### PR TITLE
lazycommit: init at 1.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15773,6 +15773,11 @@
     githubId = 8094643;
     keys = [ { fingerprint = "BAA9 7711 58CA D457 B4AE  8B06 8188 423D 2FA2 0A65"; } ];
   };
+  m7medvision = {
+    name = "Mohammed";
+    github = "m7medVision";
+    githubId = 88824957;
+  };
   ma27 = {
     email = "maximilian@mbosch.me";
     matrix = "@ma27:nicht-so.sexy";

--- a/pkgs/by-name/la/lazycommit/package.nix
+++ b/pkgs/by-name/la/lazycommit/package.nix
@@ -2,8 +2,6 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  lazycommit,
-  testers,
   nix-update-script,
 }:
 buildGoModule rec {

--- a/pkgs/by-name/la/lazycommit/package.nix
+++ b/pkgs/by-name/la/lazycommit/package.nix
@@ -38,11 +38,7 @@ buildGoModule rec {
     changelog = "https://github.com/m7medvision/lazycommit/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
-      Br1ght0ne
-      equirosa
-      khaneliman
-      starsep
-      sigmasquadron
+      m7medvision
     ];
     mainProgram = "lazycommit";
   };

--- a/pkgs/by-name/la/lazycommit/package.nix
+++ b/pkgs/by-name/la/lazycommit/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  lazycommit,
+  testers,
+  nix-update-script,
+}:
+buildGoModule rec {
+  pname = "lazycommit";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "m7medvision";
+    repo = "lazycommit";
+    tag = "v${version}";
+    hash = "sha256-DD3DXTev8WHNkAYDrPY2PISuA8WwKuK0GCLebpn01Rg=";
+  };
+
+  vendorHash = "sha256-4OPCUWXxsAnzxsqZPHhjvhxQQf5Knm7nGqrdjH4I4YY=";
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-X main.version=${version}"
+    "-X main.buildSource=nix"
+  ];
+
+  passthru = {
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "^v([0-9.]+)$"
+      ];
+    };
+  };
+
+  meta = {
+    description = "Simple cli for genrate git commits";
+    homepage = "https://github.com/m7medvision/lazycommit";
+    changelog = "https://github.com/m7medvision/lazycommit/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      Br1ght0ne
+      equirosa
+      khaneliman
+      starsep
+      sigmasquadron
+    ];
+    mainProgram = "lazycommit";
+  };
+}

--- a/pkgs/by-name/la/lazycommit/package.nix
+++ b/pkgs/by-name/la/lazycommit/package.nix
@@ -16,7 +16,6 @@ buildGoModule rec {
   };
 
   vendorHash = "sha256-4OPCUWXxsAnzxsqZPHhjvhxQQf5Knm7nGqrdjH4I4YY=";
-  subPackages = [ "." ];
 
   ldflags = [
     "-X main.version=${version}"

--- a/pkgs/by-name/la/lazycommit/package.nix
+++ b/pkgs/by-name/la/lazycommit/package.nix
@@ -33,7 +33,7 @@ buildGoModule rec {
   };
 
   meta = {
-    description = "Simple cli for genrate git commits";
+    description = "Simple cli for generating git commits";
     homepage = "https://github.com/m7medvision/lazycommit";
     changelog = "https://github.com/m7medvision/lazycommit/releases/tag/v${version}";
     license = lib.licenses.mit;


### PR DESCRIPTION
### Motivation for this change

New package: `lazycommit` - [brief description of what lazycommit does and why it's useful]

### Things done

- [x] Built a runtime test using `nix-build -A lazycommit`
- [x] Ensured that relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)

#### Testing

- [x] Tested using sandboxing ([nix.conf](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-sandbox) `sandbox = true`)
- [x] Built on platform(s):
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`