### PR TITLE
oauth2-proxy: 7.14.0 -> 7.14.2; add maintainer

### DIFF
--- a/pkgs/by-name/oa/oauth2-proxy/package.nix
+++ b/pkgs/by-name/oa/oauth2-proxy/package.nix
@@ -29,5 +29,8 @@ buildGoModule rec {
     homepage = "https://github.com/oauth2-proxy/oauth2-proxy/";
     license = lib.licenses.mit;
     mainProgram = "oauth2-proxy";
+    maintainers = with lib.maintainers; [
+      swarsel
+    ];
   };
 }

--- a/pkgs/by-name/oa/oauth2-proxy/package.nix
+++ b/pkgs/by-name/oa/oauth2-proxy/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "oauth2-proxy";
-  version = "7.14.0";
+  version = "7.14.2";
 
   src = fetchFromGitHub {
     repo = "oauth2-proxy";
     owner = "oauth2-proxy";
-    sha256 = "sha256-lFyEfSOJwzuLgHnVGEUbLTWauboUYxBNF6iTV06vmOw=";
+    sha256 = "sha256-Er5AFAuG/F2G5un/VCZkRp6NXI259vFrhtL7NYySff8=";
     rev = "v${version}";
   };
 
-  vendorHash = "sha256-HMuQSpUUnMmhsawy2PD8QONLRkJ1vi2LhJnYQzj/TJ4=";
+  vendorHash = "sha256-LAJx4PwGXNqQ5hGX33695JoQa/cJ8gnz0cYPjEmg72U=";
 
   # Taken from https://github.com/oauth2-proxy/oauth2-proxy/blob/master/Makefile
   ldflags = [ "-X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v${version}" ];


### PR DESCRIPTION
Changelog: https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.14.2
Diff: https://github.com/oauth2-proxy/oauth2-proxy/compare/v7.14.0...v7.14.2

Critically, this fixes an issue with static upstream validation that currently prevents the service from starting when using static upstreams with certain values at default.

edit: I also noticed the package currently has no maintainer and decided to adopt it

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
