### PR TITLE
mdbook-pandoc: 0.10.5 -> 0.11.0

### DIFF
--- a/pkgs/by-name/md/mdbook-pandoc/package.nix
+++ b/pkgs/by-name/md/mdbook-pandoc/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "mdbook-pandoc";
-  version = "0.10.5";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "max-heller";
     repo = "mdbook-pandoc";
     tag = "v${version}";
-    hash = "sha256-ihKju9XXJy4JciuMLw4EcKhqSQjrBiUJDG0Rd5DbFdk=";
+    hash = "sha256-lLuw6CZPWHZ8DZz/lWTd+eEv688HcbkvsxLRvW38RKs=";
   };
 
-  cargoHash = "sha256-SXXzGOBvfyLYhed5EMFUCzkFWoGEMM73PD3uWjkUcic=";
+  cargoHash = "sha256-TMFnF/aTJ2UrtnPZ4UOQke6dtUZbUxywf4JIX53mhKY=";
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -29,21 +29,6 @@ rustPlatform.buildRustPackage rec {
     # some tests require pdflatex
     texliveSmall
   ];
-
-  checkFlags =
-    let
-      skippedTests = [
-        # failing subtly
-        "tests::html::rust_reference_regression_nested_elements"
-        "tests::css::css"
-        "tests::definition_lists::dt_attributes"
-        "tests::html::attach_id_to_div_of_stripped_html_elements"
-        "tests::html::link_to_element_by_id"
-        "tests::images::images"
-      ]
-      ++ lib.optional stdenv.buildPlatform.isDarwin "pandoc::tests::five_item_deep_list";
-    in
-    builtins.map (x: "--skip=" + x) skippedTests;
 
   passthru = {
     wrapper = callPackage ./wrapper.nix { };


### PR DESCRIPTION
Upgrades to mdbook v0.5. https://github.com/max-heller/mdbook-pandoc/releases/tag/v0.11.0

Also, tests seem to be passing, so they are reenabled.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test