### PR TITLE
gnome-shell: fix gnome-shell-portal-helper

### DIFF
--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -66,6 +66,7 @@
   libxkbcommon,
   libsoup_3,
   libxml2,
+  webkitgtk_6_0,
 }:
 
 let
@@ -183,6 +184,7 @@ stdenv.mkDerivation (finalAttrs: {
     # not declared at build time, but typelib is needed at runtime
     libgweather
     libnma-gtk4
+    webkitgtk_6_0 # for gnome-shell-portal-helper
 
     # for gnome-extension tool
     bash-completion


### PR DESCRIPTION
## Things done

Add `webkitgtk_6_0` typelib needed by `gnome-shell-portal-helper`.

When NetworkManager connectivity check is enabled, GNOME will pop up a notification when a captive portal is detected. Clicking the notification _should_ launch a WebKit browser window allowing you to log in to the network. Without including the typelib, this fails with the following error in the journal: `JS ERROR: Error: Requiring WebKit, version 6.0: Typelib file for namespace 'WebKit', version '6.0' not found`.

You can enable NetworkManager connectivity checks with the following NixOS config:

```nix
networking = {
  networkmanager = {
    enable = true;
    settings = {
      connectivity = {
        enabled = true;
        uri = "http://nmcheck.gnome.org/check_network_status.txt";
        interval = 300;
      };
    };
  };
};
```

To test this, you need to connect to a public WiFi that requires clicking through a log in page or simulate a captive portal in some other way. You can also test launching the authentication window directly with a script similar to the following. This will not work prior to the fix. 

```bash
#!/usr/bin/env bash

gdbus call --session \
  --dest org.gnome.Shell.PortalHelper \
  --object-path /org/gnome/Shell/PortalHelper \
  --method org.gnome.Shell.PortalHelper.Close \
  "/org/freedesktop/NetworkManager/ActiveConnection/1"

gdbus call --session \
  --dest org.gnome.Shell.PortalHelper \
  --object-path /org/gnome/Shell/PortalHelper \
  --method org.gnome.Shell.PortalHelper.Authenticate \
  "/org/freedesktop/NetworkManager/ActiveConnection/1" \
  "http://example.com" \
  0
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
