### PR TITLE
treewide: remove unnecessary dependencies on mesa

### DIFF
--- a/pkgs/by-name/bi/bionic-translation/package.nix
+++ b/pkgs/by-name/bi/bionic-translation/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitLab,
-  mesa,
   wayland,
   libglvnd,
   libbsd,
@@ -35,7 +34,6 @@ stdenv.mkDerivation (finalAttrs: {
     libelf
     libglvnd
     libunwind
-    mesa
     wayland
   ];
 

--- a/pkgs/by-name/ce/celestegame/package.nix
+++ b/pkgs/by-name/ce/celestegame/package.nix
@@ -88,7 +88,6 @@ buildFHSEnv {
       kdePackages.wayland
       libxkbcommon
       libgcc
-      mesa
       libdrm
       expat
       alsa-lib

--- a/pkgs/by-name/gp/gpac/package.nix
+++ b/pkgs/by-name/gp/gpac/package.nix
@@ -20,7 +20,6 @@
   nghttp2,
   openjpeg,
   libcaca,
-  mesa,
   mesa_glu,
   xvidcore,
   openssl,
@@ -113,7 +112,6 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     libxv
     xorgproto
-    mesa
     mesa_glu
     xvidcore
     openssl

--- a/pkgs/by-name/gr/grayjay/package.nix
+++ b/pkgs/by-name/gr/grayjay/package.nix
@@ -7,6 +7,7 @@
   libz,
   icu,
   openssl,
+  libgbm,
   libxrandr,
   libxfixes,
   libxext,
@@ -28,7 +29,6 @@
   cairo,
   udev,
   alsa-lib,
-  mesa,
   libGL,
   libsecret,
   nix-update-script,
@@ -74,12 +74,12 @@ buildDotnetModule (finalAttrs: {
 
   buildInputs = [
     openssl
+    libgbm
     libgcc
     libx11
     gtk3
     glib
     alsa-lib
-    mesa
     nspr
     nss
     icu

--- a/pkgs/by-name/is/isle-portable/package.nix
+++ b/pkgs/by-name/is/isle-portable/package.nix
@@ -23,7 +23,6 @@
   wayland-protocols,
   glew,
   qt6,
-  mesa,
   alsa-lib,
   sdl3,
   iniparser,
@@ -81,7 +80,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxkbcommon
     wayland-protocols
     glew
-    mesa
     alsa-lib
   ];
 

--- a/pkgs/by-name/ma/magic-vlsi/package.nix
+++ b/pkgs/by-name/ma/magic-vlsi/package.nix
@@ -55,7 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
     cairo
     libX11
     m4
-    mesa
     mesa_glu
     ncurses
     tcl

--- a/pkgs/by-name/qq/qqmusic/package.nix
+++ b/pkgs/by-name/qq/qqmusic/package.nix
@@ -21,7 +21,6 @@
   libdbusmenu,
   libglvnd,
   libpulseaudio,
-  mesa,
   nspr,
   nss,
   pango,
@@ -74,7 +73,6 @@ stdenv.mkDerivation (finalAttrs: {
     libdbusmenu
     libglvnd
     libpulseaudio
-    mesa
     nspr
     nss
     pango

--- a/pkgs/by-name/ro/rovium/package.nix
+++ b/pkgs/by-name/ro/rovium/package.nix
@@ -7,8 +7,8 @@
   wrapGAppsHook3,
   dpkg,
   alsa-lib,
-  mesa,
   gtk3,
+  libgbm,
   nss,
   libxkbfile,
   libsecret,
@@ -35,8 +35,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   buildInputs = [
     alsa-lib
-    mesa
     gtk3
+    libgbm
     nss
     libxkbfile
     libsecret

--- a/pkgs/development/cuda-modules/packages/cuda_demo_suite.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_demo_suite.nix
@@ -5,7 +5,6 @@
   libGLU,
   libglut,
   libglvnd,
-  mesa,
 }:
 buildRedist {
   redistName = "cuda";
@@ -17,7 +16,6 @@ buildRedist {
     libGLU
     libglut
     libglvnd
-    mesa
   ];
 
   outputs = [ "out" ];

--- a/pkgs/development/libraries/intel-oneapi/base.nix
+++ b/pkgs/development/libraries/intel-oneapi/base.nix
@@ -27,7 +27,6 @@
   gtk3,
   pango,
   cairo,
-  mesa,
   expat,
   libxkbcommon,
   eudev,
@@ -104,7 +103,6 @@ intel-oneapi.mkIntelOneApi (finalAttrs: {
       nss
       dbus
       cups
-      mesa
       expat
       libxkbcommon
       eudev
@@ -156,7 +154,6 @@ intel-oneapi.mkIntelOneApi (finalAttrs: {
       gtk3
       pango
       cairo
-      mesa
       expat
       libxkbcommon
       eudev


### PR DESCRIPTION
None of those should be real. Things should not depend on mesa directly for any reason ever, except llvmpipeHook.

Most things here just don't need it _at all_, and `rovium` only needs libgbm.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
