### PR TITLE
highscore-unwrapped: 0-unstable-2026-01-01 -> 0-unstable-2026-02-01

### DIFF
--- a/pkgs/by-name/hi/highscore-unwrapped/package.nix
+++ b/pkgs/by-name/hi/highscore-unwrapped/package.nix
@@ -46,14 +46,14 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "highscore-unwrapped";
-  version = "0-unstable-2026-01-01";
+  version = "0-unstable-2026-02-01";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "highscore";
-    rev = "c9f537e06414a32632e9f9d7a73d9028b788f275";
-    hash = "sha256-6sBfjVFIFg0w3apzJBYMYEIjTavnOAE0YK3ayzoyDks=";
+    rev = "281d8e1d7d9abaa8452b869d1d52d4a933a00d26";
+    hash = "sha256-HQD8Dge/nSvIDgiekCxHzCmRl4cO98Er8X24ZoP8OiQ=";
   };
 
   patches = [
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace meson.build --replace-fail \
-      "run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()" \
+      "run_command('git', 'rev-parse', '--short', 'HEAD', check: false).stdout().strip()" \
       "'${finalAttrs.src.rev}'"
   '';
 

--- a/pkgs/by-name/li/libhighscore/package.nix
+++ b/pkgs/by-name/li/libhighscore/package.nix
@@ -13,14 +13,14 @@
 
 stdenv.mkDerivation {
   pname = "libhighscore";
-  version = "0-unstable-2025-12-06";
+  version = "0-unstable-2026-01-30";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
     owner = "alicem";
     repo = "libhighscore";
-    rev = "6920d96b440ccfc070fc87c39c51beab8ac053bd";
-    hash = "sha256-JXfPLPHA3HwXRG6sT/5TSMbtU+BqBh/+ZVrzJxW0xLg=";
+    rev = "81366c670b777a6943dbdd955b9e867c8da247e7";
+    hash = "sha256-z+gMU9IA0F9alrhXNf5e+0/J87ChwVyCn26iA+ythBE=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Supersedes #485262

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
