### PR TITLE
openclaw: init at 2026.2.26

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4808,6 +4808,12 @@
     githubId = 1438690;
     name = "Chris Pickard";
   };
+  chrisportela = {
+    email = "chris@chrisportela.com";
+    github = "chrisportela";
+    githubId = 505649;
+    name = "Chris Portela";
+  };
   chrispwill = {
     email = "chris@chrispwill.com";
     github = "ChrisPWill";

--- a/pkgs/by-name/op/openclaw/package.nix
+++ b/pkgs/by-name/op/openclaw/package.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs_22,
+  makeWrapper,
+  versionCheckHook,
+  nix-update-script,
+  rolldown,
+  version ? "2026.2.26",
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "openclaw";
+  version = version;
+
+  src = fetchFromGitHub {
+    owner = "openclaw";
+    repo = "openclaw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9kej1aK7j3/FU2X/bN983YqQClfnWfFPvByEkQKlQ4E=";
+  };
+
+  pnpmDepsHash = "sha256-Jcj0i/2Mh8Z5lp909Fkotw/isfLTIVMxtJgWwAtctEw=";
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = finalAttrs.pnpmDepsHash;
+  };
+
+  buildInputs = [ rolldown ];
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm_10
+    nodejs_22
+    makeWrapper
+  ];
+
+  preBuild = ''
+    rm -rf node_modules/rolldown node_modules/@rolldown/pluginutils
+    mkdir -p node_modules/@rolldown
+    cp -r ${rolldown}/lib/node_modules/rolldown node_modules/rolldown
+    cp -r ${rolldown}/lib/node_modules/@rolldown/pluginutils node_modules/@rolldown/pluginutils
+    chmod -R u+w node_modules/rolldown node_modules/@rolldown/pluginutils
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm install --frozen-lockfile
+    pnpm build
+    pnpm ui:build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    libdir=$out/lib/openclaw
+    mkdir -p $libdir $out/bin
+
+
+    cp --reflink=auto -r package.json dist node_modules $libdir/
+    cp --reflink=auto -r assets docs skills patches extensions $libdir/ 2>/dev/null || true
+
+    rm -f $libdir/node_modules/.pnpm/node_modules/clawdbot \
+      $libdir/node_modules/.pnpm/node_modules/moltbot \
+      $libdir/node_modules/.pnpm/node_modules/openclaw-control-ui
+
+    makeWrapper ${lib.getExe nodejs_22} $out/bin/openclaw \
+      --add-flags "$libdir/dist/index.js" \
+      --set NODE_PATH "$libdir/node_modules"
+    ln -s $out/bin/openclaw $out/bin/moltbot
+    ln -s $out/bin/openclaw $out/bin/clawdbot
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Self-hosted, open-source AI assistant/agent";
+    longDescription = ''
+      Self-hosted AI assistant/agent connected to all your apps on your Linux
+      or macOS machine and controlled via your choice of chat app.
+
+      Note: Project is in early/rapid development and uses LLMs to parse untrusted
+      content while having full access to system by default.
+
+      Parsing untrusted input with LLMs leaves them vulnerable to prompt injection.
+
+      (Originally known as Moltbot and ClawdBot)
+    '';
+    homepage = "https://openclaw.ai";
+    changelog = "https://github.com/openclaw/openclaw/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "openclaw";
+    maintainers = with lib.maintainers; [ chrisportela ];
+    platforms = with lib.platforms; linux ++ darwin;
+    knownVulnerabilities = [
+      "Project uses LLMs to parse untrusted content, making it vulnerable to prompt injection, while having full access to system by default."
+    ];
+  };
+})

--- a/pkgs/by-name/ro/rolldown/package.nix
+++ b/pkgs/by-name/ro/rolldown/package.nix
@@ -1,0 +1,92 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm_10,
+  nodejs_22,
+  rustPlatform,
+  cargo,
+  rustc,
+  cmake,
+  version ? "1.0.0-rc.5",
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rolldown";
+  # Default from top-level; .override { version = "..." } replaces this via merge, and src/cargoDeps/pnpmDeps use finalAttrs.version below.
+  version = version;
+
+  # To obtain hashes: use `nix store prefetch-file --unpack <url>` for source; set hash = "" and build for cargoDeps/pnpmDeps.
+  src = fetchFromGitHub {
+    owner = "rolldown";
+    repo = "rolldown";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-uqgJN7jn70z3cQlEEyk+0TeiHDn1AkvMmCaEOksHxhM=";
+  };
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    pname = "rolldown";
+    version = finalAttrs.version;
+    src = finalAttrs.src;
+    hash = "sha256-tyayOAwdqP1euzicJrstwHiHxoFRWq+IGSiN/uFNZz8=";
+  };
+  pnpmDeps = fetchPnpmDeps {
+    pname = "rolldown";
+    version = finalAttrs.version;
+    src = finalAttrs.src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-16NBCf4dP8a8dbgnmtFawMHKD7geIkLXt4F4w18FSUM=";
+  };
+
+  # cmake is only needed for Rust build (mimalloc-sys), not for a top-level configure
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm_10
+    nodejs_22
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    cmake
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run --filter "@rolldown/pluginutils" build
+    pnpm run --filter rolldown build-native:release
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    local -r nodeModules="$out/lib/node_modules"
+    mkdir -p "$nodeModules"
+
+    # Install rolldown package
+    local -r outPath="$nodeModules/rolldown"
+    mkdir -p "$outPath"
+    cp packages/rolldown/package.json "$outPath/"
+    for d in bin cli dist; do
+      [[ -d packages/rolldown/$d ]] && cp -r "packages/rolldown/$d" "$outPath/"
+    done
+    cp packages/rolldown/*.node "$outPath/" 2>/dev/null || true
+    cp packages/rolldown/dist/*.node "$outPath/dist/" 2>/dev/null || true
+    cp packages/rolldown/src/rolldown-binding.*.node "$outPath/dist/" 2>/dev/null || true
+
+    # Install @rolldown/pluginutils (rolldown's runtime dependency; only built output, no node_modules)
+    mkdir -p "$nodeModules/@rolldown/pluginutils"
+    cp packages/pluginutils/package.json "$nodeModules/@rolldown/pluginutils/"
+    [[ -d packages/pluginutils/dist ]] && cp -r packages/pluginutils/dist "$nodeModules/@rolldown/pluginutils/"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fast Rust-based bundler for JavaScript (built for openclaw)";
+    inherit (nodejs_22.meta) platforms;
+  };
+})


### PR DESCRIPTION
## Things done

Added openclaw (previously clawdbot, moltbot) package v2026.2.26

Newer versions require rolldown; So that was added too. Package v1.0.0-rc.5

https://openclaw.ai/

https://github.com/openclaw/openclaw/

https://rolldown.rs/

https://github.com/rolldown/rolldown

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
