### PR TITLE
fuzzel: 1.13.1 -> 1.14.0

### DIFF
--- a/pkgs/by-name/fu/fuzzel/package.nix
+++ b/pkgs/by-name/fu/fuzzel/package.nix
@@ -16,9 +16,10 @@
   enableCairo ? true,
   pngSupport ? true,
   svgSupport ? true,
-  svgBackend ? "nanosvg", # alternative: "librsvg"
+  svgBackend ? "resvg", # alternative: "librsvg", "nanosvg"
   # Optional dependencies
   cairo,
+  resvg,
   libpng,
   librsvg,
 }:
@@ -27,13 +28,13 @@ assert (svgSupport && svgBackend == "nanosvg") -> enableCairo;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fuzzel";
-  version = "1.13.1";
+  version = "1.14.0";
 
   src = fetchFromCodeberg {
     owner = "dnkl";
     repo = "fuzzel";
     rev = finalAttrs.version;
-    hash = "sha256-JW6MvLXax7taJfBjJjRkEKCczzO4AYsQ47akJK2pkh0=";
+    hash = "sha256-9O6CABh149ZtNu3sEhuycsM7pinVrBzU+rLxCAbxobs=";
   };
 
   depsBuildBuild = [
@@ -58,7 +59,8 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional enableCairo cairo
   ++ lib.optional pngSupport libpng
-  ++ lib.optional (svgSupport && svgBackend == "librsvg") librsvg;
+  ++ lib.optional (svgSupport && svgBackend == "librsvg") librsvg
+  ++ lib.optional (svgSupport && svgBackend == "resvg") resvg;
 
   mesonBuildType = "release";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Supersedes https://github.com/NixOS/nixpkgs/pull/484922

Enable `resvg` backend and make it the default, per upstream recommendation.
See https://codeberg.org/dnkl/fuzzel/releases/tag/1.14.0.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
