### PR TITLE
clash-verge-rev: 2.4.3 -> 2.4.6; nixos/clash-verge: add group option

### DIFF
--- a/nixos/modules/programs/clash-verge.nix
+++ b/nixos/modules/programs/clash-verge.nix
@@ -23,6 +23,17 @@
     serviceMode = lib.mkEnableOption "Service Mode";
     tunMode = lib.mkEnableOption "Setcap for TUN Mode. DNS settings won't work on this way";
     autoStart = lib.mkEnableOption "Clash Verge auto launch";
+    group = lib.mkOption {
+      type = lib.types.str;
+      example = "wheel";
+      default = "users";
+      description = ''
+        The group to grant access to clash-verge-rev's service socket.
+
+        For better security, you should set a group that only contains
+        users who need to access clash-verge-rev's service socket.
+      '';
+    };
   };
 
   config =
@@ -54,6 +65,7 @@
         serviceConfig = {
           ExecStart = "${cfg.package}/bin/clash-verge-service";
           Restart = "on-failure";
+          Group = cfg.group;
           ProtectSystem = "strict";
           NoNewPrivileges = true;
           ProtectHostname = true;

--- a/nixos/modules/programs/clash-verge.nix
+++ b/nixos/modules/programs/clash-verge.nix
@@ -100,8 +100,5 @@
       };
     };
 
-  meta.maintainers = with lib.maintainers; [
-    bot-wxt1221
-    Guanran928
-  ];
+  meta.maintainers = pkgs.clash-verge-rev.meta.maintainers;
 }

--- a/pkgs/by-name/cl/clash-verge-rev/package.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/package.nix
@@ -12,17 +12,18 @@
 }:
 let
   pname = "clash-verge-rev";
-  version = "2.4.3";
+  # Please keep service version in sync
+  version = "2.4.6";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-rev";
     tag = "v${version}";
-    hash = "sha256-GmoeOLKxdW1x6PHtslwNPVq8wDWA413NHA/VeDRb4mA=";
+    hash = "sha256-s/dUy9vYxdUlAahVPkoOHjoF+WCl3xhJOubZtS1PB5o=";
   };
 
-  pnpm-hash = "sha256-o3VPb+D74bjwEex7UFmwfx8N1yGolPqNaIeJ7/cjB0c=";
-  vendor-hash = "sha256-z5xVbqh+CiaTDtAx2VPQ4UjliYnV44tdp3pS8vzb1K4=";
+  pnpm-hash = "sha256-7xNaLlnXLty80x1d25pBeLZUu0r3R+87DYoJ6rTHSTA=";
+  vendor-hash = "sha256-1b0vmx0apWSNlaTMR58eufinBuIC7/F3UG3C8X62/gE=";
 
   service = callPackage ./service.nix {
     inherit
@@ -85,4 +86,6 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+  # For testing convenience
+  passthru = { inherit unwrapped service; };
 }

--- a/pkgs/by-name/cl/clash-verge-rev/patch-cargo-lock.patch
+++ b/pkgs/by-name/cl/clash-verge-rev/patch-cargo-lock.patch
@@ -1,0 +1,39 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index d5895c0b..a7954a89 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -7255,7 +7255,7 @@ dependencies = [
+  "once_cell",
+  "parking_lot",
+  "raw-window-handle",
+- "tao-macros 0.1.3 (git+https://github.com/tauri-apps/tao)",
++ "tao-macros",
+  "unicode-segmentation",
+  "url",
+  "windows 0.61.3",
+@@ -7275,16 +7275,6 @@ dependencies = [
+  "syn 2.0.114",
+ ]
+ 
+-[[package]]
+-name = "tao-macros"
+-version = "0.1.3"
+-source = "git+https://github.com/tauri-apps/tao#a133504b6dc963a5ad7786e01e746dba72236b65"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "syn 2.0.114",
+-]
+-
+ [[package]]
+ name = "tap"
+ version = "1.0.1"
+@@ -10040,7 +10030,7 @@ dependencies = [
+  "raw-window-handle",
+  "sha2 0.10.9",
+  "soup3",
+- "tao-macros 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
++ "tao-macros",
+  "thiserror 2.0.18",
+  "tracing",
+  "url",

--- a/pkgs/by-name/cl/clash-verge-rev/patch-service-directory.patch
+++ b/pkgs/by-name/cl/clash-verge-rev/patch-service-directory.patch
@@ -1,0 +1,26 @@
+diff --git a/src/core/server.rs b/src/core/server.rs
+index 45570ea..d459b3e 100644
+--- a/src/core/server.rs
++++ b/src/core/server.rs
+@@ -123,7 +123,7 @@ async fn make_ipc_dir() -> Result<()> {
+         // on macOS or the primary group on Linux) to manage the socket's lifecycle. This prevents
+         // permission denied errors when the GUI process, running with non-root privileges,
+         // attempts to recreate the socket during service initialization or sidecar fallbacks.
+-        fs::set_permissions(dir_path, Permissions::from_mode(0o2770)).await?;
++        fs::set_permissions(dir_path, Permissions::from_mode(0o770)).await?;
+     }
+     #[cfg(windows)]
+     {
+diff --git a/src/lib.rs b/src/lib.rs
+index a21f89b..81175fc 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -12,7 +12,7 @@ pub use core::{run_ipc_server, stop_ipc_server};
+ pub use client::*;
+ 
+ #[cfg(all(unix, not(feature = "test")))]
+-pub static IPC_PATH: &str = "/tmp/verge/clash-verge-service.sock";
++pub static IPC_PATH: &str = "/run/clash-verge-rev/service.sock";
+ #[cfg(all(windows, not(feature = "test")))]
+ pub static IPC_PATH: &str = r"\\.\pipe\clash-verge-service";
+ 

--- a/pkgs/by-name/cl/clash-verge-rev/service.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/service.nix
@@ -7,25 +7,25 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clash-verge-service-ipc";
-  version = "2.0.21";
+  version = "2.1.3";
 
   src = fetchFromGitHub {
     owner = "clash-verge-rev";
     repo = "clash-verge-service-ipc";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-9c9fM1l31NbY//Ri50Ql60BWWgISjMWj72ABixRaXvM=";
+    # upstream uses branch
+    rev = "a486e7df6ac3d641014085f43bd08e99ff09b5a2";
+    hash = "sha256-WmQ3s6uED4Q1E2ORtjDqdxaUaPD+RIB5x8bYPOuGUSk=";
   };
 
-  postPatch = ''
-    # set socket path for service and test respectively
-    substituteInPlace src/lib.rs \
-      --replace-fail "/tmp/verge/clash-verge-service.sock" "/run/clash-verge-rev/service.sock" \
-      --replace-fail "/tmp/verge/clash-verge-service-test.sock" "$sourceRoot/clash-verge-service-test.sock"
-    substituteInPlace tests/test_start_permissions.rs \
-      --replace-fail "owner_perm | group_perm | other_perm" "0o0755"
-  '';
+  patches = [
+    # 1. Don't SetGID because the path is managed by systemd in NixOS, and we
+    #    use different IPC path for sidecar mode. We can keep RestrictSUIDSGID
+    #    in systemd serviceConfig.
+    # 2. Set IPC socket path
+    ./patch-service-directory.patch
+  ];
 
-  cargoHash = "sha256-UbNN3uFu5anQV+3KMFPNnGrCDQTGb4uC9K83YghfQgY=";
+  cargoHash = "sha256-xE8ihRlox7qrmLHEGQ76pbisFj+1bqjwr+tllxLRDoA=";
 
   buildFeatures = [
     "standalone"

--- a/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/unwrapped.nix
@@ -8,8 +8,6 @@
   vendor-hash,
 
   rustPlatform,
-  fetchpatch,
-
   cargo-tauri,
   jq,
   moreutils,
@@ -31,9 +29,6 @@ rustPlatform.buildRustPackage {
   inherit version src meta;
   pname = "${pname}-unwrapped";
 
-  cargoRoot = "src-tauri";
-  buildAndTestSubdir = "src-tauri";
-
   cargoHash = vendor-hash;
 
   pnpmDeps = fetchPnpmDeps {
@@ -51,11 +46,9 @@ rustPlatform.buildRustPackage {
     OPENSSL_NO_VENDOR = 1;
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/clash-verge-rev/clash-verge-rev/commit/645b92bc2815fe55bbc827907bff0edbfee48674.patch";
-      hash = "sha256-BH0SvVofW6YJ3e/LOHojisenMwcxYfm3gG/dbxvYBMs=";
-    })
+  cargoPatches = [
+    # Duplicate versions of tao-macros make fetchCargoVendor fail, keep one of them.
+    ./patch-cargo-lock.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- Updated the package to 2.4.5
- Added `group` option to specify the group used to access the service socket.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
