### PR TITLE
gruppled-{black,white}{,-lite}-cursors: move to pkgs/by-name

### DIFF
--- a/pkgs/by-name/gr/gruppled-black-cursors/package.nix
+++ b/pkgs/by-name/gr/gruppled-black-cursors/package.nix
@@ -1,12 +1,17 @@
 {
+  lib,
   stdenvNoCC,
   fetchFromGitHub,
-  theme,
-  lib,
+  theme ? "black",
 }:
 
+assert lib.asserts.assertOneOf "theme" theme [
+  "black"
+  "white"
+];
+
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "gruppled-cursors";
+  pname = "gruppled-${theme}-cursors";
   version = "1.0.0";
 
   src = fetchFromGitHub {
@@ -17,12 +22,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   installPhase = ''
-    mkdir -p $out/share/icons/${theme}
-    cp -r ${theme}/{cursors,index.theme} $out/share/icons/${theme}
+    mkdir -p $out/share/icons/gruppled_${theme}
+    cp -r gruppled_${theme}/{cursors,index.theme} $out/share/icons/gruppled_${theme}
   '';
 
   meta = {
-    description = "Gruppled Cursors theme";
+    description = "Gruppled ${lib.toSentenceCase theme} Cursors theme";
     homepage = "https://github.com/nim65s/gruppled-cursors";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ nim65s ];

--- a/pkgs/by-name/gr/gruppled-black-lite-cursors/package.nix
+++ b/pkgs/by-name/gr/gruppled-black-lite-cursors/package.nix
@@ -1,12 +1,17 @@
 {
+  lib,
   stdenvNoCC,
   fetchFromGitHub,
-  theme,
-  lib,
+  theme ? "black",
 }:
 
+assert lib.asserts.assertOneOf "theme" theme [
+  "black"
+  "white"
+];
+
 stdenvNoCC.mkDerivation (finalAttrs: {
-  pname = "gruppled-lite-cursors";
+  pname = "gruppled-${theme}-lite-cursors";
   version = "1.0.0";
 
   src = fetchFromGitHub {
@@ -17,12 +22,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
 
   installPhase = ''
-    mkdir -p $out/share/icons/${theme}
-    cp -r ${theme}/{cursors,index.theme} $out/share/icons/${theme}
+    mkdir -p $out/share/icons/gruppled_${theme}_lite
+    cp -r gruppled_${theme}_lite/{cursors,index.theme} $out/share/icons/gruppled_${theme}_lite
   '';
 
   meta = {
-    description = "Gruppled Lite Cursors theme";
+    description = "Gruppled ${lib.toSentenceCase theme} Lite Cursors theme";
     homepage = "https://github.com/nim65s/gruppled-lite-cursors";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [ nim65s ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9658,20 +9658,18 @@ with pkgs;
 
   inherit
     ({
-      gruppled-black-cursors = callPackage ../data/icons/gruppled-cursors { theme = "gruppled_black"; };
       gruppled-black-lite-cursors = callPackage ../data/icons/gruppled-lite-cursors {
         theme = "gruppled_black_lite";
       };
-      gruppled-white-cursors = callPackage ../data/icons/gruppled-cursors { theme = "gruppled_white"; };
       gruppled-white-lite-cursors = callPackage ../data/icons/gruppled-lite-cursors {
         theme = "gruppled_white_lite";
       };
     })
-    gruppled-black-cursors
     gruppled-black-lite-cursors
-    gruppled-white-cursors
     gruppled-white-lite-cursors
     ;
+
+  gruppled-white-cursors = gruppled-black-cursors.override { theme = "white"; };
 
   iosevka-comfy = recurseIntoAttrs (callPackages ../data/fonts/iosevka/comfy.nix { });
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9656,20 +9656,8 @@ with pkgs;
 
   spacx-gtk-theme = callPackage ../data/themes/gtk-theme-framework { theme = "spacx"; };
 
-  inherit
-    ({
-      gruppled-black-lite-cursors = callPackage ../data/icons/gruppled-lite-cursors {
-        theme = "gruppled_black_lite";
-      };
-      gruppled-white-lite-cursors = callPackage ../data/icons/gruppled-lite-cursors {
-        theme = "gruppled_white_lite";
-      };
-    })
-    gruppled-black-lite-cursors
-    gruppled-white-lite-cursors
-    ;
-
   gruppled-white-cursors = gruppled-black-cursors.override { theme = "white"; };
+  gruppled-white-lite-cursors = gruppled-black-lite-cursors.override { theme = "white"; };
 
   iosevka-comfy = recurseIntoAttrs (callPackages ../data/fonts/iosevka/comfy.nix { });
 


### PR DESCRIPTION
since this changes the pnames this unfortunately creates 4 rebuilds

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
