### PR TITLE
codecov-cli: 10.4.0 -> 11.2.6

### DIFF
--- a/pkgs/by-name/co/codecov-cli/package.nix
+++ b/pkgs/by-name/co/codecov-cli/package.nix
@@ -6,45 +6,32 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "codecov-cli";
-  version = "10.4.0";
+  version = "11.2.6";
   pyproject = true;
 
-  src =
-    (fetchFromGitHub {
-      owner = "codecov";
-      repo = "codecov-cli";
-      tag = "v${version}";
-      hash = "sha256-R1GFQ81N/e2OX01oSs8Xs+PM0JKVZofiUPADVdxCzWk=";
-      fetchSubmodules = true;
-    }).overrideAttrs
-      (_: {
-        env = {
-          GIT_CONFIG_COUNT = 1;
-          GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
-          GIT_CONFIG_VALUE_0 = "git@github.com:";
-        };
-      });
+  src = fetchFromGitHub {
+    owner = "getsentry";
+    repo = "prevent-cli";
+    tag = "v${version}";
+    hash = "sha256-8KBemqwMqiio4pnftsBgnFj69Bgb5jQr5YlMegujPZY=";
+  };
+
+  sourceRoot = "${src.name}/${pname}";
 
   build-system = with python3Packages; [ setuptools ];
 
   pythonRelaxDeps = [
-    "httpx"
+    "click"
     "responses"
-    "test-results-parser"
-    "tree-sitter"
   ];
 
   dependencies = with python3Packages; [
     click
-    httpx
     ijson
     pyyaml
-    regex
     responses
-    test-results-parser
-    tree-sitter
     sentry-sdk
-    wrapt
+    test-results-parser
   ];
 
   meta = {


### PR DESCRIPTION
Codecov moved the `codecov-cli` code to the [getsentry/prevent-cli project](https://github.com/getsentry/prevent-cli/tree/main/codecov-cli).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
