### PR TITLE
ft2-clone: install .desktop & icon

### DIFF
--- a/pkgs/by-name/ft/ft2-clone/package.nix
+++ b/pkgs/by-name/ft/ft2-clone/package.nix
@@ -29,6 +29,17 @@ stdenv.mkDerivation (finalAttrs: {
     libiconv
   ];
 
+  postInstall = ''
+    install -Dm444 "$src/release/other/Freedesktop.org Resources/Fasttracker II clone.desktop" \
+      $out/share/applications/ft2-clone.desktop
+    install -Dm444 "$src/release/other/Freedesktop.org Resources/Fasttracker II clone.png" \
+      $out/share/icons/hicolor/512x512/apps/ft2-clone.png
+    # gtk-update-icon-cache does not like whitespace. Note that removing this
+    # will not make the build fail, but it will make the NixOS test fail.
+    substituteInPlace $out/share/applications/ft2-clone.desktop \
+      --replace-fail "Icon=Fasttracker II clone" Icon=ft2-clone
+  '';
+
   passthru.tests = {
     ft2-clone-starts = nixosTests.ft2-clone;
   };


### PR DESCRIPTION
ft2-clone was missing the desktop entry provided by upstream. This change matches pt2-clone's packaging (same upstream dev).
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
