### PR TITLE
pantalaimon{,-headless}: migrate to by-name

### DIFF
--- a/pkgs/by-name/pa/pantalaimon-headless/package.nix
+++ b/pkgs/by-name/pa/pantalaimon-headless/package.nix
@@ -1,0 +1,11 @@
+{
+  pantalaimon,
+  ...
+}@args:
+
+pantalaimon.override (
+  {
+    enableDbusUi = false;
+  }
+  // removeAttrs args [ "pantalaimon" ]
+)

--- a/pkgs/by-name/pa/pantalaimon/package.nix
+++ b/pkgs/by-name/pa/pantalaimon/package.nix
@@ -77,7 +77,8 @@ python3Packages.buildPythonApplication rec {
   ];
 
   # darwin has difficulty communicating with server, fails some integration tests
-  doCheck = !stdenv.hostPlatform.isDarwin;
+  # Tests are incompatible with pytest>=8 and Python 3.13
+  doCheck = !stdenv.hostPlatform.isDarwin && python3Packages.pythonOlder "3.13";
 
   postInstall = ''
     installManPage docs/man/*.[1-9]

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9822,10 +9822,6 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };
 
-  pantalaimon-headless = pantalaimon.override {
-    enableDbusUi = false;
-  };
-
   parsec-bin = callPackage ../applications/misc/parsec/bin.nix { };
 
   pdfpc = callPackage ../applications/misc/pdfpc {


### PR DESCRIPTION
This pull request refactors the packaging of `pantalaimon` and its headless variant to improve maintainability and compatibility. The main changes involve moving and updating the package definitions, as well as refining test conditions for Python compatibility.

**Refactoring and package definition changes:**

* Moved the `pantalaimon` package from `pkgs/applications/networking/instant-messengers/pantalaimon/default.nix` to `pkgs/by-name/pa/pantalaimon/package.nix`, and updated references accordingly in `all-packages.nix`.
* Created a new `pantalaimon-headless` package definition in `pkgs/by-name/pa/pantalaimon-headless/package.nix` using the override mechanism to disable the D-Bus UI.

**Test and compatibility improvements:**

* Updated the `doCheck` condition in the `pantalaimon` package to skip tests on Python 3.13 and newer, as tests are incompatible with pytest >=8 and Python 3.13.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
