### PR TITLE
vue-language-server: keep .d.ts files in build

### DIFF
--- a/pkgs/by-name/vu/vue-language-server/package.nix
+++ b/pkgs/by-name/vu/vue-language-server/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     find packages.dontpruneme/**/node_modules -xtype l -delete
     mv packages.dontpruneme packages
 
-    find -type f \( -name "*.ts" -o -name "*.map" \) -exec rm -rf {} +
+    find -type f \( -name "*.ts" ! -name "*.d.ts" -o -name "*.map" \) -exec rm -rf {} +
 
     # https://github.com/pnpm/pnpm/issues/3645
     find node_modules packages/language-server/node_modules -xtype l -delete


### PR DESCRIPTION
Since v3.2.0, vue-language-server replaced dynamic type generation with static files (see [this PR](https://github.com/vuejs/language-tools/pull/5872)). The current package build removes all `*.ts` files, including the now-required `.d.ts` files, since they aren’t generated at runtime anymore. Removing the `.d.ts` files leads to confusing lsp errors in vue files (e.g. v-for always typing items as `any`). This PR simply excludes `.d.ts` files from removal.

For vue-language-server to work correctly, only the `.d.ts` files in `packages/language-core/types` are needed. There are more `.d.ts` files in `test-workspace` (currently four small files) that could potentially be removed, but I didn’t want to overcomplicate the cleanup.

@friedow This should probably be merged before #483107, since the package is currently partly broken, right?
This is my first contribution to nixpkgs, so I hope tagging you is okay!

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
