### PR TITLE
nixos/ifm: replace activation script with systemd tmpfiles

### DIFF
--- a/nixos/modules/services/web-apps/ifm.nix
+++ b/nixos/modules/services/web-apps/ifm.nix
@@ -53,6 +53,7 @@ in
       description = "Improved file manager, a single-file web based filemanager";
 
       after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];
 
       environment = {

--- a/nixos/tests/ifm.nix
+++ b/nixos/tests/ifm.nix
@@ -7,30 +7,42 @@
   };
 
   nodes = {
-    server = rec {
-      services.ifm = {
-        enable = true;
-        port = 9001;
-        dataDir = "/data";
-      };
+    server =
+      { config, ... }:
+      {
+        services.ifm = {
+          enable = true;
+          port = 9001;
+          dataDir = "/data";
+        };
 
-      system.activationScripts.ifm-setup-dir = ''
-        mkdir -p ${services.ifm.dataDir}
-        chmod u+w,g+w,o+w ${services.ifm.dataDir}
-      '';
-    };
+        systemd.tmpfiles.settings = {
+          ifm-data-dir = {
+            ${config.services.ifm.dataDir}.d = {
+              mode = "0777";
+              user = "root";
+              group = "root";
+            };
+          };
+        };
+      };
   };
 
-  testScript = ''
-    start_all()
-    server.wait_for_unit("ifm.service")
-    server.wait_for_open_port(9001)
-    server.succeed("curl --fail http://localhost:9001")
+  testScript =
+    # python
+    ''
+      start_all()
+      server.wait_for_unit("ifm.service")
+      server.wait_for_open_port(9001)
+      server.succeed("curl --fail http://localhost:9001")
 
-    server.succeed("echo \"testfile\" > testfile && shasum testfile >> checksums")
-    server.succeed("curl --fail http://localhost:9001 -X POST -F \"api=upload\" -F \"dir=\" -F \"file=@testfile\" | grep \"OK\"");
-    server.succeed("rm testfile")
-    server.succeed("curl --fail http://localhost:9001 -X POST -F \"api=download\" -F \"filename=testfile\" -F \"dir=\" --output testfile");
-    server.succeed("shasum testfile >> checksums && shasum --check checksums")
-  '';
+      server.succeed('echo "testfile" > testfile')
+      server.succeed("shasum testfile | tee checksums")
+
+      server.succeed('curl --fail http://localhost:9001 -X POST -F "api=upload" -F "dir=" -F "file=@testfile" | grep "OK"');
+      server.succeed("rm testfile")
+
+      server.succeed('curl --fail http://localhost:9001 -X POST -F "api=download" -F "filename=testfile" -F "dir=" --output testfile');
+      server.succeed("shasum --check checksums")
+    '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

See https://github.com/NixOS/nixpkgs/issues/475305
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
