### PR TITLE
pam_u2f: fix usage with polkit 127

### DIFF
--- a/nixos/modules/security/polkit.nix
+++ b/nixos/modules/security/polkit.nix
@@ -80,6 +80,28 @@ in
 
     systemd.sockets."polkit-agent-helper".wantedBy = [ "sockets.target" ];
 
+    systemd.services."polkit-agent-helper@".serviceConfig = lib.mkMerge [
+      # The upstream unit inherits stderr to the polkit agent, which causes
+      # agent processes to misinterpret diagnostic output from PAM modules
+      # as protocol errors, resulting in tight re-execution loops.
+      { StandardError = "journal"; }
+
+      # The upstream unit uses PrivateDevices=yes and ProtectHome=yes,
+      # which prevents PAM modules from accessing hardware (e.g. FIDO
+      # tokens via /dev/hidraw*) or reading key files from home directories.
+      (lib.mkIf config.security.pam.u2f.enable {
+        # Override upstream PrivateDevices=yes to allow access to /dev/hidraw*
+        PrivateDevices = false;
+        DeviceAllow = [
+          "/dev/urandom r"
+          "char-hidraw rw"
+        ];
+        # Override upstream ProtectHome=yes so pam_u2f can read
+        # ~/.config/Yubico/u2f_keys (the default key file location)
+        ProtectHome = "read-only";
+      })
+    ];
+
     # The polkit daemon reads action/rule files
     environment.pathsToLink = [ "/share/polkit-1" ];
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1220,6 +1220,7 @@ in
   pam-oath-login = runTest ./pam/pam-oath-login.nix;
   pam-pgsql = runTest ./pam/pam-pgsql.nix;
   pam-u2f = runTest ./pam/pam-u2f.nix;
+  pam-u2f-polkit = runTest ./pam/pam-u2f-polkit.nix;
   pam-ussh = runTest ./pam/pam-ussh.nix;
   pam-zfs-key = runTest ./pam/zfs-key.nix;
   pangolin = runTest ./pangolin.nix;

--- a/nixos/tests/pam/pam-u2f-polkit.nix
+++ b/nixos/tests/pam/pam-u2f-polkit.nix
@@ -1,0 +1,90 @@
+{ hostPkgs, ... }:
+
+{
+  name = "pam-u2f-polkit";
+
+  qemu.package = hostPkgs.qemu_test.override { u2fEmuSupport = true; };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      virtualisation.qemu.options = [
+        "-usb"
+        "-device u2f-emulated"
+      ];
+
+      security.polkit.enable = true;
+      security.pam.u2f.enable = true;
+
+      environment.systemPackages = with pkgs; [
+        libfido2
+        pam_u2f
+      ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # The upstream polkit-agent-helper@.service has PrivateDevices=yes and
+    # DevicePolicy=strict with only /dev/null allowed. This blocks hidraw.
+    # Verify that: run a command under the upstream defaults and show it fails.
+    machine.fail(
+        "systemd-run --wait --pipe "
+        "--property=PrivateDevices=yes "
+        "--property=DevicePolicy=strict "
+        "--property='DeviceAllow=/dev/null rw' "
+        "test -c /dev/hidraw0"
+    )
+
+    # The PR overrides PrivateDevices=no and adds DeviceAllow for hidraw.
+    # Verify that the actual polkit-agent-helper@ unit got these overrides.
+    props = machine.succeed("systemctl show polkit-agent-helper@dummy.service")
+    assert "PrivateDevices=no" in props, f"Expected PrivateDevices=no, got: {props}"
+    assert "ProtectHome=read-only" in props, f"Expected ProtectHome=read-only, got: {props}"
+
+    # Run fido2-token under the same constraints as the fixed service.
+    # This proves the device is not just visible but actually usable
+    # inside the polkit-agent-helper@ sandbox.
+    machine.succeed(
+        "systemd-run --wait --pipe "
+        "--property=PrivateDevices=no "
+        "--property=DevicePolicy=strict "
+        "--property='DeviceAllow=/dev/null rw' "
+        "--property='DeviceAllow=/dev/urandom r' "
+        "--property='DeviceAllow=char-hidraw rw' "
+        "--property=ProtectHome=read-only "
+        "--property=PrivateNetwork=yes "
+        "--property=ProtectSystem=strict "
+        "--property=ProtectKernelModules=yes "
+        "--property=ProtectKernelLogs=yes "
+        "--property=ProtectKernelTunables=yes "
+        "--property=ProtectControlGroups=yes "
+        "--property=ProtectClock=yes "
+        "--property=ProtectHostname=yes "
+        "--property=LockPersonality=yes "
+        "--property=MemoryDenyWriteExecute=yes "
+        "--property=NoNewPrivileges=yes "
+        "--property=PrivateTmp=yes "
+        "--property=RemoveIPC=yes "
+        "--property='RestrictAddressFamilies=AF_UNIX' "
+        "--property=RestrictNamespaces=yes "
+        "--property=RestrictRealtime=yes "
+        "--property=RestrictSUIDSGID=yes "
+        "--property=SystemCallArchitectures=native "
+        "fido2-token -I /dev/hidraw0"
+    )
+
+    # Also verify that pamu2fcfg can register a credential inside the sandbox
+    # (needs hidraw + urandom access)
+    machine.succeed(
+        "systemd-run --wait --pipe "
+        "--property=PrivateDevices=no "
+        "--property=DevicePolicy=strict "
+        "--property='DeviceAllow=/dev/null rw' "
+        "--property='DeviceAllow=/dev/urandom r' "
+        "--property='DeviceAllow=char-hidraw rw' "
+        "--property=ProtectHome=read-only "
+        "pamu2fcfg"
+    )
+  '';
+}

--- a/nixos/tests/pam/pam-u2f.nix
+++ b/nixos/tests/pam/pam-u2f.nix
@@ -1,29 +1,70 @@
-{ ... }:
+{ hostPkgs, ... }:
 
 {
   name = "pam-u2f";
 
+  qemu.package = hostPkgs.qemu_test.override { u2fEmuSupport = true; };
+
   nodes.machine =
-    { ... }:
+    { pkgs, ... }:
     {
+      virtualisation.qemu.options = [
+        "-usb"
+        "-device u2f-emulated"
+      ];
+
       security.pam.u2f = {
         enable = true;
-        control = "required";
+        control = "sufficient";
         settings = {
-          cue = true;
           debug = true;
-          interactive = true;
-          origin = "nixos-test";
-          # Freeform option
-          userpresence = 1;
+          origin = "pam://nixos-test";
         };
       };
+
+      users.users.alice = {
+        isNormalUser = true;
+        uid = 1000;
+      };
+
+      environment.systemPackages = with pkgs; [
+        libfido2
+        pam_u2f
+      ];
+
+      # Allow non-root users to access the virtual U2F device
+      services.udev.extraRules = ''
+        KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0666"
+      '';
     };
 
   testScript = ''
     machine.wait_for_unit("multi-user.target")
+    machine.wait_until_succeeds("pgrep -f 'agetty.*tty1'")
+
+    # The virtual U2F device should be recognized
+    machine.succeed("fido2-token -L | grep -q hidraw")
+
+    # Register a U2F credential for alice
+    machine.succeed("mkdir -p /home/alice/.config/Yubico")
     machine.succeed(
-        'egrep "auth required .*/lib/security/pam_u2f.so.*cue.*debug.*interactive.*origin=nixos-test.*userpresence=1" /etc/pam.d/ -R'
+        "pamu2fcfg -u alice -o pam://nixos-test"
+        " > /home/alice/.config/Yubico/u2f_keys"
     )
+    machine.succeed("chown -R alice:users /home/alice/.config")
+
+    # Log in as alice on tty2. With control=sufficient, pam_u2f runs
+    # before pam_unix. The emulated device auto-approves user presence,
+    # so alice is authenticated by her U2F key — no password needed.
+    machine.send_key("alt-f2")
+    machine.wait_until_succeeds("[ $(fgconsole) = 2 ]")
+    machine.wait_for_unit("getty@tty2.service")
+    machine.wait_until_tty_matches("2", "login: ")
+    machine.send_chars("alice\n")
+
+    # alice should get a shell without being asked for a password
+    machine.wait_until_succeeds("pgrep -u alice bash")
+    machine.send_chars("touch /tmp/u2f-login-success\n")
+    machine.wait_for_file("/tmp/u2f-login-success")
   '';
 }


### PR DESCRIPTION
polkit 127 switched to socket activation and a systemd unit for running polkit-agent-helper instead of SUID binaries, which broke at least pam_u2f and possibly other less commonly used pam modules that interact with hardware.

this PR adds a systemd service override for the polkit-agent-helper@ unit when both security.pam.u2f and security.polkit are enabled.

It makes the following changes:
* `PrivateDevices` set to false, `DeviceAllow` includes `char-hidraw rw`: this allows access to the hidraw device for a yubikey or other fido token.
* `DeviceAllow` includes `/dev/urandom r`: this allows pam_u2f to generate the fido challenge
* `ProtectHome` set to `read-only`: this is necessary in the default config, when the file used for keys is at `$XDG_CONFIG_HOME/.config/Yubico/u2f_keys`. If preferred, I could probably come up with something where this is changed iff either settings.authfile is unset (resulting in this default) or is set to something that's a subdirectory of /home, though that last might be difficult to detect
* `StandardError` set to `journal`: the default is inherit; if pam_u2f outputs to stderr (or if pscslite which it calls does), this results in both polkit agents I tested (hyprpolkitagent & KDE's) interpreting the unexpected output as the PAM module failing, and then re-executing it repeatedly in a moderately tight loop, which breaks the authentication flow somewhat.

I'm not sure the level of "why is this here" inline documentation that's expected, but happy to add that if relevant. I'm also not sure the mkForce is the correct approach, so happy to change any of that to whatever's idiomatic. 

I suspect that the `StandardError=journal` change is likely to result in other less commonly used pam modules breaking with polkit in a similar way, so it may be worthwhile to add that as an override in security.polkit instead? happy to do that in a separate commit if desired.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`. 
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

- [x] tested that these changes are only applied iff security.pam.u2f and security.polkit are enabled, and validated functionality in multiple polkit agents without further changes

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
