### PR TITLE
mkCoqDerivation: warn on superfluous enableParallelBuilding

### DIFF
--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -98,6 +98,7 @@ let
       "dropAttrs"
       "dropDerivationAttrs"
       "keepAttrs"
+      "enableParallelBuilding"
     ]
     ++ dropAttrs
   ) keepAttrs;
@@ -201,7 +202,10 @@ stdenv.mkDerivation (
         );
       buildInputs =
         args.overrideBuildInputs or ([ coq ] ++ (args.buildInputs or [ ]) ++ extraBuildInputs);
-      inherit enableParallelBuilding;
+      enableParallelBuilding =
+        lib.warnIf (args ? enableParallelBuilding && args.enableParallelBuilding == true)
+          "mkCoqDerivation: enableParallelBuilding is enabled by default; remove the explicit setting"
+          enableParallelBuilding;
 
       meta =
         (

--- a/pkgs/development/coq-modules/compcert/default.nix
+++ b/pkgs/development/coq-modules/compcert/default.nix
@@ -91,8 +91,6 @@ let
       MenhirLib
     ];
 
-    enableParallelBuilding = true;
-
     postPatch = ''
       substituteInPlace ./configure \
         --replace \$\{toolprefix\}ar 'ar' \

--- a/pkgs/development/coq-modules/interval/default.nix
+++ b/pkgs/development/coq-modules/interval/default.nix
@@ -68,7 +68,6 @@ mkCoqDerivation rec {
     ++ lib.optionals (lib.versions.isGe "4.2.0" defaultVersion) [ gnuplot_qt ];
   useMelquiondRemake.logpath = "Interval";
   mlPlugin = true;
-  enableParallelBuilding = true;
 
   meta = {
     description = "Tactics for simplifying the proofs of inequalities on expressions of real numbers for the Coq proof assistant";


### PR DESCRIPTION
I have plans to extend this to other builders in future

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
