### PR TITLE
pyrra: init at 0.9.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16954,7 +16954,7 @@
     githubId = 22659757;
   };
   metalmatze = {
-    email = "matthias.loibl@polarsignals.com";
+    email = "mail@matthiasloibl.com";
     name = "Matthias Loibl";
     github = "metalmatze";
     githubId = 872251;
@@ -19364,6 +19364,12 @@
     name = "nullishamy";
     github = "nullishamy";
     githubId = 99221043;
+  };
+  numbleroot = {
+    email = "hello@lennartoldenburg.de";
+    name = "Lennart Oldenburg";
+    github = "numbleroot";
+    githubId = 1864826;
   };
   numinit = {
     email = "me+nixpkgs@numin.it";

--- a/pkgs/by-name/py/pyrra/package.nix
+++ b/pkgs/by-name/py/pyrra/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildGoModule,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pyrra";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "pyrra-dev";
+    repo = "pyrra";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3eEnwS3nnDuIYfZCDUrWFeNmAHEGWtpxtSVoI+XIMVM=";
+  };
+
+  vendorHash = "sha256-E2/OrAC2Wkv7OYPjs9ROE1RL4UUXYTByJZRY1qZB3gE=";
+
+  ui = buildNpmPackage {
+    inherit (finalAttrs) version;
+
+    pname = "${finalAttrs.pname}-ui";
+    src = "${finalAttrs.src}/ui";
+
+    npmDepsHash = "sha256-1KSkYUIJy6uci+Cy2q4dXO2PGpnwKcXQmWaWmpjPneA=";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/pyrra
+      mv build $out/share/pyrra/ui
+      runHook postInstall
+    '';
+  };
+
+  preBuild = ''
+    mkdir -p ui/build
+    cp -r ${finalAttrs.ui}/share/pyrra/ui/* ui/build
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--subpackage"
+      "ui"
+    ];
+  };
+
+  meta = {
+    mainProgram = "pyrra";
+    description = "Making SLOs with Prometheus manageable, accessible, and easy to use for everyone!";
+    homepage = "https://github.com/pyrra-dev/pyrra";
+    changelog = "https://github.com/pyrra-dev/pyrra/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      metalmatze
+      numbleroot
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Pyrra](https://github.com/pyrra-dev/pyrra) is a tool that makes Service Level Objectives (SLOs) with Prometheus manageable, accessible, and easy to use. It provides a web UI and API for managing SLO configurations and visualizing SLO performance.                                                                                                                                                                                   
I am the co-creator and maintainer of Pyrra. 

@numbleroot and I followed the same approach as the existing `parca` package, building a Go binary with an embedded React UI. The tech stack is super close and I'm familiar with Parca as I'm also a maintainer of Parca.

### Future Work 

We're also planning on bringing a module for both Pyrra and Parca for easier use and configuration in the near future. I want to use both of these on my NixOS based NAS. I therefore have some long lasting interest in improving both of these.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
