### PR TITLE
cc-wrapper: remove some trailing and leading spaces

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -786,29 +786,31 @@ stdenvNoCC.mkDerivation {
     # This confuses libtool.  So add it to the compiler tool search
     # path explicitly.
     + optionalString (!nativeTools && !isArocc) ''
+      ccLDFlags=()
+      ccCFlags=()
       if [ -e "${cc_solib}/lib64" -a ! -L "${cc_solib}/lib64" ]; then
-        ccLDFlags+=" -L${cc_solib}/lib64"
-        ccCFlags+=" -B${cc_solib}/lib64"
+        ccLDFlags+=("-L${cc_solib}/lib64")
+        ccCFlags+=("-B${cc_solib}/lib64")
       fi
-      ccLDFlags+=" -L${cc_solib}/lib"
-      ccCFlags+=" -B${cc_solib}/lib"
+      ccLDFlags+=("-L${cc_solib}/lib")
+      ccCFlags+=("-B${cc_solib}/lib")
 
     ''
     + optionalString (cc.langAda or false && !isArocc) ''
       touch "$out/nix-support/gnat-cflags"
       touch "$out/nix-support/gnat-ldflags"
       basePath=$(echo $cc/lib/*/*/*)
-      ccCFlags+=" -B$basePath -I$basePath/adainclude"
+      ccCFlags+=("-B$basePath" "-I$basePath/adainclude")
       gnatCFlags="-I$basePath/adainclude -I$basePath/adalib"
 
       echo "$gnatCFlags" >> $out/nix-support/gnat-cflags
     ''
     + ''
-      echo "$ccLDFlags" >> $out/nix-support/cc-ldflags
-      echo "$ccCFlags" >> $out/nix-support/cc-cflags
+      echo "''${ccLDFlags[*]}" >> $out/nix-support/cc-ldflags
+      echo "''${ccCFlags[*]}" >> $out/nix-support/cc-cflags
     ''
     + optionalString (targetPlatform.isDarwin && (libcxx != null) && (cc.isClang or false)) ''
-      echo " -L${libcxx_solib}" >> $out/nix-support/cc-ldflags
+      echo "-L${libcxx_solib}" >> $out/nix-support/cc-ldflags
     ''
 
     ## Prevent clang from seeing /usr/include. There is a desire to achieve this
@@ -830,7 +832,7 @@ stdenvNoCC.mkDerivation {
           && !targetPlatform.isAndroid
         )
         ''
-          echo " -nostdlibinc" >> $out/nix-support/cc-cflags
+          echo "-nostdlibinc" >> $out/nix-support/cc-cflags
         ''
 
     ##
@@ -867,7 +869,7 @@ stdenvNoCC.mkDerivation {
           );
       in
       optionalString enable_fp ''
-        echo " -fno-omit-frame-pointer ${optionalString enable_leaf_fp "-mno-omit-leaf-frame-pointer "}" >> $out/nix-support/cc-cflags-before
+        echo "-fno-omit-frame-pointer${optionalString enable_leaf_fp " -mno-omit-leaf-frame-pointer"}" >> $out/nix-support/cc-cflags-before
       ''
     )
 


### PR DESCRIPTION
Fixes extra spaces appearing in compiler flags during builds (e.g., `g++ -std=c++14  -fno-PIE` with double spaces).

Changes:
- Remove leading space before `-fno-omit-frame-pointer` and trailing space after `-mno-omit-leaf-frame-pointer`
- Remove leading spaces from `-L${libcxx_solib}` and `-nostdlibinc`
- Use `${var:+ }` pattern for `ccCFlags` and `ccLDFlags` to conditionally add separator space only when variables are non-empty

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test