### PR TITLE
oscar: 1.6.1 -> 1.7.0

### DIFF
--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -63,7 +63,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Software for reviewing and exploring data produced by CPAP and related machines used in the treatment of sleep apnea";
     mainProgram = "OSCAR";
     license = lib.licenses.gpl3Only;
-    maintainers = [ lib.maintainers.roconnor ];
+    maintainers = with lib.maintainers; [
+      roconnor
+      ilkecan
+    ];
     # Someone needs to create a suitable installPhase for Darwin and Windows.
     # See https://gitlab.com/pholy/OSCAR-code/-/tree/master/Building.
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/os/oscar/package.nix
+++ b/pkgs/by-name/os/oscar/package.nix
@@ -8,13 +8,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "oscar";
-  version = "1.6.1";
+  version = "1.7.0";
 
   src = fetchFromGitLab {
     owner = "CrimsonNape";
     repo = "OSCAR-code";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-idooSDmozMtf0akhbaQP1aBIv6Ae9UMhMmN1P48u7FE=";
+    hash = "sha256-4ekhhzX//u/UFrqIriPmhxdjEGJ1LXczZU2ZCmC+Uvo=";
   };
 
   buildInputs = [


### PR DESCRIPTION
https://gitlab.com/CrimsonNape/OSCAR-code/-/compare/v1.6.1...v1.7.0
https://gitlab.com/CrimsonNape/OSCAR-code/-/releases/1.7.0

From the homepage:
```
 Changes and fixes in OSCAR v1.7.0
Portions of OSCAR are © 2019-2025 by The OSCAR Team

    [fix] Crash when importing into a new profile
    [fix] Import dialog button error
    [fix] Import Dialog: Better support for existing directory
    [fix] Change "Passive" to "Permissive" label in Steady Breathing preference settings
    [fix] Fix crash when importing into a new profile
    [fix] OSCAR crash when using a pop-out graph
    [added] Qt version number to the installation filename for future updates
    [added] Qt6 build directives for All Platforms
    [added] Support documentation for building with Qt6
    [added] Support for the vREM CPAP
    [added] Support for the BMC CPAP
    [updated] OSCAR building documentation for all supported OS platforms
    [updated] Wellue POD-2 code improvements
    [updated] Improvement of Steady Breathing
    [updated] Update to Chinese.zh_TW.ts
    [updated] Update to Polski.pl.ts
    [updated] Update to Deutsch.de.ts by Steffen Reitz
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
