### PR TITLE
dune, opaline: remove top-level inherit, modernize

### DIFF
--- a/pkgs/by-name/du/dune/package.nix
+++ b/pkgs/by-name/du/dune/package.nix
@@ -2,10 +2,13 @@
   lib,
   stdenv,
   fetchurl,
-  ocamlPackages,
+  buildPackages,
   version ? "3.20.2",
 }:
-
+let
+  # needed for pkgsStatic
+  inherit (buildPackages.buildPackages) ocamlPackages;
+in
 stdenv.mkDerivation {
   pname = "dune";
   inherit version;
@@ -29,7 +32,10 @@ stdenv.mkDerivation {
     findlib
   ];
 
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+
   strictDeps = true;
+  __structuredAttrs = true;
 
   buildFlags = [ "release" ];
 

--- a/pkgs/by-name/op/opaline/package.nix
+++ b/pkgs/by-name/op/opaline/package.nix
@@ -1,10 +1,13 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchFromGitHub,
-  ocamlPackages,
 }:
-
+let
+  # needed for pkgsStatic
+  inherit (buildPackages.buildPackages) ocamlPackages;
+in
 stdenv.mkDerivation (finalAttrs: {
   version = "0.3.3";
   pname = "opaline";
@@ -12,9 +15,14 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jaapb";
     repo = "opaline";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-6htaiFIcRMUYWn0U7zTNfCyDaTgDEvPch2q57qzvND4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6htaiFIcRMUYWn0U7zTNfCyDaTgDEvPch2q57qzvND4=";
   };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   nativeBuildInputs = with ocamlPackages; [
     ocaml
@@ -32,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "opaline";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
-    inherit (finalAttrs.src.meta) homepage;
+    homepage = "https://github.com/jaapb/opaline";
     inherit (ocamlPackages.ocaml.meta) platforms;
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1706,12 +1706,9 @@ with pkgs;
 
   dune_2 = callPackage ../by-name/du/dune/package.nix {
     version = "2.9.3";
-    inherit ocamlPackages;
   };
 
-  dune_3 = callPackage ../by-name/du/dune/package.nix {
-    inherit ocamlPackages;
-  };
+  dune_3 = callPackage ../by-name/du/dune/package.nix { };
 
   dvc = with python3.pkgs; toPythonApplication dvc;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1899,8 +1899,6 @@ with pkgs;
 
   online-judge-tools = with python3.pkgs; toPythonApplication online-judge-tools;
 
-  opaline = callPackage ../by-name/op/opaline/package.nix { inherit ocamlPackages; };
-
   inherit (ocamlPackages) patdiff;
 
   patool = with python3Packages; toPythonApplication patool;


### PR DESCRIPTION
This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test