### PR TITLE
Various repart image simplifications

### DIFF
--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -112,10 +112,11 @@ in
     };
 
     system.build = {
+      finalImage = lib.warn "system.build.finalImage has been renamed to system.build.image" config.system.build.image;
 
       # intermediate system image without ESP
       intermediateImage =
-        (config.system.build.image.override {
+        (config.image.repart.image.override {
           # always disable compression for the intermediate image
           compression.enable = false;
         }).overrideAttrs
@@ -162,8 +163,8 @@ in
         );
 
       # final system image that is created from the intermediate image by injecting the UKI from above
-      finalImage =
-        (config.system.build.image.override {
+      image = lib.mkOverride 99 (
+        (config.image.repart.image.override {
           # continue building with existing intermediate image
           createEmpty = false;
         }).overrideAttrs
@@ -216,7 +217,8 @@ in
                 rm -v repart-output_orig.json
               '';
             }
-          );
+          )
+      );
     };
   };
 

--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -123,7 +123,11 @@ in
           (
             _: previousAttrs: {
               # make it easier to identify the intermediate image in build logs
-              pname = "${previousAttrs.pname}-intermediate";
+              name =
+                if previousAttrs ? pname then
+                  "${previousAttrs.pname}-${previousAttrs.version}-intermediate"
+                else
+                  "${previousAttrs.name}-intermediate";
 
               # do not prepare the ESP, this is done in the final image
               systemdRepartFlags = previousAttrs.systemdRepartFlags ++ [ "--defer-partitions=esp" ];

--- a/nixos/modules/image/repart-verity-store.nix
+++ b/nixos/modules/image/repart-verity-store.nix
@@ -96,6 +96,7 @@ in
         Verity = "hash";
         VerityMatchKey = lib.mkDefault verityMatchKey;
         Label = lib.mkDefault "store-verity";
+        Minimize = lib.mkDefault "best";
       };
       # dm-verity data partition that contains the nix store
       ${cfg.partitionIds.store} = {
@@ -106,6 +107,7 @@ in
           Format = lib.mkDefault "erofs";
           VerityMatchKey = lib.mkDefault verityMatchKey;
           Label = lib.mkDefault "store";
+          Minimize = lib.mkDefault "best";
         };
       };
 

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -101,7 +101,7 @@
         "-f",
         "qcow2",
         "-b",
-        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.repart.imageFile}",
+        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.filePath}",
         "-F",
         "raw",
         tmp_disk_image.name,

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -101,7 +101,7 @@
         "-f",
         "qcow2",
         "-b",
-        "${nodes.machine.system.build.finalImage}/${nodes.machine.image.filePath}",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.filePath}",
         "-F",
         "raw",
         tmp_disk_image.name,

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -50,12 +50,6 @@
               SizeMinBytes = if config.nixpkgs.hostPlatform.isx86_64 then "64M" else "96M";
             };
           };
-          ${partitionIds.store-verity}.repartConfig = {
-            Minimize = "best";
-          };
-          ${partitionIds.store}.repartConfig = {
-            Minimize = "best";
-          };
         };
       };
 

--- a/nixos/tests/appliance-repart-image-verity-store.nix
+++ b/nixos/tests/appliance-repart-image-verity-store.nix
@@ -10,13 +10,8 @@
     willibutz
   ];
 
-  nodes.machine =
-    {
-      config,
-      lib,
-      pkgs,
-      ...
-    }:
+  defaults =
+    { config, lib, ... }:
     let
       inherit (config.image.repart.verityStore) partitionIds;
     in
@@ -75,16 +70,19 @@
         initrd.systemd.enable = true;
       };
 
-      system.image = {
-        id = "nixos-appliance";
-        version = "1";
-      };
+      system.image.id = "nixos-appliance";
 
       # don't create /usr/bin/env
       # this would require some extra work on read-only /usr
       # and it is not a strict necessity
       system.activationScripts.usrbinenv = lib.mkForce "";
     };
+
+  nodes.machine = {
+    system.image.version = "1";
+  };
+
+  nodes.without-version = { };
 
   testScript =
     { nodes, ... }: # python
@@ -93,32 +91,50 @@
       import subprocess
       import tempfile
 
-      tmp_disk_image = tempfile.NamedTemporaryFile()
+      def create_disk_image(qemu_img, backing_file):
+        tmp = tempfile.NamedTemporaryFile()
+        subprocess.run([
+          qemu_img,
+          "create",
+          "-f",
+          "qcow2",
+          "-b",
+          backing_file,
+          "-F",
+          "raw",
+          tmp.name,
+        ], check=True)
+        return tmp
 
-      subprocess.run([
+      def run_verity_tests(machine):
+        with subtest("Running with volatile root"):
+          machine.succeed("findmnt --kernel --type tmpfs /")
+
+        with subtest("/nix/store is backed by dm-verity protected fs"):
+          verity_info = machine.succeed("dmsetup info --target verity usr")
+          assert "ACTIVE" in verity_info, f"unexpected verity info: {verity_info}"
+
+          backing_device = machine.succeed("df --output=source /nix/store | tail -n1").strip()
+          assert "/dev/mapper/usr" == backing_device, f"unexpected backing device: {backing_device}"
+
+      tmp_disk_machine = create_disk_image(
         "${nodes.machine.virtualisation.qemu.package}/bin/qemu-img",
-        "create",
-        "-f",
-        "qcow2",
-        "-b",
         "${nodes.machine.system.build.image}/${nodes.machine.image.filePath}",
-        "-F",
-        "raw",
-        tmp_disk_image.name,
-      ])
-
-      os.environ['NIX_DISK_IMAGE'] = tmp_disk_image.name
-
+      )
+      os.environ['NIX_DISK_IMAGE'] = tmp_disk_machine.name
       machine.wait_for_unit("default.target")
+      run_verity_tests(machine)
+      with subtest("Image version is set"):
+        machine.succeed("grep IMAGE_VERSION=1 /etc/os-release")
 
-      with subtest("Running with volatile root"):
-        machine.succeed("findmnt --kernel --type tmpfs /")
-
-      with subtest("/nix/store is backed by dm-verity protected fs"):
-        verity_info = machine.succeed("dmsetup info --target verity usr")
-        assert "ACTIVE" in verity_info,f"unexpected verity info: {verity_info}"
-
-        backing_device = machine.succeed("df --output=source /nix/store | tail -n1").strip()
-        assert "/dev/mapper/usr" == backing_device,"unexpected backing device: {backing_device}"
+      tmp_disk_without_version = create_disk_image(
+        "${nodes."without-version".virtualisation.qemu.package}/bin/qemu-img",
+        "${nodes."without-version".system.build.image}/${nodes."without-version".image.filePath}",
+      )
+      os.environ['NIX_DISK_IMAGE'] = tmp_disk_without_version.name
+      without_version.wait_for_unit("default.target")
+      run_verity_tests(without_version)
+      with subtest("Image version is not set"):
+        without_version.succeed('grep IMAGE_VERSION="" /etc/os-release')
     '';
 }

--- a/nixos/tests/appliance-repart-image.nix
+++ b/nixos/tests/appliance-repart-image.nix
@@ -109,7 +109,7 @@ in
         "-f",
         "qcow2",
         "-b",
-        "${nodes.machine.system.build.image}/${nodes.machine.image.repart.imageFile}",
+        "${nodes.machine.system.build.image}/${nodes.machine.image.filePath}",
         "-F",
         "raw",
         tmp_disk_image.name,


### PR DESCRIPTION
This sets the stage for making repart images compatible with `nixos-rebuild build-image`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
