### PR TITLE
python3Packages.skytemple-rust: cleanup, fix for python>=3.14

### DIFF
--- a/pkgs/by-name/ar/armips/package.nix
+++ b/pkgs/by-name/ar/armips/package.nix
@@ -5,21 +5,27 @@
   cmake,
 }:
 
-clangStdenv.mkDerivation rec {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "armips";
   version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "Kingcom";
     repo = "armips";
-    rev = "v${version}";
-    sha256 = "sha256-L+Uxww/WtvDJn1xZqoqA6Pkzq/98sy1qTxZbv6eEjbA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-L+Uxww/WtvDJn1xZqoqA6Pkzq/98sy1qTxZbv6eEjbA=";
   };
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail c++11 c++17 \
-      --replace-fail "cmake_minimum_required(VERSION 2.8)" "cmake_minimum_required(VERSION 3.13)" # done by https://github.com/Kingcom/armips/commit/e1ed5bf0f4565250b98b0ddfb9112f15dc8e8e3b upstream, patch not directly compatible
+      --replace-fail c++11 c++17
+  ''
+  # done by https://github.com/Kingcom/armips/commit/e1ed5bf0f4565250b98b0ddfb9112f15dc8e8e3b upstream, patch not directly compatible
+  + ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        "cmake_minimum_required(VERSION 2.8)" \
+        "cmake_minimum_required(VERSION 3.13)"
   '';
 
   nativeBuildInputs = [ cmake ];
@@ -48,4 +54,4 @@ clangStdenv.mkDerivation rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ marius851000 ];
   };
-}
+})

--- a/pkgs/by-name/ar/armips/package.nix
+++ b/pkgs/by-name/ar/armips/package.nix
@@ -28,6 +28,10 @@ clangStdenv.mkDerivation (finalAttrs: {
         "cmake_minimum_required(VERSION 3.13)"
   '';
 
+  # Fix GCC 15 compatibility
+  # error: unknown type name 'uint32_t'
+  env.CXXFLAGS = "-include cstdint";
+
   nativeBuildInputs = [ cmake ];
 
   installPhase = ''

--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -32,7 +32,14 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-9OgUuuMuo2l4YsZMhBZJBqKqbNwj1W4yidoogjcNgm8=";
   };
 
-  env.GETTEXT_SYSTEM = true;
+  env = {
+    GETTEXT_SYSTEM = true;
+
+    # Python 3.14 compatibility
+    # error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported
+    # version (3.13)
+    PYO3_USE_ABI3_FORWARD_COMPATIBILITY = 1;
+  };
 
   build-system = [
     setuptools-rust

--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -1,17 +1,21 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
-  cargo,
   fetchFromGitHub,
-  libiconv,
+
+  # build-system
+  setuptools-rust,
+
+  # nativeBuildInputs
+  cargo,
   rustPlatform,
   rustc,
-  setuptools-rust,
+
+  # dependencies
   range-typed-integers,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "skytemple-rust";
   version = "1.8.5";
   pyproject = true;
@@ -19,35 +23,38 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = "skytemple-rust";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-yJ78P00h4SITVuDnIh5IIlWkoed/VtIw3NB8ETB95bk=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-9OgUuuMuo2l4YsZMhBZJBqKqbNwj1W4yidoogjcNgm8=";
   };
 
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    libiconv
-  ];
-  nativeBuildInputs = [
+  env.GETTEXT_SYSTEM = true;
+
+  build-system = [
     setuptools-rust
-    rustPlatform.cargoSetupHook
+  ];
+
+  nativeBuildInputs = [
     cargo
+    rustPlatform.cargoSetupHook
     rustc
   ];
-  propagatedBuildInputs = [ range-typed-integers ];
 
-  GETTEXT_SYSTEM = true;
+  dependencies = [
+    range-typed-integers
+  ];
 
   doCheck = false; # tests for this package are in skytemple-files package
   pythonImportsCheck = [ "skytemple_rust" ];
 
   meta = {
-    homepage = "https://github.com/SkyTemple/skytemple-rust";
     description = "Binary Rust extensions for SkyTemple";
+    homepage = "https://github.com/SkyTemple/skytemple-rust";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ marius851000 ];
   };
-}
+})

--- a/pkgs/development/python-modules/skytemple-ssb-emulator/default.nix
+++ b/pkgs/development/python-modules/skytemple-ssb-emulator/default.nix
@@ -44,6 +44,13 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-MSPqQmC70pq+sEM8zJrrFiz32dorOJxr2G/y2H4EUQI=";
   };
 
+  env = {
+    # Python 3.14 compatibility
+    # error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported
+    # version (3.13)
+    PYO3_USE_ABI3_FORWARD_COMPATIBILITY = 1;
+  };
+
   build-system = [
     meson
     setuptools

--- a/pkgs/development/python-modules/skytemple-ssb-emulator/default.nix
+++ b/pkgs/development/python-modules/skytemple-ssb-emulator/default.nix
@@ -27,7 +27,7 @@
   # dependencies
   range-typed-integers,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "skytemple-ssb-emulator";
   version = "1.8.2";
   pyproject = true;
@@ -35,12 +35,12 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "SkyTemple";
     repo = "skytemple-ssb-emulator";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-zmLEvE96gkElTggcRG9fZDrJPLOXeNuSk49zXQAB69Y=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src pname;
+    inherit (finalAttrs) src pname version;
     hash = "sha256-MSPqQmC70pq+sEM8zJrrFiz32dorOJxr2G/y2H4EUQI=";
   };
 
@@ -81,4 +81,4 @@ buildPythonPackage rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ marius851000 ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.skytemple-rust: cleanup**
- **python3Packages.skytemple-rust: fix for python>=3.14**
  Tracking: https://github.com/NixOS/nixpkgs/issues/475732
- **armips: cleanup**
- **armips: fix build (GCC 15 compatibility)**
  Tacking: https://github.com/NixOS/nixpkgs/issues/475479
- **python3Packages.skytemple-ssb-emulator: use finalAttrs**
- **python3Packages.skytemple-ssb-emulator: fix for python>=3.14**
  Tracking: https://github.com/NixOS/nixpkgs/issues/475732

cc @marius851000

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
