### PR TITLE
suitesparsePackages: init at 7.12.1

### DIFF
--- a/pkgs/by-name/su/suitesparse/by-name/amd.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/amd.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "amd";
+  moduleName = "AMD";
+  version = "3.3.4";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Set of routines for permuting sparse matrices prior to factorization";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/btf.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/btf.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "btf";
+  moduleName = "BTF";
+  version = "2.3.3";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Software package for permuting a matrix into block upper triangular form";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/camd.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/camd.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "camd";
+  moduleName = "CAMD";
+  version = "3.3.5";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Set of routines for permuting sparse matrices prior to factorization";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/ccolamd.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/ccolamd.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "ccolamd";
+  moduleName = "CCOLAMD";
+  version = "3.3.5";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Constrained column approximate minimum degree ordering";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/cholmod.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/cholmod.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  amd,
+  colamd,
+  camd,
+  ccolamd,
+  blas,
+  lapack,
+  llvmPackages,
+  suitesparse-config,
+}:
+assert (blas.isILP64 == lapack.isILP64);
+
+mkDerivation {
+  pname = "cholmod";
+  moduleName = "CHOLMOD";
+  version = "5.3.4";
+
+  buildInputs = [
+    blas
+    lapack
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
+
+  propagatedBuildInputs = [
+    amd
+    colamd
+    camd
+    ccolamd
+    suitesparse-config
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
+    (lib.cmakeFeature "BLA_VENDOR" "Generic")
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Sparse CHOLesky MODification package";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/colamd.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/colamd.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "colamd";
+  moduleName = "COLAMD";
+  version = "3.3.5";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Column approximate minimum degree ordering";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/cxsparse.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/cxsparse.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "cxsparse";
+  moduleName = "CXSparse";
+  version = "4.4.2";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Concise eXtended Sparse Matrix Package";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/graphblas.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/graphblas.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  llvmPackages,
+  writableTmpDirAsHomeHook,
+}:
+
+mkDerivation {
+  pname = "graphblas";
+  version = "10.2.0";
+  moduleName = "GraphBLAS";
+
+  nativeBuildInputs = [
+    # Needs to create directories as part of the build for the JIT
+    writableTmpDirAsHomeHook
+  ];
+
+  buildInputs = lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "GRAPHBLAS_USE_JIT" true)
+  ];
+
+  meta = {
+    description = "Graph algorithms in the language of linear algebra";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/klu.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/klu.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  mkDerivation,
+  amd,
+  colamd,
+  btf,
+  cholmod,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "klu";
+  moduleName = "KLU";
+  version = "2.3.6";
+
+  propagatedBuildInputs = [
+    amd
+    btf
+    colamd
+    cholmod
+    suitesparse-config
+  ];
+
+  meta = {
+    description = "Set of routines for solving sparse linear systems of equations";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/lagraph.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/lagraph.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  graphblas,
+  llvmPackages,
+}:
+
+mkDerivation {
+  pname = "lagraph";
+  moduleName = "LAGraph";
+  version = "1.2.1";
+
+  buildInputs = lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
+
+  propagatedBuildInputs = [
+    graphblas
+  ];
+
+  meta = {
+    description = "Library plus a test harness for collecting algorithms that use GraphBLAS";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/ldl.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/ldl.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "ldl";
+  moduleName = "LDL";
+  version = "3.3.3";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Sparse LDL' factorization and solve package";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/mongoose.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/mongoose.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "mongoose";
+  moduleName = "Mongoose";
+  version = "3.3.6";
+
+  outputs = [
+    "bin"
+    "out"
+    "dev"
+  ];
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "Graph Coarsening and Partitioning Library";
+    mainProgram = "suitesparse_mongoose";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      qbisi
+      wegank
+    ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/paru.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/paru.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  cholmod,
+  umfpack,
+  blas,
+  llvmPackages,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "paru";
+  moduleName = "ParU";
+  version = "1.1.0";
+
+  buildInputs = [
+    blas
+  ]
+  ++ lib.optional stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
+
+  propagatedBuildInputs = [
+    cholmod
+    umfpack
+    suitesparse-config
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
+    (lib.cmakeFeature "BLA_VENDOR" "Generic")
+  ];
+
+  meta = {
+    description = "Parallel multifrontal LU factorization algorithms";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/rbio.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/rbio.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  mkDerivation,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "rbio";
+  moduleName = "RBio";
+  version = "4.3.5";
+
+  propagatedBuildInputs = [ suitesparse-config ];
+
+  meta = {
+    description = "MATLAB Toolbox for reading/writing sparse matrices in Rutherford/Boeing format";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/spex.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/spex.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  llvmPackages,
+  amd,
+  colamd,
+  gmp,
+  mpfr,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "spex";
+  moduleName = "SPEX";
+  version = "3.2.4";
+
+  buildInputs = lib.optional stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
+
+  propagatedBuildInputs = [
+    amd
+    colamd
+    gmp
+    mpfr
+    suitesparse-config
+  ];
+
+  meta = {
+    description = "Software package for SParse EXact algebra";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/spqr.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/spqr.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  mkDerivation,
+  cholmod,
+  blas,
+  lapack,
+  suitesparse-config,
+}:
+assert (blas.isILP64 == lapack.isILP64);
+
+mkDerivation {
+  pname = "spqr";
+  moduleName = "SPQR";
+  version = "4.3.6";
+
+  buildInputs = [
+    blas
+    lapack
+  ];
+
+  propagatedBuildInputs = [
+    cholmod
+    suitesparse-config
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
+    (lib.cmakeFeature "BLA_VENDOR" "Generic")
+  ];
+
+  meta = {
+    description = "Multithreaded, multifrontal, rank-revealing sparse QR factorization method";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/suitesparse-config.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/suitesparse-config.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  blas,
+  llvmPackages,
+}:
+
+mkDerivation {
+  pname = "config";
+  moduleName = "SuiteSparse_config";
+  version = "7.12.1";
+
+  buildInputs = [
+    blas
+  ];
+
+  propagatedBuildInputs = lib.optionals stdenv.cc.isClang [
+    llvmPackages.openmp
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
+    (lib.cmakeFeature "BLA_VENDOR" "Generic")
+  ];
+
+  meta = {
+    description = "Library with common functions and configuration for most suitesparse packages";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/by-name/umfpack.nix
+++ b/pkgs/by-name/su/suitesparse/by-name/umfpack.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  mkDerivation,
+  amd,
+  cholmod,
+  blas,
+  suitesparse-config,
+}:
+
+mkDerivation {
+  pname = "umfpack";
+  moduleName = "UMFPACK";
+  version = "6.3.7";
+
+  buildInputs = [
+    amd
+    cholmod
+    blas
+  ];
+
+  propagatedBuildInputs = [
+    suitesparse-config
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "SUITESPARSE_USE_64BIT_BLAS" blas.isILP64)
+    (lib.cmakeFeature "BLA_VENDOR" "Generic")
+  ];
+
+  doCheck = true;
+
+  meta = {
+    description = "Sparse CHOLesky MODification package";
+    license = lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ qbisi ];
+  };
+}

--- a/pkgs/by-name/su/suitesparse/default.nix
+++ b/pkgs/by-name/su/suitesparse/default.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  stdenv,
+  config,
+  newScope,
+  fetchFromGitHub,
+  cudaPackages,
+}:
+let
+  suitesparseVersion = "7.12.2";
+in
+lib.makeScope newScope (
+  self:
+  lib.packagesFromDirectoryRecursive {
+    inherit (self) callPackage;
+    directory = ./by-name;
+  }
+  // {
+    enableCuda = config.cudaSupport;
+    stdenv = if self.enableCuda then cudaPackages.backendStdenv else stdenv;
+    mkDerivation = self.callPackage ./mk-suitesparse-derivation.nix {
+      suitesparseSource = fetchFromGitHub {
+        owner = "DrTimothyAldenDavis";
+        repo = "SuiteSparse";
+        tag = "v${suitesparseVersion}";
+        hash = "sha256-reR23aBs3rdNdDYpjuN6XbAmrBZ1euFsKreBdPI//gI=";
+      };
+    };
+  }
+)

--- a/pkgs/by-name/su/suitesparse/mk-suitesparse-derivation.nix
+++ b/pkgs/by-name/su/suitesparse/mk-suitesparse-derivation.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  suitesparseSource,
+  cmake,
+  fixDarwinDylibNames,
+  testers,
+  enableCuda,
+  addDriverRunpath,
+  cudaPackages,
+}:
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  excludeDrvArgNames = [
+    "moduleName"
+  ];
+  extendDrvArgs =
+    finalAttrs:
+    {
+      pname,
+      moduleName,
+      cmakeDir ? "../${moduleName}",
+      src ? suitesparseSource,
+      outputs ? [
+        "out"
+        "dev"
+      ],
+      nativeBuildInputs ? [ ],
+      buildInputs ? [ ],
+      cmakeFlags ? [ ],
+      passthru ? { },
+      meta ? { },
+      ...
+    }@attrs:
+    {
+      pname = "suitesparse-${pname}";
+      inherit src outputs cmakeDir;
+
+      nativeBuildInputs = [
+        cmake
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        fixDarwinDylibNames
+      ]
+      ++ lib.optionals enableCuda [
+        addDriverRunpath
+        cudaPackages.cuda_nvcc
+      ]
+      ++ nativeBuildInputs;
+
+      buildInputs =
+        lib.optionals enableCuda [
+          cudaPackages.cuda_cudart
+          cudaPackages.cuda_nvrtc
+          cudaPackages.libcublas
+        ]
+        ++ buildInputs;
+
+      cmakeFlags = [
+        (lib.cmakeBool "BUILD_STATIC_LIBS" stdenv.hostPlatform.isStatic)
+        (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+        (lib.cmakeBool "BUILD_TESTING" finalAttrs.finalPackage.doCheck)
+        (lib.cmakeBool "SUITESPARSE_DEMOS" false)
+        (lib.cmakeBool "SUITESPARSE_USE_STRICT" true)
+        (lib.cmakeBool "SUITESPARSE_USE_FORTRAN" false)
+        (lib.cmakeBool "SUITESPARSE_USE_CUDA" enableCuda)
+      ]
+      ++ lib.optionals enableCuda [
+        (lib.cmakeFeature "SUITESPARSE_CUDA_ARCHITECTURES" cudaPackages.flags.cmakeCudaArchitecturesString)
+      ]
+      ++ cmakeFlags;
+
+      # Follow Spack's practice of enabling backwards compatiblity by creating symlinks to headers
+      # found in the nested include/suitesparse directory at the root of include:
+      # https://github.com/spack/spack-packages/blob/9a7f32a93e4096ca0747ac19a10f77f9d2762786/repos/spack_repo/builtin/packages/suite_sparse/package.py#L324-L332
+      postInstall = ''
+        nixLog "creating symlinks in ''${!outputDev:?}/include for backwards compat"
+        pushd "''${!outputDev:?}/include" >/dev/null
+        ln -svrf suitesparse/* .
+        popd >/dev/null
+      '';
+
+      passthru = {
+        tests = {
+          cmake-config = testers.hasCmakeConfigModules {
+            inherit (finalAttrs) version;
+            package = finalAttrs.finalPackage;
+            moduleNames = [ moduleName ];
+            versionCheck = true;
+          };
+          pkg-config = testers.hasPkgConfigModules {
+            inherit (finalAttrs) version;
+            moduleNames = [ moduleName ];
+            package = finalAttrs.finalPackage;
+            versionCheck = true;
+          };
+        };
+      }
+      // passthru;
+
+      meta = {
+        homepage = "https://github.com/DrTimothyAldenDavis/SuiteSparse/tree/dev/${moduleName}";
+        platforms = with lib.platforms; unix;
+      }
+      // meta;
+    };
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10478,6 +10478,10 @@ with pkgs;
     lapack = lapack-ilp64;
   };
 
+  suitesparsePackages = recurseIntoAttrs (
+    callPackage ../by-name/su/suitesparse/default.nix { }
+  );
+
   trilinos-mpi = trilinos.override { withMPI = true; };
 
   wolfram-for-jupyter-kernel = callPackage ../applications/editors/jupyter-kernels/wolfram { };


### PR DESCRIPTION
Inspired by https://github.com/NixOS/nixpkgs/pull/485208.
I found that most downstream packages rely on suitesparse does not need full suite of these sparse routine. Hence i splitted them into suitesparsePackages.

Todo: also bump ceres-solver as an example of using splitted suitesparesePackages.

@wegank should i make mongoose and suitesparese-graphblas alias to suiteSparsePackages.{mongoose,graphblas} 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
