### PR TITLE
Add TuringDB package

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22792,6 +22792,12 @@
     githubId = 55679162;
     keys = [ { fingerprint = "1401 1B63 393D 16C1 AA9C  C521 8526 B757 4A53 6236"; } ];
   };
+  roquess = {
+    name = "Roques Steve";
+    email = "steve.roques@gmail.com";
+    github = "roquess";
+    githubId = 8398054;
+  };
   rorosen = {
     email = "robert.rose@mailbox.org";
     github = "rorosen";

--- a/pkgs/by-name/tu/turingdb/package.nix
+++ b/pkgs/by-name/tu/turingdb/package.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  git,
+  bison,
+  flex,
+  curl,
+  openssl,
+  boost,
+  openblas,
+  aws-sdk-cpp,
+  faiss,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "turingdb";
+  version = "1.20";
+
+  src = fetchFromGitHub {
+    owner = "turing-db";
+    repo = "turingdb";
+    rev = "v1.20";
+    hash = "sha256-Izm5Gv7xoPKqCi+4mIfTwmhQGXWeA1dG0hci7iJDEto=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    git
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    curl
+    openssl
+    boost
+    openblas
+    aws-sdk-cpp
+    faiss
+    zlib
+  ];
+
+  env.NIX_CFLAGS_COMPILE = "-DHEAD_COMMIT_TIMESTAMP=${toString builtins.currentTime}";
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+  ];
+
+  preConfigure = ''
+    if [ ! -d "common/.git" ]; then
+      echo "Warning: Submodules might not be properly initialized"
+    fi
+  '';
+
+  # Tests are disabled because they require network access and external dependencies
+  # that are not available in the Nix build sandbox
+  doCheck = false;
+
+  meta = with lib; {
+    description = "High performance in-memory column-oriented graph database engine";
+    longDescription = ''
+      TuringDB is a high-performance in-memory column-oriented graph database engine
+      designed for analytical and read-intensive workloads. Built from scratch in C++,
+      it delivers millisecond query latency on graphs with millions of nodes and edges.
+
+      Key features:
+      - 0.1-50ms query latency for analytical queries on 10M+ node graphs
+      - Zero-lock concurrency model
+      - Git-like versioning system for graphs
+      - OpenCypher query language support
+      - Python SDK with comprehensive API
+    '';
+    homepage = "https://turingdb.ai";
+    changelog = "https://github.com/turing-db/turingdb/releases";
+    license = lib.licenses.bsl11;
+    platforms = lib.platforms.linux;
+    mainProgram = "turingdb";
+    maintainers = with maintainers; [ roquess ];
+  };
+})


### PR DESCRIPTION
## Summary

This PR adds a new package, **TuringDB**, to Nixpkgs. TuringDB is a graph database designed for high-performance and scalable data storage with vector support. The package is licensed under BSL-1.1, so `NIXPKGS_ALLOW_UNFREE=1` is required to build it.

The PR includes:
- `pkgs/applications/databases/turingdb/default.nix` — the package definition.
- Update to `pkgs/top-level/all-packages.nix` to include TuringDB.
- `.gitignore` update to exclude execution outputs (`turingdb.out/`).

## Platforms tested

- Built on `x86_64-linux` (NixOS)
- Verified basic functionality: running `./result/bin/turingdb` starts the server and creates required directories under `$HOME/.turing`.
