### PR TITLE
cargo-tauri: hook fix darwin builds and add dontTauriFixup documentation

### DIFF
--- a/doc/hooks/tauri.section.md
+++ b/doc/hooks/tauri.section.md
@@ -79,6 +79,10 @@ The [bundle type](https://tauri.app/v1/guides/building/) to build.
 
 Disables using `tauriBuildHook`.
 
+#### `dontTauriFixup` {#dont-tauri-fixup}
+
+Disables the `tauriFixupHook` pre fixup phase.
+
 #### `dontTauriInstall` {#dont-tauri-install}
 
 Disables using `tauriInstallPostBuildHook` and `tauriInstallHook`.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -2671,6 +2671,9 @@
   "dont-tauri-build": [
     "index.html#dont-tauri-build"
   ],
+  "dont-tauri-fixup": [
+    "index.html#dont-tauri-fixup"
+  ],
   "dont-tauri-install": [
     "index.html#dont-tauri-install"
   ],

--- a/pkgs/by-name/ca/cargo-tauri/hook.sh
+++ b/pkgs/by-name/ca/cargo-tauri/hook.sh
@@ -93,6 +93,8 @@ tauriInstallHook() {
 }
 
 tauriFixupHook() {
+  echo "Executing tauriFixupHook"
+
   # NOTE: This runs as a preFixupPhase and does not replace the original hook.
   @fixupScript@
 }


### PR DESCRIPTION
The hook additions in #483356 broke the Darwin setup-hook. It ends up with an empty `tauriFixupHook`, which causes a syntax error. See https://github.com/NixOS/nixpkgs/pull/483356#issuecomment-3830905090

```
 nl -ba /nix/store/1f5l63h09c7ny3gn1mkxmhfrnl0h1bkj-tauri-hook/nix-support/setup-hook | head -n 115 | tail -n 10
   106	
   107	tauriFixupHook() {
   108	  # NOTE: This runs as a preFixupPhase and does not replace the original hook.
   109	  
   110	} <== syntax error on this line.
   111	
   112	if [ -z "${dontTauriBuild:-}" ] && [ -z "${buildPhase:-}" ]; then
   113	    buildPhase=tauriBuildHook
   114	fi
   115	
```


I also added `dontTauriFixup` to the hook documentation.

ping @JuliusFreudenberger (for testing?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
