### PR TITLE
gopro-tool: move overrides to package.nix, modernize

### DIFF
--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -10,6 +10,7 @@
   }),
   jq,
   x264,
+  nixosTests,
 }:
 
 stdenv.mkDerivation {
@@ -42,6 +43,10 @@ stdenv.mkDerivation {
         ]
       }
   '';
+
+  passthru.tests = {
+    inherit (nixosTests) gopro-tool;
+  };
 
   meta = {
     description = "Tool to control GoPro webcam mode in Linux (requires v4l2loopback kernel module and a firewall rule)";

--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -25,6 +25,9 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   installPhase = ''
     mkdir -p $out/bin
     cp $src/gopro-tool $out/bin/gopro-tool

--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -5,7 +5,11 @@
   makeWrapper,
   ffmpeg,
   vlc,
+  vlc' ? vlc.overrideAttrs (old: {
+    buildInputs = old.buildInputs ++ [ x264 ];
+  }),
   jq,
+  x264,
 }:
 
 stdenv.mkDerivation {
@@ -30,7 +34,7 @@ stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath [
           ffmpeg
-          vlc
+          vlc'
           jq
         ]
       }

--- a/pkgs/by-name/go/gopro-tool/package.nix
+++ b/pkgs/by-name/go/gopro-tool/package.nix
@@ -13,15 +13,15 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gopro-tool";
-  version = "0-unstable-2024-04-18";
+  version = "1.18";
 
   src = fetchFromGitHub {
     owner = "juchem";
     repo = "gopro-tool";
-    rev = "a678f0ea65e24dca9b8d848b245bd2d487d3c8ca";
-    sha256 = "0sh3s38m17pci24x4kdlmlhn0gwgm28aaa6p7qs16wysk0q0h6wz";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nxsIMJjacxM0PtcopZCojz9gIa20TdKJiOyeUNHQA2o=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -54,4 +54,4 @@ stdenv.mkDerivation {
     maintainers = with lib.maintainers; [ ZMon3y ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4528,12 +4528,6 @@ with pkgs;
 
   dotnetPackages = recurseIntoAttrs (callPackage ./dotnet-packages.nix { });
 
-  gopro-tool = callPackage ../by-name/go/gopro-tool/package.nix {
-    vlc = vlc.overrideAttrs (old: {
-      buildInputs = old.buildInputs ++ [ x264 ];
-    });
-  };
-
   gwe = callPackage ../tools/misc/gwe {
     nvidia_x11 = linuxPackages.nvidia_x11;
   };


### PR DESCRIPTION
Split from #474456.

This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
