### PR TITLE
mysql-workbench: move overrides to package.nix

### DIFF
--- a/pkgs/by-name/my/mysql-workbench/package.nix
+++ b/pkgs/by-name/my/mysql-workbench/package.nix
@@ -20,7 +20,7 @@
   python3Packages,
 
   cairo,
-  mysql,
+  mysql80,
   libiodbc,
   proj,
 
@@ -41,8 +41,12 @@
 }:
 
 let
+  mysql = mysql80;
+  gdal' = gdal.override { libmysqlclient = mysql; };
+  antlr = antlr4_13;
+
   # for some reason the package doesn't build with swig 4.3.0
-  swig_4_2 = swig.overrideAttrs (prevAttrs: {
+  swig' = swig.overrideAttrs (prevAttrs: {
     version = "4.2.1";
     src = prevAttrs.src.override {
       hash = "sha256-VlUsiRZLScmbC7hZDzKqUr9481YXVwo0eXT/jy6Fda8=";
@@ -99,14 +103,14 @@ stdenv.mkDerivation (finalAttrs: {
     jre
     ninja
     pkg-config
-    swig_4_2
+    swig'
     wrapGAppsHook3
   ];
 
   buildInputs = [
-    antlr4_13.runtime.cpp
+    antlr.runtime.cpp
     boost
-    gdal
+    gdal'
     gtkmm3
     libiodbc
     libmysqlconnectorcpp
@@ -147,7 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "MySQL_CONFIG_PATH" (lib.getExe' mysql "mysql_config"))
     (lib.cmakeFeature "IODBC_CONFIG_PATH" (lib.getExe' libiodbc "iodbc-config"))
-    (lib.cmakeFeature "ANTLR_JAR_PATH" "${antlr4_13.jarLocation}")
+    (lib.cmakeFeature "ANTLR_JAR_PATH" "${antlr.jarLocation}")
     # mysql-workbench 8.0.21 depends on libmysqlconnectorcpp 1.1.8.
     # Newer versions of connector still provide the legacy library when enabled
     # but the headers are in a different location.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13120,18 +13120,6 @@ with pkgs;
     }
   );
 
-  mysql-workbench = callPackage ../by-name/my/mysql-workbench/package.nix (
-    let
-      mysql = mysql80;
-    in
-    {
-      gdal = gdal.override {
-        libmysqlclient = mysql;
-      };
-      mysql = mysql;
-    }
-  );
-
   pgadmin4-desktopmode = pgadmin4.override { server-mode = false; };
 
   philipstv = with python3Packages; toPythonApplication philipstv;


### PR DESCRIPTION
Split from #474456.

This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
