### PR TITLE
kdePackages.kwallet: add gpgmepp for GPG wallet support

### DIFF
--- a/pkgs/kde/frameworks/kwallet/default.nix
+++ b/pkgs/kde/frameworks/kwallet/default.nix
@@ -1,7 +1,7 @@
 {
   mkKdeDerivation,
   pkg-config,
-  gpgme,
+  gpgmepp,
   libgcrypt,
   libsecret,
   kdoctools,
@@ -14,7 +14,7 @@ mkKdeDerivation {
   ];
 
   extraBuildInputs = [
-    gpgme
+    gpgmepp
     libgcrypt
     libsecret
     kdoctools


### PR DESCRIPTION
Problem:
GPG-encrypted KWallets fail to unlock with:
  "Error code -41: Unknown cipher or hash"
after updating `nixpkgs` to `gpgme 2.x` (GPG wallet backend not available).

It was working with `3e2499d5539c`, wasn't working anymore with `5912c1772a44`

Cause:
`gpgme` package was split (into `gpgme`, `gpgmepp` and `kdePackages.qgpgme`), and no longer provides the C++ bindings (`libgpgmepp`), but `kdePackages.kwallet` still only depends on `gpgme`, so GPG wallet support is not built/enabled.

Fix:
Add `gpgmepp` to `kwallet` build inputs.

Testing:
- `nix build .#kdePackages.kwallet`
- Verified resulting `kwallet` references `gpgmepp`
- Booted `nixos-26.05pre923638.5912c1772a44` with an overlay applying the same change as this PR, and confirmed my GPG-encrypted wallet unlocks normally.