### PR TITLE
terraria-server: 1.4.5.0 -> 1.4.5.3

### DIFF
--- a/pkgs/by-name/te/terraria-server/package.nix
+++ b/pkgs/by-name/te/terraria-server/package.nix
@@ -5,26 +5,26 @@
 
   autoPatchelfHook,
   unzip,
-  zlib,
+  sdl3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "terraria-server";
-  version = "1.4.5.0";
-  urlVersion = lib.replaceStrings [ "." ] [ "" ] version;
+  version = "1.4.5.3";
+  urlVersion = lib.replaceStrings [ "." ] [ "" ] finalAttrs.version;
 
   src = fetchurl {
-    url = "https://terraria.org/api/download/pc-dedicated-server/terraria-server-${urlVersion}.zip";
-    hash = "sha256-PRA7cCFL2WJlT5Bat24PSgs9rhLu4C2mu5zWbut3kdQ=";
+    url = "https://terraria.org/api/download/pc-dedicated-server/terraria-server-${finalAttrs.urlVersion}.zip";
+    hash = "sha256-5W6XpGaWQTs9lSy1UJq60YR6mfvb3LTts9ppK05XNCg=";
   };
 
   nativeBuildInputs = [
     autoPatchelfHook
     unzip
   ];
+
   buildInputs = [
     stdenv.cc.cc.libgcc
-    zlib
   ];
 
   installPhase = ''
@@ -34,6 +34,10 @@ stdenv.mkDerivation rec {
     cp -r Linux $out/
     chmod +x "$out/Linux/TerrariaServer.bin.x86_64"
     ln -s "$out/Linux/TerrariaServer.bin.x86_64" $out/bin/TerrariaServer
+
+    # use our own SDL3 library
+    rm $out/Linux/lib64/libSDL3.so.0
+    ln -s ${lib.getLib sdl3}/lib/libSDL3.so.0 $out/Linux/lib64/libSDL3.so.0
 
     runHook postInstall
   '';
@@ -49,4 +53,4 @@ stdenv.mkDerivation rec {
       tomasajt
     ];
   };
-}
+})


### PR DESCRIPTION
Alternative to: https://github.com/NixOS/nixpkgs/pull/485058

Updates are coming out pretty frequently, but I'll try to update as soon as I can.

I removed the bundled SDL3 shared library because in the 1.4.5.0 version it barely had barely anything that needed to be autoPatchelf-ed, however in later versions, the shared library started requiring X11, audio libs, etc..., like sdl3 does on nixpkgs.
So I just swapped them out.

Edit: seems like these new dependencies are just soft dependenies that have always been present, but autoPatchelf started detecting due to metadata changes.

Also, `zlib` is no longer needed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
