### PR TITLE
spideroak: 7.5.0 -> 7.5.2

### DIFF
--- a/pkgs/by-name/sp/spideroak/package.nix
+++ b/pkgs/by-name/sp/spideroak/package.nix
@@ -30,7 +30,7 @@ let
     zlib
   ];
 
-  version = "7.5.0";
+  version = "7.5.2";
 
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
Just update to the latest patch version.