### PR TITLE
nushell: skip failing test on darwin

### DIFF
--- a/pkgs/by-name/nu/nushell/package.nix
+++ b/pkgs/by-name/nu/nushell/package.nix
@@ -67,6 +67,9 @@ rustPlatform.buildRustPackage {
       # The skipped tests all fail in the sandbox because in the nushell test playground,
       # the tmp $HOME is not set, so nu falls back to looking up the passwd dir of the build
       # user (/var/empty). The assertions however do respect the set $HOME.
+      #
+      # On Darwin, path_is_a_list_in_repl fails with "Operation not permitted" in the sandbox:
+      # https://github.com/NixOS/nixpkgs/issues/485915
       set -x
       HOME=$(mktemp -d) cargo test -j $NIX_BUILD_CORES --offline -- \
         --test-threads=$NIX_BUILD_CORES \
@@ -77,7 +80,8 @@ rustPlatform.buildRustPackage {
                   --skip=plugins::config::some \
                   --skip=plugins::stress_internals::test_exit_early_local_socket \
                   --skip=plugins::stress_internals::test_failing_local_socket_fallback \
-                  --skip=plugins::stress_internals::test_local_socket
+                  --skip=plugins::stress_internals::test_local_socket \
+                  --skip=shell::environment::env::path_is_a_list_in_repl
         ''}
     )
     runHook postCheck


### PR DESCRIPTION
Skip `shell::environment::env::path_is_a_list_in_repl` test on Darwin which fails with "Operation not permitted" (os error 1) in the macOS sandbox.

The test was introduced upstream and fails specifically in Nix sandbox builds on macOS due to permission restrictions. This is a known upstream issue.

Resolves #485915.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
