### PR TITLE
nixos/httpd: set `Type=notify` for systemd unit

### DIFF
--- a/nixos/modules/services/web-servers/apache-httpd/default.nix
+++ b/nixos/modules/services/web-servers/apache-httpd/default.nix
@@ -90,6 +90,7 @@ let
     "unixd"
     "slotmem_shm"
     "socache_shmcb"
+    "systemd"
     "mpm_${cfg.mpm}"
   ]
   ++ (if cfg.mpm == "prefork" then [ "cgi" ] else [ "cgid" ])
@@ -992,12 +993,12 @@ in
       '';
 
       serviceConfig = {
-        ExecStart = "@${pkg}/bin/httpd httpd -f /etc/httpd/httpd.conf";
-        ExecStop = "${pkg}/bin/httpd -f /etc/httpd/httpd.conf -k graceful-stop";
+        ExecStart = "${pkg}/bin/httpd -D FOREGROUND -f /etc/httpd/httpd.conf";
         ExecReload = "${pkg}/bin/httpd -f /etc/httpd/httpd.conf -k graceful";
+        KillMode = "mixed";
         User = cfg.user;
         Group = cfg.group;
-        Type = "forking";
+        Type = "notify";
         PIDFile = "${runtimeDir}/httpd.pid";
         Restart = "always";
         RestartSec = "5s";

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -3,6 +3,8 @@
   stdenv,
   fetchurl,
   fetchpatch2,
+  autoreconfHook,
+  pkg-config,
   perl,
   zlib,
   apr,
@@ -63,6 +65,8 @@ stdenv.mkDerivation rec {
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
     perl
     which
   ];
@@ -76,13 +80,16 @@ stdenv.mkDerivation rec {
   ++ lib.optional sslSupport openssl
   ++ lib.optional ldapSupport openldap
   # there is no --with-ldap flag
+  ++ lib.optional luaSupport lua5
   ++ lib.optional libxml2Support libxml2
   ++ lib.optional http2Support nghttp2
   ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
 
   postPatch = ''
     sed -i config.layout -e "s|installbuilddir:.*|installbuilddir: $dev/share/build|"
-    sed -i configure -e 's|perlbin=.*|perlbin="/usr/bin/env perl"|'
+    sed -i configure.in \
+      -e 's|AC_PATH_PROG|AC_PATH_TOOL|' \
+      -e 's|perlbin=.*|perlbin="/usr/bin/env perl"|'
     ${lib.optionalString withLynx "sed -i support/apachectl.in -e 's|@LYNX_PATH@|${lynx}/bin/lynx|'"}
   '';
 
@@ -104,19 +111,13 @@ stdenv.mkDerivation rec {
     "--enable-imagemap"
     "--enable-cgi"
     "--includedir=${placeholder "dev"}/include"
+    "--docdir=$(doc)/share/doc"
     (lib.enableFeature proxySupport "proxy")
     (lib.enableFeature sslSupport "ssl")
     (lib.withFeatureAs libxml2Support "libxml2" "${libxml2.dev}/include/libxml2")
-    "--docdir=$(doc)/share/doc"
-
     (lib.enableFeature brotliSupport "brotli")
-    (lib.withFeatureAs brotliSupport "brotli" brotli)
-
     (lib.enableFeature http2Support "http2")
-    (lib.withFeature http2Support "nghttp2")
-
     (lib.enableFeature luaSupport "lua")
-    (lib.withFeatureAs luaSupport "lua" lua5)
   ]
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
     # skip bad config check when cross compiling

--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -32,6 +32,8 @@
   brotli,
   luaSupport ? false,
   lua5,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemdLibs,
 }:
 
 stdenv.mkDerivation rec {
@@ -83,7 +85,8 @@ stdenv.mkDerivation rec {
   ++ lib.optional luaSupport lua5
   ++ lib.optional libxml2Support libxml2
   ++ lib.optional http2Support nghttp2
-  ++ lib.optional stdenv.hostPlatform.isDarwin libiconv;
+  ++ lib.optional stdenv.hostPlatform.isDarwin libiconv
+  ++ lib.optional systemdSupport systemdLibs;
 
   postPatch = ''
     sed -i config.layout -e "s|installbuilddir:.*|installbuilddir: $dev/share/build|"
@@ -117,6 +120,7 @@ stdenv.mkDerivation rec {
     (lib.withFeatureAs libxml2Support "libxml2" "${libxml2.dev}/include/libxml2")
     (lib.enableFeature brotliSupport "brotli")
     (lib.enableFeature http2Support "http2")
+    (lib.enableFeature systemdSupport "systemd")
     (lib.enableFeature luaSupport "lua")
   ]
   ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds better systemd integration for httpd, both in the package and in the module.

[The package's configure script only looks for the systemd library via pkg-config](https://github.com/apache/httpd/blob/e4a77ef6051b3fe22eafacbcf54855b178a0bddd/acinclude.m4#L617-L638), so I added this in a separate commit. There were some extra patching needed to fix use of pkg-config while cross compiling, mostly because the configure script assumed the executable would always be called `pkg-config` and not `aarch64-unknown-linux-gnu-pkg-config`.

Tests are running successfully on my computer with
`nix build .#apacheHttpd.tests.{acme-integration,proxy,php,cross} -L`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
