### PR TITLE
nixos/{act,gitea-actions}-runner: refactor, nixos/forgejo-runner: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -132,6 +132,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `hyphen` now supports over 40 language variants through `hyphenDicts` and now allows to enable all supported languages through `hyphenDicts.all`.
 
+- The `services.forgejo-runner` module can now be used instead of `services.gitea-actions-runner`. It will set the `package` option to `pkgs.forgejo-runner` automatically, and use Forgejo's directories instead of Gitea's. No changes to the instance configurations are necessary.
+
 - [services.resolved](#opt-services.resolved.enable) module was converted to RFC42-style settings. The moved options have also been renamed to match the upstream names. Aliases mean current configs will continue to function, but users should move to the new options as convenient.
 
 - Support for Bluetooth audio based on `bluez-alsa` has been added to the `hardware.alsa` module. It can be enabled with the new [enableBluetooth](#opt-hardware.alsa.enableBluetooth) option.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -499,6 +499,7 @@
   ./services/computing/slurm/slurm.nix
   ./services/computing/torque/mom.nix
   ./services/computing/torque/server.nix
+  ./services/continuous-integration/act-runner/forgejo-runner.nix
   ./services/continuous-integration/act-runner/gitea-actions-runner.nix
   ./services/continuous-integration/buildbot/master.nix
   ./services/continuous-integration/buildbot/worker.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -499,10 +499,10 @@
   ./services/computing/slurm/slurm.nix
   ./services/computing/torque/mom.nix
   ./services/computing/torque/server.nix
+  ./services/continuous-integration/act-runner/gitea-actions-runner.nix
   ./services/continuous-integration/buildbot/master.nix
   ./services/continuous-integration/buildbot/worker.nix
   ./services/continuous-integration/buildkite-agents.nix
-  ./services/continuous-integration/gitea-actions-runner.nix
   ./services/continuous-integration/github-runners.nix
   ./services/continuous-integration/gitlab-runner/runner.nix
   ./services/continuous-integration/gocd-agent/default.nix

--- a/nixos/modules/services/continuous-integration/act-runner/forgejo-runner.nix
+++ b/nixos/modules/services/continuous-integration/act-runner/forgejo-runner.nix
@@ -1,0 +1,14 @@
+{
+  imports = [
+    (import ./generic.nix {
+      attributeName = "forgejo-runner";
+      name = "forgejo";
+      prettyName = "Forgejo";
+      runnerPrettyName = "Forgejo Runner";
+      srcUrl = "https://code.forgejo.org/forgejo/runner";
+      docsUrl = "https://forgejo.org/docs/latest/user/actions/overview";
+      labelsUrl = "https://forgejo.org/docs/latest/admin/actions";
+      mainProgram = "forgejo-runner";
+    })
+  ];
+}

--- a/nixos/modules/services/continuous-integration/act-runner/generic.nix
+++ b/nixos/modules/services/continuous-integration/act-runner/generic.nix
@@ -1,5 +1,7 @@
 {
   attributeName,
+  docsUrl,
+  labelsUrl,
   mainProgram,
   name,
   prettyName,
@@ -69,6 +71,8 @@ in
       default = { };
       description = ''
         ${runnerPrettyName} instances.
+
+        See <${docsUrl}> for additional information on how to use these CI instances.
       '';
       type = attrsOf (submodule {
         options = {
@@ -126,6 +130,8 @@ in
 
               Many common actions require `bash`, `git` and `nodejs`, as well as a
               filesystem that follows the filesystem hierarchy standard.
+
+              See <${labelsUrl}> for more information.
             '';
           };
           settings = mkOption {

--- a/nixos/modules/services/continuous-integration/act-runner/generic.nix
+++ b/nixos/modules/services/continuous-integration/act-runner/generic.nix
@@ -1,11 +1,11 @@
-let
-  attributeName = "gitea-actions-runner";
-  mainProgram = "act_runner";
-  name = "gitea";
-  prettyName = "Gitea";
-  runnerPrettyName = "Gitea Actions Runner";
-  srcUrl = "https://gitea.com/gitea/act_runner";
-in
+{
+  attributeName,
+  mainProgram,
+  name,
+  prettyName,
+  runnerPrettyName,
+  srcUrl,
+}:
 {
   config,
   lib,

--- a/nixos/modules/services/continuous-integration/act-runner/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/act-runner/gitea-actions-runner.nix
@@ -1,0 +1,12 @@
+{
+  imports = [
+    (import ./generic.nix {
+      attributeName = "gitea-actions-runner";
+      mainProgram = "act_runner";
+      name = "gitea";
+      prettyName = "Gitea";
+      runnerPrettyName = "Gitea Actions Runner";
+      srcUrl = "https://gitea.com/gitea/act_runner";
+    })
+  ];
+}

--- a/nixos/modules/services/continuous-integration/act-runner/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/act-runner/gitea-actions-runner.nix
@@ -2,6 +2,8 @@
   imports = [
     (import ./generic.nix {
       attributeName = "gitea-actions-runner";
+      docsUrl = "https://docs.gitea.com/usage/actions";
+      labelsUrl = "https://docs.gitea.com/usage/actions/act-runner#labels";
       mainProgram = "act_runner";
       name = "gitea";
       prettyName = "Gitea";

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -39,6 +39,7 @@ in
 {
   meta.maintainers = with maintainers; [
     hexa
+    sigmasquadron
   ];
 
   options.services.gitea-actions-runner = with types; {

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -1,3 +1,11 @@
+let
+  attributeName = "gitea-actions-runner";
+  mainProgram = "act_runner";
+  name = "gitea";
+  prettyName = "Gitea";
+  runnerPrettyName = "Gitea Actions Runner";
+  srcUrl = "https://gitea.com/gitea/act_runner";
+in
 {
   config,
   lib,
@@ -44,7 +52,7 @@ let
     escapeSystemdPath
     ;
 
-  cfg = config.services.gitea-actions-runner;
+  cfg = config.services.${attributeName};
 
   settingsFormat = pkgs.formats.yaml { };
 in
@@ -54,23 +62,23 @@ in
     sigmasquadron
   ];
 
-  options.services.gitea-actions-runner = {
-    package = mkPackageOption pkgs "gitea-actions-runner" { };
+  options.services.${attributeName} = {
+    package = mkPackageOption pkgs attributeName { };
 
     instances = mkOption {
       default = { };
       description = ''
-        Gitea Actions Runner instances.
+        ${runnerPrettyName} instances.
       '';
       type = attrsOf (submodule {
         options = {
-          enable = mkEnableOption "Gitea Actions Runner instance";
+          enable = mkEnableOption "${runnerPrettyName} instance";
 
           name = mkOption {
             type = str;
             example = literalExpression "config.networking.hostName";
             description = ''
-              The name identifying the runner instance towards the Gitea/Forgejo instance.
+              The name identifying the runner instance towards the ${prettyName} instance.
             '';
           };
 
@@ -78,7 +86,7 @@ in
             type = str;
             example = "https://forge.example.com";
             description = ''
-              Base URL of your Gitea/Forgejo instance.
+              Base URL of your ${prettyName} instance.
             '';
           };
 
@@ -86,7 +94,7 @@ in
             type = nullOr str;
             default = null;
             description = ''
-              Plain token to register at the configured Gitea/Forgejo instance.
+              Plain token to register at the configured ${prettyName} instance.
             '';
           };
 
@@ -96,7 +104,7 @@ in
             description = ''
               Path to an environment file, containing the `TOKEN` environment
               variable, that holds a token to register at the configured
-              Gitea/Forgejo instance.
+              ${prettyName} instance.
             '';
           };
 
@@ -122,8 +130,8 @@ in
           };
           settings = mkOption {
             description = ''
-              Configuration for the `act_runner` daemon.
-              See <https://gitea.com/gitea/act_runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration.
+              Configuration for the `${mainProgram}` daemon.
+              See <${srcUrl}/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration.
             '';
 
             type = types.submodule {
@@ -177,7 +185,6 @@ in
 
         # Check whether any runner instance label requires a container runtime.
         # Empty label strings result in the upstream defined defaultLabels, which require docker.
-        # https://gitea.com/gitea/act_runner/src/tag/v0.1.5/internal/app/cmd/register.go#L93-L98
         hasDockerScheme =
           instance: instance.labels == [ ] || any (label: hasInfix ":docker:" label) instance.labels;
         anyWantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
@@ -191,18 +198,18 @@ in
         assertions = [
           {
             assertion = any tokenXorTokenFile (attrValues cfg.instances);
-            message = "Gitea Actions Runner instances may have either a `token` or a `tokenFile` configured, but not both simultaneously.";
+            message = "${runnerPrettyName} instances may have either a `token` or a `tokenFile` configured, but not both simultaneously.";
           }
           {
             assertion = anyWantsContainerRuntime -> hasDocker || hasPodman;
-            message = "At least one of the configured Gitea Actions Runner instances require a container hypervisor, but neither Docker nor Podman are enabled.";
+            message = "At least one of the configured ${runnerPrettyName} instances require a container hypervisor, but neither Docker nor Podman are enabled.";
           }
         ];
 
         systemd.services =
           let
             mkRunnerService =
-              name: instance:
+              id: instance:
               let
                 wantsContainerRuntime = hasDockerScheme instance;
                 wantsHost = hasHostScheme instance;
@@ -210,9 +217,9 @@ in
                 wantsPodman = wantsContainerRuntime && hasPodman;
                 configFile = settingsFormat.generate "config.yaml" instance.settings;
               in
-              nameValuePair "gitea-runner-${escapeSystemdPath name}" {
+              nameValuePair "${name}-runner-${escapeSystemdPath id}" {
                 inherit (instance) enable;
-                description = "Gitea Actions Runner";
+                description = runnerPrettyName;
                 wants = [ "network-online.target" ];
                 after = [
                   "network-online.target"
@@ -234,7 +241,7 @@ in
                     DOCKER_HOST = "unix:///run/podman/podman.sock";
                   }
                   // {
-                    HOME = "/var/lib/gitea-runner/${name}";
+                    HOME = "/var/lib/${name}-runner/${id}";
                   };
                 path =
                   with pkgs;
@@ -244,17 +251,17 @@ in
                   ++ optionals wantsHost instance.hostPackages;
                 serviceConfig = {
                   DynamicUser = true;
-                  User = "gitea-runner";
-                  StateDirectory = "gitea-runner";
-                  WorkingDirectory = "-/var/lib/gitea-runner/${name}";
+                  User = "${name}-runner";
+                  StateDirectory = "${name}-runner";
+                  WorkingDirectory = "-/var/lib/${name}-runner/${id}";
 
-                  # gitea-runner might fail when gitea is restarted during upgrade.
+                  # act_runner might fail when the forge is restarted during an upgrade.
                   Restart = "on-failure";
                   RestartSec = 2;
 
                   ExecStartPre = [
-                    (pkgs.writeShellScript "gitea-register-runner-${name}" ''
-                      export INSTANCE_DIR="$STATE_DIRECTORY/${name}"
+                    (pkgs.writeShellScript "${name}-register-runner-${id}" ''
+                      export INSTANCE_DIR="$STATE_DIRECTORY/${id}"
                       mkdir -vp "$INSTANCE_DIR"
                       cd "$INSTANCE_DIR"
 

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -191,11 +191,11 @@ in
         assertions = [
           {
             assertion = any tokenXorTokenFile (attrValues cfg.instances);
-            message = "Instances of gitea-actions-runner can have `token` or `tokenFile`, not both.";
+            message = "Gitea Actions Runner instances may have either a `token` or a `tokenFile` configured, but not both simultaneously.";
           }
           {
             assertion = anyWantsContainerRuntime -> hasDocker || hasPodman;
-            message = "Label configuration on gitea-actions-runner instance requires either docker or podman.";
+            message = "At least one of the configured Gitea Actions Runner instances require a container hypervisor, but neither Docker nor Podman are enabled.";
           }
         ];
 

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -15,6 +15,7 @@ let
     hasInfix
     hasSuffix
     literalExpression
+    maintainers
     mapAttrs'
     mkEnableOption
     mkIf
@@ -36,7 +37,7 @@ let
   settingsFormat = pkgs.formats.yaml { };
 in
 {
-  meta.maintainers = with lib.maintainers; [
+  meta.maintainers = with maintainers; [
     hexa
   ];
 
@@ -227,7 +228,7 @@ in
                   [
                     coreutils
                   ]
-                  ++ lib.optionals wantsHost instance.hostPackages;
+                  ++ optionals wantsHost instance.hostPackages;
                 serviceConfig = {
                   DynamicUser = true;
                   User = "gitea-runner";

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -28,6 +28,17 @@ let
     types
     ;
 
+  inherit (types)
+    attrsOf
+    either
+    listOf
+    nullOr
+    package
+    path
+    str
+    submodule
+    ;
+
   inherit (utils)
     escapeSystemdPath
     ;
@@ -42,7 +53,7 @@ in
     sigmasquadron
   ];
 
-  options.services.gitea-actions-runner = with types; {
+  options.services.gitea-actions-runner = {
     package = mkPackageOption pkgs "gitea-actions-runner" { };
 
     instances = mkOption {

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -116,14 +116,14 @@ in
               Labels used to map jobs to their runtime environment. Changing these
               labels currently requires a new registration token.
 
-              Many common actions require bash, git and nodejs, as well as a filesystem
-              that follows the filesystem hierarchy standard.
+              Many common actions require `bash`, `git` and `nodejs`, as well as a
+              filesystem that follows the filesystem hierarchy standard.
             '';
           };
           settings = mkOption {
             description = ''
-              Configuration for `act_runner daemon`.
-              See <https://gitea.com/gitea/act_runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration
+              Configuration for the `act_runner` daemon.
+              See <https://gitea.com/gitea/act_runner/src/branch/main/internal/pkg/config/config.example.yaml> for an example configuration.
             '';
 
             type = types.submodule {
@@ -158,8 +158,8 @@ in
               ]
             '';
             description = ''
-              List of packages, that are available to actions, when the runner is configured
-              with a host execution label.
+              List of packages that are available to actions when the runner
+              is configured with a host execution label.
             '';
           };
         };

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -167,7 +167,7 @@ in
         # https://gitea.com/gitea/act_runner/src/tag/v0.1.5/internal/app/cmd/register.go#L93-L98
         hasDockerScheme =
           instance: instance.labels == [ ] || any (label: hasInfix ":docker:" label) instance.labels;
-        wantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
+        anyWantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
 
         # provide shorthands for whether container runtimes are enabled and whether host execution is possible.
         hasDocker = config.virtualisation.docker.enable;
@@ -181,7 +181,7 @@ in
             message = "Instances of gitea-actions-runner can have `token` or `tokenFile`, not both.";
           }
           {
-            assertion = wantsContainerRuntime -> hasDocker || hasPodman;
+            assertion = anyWantsContainerRuntime -> hasDocker || hasPodman;
             message = "Label configuration on gitea-actions-runner instance requires either docker or podman.";
           }
         ];
@@ -193,8 +193,8 @@ in
               let
                 wantsContainerRuntime = hasDockerScheme instance;
                 wantsHost = hasHostScheme instance;
-                wantsDocker = wantsContainerRuntime && config.virtualisation.docker.enable;
-                wantsPodman = wantsContainerRuntime && config.virtualisation.podman.enable;
+                wantsDocker = wantsContainerRuntime && hasDocker;
+                wantsPodman = wantsContainerRuntime && hasPodman;
                 configFile = settingsFormat.generate "config.yaml" instance.settings;
               in
               nameValuePair "gitea-runner-${escapeSystemdPath name}" {

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -18,6 +18,7 @@ let
     mapAttrs'
     mkEnableOption
     mkIf
+    mkMerge
     mkOption
     mkPackageOption
     nameValuePair
@@ -170,114 +171,120 @@ in
     };
   };
 
-  config = mkIf (cfg.instances != { }) {
-    assertions = [
-      {
-        assertion = any tokenXorTokenFile (attrValues cfg.instances);
-        message = "Instances of gitea-actions-runner can have `token` or `tokenFile`, not both.";
-      }
-      {
-        assertion = wantsContainerRuntime -> hasDocker || hasPodman;
-        message = "Label configuration on gitea-actions-runner instance requires either docker or podman.";
-      }
-    ];
-
-    systemd.services =
+  config = mkMerge [
+    (mkIf (cfg.instances != { }) (
       let
-        mkRunnerService =
-          name: instance:
+      in
+      {
+        assertions = [
+          {
+            assertion = any tokenXorTokenFile (attrValues cfg.instances);
+            message = "Instances of gitea-actions-runner can have `token` or `tokenFile`, not both.";
+          }
+          {
+            assertion = wantsContainerRuntime -> hasDocker || hasPodman;
+            message = "Label configuration on gitea-actions-runner instance requires either docker or podman.";
+          }
+        ];
+
+        systemd.services =
           let
-            wantsContainerRuntime = hasDockerScheme instance;
-            wantsHost = hasHostScheme instance;
-            wantsDocker = wantsContainerRuntime && config.virtualisation.docker.enable;
-            wantsPodman = wantsContainerRuntime && config.virtualisation.podman.enable;
-            configFile = settingsFormat.generate "config.yaml" instance.settings;
-          in
-          nameValuePair "gitea-runner-${escapeSystemdPath name}" {
-            inherit (instance) enable;
-            description = "Gitea Actions Runner";
-            wants = [ "network-online.target" ];
-            after = [
-              "network-online.target"
-            ]
-            ++ optionals wantsDocker [
-              "docker.service"
-            ]
-            ++ optionals wantsPodman [
-              "podman.service"
-            ];
-            wantedBy = [
-              "multi-user.target"
-            ];
-            environment =
-              optionalAttrs (instance.token != null) {
-                TOKEN = "${instance.token}";
-              }
-              // optionalAttrs wantsPodman {
-                DOCKER_HOST = "unix:///run/podman/podman.sock";
-              }
-              // {
-                HOME = "/var/lib/gitea-runner/${name}";
-              };
-            path =
-              with pkgs;
-              [
-                coreutils
-              ]
-              ++ lib.optionals wantsHost instance.hostPackages;
-            serviceConfig = {
-              DynamicUser = true;
-              User = "gitea-runner";
-              StateDirectory = "gitea-runner";
-              WorkingDirectory = "-/var/lib/gitea-runner/${name}";
-
-              # gitea-runner might fail when gitea is restarted during upgrade.
-              Restart = "on-failure";
-              RestartSec = 2;
-
-              ExecStartPre = [
-                (pkgs.writeShellScript "gitea-register-runner-${name}" ''
-                  export INSTANCE_DIR="$STATE_DIRECTORY/${name}"
-                  mkdir -vp "$INSTANCE_DIR"
-                  cd "$INSTANCE_DIR"
-
-                  # force reregistration on changed labels
-                  export LABELS_FILE="$INSTANCE_DIR/.labels"
-                  export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
-                  export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
-
-                  if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED" != "$LABELS_CURRENT" ]; then
-                    # remove existing registration file, so that changing the labels forces a re-registration
-                    rm -v "$INSTANCE_DIR/.runner" || true
-
-                    # perform the registration
-                    ${cfg.package}/bin/act_runner register --no-interactive \
-                      --instance ${escapeShellArg instance.url} \
-                      --token "$TOKEN" \
-                      --name ${escapeShellArg instance.name} \
-                      --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
-                      --config ${configFile}
-
-                    # and write back the configured labels
-                    echo "$LABELS_WANTED" > "$LABELS_FILE"
-                  fi
-
-                '')
-              ];
-              ExecStart = "${cfg.package}/bin/act_runner daemon --config ${configFile}";
-              SupplementaryGroups =
-                optionals wantsDocker [
-                  "docker"
+            mkRunnerService =
+              name: instance:
+              let
+                wantsContainerRuntime = hasDockerScheme instance;
+                wantsHost = hasHostScheme instance;
+                wantsDocker = wantsContainerRuntime && config.virtualisation.docker.enable;
+                wantsPodman = wantsContainerRuntime && config.virtualisation.podman.enable;
+                configFile = settingsFormat.generate "config.yaml" instance.settings;
+              in
+              nameValuePair "gitea-runner-${escapeSystemdPath name}" {
+                inherit (instance) enable;
+                description = "Gitea Actions Runner";
+                wants = [ "network-online.target" ];
+                after = [
+                  "network-online.target"
+                ]
+                ++ optionals wantsDocker [
+                  "docker.service"
                 ]
                 ++ optionals wantsPodman [
-                  "podman"
+                  "podman.service"
                 ];
-            }
-            // optionalAttrs (instance.tokenFile != null) {
-              EnvironmentFile = instance.tokenFile;
-            };
-          };
-      in
-      mapAttrs' mkRunnerService cfg.instances;
-  };
+                wantedBy = [
+                  "multi-user.target"
+                ];
+                environment =
+                  optionalAttrs (instance.token != null) {
+                    TOKEN = "${instance.token}";
+                  }
+                  // optionalAttrs wantsPodman {
+                    DOCKER_HOST = "unix:///run/podman/podman.sock";
+                  }
+                  // {
+                    HOME = "/var/lib/gitea-runner/${name}";
+                  };
+                path =
+                  with pkgs;
+                  [
+                    coreutils
+                  ]
+                  ++ lib.optionals wantsHost instance.hostPackages;
+                serviceConfig = {
+                  DynamicUser = true;
+                  User = "gitea-runner";
+                  StateDirectory = "gitea-runner";
+                  WorkingDirectory = "-/var/lib/gitea-runner/${name}";
+
+                  # gitea-runner might fail when gitea is restarted during upgrade.
+                  Restart = "on-failure";
+                  RestartSec = 2;
+
+                  ExecStartPre = [
+                    (pkgs.writeShellScript "gitea-register-runner-${name}" ''
+                      export INSTANCE_DIR="$STATE_DIRECTORY/${name}"
+                      mkdir -vp "$INSTANCE_DIR"
+                      cd "$INSTANCE_DIR"
+
+                      # force reregistration on changed labels
+                      export LABELS_FILE="$INSTANCE_DIR/.labels"
+                      export LABELS_WANTED="$(echo ${escapeShellArg (concatStringsSep "\n" instance.labels)} | sort)"
+                      export LABELS_CURRENT="$(cat $LABELS_FILE 2>/dev/null || echo 0)"
+
+                      if [ ! -e "$INSTANCE_DIR/.runner" ] || [ "$LABELS_WANTED" != "$LABELS_CURRENT" ]; then
+                        # remove existing registration file, so that changing the labels forces a re-registration
+                        rm -v "$INSTANCE_DIR/.runner" || true
+
+                        # perform the registration
+                        ${cfg.package}/bin/act_runner register --no-interactive \
+                          --instance ${escapeShellArg instance.url} \
+                          --token "$TOKEN" \
+                          --name ${escapeShellArg instance.name} \
+                          --labels ${escapeShellArg (concatStringsSep "," instance.labels)} \
+                          --config ${configFile}
+
+                        # and write back the configured labels
+                        echo "$LABELS_WANTED" > "$LABELS_FILE"
+                      fi
+
+                    '')
+                  ];
+                  ExecStart = "${cfg.package}/bin/act_runner daemon --config ${configFile}";
+                  SupplementaryGroups =
+                    optionals wantsDocker [
+                      "docker"
+                    ]
+                    ++ optionals wantsPodman [
+                      "podman"
+                    ];
+                }
+                // optionalAttrs (instance.tokenFile != null) {
+                  EnvironmentFile = instance.tokenFile;
+                };
+              };
+          in
+          mapAttrs' mkRunnerService cfg.instances;
+      }
+    ))
+  ];
 }

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -12,6 +12,7 @@ let
     attrValues
     concatStringsSep
     escapeShellArg
+    getExe
     hasInfix
     hasSuffix
     literalExpression
@@ -267,7 +268,7 @@ in
                         rm -v "$INSTANCE_DIR/.runner" || true
 
                         # perform the registration
-                        ${cfg.package}/bin/act_runner register --no-interactive \
+                        ${getExe cfg.package} register --no-interactive \
                           --instance ${escapeShellArg instance.url} \
                           --token "$TOKEN" \
                           --name ${escapeShellArg instance.name} \
@@ -280,7 +281,7 @@ in
 
                     '')
                   ];
-                  ExecStart = "${cfg.package}/bin/act_runner daemon --config ${configFile}";
+                  ExecStart = "${getExe cfg.package} daemon --config ${configFile}";
                   SupplementaryGroups =
                     optionals wantsDocker [
                       "docker"

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -14,15 +14,15 @@ let
     escapeShellArg
     hasInfix
     hasSuffix
-    optionalAttrs
-    optionals
     literalExpression
     mapAttrs'
     mkEnableOption
+    mkIf
     mkOption
     mkPackageOption
-    mkIf
     nameValuePair
+    optionalAttrs
+    optionals
     types
     ;
 

--- a/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
+++ b/nixos/modules/services/continuous-integration/gitea-actions-runner.nix
@@ -34,24 +34,6 @@ let
   cfg = config.services.gitea-actions-runner;
 
   settingsFormat = pkgs.formats.yaml { };
-
-  # Check whether any runner instance label requires a container runtime
-  # Empty label strings result in the upstream defined defaultLabels, which require docker
-  # https://gitea.com/gitea/act_runner/src/tag/v0.1.5/internal/app/cmd/register.go#L93-L98
-  hasDockerScheme =
-    instance: instance.labels == [ ] || any (label: hasInfix ":docker:" label) instance.labels;
-  wantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
-
-  hasHostScheme = instance: any (label: hasSuffix ":host" label) instance.labels;
-
-  # provide shorthands for whether container runtimes are enabled
-  hasDocker = config.virtualisation.docker.enable;
-  hasPodman = config.virtualisation.podman.enable;
-
-  tokenXorTokenFile =
-    instance:
-    (instance.token == null && instance.tokenFile != null)
-    || (instance.token != null && instance.tokenFile == null);
 in
 {
   meta.maintainers = with lib.maintainers; [
@@ -174,6 +156,22 @@ in
   config = mkMerge [
     (mkIf (cfg.instances != { }) (
       let
+        tokenXorTokenFile =
+          instance:
+          (instance.token == null && instance.tokenFile != null)
+          || (instance.token != null && instance.tokenFile == null);
+
+        # Check whether any runner instance label requires a container runtime.
+        # Empty label strings result in the upstream defined defaultLabels, which require docker.
+        # https://gitea.com/gitea/act_runner/src/tag/v0.1.5/internal/app/cmd/register.go#L93-L98
+        hasDockerScheme =
+          instance: instance.labels == [ ] || any (label: hasInfix ":docker:" label) instance.labels;
+        wantsContainerRuntime = any hasDockerScheme (attrValues cfg.instances);
+
+        # provide shorthands for whether container runtimes are enabled and whether host execution is possible.
+        hasDocker = config.virtualisation.docker.enable;
+        hasPodman = config.virtualisation.podman.enable;
+        hasHostScheme = instance: any (label: hasSuffix ":host" label) instance.labels;
       in
       {
         assertions = [

--- a/nixos/tests/forgejo.nix
+++ b/nixos/tests/forgejo.nix
@@ -62,18 +62,15 @@ let
 
             specialisation.runner = {
               inheritParentConfig = true;
-              configuration.services.gitea-actions-runner = {
-                package = pkgs.forgejo-runner;
-                instances."test" = {
-                  enable = true;
-                  name = "ci";
-                  url = "http://localhost:3000";
-                  labels = [
-                    # type ":host" does not depend on docker/podman/lxc
-                    "native:host"
-                  ];
-                  tokenFile = "/var/lib/forgejo/runner_token";
-                };
+              configuration.services.forgejo-runner.instances."test" = {
+                enable = true;
+                name = "ci";
+                url = "http://localhost:3000";
+                labels = [
+                  # type ":host" does not depend on docker/podman/lxc
+                  "native:host"
+                ];
+                tokenFile = "/var/lib/forgejo/runner_token";
               };
             };
             specialisation.dump = {
@@ -222,8 +219,8 @@ let
                   "su -l forgejo -c 'GITEA_WORK_DIR=/var/lib/forgejo forgejo actions generate-runner-token' | sed 's/^/TOKEN=/' | tee /var/lib/forgejo/runner_token"
               )
               server.succeed("${serverSystem}/specialisation/runner/bin/switch-to-configuration test")
-              server.wait_for_unit("gitea-runner-test.service")
-              server.succeed("journalctl -o cat -u gitea-runner-test.service | grep -q 'Runner registered successfully'")
+              server.wait_for_unit("forgejo-runner-test.service")
+              server.succeed("journalctl -o cat -u forgejo-runner-test.service | grep -q 'Runner registered successfully'")
 
               # enable actions feature for this repository, defaults to disabled
               server.succeed(


### PR DESCRIPTION
Makes the gitea-actions-runner module into a generic act-runner module, allowing forgejo to be aliased to it.

Would highly recommend reviewing commit-by-commit.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
