### PR TITLE
efitools: Fix cross-compile

### DIFF
--- a/pkgs/by-name/ef/efitools/cross.patch
+++ b/pkgs/by-name/ef/efitools/cross.patch
@@ -1,0 +1,89 @@
+--- a/Make.rules
++++ b/Make.rules
+@@ -68,35 +68,35 @@ endif
+ %.h: %.auth
+ 	./xxdi.pl $< > $@
+ 
+-%.hash: %.efi hash-to-efi-sig-list
+-	./hash-to-efi-sig-list $< $@
++%.hash: %.efi
++	hash-to-efi-sig-list $< $@
+ 
+-%-blacklist.esl: %.crt cert-to-efi-hash-list
+-	./cert-to-efi-sig-list $< $@
++%-blacklist.esl: %.crt
++	cert-to-efi-sig-list $< $@
+ 
+-%-hash-blacklist.esl: %.crt cert-to-efi-hash-list
+-	./cert-to-efi-hash-list $< $@
++%-hash-blacklist.esl: %.crt
++	cert-to-efi-hash-list $< $@
+ 
+-%.esl: %.crt cert-to-efi-sig-list
+-	./cert-to-efi-sig-list -g $(MYGUID) $< $@
++%.esl: %.crt
++	cert-to-efi-sig-list -g $(MYGUID) $< $@
+ 
+ getcert = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo "-c PK.crt -k PK.key"; else echo "-c KEK.crt -k KEK.key"; fi)
+ getvar = $(shell if [ "$(1)" = "PK" -o "$(1)" = "KEK" ]; then echo $(1); else echo db; fi)
+ 
+-%.auth: %.esl PK.crt KEK.crt sign-efi-sig-list
+-	./sign-efi-sig-list $(call getcert,$*) $(call getvar,$*) $< $@
++%.auth: %.esl PK.crt KEK.crt
++	sign-efi-sig-list $(call getcert,$*) $(call getvar,$*) $< $@
+ 
+-%-update.auth: %.esl PK.crt KEK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a $(call getcert,$*) $(call getvar,$*) $< $@
++%-update.auth: %.esl PK.crt KEK.crt
++	sign-efi-sig-list -a $(call getcert,$*) $(call getvar,$*) $< $@
+ 
+-%-pkupdate.auth: %.esl PK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a -c PK.crt -k PK.key $(call getvar,$*) $< $@
++%-pkupdate.auth: %.esl PK.crt
++	sign-efi-sig-list -a -c PK.crt -k PK.key $(call getvar,$*) $< $@
+ 
+-%-blacklist.auth: %-blacklist.esl KEK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a -c KEK.crt -k KEK.key dbx $< $@
++%-blacklist.auth: %-blacklist.esl KEK.crt
++	sign-efi-sig-list -a -c KEK.crt -k KEK.key dbx $< $@
+ 
+-%-pkblacklist.auth: %-blacklist.esl PK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -a -c PK.crt -k PK.key dbx $< $@
++%-pkblacklist.auth: %-blacklist.esl PK.crt
++	sign-efi-sig-list -a -c PK.crt -k PK.key dbx $< $@
+ 
+ %.o: %.c
+ 	$(CC) $(INCDIR) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
+--- a/Makefile
++++ b/Makefile
+@@ -27,13 +27,11 @@ include Make.rules
+ 
+ EFISIGNED = $(patsubst %.efi,%-signed.efi,$(EFIFILES))
+ 
+-all: $(EFISIGNED) $(BINARIES) $(MANPAGES) noPK.auth $(KEYAUTH) \
++all: $(EFISIGNED) $(BINARIES) noPK.auth $(KEYAUTH) \
+ 	$(KEYUPDATEAUTH) $(KEYBLACKLISTAUTH) $(KEYHASHBLACKLISTAUTH)
+ 
+ 
+ install: all
+-	$(INSTALL) -m 755 -d $(MANDIR)
+-	$(INSTALL) -m 644 $(MANPAGES) $(MANDIR)
+ 	$(INSTALL) -m 755 -d $(EFIDIR)
+ 	$(INSTALL) -m 755 $(EFIFILES) $(EFIDIR)
+ 	$(INSTALL) -m 755 -d $(BINDIR)
+@@ -65,11 +63,11 @@ DB.h: DB.auth
+ noPK.esl:
+ 	> noPK.esl
+ 
+-noPK.auth: noPK.esl PK.crt sign-efi-sig-list
+-	./sign-efi-sig-list -t "$(shell date --date='1 second' +'%Y-%m-%d %H:%M:%S')" -c PK.crt -k PK.key PK $< $@
++noPK.auth: noPK.esl PK.crt
++	sign-efi-sig-list -t "$(shell date --date='1 second' +'%Y-%m-%d %H:%M:%S')" -c PK.crt -k PK.key PK $< $@
+ 
+-ms-%.esl: ms-%.crt cert-to-efi-sig-list
+-	./cert-to-efi-sig-list -g $(MSGUID) $< $@
++ms-%.esl: ms-%.crt
++	cert-to-efi-sig-list -g $(MSGUID) $< $@
+ 
+ hashlist.h: HashTool.hash
+ 	cat $^ > /tmp/tmp.hash

--- a/pkgs/by-name/ef/efitools/package.nix
+++ b/pkgs/by-name/ef/efitools/package.nix
@@ -8,7 +8,13 @@
   perlPackages,
   help2man,
   fetchzip,
+  pkgsCross,
+  efitools,
+  buildPackages,
 }:
+let
+  isCross = !(stdenv.buildPlatform.canExecute stdenv.hostPlatform);
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "efitools";
   version = "1.9.2";
@@ -16,13 +22,17 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gnu-efi
     openssl
-    sbsigntool
   ];
 
   nativeBuildInputs = [
     perl
     perlPackages.FileSlurp
     help2man
+    openssl
+    sbsigntool
+  ]
+  ++ lib.optionals isCross [
+    efitools
   ];
 
   src = fetchzip {
@@ -39,6 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     # https://bugs.debian.org/1122408
     ./objcopy-output-target.patch
+  ]
+  ++ lib.optionals isCross [
+    # Use builder's efitools to create sig lists for host
+    ./cross.patch
   ];
 
   postPatch = ''
@@ -47,8 +61,25 @@ stdenv.mkDerivation (finalAttrs: {
     sed -i -e 's#$(DESTDIR)/usr#$(out)#g' Make.rules
     sed -i '$asign-efi-sig-list.o flash-var.o: CFLAGS += -D_GNU_SOURCE' Makefile
     substituteInPlace lib/console.c --replace "EFI_WARN_UNKOWN_GLYPH" "EFI_WARN_UNKNOWN_GLYPH"
+    # Fix cross-compilation: use $(AR) and $(NM) variables instead of hardcoded commands
+    substituteInPlace Make.rules --replace-fail 'ar rcv' '$(AR) rcv'
+    substituteInPlace Make.rules --replace-fail 'nm -D' '$(NM) -D'
     patchShebangs .
   '';
+
+  makeFlags = [
+    "ARCH=${stdenv.hostPlatform.parsed.cpu.name}"
+    "AR=${stdenv.cc.targetPrefix}ar"
+    "NM=${stdenv.cc.targetPrefix}nm"
+    "OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
+  ]
+  ++ lib.optionals isCross [
+    "MANPAGES="
+  ];
+
+  passthru.tests = {
+    cross-aarch64 = pkgsCross.aarch64-multiplatform.efitools;
+  };
 
   meta = {
     description = "Tools for manipulating UEFI secure boot platforms";

--- a/pkgs/by-name/sb/sbsigntool/package.nix
+++ b/pkgs/by-name/sb/sbsigntool/package.nix
@@ -10,6 +10,11 @@
   libuuid,
   gnu-efi,
   libbfd,
+  util-linux,
+  buildPackages,
+  deterministic-host-uname,
+  # help2man runs host executables
+  withMan ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -31,6 +36,8 @@ stdenv.mkDerivation (finalAttrs: {
     automake
     pkg-config
     help2man
+    util-linux # for getopt used by create-ccan-tree
+    deterministic-host-uname # build system incorrectly uses uname to determine host CPU
   ];
   buildInputs = [
     openssl
@@ -39,26 +46,24 @@ stdenv.mkDerivation (finalAttrs: {
     gnu-efi
   ];
 
-  configurePhase = ''
-    runHook preConfigure
+  preConfigure = ''
+    substituteInPlace configure.ac --replace-fail "@@NIX_GNUEFI@@" "${gnu-efi}"
 
-    substituteInPlace configure.ac --replace "@@NIX_GNUEFI@@" "${gnu-efi}"
-
-    lib/ccan.git/tools/create-ccan-tree --build-type=automake lib/ccan "talloc read_write_all build_assert array_size endian"
+    CC=${lib.getExe buildPackages.stdenv.cc} lib/ccan.git/tools/create-ccan-tree --build-type=automake lib/ccan "talloc read_write_all build_assert array_size endian"
     touch AUTHORS
     touch ChangeLog
 
-    echo "SUBDIRS = lib/ccan src docs" >> Makefile.am
+    echo "SUBDIRS = lib/ccan src ${lib.optionalString withMan "docs"}" > Makefile.am
 
     aclocal
     autoheader
     autoconf
     automake --add-missing -Wno-portability
-
-    ./configure --prefix=$out
-
-    runHook postConfigure
   '';
+
+  makeFlags = [
+    "AR=${stdenv.cc.targetPrefix}ar"
+  ];
 
   meta = {
     description = "Tools for maintaining UEFI signature databases";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
both sbsigntool and efitool are failing to cross compile. these changes address the issues so that it can build with a cross setup. verified with:

`nix build .#pkgsCross.aarch64-multiplatform.efitools`


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
