### PR TITLE
maintainers: drop squalus

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25082,12 +25082,6 @@
     githubId = 8904314;
     name = "Konstantin Nick";
   };
-  squalus = {
-    email = "squalus@squalus.net";
-    github = "squalus";
-    githubId = 36899624;
-    name = "squalus";
-  };
   squarepear = {
     email = "contact@jeffreyharmon.dev";
     github = "SquarePear";

--- a/nixos/tests/systemd-coredump.nix
+++ b/nixos/tests/systemd-coredump.nix
@@ -17,8 +17,8 @@ in
 
 {
   name = "systemd-coredump";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [ squalus ];
+  meta = {
+    maintainers = [ ];
   };
 
   nodes.machine1 = { pkgs, lib, ... }: commonConfig;

--- a/pkgs/by-name/li/librewolf-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/package.nix
@@ -29,7 +29,6 @@ in
     description = "Fork of Firefox, focused on privacy, security and freedom";
     homepage = "https://librewolf.net/";
     maintainers = with lib.maintainers; [
-      squalus
       dwrege
       fpletz
     ];

--- a/pkgs/by-name/mc/mcap-cli/package.nix
+++ b/pkgs/by-name/mc/mcap-cli/package.nix
@@ -79,7 +79,6 @@ buildGoModule {
     homepage = "https://github.com/foxglove/mcap";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
-      squalus
       therishidesai
     ];
     mainProgram = "mcap";

--- a/pkgs/by-name/na/navidrome/package.nix
+++ b/pkgs/by-name/na/navidrome/package.nix
@@ -95,7 +95,6 @@ buildGoModule (finalAttrs: {
     sourceProvenance = with lib.sourceTypes; [ fromSource ];
     maintainers = with lib.maintainers; [
       aciceri
-      squalus
       tebriel
     ];
     # Broken on Darwin: sandbox-exec: pattern serialization length exceeds maximum (NixOS/nix#4119)

--- a/pkgs/by-name/os/osquery/package.nix
+++ b/pkgs/by-name/os/osquery/package.nix
@@ -104,7 +104,6 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [
       znewman01
       lewo
-      squalus
       lesuisse
     ];
   };

--- a/pkgs/by-name/os/osquery/toolchain-bin.nix
+++ b/pkgs/by-name/os/osquery/toolchain-bin.nix
@@ -48,6 +48,6 @@ stdenv.mkDerivation {
       gpl2Only
       asl20
     ];
-    maintainers = with lib.maintainers; [ squalus ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/sc/scarlett2/package.nix
+++ b/pkgs/by-name/sc/scarlett2/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
     description = "Firmware Management Utility for Scarlett 2nd, 3rd, and 4th Gen, Clarett USB, and Clarett+ interfaces";
     homepage = "https://github.com/geoffreybennett/scarlett2";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ squalus ];
+    maintainers = [ ];
     mainProgram = "scarlett2";
   };
 

--- a/pkgs/by-name/st/standardnotes/package.nix
+++ b/pkgs/by-name/st/standardnotes/package.nix
@@ -89,7 +89,6 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [
       mgregoire
       chuangzhu
-      squalus
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
     platforms = builtins.attrNames srcjson.deb;


### PR DESCRIPTION
## Reasons

- Last commented in [March 2025](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Asqualus)
- Hasn't created any PRs / Issues since [March 2025](https://github.com/NixOS/nixpkgs/issues?q=author%3Asqualus)
- About 369 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Asqualus%20-commenter%3Asqualus%20-author%3Asqualus%20-reviewed-by%3Asqualus) PRs / Issues

See [lossing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this.

## Packages 

Those packages / tests only have them as their maintainer and would need at least one new maintainer.

- [ ] nixos/tests/systemd-coredump.nix
- [ ] osquery/toolchain-bin
- [ ] scarlett2