### PR TITLE
python3Packages: add more vacuum-map-parser-*

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5718,6 +5718,12 @@
     github = "dadada";
     githubId = 7216772;
   };
+  dady8889 = {
+    email = "dady8889@gmail.com";
+    github = "dady8889";
+    githubId = 5238573;
+    name = "dady8889";
+  };
   dalance = {
     email = "dalance@gmail.com";
     github = "dalance";

--- a/pkgs/development/python-modules/vacuum-map-parser-dreame/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-dreame/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  pillow,
+  vacuum-map-parser-base,
+  pycryptodome,
+}:
+
+buildPythonPackage rec {
+  pname = "vacuum-map-parser-dreame";
+  version = "0.1.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "PiotrMachowski";
+    repo = "Python-package-${pname}";
+    tag = "v${version}";
+    hash = "sha256-7ZuyRK5KKlul+VycH6lQFRJVKCT4AUFXjeY+t4sHqtk=";
+  };
+
+  postPatch = ''
+    # Upstream doesn't set a version in the pyproject.toml file
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}"
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pillow
+    pycryptodome
+    vacuum-map-parser-base
+  ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "vacuum_map_parser_dreame" ];
+
+  meta = {
+    description = "Functionalities for Dreame vacuum map parsing";
+    homepage = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-dreame";
+    changelog = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-dreame/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ dady8889 ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/vacuum-map-parser-ijai/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-ijai/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  pillow,
+  vacuum-map-parser-base,
+  pycryptodome,
+}:
+
+buildPythonPackage rec {
+  pname = "vacuum-map-parser-ijai";
+  version = "0.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "maksp86";
+    repo = "Python-package-${pname}";
+    tag = "v${version}";
+    hash = "sha256-mxLEfpifPBR5gYbxskpviaj4k7S2OImh0wyfpy6aXv0=";
+  };
+
+  postPatch = ''
+    # Upstream doesn't set a version in the pyproject.toml file
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}"
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pillow
+    pycryptodome
+    vacuum-map-parser-base
+  ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "vacuum_map_parser_ijai" ];
+
+  meta = {
+    description = "Functionalities for Ijai vacuum map parsing";
+    homepage = "https://github.com/maksp86/Python-package-vacuum-map-parser-ijai";
+    changelog = "https://github.com/maksp86/Python-package-vacuum-map-parser-ijai/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ dady8889 ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/vacuum-map-parser-roidmi/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-roidmi/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  pillow,
+  vacuum-map-parser-base,
+}:
+
+buildPythonPackage rec {
+  pname = "vacuum-map-parser-roidmi";
+  version = "0.1.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "PiotrMachowski";
+    repo = "Python-package-${pname}";
+    tag = "v${version}";
+    hash = "sha256-E4DCvDQRrdueGnKbY3D+Oh/hvr8hcW5FZF3Of0Vbvs4=";
+  };
+
+  postPatch = ''
+    # Upstream doesn't set a version in the pyproject.toml file
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}"
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pillow
+    vacuum-map-parser-base
+  ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "vacuum_map_parser_roidmi" ];
+
+  meta = {
+    description = "Functionalities for Roidmi vacuum map parsing";
+    homepage = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roidmi";
+    changelog = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-roidmi/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ dady8889 ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/development/python-modules/vacuum-map-parser-viomi/default.nix
+++ b/pkgs/development/python-modules/vacuum-map-parser-viomi/default.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildPythonPackage,
+  pythonOlder,
+  fetchFromGitHub,
+  poetry-core,
+  pillow,
+  vacuum-map-parser-base,
+}:
+
+buildPythonPackage rec {
+  pname = "vacuum-map-parser-viomi";
+  version = "0.1.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.11";
+
+  src = fetchFromGitHub {
+    owner = "PiotrMachowski";
+    repo = "Python-package-${pname}";
+    tag = "v${version}";
+    hash = "sha256-ritPucFznZvqgvCmp2RJ6SoGJko6LHL74ecSDhu7JG0=";
+  };
+
+  postPatch = ''
+    # Upstream doesn't set a version in the pyproject.toml file
+    substituteInPlace pyproject.toml \
+      --replace "0.0.0" "${version}"
+  '';
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    pillow
+    vacuum-map-parser-base
+  ];
+
+  # No tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "vacuum_map_parser_viomi" ];
+
+  meta = {
+    description = "Functionalities for Viomi vacuum map parsing";
+    homepage = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-viomi";
+    changelog = "https://github.com/PiotrMachowski/Python-package-vacuum-map-parser-viomi/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ dady8889 ];
+    license = lib.licenses.asl20;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20322,6 +20322,8 @@ self: super: with self; {
 
   vacuum-map-parser-dreame = callPackage ../development/python-modules/vacuum-map-parser-dreame { };
 
+  vacuum-map-parser-ijai = callPackage ../development/python-modules/vacuum-map-parser-ijai { };
+
   vacuum-map-parser-roborock =
     callPackage ../development/python-modules/vacuum-map-parser-roborock
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20320,6 +20320,8 @@ self: super: with self; {
 
   vacuum-map-parser-base = callPackage ../development/python-modules/vacuum-map-parser-base { };
 
+  vacuum-map-parser-dreame = callPackage ../development/python-modules/vacuum-map-parser-dreame { };
+
   vacuum-map-parser-roborock =
     callPackage ../development/python-modules/vacuum-map-parser-roborock
       { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20328,6 +20328,8 @@ self: super: with self; {
     callPackage ../development/python-modules/vacuum-map-parser-roborock
       { };
 
+  vacuum-map-parser-roidmi = callPackage ../development/python-modules/vacuum-map-parser-roidmi { };
+
   validate-email = callPackage ../development/python-modules/validate-email { };
 
   validator-collection = callPackage ../development/python-modules/validator-collection { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20330,6 +20330,8 @@ self: super: with self; {
 
   vacuum-map-parser-roidmi = callPackage ../development/python-modules/vacuum-map-parser-roidmi { };
 
+  vacuum-map-parser-viomi = callPackage ../development/python-modules/vacuum-map-parser-viomi { };
+
   validate-email = callPackage ../development/python-modules/validate-email { };
 
   validator-collection = callPackage ../development/python-modules/validator-collection { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Changes

- Added python3 packages: `vacuum-map-parser-dreame` `vacuum-map-parser-ijai` `vacuum-map-parser-roidmi` `vacuum-map-parser-viomi`

## Why

Packages are a requirement for https://github.com/PiotrMachowski/Home-Assistant-custom-components-Xiaomi-Cloud-Map-Extractor/releases/tag/v3.0.0-alpha-21

This PR is mainly just a copy of #277960

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
