### PR TITLE
music-assistant: 2.7.5 -> 2.7.6

### DIFF
--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-frontend";
-  version = "2.17.55";
+  version = "2.17.76";
   pyproject = true;
 
   src = fetchPypi {
     pname = "music_assistant_frontend";
     inherit version;
-    hash = "sha256-fRn2hLg0y+G2atyxpzMq86mJJA41nfSS5UweNZL+0ew=";
+    hash = "sha256-wQ+6xD1BDajMIpz7VVH0j/AIgCcIVjv1Y/k/kMYv96U=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -47,14 +47,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.7.5";
+  version = "2.7.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-iWdOGdmPJO7Pjdn8UjuSOhWnRGBFjmARFsuHmP6IP58=";
+    hash = "sha256-tAzCEU8jFWENOy0WaAchuhQGjmQl8BTW9TuGZPJByPw=";
   };
 
   patches = [

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,10 +1,12 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.7.5";
+  version = "2.7.6";
   providers = {
-    airplay = ps: [
-    ];
+    airplay =
+      ps: with ps; [
+        srptools
+      ];
     airplay_receiver = ps: [
     ];
     alexa =


### PR DESCRIPTION
https://github.com/music-assistant/server/releases/tag/2.7.6

diff: https://github.com/music-assistant/server/compare/2.7.5...2.7.6

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
