### PR TITLE
clazy: migrate to by-name, migrate llvmpackages.stdenv from top-level

### DIFF
--- a/pkgs/by-name/cl/clazy/package.nix
+++ b/pkgs/by-name/cl/clazy/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   fetchFromGitHub,
   llvmPackages,
   cmake,
@@ -9,7 +8,7 @@
   gitUpdater,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "clazy";
   version = "1.15";
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3635,10 +3635,6 @@ with pkgs;
 
   clang-tools = llvmPackages.clang-tools;
 
-  clazy = callPackage ../development/tools/analysis/clazy {
-    stdenv = llvmPackages.stdenv;
-  };
-
   #Use this instead of stdenv to build with clang
   clangStdenv = if stdenv.cc.isClang then stdenv else lowPrio llvmPackages.stdenv;
   libcxxStdenv = if stdenv.hostPlatform.isDarwin then stdenv else lowPrio llvmPackages.libcxxStdenv;


### PR DESCRIPTION
This pull request refactors the packaging of `clazy` to align with the new package organization and simplify its usage. The main changes involve moving the package file to a new location, updating the build environment to use `llvmPackages.stdenv` directly, and cleaning up the top-level package definitions to remove redundant parameters.

Package reorganization and build environment update:

* Renamed the `clazy` package file from `pkgs/development/tools/analysis/clazy/default.nix` to `pkgs/by-name/cl/clazy/package.nix` to follow the new package naming conventions.
* Updated the derivation in `package.nix` to use `llvmPackages.stdenv.mkDerivation` directly, removing the need to pass `stdenv` as a parameter.

Top-level package definition cleanup:

* Removed the explicit `clazy` package definition from `pkgs/top-level/all-packages.nix`, as the new organization and usage of `llvmPackages.stdenv` make it unnecessary.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
