### PR TITLE
x2t: move overrides to package.nix

### DIFF
--- a/pkgs/by-name/x2/x2t/package.nix
+++ b/pkgs/by-name/x2/x2t/package.nix
@@ -16,7 +16,6 @@
   jdk,
   lib,
   nodejs_22,
-  # needs to be static and built with MD2 support!
   openssl,
   pkg-config,
   python3,
@@ -30,6 +29,11 @@
 }:
 
 let
+  openssl' = openssl.override {
+    enableMD2 = true;
+    static = true;
+  };
+
   qmake = qt5.qmake;
   fixIcu = writeScript "fix-icu.sh" ''
     substituteInPlace \
@@ -722,9 +726,9 @@ let
 
       echo "== openssl =="
       mkdir -p Common/3dParty/openssl/build/linux_64/lib
-      echo "Including openssl from ${openssl.dev}"
-      ln -s ${openssl.dev}/include Common/3dParty/openssl/build/linux_64/include
-      for i in ${openssl.out}/lib/*; do
+      echo "Including openssl from ${openssl'.dev}"
+      ln -s ${openssl'.dev}/include Common/3dParty/openssl/build/linux_64/include
+      for i in ${openssl'.out}/lib/*; do
         ln -s $i Common/3dParty/openssl/build/linux_64/lib/$(basename $i)
       done
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1078,13 +1078,6 @@ with pkgs;
     wine = wineWowPackages.stable;
   };
 
-  x2t = callPackage ../by-name/x2/x2t/package.nix {
-    openssl = openssl.override {
-      enableMD2 = true;
-      static = true;
-    };
-  };
-
   yabridge = callPackage ../tools/audio/yabridge {
     wine = wineWowPackages.yabridge;
   };


### PR DESCRIPTION
Split from #474456.

This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
