### PR TITLE
treewide: move NIX_LDFLAGS into env for structuredAttrs (p-s)

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/default.nix
+++ b/pkgs/applications/misc/prusa-slicer/default.nix
@@ -145,14 +145,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   doInstallCheck = true;
 
-  # The build system uses custom logic - defined in
-  # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt
-  # library, which doesn't pick up the package in the nix store.  We
-  # additionally need to set the path via the NLOPT environment variable.
-  NLOPT = nlopt;
-
-  # prusa-slicer uses dlopen on `libudev.so` at runtime
-  NIX_LDFLAGS = lib.optionalString withSystemd "-ludev";
+  env = {
+    # The build system uses custom logic - defined in
+    # cmake/modules/FindNLopt.cmake in the package source - for finding the nlopt
+    # library, which doesn't pick up the package in the nix store.  We
+    # additionally need to set the path via the NLOPT environment variable.
+    NLOPT = nlopt;
+  }
+  // lib.optionalAttrs withSystemd {
+    # prusa-slicer uses dlopen on `libudev.so` at runtime
+    NIX_LDFLAGS = "-ludev";
+  };
 
   prePatch = ''
     # Since version 2.5.0 of nlopt we need to link to libnlopt, as libnlopt_cxx

--- a/pkgs/applications/version-management/svn-all-fast-export/default.nix
+++ b/pkgs/applications/version-management/svn-all-fast-export/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     "SVN_INCLUDE=${subversion.dev}/include/subversion-1"
   ];
 
-  NIX_LDFLAGS = "-lsvn_fs-1";
+  env.NIX_LDFLAGS = "-lsvn_fs-1";
 
   dontWrapQtApps = true;
 

--- a/pkgs/by-name/pa/pax/package.nix
+++ b/pkgs/by-name/pa/pax/package.nix
@@ -16,7 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = lib.optional stdenv.hostPlatform.isMusl musl-fts;
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isMusl "-lfts";
+  env = lib.optionalAttrs stdenv.hostPlatform.isMusl {
+    NIX_LDFLAGS = "-lfts";
+  };
 
   buildPhase = ''
     sh Build.sh -r -tpax

--- a/pkgs/by-name/ph/phash/package.nix
+++ b/pkgs/by-name/ph/phash/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-frISiZ89ei7XfI5F2nJJehfQZsk0Mlb4n91q/AiZ2vA=";
   };
 
-  NIX_LDFLAGS = "-lfftw3_threads";
+  env.NIX_LDFLAGS = "-lfftw3_threads";
 
   patches = [
     # proper pthread return value (https://github.com/clearscene/pHash/pull/20)

--- a/pkgs/by-name/ph/phodav/package.nix
+++ b/pkgs/by-name/ph/phodav/package.nix
@@ -45,7 +45,9 @@ stdenv.mkDerivation rec {
     "-Dudevrulesdir=${placeholder "out"}/lib/udev/rules.d"
   ];
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-lintl";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-lintl";
+  };
 
   doInstallCheck = true;
 

--- a/pkgs/by-name/pk/pktgen/package.nix
+++ b/pkgs/by-name/pk/pktgen/package.nix
@@ -45,15 +45,16 @@ stdenv.mkDerivation (finalAttrs: {
     gtk2
   ];
 
-  RTE_SDK = dpdk;
-  GUI = lib.optionalString withGtk "true";
+  env = {
+    RTE_SDK = dpdk;
+    GUI = lib.optionalString withGtk "true";
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=sign-compare"
-  ];
-
-  # requires symbols from this file
-  NIX_LDFLAGS = "-lrte_net_bond";
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error=sign-compare"
+    ];
+    # requires symbols from this file
+    NIX_LDFLAGS = "-lrte_net_bond";
+  };
 
   postPatch = ''
     substituteInPlace lib/common/lscpu.h --replace /usr/bin/lscpu ${util-linux}/bin/lscpu

--- a/pkgs/by-name/pl/plugdata/package.nix
+++ b/pkgs/by-name/pl/plugdata/package.nix
@@ -92,18 +92,16 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcomposite"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-      "-lXtst"
-      "-lXdmcp"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcomposite"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-lXtst"
+    "-lXdmcp"
+  ];
 
   patches = [
     # fiddle~.c prevents building with gcc15. Upstream puredata has fixed this issue,

--- a/pkgs/by-name/po/postfix/package.nix
+++ b/pkgs/by-name/po/postfix/package.nix
@@ -147,7 +147,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  NIX_LDFLAGS = lib.optionalString withLDAP "-llber";
+  env = lib.optionalAttrs withLDAP {
+    NIX_LDFLAGS = "-llber";
+  };
 
   installTargets = [ "non-interactive-package" ];
 

--- a/pkgs/by-name/pp/ppp/package.nix
+++ b/pkgs/by-name/pp/ppp/package.nix
@@ -73,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
-  NIX_LDFLAGS = "-lcrypt";
+  env.NIX_LDFLAGS = "-lcrypt";
 
   installFlags = [
     "sysconfdir=$(out)/etc"

--- a/pkgs/by-name/qt/qtgreet/package.nix
+++ b/pkgs/by-name/qt/qtgreet/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "dynpath" "${placeholder "out"}/var/lib/qtgreet")
   ];
 
-  NIX_LDFLAGS = "-lwayqt-utils-qt6";
+  env.NIX_LDFLAGS = "-lwayqt-utils-qt6";
 
   meta = {
     description = "Qt based greeter for greetd, to be run under wayfire or similar wlr-based compositors";

--- a/pkgs/by-name/ri/ripplerx/package.nix
+++ b/pkgs/by-name/ri/ripplerx/package.nix
@@ -52,28 +52,30 @@ stdenv.mkDerivation (finalAttrs: {
     libXrandr
   ];
 
-  # JUCE dlopens these at runtime, standalone executable crashes without them
-  NIX_LDFLAGS = [
-    "-lX11"
-    "-lXext"
-    "-lXcursor"
-    "-lXinerama"
-    "-lXrandr"
-  ];
+  env = {
+    # JUCE dlopens these at runtime, standalone executable crashes without them
+    NIX_LDFLAGS = toString [
+      "-lX11"
+      "-lXext"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+    ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
-    # a Link Time Optimization flag, and instructs the plugin compiled here to
-    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
-    # successful linking while still providing LTO benefits. If our build of
-    # `juce` was used as a dependency, we could have patched that `-flto` line
-    # in our juce's source, but that is not possible because it is used as a
-    # Git Submodule.
-    "-ffat-lto-objects"
-  ];
+    NIX_CFLAGS_COMPILE = toString [
+      # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+      # a Link Time Optimization flag, and instructs the plugin compiled here to
+      # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+      # successful linking while still providing LTO benefits. If our build of
+      # `juce` was used as a dependency, we could have patched that `-flto` line
+      # in our juce's source, but that is not possible because it is used as a
+      # Git Submodule.
+      "-ffat-lto-objects"
+    ];
 
-  # Fontconfig error: Cannot load default config file: No such file: (null)
-  env.FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+    # Fontconfig error: Cannot load default config file: No such file: (null)
+    FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+  };
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ro/rox-filer/package.nix
+++ b/pkgs/by-name/ro/rox-filer/package.nix
@@ -30,8 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     shared-mime-info
     libSM
   ];
-  NIX_LDFLAGS = "-lm";
-  NIX_CFLAGS_COMPILE = " -fpermissive";
+
+  env = {
+    NIX_LDFLAGS = "-lm";
+    NIX_CFLAGS_COMPILE = "-fpermissive";
+  };
 
   patches = [
     ./rox-filer-2.11-in-source-build.patch

--- a/pkgs/by-name/sc/scorched3d/package.nix
+++ b/pkgs/by-name/sc/scorched3d/package.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [ "--with-fftw=${fftwSinglePrec.dev}" ];
 
-  NIX_LDFLAGS = "-lopenal";
+  env.NIX_LDFLAGS = "-lopenal";
 
   meta = {
     homepage = "http://scorched3d.co.uk/";

--- a/pkgs/by-name/si/siege/package.nix
+++ b/pkgs/by-name/si/siege/package.nix
@@ -15,9 +15,14 @@ stdenv.mkDerivation rec {
     hash = "sha256-7BQM7dFZl5OD1g2+h6AVHCwSraeHkQlaj6hK5jW5MCY=";
   };
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux [
-    "-lgcc_s"
-  ];
+  env =
+    lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      NIX_LDFLAGS = toString [ "-lgcc_s" ];
+    }
+    // lib.optionalAttrs stdenv.cc.isClang {
+      # Borrowed solution from homebrew: https://github.com/Homebrew/homebrew-core/blob/1c7c95183c0984a84b1680422afab6578c300a27/Formula/s/siege.rb#L31
+      CFLAGS = "-Wno-int-conversion";
+    };
 
   buildInputs = [
     openssl
@@ -32,9 +37,6 @@ stdenv.mkDerivation rec {
     "--with-ssl=${openssl.dev}"
     "--with-zlib=${zlib.dev}"
   ];
-
-  # Borrowed solution from homebrew: https://github.com/Homebrew/homebrew-core/blob/1c7c95183c0984a84b1680422afab6578c300a27/Formula/s/siege.rb#L31
-  CFLAGS = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
 
   meta = {
     description = "HTTP load tester";

--- a/pkgs/by-name/si/siesta/package.nix
+++ b/pkgs/by-name/si/siesta/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     scalapack
   ];
 
-  NIX_LDFLAGS = "-lm";
+  env.NIX_LDFLAGS = "-lm";
 
   cmakeFlags = [
     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"

--- a/pkgs/by-name/si/silver-searcher/package.nix
+++ b/pkgs/by-name/si/silver-searcher/package.nix
@@ -22,13 +22,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [ ./bash-completion.patch ];
 
-  # Workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: src/zfile.o:/build/source/src/log.h:12: multiple definition of
-  #     `print_mtx'; src/ignore.o:/build/source/src/log.h:12: first defined here
-  # TODO: remove once next release has https://github.com/ggreer/the_silver_searcher/pull/1377
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux "-lgcc_s";
+  env = {
+    # Workaround build failure on -fno-common toolchains like upstream
+    # gcc-10. Otherwise build fails as:
+    #   ld: src/zfile.o:/build/source/src/log.h:12: multiple definition of
+    #     `print_mtx'; src/ignore.o:/build/source/src/log.h:12: first defined here
+    # TODO: remove once next release has https://github.com/ggreer/the_silver_searcher/pull/1377
+    NIX_CFLAGS_COMPILE = "-fcommon";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    NIX_LDFLAGS = "-lgcc_s";
+  };
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/sm/smpeg/package.nix
+++ b/pkgs/by-name/sm/smpeg/package.nix
@@ -93,7 +93,9 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PKG_CONFIG_PATH ":" "${lib.getDev SDL}/lib/pkgconfig"
   '';
 
-  NIX_LDFLAGS = lib.optionalString (!stdenv.hostPlatform.isDarwin) "-lX11";
+  env = lib.optionalAttrs (!stdenv.hostPlatform.isDarwin) {
+    NIX_LDFLAGS = "-lX11";
+  };
 
   meta = {
     homepage = "https://icculus.org/smpeg/";

--- a/pkgs/by-name/so/socalabs-papu/package.nix
+++ b/pkgs/by-name/so/socalabs-papu/package.nix
@@ -120,18 +120,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = nix-update-script { };
 
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcomposite"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-      "-lXtst"
-      "-lXdmcp"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcomposite"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-lXtst"
+    "-lXdmcp"
+  ];
 
   meta = {
     description = "Socalabs Nintendo Gameboy PAPU Emulation Plugin";

--- a/pkgs/by-name/so/socalabs-rp2a03/package.nix
+++ b/pkgs/by-name/so/socalabs-rp2a03/package.nix
@@ -117,18 +117,16 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcomposite"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-      "-lXtst"
-      "-lXdmcp"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcomposite"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-lXtst"
+    "-lXdmcp"
+  ];
 
   meta = {
     description = "Socalabs NES Ricoh 2A03 Emulation Plugin";

--- a/pkgs/by-name/so/socalabs-sid/package.nix
+++ b/pkgs/by-name/so/socalabs-sid/package.nix
@@ -152,18 +152,16 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcomposite"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-      "-lXtst"
-      "-lXdmcp"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcomposite"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-lXtst"
+    "-lXdmcp"
+  ];
 
   meta = {
     description = "Socalabs Commodore 64 SID Emulation Plugin";

--- a/pkgs/by-name/so/socalabs-sn76489/package.nix
+++ b/pkgs/by-name/so/socalabs-sn76489/package.nix
@@ -127,18 +127,16 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcomposite"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-      "-lXtst"
-      "-lXdmcp"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcomposite"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-lXtst"
+    "-lXdmcp"
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/so/socalabs-voc/package.nix
+++ b/pkgs/by-name/so/socalabs-voc/package.nix
@@ -130,18 +130,16 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcomposite"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-      "-lXtst"
-      "-lXdmcp"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcomposite"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+    "-lXtst"
+    "-lXdmcp"
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/su/surge-XT/package.nix
+++ b/pkgs/by-name/su/surge-XT/package.nix
@@ -77,15 +77,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # JUCE dlopen's these at runtime, crashes without them
-  NIX_LDFLAGS = (
-    toString [
-      "-lX11"
-      "-lXext"
-      "-lXcursor"
-      "-lXinerama"
-      "-lXrandr"
-    ]
-  );
+  env.NIX_LDFLAGS = toString [
+    "-lX11"
+    "-lXext"
+    "-lXcursor"
+    "-lXinerama"
+    "-lXrandr"
+  ];
 
   passthru = {
     rev-prefix = "release_xt_";

--- a/pkgs/by-name/sv/svnfs/package.nix
+++ b/pkgs/by-name/sv/svnfs/package.nix
@@ -41,12 +41,20 @@ stdenv.mkDerivation (finalAttrs: {
     export LD_LIBRARY_PATH=${subversion.out}/lib
   '';
 
-  # -fcommon: workaround build failure on -fno-common toolchains like upstream
-  # gcc-10. Otherwise build fails as:
-  #   ld: svnclient.o:/build/svnfs-0.4/src/svnfs.h:40: multiple definition of
-  #     `dirbuf'; svnfs.o:/build/svnfs-0.4/src/svnfs.h:40: first defined here
-  env.NIX_CFLAGS_COMPILE = "-I ${subversion.dev}/include/subversion-1 -fcommon";
-  NIX_LDFLAGS = "-lsvn_client-1 -lsvn_subr-1";
+  env = {
+    # -fcommon: workaround build failure on -fno-common toolchains like upstream
+    # gcc-10. Otherwise build fails as:
+    #   ld: svnclient.o:/build/svnfs-0.4/src/svnfs.h:40: multiple definition of
+    #     `dirbuf'; svnfs.o:/build/svnfs-0.4/src/svnfs.h:40: first defined here
+    NIX_CFLAGS_COMPILE = toString [
+      "-I ${subversion.dev}/include/subversion-1"
+      "-fcommon"
+    ];
+    NIX_LDFLAGS = toString [
+      "-lsvn_client-1"
+      "-lsvn_subr-1"
+    ];
+  };
 
   meta = {
     description = "FUSE filesystem for accessing Subversion repositories";

--- a/pkgs/by-name/sy/sylpheed/package.nix
+++ b/pkgs/by-name/sy/sylpheed/package.nix
@@ -54,7 +54,9 @@ stdenv.mkDerivation rec {
   configureFlags = lib.optional gpgSupport "--enable-gpgme" ++ lib.optional sslSupport "--enable-ssl";
 
   # Undefined symbols for architecture arm64: "_OBJC_CLASS_$_NSAutoreleasePool"
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework Foundation";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-framework Foundation";
+  };
 
   meta = {
     homepage = "https://sylpheed.sraoss.jp/en/";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
