### PR TITLE
plausible: move overrides to package.nix

### DIFF
--- a/pkgs/by-name/pl/plausible/package.nix
+++ b/pkgs/by-name/pl/plausible/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
-  beamPackages,
+  beam27Packages,
+  elixir_1_18,
   buildNpmPackage,
   rustPlatform,
   fetchFromGitHub,
@@ -110,6 +111,8 @@ let
           ln -s "$lib" $out/mjml/priv/native/$base.so
         done
       '';
+
+  beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_18; });
 
 in
 beamPackages.mixRelease rec {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1559,10 +1559,6 @@ with pkgs;
     stdenv = clangStdenv;
   };
 
-  plausible = callPackage ../by-name/pl/plausible/package.nix {
-    beamPackages = beam27Packages.extend (self: super: { elixir = elixir_1_18; });
-  };
-
   reattach-to-user-namespace = callPackage ../os-specific/darwin/reattach-to-user-namespace { };
 
   xcodeenv = callPackage ../development/mobile/xcodeenv { };


### PR DESCRIPTION
Split from #474456.

This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
