### PR TITLE
python3Packages.aioboto3: cleanup, skip flaky tests on darwin

### DIFF
--- a/pkgs/development/python-modules/aioboto3/default.nix
+++ b/pkgs/development/python-modules/aioboto3/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -67,6 +68,13 @@ buildPythonPackage (finalAttrs: {
 
   disabledTests = [
     "test_patches"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Flaky: PermissionError: [Errno 13] Permission denied: '/tmp/somefile'
+    "test_s3_copy"
+    "test_s3_copy_multipart"
+    "test_s3_download_file_404"
+    "test_s3_upload_file"
   ];
 
   pythonImportsCheck = [ "aioboto3" ];

--- a/pkgs/development/python-modules/aioboto3/default.nix
+++ b/pkgs/development/python-modules/aioboto3/default.nix
@@ -1,20 +1,30 @@
 {
   lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+  setuptools-scm,
+
+  # dependencies
   aiobotocore,
   aiofiles,
-  buildPythonPackage,
+
+  # optional-dependencies
+  # chalice
   chalice,
+  # s3cse
   cryptography,
+
+  # tests
   dill,
-  fetchFromGitHub,
   moto,
   pytest-asyncio,
   pytestCheckHook,
-  setuptools,
-  setuptools-scm,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aioboto3";
   version = "15.5.0";
   pyproject = true;
@@ -22,7 +32,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "terricain";
     repo = "aioboto3";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-yGKjcZlXs1f72OGX5rUWvfDKZAYU3ZV2RVQnd0InxBQ=";
   };
 
@@ -53,7 +63,7 @@ buildPythonPackage rec {
     pytestCheckHook
   ]
   ++ moto.optional-dependencies.server
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.concatAttrValues finalAttrs.passthru.optional-dependencies;
 
   disabledTests = [
     "test_patches"
@@ -64,8 +74,8 @@ buildPythonPackage rec {
   meta = {
     description = "Wrapper to use boto3 resources with the aiobotocore async backend";
     homepage = "https://github.com/terricain/aioboto3";
-    changelog = "https://github.com/terricain/aioboto3/blob/${src.rev}/CHANGELOG.rst";
+    changelog = "https://github.com/terricain/aioboto3/blob/${finalAttrs.src.tag}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.aioboto3: cleanup**
- **python3Packages.aioboto3: skip flaky tests on darwin**

---

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
