### PR TITLE
govctl: init at 0.3.0

### DIFF
--- a/pkgs/by-name/go/govctl/package.nix
+++ b/pkgs/by-name/go/govctl/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "govctl";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "govctl-org";
+    repo = pname;
+    rev = "v${version}";
+    sha256 = "sha256-eNteRJSghzIKApmDAUJGUlPVe8WxNUD7LhWx9sKEUW4=";
+  };
+
+  cargoHash = "sha256-IWS4V4dBEFSf3S5osnexbj856WVspyANcaPE6VDbSXg=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = lib.optionals stdenv.isLinux [ openssl ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = with lib; {
+    homepage = "https://github.com/govctl-org/govctl";
+    description = "Opinionated CLI tool to enforce RFC-driven AI coding";
+    license = licenses.mit;
+    maintainers = with maintainers; [ waelwindows ];
+    mainProgram = "govctl";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

# govctl
Opinionated CLI tool to enforce RFC-driven AI coding.

Upstream: https://github.com/govctl-org/govctl

## Things done

Built derivation on aarch64-darwin and made sure help displays!
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
