### PR TITLE
Unset meta.platforms

### DIFF
--- a/pkgs/by-name/ex/extract-dtb/package.nix
+++ b/pkgs/by-name/ex/extract-dtb/package.nix
@@ -23,7 +23,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/PabloCastellano/extract-dtb";
     changelog = "https://github.com/PabloCastellano/extract-dtb/releases/tag/${version}";
     license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ ungeskriptet ];
     mainProgram = "extract-dtb";
   };

--- a/pkgs/by-name/sa/samfirm-js/package.nix
+++ b/pkgs/by-name/sa/samfirm-js/package.nix
@@ -27,7 +27,6 @@ buildNpmPackage {
     description = "Program for downloading Samsung firmware";
     homepage = "https://github.com/DavidArsene/samfirm.js";
     license = lib.licenses.gpl3;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ ungeskriptet ];
     mainProgram = "samfirm-js";
   };

--- a/pkgs/by-name/ss/sshwifty/package.nix
+++ b/pkgs/by-name/ss/sshwifty/package.nix
@@ -69,7 +69,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/nirui/sshwifty";
     changelog = "https://github.com/nirui/sshwifty/releases/tag/${finalAttrs.version}";
     license = lib.licenses.agpl3Plus;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ ungeskriptet ];
     mainProgram = "sshwifty";
   };

--- a/pkgs/development/python-modules/liblp/default.nix
+++ b/pkgs/development/python-modules/liblp/default.nix
@@ -28,7 +28,6 @@ buildPythonPackage rec {
     description = "Android logical partitions library ported from C++ to Python";
     homepage = "https://github.com/sebaubuntu-python/liblp";
     license = lib.licenses.asl20;
-    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ ungeskriptet ];
     mainProgram = "lpunpack";
   };


### PR DESCRIPTION
Remove meta.platforms for packages maintained by me.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
