### PR TITLE
python313Packages.pytest-assume: init at 2.4.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12562,6 +12562,11 @@
     githubId = 277474;
     keys = [ { fingerprint = "F1F1 3395 8E8E 9CC4 D9FC  9647 1931 9CD8 416A 642B"; } ];
   };
+  jfr = {
+    name = "Joseph Fox-Rabinovitz";
+    github = " joe-saronic";
+    githubId = 156837150;
+  };
   jfroche = {
     name = "Jean-François Roche";
     email = "jfroche@pyxel.be";

--- a/pkgs/development/python-modules/pytest-assume/default.nix
+++ b/pkgs/development/python-modules/pytest-assume/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytest,
+  pytestCheckHook,
+  six,
+}:
+
+buildPythonPackage rec {
+  pname = "pytest-assume";
+  version = "2.4.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "astraw38";
+    repo = "pytest-assume";
+    tag = "v${version}";
+    sha256 = "sha256-QIwETun/n8SnBzK/axWiVTcuWiJ0ph3+2pQYVRMmVWI=";
+  };
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ pytest ];
+
+  dependencies = [ six ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pytest_assume" ];
+
+  meta = {
+    description = "Pytest plugin that allows multiple failures per test";
+    homepage = "https://github.com/astraw38/pytest-assume";
+    changelog = "https://github.com/astraw38/pytest-assume/releases/tag/${src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jfr ];
+  };
+}

--- a/pkgs/development/python-modules/pytest-assume/default.nix
+++ b/pkgs/development/python-modules/pytest-assume/default.nix
@@ -8,7 +8,7 @@
   six,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-assume";
   version = "2.4.3";
   pyproject = true;
@@ -16,8 +16,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "astraw38";
     repo = "pytest-assume";
-    tag = "v${version}";
-    sha256 = "sha256-QIwETun/n8SnBzK/axWiVTcuWiJ0ph3+2pQYVRMmVWI=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QIwETun/n8SnBzK/axWiVTcuWiJ0ph3+2pQYVRMmVWI=";
   };
 
   build-system = [ setuptools ];
@@ -33,8 +33,8 @@ buildPythonPackage rec {
   meta = {
     description = "Pytest plugin that allows multiple failures per test";
     homepage = "https://github.com/astraw38/pytest-assume";
-    changelog = "https://github.com/astraw38/pytest-assume/releases/tag/${src.tag}";
+    changelog = "https://github.com/astraw38/pytest-assume/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jfr ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15271,6 +15271,8 @@ self: super: with self; {
 
   pytest-arraydiff = callPackage ../development/python-modules/pytest-arraydiff { };
 
+  pytest-assume = callPackage ../development/python-modules/pytest-assume { };
+
   pytest-astropy = callPackage ../development/python-modules/pytest-astropy { };
 
   pytest-astropy-header = callPackage ../development/python-modules/pytest-astropy-header { };


### PR DESCRIPTION
`pytest-assume` is an improved version of `pytest-expect`, which is already in nixpkgs. My colleagues and I use it frequently.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
