### PR TITLE
haskellPackages: fix eval cycle when doCheck is enabled for cross

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -2230,21 +2230,20 @@ builtins.intersectAttrs super {
 
   botan-bindings = super.botan-bindings.override { botan = pkgs.botan3; };
 
-  # Avoids a cycle by disabling use of the external interpreter for the packages that are dependencies of iserv-proxy.
-  # These in particular can't rely on template haskell for cross-compilation anyway as they can't rely on iserv-proxy.
-  inherit
-    (
-      let
-        noExternalInterpreter = overrideCabal {
-          enableExternalInterpreter = false;
-        };
-      in
-      lib.mapAttrs (_: noExternalInterpreter) { inherit (super) libiserv iserv-proxy network; }
-    )
-    libiserv
-    iserv-proxy
-    network
-    ;
+  iserv-proxy =
+    let
+      # Avoid a cycle by disabling tests and the external interpreter for packages that are dependencies of iserv-proxy.
+      # These in particular can't rely on template haskell for cross-compilation anyway as they can't rely on iserv-proxy.
+      # Also disable tests during iserv-proxy bootstrap since test packages tend to rely on TH for discovering test cases
+      breakExternalInterpreterBootstrapCycle = overrideCabal {
+        doCheck = false;
+        enableExternalInterpreter = false;
+      };
+      overlay = lib.mapAttrs (
+        _: pkg: if (pkg ? isHaskellLibrary) then breakExternalInterpreterBootstrapCycle pkg else pkg
+      );
+    in
+    super.iserv-proxy.overrideScope (_: overlay);
 
   # Workaround for flaky test: https://github.com/basvandijk/threads/issues/10
   threads = appendPatch ./patches/threads-flaky-test.patch super.threads;

--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -37,21 +37,4 @@ with haskellLib;
   # Root cause seems to be undefined references to libffi as shown by linking errors if we instead use "-Wl,--disable-auto-import"
   # See https://github.com/rust-lang/rust/issues/132226#issuecomment-2445100058
   iserv-proxy = appendConfigureFlag "--ghc-option=-optl=-Wl,--disable-runtime-pseudo-reloc" super.iserv-proxy;
-
-  # Avoids a cycle by disabling use of the external interpreter for the packages that are dependencies of iserv-proxy.
-  # See configuration-nix.nix, where iserv-proxy and network are handled.
-  # On Windows, network depends on temporary (see above), which depends on random, which depends on splitmix.
-  inherit
-    (
-      let
-        noExternalInterpreter = overrideCabal {
-          enableExternalInterpreter = false;
-        };
-      in
-      lib.mapAttrs (_: noExternalInterpreter) { inherit (super) random splitmix temporary; }
-    )
-    random
-    splitmix
-    temporary
-    ;
 })


### PR DESCRIPTION
`nix-build -E 'with (import ./. {}); haskell.lib.doCheck (pkgsStatic.haskellPackages.network)'` does currently pass eval, but that's because it doesn't affect the `network` inside the package set. When that one is modified, either via override, or by making
https://github.com/NixOS/nixpkgs/blob/5760a085ffd606c9827dae35c72014d0bee3e5fb/pkgs/development/haskell-modules/generic-builder.nix#L118
default to `true`, we end up with `error: infinite recursion encountered` due to `test-libs -> iserv-proxy -> network -> test-libs`

Tested with `nix-build -A pkgsStatic.haskellPackages.network` and manually changing `doCheck` inside the package set.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
