### PR TITLE
python3Packages.moviepy: remove unnecessary dependencies

### DIFF
--- a/pkgs/development/python-modules/moviepy/default.nix
+++ b/pkgs/development/python-modules/moviepy/default.nix
@@ -17,13 +17,6 @@
   requests,
   tqdm,
 
-  # optional-dependencies
-  matplotlib,
-  scikit-image,
-  scikit-learn,
-  scipy,
-  yt-dlp,
-
   # tests
   pytest-timeout,
   pytestCheckHook,
@@ -56,21 +49,10 @@ buildPythonPackage rec {
     tqdm
   ];
 
-  optional-dependencies = {
-    optionals = [
-      matplotlib
-      scikit-image
-      scikit-learn
-      scipy
-      yt-dlp
-    ];
-  };
-
   nativeCheckInputs = [
     pytest-timeout
     pytestCheckHook
-  ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ];
 
   # See https://github.com/NixOS/nixpkgs/issues/381908 and https://github.com/NixOS/nixpkgs/issues/385450.
   pytestFlags = [ "--timeout=600" ];


### PR DESCRIPTION
According to the [2.x migration guide](https://zulko.github.io/moviepy/getting_started/updating_to_v2.html#dropping-many-external-dependencies-and-unifying-environment), a lot of external dependencies were dropped and are no longer used. I also searched the codebase for these deps and didn't find any meaningful usage.

These don't end up as runtime dependencies, but they unnecessarily increase the rebuild count of packages like `yt-dlp` (this is how I found the issue)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
