### PR TITLE
dclint: init at 3.1.0

### DIFF
--- a/pkgs/by-name/dc/dclint/package.nix
+++ b/pkgs/by-name/dc/dclint/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "dclint";
+  version = "3.1.0";
+
+  src = fetchFromGitHub {
+    owner = "zavoloklom";
+    repo = "docker-compose-linter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bHu6EtMeMFrhR0oZYGCG/fd26FGO1JlBMDU8kd2xio4=";
+  };
+
+  npmDepsHash = "sha256-N9UiemBlFz88EAdbTazz29YQQGxG3ZYX1tRxhQkEMsE=";
+
+  doCheck = true;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "A command-line tool for validating and enforcing best practices in Docker Compose files";
+    longDescription = ''
+      Docker Compose Linter (DCLint) is a utility designed to analyze,
+      validate and fix Docker Compose files. It helps identify errors,
+      style violations, and potential issues, ensuring your configurations are robust,
+      maintainable, and free from common pitfalls.
+    '';
+    homepage = "https://github.com/zavoloklom/docker-compose-linter";
+    changelog = "https://github.com/zavoloklom/docker-compose-linter/releases/tag/v${finalAttrs.version}";
+    downloadPage = "https://github.com/zavoloklom/docker-compose-linter/releases";
+    license = lib.licenses.mit;
+    mainProgram = "dclint";
+    maintainers = with lib.maintainers; [ MH0386 ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
