### PR TITLE
nixos/nextcloud: fix test import

### DIFF
--- a/nixos/tests/nextcloud/with-mail.nix
+++ b/nixos/tests/nextcloud/with-mail.nix
@@ -57,7 +57,7 @@ runTest (
       stalwart =
         { pkgs, ... }:
         {
-          imports = [ ../stalwart/stalwart-mail-config.nix ];
+          imports = [ ../stalwart/stalwart-config.nix ];
 
           networking.firewall.allowedTCPPorts = [ 587 ];
 


### PR DESCRIPTION
* `stalwart` module refactored as part of https://github.com/NixOS/nixpkgs/pull/481815 resulted in rename of `../stalwart/stalwart-mail-config.nix` to `../stalwart/stalwart-config.nix`


```
# nix build ./#nextcloud32.passthru.tests.with-mail32
...
       error: path '/nix/store/6vwdl8qj5fash54q37f6r6n4c827zr6c-source/nixos/tests/stalwart/stalwart-mail-config.nix' does not exist
```

@bachp @britter @dotlambda @Ma27 @provokateurin

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
