### PR TITLE
ncrypto: init at 1.1.0

### DIFF
--- a/pkgs/by-name/nc/ncrypto/package.nix
+++ b/pkgs/by-name/nc/ncrypto/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  gtest,
+  openssl,
+  nix-update-script,
+  stdenv,
+  testers,
+  validatePkgConfig,
+  static ? stdenv.hostPlatform.isStatic,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ncrypto";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "nodejs";
+    repo = "ncrypto";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-9lAlIdY1gmzGR6+FldQQjj09e41mvl2V0Lf/iFmeQhU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    validatePkgConfig
+  ];
+  buildInputs = [ openssl ];
+
+  doCheck = true;
+  checkInputs = [ gtest ];
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!static))
+    (lib.cmakeBool "NCRYPTO_SHARED_LIBS" true)
+    (lib.cmakeBool "NCRYPTO_TESTING" finalAttrs.finalPackage.doCheck)
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+  };
+
+  meta = {
+    description = "Library of byte handling functions extracted from Node.js core";
+    homepage = "https://github.com/nodejs/ncrypto";
+    changelog = "https://github.com/nodejs/ncrypto/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aduh95 ];
+    platforms = lib.platforms.all;
+    pkgConfigModules = [ "ncrypto" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Another nodejs dependency: https://github.com/nodejs/ncrypto

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
