### PR TITLE
pi-coding-agent: init at 0.58.3

### DIFF
--- a/pkgs/by-name/pi/pi-coding-agent/package.nix
+++ b/pkgs/by-name/pi/pi-coding-agent/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  typescript-go,
+  nix-update-script,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  ripgrep,
+  makeBinaryWrapper,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "pi-coding-agent";
+  version = "0.58.3";
+
+  src = fetchFromGitHub {
+    owner = "badlogic";
+    repo = "pi-mono";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3GrE60n+EY5G50iRrbH7R74e+LQIy1M9+huZTp0ZTns=";
+  };
+
+  npmDepsHash = "sha256-EC5fXZTtBTRkYXLg5p4xWE/ghi2iw30XwnSqJs/PT8I=";
+
+  npmWorkspace = "packages/coding-agent";
+
+  # Skip native module rebuild for unneeded workspaces (e.g. canvas from web-ui)
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [
+    typescript-go
+    makeBinaryWrapper
+  ];
+
+  # Build workspace dependencies in order, then the coding-agent.
+  # We invoke tsgo directly for workspace deps to skip pi-ai's
+  # generate-models script which requires network access
+  # (models.generated.ts is committed to the repo).
+  buildPhase = ''
+    runHook preBuild
+
+    tsgo -p packages/ai/tsconfig.build.json
+    tsgo -p packages/tui/tsconfig.build.json
+    tsgo -p packages/agent/tsconfig.build.json
+    npm run build --workspace=packages/coding-agent
+
+    runHook postBuild
+  '';
+
+  # npm workspace symlinks in the output point into packages/ which
+  # doesn't exist there. Replace runtime deps with built content and
+  # delete the rest.
+  postInstall = ''
+    local nm="$out/lib/node_modules/pi-monorepo/node_modules"
+
+    # Replace workspace deps needed at runtime with real copies
+    for ws in @mariozechner/pi-ai:packages/ai \
+              @mariozechner/pi-agent-core:packages/agent \
+              @mariozechner/pi-tui:packages/tui; do
+      IFS=: read -r pkg src <<< "$ws"
+      rm "$nm/$pkg"
+      cp -r "$src" "$nm/$pkg"
+    done
+
+    # Delete remaining workspace symlinks
+    find "$nm" -type l -lname '*/packages/*' -delete
+
+    # Clean up now-dangling .bin symlinks
+    find "$nm/.bin" -xtype l -delete
+  '';
+  postFixup = "wrapProgram $out/bin/pi --prefix PATH : ${lib.makeBinPath [ ripgrep ]}";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    writableTmpDirAsHomeHook
+    versionCheckHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+  versionCheckProgram = "${placeholder "out"}/bin/pi";
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Coding agent CLI with read, bash, edit, write tools and session management";
+    homepage = "https://shittycodingagent.ai/";
+    downloadPage = "https://www.npmjs.com/package/@mariozechner/pi-coding-agent";
+    changelog = "https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ munksgaard ];
+    mainProgram = "pi";
+  };
+})


### PR DESCRIPTION
Pi is a minimal terminal coding harness.

Read more [here](https://shittycodingagent.ai/) and [here](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
