### PR TITLE
skim: 0.20.5 -> 2.0.1

### DIFF
--- a/pkgs/by-name/sk/skim/package.nix
+++ b/pkgs/by-name/sk/skim/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  tmux,
   fetchFromGitHub,
   installShellFiles,
   nix-update-script,
@@ -9,10 +9,9 @@
   skim,
   testers,
 }:
-
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "skim";
-  version = "0.20.5";
+  version = "2.0.1";
 
   outputs = [
     "out"
@@ -23,17 +22,21 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "skim-rs";
     repo = "skim";
-    tag = "v${version}";
-    hash = "sha256-BX0WW7dNpNLwxlclFCxj0QnrQ58lchKiEnmethzceqk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MQV7Fcbna6x4t3NFFn8m/EHvOM1CrPpfdwUJGQz09LU=";
   };
 
   postPatch = ''
     sed -i -e "s|expand('<sfile>:h:h')|'$out'|" plugin/skim.vim
   '';
 
-  cargoHash = "sha256-t2hkWTb/GhesNCWe2/YunZFo26xcXMjoNCiaKaFLOBk=";
+  cargoHash = "sha256-BlY1idYk6LpVI40dLdH0Sn49ZChbecp6KhwWORgKP3k=";
 
   nativeBuildInputs = [ installShellFiles ];
+  nativeCheckInputs = [ tmux ];
+
+  # frizbee requires nightly features
+  env.RUSTC_BOOTSTRAP = 1;
 
   postBuild = ''
     cat <<SCRIPT > sk-share
@@ -58,9 +61,36 @@ rustPlatform.buildRustPackage rec {
       --zsh shell/completion.zsh
   '';
 
-  # Doc tests are broken on aarch64
-  # https://github.com/lotabout/skim/issues/440
-  cargoTestFlags = lib.optional stdenv.hostPlatform.isAarch64 "--all-targets";
+  useNextest = true;
+
+  checkPhase =
+    let
+      skippedTests = [
+        # Assertion Error: Insta: Code output doesn't match the expected snapshot
+        "opt_replstr"
+        "opt_with_nth_preview"
+        "preview_offset_expr"
+        "preview_navigation"
+        "preview_offset_fixed"
+        "preview_nul_char"
+        "preview_nowrap"
+        "preview_offset_fixed_and_expr"
+        "preview_plus"
+        "preview_preserve_quotes"
+        "preview_pty_linux"
+        "preview_wrap"
+        "preview_window_down"
+        "preview_window_left"
+        "preview_window_up"
+      ];
+      filterExpr =
+        "not ("
+        + (builtins.concatStringsSep " or " (map (testName: "test(${testName})") skippedTests))
+        + ")";
+    in
+    ''
+      cargo nextest run --features test-utils --release --offline -E '${filterExpr}'
+    '';
 
   passthru = {
     tests.version = testers.testVersion { package = skim; };
@@ -70,7 +100,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Command-line fuzzy finder written in Rust";
     homepage = "https://github.com/skim-rs/skim";
-    changelog = "https://github.com/skim-rs/skim/releases/tag/v${version}";
+    changelog = "https://github.com/skim-rs/skim/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       dywedir
@@ -79,4 +109,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "sk";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
diff: https://github.com/skim-rs/skim/compare/v0.20.5...v2.0.1
changes: https://github.com/skim-rs/skim/releases/tag/v2.0.1
Resolves: https://github.com/NixOS/nixpkgs/issues/484272

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

EDIT: do not merge this, some tests fail and need to be disabled.