### PR TITLE
tsm-client: set pname and version

### DIFF
--- a/pkgs/by-name/ts/tsm-client/package.nix
+++ b/pkgs/by-name/ts/tsm-client/package.nix
@@ -90,7 +90,7 @@ let
     }/client/v${major}r${minor}/Linux/LinuxX86/BA/v${major}${minor}${patch}/${version}-TIV-TSMBAC-LinuxX86.tar";
 
   unwrapped = stdenv.mkDerivation (finalAttrs: {
-    name = "tsm-client-${finalAttrs.version}-unwrapped";
+    pname = "tsm-client-unwrapped";
     version = "8.1.27.1";
     src = fetchurl {
       url = mkSrcUrl finalAttrs.version;
@@ -152,7 +152,8 @@ let
 in
 
 buildEnv {
-  name = "tsm-client-${unwrapped.version}";
+  pname = "tsm-client";
+  inherit (unwrapped) version;
   meta =
     meta
     // lib.attrsets.optionalAttrs enableGui {


### PR DESCRIPTION
Equip `tsm-client{,-withGui}` with a proper `pname` and `version`, cf. https://github.com/NixOS/nixpkgs/issues/485742 .

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `05f9af0856ce96edc1e2910cf4abf18b81165331`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 2 packages built:</summary>
  <ul>
    <li>tsm-client</li>
    <li>tsm-client-withGui</li>
  </ul>
</details>