### PR TITLE
[release 25.11]  treewide: fix broken-string-escape

### DIFF
--- a/nixos/modules/services/networking/llama-swap.nix
+++ b/nixos/modules/services/networking/llama-swap.nix
@@ -48,7 +48,7 @@ in
           healthCheckTimeout = 60;
           models = {
             "some-model" = {
-              cmd = "''\${llama-server} --port ''\${PORT} -m /var/lib/llama-cpp/models/some-model.gguf -ngl 0 --no-webui";
+              cmd = "''${llama-server} --port ''${PORT} -m /var/lib/llama-cpp/models/some-model.gguf -ngl 0 --no-webui";
               aliases = [
                 "the-best"
               ];

--- a/pkgs/by-name/ed/edgetx/package.nix
+++ b/pkgs/by-name/ed/edgetx/package.nix
@@ -142,7 +142,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Yes, this is really how upstream expects packaging to look like ¯\_(ツ)_/¯.
     # https://github.com/EdgeTX/edgetx/wiki/Build-Instructions-under-Ubuntu-20.04#building-companion-simulator-and-radio-simulator-libraries
-    for plugin in "$''\{targetsToBuild[@]''\}"
+    for plugin in "''${targetsToBuild[@]}"
     do
       # Variable modified by `get_target_build_options` from build-common.sh.
       local BUILD_OPTIONS=""

--- a/pkgs/by-name/li/libcupsfilters/package.nix
+++ b/pkgs/by-name/li/libcupsfilters/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation {
       name = "CVE-2025-64503.patch";
       url = "https://github.com/OpenPrinting/libcupsfilters/commit/fd01543f372ca3ba1f1c27bd3427110fa0094e3f.patch";
       # File has been renamed before the fix
-      decode = "sed -e 's/pdftoraster\.c/pdftoraster\.cxx/g'";
+      decode = "sed -e 's/pdftoraster\\.c/pdftoraster\\.cxx/g'";
       hash = "sha256-cKbDHZEc/A51M+ce3kVsRxjRUWA96ynGv/avpq4iUHU=";
     })
     (fetchpatch {


### PR DESCRIPTION
The lix deprecation for broken-escape-string has been merged on main, this commit fix the broken escapes that were added since the last patch or left behind.

@piegamesde you'll want to review this one too.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
