### PR TITLE
tenesEmpanadasGraciela: init at 0.13.0

### DIFF
--- a/pkgs/by-name/te/tenesEmpanadasGraciela/package.nix
+++ b/pkgs/by-name/te/tenesEmpanadasGraciela/package.nix
@@ -1,0 +1,76 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  gettext,
+  glib,
+  gnumake,
+  goocanvas_2,
+  libtool,
+  libxml2,
+  pkg-config,
+  wrapGAppsHook3,
+  xmlto,
+  lib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "tenesEmpanadasGraciela";
+  version = "0.13.0";
+
+  src = fetchFromGitHub {
+    owner = "wfx";
+    repo = "teg";
+    tag = version;
+    hash = "sha256-NbuQOaMFFVFOTvEOHoXuzKccnmyIEKeYdB2bXzpf7VQ=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    gettext
+    glib
+    gnumake
+    goocanvas_2
+    libtool
+    libxml2
+    pkg-config
+    wrapGAppsHook3
+    xmlto
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/applications $out/share/teg/themes $out/share/glib-2.0/schemas compiled-schema
+
+    cp tegclient $out/bin
+    cp tegserver $out/bin
+    cp tegrobot $out/bin
+
+    cp client/gui-gnome/teg.desktop $out/share/applications
+
+    cp -r client/themes/m2 $out/share/teg/themes
+    cp -r client/themes/m3 $out/share/teg/themes
+    cp -r client/themes/teg_game $out/share/teg/themes
+    cp -r client/themes/teg_classic $out/share/teg/themes
+    cp -r client/themes/risk_game $out/share/teg/themes
+    cp -r client/themes/modern $out/share/teg/themes
+    cp -r client/themes/draco $out/share/teg/themes
+    cp -r client/themes/sentimental $out/share/teg/themes
+    ls client/themes
+
+    glib-compile-schemas --targetdir=compiled-schema client/gui-gnome
+    cp compiled-schema/gschemas.compiled $out/share/glib-2.0/schemas
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Clone of the board game Plan Tactico y Estrategico de la Guerra";
+    longDescription = "Tenes Empanadas Graciela (TEG) is a clone of 'Plan Tactico y Estrategico de la Guerra', which is a pseudo-clone of Risk, a multiplayer turn-based strategy game.";
+    license = licenses.gpl2Only;
+    mainProgram = "tegclient";
+    platforms = platforms.all;
+    maintainers = with maintainers; [ reylak ];
+  };
+}


### PR DESCRIPTION
Packaged the game "Tenes Empanadas Graciela" wich is a clone of the board "Plan Tactico y Estratitegico de la Guerra" which in turn is a clone of "Risk"

PD: If someone wants to play, i invite

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
