### PR TITLE
dbus: more fixes on Darwin

### DIFF
--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -156,6 +156,14 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
   '';
 
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # For some reason, only these binaries reference the dylib by rpath instead of by an absolute install name.
+    for exe in bin/dbus-daemon bin/dbus-run-session libexec/dbus-daemon-launch-helper; do
+      install_name_tool "$out/$exe" \
+        -change "@rpath/libdbus-1.3.dylib" "$lib/lib/libdbus-1.3.dylib"
+    done
+  '';
+
   postFixup = ''
     # It's executed from $lib by absolute path
     moveToOutput bin/dbus-launch "$lib"

--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -129,6 +129,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dselinux=disabled"
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # D-Bus defaults to launchd-activation on Darwin, but that requires the launch agent be installed. It also breaks
+    # anything that uses `dbus-run-session` in tests. Changing the default aligns Darwin with other UNIX platforms.
+    "-Ddbus_session_bus_listen_address=unix:tmpdir=/tmp"
     # `launchctl` is only needed at runtime. Lie to `find_program` because it will always be present on a Darwin host.
     "--cross-file=${writeText "darwin.ini" ''
       [binaries]


### PR DESCRIPTION
This time I tested that packages depending on `dbus` built (particularly `python3Packages.jeepney`) and not that (most of, apparently) the binaries in `$out/bin` ran.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
