### PR TITLE
fetchtastic: init at 0.10.2

### DIFF
--- a/pkgs/by-name/fe/fetchtastic/package.nix
+++ b/pkgs/by-name/fe/fetchtastic/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "fetchtastic";
+  version = "0.10.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jeremiah-k";
+    repo = "fetchtastic";
+    tag = finalAttrs.version;
+    hash = "sha256-E8f0je4w4sTmf/EX9I8dZ4Ge4bsEvr8E6S5i02n5k+E=";
+  };
+
+  pythonRelaxDeps = [ "platformdirs" ];
+
+  build-system = with python3.pkgs; [ setuptools ];
+
+  dependencies = with python3.pkgs; [
+    packaging
+    pick
+    platformdirs
+    pyyaml
+    requests
+    rich
+    urllib3
+  ];
+
+  nativeCheckInputs = with python3.pkgs; [
+    pytest-cov-stub
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fetchtastic" ];
+
+  meta = {
+    description = "Utility for downloading and managing the latest Meshtastic firmware releases";
+    homepage = "https://github.com/jeremiah-k/fetchtastic";
+    changelog = "https://github.com/jeremiah-k/fetchtastic/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "fetchtastic";
+  };
+})


### PR DESCRIPTION
Utility for downloading and managing the latest Meshtastic firmware releases

https://github.com/jeremiah-k/fetchtastic


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
