### PR TITLE
treewide: move NIX_CFLAGS_COMPILE into env for structuredAttrs

### DIFF
--- a/pkgs/applications/radio/pothos/default.nix
+++ b/pkgs/applications/radio/pothos/default.nix
@@ -61,7 +61,7 @@ mkDerivation rec {
   '';
 
   # poco 1.14 requires c++17
-  NIX_CFLAGS_COMPILE = [ "-std=gnu++17" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-std=gnu++17" ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -243,19 +243,29 @@ stdenv.mkDerivation {
     echo CONFIG_MPEGAUDIODSP=yes >> config.mak
   '';
 
-  # Fixes compilation with newer versions of clang that make these warnings errors by default.
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion -Wno-incompatible-function-pointer-types";
-
-  NIX_LDFLAGS = toString (
-    lib.optional fontconfigSupport "-lfontconfig"
-    ++ lib.optional fribidiSupport "-lfribidi"
-    ++ lib.optionals x11Support [
-      "-lX11"
-      "-lXext"
-    ]
-    ++ lib.optional x264Support "-lx264"
-    ++ [ "-lfreetype" ]
-  );
+  env =
+    lib.optionalAttrs stdenv.cc.isClang {
+      # Fixes compilation with newer versions of clang that make these warnings errors by default.
+      NIX_CFLAGS_COMPILE = "-Wno-int-conversion -Wno-incompatible-function-pointer-types";
+    }
+    // {
+      NIX_LDFLAGS = toString (
+        lib.optionals fontconfigSupport [
+          "-lfontconfig"
+        ]
+        ++ lib.optionals fribidiSupport [
+          "-lfribidi"
+        ]
+        ++ lib.optionals x11Support [
+          "-lX11"
+          "-lXext"
+        ]
+        ++ lib.optionals x264Support [
+          "-lx264"
+        ]
+        ++ [ "-lfreetype" ]
+      );
+    };
 
   installTargets = [ "install" ] ++ lib.optional x11Support "install-gui";
 

--- a/pkgs/by-name/ag/agg/package.nix
+++ b/pkgs/by-name/ag/agg/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--x-libraries=${lib.getLib libX11}/lib"
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];
 
   # libtool --tag=CXX --mode=link g++ -g -O2 libexamples.la ../src/platform/X11/libaggplatformX11.la ../src/libagg.la -o alpha_mask2 alpha_mask2.o
   # libtool: error: cannot find the library 'libexamples.la'

--- a/pkgs/by-name/al/alsa-scarlett-gui/package.nix
+++ b/pkgs/by-name/al/alsa-scarlett-gui/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-DkfpMK0T67B4mnriignf4hx6Ifddls0rN0SxyfEsPZg=";
   };
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=deprecated-declarations" ];
 
   makeFlags = [
     "DESTDIR=\${out}"

--- a/pkgs/by-name/ba/bambu-studio/package.nix
+++ b/pkgs/by-name/ba/bambu-studio/package.nix
@@ -136,23 +136,25 @@ stdenv.mkDerivation (finalAttrs: {
 
   separateDebugInfo = true;
 
-  # The build system uses custom logic - defined in
-  # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt
-  # library, which doesn't pick up the package in the nix store.  We
-  # additionally need to set the path via the NLOPT environment variable.
-  NLOPT = nlopt;
+  env = {
+    # The build system uses custom logic - defined in
+    # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt
+    # library, which doesn't pick up the package in the nix store.  We
+    # additionally need to set the path via the NLOPT environment variable.
+    NLOPT = nlopt;
 
-  NIX_CFLAGS_COMPILE = toString [
-    "-DBOOST_TIMER_ENABLE_DEPRECATED"
-    # Disable compiler warnings that clutter the build log.
-    # It seems to be a known issue for Eigen:
-    # http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
-    "-Wno-ignored-attributes"
-    "-I${opencv}/include/opencv4"
-  ];
+    NIX_CFLAGS_COMPILE = toString [
+      "-DBOOST_TIMER_ENABLE_DEPRECATED"
+      # Disable compiler warnings that clutter the build log.
+      # It seems to be a known issue for Eigen:
+      # http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
+      "-Wno-ignored-attributes"
+      "-I${opencv}/include/opencv4"
+    ];
 
-  # prusa-slicer uses dlopen on `libudev.so` at runtime
-  NIX_LDFLAGS = lib.optionalString withSystemd "-ludev" + " -L${opencv}/lib -lopencv_imgcodecs";
+    # prusa-slicer uses dlopen on `libudev.so` at runtime
+    NIX_LDFLAGS = lib.optionalString withSystemd "-ludev" + " -L${opencv}/lib -lopencv_imgcodecs";
+  };
 
   # TODO: macOS
   prePatch = ''

--- a/pkgs/by-name/cu/curv/package.nix
+++ b/pkgs/by-name/cu/curv/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation {
 
   # force char to be unsigned on aarch64
   # https://codeberg.org/doug-moen/curv/issues/227
-  NIX_CFLAGS_COMPILE = [ "-fsigned-char" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-fsigned-char" ];
 
   # GPU tests do not work in sandbox, instead we do this for sanity
   doInstallCheck = true;

--- a/pkgs/by-name/cw/cwiid/package.nix
+++ b/pkgs/by-name/cw/cwiid/package.nix
@@ -45,8 +45,10 @@ stdenv.mkDerivation {
     flex
   ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
-  NIX_LDFLAGS = "-lbluetooth";
+  env = {
+    NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+    NIX_LDFLAGS = "-lbluetooth";
+  };
 
   postInstall = ''
     # Some programs (for example, cabal-install) have problems with the double 0

--- a/pkgs/by-name/de/denemo/package.nix
+++ b/pkgs/by-name/de/denemo/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
   ];
 
   # error by default in GCC 14
-  NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
 
   preFixup = ''
     gappsWrapperArgs+=(

--- a/pkgs/by-name/dn/dnf5/package.nix
+++ b/pkgs/by-name/dn/dnf5/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-  NIX_CFLAGS_COMPILE = "-Wno-restrict -Wno-maybe-uninitialized";
+  env.NIX_CFLAGS_COMPILE = "-Wno-restrict -Wno-maybe-uninitialized";
 
   cmakeFlags = [
     "-DWITH_PERL5=OFF"

--- a/pkgs/by-name/ee/ee/package.nix
+++ b/pkgs/by-name/ee/ee/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
     substituteInPlace create.make --replace-fail "-lcurses" "-lncurses"
   '';
 
-  NIX_CFLAGS_COMPILE = "-DHAS_UNISTD=1 -DHAS_STDLIB=1 -DHAS_SYS_WAIT=1";
+  env.NIX_CFLAGS_COMPILE = "-DHAS_UNISTD=1 -DHAS_STDLIB=1 -DHAS_SYS_WAIT=1";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/el/elmerfem/package.nix
+++ b/pkgs/by-name/el/elmerfem/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
     patchShebangs ./
   '';
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
   cmakeFlags = [
     (lib.cmakeFeature "ELMER_INSTALL_LIB_DIR" "${placeholder "out"}/lib")

--- a/pkgs/by-name/fa/fairymax/package.nix
+++ b/pkgs/by-name/fa/fairymax/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
   '';
 
   # errors by default in GCC 14
-  NIX_CFLAGS_COMPILE = "-Wno-error=return-mismatch -Wno-error=implicit-int";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=return-mismatch -Wno-error=implicit-int";
 
   installPhase = ''
     mkdir -p "$out"/{bin,share/fairymax}

--- a/pkgs/by-name/fl/flashrom/package.nix
+++ b/pkgs/by-name/fl/flashrom/package.nix
@@ -70,9 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 $NIX_BUILD_TOP/$sourceRoot/util/flashrom_udev.rules $out/lib/udev/rules.d/flashrom.rules
   '';
 
-  NIX_CFLAGS_COMPILE = lib.optionalString (
-    stdenv.cc.isClang && !stdenv.hostPlatform.isDarwin
-  ) "-Wno-gnu-folding-constant";
+  env = lib.optionalAttrs (stdenv.cc.isClang && !stdenv.hostPlatform.isDarwin) {
+    NIX_CFLAGS_COMPILE = "-Wno-gnu-folding-constant";
+  };
 
   meta = {
     homepage = "https://www.flashrom.org";

--- a/pkgs/by-name/gi/gif2apng/package.nix
+++ b/pkgs/by-name/gi/gif2apng/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}c++" ];
 
-  NIX_CFLAGS_COMPILE = "-DENABLE_LOCAL_ZOPFLI";
+  env.NIX_CFLAGS_COMPILE = "-DENABLE_LOCAL_ZOPFLI";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/gr/gravit/package.nix
+++ b/pkgs/by-name/gr/gravit/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-DSDL_INCLUDE_GLU_H"
   ];
 

--- a/pkgs/by-name/gu/guacamole-server/package.nix
+++ b/pkgs/by-name/gu/guacamole-server/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OjTwAQzKUuXfwZXLsL9XjrJc/0be38CmAGG+CoCeNwk=";
   };
 
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=format-truncation"
     "-Wno-error=format-overflow"
     "-Wno-error=deprecated-declarations"

--- a/pkgs/by-name/ha/hal-hardware-analyzer/package.nix
+++ b/pkgs/by-name/ha/hal-hardware-analyzer/package.nix
@@ -87,7 +87,9 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeBuildType = "MinSizeRel";
 
   # https://github.com/emsec/hal/issues/598
-  NIX_CFLAGS_COMPILE = lib.optional stdenv.hostPlatform.isAarch64 "-flax-vector-conversions";
+  env = lib.optionalAttrs stdenv.hostPlatform.isAarch64 {
+    NIX_CFLAGS_COMPILE = "-flax-vector-conversions";
+  };
 
   # some plugins depend on other plugins and need to be able to load them
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''

--- a/pkgs/by-name/hu/hugs/package.nix
+++ b/pkgs/by-name/hu/hugs/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ bison ];
 
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=implicit-int"
     "-Wno-error=implicit-function-declaration"
   ];

--- a/pkgs/by-name/ji/jitsi-meet-electron/package.nix
+++ b/pkgs/by-name/ji/jitsi-meet-electron/package.nix
@@ -45,10 +45,12 @@ buildNpmPackage rec {
 
   makeCacheWritable = true;
 
-  env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
-
-  # disable code signing on Darwin
-  env.CSC_IDENTITY_AUTO_DISCOVERY = "false";
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+    # disable code signing on Darwin
+    CSC_IDENTITY_AUTO_DISCOVERY = "false";
+    NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
+  };
 
   preBuild = ''
     # remove some prebuilt binaries
@@ -73,8 +75,6 @@ buildNpmPackage rec {
         -c.electronDist=electron-dist \
         -c.electronVersion=${electron.version}
   '';
-
-  NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/li/libisds/package.nix
+++ b/pkgs/by-name/li/libisds/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     docbook_xsl
   ];
 
-  NIX_CFLAGS_COMPILE = [ "-Wno-error=deprecated-declarations" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=deprecated-declarations" ];
 
   meta = {
     description = "Client library for accessing SOAP services of Czech government-provided Databox infomation system";

--- a/pkgs/by-name/li/libkrunfw/package.nix
+++ b/pkgs/by-name/li/libkrunfw/package.nix
@@ -65,7 +65,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Fixes https://github.com/containers/libkrunfw/issues/55
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.targetPlatform.isAarch64 "-march=armv8-a+crypto";
+  env = lib.optionalAttrs stdenv.targetPlatform.isAarch64 {
+    NIX_CFLAGS_COMPILE = "-march=armv8-a+crypto";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/li/libnop/package.nix
+++ b/pkgs/by-name/li/libnop/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ gtest ];
 
   # Add optimization flags to address _FORTIFY_SOURCE warning
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-O1"
     "-std=c++17"
   ];

--- a/pkgs/by-name/li/libwtk-sdl2/package.nix
+++ b/pkgs/by-name/li/libwtk-sdl2/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL2_image
   ];
   # From some reason, this is needed as otherwise SDL.h is not found
-  NIX_CFLAGS_COMPILE = "-I${lib.getInclude SDL2}/include/SDL2";
+  env.NIX_CFLAGS_COMPILE = "-I${lib.getInclude SDL2}/include/SDL2";
 
   outputs = [
     "out"

--- a/pkgs/by-name/li/libx86emu/package.nix
+++ b/pkgs/by-name/li/libx86emu/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
+  env.NIX_CFLAGS_COMPILE = "-Wno-implicit-function-declaration";
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/lu/luau-lsp/package.nix
+++ b/pkgs/by-name/lu/luau-lsp/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
     fetchSubmodules = true;
   };
 
-  NIX_CFLAGS_COMPILE = "-Wno-error";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     (lib.cmakeFeature "CMAKE_OSX_ARCHITECTURES" stdenv.hostPlatform.darwinArch)

--- a/pkgs/by-name/ma/mailsend/package.nix
+++ b/pkgs/by-name/ma/mailsend/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/mi/minizip-ng/package.nix
+++ b/pkgs/by-name/mi/minizip-ng/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DMZ_LIBCOMP=OFF"
   ];
 
-  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-register";
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-register";
 
   postInstall = ''
     # make lib findable as libminizip-ng even if compat is enabled

--- a/pkgs/by-name/mm/mmh/package.nix
+++ b/pkgs/by-name/mm/mmh/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
 
   # mhl.c:1031:58: error: pointer type mismatch in conditional expression []
   #  1031 |                 putstr((c1->c_flags & RTRIM) ? rtrim(cp) : cp);
-  NIX_CFLAGS_COMPILE = [ " -Wno-error=incompatible-pointer-types" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=incompatible-pointer-types" ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ni/nibtools/package.nix
+++ b/pkgs/by-name/ni/nibtools/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     hash = "sha256-0skAavJe01b+4Z7LEfS2qIhqkwj8XhOwmflhYPEynw4=";
   };
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
 
   nativeBuildInputs = [
     cc65

--- a/pkgs/by-name/nu/numcpp/package.nix
+++ b/pkgs/by-name/nu/numcpp/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "\''${PACKAGE_PREFIX_DIR}/" ""
   '';
 
-  NIX_CFLAGS_COMPILE = "-Wno-error";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
   meta = {
     description = "Templatized Header Only C++ Implementation of the Python NumPy Library";

--- a/pkgs/by-name/or/orca-slicer/package.nix
+++ b/pkgs/by-name/or/orca-slicer/package.nix
@@ -142,41 +142,43 @@ stdenv.mkDerivation (finalAttrs: {
 
   separateDebugInfo = true;
 
-  NLOPT = nlopt;
+  env = {
+    NLOPT = nlopt;
 
-  NIX_CFLAGS_COMPILE = toString (
-    [
-      "-Wno-ignored-attributes"
-      "-I${opencv.out}/include/opencv4"
-      "-Wno-error=incompatible-pointer-types"
-      "-Wno-template-id-cdtor"
-      "-Wno-uninitialized"
-      "-Wno-unused-result"
-      "-Wno-deprecated-declarations"
-      "-Wno-use-after-free"
-      "-Wno-format-overflow"
-      "-Wno-stringop-overflow"
-      "-DBOOST_ALLOW_DEPRECATED_HEADERS"
-      "-DBOOST_MATH_DISABLE_STD_FPCLASSIFY"
-      "-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS"
-      "-DBOOST_MATH_DISABLE_FLOAT128"
-      "-DBOOST_MATH_NO_QUAD_SUPPORT"
-      "-DBOOST_MATH_MAX_FLOAT128_DIGITS=0"
-      "-DBOOST_CSTDFLOAT_NO_LIBQUADMATH_SUPPORT"
-      "-DBOOST_MATH_DISABLE_FLOAT128_BUILTIN_FPCLASSIFY"
-    ]
-    # Making it compatible with GCC 14+, see https://github.com/SoftFever/OrcaSlicer/pull/7710
-    ++ lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "14") [
-      "-Wno-error=template-id-cdtor"
-    ]
-  );
+    NIX_CFLAGS_COMPILE = toString (
+      [
+        "-Wno-ignored-attributes"
+        "-I${opencv.out}/include/opencv4"
+        "-Wno-error=incompatible-pointer-types"
+        "-Wno-template-id-cdtor"
+        "-Wno-uninitialized"
+        "-Wno-unused-result"
+        "-Wno-deprecated-declarations"
+        "-Wno-use-after-free"
+        "-Wno-format-overflow"
+        "-Wno-stringop-overflow"
+        "-DBOOST_ALLOW_DEPRECATED_HEADERS"
+        "-DBOOST_MATH_DISABLE_STD_FPCLASSIFY"
+        "-DBOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS"
+        "-DBOOST_MATH_DISABLE_FLOAT128"
+        "-DBOOST_MATH_NO_QUAD_SUPPORT"
+        "-DBOOST_MATH_MAX_FLOAT128_DIGITS=0"
+        "-DBOOST_CSTDFLOAT_NO_LIBQUADMATH_SUPPORT"
+        "-DBOOST_MATH_DISABLE_FLOAT128_BUILTIN_FPCLASSIFY"
+      ]
+      # Making it compatible with GCC 14+, see https://github.com/SoftFever/OrcaSlicer/pull/7710
+      ++ lib.optionals (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "14") [
+        "-Wno-error=template-id-cdtor"
+      ]
+    );
 
-  NIX_LDFLAGS = toString [
-    (lib.optionalString withSystemd "-ludev")
-    "-L${boost186}/lib"
-    "-lboost_log"
-    "-lboost_log_setup"
-  ];
+    NIX_LDFLAGS = toString [
+      (lib.optionalString withSystemd "-ludev")
+      "-L${boost186}/lib"
+      "-lboost_log"
+      "-lboost_log_setup"
+    ];
+  };
 
   prePatch = ''
     sed -i 's|nlopt_cxx|nlopt|g' cmake/modules/FindNLopt.cmake

--- a/pkgs/by-name/pd/pdf4qt/package.nix
+++ b/pkgs/by-name/pd/pdf4qt/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # `blend2d.h` moved to `blend2d/blend2d.h` in blend2d >= 0.21.2
-  NIX_CFLAGS_COMPILE = "-I${blend2d.dev}/include/blend2d";
+  env.NIX_CFLAGS_COMPILE = "-I${blend2d.dev}/include/blend2d";
 
   cmakeFlags = [
     (lib.cmakeBool "PDF4QT_INSTALL_TO_USR" false)

--- a/pkgs/by-name/pr/projectm-sdl-cpp/package.nix
+++ b/pkgs/by-name/pr/projectm-sdl-cpp/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
   ];
 
   # poco 1.14 requires c++17
-  NIX_CFLAGS_COMPILE = [ "-std=gnu++17" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-std=gnu++17" ];
 
   strictDeps = true;
 

--- a/pkgs/by-name/ro/rox-filer/package.nix
+++ b/pkgs/by-name/ro/rox-filer/package.nix
@@ -30,8 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     shared-mime-info
     libSM
   ];
-  NIX_LDFLAGS = "-lm";
-  NIX_CFLAGS_COMPILE = " -fpermissive";
+
+  env = {
+    NIX_LDFLAGS = "-lm";
+    NIX_CFLAGS_COMPILE = "-fpermissive";
+  };
 
   patches = [
     ./rox-filer-2.11-in-source-build.patch

--- a/pkgs/by-name/rt/rtabmap/package.nix
+++ b/pkgs/by-name/rt/rtabmap/package.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Configure environment variables
-  NIX_CFLAGS_COMPILE = "-Wno-c++20-extensions";
+  env.NIX_CFLAGS_COMPILE = "-Wno-c++20-extensions";
 
   cmakeFlags = [
     (lib.cmakeFeature "CMAKE_INCLUDE_PATH" "${pcl'}/include/pcl-${lib.versions.majorMinor pcl'.version}")

--- a/pkgs/by-name/sc/scummvm/package.nix
+++ b/pkgs/by-name/sc/scummvm/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail ${stdenv.hostPlatform.config}-ranlib ${cctools}/bin/ranlib
   '';
 
-  NIX_CFLAGS_COMPILE = [ "-fpermissive" ];
+  env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];
 
   passthru = {
     updateScript = nix-update-script { };

--- a/pkgs/by-name/sp/spaghettikart/package.nix
+++ b/pkgs/by-name/sp/spaghettikart/package.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Recent builds enabled LTO which won't build with nix
-  NIX_CFLAGS_COMPILE = "-fno-lto";
+  env.NIX_CFLAGS_COMPILE = "-fno-lto";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/sp/speed-dreams/package.nix
+++ b/pkgs/by-name/sp/speed-dreams/package.nix
@@ -85,7 +85,14 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-ZY/0tf0wFbepEUNqpaBA4qgkWDij/joqPtbiF/48oN4=";
     fetchSubmodules = true;
   };
-  NIX_CFLAGS_COMPILE = "-I${finalAttrs.src}/src/libs/tgf -I${finalAttrs.src}/src/libs/tgfdata -I${finalAttrs.src}/src/interfaces -I${finalAttrs.src}/src/libs/math -I${finalAttrs.src}/src/libs/portability";
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${finalAttrs.src}/src/libs/tgf"
+    "-I${finalAttrs.src}/src/libs/tgfdata"
+    "-I${finalAttrs.src}/src/interfaces"
+    "-I${finalAttrs.src}/src/libs/math"
+    "-I${finalAttrs.src}/src/libs/portability"
+  ];
 
   patches = [
     ./darwin-gl-compat.patch

--- a/pkgs/by-name/th/thttpd/package.nix
+++ b/pkgs/by-name/th/thttpd/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   # Work around failures with GCC 14, upstream is inactive unfortunately
   # https://gcc.gnu.org/gcc-14/porting_to.html#warnings-as-errors
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=implicit-int"
     "-Wno-error=implicit-function-declaration"
   ];

--- a/pkgs/by-name/uh/uhhyou-plugins-juce/package.nix
+++ b/pkgs/by-name/uh/uhhyou-plugins-juce/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Disable LTO to avoid optimization mismatch issues
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-fno-lto"
   ];
 

--- a/pkgs/by-name/va/vanillatd/package.nix
+++ b/pkgs/by-name/va/vanillatd/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-iUF9UFc0FMvOwLkGqSyLYGy5E8YqNySqDp5VVUa+u4o=";
   };
   # TODO: Remove this. Just add this flag to ignore the format-security error temporarily.
-  NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=format-security";
 
   buildInputs = [
     SDL2

--- a/pkgs/by-name/xa/xawtv/package.nix
+++ b/pkgs/by-name/xa/xawtv/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0001-Fix-build-for-glibc-2.32.patch
   ];
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
   buildInputs = [
     ncurses

--- a/pkgs/by-name/xe/xenia-canary/package.nix
+++ b/pkgs/by-name/xe/xenia-canary/package.nix
@@ -47,7 +47,7 @@ llvmPackages_20.stdenv.mkDerivation {
       --replace-fail "cdialect(\"C17\")" ""
   ''; # Prevent build failure
 
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=unused-result"
   ];
 

--- a/pkgs/development/libraries/ipu6-camera-hal/default.nix
+++ b/pkgs/development/libraries/ipu6-camera-hal/default.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation {
     "-DUSE_PG_LITE_PIPE=ON"
   ];
 
-  NIX_CFLAGS_COMPILE = [
+  env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error"
   ];
 

--- a/pkgs/development/tools/boomerang/default.nix
+++ b/pkgs/development/tools/boomerang/default.nix
@@ -27,7 +27,7 @@ mkDerivation rec {
   # Boomerang usually compiles with -Werror but has not been updated for newer
   # compilers. Disable -Werror for now. Consider trying to remove this when
   # updating this derivation.
-  NIX_CFLAGS_COMPILE = "-Wno-error";
+  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error" ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/games/openloco/default.nix
+++ b/pkgs/games/openloco/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     sed -i 's#URL \+${openloco-objects.url}#URL ${openloco-objects}#' CMakeLists.txt
   '';
 
-  NIX_CFLAGS_COMPILE = "-Wno-error=null-dereference";
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=null-dereference";
 
   cmakeFlags = [
     "-DOPENLOCO_BUILD_TESTS=NO"

--- a/pkgs/os-specific/linux/freeipa/default.nix
+++ b/pkgs/os-specific/linux/freeipa/default.nix
@@ -141,7 +141,7 @@ stdenv.mkDerivation rec {
       --subst-var-by kerberos ${kerberos}
   '';
 
-  NIX_CFLAGS_COMPILE = "-I${_389-ds-base}/include/dirsrv";
+  env.NIX_CFLAGS_COMPILE = "-I${_389-ds-base}/include/dirsrv";
   pythonPath = pythonInputs;
 
   # Building and installing the server fails with silent Rhino errors, skipping


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
