### PR TITLE
mockgen: modernize

### DIFF
--- a/pkgs/by-name/mo/mockgen/package.nix
+++ b/pkgs/by-name/mo/mockgen/package.nix
@@ -2,8 +2,7 @@
   buildGoModule,
   fetchFromGitHub,
   lib,
-  testers,
-  mockgen,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -13,8 +12,8 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "uber-go";
     repo = "mock";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-gYUL+ucnKQncudQDcRt8aDqM7xE5XSKHh4X0qFrvfGs=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-gYUL+ucnKQncudQDcRt8aDqM7xE5XSKHh4X0qFrvfGs=";
   };
 
   vendorHash = "sha256-Cf7lKfMuPFT/I1apgChUNNCG2C7SrW7ncF8OusbUs+A=";
@@ -26,18 +25,12 @@ buildGoModule (finalAttrs: {
   ldflags = [
     "-X=main.version=${finalAttrs.version}"
     "-X=main.date=1970-01-01T00:00:00Z"
-    "-X=main.commit=unknown"
+    "-X=main.commit=${finalAttrs.src.rev}"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = mockgen;
-    command = "mockgen -version";
-    version = ''
-      v${finalAttrs.version}
-      Commit: unknown
-      Date: 1970-01-01T00:00:00Z
-    '';
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-version";
+  doInstallCheck = true;
 
   meta = {
     description = "Mocking framework for the Go programming language";


### PR DESCRIPTION
- Switch to `finalAttrs`
- Replace `rev` and `sha256` in fetcher with `tag` and `hash`, respectively
- Set `main.commit` LD flag to source revision instead of "unknown"

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
