### PR TITLE
treewide: move NIX_LDFLAGS into env for structuredAttrs (l-o)

### DIFF
--- a/pkgs/by-name/li/libdiscid/package.nix
+++ b/pkgs/by-name/li/libdiscid/package.nix
@@ -23,7 +23,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-lGq2iGt7c4h8HntEPeQcd7X+IykRLm0kvjrLswRWSSs=";
   };
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework CoreFoundation -framework IOKit";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = toString [
+      "-framework"
+      "CoreFoundation"
+      "-framework"
+      "IOKit"
+    ];
+  };
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/li/libdvdread_4_9_9/package.nix
+++ b/pkgs/by-name/li/libdvdread_4_9_9/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ libdvdcss ];
 
-  NIX_LDFLAGS = "-ldvdcss";
+  env.NIX_LDFLAGS = "-ldvdcss";
 
   postInstall = ''
     ln -s dvdread $out/include/libdvdread

--- a/pkgs/by-name/li/libfakekey/package.nix
+++ b/pkgs/by-name/li/libfakekey/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     xorgproto
   ];
 
-  NIX_LDFLAGS = "-lX11";
+  env.NIX_LDFLAGS = "-lX11";
 
   meta = {
     description = "X virtual keyboard library";

--- a/pkgs/by-name/li/libgdiplus/package.nix
+++ b/pkgs/by-name/li/libgdiplus/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./configure-pkg-config.patch
   ];
 
-  NIX_LDFLAGS = "-lgif";
+  env.NIX_LDFLAGS = "-lgif";
 
   outputs = [
     "out"

--- a/pkgs/by-name/li/libmikmod/package.nix
+++ b/pkgs/by-name/li/libmikmod/package.nix
@@ -29,7 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
-  NIX_LDFLAGS = optionalString stdenv.hostPlatform.isLinux "-lasound";
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    NIX_LDFLAGS = "-lasound";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/li/libnvidia-container/package.nix
+++ b/pkgs/by-name/li/libnvidia-container/package.nix
@@ -121,11 +121,11 @@ stdenv.mkDerivation (finalAttrs: {
     CGO_ENABLED = "1"; # Needed for cross-compilation
     GOFLAGS = "-trimpath"; # Don't include paths to Go stdlib to resulting binary
     inherit (go) GOARCH GOOS;
+    NIX_LDFLAGS = toString [
+      "-L${lib.getLib libtirpc}/lib"
+      "-ltirpc"
+    ];
   };
-  NIX_LDFLAGS = [
-    "-L${lib.getLib libtirpc}/lib"
-    "-ltirpc"
-  ];
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/li/libvpx/package.nix
+++ b/pkgs/by-name/li/libvpx/package.nix
@@ -249,7 +249,7 @@ stdenv.mkDerivation (finalAttrs: {
       curl
     ];
 
-  NIX_LDFLAGS = [
+  env.NIX_LDFLAGS = toString [
     "-lpthread" # fixes linker errors
   ];
 

--- a/pkgs/by-name/ma/macopix/package.nix
+++ b/pkgs/by-name/ma/macopix/package.nix
@@ -32,12 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  # Workaround build failure on -fno-common toolchains:
-  #   ld: dnd.o:src/main.h:136: multiple definition of
-  #     `MENU_EXT'; main.o:src/main.h:136: first defined here
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
-
-  NIX_LDFLAGS = "-lX11";
+  env = {
+    # Workaround build failure on -fno-common toolchains:
+    #   ld: dnd.o:src/main.h:136: multiple definition of
+    #     `MENU_EXT'; main.o:src/main.h:136: first defined here
+    NIX_CFLAGS_COMPILE = "-fcommon";
+    NIX_LDFLAGS = "-lX11";
+  };
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/ma/matchbox/package.nix
+++ b/pkgs/by-name/ma/matchbox/package.nix
@@ -15,7 +15,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ libmatchbox ];
-  NIX_LDFLAGS = "-lX11 -L${libx11}/lib -lXext -L${libxext}/lib";
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-L${libx11}/lib"
+    "-lXext"
+    "-L${libxext}/lib"
+  ];
 
   src = fetchurl {
     url = "https://downloads.yoctoproject.org/releases/matchbox/matchbox-window-manager/${finalAttrs.version}/matchbox-window-manager-${finalAttrs.version}.tar.bz2";

--- a/pkgs/by-name/mc/mceinject/package.nix
+++ b/pkgs/by-name/mc/mceinject/package.nix
@@ -22,9 +22,14 @@ stdenv.mkDerivation {
     bison
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-Os -g -Wall";
-
-  NIX_LDFLAGS = [ "-lpthread" ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Os"
+      "-g"
+      "-Wall"
+    ];
+    NIX_LDFLAGS = toString [ "-lpthread" ];
+  };
 
   makeFlags = [ "prefix=" ];
 

--- a/pkgs/by-name/mi/min/package.nix
+++ b/pkgs/by-name/mi/min/package.nix
@@ -31,7 +31,7 @@ buildNimPackage (finalAttrs: {
       -exec sed 's|{\.passL:.*\.}|discard|g' -i {} \;
   '';
 
-  NIX_LDFLAGS = [ "-lpcre" ];
+  env.NIX_LDFLAGS = toString [ "-lpcre" ];
 
   meta = {
     description = "Functional, concatenative programming language with a minimalist syntax";

--- a/pkgs/by-name/ms/mslicer/package.nix
+++ b/pkgs/by-name/ms/mslicer/package.nix
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # Force linking to libEGL, which is always dlopen()ed, and to
   # libwayland-client & libxkbcommon, which is dlopen()ed based on the
   # winit backend.
-  NIX_LDFLAGS = [
+  env.NIX_LDFLAGS = toString [
     "--push-state"
     "--no-as-needed"
     "-lEGL"

--- a/pkgs/by-name/ne/newt/package.nix
+++ b/pkgs/by-name/ne/newt/package.nix
@@ -42,9 +42,15 @@ stdenv.mkDerivation rec {
     gettext # for darwin with clang
   ];
 
-  NIX_LDFLAGS =
-    "-lncurses"
-    + lib.optionalString stdenv.hostPlatform.isDarwin " -L${python3}/lib -lpython${python3.pythonVersion}";
+  env.NIX_LDFLAGS = toString (
+    [
+      "-lncurses"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      "-L${python3}/lib"
+      "-lpython${python3.pythonVersion}"
+    ]
+  );
 
   preConfigure = ''
     # If CPP is set explicitly, configure and make will not agree about which

--- a/pkgs/by-name/ne/nexuiz/package.nix
+++ b/pkgs/by-name/ne/nexuiz/package.nix
@@ -66,16 +66,16 @@ stdenv.mkDerivation {
     cd ../../
   '';
 
-  NIX_LDFLAGS = ''
-    -rpath ${zlib.out}/lib
-    -rpath ${curl.out}/lib
-    -rpath ${libjpeg.out}/lib
-    -rpath ${libpng.out}/lib
-    -rpath ${libvorbis.out}/lib
-    -rpath ${libtheora.out}/lib
-    -rpath ${libogg.out}/lib
-    -rpath ${libmodplug.out}/lib
-  '';
+  env.NIX_LDFLAGS = toString [
+    "-rpath ${zlib.out}/lib"
+    "-rpath ${curl.out}/lib"
+    "-rpath ${libjpeg.out}/lib"
+    "-rpath ${libpng.out}/lib"
+    "-rpath ${libvorbis.out}/lib"
+    "-rpath ${libtheora.out}/lib"
+    "-rpath ${libogg.out}/lib"
+    "-rpath ${libmodplug.out}/lib"
+  ];
 
   buildPhase = ''
     cd sources/darkplaces/

--- a/pkgs/by-name/nn/nnn/package.nix
+++ b/pkgs/by-name/nn/nnn/package.nix
@@ -59,8 +59,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.hostPlatform.isMusl musl-fts
   ++ lib.optional withPcre pcre;
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isMusl "-I${musl-fts}/include";
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-lfts";
+  env = lib.optionalAttrs stdenv.hostPlatform.isMusl {
+    NIX_CFLAGS_COMPILE = "-I${musl-fts}/include";
+    NIX_LDFLAGS = "-lfts";
+  };
 
   makeFlags = [
     "PREFIX=$(out)"

--- a/pkgs/by-name/nr/nrpl/package.nix
+++ b/pkgs/by-name/nr/nrpl/package.nix
@@ -31,7 +31,7 @@ buildNimPackage {
     })
   ];
 
-  NIX_LDFLAGS = "-lpcre";
+  env.NIX_LDFLAGS = "-lpcre";
 
   postFixup = ''
     wrapProgram $out/bin/nrpl \

--- a/pkgs/by-name/nx/nx-libs/package.nix
+++ b/pkgs/by-name/nx/nx-libs/package.nix
@@ -75,8 +75,10 @@ stdenv.mkDerivation (finalAttrs: {
     libtirpc
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
-  NIX_LDFLAGS = [ "-ltirpc" ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
+    NIX_LDFLAGS = toString [ "-ltirpc" ];
+  };
 
   postPatch = ''
     patchShebangs .
@@ -90,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace nx-X11/config/cf/Imake.tmpl --replace "clq" "cq"
   '';
 
-  PREFIX = ""; # Don't install to $out/usr/local
+  env.PREFIX = ""; # Don't install to $out/usr/local
   installPhase = ''
     make DESTDIR="$out" install
     # See:

--- a/pkgs/by-name/od/odin/package.nix
+++ b/pkgs/by-name/od/odin/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs --build build_odin.sh
   '';
 
-  LLVM_CONFIG = lib.getExe' llvmPackages.llvm.dev "llvm-config";
+  env.LLVM_CONFIG = lib.getExe' llvmPackages.llvm.dev "llvm-config";
 
   dontConfigure = true;
 

--- a/pkgs/by-name/od/odin2/package.nix
+++ b/pkgs/by-name/od/odin2/package.nix
@@ -52,15 +52,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # JUCE dlopen's these at runtime, crashes without them
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ];
 
   # JUCE wants to write to $HOME/.{lv2,vst3}
   preConfigure = ''

--- a/pkgs/by-name/or/orthanc-framework/package.nix
+++ b/pkgs/by-name/or/orthanc-framework/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     icu
   ];
 
-  NIX_LDFLAGS = lib.strings.concatStringsSep " " [
+  env.NIX_LDFLAGS = toString [
     "-L${lib.getLib zlib}"
     "-lz"
     "-L${lib.getLib gtest}"

--- a/pkgs/by-name/or/orthanc-plugin-dicomweb/package.nix
+++ b/pkgs/by-name/or/orthanc-plugin-dicomweb/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  NIX_LDFLAGS = lib.strings.concatStringsSep " " [
+  env.NIX_LDFLAGS = toString [
     "-L${lib.getLib gtest}"
     "-lgtest"
   ];

--- a/pkgs/by-name/os/osi/package.nix
+++ b/pkgs/by-name/os/osi/package.nix
@@ -47,10 +47,14 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-cplex-lib=-lcplex${cplex.libSuffix}"
     ];
 
-  NIX_LDFLAGS = lib.optionalString withCplex "-L${cplex}/cplex/bin/${cplex.libArch}";
+  env = {
+    # Compile errors
+    NIX_CFLAGS_COMPILE = "-Wno-cast-qual";
+  }
+  // lib.optionalAttrs withCplex {
+    NIX_LDFLAGS = "-L${cplex}/cplex/bin/${cplex.libArch}";
+  };
 
-  # Compile errors
-  env.NIX_CFLAGS_COMPILE = "-Wno-cast-qual";
   hardeningDisable = [ "format" ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/compilers/fpc/lazarus.nix
+++ b/pkgs/development/compilers/fpc/lazarus.nix
@@ -43,6 +43,8 @@ let
     )
   );
 
+  LCL_PLATFORM = if withQt then "qt${qtVersion}" else "gtk2";
+
   qtVersion = lib.versions.major qtbase.version;
 in
 stdenv.mkDerivation rec {
@@ -95,29 +97,30 @@ stdenv.mkDerivation rec {
     "bigide"
   ];
 
-  LCL_PLATFORM = if withQt then "qt${qtVersion}" else "gtk2";
-
-  NIX_LDFLAGS = lib.concatStringsSep " " (
-    [
-      "-L${lib.getLib stdenv.cc.cc}/lib"
-      "-lX11"
-      "-lXext"
-      "-lXi"
-      "-latk-1.0"
-      "-lc"
-      "-lcairo"
-      "-lgcc_s"
-      "-lgdk-x11-2.0"
-      "-lgdk_pixbuf-2.0"
-      "-lglib-2.0"
-      "-lgtk-x11-2.0"
-      "-lpango-1.0"
-    ]
-    ++ lib.optionals withQt [
-      "-L${lib.getLib libqtpas}/lib"
-      "-lQt${qtVersion}Pas"
-    ]
-  );
+  env = {
+    inherit LCL_PLATFORM;
+    NIX_LDFLAGS = toString (
+      [
+        "-L${lib.getLib stdenv.cc.cc}/lib"
+        "-lX11"
+        "-lXext"
+        "-lXi"
+        "-latk-1.0"
+        "-lc"
+        "-lcairo"
+        "-lgcc_s"
+        "-lgdk-x11-2.0"
+        "-lgdk_pixbuf-2.0"
+        "-lglib-2.0"
+        "-lgtk-x11-2.0"
+        "-lpango-1.0"
+      ]
+      ++ lib.optionals withQt [
+        "-L${lib.getLib libqtpas}/lib"
+        "-lQt${qtVersion}Pas"
+      ]
+    );
+  };
 
   preBuild = ''
     mkdir -p $out/share "$out/lazarus"

--- a/pkgs/development/misc/msp430/mspds/default.nix
+++ b/pkgs/development/misc/msp430/mspds/default.nix
@@ -31,11 +31,16 @@ stdenv.mkDerivation {
     "OUTPUT=$(libName)"
     "HIDOBJ="
   ];
-  NIX_LDFLAGS = [
-    "-lpugixml"
-    "-lhidapi${hidapiDriver}"
-  ];
-  env.NIX_CFLAGS_COMPILE = toString [ "-I${hidapi}/include/hidapi" ];
+
+  env = {
+    NIX_LDFLAGS = toString [
+      "-lpugixml"
+      "-lhidapi${hidapiDriver}"
+    ];
+    NIX_CFLAGS_COMPILE = toString [
+      "-I${hidapi}/include/hidapi"
+    ];
+  };
 
   patches = [ ./bsl430.patch ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
