### PR TITLE
python313Packages.a2a-sdk: init at 0.3.22

### DIFF
--- a/pkgs/development/python-modules/a2a-sdk/default.nix
+++ b/pkgs/development/python-modules/a2a-sdk/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  aiosqlite,
+  buildPythonPackage,
+  cryptography,
+  fastapi,
+  fetchFromGitHub,
+  google-api-core,
+  grpcio-reflection,
+  grpcio-tools,
+  grpcio,
+  hatchling,
+  httpx-sse,
+  httpx,
+  opentelemetry-api,
+  opentelemetry-sdk,
+  protobuf,
+  pydantic,
+  pyjwt,
+  pytest-asyncio,
+  pytestCheckHook,
+  pythonAtLeast,
+  respx,
+  sqlalchemy,
+  sse-starlette,
+  starlette,
+  uv-dynamic-versioning,
+  uvicorn,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "a2a-sdk";
+  version = "0.3.22";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "a2aproject";
+    repo = "a2a-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-RGD55BGxWSPJXKqDPcTYW3pIzlOVPoOqd3hyTArifqc=";
+  };
+
+  build-system = [
+    hatchling
+    uv-dynamic-versioning
+  ];
+
+  dependencies = [
+    google-api-core
+    httpx
+    httpx-sse
+    protobuf
+    pydantic
+  ];
+
+  optional-dependencies = {
+    encryption = [ cryptography ];
+    grpc = [
+      grpcio
+      grpcio-reflection
+      grpcio-tools
+    ];
+    http-server = [
+      fastapi
+      sse-starlette
+      starlette
+    ];
+    mysql = [ sqlalchemy ];
+    postgresql = [ sqlalchemy ];
+    signing = [ pyjwt ];
+    sqlite = [ sqlalchemy ];
+    telemetry = [
+      opentelemetry-api
+      opentelemetry-sdk
+    ];
+  };
+
+  nativeCheckInputs = [
+    aiosqlite
+    pytest-asyncio
+    pytestCheckHook
+    respx
+    uvicorn
+  ]
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
+
+  pythonImportsCheck = [ "a2a" ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # _pickle.PicklingError: Can't pickle local object <function...
+    "test_notification_triggering"
+  ];
+
+  meta = {
+    description = "Python SDK for the Agent2Agent (A2A) Protocol";
+    homepage = "https://github.com/a2aproject/a2a-python";
+    changelog = "https://github.com/a2aproject/a2a-python/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -29,6 +29,8 @@ self: super: with self; {
 
   # by_regex ensures inherit statements are sorted after the (first) attribute name that is inherited.
   # keep-sorted start block=yes newline_separated=yes by_regex=["(?:inherit\\s+\\([^)]+\\)\\n?\\s*)?(.+)"]
+  a2a-sdk = callPackage ../development/python-modules/a2a-sdk { };
+
   a2wsgi = callPackage ../development/python-modules/a2wsgi { };
 
   aafigure = callPackage ../development/python-modules/aafigure { };


### PR DESCRIPTION
Python SDK for the Agent2Agent (A2A) Protocol

https://github.com/a2aproject/a2a-python

Needed for smolagents update.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
