### PR TITLE
treewide: move NIX_LDFLAGS into env for structuredAttrs (a-k)

### DIFF
--- a/pkgs/applications/blockchains/bitcoin-knots/default.nix
+++ b/pkgs/applications/blockchains/bitcoin-knots/default.nix
@@ -164,9 +164,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_GUI" true)
   ];
 
-  NIX_LDFLAGS = lib.optionals (
-    stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isStatic
-  ) "-levent_core";
+  env = lib.optionalAttrs (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isStatic) {
+    NIX_LDFLAGS = "-levent_core";
+  };
 
   nativeCheckInputs = [ python3 ];
 

--- a/pkgs/applications/blockchains/bitcoin/default.nix
+++ b/pkgs/applications/blockchains/bitcoin/default.nix
@@ -165,9 +165,9 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_GUI" true)
   ];
 
-  NIX_LDFLAGS = lib.optionals (
-    stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isStatic
-  ) "-levent_core";
+  env = lib.optionalAttrs (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isStatic) {
+    NIX_LDFLAGS = "-levent_core";
+  };
 
   nativeCheckInputs = [ python3 ];
 

--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -81,7 +81,11 @@ stdenv.mkDerivation rec {
   ++ lib.optional (widgetset == "gtk3") gtk3
   ++ lib.optional (widgetset == "qt5") libsForQt5.libqtpas;
 
-  NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
+  env.NIX_LDFLAGS = toString [
+    "--as-needed"
+    "-rpath"
+    (lib.makeLibraryPath buildInputs)
+  ];
 
   buildPhase =
     lib.concatStringsSep "\n" (

--- a/pkgs/applications/networking/instant-messengers/dino/default.nix
+++ b/pkgs/applications/networking/instant-messengers/dino/default.nix
@@ -87,7 +87,9 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   # Undefined symbols for architecture arm64: "_gpg_strerror"
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-lgpg-error";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-lgpg-error";
+  };
 
   # Dino looks for plugins with a .so filename extension, even on macOS where
   # .dylib is appropriate, and despite the fact that it builds said plugins with

--- a/pkgs/by-name/ad/adlplug/package.nix
+++ b/pkgs/by-name/ad/adlplug/package.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation {
     ./cmake-v4.patch
   ];
 
-  NIX_LDFLAGS = toString (
+  env.NIX_LDFLAGS = toString (
     lib.optionals stdenv.hostPlatform.isDarwin [
       # Framework that JUCE needs which don't get linked properly
       "-framework CoreAudioKit"

--- a/pkgs/by-name/ae/aescrypt/package.nix
+++ b/pkgs/by-name/ae/aescrypt/package.nix
@@ -14,7 +14,9 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-4uGS0LReq5dI7+Wel7ZWzFXx+utZWi93q4TUSw7AhNI=";
   };
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-liconv";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-liconv";
+  };
 
   preBuild = ''
     substituteInPlace src/Makefile --replace "CC=gcc" "CC?=gcc"

--- a/pkgs/by-name/ah/ahoviewer/package.nix
+++ b/pkgs/by-name/ah/ahoviewer/package.nix
@@ -56,7 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional useUnrar unrar;
 
-  NIX_LDFLAGS = "-lpthread";
+  env.NIX_LDFLAGS = "-lpthread";
 
   postPatch = "patchShebangs version.sh";
 

--- a/pkgs/by-name/ai/airstrike/package.nix
+++ b/pkgs/by-name/ai/airstrike/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL_image
   ];
 
-  NIX_LDFLAGS = "-lm";
+  env.NIX_LDFLAGS = "-lm";
 
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -175,17 +175,15 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcomposite"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-      "-lXrender"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcomposite"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-lXrender"
+  ];
 
   meta = {
     description = "JUCE Plugin Version of Airwindows Consolidated";

--- a/pkgs/by-name/bl/bloodspilot-client/package.nix
+++ b/pkgs/by-name/bl/bloodspilot-client/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  NIX_LDFLAGS = "-lX11";
+  env.NIX_LDFLAGS = "-lX11";
 
   meta = {
     description = "Multiplayer space combat game (client part)";

--- a/pkgs/by-name/bo/boinc/package.nix
+++ b/pkgs/by-name/bo/boinc/package.nix
@@ -67,7 +67,9 @@ stdenv.mkDerivation rec {
     xcbutil
   ];
 
-  NIX_LDFLAGS = lib.optionalString (!headless) "-lX11";
+  env = lib.optionalAttrs (!headless) {
+    NIX_LDFLAGS = "-lX11";
+  };
 
   preConfigure = ''
     ./_autosetup

--- a/pkgs/by-name/br/brush-splat/package.nix
+++ b/pkgs/by-name/br/brush-splat/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Force linking to libEGL, which is always dlopen()ed, and to
   # libwayland-client & libxkbcommon, which is dlopen()ed based on the
   # winit backend.
-  NIX_LDFLAGS = [
+  env.NIX_LDFLAGS = toString [
     "--no-as-needed"
     "-lvulkan"
     "-lwayland-client"

--- a/pkgs/by-name/bu/buddy/package.nix
+++ b/pkgs/by-name/bu/buddy/package.nix
@@ -20,8 +20,13 @@ stdenv.mkDerivation rec {
     "CFLAGS=-O3"
     "CXXFLAGS=-O3"
   ];
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=register";
-  NIX_LDFLAGS = "-lm";
+  env = {
+    NIX_LDFLAGS = "-lm";
+  }
+  // lib.optionalAttrs stdenv.cc.isClang {
+    NIX_CFLAGS_COMPILE = "-Wno-error=register";
+  };
+
   doCheck = true;
 
   meta = {

--- a/pkgs/by-name/ca/cargo-watch/package.nix
+++ b/pkgs/by-name/ca/cargo-watch/package.nix
@@ -18,10 +18,12 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-4AVZ747d6lOjxHN+co0A7APVB5Xj6g5p/Al5fLbgPnc=";
 
-  NIX_LDFLAGS = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    "-framework"
-    "AppKit"
-  ];
+  env = lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) {
+    NIX_LDFLAGS = toString [
+      "-framework"
+      "AppKit"
+    ];
+  };
 
   # `test with_cargo` tries to call cargo-watch as a cargo subcommand
   # (calling cargo-watch with command `cargo watch`)

--- a/pkgs/by-name/ch/chow-tape-model/package.nix
+++ b/pkgs/by-name/ch/chow-tape-model/package.nix
@@ -116,15 +116,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   # JUCE dlopens these, make sure they are in rpath
   # Otherwise, segfault will happen
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ];
 
   meta = {
     homepage = "https://github.com/jatinchowdhury18/AnalogTapeModel";

--- a/pkgs/by-name/ch/chunksync/package.nix
+++ b/pkgs/by-name/ch/chunksync/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     perl
   ];
 
-  NIX_LDFLAGS = "-lgcc_s";
+  env.NIX_LDFLAGS = "-lgcc_s";
 
   makeFlags = [
     "DESTDIR=$(out)"

--- a/pkgs/by-name/cr/cre2/package.nix
+++ b/pkgs/by-name/cr/cre2/package.nix
@@ -30,7 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
     texinfo
   ];
 
-  NIX_LDFLAGS = "-lre2 -lpthread";
+  env.NIX_LDFLAGS = toString [
+    "-lre2"
+    "-lpthread"
+  ];
 
   configureFlags = [
     "--enable-maintainer-mode"

--- a/pkgs/by-name/dd/ddrescueview/package.nix
+++ b/pkgs/by-name/dd/ddrescueview/package.nix
@@ -38,7 +38,11 @@ stdenv.mkDerivation rec {
     pango
   ];
 
-  NIX_LDFLAGS = "--as-needed -rpath ${lib.makeLibraryPath buildInputs}";
+  env.NIX_LDFLAGS = toString [
+    "--as-needed"
+    "-rpath"
+    (lib.makeLibraryPath buildInputs)
+  ];
 
   buildPhase = ''
     lazbuild --lazarusdir=${lazarus}/share/lazarus ddrescueview.lpi

--- a/pkgs/by-name/de/dexed/package.nix
+++ b/pkgs/by-name/de/dexed/package.nix
@@ -53,26 +53,27 @@ stdenv.mkDerivation (finalAttrs: {
     libjack2
   ];
 
-  # JUCE insists on only dlopen'ing these
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux (toString [
-    "-lX11"
-    "-lXext"
-    "-lXcursor"
-    "-lXinerama"
-    "-lXrandr"
-    "-ljack"
-  ]);
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux (toString [
-    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
-    # a Link Time Optimization flag, and instructs the plugin compiled here to
-    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
-    # successful linking while still providing LTO benefits. If our build of
-    # `juce` was used as a dependency, we could have patched that `-flto` line
-    # in our juce's source, but that is not possible because it is used as a
-    # Git Submodule.
-    "-ffat-lto-objects"
-  ]);
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # JUCE insists on only dlopen'ing these
+    NIX_LDFLAGS = toString [
+      "-lX11"
+      "-lXext"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-ljack"
+    ];
+    NIX_CFLAGS_COMPILE = toString [
+      # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+      # a Link Time Optimization flag, and instructs the plugin compiled here to
+      # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+      # successful linking while still providing LTO benefits. If our build of
+      # `juce` was used as a dependency, we could have patched that `-flto` line
+      # in our juce's source, but that is not possible because it is used as a
+      # Git Submodule.
+      "-ffat-lto-objects"
+    ];
+  };
 
   installPhase =
     let

--- a/pkgs/by-name/dn/dnstracer/package.nix
+++ b/pkgs/by-name/dn/dnstracer/package.nix
@@ -33,7 +33,9 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.libresolv ];
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-lresolv";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-lresolv";
+  };
 
   meta = {
     description = "Determines where a given Domain Name Server (DNS) gets its information from, and follows the chain of DNS servers back to the servers which know the data";

--- a/pkgs/by-name/ec/ecwolf/package.nix
+++ b/pkgs/by-name/ec/ecwolf/package.nix
@@ -44,7 +44,12 @@ stdenv.mkDerivation (finalAttrs: {
     gtk3
   ];
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework AppKit";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = toString [
+      "-framework"
+      "AppKit"
+    ];
+  };
 
   # ECWolf installs its binary to the games/ directory, but Nix only adds bin/
   # directories to the PATH.

--- a/pkgs/by-name/eg/egoboo/package.nix
+++ b/pkgs/by-name/eg/egoboo/package.nix
@@ -62,12 +62,14 @@ stdenv.mkDerivation (finalAttrs: {
     '';
   */
 
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: mad.o:(.bss+0x233800): multiple definition of `tile_dict'; camera.o:(.bss+0x140): first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  env = {
+    # Workaround build failure on -fno-common toolchains like upstream
+    # gcc-10. Otherwise build fails as:
+    #   ld: mad.o:(.bss+0x233800): multiple definition of `tile_dict'; camera.o:(.bss+0x140): first defined here
+    NIX_CFLAGS_COMPILE = "-fcommon";
 
-  NIX_LDFLAGS = "-lm";
+    NIX_LDFLAGS = "-lm";
+  };
 
   meta = {
     description = "3D dungeon crawling adventure";

--- a/pkgs/by-name/fi/fileshelter/package.nix
+++ b/pkgs/by-name/fi/fileshelter/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     libarchive
   ];
 
-  NIX_LDFLAGS = "-lpthread";
+  env.NIX_LDFLAGS = "-lpthread";
 
   postInstall = ''
     ln -s ${wt}/share/Wt/resources $out/share/fileshelter/docroot/resources

--- a/pkgs/by-name/fi/firestarter/package.nix
+++ b/pkgs/by-name/fi/firestarter/package.nix
@@ -98,9 +98,9 @@ stdenv.mkDerivation rec {
       [ glibc.static ]
   );
 
-  NIX_LDFLAGS = lib.optionals withCuda [
-    "-L${cudatoolkit}/lib/stubs"
-  ];
+  env = lib.optionalAttrs withCuda {
+    NIX_LDFLAGS = "-L${cudatoolkit}/lib/stubs";
+  };
 
   cmakeFlags = [
     "-DFIRESTARTER_BUILD_HWLOC=OFF"

--- a/pkgs/by-name/fu/fuseiso/package.nix
+++ b/pkgs/by-name/fu/fuseiso/package.nix
@@ -55,7 +55,10 @@ stdenv.mkDerivation rec {
 
   # after autoreconfHook, glib and zlib are not found, so force link against
   # them
-  NIX_LDFLAGS = "-lglib-2.0 -lz";
+  env.NIX_LDFLAGS = toString [
+    "-lglib-2.0"
+    "-lz"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/gl/globulation2/package.nix
+++ b/pkgs/by-name/gl/globulation2/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
     "DATADIR=${placeholder "out"}/share/globulation2/glob2"
   ];
 
-  NIX_LDFLAGS = "-lboost_system";
+  env.NIX_LDFLAGS = "-lboost_system";
 
   meta = {
     description = "RTS without micromanagement";

--- a/pkgs/by-name/gn/gnujump/package.nix
+++ b/pkgs/by-name/gn/gnujump/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     SDL_mixer
   ];
 
-  NIX_LDFLAGS = "-lm";
+  env.NIX_LDFLAGS = "-lm";
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/go/golden-cheetah/package.nix
+++ b/pkgs/by-name/go/golden-cheetah/package.nix
@@ -70,7 +70,11 @@ stdenv.mkDerivation (finalAttrs: {
     ./0001-Fix-building-with-bison-3.7.patch
   ];
 
-  NIX_LDFLAGS = "-lz -lgsl -lblas";
+  env.NIX_LDFLAGS = toString [
+    "-lz"
+    "-lgsl"
+    "-lblas"
+  ];
 
   qtWrapperArgs = [
     "--prefix"

--- a/pkgs/by-name/ha/handbrake/package.nix
+++ b/pkgs/by-name/ha/handbrake/package.nix
@@ -305,7 +305,9 @@ let
     ++ optional stdenv.hostPlatform.isx86 "--harden";
 
     # NOTE: 2018-12-27: Check NixOS HandBrake test if changing
-    NIX_LDFLAGS = [ "-lx265" ];
+    env.NIX_LDFLAGS = toString [
+      "-lx265"
+    ];
 
     # meson/ninja are used only for the subprojects, not the toplevel
     dontUseMesonConfigure = true;

--- a/pkgs/by-name/he/hedgewars/package.nix
+++ b/pkgs/by-name/he/hedgewars/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DNOSERVER=${if withServer then "OFF" else "ON"}"
   ];
 
-  NIX_LDFLAGS = lib.concatMapStringsSep " " (e: "-rpath ${e}/lib") [
+  env.NIX_LDFLAGS = lib.concatMapStringsSep " " (e: "-rpath ${e}/lib") [
     SDL2.out
     SDL2_image
     SDL2_mixer
@@ -93,14 +93,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   qtWrapperArgs = [
-    "--prefix LD_LIBRARY_PATH : ${
-      lib.makeLibraryPath [
-        libGL
-        libGLU
-        libglut
-        physfs
-      ]
-    }"
+    "--prefix"
+    "LD_LIBRARY_PATH"
+    ":"
+    (lib.makeLibraryPath [
+      libGL
+      libGLU
+      libglut
+      physfs
+    ])
   ];
 
   meta = {

--- a/pkgs/by-name/ia/iay/package.nix
+++ b/pkgs/by-name/ia/iay/package.nix
@@ -26,10 +26,12 @@ rustPlatform.buildRustPackage rec {
     openssl
   ];
 
-  NIX_LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin [
-    "-framework"
-    "AppKit"
-  ];
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = toString [
+      "-framework"
+      "AppKit"
+    ];
+  };
 
   meta = {
     description = "Minimalistic, blazing-fast, and extendable prompt for bash and zsh";

--- a/pkgs/by-name/in/instead/package.nix
+++ b/pkgs/by-name/in/instead/package.nix
@@ -47,7 +47,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-d5BvzZCZ3P5CLptuCuJ4KxfEp4CDbtmIZDIbGDcyV3o=";
   };
 
-  NIX_LDFLAGS = "-llua -lgcc_s";
+  env.NIX_LDFLAGS = toString [
+    "-llua"
+    "-lgcc_s"
+  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ke/keepassxc/package.nix
+++ b/pkgs/by-name/ke/keepassxc/package.nix
@@ -46,13 +46,20 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Hec3RBC/f0GV6ZBniy+BjMAkABlg111mShrQv0aYm6g=";
   };
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang (toString [
-    "-Wno-old-style-cast"
-    "-Wno-error"
-    "-D__BIG_ENDIAN__=${if stdenv.hostPlatform.isBigEndian then "1" else "0"}"
-  ]);
-
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-rpath ${libargon2}/lib";
+  env =
+    lib.optionalAttrs stdenv.cc.isClang {
+      NIX_CFLAGS_COMPILE = toString [
+        "-Wno-old-style-cast"
+        "-Wno-error"
+        "-D__BIG_ENDIAN__=${if stdenv.hostPlatform.isBigEndian then "1" else "0"}"
+      ];
+    }
+    // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      NIX_LDFLAGS = toString [
+        "-rpath"
+        "${libargon2}/lib"
+      ];
+    };
 
   patches = [
     ./darwin.patch

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -86,7 +86,9 @@ stdenv.mkDerivation rec {
   '';
 
   # Required for ‘pthread_cancel’.
-  NIX_LDFLAGS = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-lgcc_s";
+  env = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
+    NIX_LDFLAGS = "-lgcc_s";
+  };
 
   configureFlags = [
     "--with-apr=${apr.dev}"


### PR DESCRIPTION
To be continued later for the rest of the alphabet in a different PR...

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
