### PR TITLE
yarn-zpm: init at 6.0.0-rc.13

### DIFF
--- a/pkgs/by-name/ya/yarn-zpm/package.nix
+++ b/pkgs/by-name/ya/yarn-zpm/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "yarn-zpm";
+  version = "6.0.0-rc.13";
+
+  src = fetchFromGitHub {
+    owner = "yarnpkg";
+    repo = "zpm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Mfzy2dmnQWD8B3bYhMnqAic7rv4JS6pzuqGKrrCqCY0=";
+  };
+
+  cargoHash = "sha256-k5lOVe9Ju6BjHswaN7WrzpHgyuOcHTCOEH+ExzUC5lc=";
+
+  cargoBuildFlags = [ "--package=zpm" ];
+  cargoTestFlags = [ "--package=zpm" ];
+
+  # yarn is the Yarn Switch binary (zpm-switch package), yarn-bin is the actual package manager (zpm package)
+  # See https://yarn6.netlify.app/getting-started/#:~:text=You%20can%20bypass%20Yarn%20Switch
+  postInstall = ''
+    mv $out/bin/yarn-bin $out/bin/yarn
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Yarn is an open-source package manager for JavaScript and TypeScript projects";
+    homepage = "https://yarn6.netlify.app";
+    changelog = "https://github.com/yarnpkg/zpm/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [ DimitarNestorov ];
+    mainProgram = "yarn";
+  };
+})


### PR DESCRIPTION

https://yarn6.netlify.app/blog/2026-01-28-yarn-6-preview/

https://github.com/yarnpkg/zpm/

<img width="758" height="158" alt="image" src="https://github.com/user-attachments/assets/f85029e0-1933-4cc5-af1b-69b6f720c140" />

Tested manually on `aarch64-darwin` with the following commands:

```console
$ nix-build -A yarn-zpm
/nix/store/0s0474ja75s8kp7qqfwi451946sc3zgs-yarn-zpm-6.0.0-rc.13
$ cd /tmp
$ mkdir test-package
$ cd test-package
$ /nix/store/0s0474ja75s8kp7qqfwi451946sc3zgs-yarn-zpm-6.0.0-rc.13/bin/yarn -v
6.0.0-rc.13.local
$ /nix/store/0s0474ja75s8kp7qqfwi451946sc3zgs-yarn-zpm-6.0.0-rc.13/bin/yarn init
➤ · Yarn 6.0.0-rc.13.local
➤ ┌ Installing packages
➤ └ Completed in 3ms
➤ ┌ Linking the project
➤ └ Completed in 4ms
$ /nix/store/0s0474ja75s8kp7qqfwi451946sc3zgs-yarn-zpm-6.0.0-rc.13/bin/yarn add express
➤ · Yarn 6.0.0-rc.13.local
➤ ┌ Installing packages
➤ │ Resolved 82 packages
➤ └ Completed in 1s 220ms
➤ ┌ Linking the project
➤ └ Completed in 6ms
$ nix shell nixpkgs#nodejs --command /nix/store/0s0474ja75s8kp7qqfwi451946sc3zgs-yarn-zpm-6.0.0-rc.13/bin/yarn node -p "require('express/package.json').version"
5.2.1
$ cat package.json 
{
  "dependencies": {
    "express": "^5.2.1"
  },
  "name": "test-package"
}
$ mv yarn.lock yarn-lock.json
$ nix shell nixpkgs#nodejs --command /nix/store/0s0474ja75s8kp7qqfwi451946sc3zgs-yarn-zpm-6.0.0-rc.13/bin/yarn node -p "require('./yarn-lock.json').__metadata"
{ version: 9 }
$ nix shell nixpkgs#nodejs --command /nix/store/0s0474ja75s8kp7qqfwi451946sc3zgs-yarn-zpm-6.0.0-rc.13/bin/yarn node -p "Object.keys(require('./yarn-lock.json').entries).find(i => i.includes('express'))"
express@npm:^5.2.1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
