### PR TITLE
tft-cli: init at 0.0.37

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18027,6 +18027,13 @@
     github = "mfairley";
     githubId = 4374785;
   };
+  mfocko = {
+    name = "Matej Focko";
+    github = "mfocko";
+    githubId = 8149784;
+    email = "me@mfocko.xyz";
+    matrix = "@mfocko:fedora.im";
+  };
   mfossen = {
     email = "msfossen@gmail.com";
     github = "mfossen";

--- a/pkgs/by-name/tf/tft-cli/package.nix
+++ b/pkgs/by-name/tf/tft-cli/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  fetchFromGitLab,
+  python3Packages,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonPackage (finalAttrs: {
+  pname = "tft-cli";
+  version = "0.0.37";
+  pyproject = true;
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitLab {
+    owner = "testing-farm";
+    repo = "cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NmRVe0xjGEU18ZtzPCBGsWlSzXIl1VgunAZ4tDFH5gY=";
+  };
+
+  build-system = with python3Packages; [
+    poetry-core
+    poetry-dynamic-versioning
+  ];
+
+  dependencies = with python3Packages; [
+    click
+    typer
+    dynaconf
+    colorama
+    requests
+    rich
+    ruamel-yaml
+    shellingham
+    pendulum
+    python-dotenv
+    keyring
+    cryptography
+  ];
+
+  pythonImportsCheck = [ "tft" ];
+
+  nativeCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  meta = {
+    homepage = "https://testing-farm.io/";
+    changelog = "https://gitlab.com/testing-farm/cli/-/releases/${finalAttrs.src.tag}";
+    description = "Command-line interface for Testing Farm";
+
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      mfocko
+      thrix
+    ];
+    mainProgram = "testing-farm";
+  };
+})


### PR DESCRIPTION
Adding a Python package that provides CLI for usage of [Testing Farm](https://testing-farm.io). Till now I've been using the containerized version, but there are some issues I've hit, namely with passing SSH agent into the container. Tried locally building it via Nix, ant it looks OK, therefore adding it here, so I don't have to keep custom package definition in my home-manager config.

Cc @thrix

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
