### PR TITLE
dnstt: init at 0-unstable-2026-01-25

### DIFF
--- a/pkgs/by-name/dn/dnstt/package.nix
+++ b/pkgs/by-name/dn/dnstt/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchgit,
+}:
+buildGoModule {
+  pname = "dnstt";
+  version = "0-unstable-2026-01-25";
+  src = fetchgit {
+    url = "https://www.bamsoftware.com/git/dnstt.git";
+    rev = "e5e873bd64d9e3edefb8978175572730494f89a8";
+    hash = "sha256-PrRbPRn9sthuM3Rmo8QDX1WBaiLMTsl/05uKh8oYlEc=";
+  };
+  vendorHash = "sha256-fWH2pwLRDemFZP3yqxG15YpvdtyIjJvpmLckhaloMvA=";
+
+  subPackages = [
+    "dnstt-server"
+    "dnstt-client"
+  ];
+
+  meta = {
+    description = "A DNS tunnel that can use DNS over HTTPS (DoH) and DNS over TLS (DoT) resolvers";
+    homepage = "https://www.bamsoftware.com/software/dnstt";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ nix-julia ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
