### PR TITLE
systemd: fix patches

### DIFF
--- a/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
+++ b/pkgs/os-specific/linux/systemd/0003-Fix-NixOS-containers.patch
@@ -10,10 +10,10 @@ container, so checking early whether it exists will fail.
  1 file changed, 2 insertions(+)
 
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index ab8746c442..480a9c55c6 100644
+index 811210061b..9e35349dab 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -6165,6 +6165,7 @@ static int run(int argc, char *argv[]) {
+@@ -6167,6 +6167,7 @@ static int run(int argc, char *argv[]) {
                                  goto finish;
                          }
                  } else {
@@ -21,7 +21,7 @@ index ab8746c442..480a9c55c6 100644
                          _cleanup_free_ char *p = NULL;
  
                          if (arg_pivot_root_new)
-@@ -6184,6 +6185,7 @@ static int run(int argc, char *argv[]) {
+@@ -6186,6 +6187,7 @@ static int run(int argc, char *argv[]) {
                                  log_error_errno(r, "Unable to determine if %s looks like it has an OS tree (i.e. whether /usr/ exists): %m", arg_directory);
                                  goto finish;
                          }

--- a/pkgs/os-specific/linux/systemd/0005-Get-rid-of-a-useless-message-in-user-sessions.patch
+++ b/pkgs/os-specific/linux/systemd/0005-Get-rid-of-a-useless-message-in-user-sessions.patch
@@ -13,7 +13,7 @@ in containers.
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index d85896577f..2a4782a55e 100644
+index 20a535f2f4..c442672dfe 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
 @@ -1575,7 +1575,8 @@ static unsigned manager_dispatch_stop_when_bound_queue(Manager *m) {

--- a/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
+++ b/pkgs/os-specific/linux/systemd/0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
@@ -35,10 +35,10 @@ index 3a13e04a27..4fd58068a1 100644
      <literal>Etc/UTC</literal>. The resulting link should lead to the
      corresponding binary
 diff --git a/src/basic/time-util.c b/src/basic/time-util.c
-index 55931a2546..2e00bd7539 100644
+index 5add913c8a..af328a7436 100644
 --- a/src/basic/time-util.c
 +++ b/src/basic/time-util.c
-@@ -1410,7 +1410,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
+@@ -1406,7 +1406,7 @@ static int get_timezones_from_zone1970_tab(char ***ret) {
  
          assert(ret);
  
@@ -56,7 +56,7 @@ index 55931a2546..2e00bd7539 100644
          if (!f)
                  return -errno;
  
-@@ -1562,7 +1562,7 @@ int verify_timezone(const char *name, int log_level) {
+@@ -1566,7 +1566,7 @@ int verify_timezone(const char *name, int log_level) {
          if (p - name >= PATH_MAX)
                  return -ENAMETOOLONG;
  
@@ -65,7 +65,7 @@ index 55931a2546..2e00bd7539 100644
  
          fd = open(t, O_RDONLY|O_CLOEXEC);
          if (fd < 0)
-@@ -1614,7 +1614,7 @@ int get_timezone(char **ret) {
+@@ -1618,7 +1618,7 @@ int get_timezone(char **ret) {
          if (r < 0)
                  return r; /* Return EINVAL if not a symlink */
  
@@ -103,10 +103,10 @@ index 5ed6d3a9d2..f922d91a9d 100644
                  return log_error_errno(r, "Failed to create /etc/localtime symlink: %m");
  
 diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
-index 480a9c55c6..02c9ae6608 100644
+index 9e35349dab..b765989a70 100644
 --- a/src/nspawn/nspawn.c
 +++ b/src/nspawn/nspawn.c
-@@ -1821,8 +1821,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
+@@ -1823,8 +1823,8 @@ int userns_mkdir(const char *root, const char *path, mode_t mode, uid_t uid, gid
  static const char *timezone_from_path(const char *path) {
          return PATH_STARTSWITH_SET(
                          path,
@@ -118,7 +118,7 @@ index 480a9c55c6..02c9ae6608 100644
  
  static bool etc_writable(void) {
 diff --git a/src/timedate/timedated.c b/src/timedate/timedated.c
-index 57f3413dc6..6a456fe601 100644
+index 57f3413dc6..fb2bc354aa 100644
 --- a/src/timedate/timedated.c
 +++ b/src/timedate/timedated.c
 @@ -266,7 +266,7 @@ static int context_read_data(Context *c) {

--- a/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
+++ b/pkgs/os-specific/linux/systemd/0013-inherit-systemd-environment-when-calling-generators.patch
@@ -16,7 +16,7 @@ executables that are being called from managers.
  1 file changed, 8 insertions(+)
 
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 2a4782a55e..8dfdc227a1 100644
+index c442672dfe..a4132fd2e4 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
 @@ -3977,9 +3977,17 @@ static int build_generator_environment(Manager *m, char ***ret) {

--- a/pkgs/os-specific/linux/systemd/0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
+++ b/pkgs/os-specific/linux/systemd/0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch
@@ -30,11 +30,11 @@ are written into `$XDG_CONFIG_HOME/systemd/user`.
  1 file changed, 3 insertions(+)
 
 diff --git a/src/systemctl/systemctl-edit.c b/src/systemctl/systemctl-edit.c
-index 53bc57186a..0ed12ce931 100644
+index a28180922a..22c9c8fdbd 100644
 --- a/src/systemctl/systemctl-edit.c
 +++ b/src/systemctl/systemctl-edit.c
-@@ -330,6 +330,9 @@ int verb_edit(int argc, char *argv[], void *userdata) {
-         sd_bus *bus;
+@@ -336,6 +336,9 @@ int verb_edit(int argc, char *argv[], void *userdata) {
+         sd_bus *bus = NULL;
          int r;
  
 +        if (!arg_runtime && arg_runtime_scope == RUNTIME_SCOPE_SYSTEM)

--- a/pkgs/os-specific/linux/systemd/0017-meson.build-do-not-create-systemdstatedir.patch
+++ b/pkgs/os-specific/linux/systemd/0017-meson.build-do-not-create-systemdstatedir.patch
@@ -8,10 +8,10 @@ Subject: [PATCH] meson.build: do not create systemdstatedir
  1 file changed, 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index 238b935372..b0b67c9b99 100644
+index 3fbab32730..10d0ded35b 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -2791,7 +2791,6 @@ install_data('LICENSE.GPL2',
+@@ -2794,7 +2794,6 @@ install_data('LICENSE.GPL2',
  install_subdir('LICENSES',
                 install_dir : docdir)
  

--- a/pkgs/os-specific/linux/systemd/0018-meson-Don-t-link-ssh-dropins.patch
+++ b/pkgs/os-specific/linux/systemd/0018-meson-Don-t-link-ssh-dropins.patch
@@ -8,7 +8,7 @@ Subject: [PATCH] meson: Don't link ssh dropins
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index b0b67c9b99..4721b7482b 100644
+index 10d0ded35b..a43d56a0cb 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -219,13 +219,13 @@ sshconfdir = get_option('sshconfdir')


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

One of the systemd patches is no longer applying on the master branch of nixpkgs:

- [0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch](https://github.com/NixOS/nixpkgs/blob/54b154f971b71d260378b284789df6b272b49634/pkgs/os-specific/linux/systemd/0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch)

This is because on upstream `sd_bus *bus;` is `sd_bus *bus = NULL;` for version `v258.3`, which is the current version of the nixpkgs master branch.

Note that this PR also caused other patches to change, because hashes and file positions changed.
I can change my branch to only include the `0016-systemctl-edit-suggest-systemdctl-edit-runtime-on-sy.patch` if needed.

## Things done

I have done the following:

- `git checkout v258.3`
- `git am 00*.patch`
- One patch failed to apply
- `git am --show-current-patch=diff`
- Applied the patch manually
- `git add .`
- `git am --continue`
- `git -c format.signoff=false format-patch v258.3 --no-numbered --zero-commit --no-signature`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Context / Out Of Scope

I encountered this issue, because I am developing a feature to be able to change the systemd boot loader colors in its config instead of changing them during compile time.
This is why I am trying to rebase the patches on the systemd `main` branch, but they did not apply to the current systemd version.
Also I am trying to get a develop shell for systemd, and when I run `nix develop nixpkgs#systemd` I get the following error:
```
error: output '/nix/store/3i511sknkfq83zzcw1h3sjs9vr1pn4fm-systemd-258.2-env-dev' is not allowed to refer to the following paths:
         /nix/store/f43k3lffqlz3n864inxz8zf28jvks1q6-bash-interactive-5.3p3
         /nix/store/j8645yndikbrvn292zgvyv64xrrmwdcb-bash-5.3p3
```
Is there an easy way to fix that?

After rebasing the patches on the systemd `main` branch; is there a way for me to submit those patches as a PR for nixpkgs or are patches from non-release version not useful?