### PR TITLE
nmstate: init at 2.2.57

### DIFF
--- a/pkgs/by-name/nm/nmstate/package.nix
+++ b/pkgs/by-name/nm/nmstate/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  rustPlatform,
+  libfaketime,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nmstate";
+  version = "2.2.57";
+
+  srcs = [
+    (fetchFromGitHub {
+      owner = "nmstate";
+      repo = "nmstate";
+      tag = "v${finalAttrs.version}";
+      hash = "sha256-7X51XmoSwlIrbsdJFfTQ23bhO3bitkHXOObL6JaGpvI=";
+    })
+    (fetchurl {
+      url = "https://github.com/nmstate/nmstate/releases/download/v${finalAttrs.version}/nmstate-vendor-${finalAttrs.version}.tar.xz";
+      hash = "sha256-stOHNezPLPjSrt/f3HmhqWMxSaSfOh/hYVGB2+l8Pb4=";
+    })
+  ];
+  sourceRoot = ".";
+  postUnpack = ''
+    mv vendor source/rust/
+    cd source
+  '';
+
+  postPatch = ''
+    substituteInPlace packaging/nmstate.service --replace-fail /usr/bin $out/bin
+  '';
+
+  cargoRoot = "rust";
+  buildAndTestSubdir = finalAttrs.cargoRoot;
+  cargoVendorDir = "vendor";
+
+  nativeBuildInputs = [
+    libfaketime
+  ];
+
+  postInstall = ''
+    ln -s ../target rust/target
+    source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
+    PREFIX=$out LIBDIR=$out/lib RELEASE=1 SKIP_PYTHON_INSTALL=1 faketime -f "$source_date" make install
+  '';
+
+  meta = {
+    description = "Nmstate: A Declarative Network API";
+    homepage = "https://nmstate.io/";
+    changelog = "https://github.com/nmstate/nmstate/blob/v${finalAttrs.version}/CHANGELOG";
+    license = lib.licenses.asl20;
+    mainProgram = "nmstatectl";
+    maintainers = with lib.maintainers; [
+      iwanb
+    ];
+    platforms = with lib.platforms; unix;
+  };
+})


### PR DESCRIPTION
Added package for [nmstate](https://nmstate.io/).

Related requests: https://github.com/NixOS/nixpkgs/issues/391680 https://github.com/nmstate/nmstate/issues/3036

## Things done

Checked nmstatectl works for reading state, checked man pages and systemd service.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
