### PR TITLE
tytanic: init at 0.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1713,6 +1713,18 @@
     githubId = 587021;
     name = "André V L Matos";
   };
+  andrew15-5 = {
+    name = "Andrew Voynov";
+    github = "Andrew15-5";
+    githubId = 37143421;
+    email = "andrewvoynov.b@gmail.com";
+    matrix = "@andrew15_5:matrix.org";
+    keys = [
+      {
+        fingerprint = "CB7B 1F73 C2AC 56C4 D4D2  D690 1BE9 2DD6 8570 0329";
+      }
+    ];
+  };
   andrewbastin = {
     email = "andrewbastin.k@gmail.com";
     github = "AndrewBastin";

--- a/pkgs/by-name/ty/tytanic/package.nix
+++ b/pkgs/by-name/ty/tytanic/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tytanic";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "typst-community";
+    repo = "tytanic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/yPRJoQ5Lr75eL5+Vc+2E278og/02CYSEuBBgHO1NnU=";
+  };
+
+  cargoHash = "sha256-/EAFV1JkOTmVkoYyaGLAk/i8PAB4LLzULIS10E9XZpM=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = true; # From the typst package.
+  };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    changelog = "https://github.com/typst-community/tytanic/releases/tag/v${finalAttrs.version}";
+    description = "Test runner for Typst projects";
+    homepage = "https://typst-community.github.io/tytanic";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    mainProgram = "tt";
+    maintainers = with lib.maintainers; [ andrew15-5 ];
+    platforms = lib.platforms.all; # Should work on most platforms.
+  };
+})


### PR DESCRIPTION
https://typst-community.github.io/tytanic

Used code from [`pkgs/by-name/ty/typship/package.nix`](https://github.com/NixOS/nixpkgs/blob/dc98539d97f206d29ce148c5b013f71412bd7678/pkgs/by-name/ty/typship/package.nix) and [`pkgs/by-name/ty/typst/package.nix`](https://github.com/NixOS/nixpkgs/blob/dc98539d97f206d29ce148c5b013f71412bd7678/pkgs/by-name/ty/typst/package.nix).

I've wanted to have this in Nixpkgs for a long time, but no one took the initiative. Me, and many others use it for testing Typst packages.

Since v0.2.2 was latest for a very long time, it was used by many for a long time. And I switched to v0.3.3 only today. Since tests can break between version upgrades, I used v0.2.2 for a bit longer.

Because of all this, I want to have at least v0.2.2 and v0.3.3 cached, so that anyone can just use them without building, etc. I will open a new WIP PR after this one is merged, and wait until this version is available in `nixos-unstable`.

However, there are 5 more versions in between. Ideally, it would be nice to have them all cached, but it's kind of a lot of versions. I'm fine with waiting for a month (at least?) until v0.3.3 is available to use. IMO, this kind of tooling should be very accessible, i.e., all "latest" versions available. This is the only testing tool that we have at the moment, apart from hand-rolling some shell scripts or just manually `typst compile`ing some tests to PDFs with no timestamp (there are some minor issue there https://github.com/typst/typst/issues/7683).

I was also wondering about multi-line formatting of `nativeInstallCheckInputs`, and whether it's needed. If there is a single item, maybe even `buildInputs` can be written in one line (and `passthru.updateScript`)? I just like it to be more compact. There is probably a near zero chance of both of them being modified in the future.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
