### PR TITLE
xf86-input-wacom: enable strictDeps, fix configured version, modernize

### DIFF
--- a/pkgs/by-name/xf/xf86-input-wacom/package.nix
+++ b/pkgs/by-name/xf/xf86-input-wacom/package.nix
@@ -30,6 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-12m9PL28NnqIwNpGHOFqjJaNrzBaagdG3Sp/jSLpgkE=";
   };
 
+  preConfigure = ''
+    # See VERFILE in git-version-gen
+    echo ${finalAttrs.version} > version
+  '';
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config

--- a/pkgs/by-name/xf/xf86-input-wacom/package.nix
+++ b/pkgs/by-name/xf/xf86-input-wacom/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
     pkg-config
     udevCheckHook
+    util-macros
   ];
 
   buildInputs = [
@@ -45,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxrender
     ncurses
     udev
-    util-macros
     pixman
     xorgproto
     xorg-server
@@ -58,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-sdkdir=${placeholder "out"}/include/xorg"
     "--with-xorg-conf-dir=${placeholder "out"}/share/X11/xorg.conf.d"
   ];
+
+  strictDeps = true;
 
   meta = {
     maintainers = with lib.maintainers; [ moni ];

--- a/pkgs/by-name/xf/xf86-input-wacom/package.nix
+++ b/pkgs/by-name/xf/xf86-input-wacom/package.nix
@@ -26,8 +26,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "linuxwacom";
     repo = "xf86-input-wacom";
-    rev = "xf86-input-wacom-${finalAttrs.version}";
-    sha256 = "sha256-12m9PL28NnqIwNpGHOFqjJaNrzBaagdG3Sp/jSLpgkE=";
+    tag = "xf86-input-wacom-${finalAttrs.version}";
+    hash = "sha256-12m9PL28NnqIwNpGHOFqjJaNrzBaagdG3Sp/jSLpgkE=";
   };
 
   preConfigure = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
