### PR TITLE
nixos/xserver: abort when encountering unknown xorg drivers

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -120,6 +120,8 @@
 
 - `pocket-id` has been updated to version 2 that contains [breaking changes](https://pocket-id.org/docs/setup/major-releases/migrate-v2).
 
+- `services.xserver` will now throw an error if an X11 driver specified in  `videoDriver(s)` cannot be found. Previously, unknown drivers would be silently ignored.
+
 - `asio` (standalone version of `boost::asio`) has been updated from 1.24.0 to 1.36.0. Some breaking changes were introduced between these
   two versions, and the one affected most was the removal of `asio::io_service` in favor of `asio::io_context` in 1.33.0. `asio_1_32_0` is
   retained for packages that have not completed migration. `asio_1_10` has been removed as no packages depend on it anymore.

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -829,7 +829,8 @@ in
 
     services.xserver.videoDrivers = mkIf (cfg.videoDriver != null) [ cfg.videoDriver ];
 
-    # FIXME: somehow check for unknown driver names.
+    # We ignore unknown drivers here because they may be resolved by other modules (e.g., the Nvidia
+    # module). We assert that all specified drivers were eventually found in the assertions below.
     services.xserver.drivers = flip concatMap cfg.videoDrivers (
       name:
       lib.optional (videoDrivers ? ${name}) (
@@ -861,7 +862,11 @@ in
         assertion = cfg.upscaleDefaultCursor -> cfg.dpi != null;
         message = "Specify `config.services.xserver.dpi` to upscale the default cursor.";
       }
-    ];
+    ]
+    ++ map (driver: {
+      assertion = builtins.elem driver (builtins.catAttrs "name" cfg.drivers);
+      message = "Unknown X11 driver ‘${driver}’ specified in `services.xserver.videoDrivers`.";
+    }) cfg.videoDrivers;
 
     environment.etc =
       (optionalAttrs cfg.exportConfiguration {


### PR DESCRIPTION
This PR asserts that all drivers listed in `services.xserver.videoDrivers` eventually get resolved into actual X11 drivers.

History: This address a FIXME in the `services.xserver` module introduced in https://github.com/NixOS/nixpkgs/commit/22088b4b25119083d8adfc055073f563b9cd8115. That commit started silently skipping unknown drivers listed in `services.xserver.videoDrivers` because the nvidia driver is _not_ included in the `knownVideoDriversPackages` list and is instead resolved out-of-band by the nvidia module.

This PR resolves this by asserting that all drivers listed in `services.xserver.videoDrivers` end up with matching drivers in `services.xserver.drivers` via a module assertion.

NOTE: this is a breaking change as previously we'd simply fall back on the modesetting driver. However, this should only be a breaking change for already broken configs that try to use drivers that don't exist.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
