### PR TITLE
tigervnc: 1.15.0 -> 1.16.0, support building w0vncserver

### DIFF
--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -46,14 +46,14 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "1.15.0";
+  version = "1.16.0";
   pname = "tigervnc";
 
   src = fetchFromGitHub {
     owner = "TigerVNC";
     repo = "tigervnc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZuuvRJe/lAqULWObPxGHVJrDPCTK4IVSqX0K1rWOctw=";
+    hash = "sha256-aIQcFX4GQ0VniacjYherpUSgzM55Han9oMvbjMUYgfE=";
   };
 
   postPatch =

--- a/pkgs/by-name/ti/tigervnc/package.nix
+++ b/pkgs/by-name/ti/tigervnc/package.nix
@@ -43,6 +43,12 @@
   ffmpeg,
   autoconf,
   automake,
+  libuuid,
+  libxkbcommon,
+  pipewire,
+  wayland,
+  wayland-scanner,
+  waylandSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
       sed -i -e '/^\$cmd \.= " -pn";/a$cmd .= " -xkbdir ${xkeyboard_config}/etc/X11/xkb";' unix/vncserver/vncserver.in
       fontPath=
       substituteInPlace vncviewer/vncviewer.cxx \
-         --replace '"/usr/bin/ssh' '"${openssh}/bin/ssh'
+         --replace-fail '"/usr/bin/ssh' '"${openssh}/bin/ssh'
       source_top="$(pwd)"
     ''
     + ''
@@ -73,9 +79,12 @@ stdenv.mkDerivation (finalAttrs: {
   dontUseCmakeBuildDir = true;
 
   cmakeFlags = [
-    "-DCMAKE_INSTALL_PREFIX=${placeholder "out"}"
-    "-DCMAKE_INSTALL_SBINDIR=${placeholder "out"}/bin"
-    "-DCMAKE_INSTALL_LIBEXECDIR=${placeholder "out"}/bin"
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" (placeholder "out"))
+    (lib.cmakeFeature "CMAKE_INSTALL_SBINDIR" "${placeholder "out"}/bin")
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBEXECDIR" "${placeholder "out"}/bin")
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    (lib.cmakeBool "ENABLE_WAYLAND" waylandSupport)
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [
@@ -172,6 +181,12 @@ stdenv.mkDerivation (finalAttrs: {
       libxdamage
     ]
     ++ xorg-server.buildInputs
+    ++ lib.optionals waylandSupport [
+      libuuid
+      libxkbcommon
+      pipewire
+      wayland
+    ]
   );
 
   nativeBuildInputs = [
@@ -189,6 +204,9 @@ stdenv.mkDerivation (finalAttrs: {
       zlib
     ]
     ++ xorg-server.nativeBuildInputs
+    ++ lib.optionals waylandSupport [
+      wayland-scanner
+    ]
   );
 
   propagatedBuildInputs = lib.optional stdenv.hostPlatform.isLinux xorg-server.propagatedBuildInputs;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Preferably supersedes #483228

I have enabled building `w0vncserver` by default if the host platform is Linux but this can be disabled via override if desired.  `w0vncserver` is working for me in NixOS + GNOME 49.3 + Mutter using the PasswordFile option for auth and RealVNC Viewer as a client on Android and iOS but that is about the extent of my testing. I haven't tested any other desktop environments or Wayland compositors.

From the `w0vncserver` man page:
`w0vncserver` is a TigerVNC server which makes a Wayland compositor that is based on wlroots, or has the RemoteDesktop portal implemented,  remotely  accessible via VNC, TigerVNC or compatible viewers. It does not create a virtual display, instead, it shares an existing display (typically, hat one connected to the physical screen).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
