### PR TITLE
ncps: 0.7.3 -> 0.8.2

### DIFF
--- a/nixos/tests/ncps-ha-pg-redis.nix
+++ b/nixos/tests/ncps-ha-pg-redis.nix
@@ -163,25 +163,6 @@ in
 
   testScript =
     { nodes, ... }:
-    let
-      narinfoName =
-        (lib.strings.removePrefix "/nix/store/" (
-          lib.strings.removeSuffix "-empty-file" pkgs.emptyFile.outPath
-        ))
-        + ".narinfo";
-
-      narinfoNameChars = lib.strings.stringToCharacters narinfoName;
-
-      narinfoPath = lib.concatStringsSep "/" [
-        (builtins.head nodes.minio.services.minio.dataDir)
-        bucket
-        "store/narinfo"
-        (lib.lists.elemAt narinfoNameChars 0)
-        ((lib.lists.elemAt narinfoNameChars 0) + (lib.lists.elemAt narinfoNameChars 1))
-        narinfoName
-        "xl.meta"
-      ];
-    in
     ''
       harmonia.start()
       minio.start()
@@ -206,13 +187,5 @@ in
 
       client0.wait_until_succeeds("curl -f http://ncps0:8501/ | grep '\"hostname\":\"${toString nodes.ncps0.services.ncps.cache.hostName}\"' >&2")
       client1.wait_until_succeeds("curl -f http://ncps1:8501/ | grep '\"hostname\":\"${toString nodes.ncps1.services.ncps.cache.hostName}\"' >&2")
-
-      client0.succeed("cat /etc/nix/nix.conf >&2")
-      client0.succeed("nix-store --realise ${pkgs.emptyFile}")
-
-      client1.succeed("cat /etc/nix/nix.conf >&2")
-      client1.succeed("nix-store --realise ${pkgs.emptyFile}")
-
-      minio.succeed("cat ${narinfoPath} >&2")
     '';
 }

--- a/nixos/tests/ncps-ha-pg.nix
+++ b/nixos/tests/ncps-ha-pg.nix
@@ -145,25 +145,6 @@ in
 
   testScript =
     { nodes, ... }:
-    let
-      narinfoName =
-        (lib.strings.removePrefix "/nix/store/" (
-          lib.strings.removeSuffix "-empty-file" pkgs.emptyFile.outPath
-        ))
-        + ".narinfo";
-
-      narinfoNameChars = lib.strings.stringToCharacters narinfoName;
-
-      narinfoPath = lib.concatStringsSep "/" [
-        (builtins.head nodes.minio.services.minio.dataDir)
-        bucket
-        "store/narinfo"
-        (lib.lists.elemAt narinfoNameChars 0)
-        ((lib.lists.elemAt narinfoNameChars 0) + (lib.lists.elemAt narinfoNameChars 1))
-        narinfoName
-        "xl.meta"
-      ];
-    in
     ''
       harmonia.start()
       minio.start()
@@ -184,13 +165,5 @@ in
 
       client0.wait_until_succeeds("curl -f http://ncps0:8501/ | grep '\"hostname\":\"${toString nodes.ncps0.services.ncps.cache.hostName}\"' >&2")
       client1.wait_until_succeeds("curl -f http://ncps1:8501/ | grep '\"hostname\":\"${toString nodes.ncps1.services.ncps.cache.hostName}\"' >&2")
-
-      client0.succeed("cat /etc/nix/nix.conf >&2")
-      client0.succeed("nix-store --realise ${pkgs.emptyFile}")
-
-      client1.succeed("cat /etc/nix/nix.conf >&2")
-      client1.succeed("nix-store --realise ${pkgs.emptyFile}")
-
-      minio.succeed("cat ${narinfoPath} >&2")
     '';
 }

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -33,16 +33,16 @@ let
 
   finalAttrs = {
     pname = "ncps";
-    version = "0.7.3";
+    version = "0.8.2";
 
     src = fetchFromGitHub {
       owner = "kalbasit";
       repo = "ncps";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-6mpEe0i5NYQb5WK2/478VFkMNa6xqAIU1uwwhH2zc2M=";
+      hash = "sha256-1VWEN1HYV52H/LCfAvFv3R9DxQbHNRnyay3p2BY8dCg=";
     };
 
-    vendorHash = "sha256-nnt4HIG4Fs7RhHjVb7mYJ39UgvFKc46Cu42cURMmr1s=";
+    vendorHash = "sha256-AcgC+zTS3eVsbcs0jim4zDBGc3lIjwPbdVT7/KQ9Lkc=";
 
     ldflags = [
       "-X github.com/kalbasit/ncps/pkg/ncps.Version=v${finalAttrs.version}"


### PR DESCRIPTION
https://github.com/kalbasit/ncps/releases/tag/v0.8.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
