### PR TITLE
masterpdfeditor4: move icon to spec-compliant location

### DIFF
--- a/pkgs/applications/misc/masterpdfeditor4/default.nix
+++ b/pkgs/applications/misc/masterpdfeditor4/default.nix
@@ -39,9 +39,9 @@ stdenv.mkDerivation rec {
     substituteInPlace masterpdfeditor4.desktop \
       --replace 'Exec=/opt/master-pdf-editor-4' "Exec=$out/bin" \
       --replace 'Path=/opt/master-pdf-editor-4' "Path=$out/bin" \
-      --replace 'Icon=/opt/master-pdf-editor-4' "Icon=$out/share/pixmaps"
+      --replace 'Icon=/opt/master-pdf-editor-4' "Icon=masterpdfeditor4"
 
-    install -Dm644 -t $out/share/pixmaps      masterpdfeditor4.png
+    install -Dm644 -t $out/share/icons/hicolor/128x128/apps masterpdfeditor4.png
     install -Dm644 -t $out/share/applications masterpdfeditor4.desktop
     install -Dm755 -t $app_dir                masterpdfeditor4
     install -Dm644 license.txt $out/share/$name/LICENSE


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Part of #428824 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
