### PR TITLE
appstream: 1.0.4 -> 1.1.2

### DIFF
--- a/nixos/tests/installed-tests/appstream-qt.nix
+++ b/nixos/tests/installed-tests/appstream-qt.nix
@@ -1,7 +1,7 @@
 { pkgs, makeInstalledTest, ... }:
 
 makeInstalledTest {
-  tested = pkgs.libsForQt5.appstream-qt;
+  tested = pkgs.kdePackages.appstream-qt;
 
   testConfig = {
     appstream.enable = true;

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -4,7 +4,6 @@
   buildPackages,
   replaceVars,
   fetchFromGitHub,
-  fetchpatch,
   meson,
   mesonEmulatorHook,
   appstream,
@@ -21,7 +20,7 @@
   xapian,
   libxml2,
   libxmlb,
-  libyaml,
+  libfyaml,
   gobject-introspection,
   itstool,
   gperf,
@@ -31,6 +30,7 @@
   gdk-pixbuf,
   pango,
   librsvg,
+  bash-completion,
   systemd,
   nixosTests,
   testers,
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "appstream";
-  version = "1.0.4";
+  version = "1.1.2";
 
   outputs = [
     "out"
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "ximion";
     repo = "appstream";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-UnSJcXH0yWK/dPKgbOx9x3iJjKcKNYFkD2Qs5c3FtM8=";
+    sha256 = "sha256-tvdWWdL6PthffAZZnNZ3+17/eJdZFx8xFkqm7IvyPWE=";
   };
 
   patches = [
@@ -65,12 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Allow installing installed tests to a separate output.
     ./installed-tests-path.patch
-
-    (fetchpatch {
-      name = "static.patch";
-      url = "https://github.com/ximion/appstream/commit/90675d8853188f65897d2453346cb0acd531b58f.patch";
-      hash = "sha256-d3h5h7B/MP3Sun5YwYCqMHcw4PMMwg1YS/S9vsMzkQ4=";
-    })
   ];
 
   strictDeps = true;
@@ -110,12 +104,13 @@ stdenv.mkDerivation (finalAttrs: {
     xapian
     libxml2
     libxmlb
-    libyaml
+    libfyaml
     curl
     cairo
     gdk-pixbuf
     pango
     librsvg
+    bash-completion
   ]
   ++ lib.optionals withSystemd [
     systemd

--- a/pkgs/development/libraries/appstream/qt.nix
+++ b/pkgs/development/libraries/appstream/qt.nix
@@ -9,9 +9,6 @@
 
 # TODO: look into using the libraries from the regular appstream derivation as we keep duplicates here
 
-let
-  qtSuffix = lib.optionalString (lib.versions.major qtbase.version == "5") "5";
-in
 stdenv.mkDerivation {
   pname = "appstream-qt";
   inherit (appstream) version src;
@@ -31,7 +28,6 @@ stdenv.mkDerivation {
 
   mesonFlags = appstream.mesonFlags ++ [
     (lib.mesonBool "qt" true)
-    (lib.mesonOption "qt-versions" (lib.versions.major qtbase.version))
   ];
 
   patches = appstream.patches;
@@ -41,9 +37,9 @@ stdenv.mkDerivation {
   # AppStreamQt tries to be relocatable, in hacky cmake ways that generally fail
   # horribly on NixOS. Just hardcode the paths.
   postFixup = ''
-    sed -i "$dev/lib/cmake/AppStreamQt${qtSuffix}/AppStreamQt${qtSuffix}Config.cmake" \
+    sed -i "$dev/lib/cmake/AppStreamQt/AppStreamQtConfig.cmake" \
       -e "/INTERFACE_INCLUDE_DIRECTORIES/ s@\''${PACKAGE_PREFIX_DIR}@$dev@"
-    sed -i "$dev/lib/cmake/AppStreamQt${qtSuffix}/AppStreamQt${qtSuffix}Config.cmake" \
+    sed -i "$dev/lib/cmake/AppStreamQt/AppStreamQtConfig.cmake" \
       -e "/IMPORTED_LOCATION/ s@\''${PACKAGE_PREFIX_DIR}@$out@"
   '';
 

--- a/pkgs/top-level/qt5-packages.nix
+++ b/pkgs/top-level/qt5-packages.nix
@@ -66,8 +66,6 @@ makeScopeWithSplicing' {
 
         accounts-qt = callPackage ../development/libraries/accounts-qt { };
 
-        appstream-qt = callPackage ../development/libraries/appstream/qt.nix { };
-
         dxflib = callPackage ../development/libraries/dxflib { };
 
         drumstick = callPackage ../development/libraries/drumstick { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Bump appstream to 1.1.2.
Note that since version 1.1.1, qt5 support has been dropped.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
