### PR TITLE
yaiiu-immich-proxy: init at 0.1.0 and module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1763,6 +1763,7 @@
   ./services/web-apps/windmill.nix
   ./services/web-apps/wordpress.nix
   ./services/web-apps/writefreely.nix
+  ./services/web-apps/yaiiu-immich-proxy.nix
   ./services/web-apps/your_spotify.nix
   ./services/web-apps/youtrack.nix
   ./services/web-apps/zabbix.nix

--- a/nixos/modules/services/web-apps/yaiiu-immich-proxy.nix
+++ b/nixos/modules/services/web-apps/yaiiu-immich-proxy.nix
@@ -1,0 +1,108 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.yaiiu-immich-proxy;
+  inherit (lib)
+    types
+    mkIf
+    mkOption
+    mkEnableOption
+    ;
+in
+{
+  options.services.yaiiu-immich-proxy = {
+    enable = mkEnableOption "YAIIU Immich Proxy";
+    package = lib.mkPackageOption pkgs "yaiiu-immich-proxy" { };
+
+    immichUrl = mkOption {
+      type = types.str;
+      description = "URL of the Immich instance";
+      example = "http://localhost:2283";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 2282;
+      description = "The port that yaiiu-immich-proxy will listen on.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Whether to open the yaiiu-immich-proxy port in the firewall";
+    };
+
+    environment = mkOption {
+      type = types.submodule {
+        freeformType = types.attrsOf (types.either types.str types.int);
+        options = {
+          IMMICH_SERVER_URL = mkOption {
+            type = types.str;
+            default = cfg.immichUrl;
+            defaultText = "\${cfg.immichUrl}";
+            description = "URL of the Immich instance";
+          };
+          LISTEN_ADDR = mkOption {
+            type = types.str;
+            default = ":${toString cfg.port}";
+            defaultText = ":\${toString cfg.port}";
+            description = "The port that yaiiu-immich-proxy will listen on, prepended with a :";
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Environment variables to be set for the service. Can use systemd specifiers.
+        Only IMMICH_SERVER_URL and LISTEN_ADDR are used directly by the program, and they're set by the immichUrl and port options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.yaiiu-immich-proxy = {
+      description = "A proxy server that sits between iOS background upload extension and Immich server. It handles the conversion of raw photo data to the multipart/form-data format required by Immich API.";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      environment = lib.mapAttrs (_: value: toString value) cfg.environment;
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        User = "yaiiu-immich-proxy";
+        Group = "yaiiu-immich-proxy";
+        DynamicUser = true;
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = 3;
+
+        # Hardening
+        CapabilityBoundingSet = [ "" ];
+        NoNewPrivileges = true;
+        PrivateUsers = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+  };
+  meta.maintainers = [ lib.maintainers.luNeder ];
+}

--- a/pkgs/by-name/ya/yaiiu-immich-proxy/package.nix
+++ b/pkgs/by-name/ya/yaiiu-immich-proxy/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule rec {
+  pname = "yaiiu-immich-proxy";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "FawenYo";
+    repo = "YAIIU";
+    tag = "v${version}";
+    hash = "sha256-uVOSszp2oKtzFCGb9nWdLPqucWavM9dcg6Ba7HR8NfQ=";
+  };
+
+  sourceRoot = "${src.name}/immich-proxy";
+
+  vendorHash = null;
+
+  postFixup = ''
+    mv $out/bin/immich-proxy $out/bin/yaiiu-immich-proxy
+  '';
+
+  meta = {
+    homepage = "https://github.com/FawenYo/YAIIU/tree/main/immich-proxy";
+    description = "A proxy server that sits between iOS background upload extension and Immich server, handling conversion to the format required by Immich API.";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ lib.maintainers.luNeder ];
+    mainProgram = "yaiiu-immich-proxy";
+  };
+}


### PR DESCRIPTION
Add a proxy needed for good immich image syncing on iOS, finally becoming on-par with iCloud Photos

- https://github.com/FawenYo/YAIIU/tree/main/immich-proxy
- https://github.com/immich-app/immich/discussions/23245

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
