### PR TITLE
pam: add missing article to the `security.pam.enableUMask` docs

### DIFF
--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -2249,7 +2249,7 @@ in
       };
     };
 
-    security.pam.enableUMask = lib.mkEnableOption "umask PAM module";
+    security.pam.enableUMask = lib.mkEnableOption "the umask PAM module";
 
     security.pam.enableFscrypt = lib.mkEnableOption ''
       fscrypt, to automatically unlock directories with the user's login password.


### PR DESCRIPTION
This adds a missing article to the documentation of the `security.pam.enableUMask` option, which not least makes it analogous to the documentation of, for example, `enableOTPW`.