### PR TITLE
hyprpaper: 0.8.1-unstable-2026-01-08 -> 0.8.3

### DIFF
--- a/pkgs/by-name/hy/hyprpaper/package.nix
+++ b/pkgs/by-name/hy/hyprpaper/package.nix
@@ -32,6 +32,7 @@
   wayland,
   wayland-protocols,
   util-linux,
+  versionCheckHook,
 }:
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
@@ -85,6 +86,9 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     wayland-protocols
     util-linux
   ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {
     inherit (finalAttrs.src.meta) homepage;

--- a/pkgs/by-name/hy/hyprpaper/package.nix
+++ b/pkgs/by-name/hy/hyprpaper/package.nix
@@ -36,18 +36,18 @@
 
 gcc15Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpaper";
-  version = "0.8.1-unstable-2026-01-08";
+  version = "0.8.3";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprpaper";
-    rev = "2953d963bec2ea63b4303e269b472524db46a121";
-    hash = "sha256-vxAZg+NzAKuWZv2yDrTcXrU+klpAcGFo1FvjYb/CqZ8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6N1JeQx9/M3XCcxErk24FLMxTgn8GH40fpckP8X3ons=";
   };
 
   prePatch = ''
     substituteInPlace src/main.cpp \
-      --replace-fail GIT_COMMIT_HASH '"${finalAttrs.src.rev}"'
+      --replace-fail GIT_COMMIT_HASH '"${finalAttrs.src.tag}"'
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/hyprwm/hyprpaper/releases/tag/v0.8.3
There wern't any changes between the latest unstable and v0.8.2 as we were on the commit directly before the version bump.
Also added version check

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
