### PR TITLE
po4a: 0.73 -> 0.74

### DIFF
--- a/pkgs/development/perl-modules/Po4a/default.nix
+++ b/pkgs/development/perl-modules/Po4a/default.nix
@@ -5,13 +5,13 @@
   docbook_xsl,
   docbook_xsl_ns,
   gettext,
+  libxml2,
   libxslt,
   glibcLocales,
   docbook_xml_dtd_45,
   docbook_sgml_dtd_41,
   opensp,
   bash,
-  fetchpatch,
   perl,
   buildPerlPackage,
   ModuleBuild,
@@ -27,11 +27,11 @@
 
 buildPerlPackage rec {
   pname = "po4a";
-  version = "0.73";
+  version = "0.74";
 
   src = fetchurl {
     url = "https://github.com/mquinson/po4a/releases/download/v${version}/po4a-${version}.tar.gz";
-    hash = "sha256-bxj4LYyyo3c5QTfqOWzD6BldbNbkVP4CGKoPDjYDjqA=";
+    hash = "sha256-JfwyPyuje71Iw68Ov0mVJkSw5GgmH5hjPpEhmoOP58I=";
   };
 
   strictDeps = true;
@@ -40,12 +40,17 @@ buildPerlPackage rec {
     # the tests for the tex-format use kpsewhich -- texlive's file finding utility.
     # We don't want to depend on texlive here, so we replace it with a minimal
     # shellscript that suffices for the tests in t/fmt/tex/, i.e. it looks up
-    # article.cls to an existing file, but doesn't find article-wrong.cls.
+    # subtext.tex and article.cls to appropriate files, but doesn't find article-wrong.cls.
     let
-      kpsewhich-stub = writeShellScriptBin "kpsewhich" ''[[ $1 = "article.cls" ]] && echo /dev/null'';
+      kpsewhich-stub = writeShellScriptBin "kpsewhich" ''
+        srcdir="$NIX_BUILD_TOP/${lib.strings.removeSuffix ".tar.gz" src.name}"
+        [[ $1 = "article.cls" ]] && echo /dev/null
+        [[ $1 = "subtext.tex" ]] && echo "$srcdir/t/fmt/tex/subtext.tex"
+      '';
     in
     [
       gettext
+      libxml2
       libxslt
       docbook_xsl
       docbook_xsl_ns
@@ -56,18 +61,6 @@ buildPerlPackage rec {
       kpsewhich-stub
       glibcLocales
     ];
-  patches = [
-    # Needs a patch for 5.40 until the next release
-    (fetchpatch {
-      url = "https://github.com/mquinson/po4a/commit/28fe52651eb8096d97d6bd3a97b3168522ba5306.patch";
-      hash = "sha256-QUXxkSzcnwRvU+2y2KoBXmtfE8qTZ2BV0StkJHqZehQ=";
-    })
-    (fetchpatch {
-      name = "gettext-0.25.patch";
-      url = "https://github.com/mquinson/po4a/commit/7d88a5e59606a9a29ffe73325fff4a5ddb865d5c.patch";
-      hash = "sha256-5x+EX++v7DxOHOZgRM2tv5eNN1Gy28f+qaqH27emZhk=";
-    })
-  ];
 
   # TODO: TermReadKey was temporarily removed from propagatedBuildInputs to unfreeze the build
   propagatedBuildInputs =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://github.com/mquinson/po4a/releases/tag/v0.74

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
