### PR TITLE
python3Packages.gluonts: disable on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/gluonts/default.nix
+++ b/pkgs/development/python-modules/gluonts/default.nix
@@ -1,6 +1,6 @@
 {
-  stdenv,
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
@@ -20,7 +20,7 @@
   lightning,
   scipy,
 
-  # test
+  # tests
   pytestCheckHook,
   distutils,
   matplotlib,
@@ -30,7 +30,7 @@
   which,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gluonts";
   version = "0.16.2";
   pyproject = true;
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "awslabs";
     repo = "gluonts";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-h0+RYgGMz0gPchiKGIu0/NGcWBky5AWNTJKzoupn/iQ=";
   };
 
@@ -100,7 +100,7 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
     which
   ]
-  ++ optional-dependencies.torch;
+  ++ finalAttrs.passthru.optional-dependencies.torch;
 
   disabledTestPaths = [
     # requires `cpflows`, not in Nixpkgs
@@ -119,8 +119,8 @@ buildPythonPackage rec {
   meta = {
     description = "Probabilistic time series modeling in Python";
     homepage = "https://ts.gluon.ai";
-    changelog = "https://github.com/awslabs/gluonts/releases/tag/${src.tag}";
+    changelog = "https://github.com/awslabs/gluonts/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bcdarwin ];
   };
-}
+})

--- a/pkgs/development/python-modules/gluonts/default.nix
+++ b/pkgs/development/python-modules/gluonts/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -41,6 +42,9 @@ buildPythonPackage (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-h0+RYgGMz0gPchiKGIu0/NGcWBky5AWNTJKzoupn/iQ=";
   };
+
+  # pydantic.v1.errors.ConfigError: unable to infer type for attribute "target"
+  disabled = pythonAtLeast "3.14";
 
   patches = [
     # Fixes _pickle.UnpicklingError: Weights only load failed.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.gluonts: use finalAttrs**
- **python3Packages.gluonts: disable on python>=3.14**

Tracking: https://github.com/NixOS/nixpkgs/issues/475732

cc @bcdarwin

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
