### PR TITLE
maintainers: remove alois31

### DIFF
--- a/maintainers/github-teams.json
+++ b/maintainers/github-teams.json
@@ -550,8 +550,7 @@
     "members": {
       "9999years": 15312184,
       "Qyriad": 1542224,
-      "RaitoBezarius": 314564,
-      "alois31": 36605164
+      "RaitoBezarius": 314564
     },
     "name": "Lix maintainers"
   },

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1398,14 +1398,6 @@
     githubId = 60479013;
     name = "Alma Cemerlic";
   };
-  alois31 = {
-    name = "Alois Wohlschlager";
-    email = "alois1@gmx-topmail.de";
-    matrix = "@aloisw:kde.org";
-    github = "alois31";
-    githubId = 36605164;
-    keys = [ { fingerprint = "CA97 A822 FF24 25D4 74AF  3E4B E0F5 9EA5 E521 6914"; } ];
-  };
   Alper-Celik = {
     email = "alper@alper-celik.dev";
     name = "Alper Çelik";

--- a/nixos/tests/replace-dependencies/default.nix
+++ b/nixos/tests/replace-dependencies/default.nix
@@ -2,7 +2,7 @@ import ../make-test-python.nix (
   { pkgs, ... }:
   {
     name = "replace-dependencies";
-    meta.maintainers = with pkgs.lib.maintainers; [ alois31 ];
+    meta.maintainers = [ ];
 
     nodes.machine =
       { ... }:

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -315,7 +315,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Cross-platform media player and streaming server";
     homepage = "https://www.videolan.org/vlc/";
     license = lib.licenses.lgpl21Plus;
-    maintainers = with lib.maintainers; [ alois31 ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "vlc";
   };


### PR DESCRIPTION
It is becoming increasingly clear that improvements to Nixpkgs will benefit disproportionately the weapons industry. Consequently, my semi-regular involvement in its development will come to an end (at least for now, but given how long the situation has been ongoing, realistically this is going to be more a resignation than an indefinite strike). Let me end with some dedications:

* To everyone who has already left because they realised the issue years ago. You were right, and I failed you by not listening. If we ever cross paths again, I hope we will be able to work with each other rather than against like this time, because (only) together we are strong.
* To everyone working in the weapons industry. May God bless you with the ability to put your skills to better use elsewhere. What is needed is more welfare, less warfare.
* To everyone who has worked on, is working on, and will work on the free and open-source software. Both for sharing something useful, and for offering learning opportunities by working together. Great things can be achieved when one works for all, and all work for one.
* To everyone who has been harmed, directly or indirectly, by the development of Nixpkgs, including but not limited to by my own involvement. Striving to not repeat this is imperative, but no excuse.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
