### PR TITLE
zathura: 0.5.14 -> 2026.02.09

### DIFF
--- a/pkgs/applications/misc/zathura/cb/default.nix
+++ b/pkgs/applications/misc/zathura/cb/default.nix
@@ -12,17 +12,18 @@
   desktop-file-utils,
   appstream,
   appstream-glib,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-cb";
-  version = "0.1.12";
+  version = "2026.02.03";
 
   src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura-cb";
     tag = finalAttrs.version;
-    hash = "sha256-Dj398aUQBxOrH5XOC5u/vNkEQ6pa05/EDB5m0EAGAxo=";
+    hash = "sha256-k5WbJR0PToiSQo00igH/3uHWp7z4dNxwSXiAos6OgJ8=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://pwmt.org/projects/zathura-cb/";

--- a/pkgs/applications/misc/zathura/core/default.nix
+++ b/pkgs/applications/misc/zathura/core/default.nix
@@ -32,13 +32,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura";
-  version = "0.5.14";
+  version = "2026.02.09";
 
   src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura";
     tag = finalAttrs.version;
-    hash = "sha256-Ejd39gUWA9YEoPpaaxo+9JkoezAjXYpXTB+FGdXt03U=";
+    hash = "sha256-Zkefujp9Ywm7swHNMMvWSV0hKHaMXpJpOcfoL+f6XfE=";
   };
 
   outputs = [

--- a/pkgs/applications/misc/zathura/djvu/default.nix
+++ b/pkgs/applications/misc/zathura/djvu/default.nix
@@ -13,17 +13,18 @@
   desktop-file-utils,
   appstream,
   appstream-glib,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-djvu";
-  version = "0.2.11";
+  version = "2026.02.03";
 
   src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura-djvu";
     tag = finalAttrs.version;
-    hash = "sha256-TehD0uTQguH8f6pdOSIyhr1m87jB3F0WTUNtUM0fPu4=";
+    hash = "sha256-5Nl9hK2uOS/NZ4MOxe3m6E9CBt5YKGeh1lZZ5E5bghw=";
   };
 
   nativeBuildInputs = [
@@ -44,6 +45,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://pwmt.org/projects/zathura-djvu/";

--- a/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-mupdf/default.nix
@@ -24,14 +24,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "0.4.6";
+  version = "2026.02.03";
   pname = "zathura-pdf-mupdf";
 
   src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura-pdf-mupdf";
     tag = finalAttrs.version;
-    hash = "sha256-vg/ac62MPTWRbTPjbh+rKcFjVb5237wBEIVvTef6K5Q=";
+    hash = "sha256-pNaawaExmBYDJbry/Ek/EpP2mojHp3MZw3cR6ku2jeg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/misc/zathura/pdf-poppler/default.nix
+++ b/pkgs/applications/misc/zathura/pdf-poppler/default.nix
@@ -11,17 +11,18 @@
   desktop-file-utils,
   appstream,
   appstream-glib,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-pdf-poppler";
-  version = "0.3.4";
+  version = "2026.02.03";
 
   src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura-pdf-poppler";
     tag = finalAttrs.version;
-    hash = "sha256-xRTJlPj8sKRjwyuf1hWDyL1n4emLnAEVxVjn6XYn5IU=";
+    hash = "sha256-ddW2SepBoR9BpqcAIAONmd2P5AjkhmWyIjIDeTnHO4Y=";
   };
 
   nativeBuildInputs = [
@@ -40,6 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://pwmt.org/projects/zathura-pdf-poppler/";

--- a/pkgs/applications/misc/zathura/ps/default.nix
+++ b/pkgs/applications/misc/zathura/ps/default.nix
@@ -12,17 +12,18 @@
   desktop-file-utils,
   appstream,
   appstream-glib,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zathura-ps";
-  version = "0.2.9";
+  version = "2026.02.03";
 
   src = fetchFromGitHub {
     owner = "pwmt";
     repo = "zathura-ps";
     tag = finalAttrs.version;
-    hash = "sha256-YQtMfHhPAe8LtJfcw8LRGe5LvtPY7DjYKFaWOYlveeI=";
+    hash = "sha256-5i3LvdjcAdofc0oZCBSm2qn/29UR1Yiia3OmVjFC4ZI=";
   };
 
   nativeBuildInputs = [
@@ -42,6 +43,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   env.PKG_CONFIG_ZATHURA_PLUGINDIR = "lib/zathura";
+
+  passthru.updateScript = gitUpdater { };
 
   meta = {
     homepage = "https://pwmt.org/projects/zathura-ps/";

--- a/pkgs/by-name/gi/girara/package.nix
+++ b/pkgs/by-name/gi/girara/package.nix
@@ -15,11 +15,12 @@
   json-glib,
   libintl,
   zathura,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "girara";
-  version = "0.4.5";
+  version = "2026.02.04";
 
   outputs = [
     "out"
@@ -30,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "pwmt";
     repo = "girara";
     tag = finalAttrs.version;
-    hash = "sha256-XjRmGgljlkvxwcbPmA9ZFAPAjbClSQDdmQU/GFeLLxI=";
+    hash = "sha256-wTVgldfo8pWdY244nNldiogioijv/k32w1A8pEqOTRE=";
   };
 
   nativeBuildInputs = [
@@ -74,8 +75,11 @@ stdenv.mkDerivation (finalAttrs: {
       meson test --print-errorlogs
   '';
 
-  passthru.tests = {
-    inherit zathura;
+  passthru = {
+    updateScript = gitUpdater { };
+    tests = {
+      inherit zathura;
+    };
   };
 
   meta = {


### PR DESCRIPTION
- girara: 0.4.5 -> 2026.02.04
https://github.com/pwmt/girara/compare/0.4.5...2026.02.04
- zathuraPackages.zathura_core: 0.5.14 -> 2026.02.09
https://github.com/pwmt/zathura/compare/0.5.14...2026.02.09
- zathuraPkgs.zathura_cb: 0.1.12 -> 2026.02.03
https://github.com/pwmt/zathura-cb/compare/0.1.12...2026.02.03
- zathuraPkgs.zathura_djvu: 0.2.11 -> 2026.02.03
https://github.com/pwmt/zathura-djvu/compare/0.2.11...2026.02.03
- zathuraPkgs.zathura_pdf_poppler: 0.3.4 -> 2026.02.03
https://github.com/pwmt/zathura-pdf-poppler/compare/0.3.4...2026.02.03
- zathuraPkgs.zathura_pdf_mupdf: 0.4.6 -> 2026.02.03
https://github.com/pwmt/zathura-pdf-mupdf/compare/0.4.6...2026.02.03
- zathuraPkgs.zathura_ps: 0.2.9 -> 2026.02.03
https://github.com/pwmt/zathura-ps/compare/0.2.9...2026.02.03

Also adds `passthru.updateScript` to all of these packages that didn't already have it.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
