### PR TITLE
shadcn: 2.0.3 -> 3.7.0

### DIFF
--- a/pkgs/by-name/sh/shadcn/package.nix
+++ b/pkgs/by-name/sh/shadcn/package.nix
@@ -12,13 +12,13 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "shadcn";
-  version = "2.0.3";
+  version = "3.7.0";
 
   src = fetchFromGitHub {
     owner = "shadcn-ui";
     repo = "ui";
     rev = "shadcn@${finalAttrs.version}";
-    hash = "sha256-OBLKCj+v5KgYslJGuwLgJHjgcrxLPiiyO5/ucrJ14Ws=";
+    hash = "sha256-9dlSAEkl6NgZGT2noVEfstt8TbIy0Fz+/s5L+MWpblg=";
   };
 
   pnpmWorkspaces = [ "shadcn" ];
@@ -30,8 +30,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       ;
     pnpm = pnpm_9;
-    fetcherVersion = 1;
-    hash = "sha256-/80LJm65ZRqyfhsNqGl83bsI2wjgVkvrA6Ij4v8rtoQ=";
+    fetcherVersion = 2;
+    hash = "sha256-clTcaTar7m2jEX9cMPtSPeBtt17LaMzlwlLXhPKc+kk=";
   };
 
   nativeBuildInputs = [
@@ -56,7 +56,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -r {packages,node_modules} $out/lib
 
     # cleanup
-    rm -r $out/lib/packages/{cli,shadcn/src}
     find $out/lib/packages/shadcn -name '*.ts' -delete
 
     makeWrapper ${lib.getExe nodejs} $out/bin/shadcn \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
changes: https://github.com/shadcn-ui/ui/releases/tag/shadcn%403.7.0
diff: https://github.com/shadcn-ui/ui/compare/shadcn%402.0.3...shadcn%403.7.0
Resolves: https://github.com/NixOS/nixpkgs/issues/480280

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
