### PR TITLE
nftables: fix reproducibility

### DIFF
--- a/pkgs/os-specific/linux/nftables/default.nix
+++ b/pkgs/os-specific/linux/nftables/default.nix
@@ -41,6 +41,28 @@ stdenv.mkDerivation rec {
       url = "https://lore.kernel.org/netfilter-devel/20241219231001.1166085-2-hi@alyssa.is/raw";
       hash = "sha256-7vMBIoDWcI/JBInYP5yYWp8BnYbATRfMTxqyZr2L9Sk=";
     })
+
+    # Following 4 commits fix reproducibility.
+    (fetchurl {
+      name = "0001-build-fix-.-configure-with-non-bash-shell.patch";
+      url = "https://git.netfilter.org/nftables/patch/?id=2e3c68f26d5bd60c8ea7467fa9018c282a7d8c47";
+      hash = "sha256-gJi6Q6mpURynzpnTFs1VJmZ+SpnNhyOrCzKarJmu/6w=";
+    })
+    (fetchurl {
+      name = "0002-build-simplify-the-instantation-of-nftversion.h.patch";
+      url = "https://git.netfilter.org/nftables/patch/?id=2a0ec8a7246e5c5eb85270e3d4de43e20a00c577";
+      hash = "sha256-gzlMHaZTXCqR8IcccIsLaMZie3CaMEPa4lnGr/x7b/o=";
+    })
+    (fetchurl {
+      name = "0003-build-generate-build-time-stamp-once-at-configure.patch";
+      url = "https://git.netfilter.org/nftables/patch/?id=b92571cc59ce49fdd9fe2daac9350529adfb2424";
+      hash = "sha256-03nexKi/tH1pGNor2/q+Q5ps9+YQRGBbR/DR164Efpo=";
+    })
+    (fetchurl {
+      name = "0004-build-support-SOURCE_DATE_EPOCH-for-build-time-stamp.patch";
+      url = "https://git.netfilter.org/nftables/patch/?id=ca86f206c92704170a295b8dc7a41f6448835dde";
+      hash = "sha256-vK/dsi9YXzEg2iShfbhnwlJJC27LTBA9fIjyJySoeFI=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
The `SOURCE_DATE_EPOCH` patch depends on 3 others, so I included them all.

Closes: https://github.com/NixOS/nixpkgs/issues/478048


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
