### PR TITLE
net-news-wire: 6.2 -> 7.0.5

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -139,6 +139,8 @@
 
 - `mactracker` has been updated to major version 8, which now [requires macOS 11 Big Sur or later](https://mactracker.ca/releasenotes-mac.html#:~:text=System%20requirements%20updated%20to%20macOS%2011%20Big%20Sur%20and%20later). The previous version supported Mac OS X 10.6.8 or later.
 
+- `net-news-wire` has been updated from 6.x to 7.x, which now requires macOS 15 (Sequoia) or newer. The previous version supported macOS 13 and newer.
+
 - `bartender` has been updated to major version 6. This removes support for MacOS Sonoma (and adds support for Tahoe). For more information, see [the release notes](https://www.macbartender.com/Bartender6/release_notes/) or [the Bartender 6 support page](https://www.macbartender.com/Bartender6/support/).
 
 - `lima` has been updated from `1.x` to `2.x`. This major update includes several breaking changes, such as `/tmp/lima` no longer being mounted by default.

--- a/pkgs/by-name/ne/net-news-wire/package.nix
+++ b/pkgs/by-name/ne/net-news-wire/package.nix
@@ -52,6 +52,7 @@ stdenvNoCC.mkDerivation rec {
     maintainers = with lib.maintainers; [
       jakuzure
       DimitarNestorov
+      shgew
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };

--- a/pkgs/by-name/ne/net-news-wire/package.nix
+++ b/pkgs/by-name/ne/net-news-wire/package.nix
@@ -9,11 +9,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "net-news-wire";
-  version = "6.2";
+  version = "7.0.5";
 
   src = fetchurl {
     url = "https://github.com/Ranchero-Software/NetNewsWire/releases/download/mac-${version}/NetNewsWire${version}.zip";
-    hash = "sha256-DXpC2bXgFRKYULXlrkDkwxtU77iChh5SITAIEQC5exQ=";
+    hash = "sha256-R0d2X7zj/aiuG3g2D91EQleWRR57MZacyr6HuQHWD+k=";
   };
 
   sourceRoot = ".";
@@ -35,7 +35,7 @@ stdenvNoCC.mkDerivation rec {
   passthru.updateScript = nix-update-script {
     extraArgs = [
       "--version-regex"
-      "^mac-(\\d+\\.\\d+\\.\\d+)$"
+      "^mac-(\\d+\\.\\d+(?:\\.\\d+)?)$"
     ];
   };
 


### PR DESCRIPTION
Changelog: https://github.com/Ranchero-Software/NetNewsWire/releases/tag/mac-7.0.5

Updates NetNewsWire to 7.0.5 and makes the patch semantic version component optional to fix the update script.

Adds backward incompatibility note: v7 requires macOS 15 (Sequoia) or newer, previously macOS 13+.