### PR TITLE
supersonic: add ToasterUwU as maintainer

### DIFF
--- a/pkgs/by-name/su/supersonic/package.nix
+++ b/pkgs/by-name/su/supersonic/package.nix
@@ -104,6 +104,7 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [
       zane
       sochotnicky
+      toasteruwu
     ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added myself as a maintainer.
The last few PRs for Supersonic neither of the two current maintainers responded to the PR itself or reviews i gave. Im unsure if they are just inactive overall, or currently busy for an extended period, but either way i want to add myself as a maintainer so that i can handle package updates without a committers help using the merge bot.

PRs that got no input or interaction from both maintainers in recent history:
#478892 #480158

And if you count 2 days as well:
#485699

@sochotnicky @vs49688 ping for you both in case you want to approve of me being added as a maintainer. No judgement on the inactivity btw, there are a million more important things than updating supersonic packages, especially in current time. I hope you dont take this as an insult or anything else hostile. I genuinely just want to help.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
