### PR TITLE
regal: set pname, use finalAttrs

### DIFF
--- a/pkgs/by-name/re/regal/package.nix
+++ b/pkgs/by-name/re/regal/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "regal";
   version = "0.38.1";
 
   src = fetchFromGitHub {
     owner = "open-policy-agent";
     repo = "regal";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-/WGZCwT9VJ5zjEmL4PZqPymaUJFaWzjbgq2KMBfl6uQ=";
   };
 
@@ -23,16 +23,16 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/open-policy-agent/regal/pkg/version.Version=${version}"
-    "-X github.com/open-policy-agent/regal/pkg/version.Commit=${version}"
+    "-X github.com/open-policy-agent/regal/pkg/version.Version=${finalAttrs.version}"
+    "-X github.com/open-policy-agent/regal/pkg/version.Commit=${finalAttrs.version}"
   ];
 
   meta = {
     description = "Linter and language server for Rego";
     mainProgram = "regal";
     homepage = "https://github.com/open-policy-agent/regal";
-    changelog = "https://github.com/open-policy-agent/regal/releases/tag/${src.rev}";
+    changelog = "https://github.com/open-policy-agent/regal/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ rinx ];
   };
-}
+})

--- a/pkgs/by-name/re/regal/package.nix
+++ b/pkgs/by-name/re/regal/package.nix
@@ -5,7 +5,7 @@
 }:
 
 buildGoModule rec {
-  name = "regal";
+  pname = "regal";
   version = "0.38.1";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
- #485742

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
