### PR TITLE
[Backport release-25.11] dcv: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8510,6 +8510,11 @@
     github = "felixdorn";
     githubId = 55788595;
   };
+  FelixLusseau = {
+    name = "Félix Lusseau";
+    github = "FelixLusseau";
+    githubId = 94113911;
+  };
   felixscheinost = {
     name = "Felix Scheinost";
     email = "felix.scheinost@posteo.de";

--- a/pkgs/by-name/dc/dcv/package.nix
+++ b/pkgs/by-name/dc/dcv/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "dcv";
+  version = "v0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "tokuhirom";
+    repo = "dcv";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-OwfGZq+ce6RNb5dhNHsQ15iMPoEp7QlaYIUVYIiVqmI=";
+  };
+
+  vendorHash = "sha256-xwTPb+eGsisYB9Jy7rG9tQlIbnKWTbAdXqJBsjB0YK0=";
+
+  # Don't use the vendored dependencies as they are out of sync with go.mod
+  # Instead, let Go download dependencies through the module proxy
+  proxyVendor = true;
+
+  # Build helper binaries for all architectures before the main build
+  # These helpers are embedded in the binary and used for container filesystem operations
+  preBuild = ''
+    make build-helpers
+  '';
+
+  # Strip debug symbols and DWARF tables to reduce binary size
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "TUI (Terminal User Interface) tool for monitoring Docker containers and Docker Compose applications";
+    homepage = "https://github.com/tokuhirom/dcv";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ FelixLusseau ];
+    mainProgram = "dcv";
+  };
+})

--- a/pkgs/by-name/dc/dcv/package.nix
+++ b/pkgs/by-name/dc/dcv/package.nix
@@ -6,12 +6,12 @@
 
 buildGoModule (finalAttrs: {
   pname = "dcv";
-  version = "v0.3.1";
+  version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "tokuhirom";
     repo = "dcv";
-    tag = "${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-OwfGZq+ce6RNb5dhNHsQ15iMPoEp7QlaYIUVYIiVqmI=";
   };
 


### PR DESCRIPTION
(cherry picked from commit 0706b85cf06c3734d9ab45a379b164093bd93c00)

Related to : https://github.com/NixOS/nixpkgs/pull/483145

> <!--
> ^ Please summarise the changes you have done and explain why they are necessary here ^
> 
> For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
> For new packages please briefly describe the package or provide a link to its homepage.
> -->
> 
> Adding the `dcv` package that is a TUI (Terminal User Interface) tool for monitoring Docker containers and Docker Compose applications and FelixLusseau as a maintainer.  
> Homepage : https://github.com/tokuhirom/dcv
> 
> ## Things done
> 
> <!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
> 
> - Built on platform:
>   - [x] x86_64-linux
>   - [ ] aarch64-linux
>   - [ ] x86_64-darwin
>   - [ ] aarch64-darwin
> - Tested, as applicable:
>   - [ ] [NixOS tests] in [nixos/tests].
>   - [ ] [Package tests] at `passthru.tests`.
>   - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
> - [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
> - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
> - Nixpkgs Release Notes
>   - [ ] Package update: when the change is major or breaking.
> - NixOS Release Notes
>   - [x] Module addition: when adding a new NixOS module.
>   - [ ] Module update: when the change is significant.
> - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
> 
> [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
> [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
> [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
> 
> [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
> [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
> [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
> [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
> [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
> [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
