### PR TITLE
listmonk: fix missing email-builder

### DIFF
--- a/pkgs/by-name/li/listmonk/email-builder.nix
+++ b/pkgs/by-name/li/listmonk/email-builder.nix
@@ -1,0 +1,37 @@
+{
+  stdenv,
+  fetchYarnDeps,
+  yarnConfigHook,
+  yarnBuildHook,
+  nodejs,
+  src,
+  version,
+  meta,
+}:
+
+stdenv.mkDerivation {
+  pname = "listmonk-email-builder";
+  inherit version;
+
+  src = "${src}/frontend/email-builder";
+
+  offlineCache = fetchYarnDeps {
+    yarnLock = "${src}/frontend/email-builder/yarn.lock";
+    hash = "sha256-glt7tMfP3x0Mr/hFG1t6TfwVJ+yZ551jeZK2UPIKI8g=";
+  };
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -R dist/* $out
+    runHook postInstall
+  '';
+
+  inherit meta;
+}

--- a/pkgs/by-name/li/listmonk/package.nix
+++ b/pkgs/by-name/li/listmonk/package.nix
@@ -49,6 +49,7 @@ buildGoModule (finalAttrs: {
         "${finalAttrs.passthru.frontend}/altcha.umd.js:/public/static/altcha.umd.js"
         "static/email-templates"
         "${finalAttrs.passthru.frontend}/admin:/admin"
+        "${finalAttrs.passthru.email-builder}:/admin/static/email-builder"
         "i18n:/i18n"
       ];
     in
@@ -59,11 +60,14 @@ buildGoModule (finalAttrs: {
 
   passthru = {
     frontend = callPackage ./frontend.nix { inherit (finalAttrs) meta version src; };
+    email-builder = callPackage ./email-builder.nix { inherit (finalAttrs) meta version src; };
     tests = { inherit (nixosTests) listmonk; };
     updateScript = nix-update-script {
       extraArgs = [
         "-s"
         "frontend"
+        "-s"
+        "email-builder"
       ];
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The current Listmonk (https://github.com/knadh/listmonk) package is missing crucial files for the visual editor to work, as can be seen

```bash
❯ curl -i https://REDACTED/admin/static/email-builder/email-builder.umd.js
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    19 100    19   0     0   282     0  --:--:-- --:--:-- --:--:--   283
HTTP/2 404
server: nginx
date: Sat, 31 Jan 2026 21:50:44 GMT
content-type: text/plain; charset=utf-8
content-length: 19
x-content-type-options: nosniff

404 page not found
```

Which can also be seen when inspecting the browser console log while trying to open a visual editor

```log
GET https://REDACTED/admin/static/email-builder/email-builder.umd.js net::ERR_ABORTED 404 (Not Found)
```

This PR packages the `email-builder` package inside https://github.com/knadh/listmonk/tree/v6.0.0/frontend/email-builder and propagates the built `/admin/static/email-builder/email-builder.umd.js` into the resulting Listmonk binary. => **This fixes the issue and makes the Visual editor functional!**

------

**Note**: Also I wouldn't mind maintaining this long term since I am managing our company listmonk instance anyway <3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
