### PR TITLE
crystalline: fix build

### DIFF
--- a/pkgs/development/tools/language-servers/crystalline/default.nix
+++ b/pkgs/development/tools/language-servers/crystalline/default.nix
@@ -29,6 +29,7 @@ crystal.buildCrystalPackage {
     openssl
     makeWrapper
   ];
+  env.LLVM_CONFIG = lib.getExe' (lib.getDev llvmPackages.llvm) "llvm-config";
 
   doCheck = false;
   doInstallCheck = false;
@@ -44,7 +45,11 @@ crystal.buildCrystalPackage {
   };
 
   postInstall = ''
-    wrapProgram "$out/bin/crystalline" --prefix PATH : '${lib.makeBinPath [ llvmPackages.llvm.dev ]}'
+    wrapProgram "$out/bin/crystalline" --prefix PATH : '${
+      lib.makeBinPath [
+        (lib.getDev llvmPackages.llvm)
+      ]
+    }'
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently fails with:
```
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Error: Could not find location of llvm-config. Please specify path in environment variable LLVM_CONFIG.
Supported LLVM versions: 22 21.1 20.1 19.1 18.1 17 16 15 14 13 12 11.1 11 10 9 8
Showing last frame. Use --error-trace for full trace.

In /nix/store/p89xdka5r7b6qxynxlcqxwfyr9xsf9s0-crystal-1.19.1-lib/crystal/llvm/lib_llvm.cr:20:44

 20 | {% llvm_config = env("LLVM_CONFIG") || `sh #{__DIR__}/ext/find-llvm-config.sh`.stringify %}
                                             ^
Error: error executing command: sh /nix/store/p89xdka5r7b6qxynxlcqxwfyr9xsf9s0-crystal-1.19.1-lib/crystal/llvm/ext/find-llvm-config.sh, got exit status 1
[1/14] Parse                             ^M[1/14] Parse                             ^M[2/14] Semantic (top level)
```

cc @donovanglover

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
