### PR TITLE
ocaml-top: remove let binding and qualify references

### DIFF
--- a/pkgs/by-name/oc/ocaml-top/package.nix
+++ b/pkgs/by-name/oc/ocaml-top/package.nix
@@ -4,11 +4,7 @@
   ocamlPackages,
 }:
 
-let
-  inherit (ocamlPackages) buildDunePackage lablgtk3-sourceview3 ocp-index;
-in
-
-buildDunePackage rec {
+ocamlPackages.buildDunePackage rec {
   pname = "ocaml-top";
   version = "1.2.0";
 
@@ -20,8 +16,8 @@ buildDunePackage rec {
   };
 
   buildInputs = [
-    lablgtk3-sourceview3
-    ocp-index
+    ocamlPackages.lablgtk3-sourceview3
+    ocamlPackages.ocp-index
   ];
 
   meta = {


### PR DESCRIPTION
This pull request makes minor improvements to the `ocaml-top` package definition by updating how dependencies are referenced. The changes ensure that dependencies are explicitly accessed through the `ocamlPackages` attribute set, which is a best practice for clarity and maintainability.

Dependency reference improvements:

* Replaced direct references to `lablgtk3-sourceview3` and `ocp-index` in `buildInputs` with qualified references (`ocamlPackages.lablgtk3-sourceview3` and `ocamlPackages.ocp-index`).
* Changed the usage of `buildDunePackage` to be explicitly accessed from `ocamlPackages` instead of using an inherited binding.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
