### PR TITLE
freedv: move overrides to package.nix

### DIFF
--- a/pkgs/by-name/fr/freedv/package.nix
+++ b/pkgs/by-name/fr/freedv/package.nix
@@ -27,6 +27,7 @@
 }:
 
 let
+  codec2' = codec2.override { freedvSupport = true; };
   ebur128Src = fetchFromGitHub {
     owner = "jiixyj";
     repo = "libebur128";
@@ -125,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    codec2
+    codec2'
     libsamplerate
     libsndfile
     lpcnet
@@ -157,7 +158,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "USE_NATIVE_AUDIO" (with stdenv.hostPlatform; isLinux || isDarwin))
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-I${codec2.src}/src";
+  env.NIX_CFLAGS_COMPILE = "-I${codec2'.src}/src";
 
   doCheck = false;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10285,12 +10285,6 @@ with pkgs;
       inherit buildPythonApplication;
     };
 
-  freedv = callPackage ../by-name/fr/freedv/package.nix {
-    codec2 = codec2.override {
-      freedvSupport = true;
-    };
-  };
-
   inherit
     ({
       freeoffice = callPackage ../applications/office/softmaker/freeoffice.nix { };


### PR DESCRIPTION
Split from #474456.

This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
