### PR TITLE
qdirstat: 1.9 -> 2.0; update to qt6

### DIFF
--- a/pkgs/by-name/qd/qdirstat/package.nix
+++ b/pkgs/by-name/qd/qdirstat/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchFromGitHub,
   stdenv,
-  libsForQt5,
+  qt6Packages,
   coreutils,
   xdg-utils,
   bash,
@@ -13,20 +13,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qdirstat";
-  version = "1.9";
+  version = "2.0";
 
   src = fetchFromGitHub {
     owner = "shundhammer";
     repo = "qdirstat";
     rev = finalAttrs.version;
-    hash = "sha256-pwdmltHDNwUMx1FNOoiXl5Pna0zlKqahmicBCN6UVSU=";
+    hash = "sha256-qkXu3W6umAlSVlTXaQT/UmC3gzVt6BVy4EZzLBYI94s=";
   };
 
   nativeBuildInputs = [
     makeWrapper
   ]
-  ++ (with libsForQt5; [
+  ++ (with qt6Packages; [
     qmake
+    qt5compat
     wrapQtAppsHook
   ]);
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

closes https://github.com/NixOS/nixpkgs/issues/481601

https://github.com/shundhammer/qdirstat/releases/tag/2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
