### PR TITLE
ueransim: backport `gcc-15` fix

### DIFF
--- a/pkgs/by-name/ue/ueransim/package.nix
+++ b/pkgs/by-name/ue/ueransim/package.nix
@@ -4,6 +4,7 @@
   cmake,
   pkg-config,
   fetchFromGitHub,
+  fetchpatch,
   lksctp-tools,
   iproute2,
   unstableGitUpdater,
@@ -19,6 +20,16 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "528061fe10389876da58d3bd15e8cba6d7c152a9";
     hash = "sha256-8OxJzEcpFT6e/nQw1VK9kBdw9ulXedCpUEaBxIAN9cA=";
   };
+
+  patches = [
+    # Fix gcc-15 build failure:
+    #   https://github.com/aligungr/UERANSIM/pull/777
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://github.com/aligungr/UERANSIM/commit/8ffce535a11b63f688552c5c81f7d3ac793f47de.patch";
+      hash = "sha256-w2T7PTR/ELNf9sre/GoHqZQb9A8k54cTKoce/RZ7XCU=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Without the change the build fails on `master` as
https://hydra.nixos.org/build/320137255:

    /build/source/src/ext/yaml-cpp/emitterutils.cpp:221:11: error: 'uint16_t' was not declared in this scope
      221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {
          |           ^~~~~~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
