### PR TITLE
extlinux-conf-builder: Allow customizing the configuration file path

### DIFF
--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -53,6 +53,14 @@ in
         '';
       };
 
+      configurationFile = mkOption {
+        default = "extlinux/extlinux.conf";
+        type = types.str;
+        description = ''
+          Path to the configuration file relative to each boot directory.
+        '';
+      };
+
       configurationLimit = mkOption {
         default = 20;
         example = 10;
@@ -105,7 +113,7 @@ in
   config =
     let
       builderArgs =
-        "-g ${toString cfg.configurationLimit} -t ${timeoutStr}"
+        "-f ${cfg.configurationFile} -g ${toString cfg.configurationLimit} -t ${timeoutStr}"
         + lib.optionalString (dtCfg.name != null) " -n ${dtCfg.name}"
         + lib.optionalString (!cfg.useGenerationDeviceTree) " -r";
       installBootLoader = pkgs.writeScript "install-extlinux-conf.sh" (

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -9,13 +9,14 @@ usage() {
     exit 1
 }
 
-timeout=                # Timeout in centiseconds
-menu=1                  # Enable menu by default
-default=                # Default configuration
-target=/boot            # Target directory
-numGenerations=0        # Number of other generations to include in the menu
+timeout=                        # Timeout in centiseconds
+menu=1                          # Enable menu by default
+default=                        # Default configuration
+target=/boot                    # Target directory
+numGenerations=0                # Number of other generations to include in the menu
+confFile=extlinux/extlinux.conf # Configuration file relative to target directory
 
-while getopts "t:c:d:g:n:r" opt; do
+while getopts "t:c:d:f:g:n:r" opt; do
     case "$opt" in
         t) # U-Boot interprets '0' as infinite
             if [ "$OPTARG" -lt 0 ]; then
@@ -33,6 +34,7 @@ while getopts "t:c:d:g:n:r" opt; do
             ;;
         c) default="$OPTARG" ;;
         d) target="$OPTARG" ;;
+        f) confFile="$OPTARG" ;;
         g) numGenerations="$OPTARG" ;;
         n) dtbName="$OPTARG" ;;
         r) noDeviceTree=1 ;;
@@ -42,8 +44,11 @@ done
 
 [ "$timeout" = "" -o "$default" = "" ] && usage
 
+confDir=$(dirname "$confFile")
+relNixOSDir=$(realpath -m --relative-to="$confDir" nixos)
+
 mkdir -p $target/nixos
-mkdir -p $target/extlinux
+mkdir -p $target/$confDir
 
 # Convert a path to a file in the Nix store such as
 # /nix/store/<hash>-<name>/file to <hash>-<name>-<file>.
@@ -100,8 +105,8 @@ addEntry() {
     else
         echo "  MENU LABEL NixOS - Configuration $tag ($timestamp - $nixosLabel)"
     fi
-    echo "  LINUX ../nixos/$(basename $kernel)"
-    echo "  INITRD ../nixos/$(basename $initrd)"
+    echo "  LINUX ${relNixOSDir}/$(basename $kernel)"
+    echo "  INITRD ${relNixOSDir}/$(basename $initrd)"
     echo "  APPEND init=$path/init $extraParams"
 
     if [ -n "$noDeviceTree" ]; then
@@ -111,9 +116,9 @@ addEntry() {
     if [ -d "$dtbDir" ]; then
         # if a dtbName was specified explicitly, use that, else use FDTDIR
         if [ -n "$dtbName" ]; then
-            echo "  FDT ../nixos/$(basename $dtbs)/${dtbName}"
+            echo "  FDT ${relNixOSDir}/$(basename $dtbs)/${dtbName}"
         else
-            echo "  FDTDIR ../nixos/$(basename $dtbs)"
+            echo "  FDTDIR ${relNixOSDir}/$(basename $dtbs)"
         fi
     else
         if [ -n "$dtbName" ]; then
@@ -123,7 +128,7 @@ addEntry() {
     fi
 }
 
-tmpFile="$target/extlinux/extlinux.conf.tmp.$$"
+tmpFile="$target/$confFile.tmp.$$"
 
 trap "rm -f $tmpFile" EXIT
 
@@ -160,7 +165,7 @@ if [ "$numGenerations" -gt 0 ]; then
     done >> $tmpFile
 fi
 
-mv -f $tmpFile $target/extlinux/extlinux.conf
+mv -f $tmpFile $target/$confFile
 
 # Remove obsolete files from $target/nixos.
 for fn in $target/nixos/*; do

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/extlinux-conf-builder.sh
@@ -63,7 +63,7 @@ copyToKernelsDir() {
     # kernels or initrd if this script is ever interrupted.
     if ! test -e $dst; then
         local dstTmp=$dst.tmp.$$
-        cp -r $src $dstTmp
+        cp -r $src $dstTmp || rm -f $dstTmp
         mv $dstTmp $dst
     fi
     filesCopied[$dst]=1
@@ -124,6 +124,8 @@ addEntry() {
 }
 
 tmpFile="$target/extlinux/extlinux.conf.tmp.$$"
+
+trap "rm -f $tmpFile" EXIT
 
 cat > $tmpFile <<EOF
 # Generated file, all changes will be lost on nixos-rebuild!


### PR DESCRIPTION
Some bootloaders support an extlinux-compatible configuration file, but look for it at a different path than `extlinux/extlinux.conf`. For example, OpenPOWER petitboot requires a file named `syslinux.cfg`[1].

[1]: https://github.com/open-power/petitboot/blob/v1.15/discover/syslinux-parser.c#L39

Additionally, petitboot parses the kernel and initrd paths relative to the boot partition, not the configuration file, so the configuration file must be in the the root directory of the boot partition, not a subdirectory. After this change setting `configurationFile = "syslinux.cfg";` generates a file that works with petitboot, while the defaults remain unchanged.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64le-linux-musl
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
