### PR TITLE
maintainers: add phanirithvij to ngi team

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -566,6 +566,7 @@ with lib.maintainers;
       ethancedwards8
       fricklerhandwerk
       OPNA2608
+      phanirithvij
       prince213
       wegank
     ];

--- a/nixos/modules/services/security/reaction.nix
+++ b/nixos/modules/services/security/reaction.nix
@@ -204,7 +204,6 @@ in
     with lib.maintainers;
     [
       ppom
-      phanirithvij
     ]
     ++ lib.teams.ngi.members;
 }

--- a/nixos/tests/reaction-firewall.nix
+++ b/nixos/tests/reaction-firewall.nix
@@ -73,7 +73,6 @@
     with lib.maintainers;
     [
       ppom
-      phanirithvij
     ]
     ++ lib.teams.ngi.members;
 }

--- a/nixos/tests/reaction.nix
+++ b/nixos/tests/reaction.nix
@@ -104,7 +104,6 @@
     with lib.maintainers;
     [
       ppom
-      phanirithvij
     ]
     ++ lib.teams.ngi.members;
 }


### PR DESCRIPTION
Adding self to ngi-nix team.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
