### PR TITLE
parallel-launcher.parallel-n64-core: 2.27.1 -> 2.28.0, fix build with GCC 15

### DIFF
--- a/pkgs/by-name/pa/parallel-launcher/parallel-n64-next.nix
+++ b/pkgs/by-name/pa/parallel-launcher/parallel-n64-next.nix
@@ -15,13 +15,13 @@ in
 # Based on the libretro parallel-n64 derivation with slight tweaks
 libretro.mkLibretroCore (finalAttrs: {
   core = "parallel-n64-next";
-  version = "2.27.1";
+  version = "2.28.0";
 
   src = fetchFromGitLab {
     owner = "parallel-launcher";
     repo = "parallel-n64";
     tag = reformatVersion finalAttrs.version;
-    hash = "sha256-u4F6CbC1NEU3OWtcqMIi/teX+SS4Jq9v5M2qc9z5bXg=";
+    hash = "sha256-o5zF100TzAO7XQXau4rglr1rO+roJao43SSFhYPCPO0=";
   };
 
   extraNativeBuildInputs = [
@@ -44,6 +44,10 @@ libretro.mkLibretroCore (finalAttrs: {
     "SYSTEM_ZLIB=1"
     "ARCH=${stdenv.hostPlatform.parsed.cpu.name}"
   ];
+
+  # Fix build with GCC 15
+  # Upstream issue: https://gitlab.com/parallel-launcher/parallel-n64/-/issues/18
+  env.NIX_CFLAGS_COMPILE = "-std=gnu17";
 
   postPatch = lib.optionalString stdenv.hostPlatform.isAarch64 ''
     sed -i -e '1 i\CPUFLAGS += -DARM_FIX -DNO_ASM -DARM_ASM -DDONT_WANT_ARM_OPTIMIZATIONS -DARM64' Makefile \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I get the feeling that upstream (understandably) doesn't care too much about the GCC 15 compilation issue (see #475479) considering their officially supported way to compile the project is via an Ubuntu 20.04 Docker container. Setting `-std=gnu17` seems easiest to maintain in the meantime rather than vendoring a patch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
