### PR TITLE
python3Packages.fastmri: skip failing tests on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/fastmri/default.nix
+++ b/pkgs/development/python-modules/fastmri/default.nix
@@ -23,7 +23,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fastmri";
   version = "0.3.0";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "facebookresearch";
     repo = "fastMRI";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0IJV8OhY5kPWQwUYPKfmdI67TyYzDAPlwohdc0jWcV4=";
   };
 
@@ -76,8 +76,8 @@ buildPythonPackage rec {
   meta = {
     description = "Pytorch-based MRI reconstruction tooling";
     homepage = "https://github.com/facebookresearch/fastMRI";
-    changelog = "https://github.com/facebookresearch/fastMRI/releases/tag/v${version}";
+    changelog = "https://github.com/facebookresearch/fastMRI/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ osbm ];
   };
-}
+})

--- a/pkgs/development/python-modules/fastmri/default.nix
+++ b/pkgs/development/python-modules/fastmri/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build system
   setuptools,
@@ -65,6 +66,12 @@ buildPythonPackage (finalAttrs: {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # AttributeError: '...' object has no attribute '__annotations__'.
+    "test_unet_scripting"
+    "test_varnet_scripting"
+  ];
 
   disabledTestPaths = [
     # much older version of pytorch-lightning is used


### PR DESCRIPTION
## Things done

- **python3Packages.fastmri: use finalAttrs**
- **python3Packages.fastmri: skip failing tests on python>=3.14**

Tracking: https://github.com/NixOS/nixpkgs/issues/475732

cc @osbm

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
