### PR TITLE
unar: migrate package and top-level argument to by-name

### DIFF
--- a/pkgs/by-name/un/unar/package.nix
+++ b/pkgs/by-name/un/unar/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  clangStdenv,
   fetchFromGitHub,
   installShellFiles,
   gnustep-base,
@@ -12,7 +12,7 @@
   xcbuildHook,
 }:
 
-stdenv.mkDerivation rec {
+clangStdenv.mkDerivation rec {
   pname = "unar";
   version = "1.10.8";
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       --replace-fail "v1.10.7" "v${version}"
   ''
   + (
-    if stdenv.hostPlatform.isDarwin then
+    if clangStdenv.hostPlatform.isDarwin then
       ''
         substituteInPlace "./XADMaster.xcodeproj/project.pbxproj" \
           --replace "libstdc++.6.dylib" "libc++.1.dylib"
@@ -47,8 +47,8 @@ stdenv.mkDerivation rec {
       ''
         for f in Makefile.linux ../UniversalDetector/Makefile.linux ; do
           substituteInPlace $f \
-            --replace "= gcc" "=${stdenv.cc.targetPrefix}cc" \
-            --replace "= g++" "=${stdenv.cc.targetPrefix}c++" \
+            --replace "= gcc" "=${clangStdenv.cc.targetPrefix}cc" \
+            --replace "= g++" "=${clangStdenv.cc.targetPrefix}c++" \
             --replace "-DGNU_RUNTIME=1" "" \
             --replace "-fgnu-runtime" "-fobjc-runtime=gnustep-2.0"
         done
@@ -65,21 +65,21 @@ stdenv.mkDerivation rec {
     wavpack
     zlib
   ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [ gnustep-base ];
+  ++ lib.optionals clangStdenv.hostPlatform.isLinux [ gnustep-base ];
 
   nativeBuildInputs = [
     installShellFiles
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuildHook ];
+  ++ lib.optionals clangStdenv.hostPlatform.isDarwin [ xcbuildHook ];
 
-  xcbuildFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+  xcbuildFlags = lib.optionals clangStdenv.hostPlatform.isDarwin [
     "-target unar"
     "-target lsar"
     "-configuration Release"
-    "MACOSX_DEPLOYMENT_TARGET=${stdenv.hostPlatform.darwinMinVersion}"
+    "MACOSX_DEPLOYMENT_TARGET=${clangStdenv.hostPlatform.darwinMinVersion}"
   ];
 
-  makefile = lib.optionalString (!stdenv.hostPlatform.isDarwin) "Makefile.linux";
+  makefile = lib.optionalString (!clangStdenv.hostPlatform.isDarwin) "Makefile.linux";
 
   enableParallelBuilding = true;
 
@@ -90,7 +90,7 @@ stdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm555 -t $out/bin ${lib.optionalString stdenv.hostPlatform.isDarwin "Products/Release/"}{lsar,unar}
+    install -Dm555 -t $out/bin ${lib.optionalString clangStdenv.hostPlatform.isDarwin "Products/Release/"}{lsar,unar}
     for f in lsar unar; do
       installManPage ./Extra/$f.?
       installShellCompletion --bash --name $f ./Extra/$f.bash_completion

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3775,10 +3775,6 @@ with pkgs;
     inherit (chickenPackages_4) eggDerivation fetchegg;
   };
 
-  unar = callPackage ../tools/archivers/unar {
-    stdenv = clangStdenv;
-  };
-
   unzipNLS = lowPrio (unzip.override { enableNLS = true; });
 
   inherit (callPackages ../servers/varnish { })


### PR DESCRIPTION
Migrate unar to by-name
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
