### PR TITLE
influxdb: ignore unused_assignments warnings in libflux dependency

### DIFF
--- a/pkgs/servers/nosql/influxdb/default.nix
+++ b/pkgs/servers/nosql/influxdb/default.nix
@@ -26,10 +26,11 @@ let
       # https://github.com/influxdata/flux/pull/5542
       ../influxdb2/fix-unsigned-char.patch
     ];
-    # Don't fail on missing code documentation and allow dead_code/lifetime warnings
+
+    # Don't fail on missing code documentation and allow dead_code/lifetime/unused_assignments warnings
     postPatch = ''
       substituteInPlace flux-core/src/lib.rs \
-        --replace-fail "deny(warnings, missing_docs))]" "deny(warnings), allow(dead_code, mismatched_lifetime_syntaxes))]"
+        --replace-fail "deny(warnings, missing_docs))]" "deny(warnings), allow(dead_code, mismatched_lifetime_syntaxes, unused_assignments))]"
     '';
     sourceRoot = "${src.name}/libflux";
 


### PR DESCRIPTION
The influxdb build was failing due to `unused_assignments` warning in the upstream `libflux` dependency:
```
❯ nix-build -A influxdb
these 2 derivations will be built:
  /nix/store/z75qqsa0bypsl2927pjj8k2sr214qys4-libflux-0.196.1.drv
  /nix/store/hr52pnqr0kiim9zq966b2b4gi1g7yqcd-influxdb-1.12.2.drv
building '/nix/store/z75qqsa0bypsl2927pjj8k2sr214qys4-libflux-0.196.1.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/r2kc1qjky7xq9d087jv32iwvqyi10k0h-source
source root is source/libflux
Executing cargoSetupPostUnpackHook
Finished cargoSetupPostUnpackHook
Running phase: patchPhase
applying patch /nix/store/43nqr62r5zy67yhdhwgwncxzzs0yzkls-fix-unsigned-char.patch
patching file flux/src/cffi.rs
Executing cargoSetupPostPatchHook
Validating consistency between /build/source/libflux/Cargo.lock and /build/libflux-0.196.1-vendor/Cargo.lock
Finished cargoSetupPostPatchHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
Running phase: buildPhase
Executing cargoBuildHook
cargoBuildHook flags: -j 24 --target x86_64-unknown-linux-gnu --offline --profile release
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which i
  |
  = note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
  = note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
  = note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
   Compiling autocfg v1.1.0
   Compiling proc-macro2 v1.0.56
   Compiling unicode-ident v1.0.8
   Compiling quote v1.0.26
   Compiling libc v0.2.141
   Compiling log v0.4.17
   Compiling syn v1.0.109
   Compiling serde v1.0.159
   Compiling serde_derive v1.0.159
   Compiling cfg-if v1.0.0
   Compiling memchr v2.5.0
   Compiling version_check v0.9.4
   Compiling unicode-segmentation v1.10.1
   Compiling semver v1.0.17
   Compiling parking_lot_core v0.8.6
   Compiling crc32fast v1.3.2
   Compiling crossbeam-utils v0.8.15
   Compiling serde_json v1.0.95
   Compiling thiserror v1.0.40
   Compiling anyhow v1.0.70
   Compiling unicode-width v0.1.10
   Compiling scopeguard v1.1.0
   Compiling smallvec v1.10.0
   Compiling instant v0.1.12
   Compiling bitflags v1.3.2
   Compiling regex-syntax v0.6.29
   Compiling textwrap v0.11.0
   Compiling rle-decode-fast v1.0.3
   Compiling vec_map v0.8.2
   Compiling termcolor v1.2.0
   Compiling ansi_term v0.12.1
   Compiling hashbrown v0.12.3
   Compiling strsim v0.8.0
   Compiling proc-macro-error-attr v1.0.4
   Compiling proc-macro-error v1.0.4
   Compiling num-traits v0.2.15
   Compiling lock_api v0.4.9
   Compiling indexmap v1.9.3
   Compiling num-integer v0.1.45
   Compiling heck v0.3.3
   Compiling libflate_lz77 v1.2.0
   Compiling adler32 v1.2.0
   Compiling arrayvec v0.5.2
   Compiling humantime v2.1.0
   Compiling typed-arena v2.0.2
   Compiling same-file v1.0.6
   Compiling rustc-hash v1.1.0
   Compiling oorandom v11.1.3
   Compiling itoa v1.0.6
   Compiling rustc_version v0.4.0
   Compiling ryu v1.0.13
   Compiling iana-time-zone v0.1.56
   Compiling lazy_static v1.4.0
   Compiling walkdir v2.3.3
   Compiling libflate v1.3.0
   Compiling ena v0.14.2
   Compiling codespan-reporting v0.11.1
   Compiling pretty v0.11.3
   Compiling fnv v1.0.7
   Compiling aho-corasick v0.7.20
   Compiling maplit v1.0.2
   Compiling flatbuffers v22.12.6
   Compiling syn v2.0.13
   Compiling atty v0.2.14
   Compiling clap v2.34.0
   Compiling parking_lot v0.11.2
   Compiling getrandom v0.2.8
   Compiling once_cell v1.17.1
   Compiling regex v1.7.3
   Compiling env_logger v0.9.3
   Compiling thiserror-impl v1.0.40
   Compiling structopt-derive v0.4.18
   Compiling salsa-macros v0.17.0-pre.2
   Compiling derivative v2.2.0
   Compiling derive_more v0.99.17
   Compiling salsa v0.17.0-pre.2
   Compiling structopt v0.3.26
   Compiling ordered-float v3.6.0
   Compiling chrono v0.4.24
   Compiling flux-core v0.154.0 (/build/source/libflux/flux-core)
error: value assigned to `tok` is never read
  --> flux-core/src/scanner/mod.rs:57:9
   |
57 |     pub tok: TokenType,
   |         ^^^
   |
   = help: maybe it is overwritten before being read?
note: the lint level is defined here
  --> flux-core/src/lib.rs:1:38
   |
 1 | #![cfg_attr(feature = "strict", deny(warnings), allow(dead_code, mismatched_lifetime_syntaxes))]
   |                                      ^^^^^^^^
   = note: `#[deny(unused_assignments)]` implied by `#[deny(warnings)]`

error: value assigned to `start_offset` is never read
  --> flux-core/src/scanner/mod.rs:61:9
   |
61 |     pub start_offset: u32,
   |         ^^^^^^^^^^^^
   |
   = help: maybe it is overwritten before being read?

error: value assigned to `end_offset` is never read
  --> flux-core/src/scanner/mod.rs:63:9
   |
63 |     pub end_offset: u32,
   |         ^^^^^^^^^^
   |
   = help: maybe it is overwritten before being read?

error: value assigned to `start_pos` is never read
  --> flux-core/src/scanner/mod.rs:65:9
   |
65 |     pub start_pos: Position,
   |         ^^^^^^^^^
   |
   = help: maybe it is overwritten before being read?

error: value assigned to `end_pos` is never read
  --> flux-core/src/scanner/mod.rs:67:9
   |
67 |     pub end_pos: Position,
   |         ^^^^^^^
   |
   = help: maybe it is overwritten before being read?

error: value assigned to `comments` is never read
  --> flux-core/src/scanner/mod.rs:69:9
   |
69 |     pub comments: Vec<Comment>,
   |         ^^^^^^^^
   |
   = help: maybe it is overwritten before being read?

error: could not compile `flux-core` (lib) due to 6 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `flux-core` (lib) due to 6 previous errors
error: Cannot build '/nix/store/z75qqsa0bypsl2927pjj8k2sr214qys4-libflux-0.196.1.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/0zrs7wnx69by8wjr8d0l8l4qrplz5h2j-libflux-0.196.1
       Last 25 log lines:
       >    |
       > 65 |     pub start_pos: Position,
       >    |         ^^^^^^^^^
       >    |
       >    = help: maybe it is overwritten before being read?
       >
       > error: value assigned to `end_pos` is never read
       >   --> flux-core/src/scanner/mod.rs:67:9
       >    |
       > 67 |     pub end_pos: Position,
       >    |         ^^^^^^^
       >    |
       >    = help: maybe it is overwritten before being read?
       >
       > error: value assigned to `comments` is never read
       >   --> flux-core/src/scanner/mod.rs:69:9
       >    |
       > 69 |     pub comments: Vec<Comment>,
       >    |         ^^^^^^^^
       >    |
       >    = help: maybe it is overwritten before being read?
       >
       > error: could not compile `flux-core` (lib) due to 6 previous errors
       > warning: build failed, waiting for other jobs to finish...
       > error: could not compile `flux-core` (lib) due to 6 previous errors
       For full logs, run:
         nix log /nix/store/z75qqsa0bypsl2927pjj8k2sr214qys4-libflux-0.196.1.drv
error: Cannot build '/nix/store/hr52pnqr0kiim9zq966b2b4gi1g7yqcd-influxdb-1.12.2.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/k3cvc5vjdh6w6ghm0sl100g9mcrqs2br-influxdb-1.12.2
```

## Things done

Added `unused_assignments` to the list of ignored linting rules

- Built on platform:
  - [x] x86_64-linux
  - [] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
