### PR TITLE
python3Packages.mcp-obsidian: init at 0.2.2

### DIFF
--- a/pkgs/development/python-modules/mcp-obsidian/default.nix
+++ b/pkgs/development/python-modules/mcp-obsidian/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  mcp,
+  python-dotenv,
+  requests,
+}:
+
+buildPythonPackage {
+  pname = "mcp-obsidian";
+  version = "0.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "MarkusPfundstein";
+    repo = "mcp-obsidian";
+    rev = "4aac5c2b874a219652e783b13fde2fb89e9fb640";
+    hash = "sha256-CWY4rgJZ8T6zRmJy8ueAk4Dg5QE7+BUSPamUuyAuXpw=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    mcp
+    python-dotenv
+    requests
+  ];
+
+  # pythonImportsCheck disabled because the module requires OBSIDIAN_API_KEY
+  # environment variable to be set at import time
+  pythonImportsCheck = [ ];
+
+  # No tests included in PyPI package
+  doCheck = false;
+
+  meta = {
+    description = "MCP server to work with Obsidian via the remote REST plugin";
+    homepage = "https://github.com/MarkusPfundstein/mcp-obsidian";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9467,6 +9467,8 @@ self: super: with self; {
 
   mcp = callPackage ../development/python-modules/mcp { };
 
+  mcp-obsidian = callPackage ../development/python-modules/mcp-obsidian { };
+
   mcpadapt = callPackage ../development/python-modules/mcpadapt { };
 
   mcstatus = callPackage ../development/python-modules/mcstatus { };


### PR DESCRIPTION
Add mcp-obsidian, an MCP server to work with Obsidian via the remote REST plugin.

Uses fetchFromGitHub as PyPI only provides wheel distributions without source tarballs for this package.

Upstream: https://github.com/MarkusPfundstein/mcp-obsidian

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
