### PR TITLE
typst-ansi-hl: init at 0.4.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1713,6 +1713,18 @@
     githubId = 587021;
     name = "André V L Matos";
   };
+  andrew15-5 = {
+    name = "Andrew Voynov";
+    github = "Andrew15-5";
+    githubId = 37143421;
+    email = "andrewvoynov.b@gmail.com";
+    matrix = "@andrew15_5:matrix.org";
+    keys = [
+      {
+        fingerprint = "CB7B 1F73 C2AC 56C4 D4D2  D690 1BE9 2DD6 8570 0329";
+      }
+    ];
+  };
   andrewbastin = {
     email = "andrewbastin.k@gmail.com";
     github = "AndrewBastin";

--- a/pkgs/by-name/ty/typst-ansi-hl/package.nix
+++ b/pkgs/by-name/ty/typst-ansi-hl/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "typst-ansi-hl";
+  version = "0.4.0";
+
+  src = fetchFromGitHub {
+    owner = "frozolotl";
+    repo = "typst-ansi-hl";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-WiWGZ/rndbW2jcP/rNikRVqY/+R4ScZc084RFDU0OCk=";
+  };
+
+  cargoHash = "sha256-LUUu97gxT1oy8Dr/3KgxErvy2YunlHaRta0o5YTysqM=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/frozolotl/typst-ansi-hl/releases/tag/v${finalAttrs.version}";
+    description = "Highlights your Typst code using ANSI escape sequences";
+    homepage = "https://github.com/frozolotl/typst-ansi-hl";
+    license = lib.licenses.eupl12;
+    mainProgram = "typst-ansi-hl";
+    maintainers = with lib.maintainers; [ andrew15-5 ];
+    platforms = lib.platforms.all; # Should work on most platforms.
+  };
+})


### PR DESCRIPTION
https://github.com/frozolotl/typst-ansi-hl

Useful tool to highlight Typst code in Discord code blocks and in terminal.

I and some others constantly use it in Discord. Through a shell alias or a global shortcut that involves clipboard (for seamless experience).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
