### PR TITLE
spotatui: init at 0.36.2

### DIFF
--- a/pkgs/by-name/sp/spotatui/package.nix
+++ b/pkgs/by-name/sp/spotatui/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  alsa-lib,
+  openssl,
+  pipewire,
+
+  withPipewireVisualizer ? true,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "spotatui";
+  version = "0.36.2";
+
+  src = fetchFromGitHub {
+    owner = "LargeModGames";
+    repo = "spotatui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-E8VIMQUGKWAauN/GTGMOdvHsghhO4E0wVdE9lIk6zEc=";
+  };
+
+  cargoHash = "sha256-nHOLOlAZfp2k0nMAywTJT+TiTkUeybRVu+PkADBY22w=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optional withPipewireVisualizer rustPlatform.bindgenHook;
+
+  buildInputs = [
+    alsa-lib
+    openssl
+  ]
+  ++ lib.optional withPipewireVisualizer pipewire;
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [
+    "discord-rpc"
+    "mpris"
+    "streaming"
+    "telemetry"
+  ]
+  ++ lib.optional withPipewireVisualizer "audio-viz";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fully standalone Spotify client for the terminal";
+    homepage = "https://github.com/LargeModGames/spotatui";
+    changelog = "https://github.com/LargeModGames/spotatui/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.lordmzte ];
+    mainProgram = "spotatui";
+
+    # macOS is supported by upstream, but the package maintainer has no way to test this.
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
https://github.com/LargeModGames/spotatui
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
