### PR TITLE
treewide: move NIX_LDFLAGS into env for structuredAttrs (t-z)

### DIFF
--- a/pkgs/by-name/te/teapot/package.nix
+++ b/pkgs/by-name/te/teapot/package.nix
@@ -32,9 +32,11 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
   ];
 
-  # By no known reason libtirpc is not detected
-  env.NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
-  NIX_LDFLAGS = [ "-ltirpc" ];
+  env = {
+    # By no known reason libtirpc is not detected
+    NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
+    NIX_LDFLAGS = [ "-ltirpc" ];
+  };
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \

--- a/pkgs/by-name/te/tenacity/package.nix
+++ b/pkgs/by-name/te/tenacity/package.nix
@@ -108,18 +108,20 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix XDG_DATA_DIRS : "$out/share:$GSETTINGS_SCHEMAS_PATH"
   '';
 
-  # Tenacity only looks for ffmpeg at runtime, so we need to link it in manually.
-  # On darwin, these are ignored by the ffmpeg search even when linked.
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux (toString [
-    "-lavcodec"
-    "-lavdevice"
-    "-lavfilter"
-    "-lavformat"
-    "-lavutil"
-    "-lpostproc"
-    "-lswresample"
-    "-lswscale"
-  ]);
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # Tenacity only looks for ffmpeg at runtime, so we need to link it in manually.
+    # On darwin, these are ignored by the ffmpeg search even when linked.
+    NIX_LDFLAGS = toString [
+      "-lavcodec"
+      "-lavdevice"
+      "-lavfilter"
+      "-lavformat"
+      "-lavutil"
+      "-lpostproc"
+      "-lswresample"
+      "-lswscale"
+    ];
+  };
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/ti/timemachine/package.nix
+++ b/pkgs/by-name/ti/timemachine/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   preConfigure = "./autogen.sh";
 
-  NIX_LDFLAGS = "-lm";
+  env.NIX_LDFLAGS = "-lm";
 
   meta = {
     description = "JACK audio recorder";

--- a/pkgs/by-name/tr/transgui/package.nix
+++ b/pkgs/by-name/tr/transgui/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     openssl
   ];
 
-  NIX_LDFLAGS = ''
+  env.NIX_LDFLAGS = ''
     -L${lib.getLib stdenv.cc.cc}/lib -lX11 -lglib-2.0 -lgtk-x11-2.0
     -lgdk-x11-2.0 -lgdk_pixbuf-2.0 -lpango-1.0 -latk-1.0 -lcairo
     -lc -lcrypto
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
     "INSTALL_PREFIX=$(out)"
   ];
 
-  LCL_PLATFORM = "gtk2";
+  env.LCL_PLATFORM = "gtk2";
 
   desktopItem = makeDesktopItem {
     name = pname;

--- a/pkgs/by-name/tr/trickle/package.nix
+++ b/pkgs/by-name/tr/trickle/package.nix
@@ -44,14 +44,16 @@ stdenv.mkDerivation {
     sed -i 's|^_select(int|select(int|' trickle-overload.c
   '';
 
-  NIX_LDFLAGS = [
-    "-levent"
-    "-ltirpc"
-  ];
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-I${libtirpc.dev}/include/tirpc"
-    "-Wno-error=incompatible-pointer-types"
-  ];
+  env = {
+    NIX_LDFLAGS = toString [
+      "-levent"
+      "-ltirpc"
+    ];
+    NIX_CFLAGS_COMPILE = toString [
+      "-I${libtirpc.dev}/include/tirpc"
+      "-Wno-error=incompatible-pointer-types"
+    ];
+  };
 
   configureFlags = [ "--with-libevent" ];
 

--- a/pkgs/by-name/un/unicorn-angr/package.nix
+++ b/pkgs/by-name/un/unicorn-angr/package.nix
@@ -23,8 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  # Ensure the linker is using atomic when compiling for RISC-V, otherwise fails
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isRiscV "-latomic";
+  env = lib.optionalAttrs stdenv.hostPlatform.isRiscV {
+    # Ensure the linker is using atomic when compiling for RISC-V, otherwise fails
+    NIX_LDFLAGS = "-latomic";
+  };
 
   cmakeFlags = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
     # Some x86 tests are interrupted by signal 10

--- a/pkgs/by-name/un/unicorn/package.nix
+++ b/pkgs/by-name/un/unicorn/package.nix
@@ -26,8 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     cctools
   ];
 
-  # Ensure the linker is using atomic when compiling for RISC-V, otherwise fails
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isRiscV "-latomic";
+  env = lib.optionalAttrs stdenv.hostPlatform.isRiscV {
+    # Ensure the linker is using atomic when compiling for RISC-V, otherwise fails
+    NIX_LDFLAGS = "-latomic";
+  };
 
   cmakeFlags = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
     # Some x86 tests are interrupted by signal 10

--- a/pkgs/by-name/un/unified-memory-framework/package.nix
+++ b/pkgs/by-name/un/unified-memory-framework/package.nix
@@ -125,11 +125,13 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
   dontUseNinjaCheck = true;
 
-  NIX_LDFLAGS = lib.optionalString finalAttrs.doCheck "-rpath ${
-    lib.makeLibraryPath [
-      onetbb
-    ]
-  }";
+  env = lib.optionalAttrs finalAttrs.doCheck {
+    NIX_LDFLAGS = "-rpath ${
+      lib.makeLibraryPath [
+        onetbb
+      ]
+    }";
+  };
 
   disabledTests = [
     # These tests try to access sysfs, which is unavailable in the sandbox

--- a/pkgs/by-name/un/unzip/package.nix
+++ b/pkgs/by-name/un/unzip/package.nix
@@ -79,7 +79,16 @@ stdenv.mkDerivation rec {
 
   makefile = "unix/Makefile";
 
-  NIX_LDFLAGS = "-lbz2" + lib.optionalString enableNLS " -lnatspec";
+  env = {
+    NIX_LDFLAGS = toString (
+      [
+        "-lbz2"
+      ]
+      ++ lib.optionals enableNLS [
+        "-lnatspec"
+      ]
+    );
+  };
 
   buildFlags = [
     "generic"

--- a/pkgs/by-name/vs/vsftpd/package.nix
+++ b/pkgs/by-name/vs/vsftpd/package.nix
@@ -56,7 +56,14 @@ stdenv.mkDerivation (finalAttrs: {
     "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
-  NIX_LDFLAGS = "-lcrypt -lssl -lcrypto -lpam -lcap -lseccomp";
+  env.NIX_LDFLAGS = toString [
+    "-lcrypt"
+    "-lssl"
+    "-lcrypto"
+    "-lpam"
+    "-lcap"
+    "-lseccomp"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/wa/watchexec/package.nix
+++ b/pkgs/by-name/wa/watchexec/package.nix
@@ -22,7 +22,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-framework AppKit";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = toString [
+      "-framework"
+      "AppKit"
+    ];
+  };
 
   checkFlags = [
     "--skip=help"

--- a/pkgs/by-name/x1/x11spice/package.nix
+++ b/pkgs/by-name/x1/x11spice/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
     spice-protocol
   ];
 
-  NIX_LDFLAGS = "-lpthread";
+  env.NIX_LDFLAGS = "-lpthread";
 
   meta = {
     description = "Enable a running X11 desktop to be available via a Spice server";

--- a/pkgs/by-name/xd/xdg-user-dirs/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs/package.nix
@@ -37,7 +37,9 @@ stdenv.mkDerivation (finalAttrs: {
     libintl
   ];
 
-  NIX_LDFLAGS = if stdenv.isDarwin then "-liconv" else null;
+  env = lib.optionalAttrs stdenv.isDarwin {
+    NIX_LDFLAGS = "-liconv";
+  };
 
   preFixup = ''
     # fallback values need to be last

--- a/pkgs/by-name/xf/xfitter/package.nix
+++ b/pkgs/by-name/xf/xfitter/package.nix
@@ -66,10 +66,10 @@ stdenv.mkDerivation {
                      'cmake_minimum_required(VERSION 3.10)'
   '';
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString (
-    stdenv.hostPlatform.libc == "glibc"
-  ) "-I${libtirpc.dev}/include/tirpc";
-  NIX_LDFLAGS = lib.optional (stdenv.hostPlatform.libc == "glibc") "-ltirpc";
+  env = lib.optionalAttrs (stdenv.hostPlatform.libc == "glibc") {
+    NIX_CFLAGS_COMPILE = "-I${libtirpc.dev}/include/tirpc";
+    NIX_LDFLAGS = "-ltirpc";
+  };
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/by-name/xi/xidel/package.nix
+++ b/pkgs/by-name/xi/xidel/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ fpc ];
   buildInputs = [ openssl ];
 
-  NIX_LDFLAGS = [ "-lcrypto" ];
+  env.NIX_LDFLAGS = toString [ "-lcrypto" ];
 
   patchPhase = ''
     patchShebangs \

--- a/pkgs/by-name/xm/xmlsec/package.nix
+++ b/pkgs/by-name/xm/xmlsec/package.nix
@@ -79,7 +79,7 @@ lib.fix (
     configureFlags = [ "--enable-soap" ];
 
     # otherwise libxmlsec1-gnutls.so won't find libgcrypt.so, after #909
-    NIX_LDFLAGS = "-lgcrypt";
+    env.NIX_LDFLAGS = "-lgcrypt";
 
     postInstall = ''
       moveToOutput "bin/xmlsec1-config" "$dev"

--- a/pkgs/by-name/zl/zlcompressor/package.nix
+++ b/pkgs/by-name/zl/zlcompressor/package.nix
@@ -67,24 +67,25 @@ clangStdenv.mkDerivation (finalAttrs: {
   ];
 
   # JUCE dlopen's these at runtime, crashes without them
-  NIX_LDFLAGS = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
-    "-lX11"
-    "-lXext"
-    "-lXcursor"
-    "-lXinerama"
-    "-lXrandr"
-  ]);
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
-    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
-    # a Link Time Optimization flag, and instructs the plugin compiled here to
-    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
-    # successful linking while still providing LTO benefits. If our build of
-    # `juce` was used as a dependency, we could have patched that `-flto` line
-    # in our juce's source, but that is not possible because it is used as a
-    # Git Submodule.
-    "-ffat-lto-objects"
-  ]);
+  env = lib.optionalAttrs clangStdenv.hostPlatform.isLinux {
+    NIX_LDFLAGS = toString [
+      "-lX11"
+      "-lXext"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+    ];
+    NIX_CFLAGS_COMPILE = toString [
+      # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+      # a Link Time Optimization flag, and instructs the plugin compiled here to
+      # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+      # successful linking while still providing LTO benefits. If our build of
+      # `juce` was used as a dependency, we could have patched that `-flto` line
+      # in our juce's source, but that is not possible because it is used as a
+      # Git Submodule.
+      "-ffat-lto-objects"
+    ];
+  };
 
   cmakeFlags = [
     # see: https://github.com/ZL-Audio/ZlEqualizer#clone-and-build

--- a/pkgs/by-name/zl/zlequalizer/package.nix
+++ b/pkgs/by-name/zl/zlequalizer/package.nix
@@ -66,25 +66,27 @@ clangStdenv.mkDerivation (finalAttrs: {
     libxkbcommon
   ];
 
-  # JUCE dlopen's these at runtime, crashes without them
-  NIX_LDFLAGS = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
-    "-lX11"
-    "-lXext"
-    "-lXcursor"
-    "-lXinerama"
-    "-lXrandr"
-  ]);
+  env = lib.optionalAttrs clangStdenv.hostPlatform.isLinux {
+    # JUCE dlopen's these at runtime, crashes without them
+    NIX_LDFLAGS = toString [
+      "-lX11"
+      "-lXext"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+    ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
-    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
-    # a Link Time Optimization flag, and instructs the plugin compiled here to
-    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
-    # successful linking while still providing LTO benefits. If our build of
-    # `juce` was used as a dependency, we could have patched that `-flto` line
-    # in our juce's source, but that is not possible because it is used as a
-    # Git Submodule.
-    "-ffat-lto-objects"
-  ]);
+    NIX_CFLAGS_COMPILE = toString [
+      # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+      # a Link Time Optimization flag, and instructs the plugin compiled here to
+      # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+      # successful linking while still providing LTO benefits. If our build of
+      # `juce` was used as a dependency, we could have patched that `-flto` line
+      # in our juce's source, but that is not possible because it is used as a
+      # Git Submodule.
+      "-ffat-lto-objects"
+    ];
+  };
 
   cmakeFlags = [
     # see: https://github.com/ZL-Audio/ZLEqualizer#clone-and-build

--- a/pkgs/by-name/zl/zlsplitter/package.nix
+++ b/pkgs/by-name/zl/zlsplitter/package.nix
@@ -66,25 +66,26 @@ clangStdenv.mkDerivation (finalAttrs: {
     libxkbcommon
   ];
 
-  # JUCE dlopen's these at runtime, crashes without them
-  NIX_LDFLAGS = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
-    "-lX11"
-    "-lXext"
-    "-lXcursor"
-    "-lXinerama"
-    "-lXrandr"
-  ]);
-
-  env.NIX_CFLAGS_COMPILE = lib.optionalString clangStdenv.hostPlatform.isLinux (toString [
-    # juce, compiled in this build as part of a Git submodule, uses `-flto` as
-    # a Link Time Optimization flag, and instructs the plugin compiled here to
-    # use this flag to. This breaks the build for us. Using _fat_ LTO allows
-    # successful linking while still providing LTO benefits. If our build of
-    # `juce` was used as a dependency, we could have patched that `-flto` line
-    # in our juce's source, but that is not possible because it is used as a
-    # Git Submodule.
-    "-ffat-lto-objects"
-  ]);
+  env = lib.optionalAttrs clangStdenv.hostPlatform.isLinux {
+    # JUCE dlopen's these at runtime, crashes without them
+    NIX_LDFLAGS = toString [
+      "-lX11"
+      "-lXext"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+    ];
+    NIX_CFLAGS_COMPILE = toString [
+      # juce, compiled in this build as part of a Git submodule, uses `-flto` as
+      # a Link Time Optimization flag, and instructs the plugin compiled here to
+      # use this flag to. This breaks the build for us. Using _fat_ LTO allows
+      # successful linking while still providing LTO benefits. If our build of
+      # `juce` was used as a dependency, we could have patched that `-flto` line
+      # in our juce's source, but that is not possible because it is used as a
+      # Git Submodule.
+      "-ffat-lto-objects"
+    ];
+  };
 
   cmakeFlags = [
     # see: https://github.com/ZL-Audio/ZlEqualizer#clone-and-build

--- a/pkgs/by-name/zr/zrythm/package.nix
+++ b/pkgs/by-name/zr/zrythm/package.nix
@@ -178,11 +178,14 @@ stdenv.mkDerivation (finalAttrs: {
     # "-Duser_manual=true" # needs sphinx-intl
   ];
 
-  NIX_LDFLAGS = ''
-    -lfftw3_threads -lfftw3f_threads
-  '';
+  env = {
+    NIX_LDFLAGS = toString [
+      "-lfftw3_threads"
+      "-lfftw3f_threads"
+    ];
 
-  GUILE_AUTO_COMPILE = 0;
+    GUILE_AUTO_COMPILE = 0;
+  };
 
   dontStrip = true;
 

--- a/pkgs/development/tools/tora/default.nix
+++ b/pkgs/development/tools/tora/default.nix
@@ -70,7 +70,13 @@ stdenv.mkDerivation {
   ];
 
   # these libraries are only searched for at runtime so we need to force-link them
-  NIX_LDFLAGS = "-lgvc -lmysqlclient -lecpg -lssl -L${libmysqlclient}/lib/mariadb";
+  env.NIX_LDFLAGS = toString [
+    "-lgvc"
+    "-lmysqlclient"
+    "-lecpg"
+    "-lssl"
+    "-L${libmysqlclient}/lib/mariadb"
+  ];
 
   qtWrapperArgs = [
     "--prefix PATH : ${lib.getBin graphviz}/bin"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
