### PR TITLE
crowdsec-blocklist-import: init at 3.7.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -152,6 +152,8 @@
 
 - [Headplane](https://headplane.net), a feature-complete Web UI for Headscale. Available as [services.headplane](#opt-services.headplane.enable).
 
+- [crowdsec-blocklist-import](https://www.crowdsec.net/), aggregates threat intelligence from 30+ public blocklists and imports them directly into CrowdSec with automatic deduplication. Available as [services.crowdsec-blocklist-import](#opt-services.crowdsec-blocklist-import.enable).
+
 - [whois](https://packages.qa.debian.org/w/whois.html), an intelligent WHOIS client. Available as `programs.whois`.
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -178,6 +178,8 @@
 
 - [LogiOps](https://github.com/PixlOne/logiops), an unofficial userspace driver for HID++ Logitech devices. Available as [services.logiops](#opt-services.logiops.enable).
 
+- [crowdsec-blocklist-import](https://www.crowdsec.net/), aggregates threat intelligence from 30+ public blocklists and imports them directly into CrowdSec with automatic deduplication. Available as [services.crowdsec-blocklist-import](#opt-services.crowdsec-blocklist-import.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1501,6 +1501,7 @@
   ./services/security/certmgr.nix
   ./services/security/cfssl.nix
   ./services/security/clamav.nix
+  ./services/security/crowdsec-blocklist-import.nix
   ./services/security/crowdsec-firewall-bouncer.nix
   ./services/security/crowdsec.nix
   ./services/security/e-imzo.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1524,6 +1524,7 @@
   ./services/security/certmgr.nix
   ./services/security/cfssl.nix
   ./services/security/clamav.nix
+  ./services/security/crowdsec-blocklist-import.nix
   ./services/security/crowdsec-firewall-bouncer.nix
   ./services/security/crowdsec.nix
   ./services/security/e-imzo.nix

--- a/nixos/modules/services/security/crowdsec-blocklist-import.nix
+++ b/nixos/modules/services/security/crowdsec-blocklist-import.nix
@@ -1,0 +1,402 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatStringsSep
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.services.crowdsec-blocklist-import;
+
+  # Source: https://github.com/wolffcatskyy/crowdsec-blocklist-import/blob/main/import.sh#L127C24-L164C3
+  feedGroupsNames = [
+    "IPsum"
+    "Spamhaus"
+    "Blocklist.de"
+    "Firehol"
+    "Abuse.ch"
+    "Emerging Threats"
+    "Binary Defense"
+    "Bruteforce Blocker"
+    "DShield"
+    "CI Army"
+    "Botvrij"
+    "GreenSnow"
+    "StopForumSpam"
+    "Tor"
+    "Scanners"
+    "Abuse IPDB"
+    "Cybercrime Tracker"
+    "Monty Security C2"
+    "VXVault"
+    "Sentinel"
+  ];
+
+  toEnvVarName =
+    f: lib.strings.replaceStrings [ " " "." "(" ")" ] [ "_" "_" "" "" ] (lib.strings.toUpper f);
+in
+{
+  options.services.crowdsec-blocklist-import = {
+    enable = mkEnableOption "CrowdSec blocklist import service";
+
+    package = mkPackageOption pkgs "crowdsec-blocklist-import" { };
+
+    crowdsecLapiUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:8080";
+      description = "URL of the CrowdSec local API";
+    };
+
+    crowdsecLapiKey = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec local API key";
+    };
+
+    crowdsecLapiKeyFile = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec local API key file path";
+    };
+
+    crowdsecMachineId = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec machine ID";
+    };
+
+    crowdsecMachinePassword = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec machine password";
+    };
+
+    crowdsecMachinePasswordFile = mkOption {
+      type = types.str;
+      default = "";
+      example = "/var/lib/crowdsec/local_api_credentials.yaml";
+      description = "CrowdSec machine password file path";
+    };
+
+    decisionDuration = mkOption {
+      type = types.str;
+      default = "24h";
+      description = ''
+        How long decisions last.
+        Examples: "24h", "12h", "48h"
+      '';
+    };
+
+    fetchTimeout = mkOption {
+      type = types.int;
+      default = 60;
+      description = "Timeout in seconds for fetching blocklists (increase for slow connections)";
+    };
+
+    logLevel = mkOption {
+      type = types.enum [
+        "DEBUG"
+        "INFO"
+        "WARN"
+        "ERROR"
+      ];
+      default = "INFO";
+      description = "Logging verbosity";
+    };
+
+    telemetryEnabled = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Send anonymous usage statistics to upstream";
+    };
+
+    dryRun = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Preview mode - shows what would be imported without making changes";
+    };
+
+    disabledSources = mkOption {
+      type = types.listOf (types.enum feedGroupsNames);
+      default = [ ];
+      description = ''
+        Which threat feeds to disable. Available feeds:
+        ${concatStringsSep "\n\t" feedGroupsNames}
+      '';
+      example = [
+        "Spamhaus DROP"
+        "Firehol level1"
+        "Emerging Threats"
+      ];
+    };
+
+    customBlockLists = mkOption {
+      type = types.listOf (types.str);
+      default = [ ];
+      description = "Import your own threat feed URLs";
+      example = [
+        "https://example.com/list1.txt"
+        "https://example.com/list2.txt"
+      ];
+    };
+
+    allowList = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Inline allow-list as comma-separated values (e.g. \"1.1.1.1,8.8.8.8,192.168.1.0/24\")";
+    };
+
+    allowListGithub = mkEnableOption "allow all github IPs";
+
+    consolidateAlerts = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Combine all IPs into a single CrowdSec alert per run";
+    };
+
+    metrics = {
+      enable = mkEnableOption "Prometheus metrics";
+
+      pushGatewayUrl = mkOption {
+        type = types.str;
+        default = "localhost:9091";
+        description = "Push URL for Prometheus metrics endpoint (default: localhost:9091)";
+      };
+    };
+
+    webhookUrl = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Webhook URL for notifications (Discord/Slack/generic)";
+    };
+
+    webhookType = mkOption {
+      type = types.enum [
+        "generic"
+        "discord"
+        "slack"
+      ];
+      default = "generic";
+      description = "Webhook format: generic, discord, slack (default: generic)";
+    };
+
+    abuseIpDbKey = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "AbuseIPDB API key, for direct blacklist queries";
+    };
+
+    abuseIpDbKeyFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "AbuseIPDB API key file path, for direct blacklist queries";
+    };
+
+    abuseIpDbMinConfidence = mkOption {
+      type = types.int;
+      default = 90;
+      description = "WebMinimum confidence score 1-100 (default: 90)";
+    };
+
+    schedule = mkOption {
+      type = types.str;
+      default = "*-*-* 04:00:00";
+      description = ''
+        When to run the import of non-rate limited sources (systemd calendar syntax). See {manpage}`systemd.time(7)` for the format.
+        Examples:
+        - "*-*-* *:00:00" (every hour)
+        - "*-*-* 04:00:00"  (daily at 4 AM)
+        - "*-*-* 04,16:00:00"  (twice daily)
+        - "Mon *-*-* 04:00:00"  (weekly)
+      '';
+    };
+
+    scheduleRateLimited = mkOption {
+      type = types.str;
+      default = "*-*-* 00,05,10,15,20:00:00"; # 5x/day, every ~5 hours
+      description = ''
+        When to run the import of rate limited sources (systemd calendar syntax). See {manpage}`systemd.time(7)` for the format.
+        Examples:
+        - "*-*-* 00,05,10,15,20:00:00"  (5x/day, every ~5 hours)
+        - "*-*-* *:00:00"  (every hour)
+        - "*-*-* 04:00:00"  (daily at 4 AM)
+        - "*-*-* 04,16:00:00"  (twice daily)
+        - "Mon *-*-* 04:00:00"  (weekly)
+      '';
+    };
+
+    refreshPeriodFrequentMn = mkOption {
+      type = types.int;
+      default = 60;
+      description = "Refresh IPs expiring under this delay";
+    };
+
+    refreshPeriodLimitedMn = mkOption {
+      type = types.int;
+      default = 300;
+      description = "Refresh IPs expiring under this delay";
+    };
+
+    randomizedDelay = mkOption {
+      type = types.str;
+      default = "15min";
+      description = "Random delay before starting to prevent thundering herd effect.";
+    };
+
+    runAt = mkOption {
+      type = types.enum [
+        "timer"
+        "manual"
+      ];
+      default = "timer";
+      description = ''
+        When to run the service:
+        - timer: Use systemd timer with schedule option, also run at boot
+        - manual: Never auto-run, use 'systemctl start' manually
+      '';
+    };
+  };
+
+  config =
+    let
+      apiKeyFile =
+        if config.services.crowdsec-firewall-bouncer.registerBouncer.enable then
+          "/var/lib/crowdsec-firewall-bouncer-register/api-key.cred"
+        else
+          config.services.crowdsec-firewall-bouncer.secrets.apiKeyPath;
+
+      mkScript = arg: {
+        description = "Import threat intelligence blocklists into CrowdSec (${arg})";
+        documentation = [ "https://github.com/wolffcatskyy/crowdsec-blocklist-import" ];
+
+        wantedBy = mkIf (cfg.runAt == "timer") [ "multi-user.target" ];
+        after = mkIf (cfg.runAt == "timer") [
+          "crowdsec.service"
+          "crowdsec-firewall-bouncer.service"
+        ];
+        wants = mkIf (cfg.runAt == "timer") [
+          "crowdsec.service"
+          "crowdsec-firewall-bouncer.service"
+        ];
+
+        script = "${lib.getExe cfg.package} --mode ${arg}";
+
+        environment = mkMerge [
+          {
+            ABUSEIPDB_API_KEY = cfg.abuseIpDbKey;
+            ABUSEIPDB_API_KEY_FILE = cfg.abuseIpDbKeyFile;
+            ABUSEIPDB_MIN_CONFIDENCE = toString cfg.abuseIpDbMinConfidence;
+            ALLOWLIST = lib.concatStringsSep "," cfg.allowList;
+            ALLOWLIST_GITHUB = if cfg.allowListGithub then "true" else "false";
+            CONSOLIDATE_ALERTS = if cfg.consolidateAlerts then "true" else "false";
+            CROWDSEC_LAPI_KEY = cfg.crowdsecLapiKey;
+            CROWDSEC_LAPI_KEY_FILE = cfg.crowdsecLapiKeyFile;
+            CROWDSEC_LAPI_URL = cfg.crowdsecLapiUrl;
+            CROWDSEC_MACHINE_ID = cfg.crowdsecMachineId;
+            CROWDSEC_MACHINE_PASSWORD = cfg.crowdsecMachinePassword;
+            CROWDSEC_MACHINE_PASSWORD_FILE = cfg.crowdsecMachinePasswordFile;
+            CUSTOM_BLOCKLISTS = lib.concatStringsSep "," cfg.customBlockLists;
+            DECISION_DURATION = cfg.decisionDuration;
+            DRY_RUN = if cfg.dryRun then "true" else "false";
+            FETCH_TIMEOUT = toString cfg.fetchTimeout;
+            LOG_LEVEL = cfg.logLevel;
+            LOG_TIMESTAMPS = "false";
+            METRICS_ENABLED = if cfg.metrics.enable then "true" else "false";
+            METRICS_PUSHGATEWAY_URL = cfg.metrics.pushGatewayUrl;
+            REFRESH_PERIOD_FREQUENT_MN = toString cfg.refreshPeriodFrequentMn;
+            REFRESH_PERIOD_LIMITED_MN = toString cfg.refreshPeriodLimitedMn;
+            TELEMETRY_ENABLED = if cfg.telemetryEnabled then "true" else "false";
+            WEBHOOK_TYPE = cfg.webhookType;
+            WEBHOOK_URL = cfg.webhookUrl;
+          }
+          (lib.listToAttrs (
+            lib.map (source: {
+              name = "ENABLE_${toEnvVarName source}";
+              value = "false";
+            }) cfg.disabledSources
+          ))
+        ];
+
+        serviceConfig = {
+          Type = "oneshot";
+
+          ExecStartPost = "+systemctl reload crowdsec.service";
+
+          # Run as crowdsec user to be able to use cscli
+          User = config.services.crowdsec.user;
+          Group = config.services.crowdsec.group;
+
+          StateDirectory = "crowdsec crowdsec-firewall-bouncer-register";
+          StateDirectoryMode = "0750";
+
+          DynamicUser = true;
+          LockPersonality = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          UMask = "0077";
+
+          StandardOutput = "journal";
+          StandardError = "journal";
+          SyslogIdentifier = "crowdsec-blocklist-import";
+        };
+      };
+    in
+    mkIf cfg.enable {
+      services.crowdsec-blocklist-import = {
+        crowdsecLapiUrl = lib.mkDefault "http://${config.services.crowdsec.settings.config.api.server.listen_uri}";
+        crowdsecLapiKeyFile = lib.mkDefault apiKeyFile;
+        crowdsecMachineId = lib.mkDefault config.services.crowdsec.name;
+        crowdsecMachinePasswordFile = lib.mkDefault config.services.crowdsec.settings.config.api.client.credentials_path;
+      };
+
+      systemd.timers = mkIf (cfg.runAt == "timer") {
+        crowdsec-blocklist-import-frequent = {
+          description = "CrowdSec blocklist import timer (frequent)";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = cfg.schedule;
+            RandomizedDelaySec = cfg.randomizedDelay;
+            Unit = "crowdsec-blocklist-import-frequent.service";
+          };
+        };
+        crowdsec-blocklist-import-limited = {
+          description = "CrowdSec blocklist import timer (rate-limited)";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = cfg.scheduleRateLimited;
+            RandomizedDelaySec = cfg.randomizedDelay;
+            Unit = "crowdsec-blocklist-import-limited.service";
+          };
+        };
+      };
+
+      systemd.services.crowdsec-blocklist-import-frequent = mkScript "frequent";
+
+      systemd.services.crowdsec-blocklist-import-limited = mkScript "limited";
+    };
+
+  meta.maintainers = with lib.maintainers; [ gaelj ];
+}

--- a/nixos/modules/services/security/crowdsec-blocklist-import.nix
+++ b/nixos/modules/services/security/crowdsec-blocklist-import.nix
@@ -1,0 +1,404 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    concatStringsSep
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    mkPackageOption
+    types
+    ;
+  cfg = config.services.crowdsec-blocklist-import;
+
+  # Source: https://github.com/wolffcatskyy/crowdsec-blocklist-import/blob/main/import.sh#L127C24-L164C3
+  feedGroupsNames = [
+    "IPsum"
+    "Spamhaus"
+    "Blocklist.de"
+    "Firehol"
+    "Abuse.ch"
+    "Emerging Threats"
+    "Binary Defense"
+    "Bruteforce Blocker"
+    "DShield"
+    "CI Army"
+    "Botvrij"
+    "GreenSnow"
+    "StopForumSpam"
+    "Tor"
+    "Scanners"
+    "Abuse IPDB"
+    "Cybercrime Tracker"
+    "Monty Security C2"
+    "VXVault"
+    "Sentinel"
+  ];
+
+  toEnvVarName =
+    f: lib.strings.replaceStrings [ " " "." "(" ")" ] [ "_" "_" "" "" ] (lib.strings.toUpper f);
+in
+{
+  options.services.crowdsec-blocklist-import = {
+    enable = mkEnableOption "CrowdSec blocklist import service";
+
+    package = mkPackageOption pkgs "crowdsec-blocklist-import" { };
+
+    crowdsecLapiUrl = mkOption {
+      type = types.str;
+      default = "http://localhost:8080";
+      description = "URL of the CrowdSec local API";
+    };
+
+    crowdsecLapiKey = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec local API key";
+    };
+
+    crowdsecLapiKeyFile = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec local API key file path";
+    };
+
+    crowdsecMachineId = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec machine ID";
+    };
+
+    crowdsecMachinePassword = mkOption {
+      type = types.str;
+      default = "";
+      description = "CrowdSec machine password";
+    };
+
+    crowdsecMachinePasswordFile = mkOption {
+      type = types.str;
+      default = "";
+      example = "/var/lib/crowdsec/local_api_credentials.yaml";
+      description = "CrowdSec machine password file path";
+    };
+
+    decisionDuration = mkOption {
+      type = types.str;
+      default = "24h";
+      description = ''
+        How long decisions last.
+        Examples: "24h", "12h", "48h"
+      '';
+    };
+
+    fetchTimeout = mkOption {
+      type = types.int;
+      default = 60;
+      description = "Timeout in seconds for fetching blocklists (increase for slow connections)";
+    };
+
+    logLevel = mkOption {
+      type = types.enum [
+        "DEBUG"
+        "INFO"
+        "WARN"
+        "ERROR"
+      ];
+      default = "INFO";
+      description = "Logging verbosity";
+    };
+
+    telemetryEnabled = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Send anonymous usage statistics to upstream";
+    };
+
+    dryRun = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Preview mode - shows what would be imported without making changes";
+    };
+
+    disabledSources = mkOption {
+      type = types.listOf (types.enum feedGroupsNames);
+      default = [ ];
+      description = ''
+        Which threat feeds to disable. Available feeds:
+        ${concatStringsSep "\n\t" feedGroupsNames}
+      '';
+      example = [
+        "Spamhaus DROP"
+        "Firehol level1"
+        "Emerging Threats"
+      ];
+    };
+
+    customBlockLists = mkOption {
+      type = types.listOf (types.str);
+      default = [ ];
+      description = "Import your own threat feed URLs";
+      example = [
+        "https://example.com/list1.txt"
+        "https://example.com/list2.txt"
+      ];
+    };
+
+    allowList = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = "Inline allow-list as comma-separated values (e.g. \"1.1.1.1,8.8.8.8,192.168.1.0/24\")";
+    };
+
+    allowListGithub = mkEnableOption "allow all github IPs";
+
+    consolidateAlerts = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Combine all IPs into a single CrowdSec alert per run";
+    };
+
+    metrics = {
+      enable = mkEnableOption "Prometheus metrics";
+
+      pushGatewayUrl = mkOption {
+        type = types.str;
+        default = "localhost:9091";
+        description = "Push URL for Prometheus metrics endpoint (default: localhost:9091)";
+      };
+    };
+
+    webhookUrl = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "Webhook URL for notifications (Discord/Slack/generic)";
+    };
+
+    webhookType = mkOption {
+      type = types.enum [
+        "generic"
+        "discord"
+        "slack"
+      ];
+      default = "generic";
+      description = "Webhook format: generic, discord, slack (default: generic)";
+    };
+
+    abuseIpDbKey = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "AbuseIPDB API key, for direct blacklist queries";
+    };
+
+    abuseIpDbKeyFile = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = "AbuseIPDB API key file path, for direct blacklist queries";
+    };
+
+    abuseIpDbMinConfidence = mkOption {
+      type = types.int;
+      default = 90;
+      description = "WebMinimum confidence score 1-100 (default: 90)";
+    };
+
+    schedule = mkOption {
+      type = types.str;
+      default = "*-*-* *:00:00";
+      description = ''
+        When to run the import of non-rate limited sources (systemd calendar syntax). See {manpage}`systemd.time(7)` for the format.
+        Examples:
+        - "*-*-* *:00:00" (every hour)
+        - "*-*-* 04:00:00"  (daily at 4 AM)
+        - "*-*-* 04,16:00:00"  (twice daily)
+        - "Mon *-*-* 04:00:00"  (weekly)
+      '';
+    };
+
+    scheduleRateLimited = mkOption {
+      type = types.str;
+      default = "*-*-* 00,06,12,18:00:00"; # 4x/day, every ~6 hours
+      description = ''
+        When to run the import of rate limited sources (systemd calendar syntax). See {manpage}`systemd.time(7)` for the format.
+        Examples:
+        - "*-*-* 00,06,12,18:00:00"  (4x/day, every ~6 hours)
+        - "*-*-* 00,05,10,15,20:00:00"  (5x/day, every ~5 hours)
+        - "*-*-* *:00:00"  (every hour)
+        - "*-*-* 04:00:00"  (daily at 4 AM)
+        - "*-*-* 04,16:00:00"  (twice daily)
+        - "Mon *-*-* 04:00:00"  (weekly)
+      '';
+    };
+
+    refreshPeriodFrequentMn = mkOption {
+      type = types.int;
+      default = 90;
+      description = "Refresh IPs expiring under this delay";
+    };
+
+    refreshPeriodLimitedMn = mkOption {
+      type = types.int;
+      default = 750;
+      description = "Refresh IPs expiring under this delay";
+    };
+
+    randomizedDelay = mkOption {
+      type = types.str;
+      default = "15min";
+      description = "Random delay before starting to prevent thundering herd effect.";
+    };
+
+    runAt = mkOption {
+      type = types.enum [
+        "timer"
+        "manual"
+      ];
+      default = "timer";
+      description = ''
+        When to run the service:
+        - timer: Use systemd timer with schedule option, also run at boot
+        - manual: Never auto-run, use 'systemctl start' manually
+      '';
+    };
+  };
+
+  config =
+    let
+      apiKeyFile =
+        if config.services.crowdsec-firewall-bouncer.registerBouncer.enable then
+          "/var/lib/crowdsec-firewall-bouncer-register/api-key.cred"
+        else
+          config.services.crowdsec-firewall-bouncer.secrets.apiKeyPath;
+
+      mkScript = arg: {
+        description = "Import threat intelligence blocklists into CrowdSec (${arg})";
+        documentation = [ "https://github.com/wolffcatskyy/crowdsec-blocklist-import" ];
+
+        restartIfChanged = false;
+        # wantedBy = mkIf (cfg.runAt == "timer") [ "multi-user.target" ];
+        after = mkIf (cfg.runAt == "timer") [
+          "crowdsec.service"
+          "crowdsec-firewall-bouncer.service"
+        ];
+        wants = mkIf (cfg.runAt == "timer") [
+          "crowdsec.service"
+          "crowdsec-firewall-bouncer.service"
+        ];
+
+        script = "${lib.getExe cfg.package} --mode ${arg}";
+
+        environment = mkMerge [
+          {
+            ABUSEIPDB_API_KEY = cfg.abuseIpDbKey;
+            ABUSEIPDB_API_KEY_FILE = cfg.abuseIpDbKeyFile;
+            ABUSEIPDB_MIN_CONFIDENCE = toString cfg.abuseIpDbMinConfidence;
+            ALLOWLIST = lib.concatStringsSep "," cfg.allowList;
+            ALLOWLIST_GITHUB = if cfg.allowListGithub then "true" else "false";
+            CONSOLIDATE_ALERTS = if cfg.consolidateAlerts then "true" else "false";
+            CROWDSEC_LAPI_KEY = cfg.crowdsecLapiKey;
+            CROWDSEC_LAPI_KEY_FILE = cfg.crowdsecLapiKeyFile;
+            CROWDSEC_LAPI_URL = cfg.crowdsecLapiUrl;
+            CROWDSEC_MACHINE_ID = cfg.crowdsecMachineId;
+            CROWDSEC_MACHINE_PASSWORD = cfg.crowdsecMachinePassword;
+            CROWDSEC_MACHINE_PASSWORD_FILE = cfg.crowdsecMachinePasswordFile;
+            CUSTOM_BLOCKLISTS = lib.concatStringsSep "," cfg.customBlockLists;
+            DECISION_DURATION = cfg.decisionDuration;
+            DRY_RUN = if cfg.dryRun then "true" else "false";
+            FETCH_TIMEOUT = toString cfg.fetchTimeout;
+            LOG_LEVEL = cfg.logLevel;
+            LOG_TIMESTAMPS = "false";
+            METRICS_ENABLED = if cfg.metrics.enable then "true" else "false";
+            METRICS_PUSHGATEWAY_URL = cfg.metrics.pushGatewayUrl;
+            REFRESH_PERIOD_FREQUENT_MN = toString cfg.refreshPeriodFrequentMn;
+            REFRESH_PERIOD_LIMITED_MN = toString cfg.refreshPeriodLimitedMn;
+            TELEMETRY_ENABLED = if cfg.telemetryEnabled then "true" else "false";
+            WEBHOOK_TYPE = cfg.webhookType;
+            WEBHOOK_URL = cfg.webhookUrl;
+          }
+          (lib.listToAttrs (
+            lib.map (source: {
+              name = "ENABLE_${toEnvVarName source}";
+              value = "false";
+            }) cfg.disabledSources
+          ))
+        ];
+
+        serviceConfig = {
+          Type = "oneshot";
+
+          ExecStartPost = "+systemctl reload crowdsec.service";
+
+          # Run as crowdsec user to be able to use cscli
+          User = config.services.crowdsec.user;
+          Group = config.services.crowdsec.group;
+
+          StateDirectory = "crowdsec crowdsec-firewall-bouncer-register";
+          StateDirectoryMode = "0750";
+
+          DynamicUser = true;
+          LockPersonality = true;
+          NoNewPrivileges = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = "strict";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = "native";
+          UMask = "0077";
+
+          StandardOutput = "journal";
+          StandardError = "journal";
+          SyslogIdentifier = "crowdsec-blocklist-import";
+        };
+      };
+    in
+    mkIf cfg.enable {
+      services.crowdsec-blocklist-import = {
+        crowdsecLapiUrl = lib.mkDefault "http://${config.services.crowdsec.settings.config.api.server.listen_uri}";
+        crowdsecLapiKeyFile = lib.mkDefault apiKeyFile;
+        crowdsecMachineId = lib.mkDefault config.services.crowdsec.name;
+        crowdsecMachinePasswordFile = lib.mkDefault config.services.crowdsec.settings.config.api.client.credentials_path;
+      };
+
+      systemd.timers = mkIf (cfg.runAt == "timer") {
+        crowdsec-blocklist-import-frequent = {
+          description = "CrowdSec blocklist import timer (frequent)";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = cfg.schedule;
+            RandomizedDelaySec = cfg.randomizedDelay;
+            Unit = "crowdsec-blocklist-import-frequent.service";
+          };
+        };
+        crowdsec-blocklist-import-limited = {
+          description = "CrowdSec blocklist import timer (rate-limited)";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = cfg.scheduleRateLimited;
+            RandomizedDelaySec = cfg.randomizedDelay;
+            Unit = "crowdsec-blocklist-import-limited.service";
+          };
+        };
+      };
+
+      systemd.services.crowdsec-blocklist-import-frequent = mkScript "frequent";
+
+      systemd.services.crowdsec-blocklist-import-limited = mkScript "limited";
+    };
+
+  meta.maintainers = with lib.maintainers; [ gaelj ];
+}

--- a/pkgs/by-name/cr/crowdsec-blocklist-import/package.nix
+++ b/pkgs/by-name/cr/crowdsec-blocklist-import/package.nix
@@ -1,0 +1,88 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "crowdsec-blocklist-import";
+  version = "3.7.1";
+
+  src = fetchFromGitHub {
+    owner = "wolffcatskyy";
+    repo = "crowdsec-blocklist-import";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KuPohvN2kN9f0N35sANwK/p2oGhim0hOghk/UZcvdsA=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    requests
+    prometheus-client
+    python-dotenv
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [
+    "test_blocklist_import.py"
+    "-v"
+  ];
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 blocklist_import.py $out/bin/crowdsec-blocklist-import
+    install -Dm644 grafana-dashboard.json $out/share/grafana/dashboards/crowdsec-blocklist-import.json
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Import 60,000+ IPs from 30+ public threat feeds directly into CrowdSec";
+    longDescription = ''
+      CrowdSec Blocklist Import aggregates threat intelligence from 30+ public
+      blocklists and imports them directly into CrowdSec with automatic deduplication.
+
+      Features:
+      - 30+ Free Blocklists: IPsum, Spamhaus, Firehol, Abuse.ch, Emerging Threats, and more
+      - Smart Deduplication: Skips IPs already in CrowdSec (CAPI, Console lists, local detections)
+      - Private IP Filtering: Automatically excludes RFC1918 and reserved ranges
+      - Docker Ready: Run as a container with Docker socket access
+      - Cron Friendly: Designed for daily runs with 24h decision expiration
+      - Selective Sources: Enable/disable individual blocklists
+      - Custom Blocklist URLs: Import your own threat feeds
+      - Dry Run Mode: Preview imports without making changes
+      - Per-Source Statistics: Summary table showing IP counts from each source
+
+      Ideal for home labs and personal projects.
+
+      Consider CrowdSec Premium when:
+
+      - Business/production environments needing SLA support
+      - Concerns about false positives on VPN/proxy traffic
+      - Need curated, lower-noise blocklists
+      - Want the official 25k-100k+ threat feed with 5-minute updates
+    '';
+    homepage = "https://github.com/wolffcatskyy/crowdsec-blocklist-import";
+    changelog = "https://github.com/wolffcatskyy/crowdsec-blocklist-import/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "crowdsec-blocklist-import";
+    maintainers = with lib.maintainers; [
+      gaelj
+      tornax
+    ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/cr/crowdsec-blocklist-import/package.nix
+++ b/pkgs/by-name/cr/crowdsec-blocklist-import/package.nix
@@ -1,0 +1,87 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "crowdsec-blocklist-import";
+  version = "3.7.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "wolffcatskyy";
+    repo = "crowdsec-blocklist-import";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KuPohvN2kN9f0N35sANwK/p2oGhim0hOghk/UZcvdsA=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    requests
+    prometheus-client
+    python-dotenv
+  ];
+
+  nativeCheckInputs = with python3Packages; [
+    pytestCheckHook
+  ];
+
+  pytestFlags = [
+    "test_blocklist_import.py"
+    "-v"
+  ];
+
+  doCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 blocklist_import.py $out/bin/crowdsec-blocklist-import
+    install -Dm644 grafana-dashboard.json $out/share/grafana/dashboards/crowdsec-blocklist-import.json
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Import 60,000+ IPs from 30+ public threat feeds directly into CrowdSec";
+    longDescription = ''
+      CrowdSec Blocklist Import aggregates threat intelligence from 30+ public
+      blocklists and imports them directly into CrowdSec with automatic deduplication.
+
+      Features:
+      - 30+ Free Blocklists: IPsum, Spamhaus, Firehol, Abuse.ch, Emerging Threats, and more
+      - Smart Deduplication: Skips IPs already in CrowdSec (CAPI, Console lists, local detections)
+      - Private IP Filtering: Automatically excludes RFC1918 and reserved ranges
+      - Docker Ready: Run as a container with Docker socket access
+      - Cron Friendly: Designed for daily runs with 24h decision expiration
+      - Selective Sources: Enable/disable individual blocklists
+      - Custom Blocklist URLs: Import your own threat feeds
+      - Dry Run Mode: Preview imports without making changes
+      - Per-Source Statistics: Summary table showing IP counts from each source
+
+      Ideal for home labs and personal projects.
+
+      Consider CrowdSec Premium when:
+
+      - Business/production environments needing SLA support
+      - Concerns about false positives on VPN/proxy traffic
+      - Need curated, lower-noise blocklists
+      - Want the official 25k-100k+ threat feed with 5-minute updates
+    '';
+    homepage = "https://github.com/wolffcatskyy/crowdsec-blocklist-import";
+    changelog = "https://github.com/wolffcatskyy/crowdsec-blocklist-import/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "crowdsec-blocklist-import";
+    maintainers = with lib.maintainers; [
+      gaelj
+      tornax
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Made a package and module for https://github.com/wolffcatskyy/crowdsec-blocklist-import

The module defines a systemd service and a systemd timer.

@wolffcatskyy @TornaxO7 @06kellyjac  @SuperSandro2000 

journalctl logs:

```
░░ The job identifier is 12436149.
févr. 01 22:42:13 aero-server systemd[1]: crowdsec-blocklist-import.service: Consumed 2.318s CPU time, 16.4M memory peak, 2.6M incoming IP traffic, 83.7K outgoing IP traffic.
░░ Subject: Resources consumed by unit runtime
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ The unit crowdsec-blocklist-import.service completed and consumed the indicated resources.
févr. 01 22:48:25 aero-server systemd[1]: Starting Import threat intelligence blocklists into CrowdSec...
░░ Subject: A start job for unit crowdsec-blocklist-import.service has begun execution
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ A start job for unit crowdsec-blocklist-import.service has begun execution.
░░ 
░░ The job identifier is 12463703.
févr. 01 22:48:25 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:25] [INFO] =========================================
févr. 01 22:48:25 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:25] [INFO] CrowdSec Blocklist Import v1.1.0
févr. 01 22:48:25 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:25] [INFO] =========================================
févr. 01 22:48:25 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:25] [INFO] Decision duration: 24h
févr. 01 22:48:25 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:25] [INFO] Using native CrowdSec (cscli in PATH)
févr. 01 22:48:25 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:25] [INFO] Fetching blocklist sources (28 built-in)...
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:30] [INFO] Sources: 24 successful, 4 unavailable, 0 disabled
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:30] [INFO] --- Source Statistics ---
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[185795]: [2026-02-01 21:48:30] [INFO] Source                         IPs
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[185887]: [2026-02-01 21:48:30] [INFO] ------------------------------ --------
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[185967]: [2026-02-01 21:48:30] [INFO] IPsum                          17647
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186060]: [2026-02-01 21:48:30] [INFO] Spamhaus DROP                  1475
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186143]: [2026-02-01 21:48:30] [INFO] Spamhaus EDROP                 0
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186213]: [2026-02-01 21:48:30] [INFO] Blocklist.de all               23925
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186279]: [2026-02-01 21:48:30] [INFO] Blocklist.de SSH               6244
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186375]: [2026-02-01 21:48:30] [INFO] Blocklist.de Apache            10083
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186449]: [2026-02-01 21:48:30] [INFO] Blocklist.de mail              12665
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186532]: [2026-02-01 21:48:30] [INFO] Firehol level1                 4492
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186626]: [2026-02-01 21:48:30] [INFO] Firehol level2                 15346
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186706]: [2026-02-01 21:48:30] [INFO] Feodo Tracker                  5
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186777]: [2026-02-01 21:48:30] [INFO] SSL Blacklist                  0
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186845]: [2026-02-01 21:48:30] [INFO] URLhaus                        9417
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[186931]: [2026-02-01 21:48:30] [INFO] Emerging Threats               566
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187022]: [2026-02-01 21:48:30] [INFO] Binary Defense                 541
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187116]: [2026-02-01 21:48:30] [INFO] Bruteforce Blocker             546
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187191]: [2026-02-01 21:48:30] [INFO] DShield                        20
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187271]: [2026-02-01 21:48:30] [INFO] CI Army                        15000
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187369]: [2026-02-01 21:48:30] [INFO] Darklist                       1
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187454]: [2026-02-01 21:48:30] [INFO] Talos                          113
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187533]: [2026-02-01 21:48:30] [INFO] Charles Haley                  0
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187632]: [2026-02-01 21:48:30] [INFO] Botvrij                        27
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187720]: [2026-02-01 21:48:30] [INFO] myip.ms                        0
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187799]: [2026-02-01 21:48:30] [INFO] GreenSnow                      4202
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187866]: [2026-02-01 21:48:30] [INFO] StopForumSpam                  53
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[187941]: [2026-02-01 21:48:30] [INFO] Tor exit nodes                 1349
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[188018]: [2026-02-01 21:48:30] [INFO] Tor (dan.me.uk)                3
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[188109]: [2026-02-01 21:48:30] [INFO] Shodan scanners                43
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[188180]: [2026-02-01 21:48:30] [INFO] Censys                         4
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[188283]: [2026-02-01 21:48:30] [INFO] ------------------------------ --------
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[188357]: [2026-02-01 21:48:30] [INFO] TOTAL (before dedup)           123767
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:30] [INFO] ------------------------
févr. 01 22:48:30 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:30] [INFO] Combining and deduplicating...
févr. 01 22:48:31 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:31] [INFO] Checking existing CrowdSec decisions...
févr. 01 22:48:32 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:32] [INFO] Importing 4 new IPs into CrowdSec...
févr. 01 22:48:32 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:32] [INFO] Import complete: 4 IPs added (total coverage: 53688 IPs)
févr. 01 22:48:32 aero-server crowdsec-blocklist-import[180646]: [2026-02-01 21:48:32] [INFO] Done!
févr. 01 22:48:32 aero-server systemd[1]: crowdsec-blocklist-import.service: Deactivated successfully.
░░ Subject: Unit succeeded
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ The unit crowdsec-blocklist-import.service has successfully entered the 'dead' state.
févr. 01 22:48:32 aero-server systemd[1]: Finished Import threat intelligence blocklists into CrowdSec.
░░ Subject: A start job for unit crowdsec-blocklist-import.service has finished successfully
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ A start job for unit crowdsec-blocklist-import.service has finished successfully.
░░ 
░░ The job identifier is 12463703.
févr. 01 22:48:32 aero-server systemd[1]: crowdsec-blocklist-import.service: Consumed 2.452s CPU time, 12.9M memory peak, 2.6M incoming IP traffic, 85K outgoing IP traffic.
░░ Subject: Resources consumed by unit runtime
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ The unit crowdsec-blocklist-import.service completed and consumed the indicated resources.
```


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
