### PR TITLE
sdl3: add option for disabling vulkan and libusb dependencies

### DIFF
--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -50,13 +50,15 @@
   ibusSupport ? stdenv.hostPlatform.isUnix && !stdenv.hostPlatform.isDarwin,
   jackSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   libdecorSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
+  libudevSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
+  libusbSupport ? stdenv.hostPlatform.isLinux,
   openglSupport ? lib.meta.availableOn stdenv.hostPlatform libGL,
   pipewireSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   pulseaudioSupport ?
     config.pulseaudio or stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
-  libudevSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   sndioSupport ? false,
   traySupport ? true,
+  vulkanSupport ? true,
   waylandSupport ? stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isAndroid,
   x11Support ? !stdenv.hostPlatform.isAndroid && !stdenv.hostPlatform.isWindows,
 }:
@@ -97,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail '"zenity"' '"${lib.getExe zenity}"'
     ''
     # https://github.com/libsdl-org/SDL/issues/14805
-    + ''
+    + lib.optionalString vulkanSupport ''
       substituteInPlace src/video/x11/SDL_x11vulkan.c \
                         src/video/wayland/SDL_waylandvulkan.c \
                         src/video/offscreen/SDL_offscreenvulkan.c \
@@ -121,7 +123,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional waylandSupport wayland-scanner;
 
   buildInputs =
-    lib.optionals stdenv.hostPlatform.isLinux [
+    lib.optionals libusbSupport [
       libusb1
     ]
     ++ lib.optional (
@@ -155,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
       libXrandr
       libxtst
     ]
-    ++ [
+    ++ lib.optionals vulkanSupport [
       vulkan-headers
       vulkan-loader
     ]
@@ -196,7 +198,11 @@ stdenv.mkDerivation (finalAttrs: {
       && !(stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isAndroid)
       && !(x11Support || waylandSupport)
     ))
-  ];
+  ]
+  ++ lib.optional (libusbSupport != stdenv.hostPlatform.isLinux) (
+    lib.cmakeBool "SDL_HIDAPI_LIBUSB" libusbSupport
+  )
+  ++ lib.optional (!vulkanSupport) (lib.cmakeBool "SDL_VULKAN" vulkanSupport);
 
   doCheck = true;
 


### PR DESCRIPTION
After making my comment on #485637, I took a closer look at the SDL3 package, and noticed there were two dependencies that didn't have a "supported" option to disable their inclusion. This adds the options `vulkanSupport` and `libusbSupport`, which allows for disabling their inclusion using `pkgs.sdl3.override`. This should not change the default behavior of the package in any meaningful way, and is just to support creating smaller builds for cases where these dependencies are not necessary (eg. skipping Vulkan support for console builds).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
