### PR TITLE
musicpresence: init at 2.3.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30257,6 +30257,12 @@
     githubId = 36118348;
     keys = [ { fingerprint = "69C9 876B 5797 1B2E 11C5  7C39 80A1 F76F C9F9 54AE"; } ];
   };
+  wiyba = {
+    name = "Dmitry Shmakov";
+    email = "contact@wiyba.org";
+    github = "wiyba";
+    githubId = 81859776;
+  };
   wizardlink = {
     name = "wizardlink";
     email = "contact@thewizard.link";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20404,6 +20404,12 @@
     githubId = 47303199;
     name = "Simon Gutgesell";
   };
+  nonplay = {
+    name = "Artem Ostrasev";
+    email = "nonplay@bxteam.org";
+    github = "NONPLAYT";
+    githubId = 76615486;
+  };
   noodlez1232 = {
     email = "contact@nathanielbarragan.xyz";
     matrix = "@noodlez1232:matrix.org";

--- a/pkgs/by-name/mu/musicpresence/package.nix
+++ b/pkgs/by-name/mu/musicpresence/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  libGL,
+  libxcb,
+  libx11,
+  wayland,
+  fontconfig,
+  freetype,
+  libgpg-error,
+  e2fsprogs,
+  xkeyboard_config,
+  qt6,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "musicpresence";
+  version = "2.3.6";
+
+  src = fetchurl {
+    url = "https://github.com/ungive/discord-music-presence/releases/download/v${finalAttrs.version}/musicpresence-${finalAttrs.version}-linux-x86_64.tar.gz";
+    hash = "sha256-w3y1I6nnztEMaihbXIfQqB0ng6s07iA8bqC8PDq+E+I=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libGL
+    libxcb
+    libx11
+    wayland
+    fontconfig
+    freetype
+    libgpg-error
+    e2fsprogs
+    stdenv.cc.cc.lib
+  ];
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r usr/share $out/
+
+    makeWrapper $out/share/musicpresence/bin/musicpresence $out/bin/musicpresence \
+      --set XKB_CONFIG_ROOT "${xkeyboard_config}/share/X11/xkb" \
+      --prefix QT_PLUGIN_PATH : "${qt6.qtwayland}/${qt6.qtbase.qtPluginPrefix}" \
+      --unset QT_STYLE_OVERRIDE
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Discord music status that works with any media player";
+    homepage = "https://github.com/ungive/discord-music-presence";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "musicpresence";
+    maintainers = with lib.maintainers; [
+      wiyba
+      nonplay
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds [musicpresence](https://github.com/ungive/discord-music-presence) - Discord RPC music status, supporting 100+ media players with album art and playback progress display. Binary package using the official release tarball. 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
