### PR TITLE
nn: use clangStdenv, bump to 2.0.10-unstable-2025-11-20

### DIFF
--- a/pkgs/by-name/nn/nn/package.nix
+++ b/pkgs/by-name/nn/nn/package.nix
@@ -1,12 +1,12 @@
 {
-  stdenv,
+  clangStdenv,
   lib,
   fetchFromGitHub,
   unstableGitUpdater,
 }:
-stdenv.mkDerivation (finalAttrs: {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "nn";
-  version = "2.0.8-unstable-2024-04-08";
+  version = "2.0.10-unstable-2025-11-20";
 
   src = fetchFromGitHub {
     owner = "sakov";


### PR DESCRIPTION
This pull request updates the packaging for the `nn` package to use a different build environment and a newer version. The main changes are:

Build environment update:
* Switched from using `stdenv` to `clangStdenv` for building the package, which may improve compatibility or performance with C/C++ code.

Version bump:
* Updated the `nn` package version from `2.0.8-unstable-2024-04-08` to `2.0.10-unstable-2025-11-20`, ensuring the package uses the latest available code.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
