### PR TITLE
homebridge-config-ui-x: 5.14.0 -> 5.16.0

### DIFF
--- a/pkgs/by-name/ho/homebridge-config-ui-x/package.nix
+++ b/pkgs/by-name/ho/homebridge-config-ui-x/package.nix
@@ -8,27 +8,28 @@
   python3,
   cacert,
   versionCheckHook,
+  nodejs_22,
 }:
 
-buildNpmPackage (finalAttrs: {
+buildNpmPackage.override { nodejs = nodejs_22; } (finalAttrs: {
   pname = "homebridge-config-ui-x";
-  version = "5.14.0";
+  version = "5.16.0";
 
   src = fetchFromGitHub {
     owner = "homebridge";
     repo = "homebridge-config-ui-x";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CAdzkFuVuJtHoUUDBIRRzxRJiOtGUJFzS/lczYXTfRw=";
+    hash = "sha256-LXOfpOmYEeHDL0uMvRSG4q51k00tyKBEU6XP6UFm/RY=";
   };
 
   # Deps hash for the root package
-  npmDepsHash = "sha256-73Xt2R3COL0WPgtqn3ZwGTmOHrNqHONrX3hQCU/v5y0=";
+  npmDepsHash = "sha256-MUfDMHxnwEBjv76NoJ6CYP3YJ+us0Nn/MUFcR1NFQAE=";
 
   # Deps src and hash for ui subdirectory
   npmDeps_ui = fetchNpmDeps {
     name = "npm-deps-ui";
     src = "${finalAttrs.src}/ui";
-    hash = "sha256-xtXAeTBryQt4FMvK3oXHJ3DdB/3umrSrmqZ3IIDgq2s=";
+    hash = "sha256-GB17rJ2D1yXl/lxM8pQl2e2xnakgA8JLX7sbbdk3P5M=";
   };
 
   # Need to also run npm ci in the ui subdirectory
@@ -58,6 +59,8 @@ buildNpmPackage (finalAttrs: {
     versionCheckHook
   ];
   doInstallCheck = true;
+
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "Configure Homebridge, monitor and backup from a browser";

--- a/pkgs/by-name/ho/homebridge-config-ui-x/update.sh
+++ b/pkgs/by-name/ho/homebridge-config-ui-x/update.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq gnugrep gnused git nix
+# shellcheck shell=bash
+set -euo pipefail
+
+nixpkgs="$(pwd)"
+cd "$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")"
+
+pkg="(import $nixpkgs/default.nix {}).homebridge-config-ui-x"
+
+nix_eval() {
+  nix eval --json --impure --expr "$pkg.$1" | jq -r
+}
+
+# Build a fixed-output derivation with an empty hash to get the correct one
+nix_prefetch() {
+  local attr="$1"
+  local expr="let src = $pkg.$attr; in (src.overrideAttrs or (f: src // f src)) (_: { outputHash = \"\"; outputHashAlgo = \"sha256\"; })"
+  nix-build --impure --no-out-link --expr "$expr" 2>&1 | tr -s ' ' | grep -oP 'got:\s+\K\S+' || true
+}
+
+update_src_hash() {
+  echo "Updating source hash..."
+  local old_hash new_hash
+  old_hash=$(nix_eval "src.outputHash")
+  new_hash=$(nix_prefetch "src")
+  if [ -z "$new_hash" ]; then
+    echo "ERROR: Failed to determine new source hash"
+    exit 1
+  fi
+  sed -i "s|$old_hash|$new_hash|g" package.nix
+}
+
+update_npm_deps_hash() {
+  echo "Updating npm dependencies hash..."
+  local old_hash new_hash
+  old_hash=$(nix_eval "npmDeps.outputHash")
+  new_hash=$(nix_prefetch "npmDeps")
+  if [ -z "$new_hash" ]; then
+    echo "ERROR: Failed to determine new npm deps hash"
+    exit 1
+  fi
+  sed -i "s|$old_hash|$new_hash|g" package.nix
+}
+
+update_npm_deps_ui_hash() {
+  echo "Updating ui npm dependencies hash..."
+  local old_hash new_hash
+  old_hash=$(nix_eval "npmDeps_ui.outputHash")
+  new_hash=$(nix_prefetch "npmDeps_ui")
+  if [ -z "$new_hash" ]; then
+    echo "ERROR: Failed to determine new npm deps ui hash"
+    exit 1
+  fi
+  sed -i "s|$old_hash|$new_hash|g" package.nix
+}
+
+LATEST_VERSION=$(curl -fsSL ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "https://api.github.com/repos/homebridge/homebridge-config-ui-x/releases/latest" \
+  | jq -r '.tag_name' \
+  | sed 's/^v//')
+
+CURRENT_VERSION=$(nix_eval "version")
+
+if [ "$CURRENT_VERSION" = "$LATEST_VERSION" ]; then
+  echo "homebridge-config-ui-x is already up to date at version $CURRENT_VERSION"
+  exit 0
+fi
+
+echo "Updating homebridge-config-ui-x from $CURRENT_VERSION to $LATEST_VERSION"
+
+sed -i "s/version = \"$CURRENT_VERSION\"/version = \"$LATEST_VERSION\"/" package.nix
+
+update_src_hash
+update_npm_deps_hash
+update_npm_deps_ui_hash
+
+echo "Successfully updated homebridge-config-ui-x from $CURRENT_VERSION to $LATEST_VERSION"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updating homebridge-config-ui-x from 5.14.0 to 5.16.0.

Changelog can be found here: [homebridge/homebridge-config-ui-x/releases](https://github.com/homebridge/homebridge-config-ui-x/releases)

5.16.0 runs back into the ENOTCACHED issue on nodejs 24, as occurred in this issue: https://github.com/NixOS/nixpkgs/issues/476761. Pinning to nodejs 22 solves the issue for now.

Also added an update script to work with r-ryantm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
