### PR TITLE
maintainers: alanpearce -> alinnow

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1049,12 +1049,6 @@
     github = "ALameLlama";
     githubId = 55490546;
   };
-  alanpearce = {
-    email = "alan@alanpearce.eu";
-    github = "alanpearce";
-    githubId = 850317;
-    name = "Alan Pearce";
-  };
   alapshin = {
     email = "alapshin@fastmail.com";
     github = "alapshin";
@@ -1337,6 +1331,12 @@
         fingerprint = "7D31 15DC D912 C15A 2781  F7BB 511C B44B C752 2A89";
       }
     ];
+  };
+  alinnow = {
+    name = "Alin";
+    email = "alin@alin.ovh";
+    github = "alinnow";
+    githubId = 850317;
   };
   alirezameskin = {
     email = "alireza.meskin@gmail.com";

--- a/pkgs/by-name/hb/hblock/package.nix
+++ b/pkgs/by-name/hb/hblock/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "hblock";
     homepage = "https://github.com/hectorm/hblock";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ alanpearce ];
+    maintainers = with lib.maintainers; [ alinnow ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/ma/maid/package.nix
+++ b/pkgs/by-name/ma/maid/package.nix
@@ -18,7 +18,7 @@ bundlerApp rec {
     description = "Rule-based file mover and cleaner in Ruby";
     homepage = "https://github.com/maid/maid";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ alanpearce ];
+    maintainers = with lib.maintainers; [ alinnow ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/zs/zsh-history-to-fish/package.nix
+++ b/pkgs/by-name/zs/zsh-history-to-fish/package.nix
@@ -38,7 +38,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Bring your ZSH history to Fish shell";
     homepage = "https://github.com/rsalmei/zsh-history-to-fish";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ alanpearce ];
+    maintainers = with lib.maintainers; [ alinnow ];
     mainProgram = "zsh-history-to-fish";
   };
 }


### PR DESCRIPTION
Renamed myself, following a GitHub username change.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
