### PR TITLE
rmpc: update website, install desktop file

### DIFF
--- a/pkgs/by-name/rm/rmpc/package.nix
+++ b/pkgs/by-name/rm/rmpc/package.nix
@@ -43,7 +43,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     changelog = "https://github.com/mierak/rmpc/releases/tag/${src.rev}";
     description = "TUI music player client for MPD with album art support via kitty image protocol";
-    homepage = "https://mierak.github.io/rmpc/";
+    homepage = "https://rmpc.mierak.dev/";
     license = lib.licenses.bsd3;
     longDescription = ''
       Rusty Music Player Client is a beautiful, modern and configurable terminal-based Music Player

--- a/pkgs/by-name/rm/rmpc/package.nix
+++ b/pkgs/by-name/rm/rmpc/package.nix
@@ -38,6 +38,8 @@ rustPlatform.buildRustPackage rec {
       --bash target/completions/rmpc.bash \
       --fish target/completions/rmpc.fish \
       --zsh target/completions/_rmpc
+
+    install -m 444 -D assets/rmpc.desktop $out/share/applications/rmpc.desktop
   '';
 
   meta = {


### PR DESCRIPTION
Both changes were part of the 0.11.0 release, but were missed out on the initial upgrade: https://github.com/NixOS/nixpkgs/pull/485924#issuecomment-3831970488

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
