### PR TITLE
python3Packages.quil: 0.17.0 -> 0.34.0

### DIFF
--- a/pkgs/development/python-modules/quil/default.nix
+++ b/pkgs/development/python-modules/quil/default.nix
@@ -1,7 +1,6 @@
 {
   lib,
   buildPythonPackage,
-  pythonAtLeast,
   fetchFromGitHub,
   rustPlatform,
   numpy,
@@ -11,25 +10,22 @@
 
 buildPythonPackage rec {
   pname = "quil";
-  version = "0.17.0";
+  version = "0.34.0";
   pyproject = true;
-
-  # error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
-  disabled = pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "rigetti";
     repo = "quil-rs";
-    tag = "quil-py/v${version}";
-    hash = "sha256-sQvHar52IFVUM+AssPEtBcSGVEma9e909K/5c8H0WQw=";
+    tag = "quil-rs/v${version}";
+    hash = "sha256-to6eKStXiJPqP22kN+gNiroiBUFiK7Q84BuTZHMr5SI=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-3qFrsevaVP2tPf0OV0hW6HhhWsj2BM/2sZUvdq1Aa4k=";
+    hash = "sha256-vNa4RUIecCHDb9rvMdiC8jtBdM/6C2bKagX1YkSMuhk=";
   };
 
-  buildAndTestSubdir = "quil-py";
+  buildAndTestSubdir = "quil-rs";
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
@@ -51,11 +47,11 @@ buildPythonPackage rec {
   ];
 
   pytestFlags = [
-    "quil-py/tests_py"
+    "quil-rs/tests_py"
   ];
 
   meta = {
-    changelog = "https://github.com/rigetti/quil-rs/blob/${src.tag}/quil-py/CHANGELOG.md";
+    changelog = "https://github.com/rigetti/quil-rs/blob/${src.tag}/quil-rs/CHANGELOG.md";
     description = "Python package for building and parsing Quil programs";
     homepage = "https://github.com/rigetti/quil-rs/tree/main/quil-py";
     license = lib.licenses.asl20;


### PR DESCRIPTION
Diff: https://github.com/rigetti/quil-rs/compare/quil-py/v0.17.0...quil-rs/v0.34.0

Changelog: https://github.com/rigetti/quil-rs/blob/quil-rs/v0.34.0/quil-rs/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
