### PR TITLE
mermaid-rs-renderer: init at 0.1.2

### DIFF
--- a/pkgs/by-name/me/mermaid-rs-renderer/package.nix
+++ b/pkgs/by-name/me/mermaid-rs-renderer/package.nix
@@ -1,0 +1,37 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mermaid-rs-renderer";
+  version = "0.2.0";
+  src = fetchFromGitHub {
+    owner = "1jehuang";
+    repo = "mermaid-rs-renderer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FmYiGAUTdHLBHmMrX4I1Lax+WTevLeW2+TSVhV0TUCk=";
+  };
+
+  cargoHash = "sha256-EICrvDm97hXvGbmp6zOMSEKCdJ6MPho2Y0llWQ9zHus=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast native Rust Mermaid diagram renderer";
+    longDescription = ''
+      mmdr renders diagrams 100-1800x faster than mermaid-cli by
+      eliminating browser overhead.
+    '';
+    homepage = "https://github.com/1jehuang/mermaid-rs-renderer";
+    license = lib.licenses.mit;
+    mainProgram = "mmdr";
+    maintainers = with lib.maintainers; [ yiyu ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
