### PR TITLE
pelican-{panel,wings}: init

### DIFF
--- a/pkgs/by-name/pe/pelican-panel/package.nix
+++ b/pkgs/by-name/pe/pelican-panel/package.nix
@@ -1,0 +1,79 @@
+{
+  fetchFromGitHub,
+  fetchpatch,
+  fetchYarnDeps,
+  lib,
+  nodejs,
+  php85,
+  php85Packages,
+  stdenvNoCC,
+  yarnConfigHook,
+  dataDir ? "/var/lib/pelican-panel",
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "pelican-panel";
+  version = "1.0.0-beta33";
+
+  src = fetchFromGitHub {
+    owner = "pelican-dev";
+    repo = "panel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+nP6J+ZdtWtR4bo8DQkvnS5jVbjvxITnWvwkR+izOYY=";
+  };
+
+  buildInputs = [ php85 ];
+
+  nativeBuildInputs = [
+    nodejs
+    php85.composerHooks2.composerInstallHook
+    php85Packages.composer
+    yarnConfigHook
+  ];
+
+  composerVendor = php85.mkComposerVendor {
+    inherit (finalAttrs)
+      pname
+      src
+      version
+      ;
+    composerNoDev = true;
+    composerNoPlugins = true;
+    composerNoScripts = true;
+    composerStrictValidation = true;
+    strictDeps = true;
+    vendorHash = "sha256-oBTmBlm31/AjPB0C0vgA94+6WMPG+IBMql3a2H+SjfQ=";
+  };
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${finalAttrs.src}/yarn.lock";
+    hash = "sha256-VLero9gHqkh6svauRSwZf2ASpEBu9iQcPUx+J77SR+o=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    yarn run build
+
+    cp -r public/build $out/share/php/pelican-panel/public
+
+    chmod -R u+w $out/share
+    mv $out/share/php/pelican-panel/* $out/
+
+    rm -rf $out/share $out/plugins $out/storage $out/bootstrap/cache
+    ln -s ${dataDir}/.env $out/.env
+    ln -s ${dataDir}/plugins $out/plugins
+    ln -s ${dataDir}/bootstrap/cache $out/bootstrap/cache
+    ln -s ${dataDir}/storage $out/storage
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Free game server control panel offering high flying security";
+    changelog = "https://github.com/pelican-dev/panel/releases/tag/v${finalAttrs.version}";
+    homepage = "https://pelican.dev";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ hythera ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/pe/pelican-wings/package.nix
+++ b/pkgs/by-name/pe/pelican-wings/package.nix
@@ -1,0 +1,33 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}:
+buildGoModule (finalAttrs: {
+  pname = "pelican-wings";
+  version = "1.0.0-beta24";
+
+  src = fetchFromGitHub {
+    owner = "pelican-dev";
+    repo = "wings";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MveNLXINvxAjJOG9nvXgfSxnEUkHI0Bnqxmgg/0Qu6Q=";
+  };
+
+  vendorHash = "sha256-juiJGX0wax1iIAODAgBUNLlfFg4kd14bB6IeEqohs8U=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/pelican-dev/wings/system.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Free game server control panel backend offering high flying security";
+    changelog = "https://github.com/pelican-dev/wings/releases/tag/v${finalAttrs.version}";
+    homepage = "https://pelican.dev";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hythera ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds the pelican `panel` and `wings` package to `nixpkgs`, a game server panel based on pterodactyl.
There seems to be a hash miss-match with the composer content hash which currently requires a temporary fix. Upstream PR: https://github.com/pelican-dev/panel/pull/2209

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
