### PR TITLE
pam_p11: 0.3.1 -> 0.6.1

### DIFF
--- a/pkgs/by-name/pa/pam_p11/package.nix
+++ b/pkgs/by-name/pa/pam_p11/package.nix
@@ -12,25 +12,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pam_p11";
-  version = "0.3.1";
+  version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "OpenSC";
     repo = "pam_p11";
     rev = "pam_p11-${finalAttrs.version}";
-    sha256 = "1caidy18rq5zk82d51x8vwidmkhwmanf3qm25x1yrdlbhxv6m7lk";
+    hash = "sha256-BYpZM+j0F5qtbkNdAk2qAczGTBlXe87FLBzKwp7fw7U=";
   };
-
-  patches = [
-    # fix with openssl 3.x
-    # https://github.com/OpenSC/pam_p11/pull/22
-    (fetchpatch {
-      name = "OpenSC-pam_p11-pull-22.patch";
-      url = "https://github.com/OpenSC/pam_p11/compare/cd4eba2e921e1c2f93cde71922a76af99376246c...debd4f7acfaf998cfe4002e0be5c35ad9a9591b5.patch";
-      excludes = [ ".github/build.sh" ];
-      hash = "sha256-bm/agnBgvrr8L8yoGK4gzBqOGgsNWf9NIgcNJG7proE=";
-    })
-  ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
Patch was already merged in: https://github.com/OpenSC/pam_p11/pull/22. Removed.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
