### PR TITLE
sawjap: remove let binding and qualify references

### DIFF
--- a/pkgs/by-name/sa/sawjap/package.nix
+++ b/pkgs/by-name/sa/sawjap/package.nix
@@ -1,24 +1,23 @@
-{ stdenv, ocamlPackages }:
-
-let
-  inherit (ocamlPackages) ocaml findlib sawja;
-in
+{
+  stdenv,
+  ocamlPackages,
+}:
 
 stdenv.mkDerivation {
 
   pname = "sawjap";
 
-  inherit (sawja) src version;
+  inherit (ocamlPackages.sawja) src version;
 
   prePatch = "cd test";
 
   strictDeps = true;
 
   nativeBuildInputs = [
-    ocaml
-    findlib
+    ocamlPackages.ocaml
+    ocamlPackages.findlib
   ];
-  buildInputs = [ sawja ];
+  buildInputs = [ ocamlPackages.sawja ];
 
   buildPhase = ''
     runHook preBuild
@@ -29,7 +28,7 @@ stdenv.mkDerivation {
 
   dontInstall = true;
 
-  meta = sawja.meta // {
+  meta = ocamlPackages.sawja.meta // {
     description = "Pretty-print .class files";
     mainProgram = "sawjap";
   };


### PR DESCRIPTION
This pull request refactors the `package.nix` file for the `sawjap` package to use fully qualified references to dependencies from `ocamlPackages`, improving clarity and maintainability.

Dependency referencing improvements:

* Updated all references to `ocaml`, `findlib`, and `sawja` to use the fully qualified `ocamlPackages` attribute set, ensuring consistency and reducing ambiguity in dependency resolution.
* Changed the `meta` attribute to inherit from `ocamlPackages.sawja.meta` instead of the previous unqualified `sawja.meta`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
