### PR TITLE
orbstack: Adds shell completions to orbstack package

### DIFF
--- a/pkgs/by-name/or/orbstack/package.nix
+++ b/pkgs/by-name/or/orbstack/package.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   fetchurl,
   _7zz,
+  installShellFiles,
 }:
 let
   inherit (stdenvNoCC.hostPlatform) system;
@@ -41,7 +42,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   # These bogus files corrupt the .app bundle and prevent it from launching.
   unpackCmd = "7zz x -snld -xr'!*:com.apple.*' $curSrc";
 
-  nativeBuildInputs = [ _7zz ];
+  nativeBuildInputs = [
+    _7zz
+    installShellFiles
+  ];
 
   sourceRoot = ".";
 
@@ -57,6 +61,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     done
 
     runHook postInstall
+  '';
+
+  postInstall = ''
+    installShellCompletion --bash "$out"/Applications/OrbStack.app/Contents/Resources/completions/bash/{docker,kubectl,orbctl}.bash
+    installShellCompletion --zsh "$out"/Applications/OrbStack.app/Contents/Resources/completions/zsh/{_docker,_kubectl,_orb,_orbctl}
+    installShellCompletion --fish "$out"/Applications/OrbStack.app/Contents/Resources/completions/fish/{docker,kubectl,orbctl}.fish
   '';
 
   passthru = {


### PR DESCRIPTION
This adds the shell completions for bash, zsh, and fish shells. I explicitly added each of the completion files, but they could also be done via wildcard globs. I went the explicit route to reduce the risk of unexpected behavior.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
