### PR TITLE
xterm: wrap UTF and KOI8R scripts properly

### DIFF
--- a/pkgs/by-name/xt/xterm/package.nix
+++ b/pkgs/by-name/xt/xterm/package.nix
@@ -60,6 +60,8 @@ stdenv.mkDerivation rec {
     freetype
     libxft
     luit
+    # for `patchShebangs`
+    bashNonInteractive
   ];
 
   configureFlags = [

--- a/pkgs/by-name/xt/xterm/package.nix
+++ b/pkgs/by-name/xt/xterm/package.nix
@@ -20,6 +20,10 @@
   pkgsCross,
   gitUpdater,
   enableDecLocator ? true,
+  gnused,
+  gawk,
+  glibc,
+  bashNonInteractive,
 }:
 
 stdenv.mkDerivation rec {
@@ -95,7 +99,18 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     for bin in $out/bin/*; do
-      wrapProgram $bin --set XAPPLRESDIR $out/lib/X11/app-defaults/
+      wrapProgramArgs=(--set XAPPLRESDIR $out/lib/X11/app-defaults/)
+      if [[ $bin =~ (u|koi8r)xterm ]]; then
+        wrapProgramArgs+=(--prefix PATH : $out/bin:${
+          lib.makeBinPath [
+            gnused
+            gawk
+            glibc
+            bashNonInteractive
+          ]
+        })
+      fi
+      wrapProgram $bin "''${wrapProgramArgs[@]}"
     done
 
     install -D -t $out/share/applications xterm.desktop


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
