### PR TITLE
kdotool: fix build using upstream patch

### DIFF
--- a/pkgs/by-name/kd/kdotool/package.nix
+++ b/pkgs/by-name/kd/kdotool/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch,
   rustPlatform,
   pkg-config,
   dbus,
@@ -16,6 +17,18 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-qx4bWAFQcoLM/r4aNzmoZdjclw8ccAW8lKLda6ON1aQ=";
   };
+
+  patches = [
+    # Remove these two on next release.
+    (fetchpatch {
+      url = "https://github.com/jinliu/kdotool/commit/049e3f5620ad8c5484241d7d06d742bc17d423ed.patch";
+      hash = "sha256-VTpHlT6XMVRgJIeLjxZPHkzaYFZCYtS8IAD0mKZ8rzs=";
+    })
+    (fetchpatch {
+      url = "https://github.com/jinliu/kdotool/commit/e0a3bff3b5d9882033dd72836e5fcff572b64135.patch";
+      hash = "sha256-6IsV9O2h9N/FxGQRHS8qAbEqdr7282ziGza5K52vpPk=";
+    })
+  ];
 
   cargoHash = "sha256-ASR2zMwVCKeEZPYQNoO54J00eZyTn1i6FE0NBCJWSCs=";
 


### PR DESCRIPTION
Without this patch, it fails to build:

    >    Compiling kdotool v0.2.1 (/build/source)
    > error: this function depends on never type fallback being `()`
    >    --> src/main.rs:553:1
    >     |
    > 553 | fn main() -> anyhow::Result<()> {
    >     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    >     |
    >     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in Rust 2024 and in a future release in all editions!
    >     = note: for more information, see <https://doc.rust-lang.org/edition-guide/rust-2024/never-type-fallback.html>
    >     = help: specify the types explicitly
    > note: in edition 2024, the requirement `!: ReadAll` will fail
    >    --> src/main.rs:635:20
    >     |
    > 635 |         kwin_proxy.method_call(
    >     |                    ^^^^^^^^^^^
    >     = note: `#[deny(dependency_on_unit_never_type_fallback)]` (part of `#[deny(rust_2024_compatibility)]`) on by default
    > help: use `()` annotations to avoid fallback changes
    >     |
    > 635 ~         kwin_proxy.method_call::<(), _, _, _>(
    > 636 |             "org.kde.kwin.Scripting",
    > ...
    > 686 |     // setup message receiver
    > 687 ~     let _receiver_thread = std::thread::spawn::<_, ()>(move || {
    > 688 |         let _receiver = self_conn.start_receive(
    > ...
    > 707 |     let start_time = chrono::Local::now();
    > 708 ~     script_proxy.method_call::<(), _, _, _>("org.kde.kwin.Script", "run", ())?;
    > 709 |     if context.shortcut.is_empty() {
    > 710 ~         script_proxy.method_call::<(), _, _, _>("org.kde.kwin.Script", "stop", ())?;
    >     |
    >
    > warning: hiding a lifetime that's elided elsewhere is confusing
    >  --> src/parser.rs:8:31
    >   |
    > 8 | pub fn next_maybe_num(parser: &mut Parser) -> anyhow::Result<Option<lexopt::Arg>> {
    >   |                               ^^^^^^^^^^^                           ^^^^^^^^^^^ the same lifetime is hidden here
    >   |                               |
    >   |                               the lifetime is elided here
    >   |
    >   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    >   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
    > help: use `'_` for type paths
    >   |
    > 8 | pub fn next_maybe_num(parser: &mut Parser) -> anyhow::Result<Option<lexopt::Arg<'_>>> {
    >   |                                                                                ++++
    >
    > warning: `kdotool` (bin "kdotool") generated 1 warning
    > error: could not compile `kdotool` (bin "kdotool") due to 2 previous errors; 1 warning emitted
    For full logs, run 'nix log /nix/store/va8rl3865x91dv54gcnvnb2xyfgp8b5p-kdotool-0.2.2-pre.drv'.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
