### PR TITLE
breakrs: init at 0.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10771,6 +10771,12 @@
     githubId = 43995067;
     name = "Songlin Jiang";
   };
+  hollymlem = {
+    email = "oliviafloof@disroot.org";
+    github = "hollymlem";
+    githubId = 35699052;
+    name = "holly";
+  };
   holymonson = {
     email = "holymonson@gmail.com";
     github = "holymonson";

--- a/pkgs/by-name/br/breakrs/package.nix
+++ b/pkgs/by-name/br/breakrs/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "breakrs";
+  version = "0.2.1";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-SvE3EMboc1ifLsXcMTltliULaiJwiO5IgQDthhJSWYU=";
+  };
+
+  cargoHash = "sha256-AFv+9Xb/18/wbIp5QcutBkP57mn3/Pdk9rlFkGk8EZc=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple, ergonomic cli to generate timed notifications";
+    homepage = "https://github.com/sqrew/breakrs";
+    changelog = "https://github.com/sqrew/breakrs/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.hollymlem ];
+    mainProgram = "breakrs";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/sqrew/breakrs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
