### PR TITLE
awakened-poe-trade: init at 3.27.106

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18055,6 +18055,12 @@
     githubId = 3073833;
     name = "Massimo Redaelli";
   };
+  mreichardt95 = {
+    email = "mreichardt95@gmail.com";
+    github = "mreichardt95";
+    githubId = 18323490;
+    name = "Milian Reichardt";
+  };
   mrene = {
     email = "mathieu.rene@gmail.com";
     github = "mrene";

--- a/pkgs/by-name/aw/awakened-poe-trade/package.nix
+++ b/pkgs/by-name/aw/awakened-poe-trade/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  appimageTools,
+  makeWrapper,
+  electron,
+  libxtst,
+  libxt,
+
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "awakened-poe-trade";
+  version = "3.27.106";
+
+  src = fetchurl {
+    url = "https://github.com/SnosMe/awakened-poe-trade/releases/download/v${finalAttrs.version}/Awakened-PoE-Trade-${finalAttrs.version}.AppImage";
+    hash = "sha256-8L5Szn0KYfUMaTe+yyhJV1YZspmJCSlXSHXLPoiRhjE=";
+  };
+
+  passthru = {
+    appImageContents = appimageTools.extractType2 {
+      inherit (finalAttrs) pname src version;
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/share/awakened-poe-trade $out/share/applications
+
+    cp -a ${finalAttrs.passthru.appImageContents}/{locales,resources} $out/share/awakened-poe-trade
+    cp -a ${finalAttrs.passthru.appImageContents}/awakened-poe-trade.desktop $out/share/applications/
+    cp -a ${finalAttrs.passthru.appImageContents}/usr/share/icons $out/share
+
+    substituteInPlace $out/share/applications/awakened-poe-trade.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=awakened-poe-trade'
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    makeWrapper ${lib.getExe electron} $out/bin/awakened-poe-trade \
+      --add-flags $out/share/awakened-poe-trade/resources/app.asar \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libxtst
+          libxt
+        ]
+      }"
+  '';
+
+  meta = {
+    description = "Path of Exile trading app for price checking";
+    homepage = "https://github.com/SnosMe/awakened-poe-trade";
+    changelog = "https://github.com/SnosMe/awakened-poe-trade/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mreichardt95
+    ];
+    platforms = with lib.platforms; linux;
+    mainProgram = "awakened-poe-trade";
+  };
+})


### PR DESCRIPTION
[Awakened PoE Trade](https://github.com/SnosMe/awakened-poe-trade) is a cross-platform desktop tool designed for the action RPG [Path of Exile](https://www.pathofexile.com/).
It provides an in-game overlay that allows players to quickly check and filter item prices using the official trade API.

The overlay is opened via a configurable keybind (default: Ctrl + Space), displaying contextual price and market data directly within the game.
On Wayland, overlay rendering is not supported, but the same functionality can be accessed by launching the interface in a standalone browser tab.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
