### PR TITLE
xcbuild: move top level override into package.nix

### DIFF
--- a/pkgs/by-name/xc/xcbuild/package.nix
+++ b/pkgs/by-name/xc/xcbuild/package.nix
@@ -8,6 +8,8 @@
   makeBinaryWrapper,
   ninja,
   stdenv,
+  # xcbuild is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv
+  stdenv' ? if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv,
   zlib,
 
   # These are deprecated and do nothing. They’re needed for compatibility and will
@@ -56,7 +58,7 @@ let
     sha256 = "sha256-nKxwWuSqr89lvI9Y3QAW5Mo7/iFfMNj/OOQVeA/FWnE=";
   };
 in
-stdenv.mkDerivation (finalAttrs: {
+stdenv'.mkDerivation (finalAttrs: {
   pname = "xcbuild";
 
   outputs = [
@@ -101,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Libraries/pbxbuild/Sources/Tool/ScriptResolver.cpp \
       --replace-fail "/bin/sh" "sh"
   ''
-  + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+  + lib.optionalString (!stdenv'.hostPlatform.isDarwin) ''
     # Fix build on gcc-13 due to missing includes
     sed -e '1i #include <cstdint>' -i \
       Libraries/libutil/Headers/libutil/Permissions.h \
@@ -112,7 +114,7 @@ stdenv.mkDerivation (finalAttrs: {
     sed 1i'#include <sys/sysmacros.h>' \
       -i Libraries/xcassets/Headers/xcassets/Slot/SystemVersion.h
   ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+  + lib.optionalString stdenv'.hostPlatform.isDarwin ''
     # Apple Open Sourced LZFSE, but not libcompression, and it isn't
     # part of an impure framework we can add
     substituteInPlace Libraries/libcar/Sources/Rendition.cpp \

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6383,12 +6383,6 @@ with pkgs;
 
   watson-ruby = callPackage ../development/tools/misc/watson-ruby { };
 
-  xcbuild = callPackage ../by-name/xc/xcbuild/package.nix {
-    stdenv =
-      # xcbuild is included in the SDK. Avoid an infinite recursion by using a bootstrap stdenv.
-      if stdenv.hostPlatform.isDarwin then darwin.bootstrapStdenv else stdenv;
-  };
-
   xcbuildHook = makeSetupHook {
     name = "xcbuild-hook";
     propagatedBuildInputs = [ xcbuild ];


### PR DESCRIPTION
This is a step towards #454525, which will help enable checking for additional by-name directories (e.g. Python) in nixpkgs-vet.

## Things done

- [x] 0 rebuilds.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test