### PR TITLE
jetbrains.jdk: 21.0.9-1163.86 -> 25.0.2-b329.72

### DIFF
--- a/pkgs/applications/editors/jetbrains/source/build.nix
+++ b/pkgs/applications/editors/jetbrains/source/build.nix
@@ -45,7 +45,7 @@ let
     };
   });
 
-  jbr = jetbrains.jdk-no-jcef;
+  jbr = jetbrains.jdk-no-jcef-21;
 
   ideaSrc = fetchFromGitHub {
     owner = "jetbrains";

--- a/pkgs/by-name/an/animeko/package.nix
+++ b/pkgs/by-name/an/animeko/package.nix
@@ -282,5 +282,8 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = [
       "x86_64-linux"
     ];
+    # Mark broken due to a breaking change in JetBrains JCEF
+    # https://github.com/NixOS/nixpkgs/pull/485812#issuecomment-4211365591
+    broken = true;
   };
 })

--- a/pkgs/by-name/an/animeko/package.nix
+++ b/pkgs/by-name/an/animeko/package.nix
@@ -142,12 +142,12 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   env = {
-    JAVA_HOME = jetbrains.jdk;
+    JAVA_HOME = jetbrains.jdk-21;
     ANDROID_SDK_HOME = "$(pwd)";
   };
 
   gradleFlags = [
-    "-Dorg.gradle.java.home=${jetbrains.jdk}"
+    "-Dorg.gradle.java.home=${jetbrains.jdk-21}"
   ];
 
   nativeBuildInputs = [

--- a/pkgs/development/compilers/jetbrains-jdk/21.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/21.nix
@@ -1,0 +1,26 @@
+{
+  callPackage,
+  jetbrains,
+  jdk,
+  debugBuild ? false,
+  withJcef ? true,
+}:
+
+callPackage ./common.nix
+  {
+    inherit jdk debugBuild withJcef;
+  }
+  {
+    # To get the new tag:
+    # git clone https://github.com/jetbrains/jetbrainsruntime
+    # cd jetbrainsruntime
+    # git tag --points-at [revision]
+    # Look for the line that starts with jbr-
+    javaVersion = "21.0.10";
+    build = "1163.110";
+    # run `git log -1 --pretty=%ct` in jdk repo for new value on update
+    sourceDateEpoch = 1765114563;
+    srcHash = "sha256-Qmffu7p6frBoH2Zh+EiqvEoMNNBE79qfkgLSC3+XuI0=";
+    homePath = "${jetbrains.jdk-21}/lib/openjdk";
+    jcefPackage = jetbrains.jcef-21;
+  }

--- a/pkgs/development/compilers/jetbrains-jdk/common.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/common.nix
@@ -1,0 +1,236 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  jdk,
+  git,
+  autoconf,
+  unzip,
+  rsync,
+  shaderc,
+  vulkan-headers,
+  libxdamage,
+  libxxf86vm,
+  libxrandr,
+  libxi,
+  libxcursor,
+  libxrender,
+  libx11,
+  libxext,
+  libxkbcommon,
+  libxcb,
+  nss,
+  nspr,
+  libdrm,
+  libgbm,
+  wayland,
+  udev,
+  fontconfig,
+  debugBuild ? false,
+  withJcef ? true,
+}:
+
+{
+  javaVersion,
+  build,
+  sourceDateEpoch,
+  srcHash,
+  homePath,
+  jcefPackage ? null,
+  extraBuildPhase ? "",
+  vendorVersionString ? null,
+  extraConfigureFlags ? [ ],
+  extraNativeBuildInputs ? [ ],
+  extraBuildInputs ? [ ],
+}:
+
+assert debugBuild -> withJcef;
+
+let
+  arch =
+    {
+      "aarch64-linux" = "aarch64";
+      "x86_64-linux" = "x64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  cpu = stdenv.hostPlatform.parsed.cpu.name;
+  version = "${javaVersion}-b${build}";
+  openjdkTag = "jbr-release-${javaVersion}b${build}";
+in
+jdk.overrideAttrs (oldAttrs: {
+  pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
+  inherit
+    javaVersion
+    build
+    version
+    openjdkTag
+    ;
+
+  src = fetchFromGitHub {
+    owner = "JetBrains";
+    repo = "JetBrainsRuntime";
+    rev = "jb${version}";
+    hash = srcHash;
+  };
+
+  env = (oldAttrs.env or { }) // {
+    BOOT_JDK = jdk.home;
+    # run `git log -1 --pretty=%ct` in jdk repo for new value on update
+    SOURCE_DATE_EPOCH = sourceDateEpoch;
+  };
+
+  patches = [ ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    ${lib.optionalString withJcef "cp -r ${jcefPackage} jcef_linux_${arch}"}
+    ${extraBuildPhase}
+
+    sed \
+        -e "s/OPENJDK_TAG=.*/OPENJDK_TAG=${openjdkTag}/" \
+        -e "s/SOURCE_DATE_EPOCH=.*//" \
+        -e "s/export SOURCE_DATE_EPOCH//" \
+        -i jb/project/tools/common/scripts/common.sh
+
+    declare -a realConfigureFlags
+
+    for configureFlag in "''${configureFlags[@]}"; do
+      case "$configureFlag" in
+        --host=*)
+          # intentionally omit flag
+          ;;
+        ${lib.optionalString (vendorVersionString != null) ''
+          --with-vendor-version-string=*)
+            # Replace the flag from the JDK to include that it is JBR and the package version, so it passes the installation tests
+            realConfigureFlags+=('--with-vendor-version-string="${vendorVersionString}"')
+            ;;
+        ''}
+        *)
+          realConfigureFlags+=("$configureFlag")
+          ;;
+      esac
+    done
+
+    ${lib.concatMapStringsSep "\n" (flag: ''realConfigureFlags+=("${flag}")'') extraConfigureFlags}
+
+    echo "computed configure flags: ''${realConfigureFlags[*]}"
+    substituteInPlace jb/project/tools/linux/scripts/mkimages_${arch}.sh --replace-fail "STATIC_CONF_ARGS" "STATIC_CONF_ARGS ''${realConfigureFlags[*]}"
+
+    sed \
+        -e "s/create_image_bundle \"jb/#/" \
+        -e "s/echo Creating /exit 0 #/" \
+        -i jb/project/tools/linux/scripts/mkimages_${arch}.sh
+
+    patchShebangs .
+    ./jb/project/tools/linux/scripts/mkimages_${arch}.sh ${build} ${
+      if debugBuild then "fd" else (if withJcef then "jcef" else "nomod")
+    }
+
+    runHook postBuild
+  '';
+
+  installPhase =
+    let
+      buildType = if debugBuild then "fastdebug" else "release";
+      debugSuffix = if debugBuild then "-fastdebug" else "";
+      jcefSuffix = if debugBuild || !withJcef then "" else "_jcef";
+      jbrsdkDir = "jbrsdk${jcefSuffix}-${javaVersion}-linux-${arch}${debugSuffix}-b${build}";
+    in
+    ''
+      runHook preInstall
+
+      mv build/linux-${cpu}-server-${buildType}/images/jdk/man build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir}
+      rm -rf build/linux-${cpu}-server-${buildType}/images/jdk
+      mv build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir} build/linux-${cpu}-server-${buildType}/images/jdk
+    ''
+    + oldAttrs.installPhase
+    + "runHook postInstall";
+
+  postInstall = lib.optionalString withJcef ''
+    chmod +x $out/lib/openjdk/lib/chrome-sandbox
+  '';
+
+  dontStrip = debugBuild;
+
+  postFixup = ''
+    # Build the set of output library directories to rpath against
+    LIBDIRS="${
+      lib.makeLibraryPath [
+        libxdamage
+        libxxf86vm
+        libxrandr
+        libxi
+        libxcursor
+        libxrender
+        libx11
+        libxext
+        libxkbcommon
+        libxcb
+        nss
+        nspr
+        libdrm
+        libgbm
+        wayland
+        udev
+        fontconfig
+      ]
+    }"
+    for output in ${lib.concatStringsSep " " oldAttrs.outputs}; do
+      if [ "$output" = debug ]; then continue; fi
+      LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
+    done
+    # Add the local library paths to remove dependencies on the bootstrap
+    for output in ${lib.concatStringsSep " " oldAttrs.outputs}; do
+      if [ "$output" = debug ]; then continue; fi
+      OUTPUTDIR=$(eval echo \$$output)
+      BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
+      echo "$BINLIBS" | while read i; do
+        patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
+      done
+    done
+  '';
+
+  nativeBuildInputs = [
+    git
+    autoconf
+    unzip
+    rsync
+    shaderc # glslc
+  ]
+  ++ extraNativeBuildInputs
+  ++ oldAttrs.nativeBuildInputs;
+
+  buildInputs = [
+    vulkan-headers
+  ]
+  ++ extraBuildInputs
+  ++ oldAttrs.buildInputs or [ ];
+
+  meta = {
+    description = "OpenJDK fork to better support Jetbrains's products";
+    longDescription = ''
+      JetBrains Runtime is a runtime environment for running IntelliJ Platform
+      based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
+      based on OpenJDK project with some modifications. These modifications
+      include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
+      support, ligatures, some fixes for native crashes not presented in
+      official build, and other small enhancements.
+      JetBrains Runtime is not a certified build of OpenJDK. Please, use at
+      your own risk.
+    '';
+    homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
+    inherit (jdk.meta) license platforms mainProgram;
+    maintainers = with lib.maintainers; [
+      aoli-al
+    ];
+
+    broken = stdenv.hostPlatform.isDarwin;
+  };
+
+  passthru = oldAttrs.passthru // {
+    home = homePath;
+  };
+})

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -1,70 +1,16 @@
 {
-  lib,
-  stdenv,
+  callPackage,
   fetchurl,
-  fetchFromGitHub,
   jetbrains,
   jdk,
-  git,
-  autoconf,
-  unzip,
-  rsync,
   debugBuild ? false,
   withJcef ? true,
-
-  libxdamage,
-  libxxf86vm,
-  libxrandr,
-  libxi,
-  libxcursor,
-  libxrender,
-  libx11,
-  libxext,
-  libxkbcommon,
-  libxcb,
-  nss,
-  nspr,
-  libdrm,
-  libgbm,
-  wayland,
   wayland-scanner,
   wayland-protocols,
-  udev,
-  fontconfig,
-  shaderc,
-  vulkan-headers,
+  libxkbcommon,
 }:
 
-assert debugBuild -> withJcef;
-
 let
-  arch =
-    {
-      "aarch64-linux" = "aarch64";
-      "x86_64-linux" = "x64";
-    }
-    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
-  cpu = stdenv.hostPlatform.parsed.cpu.name;
-in
-jdk.overrideAttrs (oldAttrs: rec {
-  pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "25.0.2";
-  build = "329.72";
-  # To get the new tag:
-  # git clone https://github.com/jetbrains/jetbrainsruntime
-  # cd jetbrainsruntime
-  # git tag --points-at [revision]
-  # Look for the line that starts with jbr-
-  version = "${javaVersion}-b${build}";
-  openjdkTag = "jbr-release-${javaVersion}b${build}";
-
-  src = fetchFromGitHub {
-    owner = "JetBrains";
-    repo = "JetBrainsRuntime";
-    rev = "jb${version}";
-    hash = "sha256-K4Izbij+1YO4UERHS0mwGKZX/VtIaxyNPZD068Vf99Q=";
-  };
-
   gtk-protocols =
     let
       rev = "refs/tags/4.22.1";
@@ -75,162 +21,33 @@ jdk.overrideAttrs (oldAttrs: rec {
       url = "https://raw.githubusercontent.com/GNOME/gtk/${rev}/gdk/wayland/protocol/gtk-shell.xml";
       hash = hash;
     };
-
-  env = (oldAttrs.env or { }) // {
-    BOOT_JDK = jdk.home;
+in
+callPackage ./common.nix
+  {
+    inherit jdk debugBuild withJcef;
+  }
+  {
+    # To get the new tag:
+    # git clone https://github.com/jetbrains/jetbrainsruntime
+    # cd jetbrainsruntime
+    # git tag --points-at [revision]
+    # Look for the line that starts with jbr-
+    javaVersion = "25.0.2";
+    build = "329.72";
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    SOURCE_DATE_EPOCH = 1769205294;
-  };
-
-  patches = [ ];
-
-  dontConfigure = true;
-
-  buildPhase = ''
-    runHook preBuild
-
-    ${lib.optionalString withJcef "cp -r ${jetbrains.jcef} jcef_linux_${arch}"}
-    cp -r ${gtk-protocols.out} gtk-shell.xml
-
-    sed \
-        -e "s/OPENJDK_TAG=.*/OPENJDK_TAG=${openjdkTag}/" \
-        -e "s/SOURCE_DATE_EPOCH=.*//" \
-        -e "s/export SOURCE_DATE_EPOCH//" \
-        -i jb/project/tools/common/scripts/common.sh
-
-    declare -a realConfigureFlags
-
-    for configureFlag in "''${configureFlags[@]}"; do
-      case "$configureFlag" in
-        --host=*)
-          # intentionally omit flag
-          ;;
-        --with-vendor-version-string=*)
-          # Replace the flag from the JDK to include that it is JBR and the package version, so it passes the installation tests
-          realConfigureFlags+=('--with-vendor-version-string="nix/JBR-${version}${lib.optionalString withJcef "-jcef"}"')
-          ;;
-        *)
-          realConfigureFlags+=("$configureFlag")
-          ;;
-      esac
-    done
-    realConfigureFlags+=("--with-wayland-protocols=${wayland-protocols.out}/share/wayland-protocols")
-    echo "computed configure flags: ''${realConfigureFlags[*]}"
-
-    substituteInPlace jb/project/tools/linux/scripts/mkimages_${arch}.sh --replace-fail "STATIC_CONF_ARGS" "STATIC_CONF_ARGS ''${realConfigureFlags[*]}"
-
-    sed \
-        -e "s/create_image_bundle \"jb/#/" \
-        -e "s/echo Creating /exit 0 #/" \
-        -i jb/project/tools/linux/scripts/mkimages_${arch}.sh
-
-    patchShebangs .
-    ./jb/project/tools/linux/scripts/mkimages_${arch}.sh ${build} ${
-      if debugBuild then "fd" else (if withJcef then "jcef" else "nomod")
-    }
-
-    runHook postBuild
-  '';
-
-  installPhase =
-    let
-      buildType = if debugBuild then "fastdebug" else "release";
-      debugSuffix = if debugBuild then "-fastdebug" else "";
-      jcefSuffix = if debugBuild || !withJcef then "" else "_jcef";
-      jbrsdkDir = "jbrsdk${jcefSuffix}-${javaVersion}-linux-${arch}${debugSuffix}-b${build}";
-    in
-    ''
-      runHook preInstall
-
-      mv build/linux-${cpu}-server-${buildType}/images/jdk/man build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir}
-      rm -rf build/linux-${cpu}-server-${buildType}/images/jdk
-      mv build/linux-${cpu}-server-${buildType}/images/${jbrsdkDir} build/linux-${cpu}-server-${buildType}/images/jdk
-    ''
-    + oldAttrs.installPhase
-    + "runHook postInstall";
-
-  postInstall = lib.optionalString withJcef ''
-    chmod +x $out/lib/openjdk/lib/chrome-sandbox
-  '';
-
-  dontStrip = debugBuild;
-
-  postFixup = ''
-    # Build the set of output library directories to rpath against
-    LIBDIRS="${
-      lib.makeLibraryPath [
-        libxdamage
-        libxxf86vm
-        libxrandr
-        libxi
-        libxcursor
-        libxrender
-        libx11
-        libxext
-        libxkbcommon
-        libxcb
-        nss
-        nspr
-        libdrm
-        libgbm
-        wayland
-        udev
-        fontconfig
-      ]
-    }"
-    for output in ${lib.concatStringsSep " " oldAttrs.outputs}; do
-      if [ "$output" = debug ]; then continue; fi
-      LIBDIRS="$(find $(eval echo \$$output) -name \*.so\* -exec dirname {} \+ | sort -u | tr '\n' ':'):$LIBDIRS"
-    done
-    # Add the local library paths to remove dependencies on the bootstrap
-    for output in ${lib.concatStringsSep " " oldAttrs.outputs}; do
-      if [ "$output" = debug ]; then continue; fi
-      OUTPUTDIR=$(eval echo \$$output)
-      BINLIBS=$(find $OUTPUTDIR/bin/ -type f; find $OUTPUTDIR -name \*.so\*)
-      echo "$BINLIBS" | while read i; do
-        patchelf --set-rpath "$LIBDIRS:$(patchelf --print-rpath "$i")" "$i" || true
-      done
-    done
-  '';
-
-  nativeBuildInputs = [
-    git
-    autoconf
-    unzip
-    rsync
-    shaderc # glslc
-    wayland-scanner
-    libxkbcommon
-  ]
-  ++ oldAttrs.nativeBuildInputs;
-
-  buildInputs = [
-    vulkan-headers
-  ]
-  ++ oldAttrs.buildInputs or [ ];
-
-  meta = {
-    description = "OpenJDK fork to better support Jetbrains's products";
-    longDescription = ''
-      JetBrains Runtime is a runtime environment for running IntelliJ Platform
-      based products on Windows, Mac OS X, and Linux. JetBrains Runtime is
-      based on OpenJDK project with some modifications. These modifications
-      include: Subpixel Anti-Aliasing, enhanced font rendering on Linux, HiDPI
-      support, ligatures, some fixes for native crashes not presented in
-      official build, and other small enhancements.
-      JetBrains Runtime is not a certified build of OpenJDK. Please, use at
-      your own risk.
+    sourceDateEpoch = 1769205294;
+    srcHash = "sha256-K4Izbij+1YO4UERHS0mwGKZX/VtIaxyNPZD068Vf99Q=";
+    homePath = "${jetbrains.jdk}/lib/openjdk";
+    jcefPackage = jetbrains.jcef;
+    extraBuildPhase = ''
+      cp -r ${gtk-protocols.out} gtk-shell.xml
     '';
-    homepage = "https://confluence.jetbrains.com/display/JBR/JetBrains+Runtime";
-    inherit (jdk.meta) license platforms mainProgram;
-    maintainers = with lib.maintainers; [
-      aoli-al
+    vendorVersionString = "nix/JBR-25.0.2-b329.72${if withJcef then "-jcef" else ""}";
+    extraConfigureFlags = [
+      "--with-wayland-protocols=${wayland-protocols.out}/share/wayland-protocols"
     ];
-
-    broken = stdenv.hostPlatform.isDarwin;
-  };
-
-  passthru = oldAttrs.passthru // {
-    home = "${jetbrains.jdk}/lib/openjdk";
-  };
-})
+    extraNativeBuildInputs = [
+      wayland-scanner
+      libxkbcommon
+    ];
+  }

--- a/pkgs/development/compilers/jetbrains-jdk/default.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchurl,
   fetchFromGitHub,
   jetbrains,
   jdk,
@@ -26,6 +27,8 @@
   libdrm,
   libgbm,
   wayland,
+  wayland-scanner,
+  wayland-protocols,
   udev,
   fontconfig,
   shaderc,
@@ -45,27 +48,38 @@ let
 in
 jdk.overrideAttrs (oldAttrs: rec {
   pname = "jetbrains-jdk" + lib.optionalString withJcef "-jcef";
-  javaVersion = "21.0.9";
-  build = "1163.86";
+  javaVersion = "25.0.2";
+  build = "329.72";
   # To get the new tag:
   # git clone https://github.com/jetbrains/jetbrainsruntime
   # cd jetbrainsruntime
   # git tag --points-at [revision]
   # Look for the line that starts with jbr-
-  openjdkTag = "jbr-release-21.0.9b1163.86";
   version = "${javaVersion}-b${build}";
+  openjdkTag = "jbr-release-${javaVersion}b${build}";
 
   src = fetchFromGitHub {
     owner = "JetBrains";
     repo = "JetBrainsRuntime";
     rev = "jb${version}";
-    hash = "sha256-P2boCbGB66X8LB4sZHGFO8lqHbv6F4kqGVMGBd9yKu0=";
+    hash = "sha256-K4Izbij+1YO4UERHS0mwGKZX/VtIaxyNPZD068Vf99Q=";
   };
+
+  gtk-protocols =
+    let
+      rev = "refs/tags/4.22.1";
+      hash = "sha256-zCcXuiEYL2N4Q+WT96ouVDwdZVSohgU/QA2BkGlnZZ0=";
+    in
+    fetchurl {
+      # We only need the wayland protocols file
+      url = "https://raw.githubusercontent.com/GNOME/gtk/${rev}/gdk/wayland/protocol/gtk-shell.xml";
+      hash = hash;
+    };
 
   env = (oldAttrs.env or { }) // {
     BOOT_JDK = jdk.home;
     # run `git log -1 --pretty=%ct` in jdk repo for new value on update
-    SOURCE_DATE_EPOCH = 1765114563;
+    SOURCE_DATE_EPOCH = 1769205294;
   };
 
   patches = [ ];
@@ -76,25 +90,35 @@ jdk.overrideAttrs (oldAttrs: rec {
     runHook preBuild
 
     ${lib.optionalString withJcef "cp -r ${jetbrains.jcef} jcef_linux_${arch}"}
+    cp -r ${gtk-protocols.out} gtk-shell.xml
 
     sed \
         -e "s/OPENJDK_TAG=.*/OPENJDK_TAG=${openjdkTag}/" \
         -e "s/SOURCE_DATE_EPOCH=.*//" \
         -e "s/export SOURCE_DATE_EPOCH//" \
         -i jb/project/tools/common/scripts/common.sh
+
     declare -a realConfigureFlags
+
     for configureFlag in "''${configureFlags[@]}"; do
       case "$configureFlag" in
         --host=*)
           # intentionally omit flag
+          ;;
+        --with-vendor-version-string=*)
+          # Replace the flag from the JDK to include that it is JBR and the package version, so it passes the installation tests
+          realConfigureFlags+=('--with-vendor-version-string="nix/JBR-${version}${lib.optionalString withJcef "-jcef"}"')
           ;;
         *)
           realConfigureFlags+=("$configureFlag")
           ;;
       esac
     done
+    realConfigureFlags+=("--with-wayland-protocols=${wayland-protocols.out}/share/wayland-protocols")
     echo "computed configure flags: ''${realConfigureFlags[*]}"
+
     substituteInPlace jb/project/tools/linux/scripts/mkimages_${arch}.sh --replace-fail "STATIC_CONF_ARGS" "STATIC_CONF_ARGS ''${realConfigureFlags[*]}"
+
     sed \
         -e "s/create_image_bundle \"jb/#/" \
         -e "s/echo Creating /exit 0 #/" \
@@ -175,6 +199,8 @@ jdk.overrideAttrs (oldAttrs: rec {
     unzip
     rsync
     shaderc # glslc
+    wayland-scanner
+    libxkbcommon
   ]
   ++ oldAttrs.nativeBuildInputs;
 

--- a/pkgs/development/compilers/jetbrains-jdk/jcef.nix
+++ b/pkgs/development/compilers/jetbrains-jdk/jcef.nix
@@ -9,6 +9,7 @@
   jdk,
   git,
   rsync,
+  which,
   lib,
   ant,
   ninja,
@@ -91,11 +92,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "jcef-jetbrains";
-  rev = "6f9ab690b28a1262f82e6f869c310bdf1d0697ac";
+  rev = "a492f5c1bbe877d2f58d4b066d0a1c89ab579b84";
   # This is the commit number
-  # Currently from the branch: https://github.com/JetBrains/jcef/tree/251
+  # Currently from the branch: https://github.com/JetBrains/jcef/tree/261
   # Run `git rev-list --count HEAD`
-  version = "1086";
+  version = "1131";
 
   nativeBuildInputs = [
     cmake
@@ -103,12 +104,14 @@ stdenv.mkDerivation rec {
     jdk
     git
     rsync
+    which
     ant
     ninja
     strip-nondeterminism
     stripJavaArchivesHook
     autoPatchelfHook
   ];
+
   buildInputs = [
     boost
     libGL
@@ -123,7 +126,7 @@ stdenv.mkDerivation rec {
     owner = "jetbrains";
     repo = "jcef";
     inherit rev;
-    hash = "sha256-w5t1M66KW5cUbNTpAc4ksGd+414EJsXwbq1UP1COFsw=";
+    hash = "sha256-c1gJu6gogALx3viLi9saLvqOn+zS9jCpWizB2g1Xa/g=";
   };
 
   # Find the hash in tools/buildtools/linux64/clang-format.sha1
@@ -172,6 +175,13 @@ stdenv.mkDerivation rec {
 
   postBuild = ''
     export JCEF_ROOT_DIR=$(realpath ..)
+
+    # Apply https://github.com/JetBrains/jcef/pull/42
+    substituteInPlace ../build.xml \
+      --replace-fail \
+        '<matches pattern="17*.*" string="''${java.version}"/>' \
+        '<javaversion atLeast="17"/>'
+
     ../tools/compile.sh ${platform} Release
   '';
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9623,11 +9623,21 @@ with pkgs;
         jdk = jdk25;
         withJcef = false;
       };
+      jdk-no-jcef-21 = callPackage ../development/compilers/jetbrains-jdk/21.nix {
+        jdk = jdk21;
+        withJcef = false;
+      };
       jdk = callPackage ../development/compilers/jetbrains-jdk {
         jdk = jdk25;
       };
+      jdk-21 = callPackage ../development/compilers/jetbrains-jdk/21.nix {
+        jdk = jdk21;
+      };
       jcef = callPackage ../development/compilers/jetbrains-jdk/jcef.nix {
         jdk = jdk25;
+      };
+      jcef-21 = callPackage ../development/compilers/jetbrains-jdk/jcef.nix {
+        jdk = jdk21;
       };
     }
     // lib.optionalAttrs config.allowAliases {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9620,14 +9620,14 @@ with pkgs;
     )
     // {
       jdk-no-jcef = callPackage ../development/compilers/jetbrains-jdk {
-        jdk = jdk21;
+        jdk = jdk25;
         withJcef = false;
       };
       jdk = callPackage ../development/compilers/jetbrains-jdk {
-        jdk = jdk21;
+        jdk = jdk25;
       };
       jcef = callPackage ../development/compilers/jetbrains-jdk/jcef.nix {
-        jdk = jdk21;
+        jdk = jdk25;
       };
     }
     // lib.optionalAttrs config.allowAliases {


### PR DESCRIPTION
Updates the Jetbrains Runtime from Java 21 to  Java 25. The Jetbrains IDEs packages default to JBR as the JDK, updating the Jetbrains JDK to Java 25 allows the IDEs to have access to Java 25 by default. JBR is also often used for developing with DCEVM.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## Extra details
The ant wrapper was patched to not pass arguments with empty values to resolve issues caused by it

Jetbrains JCEF has been updated
A temporary patch has been applied to build.xml on Jetbrains JCEF post build to compile with Java 25

I currently don't have wayland setup on my machine and so wasn't able to test the JBR under it
If someone can test it under wayland it would be great