### PR TITLE
nixos/(pretalx): Add mail password from file

### DIFF
--- a/nixos/modules/services/web-apps/pretalx.nix
+++ b/nixos/modules/services/web-apps/pretalx.nix
@@ -9,8 +9,18 @@
 let
   cfg = config.services.pretalx;
   format = pkgs.formats.ini { };
+  removeByPath = pathList: set:
+    lib.updateManyAttrsByPath [
+      {
+        path = lib.init pathList;
+        update = old:
+          lib.filterAttrs (n: v: n != (lib.last pathList)) old;
+       }
+     ] set;
+  removeEmptyByPath = pathList: set:
+    if (lib.attrByPath pathList {} set == {}) then (removeByPath pathList set) else set;
 
-  configFile = format.generate "pretalx.cfg" cfg.settings;
+  configFile = format.generate "pretalx.cfg" (removeEmptyByPath ["mail"] ( removeByPath [ "mail" "password_file"] cfg.settings ));
 
   inherit (cfg) finalPackage;
 
@@ -265,6 +275,16 @@ in
             };
           };
 
+          mail = {
+            password_file = lib.mkOption {
+              type = with lib.types; nullOr path;
+              default = null;
+              description = ''
+                Path to the secret file to read the mail password from
+              '';
+            };
+          };
+
           redis = {
             location = lib.mkOption {
               type = with lib.types; nullOr str;
@@ -469,7 +489,16 @@ in
               fi
             '';
           serviceConfig = {
-            ExecStart = "${lib.getExe' pythonEnv "gunicorn"} --bind unix:/run/pretalx/pretalx.sock ${cfg.gunicorn.extraArgs} pretalx.wsgi";
+            ExecStart = pkgs.writeShellScript "pretalx-start" ''
+              ${
+                if cfg.settings.mail.password_file != null then
+                  "export PRETALX_MAIL_PASSWORD=$(cat " + cfg.settings.mail.password_file + ")"
+                else
+                  ""
+              }
+              ${lib.getExe' pythonEnv "gunicorn"} --bind unix:/run/pretalx/pretalx.sock ${cfg.gunicorn.extraArgs} pretalx.wsgi
+            '';
+            # ExecStart = "${lib.getExe' pythonEnv "gunicorn"} --bind unix:/run/pretalx/pretalx.sock ${cfg.gunicorn.extraArgs} pretalx.wsgi";
             RuntimeDirectory = "pretalx";
           };
         };


### PR DESCRIPTION
The mail password shouldn't be added as plain text because then it will be stored in the nix store. With the file option we allow to use something like sops.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
