### PR TITLE
overskride: 0.6.5 -> 0.6.6

### DIFF
--- a/pkgs/by-name/ov/overskride/package.nix
+++ b/pkgs/by-name/ov/overskride/package.nix
@@ -72,7 +72,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     changelog = "https://github.com/kaii-lb/overskride/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     mainProgram = "overskride";
-    maintainers = with lib.maintainers; [ mrcjkb ];
+    maintainers = with lib.maintainers; [
+      mrcjkb
+      ilkecan
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ov/overskride/package.nix
+++ b/pkgs/by-name/ov/overskride/package.nix
@@ -19,13 +19,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "overskride";
-  version = "0.6.5";
+  version = "0.6.6";
 
   src = fetchFromGitHub {
     owner = "kaii-lb";
     repo = "overskride";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-q37nKP18E8aDlTlh2REgeg40KH6orD6QY+ZlDKHHC20=";
+    hash = "sha256-JKYf0172sK/+IqtQqmeHOwC/P563ww+stEc3gxNwe/I=";
   };
 
   cargoHash = "sha256-q1g+6JFW+euYCq2uMYQn4R0AP4yt5/cJoP88AXg9NLw=";


### PR DESCRIPTION
https://github.com/kaii-lb/overskride/releases/tag/v0.6.6
https://github.com/kaii-lb/overskride/compare/v0.6.5...v0.6.6
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
