### PR TITLE
abfahrt: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15141,6 +15141,11 @@
     github = "ljxfstorm";
     githubId = 7077478;
   };
+  lks = {
+    name = "Lukas";
+    github = "1H0";
+    githubId = 37246258;
+  };
   llakala = {
     email = "elevenaka11@gmail.com";
     github = "llakala";

--- a/pkgs/by-name/ab/abfahrt/package.nix
+++ b/pkgs/by-name/ab/abfahrt/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchgit,
+}:
+
+buildGoModule rec {
+  pname = "abfahrt";
+  version = "0.2.0";
+
+  src = fetchgit {
+    url = "https://codeberg.org/1H0/abfahrt";
+    rev = "v${version}";
+    hash = "sha256-l3sKPVJtDXJjE4Ynfzt2e2WoYL3pl2Mrr6WyVsTlTJs=";
+  };
+
+  vendorHash = null;
+  ldflags = [
+    "-X 'main.version=${version}'"
+  ];
+
+  env.CGO_ENABLED = 0;
+
+  meta = {
+    description = "A simple command line timetable for swiss public transport";
+    homepage = "https://codeberg.org/1H0/abfahrt";
+    license = lib.licenses.mit;
+    mainProgram = "abfahrt";
+    maintainers = with lib.maintainers; [ lks ];
+  };
+}


### PR DESCRIPTION
Add [abfahrt](https://codeberg.org/1H0/abfahrt/), a command line timetable for Swiss public transport.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
