### PR TITLE
python314Packages.py-evm: disabled from 3.14

### DIFF
--- a/pkgs/development/python-modules/py-evm/default.nix
+++ b/pkgs/development/python-modules/py-evm/default.nix
@@ -1,7 +1,9 @@
 {
   lib,
-  buildPythonPackage,
   fetchFromGitHub,
+  # python module stuff
+  buildPythonPackage,
+  pythonAtLeast,
   setuptools,
   # dependencies
   cached-property,
@@ -20,13 +22,16 @@
   hypothesis,
   pytestCheckHook,
   pytest-xdist,
-  eth-hash,
+  pycryptodome,
 }:
 
 buildPythonPackage rec {
   pname = "py-evm";
   version = "0.12.1-beta.1";
   pyproject = true;
+
+  # py-evm project has been archived by upstream; its support should be deprecated from "3.14".
+  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "ethereum";
@@ -56,8 +61,8 @@ buildPythonPackage rec {
     hypothesis
     pytestCheckHook
     pytest-xdist
-  ]
-  ++ eth-hash.optional-dependencies.pycryptodome;
+    pycryptodome
+  ];
 
   disabledTests = [
     # side-effect: runs pip online check and is blocked by sandbox


### PR DESCRIPTION
 `py-evm` project has been archived by upstream; its support should be deprecated from "3.14". This PR marks `py-evm` and its dependent broken for "python >= 3.14".

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
