### PR TITLE
treewide: move LD_LIBRARY_PATH into env for structuredAttrs 

### DIFF
--- a/pkgs/applications/networking/browsers/nyxt/default.nix
+++ b/pkgs/applications/networking/browsers/nyxt/default.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # for cffi
-  LD_LIBRARY_PATH = lib.makeLibraryPath [
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath [
     glib
     gobject-introspection
     gdk-pixbuf

--- a/pkgs/by-name/ag/age-plugin-se/package.nix
+++ b/pkgs/by-name/ag/age-plugin-se/package.nix
@@ -26,8 +26,10 @@ stdenv.mkDerivation (finalAttrs: {
     swiftpm
   ];
 
-  # Can't find libdispatch without this on NixOS. (swift 5.8)
-  LD_LIBRARY_PATH = lib.optionalString stdenv.hostPlatform.isLinux "${swiftPackages.Dispatch}/lib";
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # Can't find libdispatch without this on NixOS. (swift 5.8)
+    LD_LIBRARY_PATH = "${swiftPackages.Dispatch}/lib";
+  };
 
   postPatch =
     let

--- a/pkgs/by-name/ne/nethoscope/package.nix
+++ b/pkgs/by-name/ne/nethoscope/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     libpcap
   ];
 
-  LD_LIBRARY_PATH = lib.makeLibraryPath [
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath [
     libpcap
     alsa-lib
   ];

--- a/pkgs/by-name/pg/pgloader/package.nix
+++ b/pkgs/by-name/pg/pgloader/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
   ];
 
-  LD_LIBRARY_PATH = lib.makeLibraryPath [
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath [
     sqlite
     libzip
     curl
@@ -79,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     install -Dm755 pgloader-bundle-${finalAttrs.version}/bin/pgloader "$out/bin/pgloader"
-    wrapProgram $out/bin/pgloader --prefix LD_LIBRARY_PATH : "${finalAttrs.LD_LIBRARY_PATH}"
+    wrapProgram $out/bin/pgloader --prefix LD_LIBRARY_PATH : "${finalAttrs.env.LD_LIBRARY_PATH}"
     mkdir -p $out/bin $out/man/man1
     installManPage source/docs/_build/man/*.1
   '';

--- a/pkgs/by-name/pr/protoc-gen-swift/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-swift/package.nix
@@ -31,12 +31,12 @@ stdenv.mkDerivation (finalAttrs: {
     swiftPackages.Dispatch
   ];
 
-  # swiftpm fails to found libdispatch.so on Linux
-  LD_LIBRARY_PATH = lib.optionalString stdenv.hostPlatform.isLinux (
-    lib.makeLibraryPath [
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # swiftpm fails to found libdispatch.so on Linux
+    LD_LIBRARY_PATH = lib.makeLibraryPath [
       swiftPackages.Dispatch
-    ]
-  );
+    ];
+  };
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/sc/sc-controller/package.nix
+++ b/pkgs/by-name/sc/sc-controller/package.nix
@@ -70,7 +70,7 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace scc/device_monitor.py --replace "find_library('bluetooth')" "'libbluetooth.so.3'"
   '';
 
-  LD_LIBRARY_PATH = lib.makeLibraryPath [
+  env.LD_LIBRARY_PATH = lib.makeLibraryPath [
     libX11
     libXext
     libXfixes

--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -40,7 +40,7 @@ let
       icu73
     ];
 
-    LD_LIBRARY_PATH = lib.makeLibraryPath [ icu73 ];
+    env.LD_LIBRARY_PATH = lib.makeLibraryPath [ icu73 ];
 
     configureFlags = [
       "--with-system-editline"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
