### PR TITLE
python3Packages.polyfactory: cleanup, skip failing tests on python>=3.14

### DIFF
--- a/pkgs/development/python-modules/fnllm/default.nix
+++ b/pkgs/development/python-modules/fnllm/default.nix
@@ -1,34 +1,41 @@
 {
   lib,
-  aiolimiter,
-  azure-identity,
-  azure-storage-blob,
   buildPythonPackage,
   fetchPypi,
+
+  # build-system
   hatchling,
+  uv-dynamic-versioning,
+
+  # dependencies
+  aiolimiter,
   httpx,
   json-repair,
-  openai,
-  polyfactory,
   pydantic,
+  tenacity,
+
+  # optional-dependencies
+  # azure
+  azure-identity,
+  azure-storage-blob,
+  # openai
+  openai,
+  tiktoken,
+
+  # tests
+  polyfactory,
   pytest-asyncio,
   pytest-cov-stub,
   pytestCheckHook,
-  pythonOlder,
-  tenacity,
-  tiktoken,
-  uv-dynamic-versioning,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "fnllm";
   version = "0.4.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.11";
-
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-gKdFBpNpG/CDLhKi1wQgZHv+o1pDy5HEqcteLzkXK1A=";
   };
 
@@ -62,7 +69,7 @@ buildPythonPackage rec {
     pytest-cov-stub
     pytestCheckHook
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   pythonImportsCheck = [ "fnllm" ];
 
@@ -89,4 +96,4 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/fnllm/default.nix
+++ b/pkgs/development/python-modules/fnllm/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  pythonAtLeast,
 
   # build-system
   hatchling,
@@ -88,6 +89,10 @@ buildPythonPackage (finalAttrs: {
     "test_clear"
     "test_handles_common_errors"
     "test_children"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # RuntimeError: There is no current event loop in thread 'MainThread'
+    "test_call_batch_raises_if_response_length_mismatch"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/litestar/default.nix
+++ b/pkgs/development/python-modules/litestar/default.nix
@@ -31,7 +31,6 @@
   prometheus-client,
   psutil,
   opentelemetry-instrumentation-asgi,
-  psycopg,
   pydantic-extra-types,
   pydantic,
   email-validator,
@@ -47,6 +46,7 @@
   # valkey,
 
   # tests
+  addBinToPathHook,
   httpx-sse,
   pytest-asyncio,
   pytest-lazy-fixtures,
@@ -59,7 +59,7 @@
   versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "litestar";
   version = "2.18.0";
   pyproject = true;
@@ -67,7 +67,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "litestar-org";
     repo = "litestar";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-bqj7tvCNeMEEJKDF3g2beKfd0urbNszrbLdF96JygYk=";
   };
 
@@ -127,6 +127,7 @@ buildPythonPackage rec {
   };
 
   nativeCheckInputs = [
+    addBinToPathHook
     httpx-sse
     pytest-asyncio
     pytest-lazy-fixtures
@@ -144,10 +145,6 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  preCheck = ''
-    export PATH=$out/bin:$PATH
-  '';
-
   enabledTestPaths = [
     # Follow GitHub CI
     "docs/examples/"
@@ -161,10 +158,10 @@ buildPythonPackage rec {
   meta = {
     description = "Production-ready, Light, Flexible and Extensible ASGI API framework";
     homepage = "https://litestar.dev/";
-    changelog = "https://github.com/litestar-org/litestar/releases/tag/${src.tag}";
+    changelog = "https://github.com/litestar-org/litestar/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     mainProgram = "litestar";
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/development/python-modules/litestar/default.nix
+++ b/pkgs/development/python-modules/litestar/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   hatchling,
@@ -148,6 +149,11 @@ buildPythonPackage (finalAttrs: {
   enabledTestPaths = [
     # Follow GitHub CI
     "docs/examples/"
+  ];
+
+  pytestFlags = lib.optionals (pythonAtLeast "3.14") [
+    # UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
+    "-Wignore::UserWarning"
   ];
 
   disabledTests = [

--- a/pkgs/development/python-modules/polyfactory/default.nix
+++ b/pkgs/development/python-modules/polyfactory/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   hatchling,
@@ -58,11 +59,31 @@ buildPythonPackage (finalAttrs: {
     "tests/test_beanie_factory.py"
   ];
 
+  enabledTestPaths = [
+    "tests/test_msgspec_factory.py"
+  ];
+
   disabledTests = [
     # Unsupported type: LiteralAlias
     "test_type_alias"
     # Unsupported type: 'JsonValue' on field '' from class RecursiveTypeModelFactory.
     "test_recursive_type_annotation"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # AttributeError: 'Foo' object has no attribute 'set_field'
+    "test_other_basic_types"
+
+    # KeyError: 'foo_field'
+    "test_with_nested_struct"
+
+    # AttributeError: 'Foo' object has no attribute 'unset'
+    "test_msgspec_types"
+
+    # Failed: DID NOT RAISE <class 'polyfactory.exceptions.ParameterException'>
+    "test_datetime_constraints"
+
+    # assert <msgspec._core.Field object at 0x7ffff34794c0> == 10
+    "test_use_default_with_callable_default"
   ];
 
   pythonImportsCheck = [ "polyfactory" ];

--- a/pkgs/development/python-modules/polyfactory/default.nix
+++ b/pkgs/development/python-modules/polyfactory/default.nix
@@ -1,22 +1,28 @@
 {
-  buildPythonPackage,
   lib,
+  buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
-  hypothesis,
-  faker,
-  msgspec,
-  sqlalchemy,
+
+  # dependencies
   aiosqlite,
-  typing-extensions,
-  pymongo,
-  pytest-asyncio,
-  pydantic,
-  pytestCheckHook,
   email-validator,
+  faker,
+  hypothesis,
+  msgspec,
+  pydantic,
+  pymongo,
+  sqlalchemy,
+  typing-extensions,
+
+  # tests
+  pytest-asyncio,
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "polyfactory";
   version = "3.2.0";
   pyproject = true;
@@ -24,22 +30,22 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "litestar-org";
     repo = "polyfactory";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-J/CHf85jomybMp2U9l5kbD5q0MtYlY9hZkjxjS2jXvg=";
   };
 
   build-system = [ hatchling ];
 
   dependencies = [
-    faker
-    typing-extensions
-    hypothesis
-    pydantic
-    sqlalchemy
-    msgspec
-    pymongo
     aiosqlite
     email-validator
+    faker
+    hypothesis
+    msgspec
+    pydantic
+    pymongo
+    sqlalchemy
+    typing-extensions
   ];
 
   nativeCheckInputs = [
@@ -48,6 +54,7 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [
+    # Requires unpackaged 'beanie'
     "tests/test_beanie_factory.py"
   ];
 
@@ -64,8 +71,8 @@ buildPythonPackage rec {
     homepage = "https://polyfactory.litestar.dev/";
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
-    changelog = "https://github.com/litestar-org/polyfactory/releases/tag/${src.tag}";
+    changelog = "https://github.com/litestar-org/polyfactory/releases/tag/${finalAttrs.src.tag}";
     description = "Simple and powerful factories for mock data generation";
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.polyfactory: cleanup**
- **python3Packages.polyfactory: skip failing tests on python>=3.14**
- **python3Packages.fnllm: cleanup**
- **python3Packages.fnllm: skip failing test on python>=3.14**
- **python3Packages.litestar: use finalAttrs**
- **python3Packages.litestar: ignore warning in pytest for python>=3.14**

Tracking: https://github.com/NixOS/nixpkgs/issues/475732

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
