### PR TITLE
perlPackages.{ConfigScoped,ObjectDestroyer,SysFilesystem}: init at various

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -6135,6 +6135,30 @@ with self;
     };
   };
 
+  ConfigScoped = buildPerlModule rec {
+    pname = "Config-Scoped";
+    version = "0.22";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/G/GA/GAISSMAI/Config-Scoped-${version}.tar.gz";
+      hash = "sha256-NQ2MdJJ2EwJNA0N0KPHs7bJ3Yq05PQ5yC3wDz6uBgSs=";
+    };
+    propagatedBuildInputs = [
+      Error
+      ParseRecDescent
+    ];
+    meta = {
+      description = "Feature-rich configuration file parser";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
+    };
+  };
+
   ConfigStd = buildPerlModule {
     pname = "Config-Std";
     version = "0.903";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -26520,6 +26520,26 @@ with self;
     };
   };
 
+  ObjectDestroyer = buildPerlPackage rec {
+    pname = "Object-Destroyer";
+    version = "2.02";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/S/SI/SIMBABQUE/Object-Destroyer-${version}.tar.gz";
+      hash = "sha256-3BnVFtVuiYc9H3TSoCm+ixQ8zT1AinwcL+7angkVfYo=";
+    };
+    meta = {
+      description = "Make objects with circular references DESTROY normally";
+      license = with lib.licenses; [
+        artistic1
+        gpl1Plus
+      ];
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
+    };
+  };
+
   ObjectEvent = buildPerlPackage rec {
     pname = "Object-Event";
     version = "1.23";

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -32379,6 +32379,27 @@ with self;
     };
   };
 
+  SysFilesystem = buildPerlPackage rec {
+    pname = "Sys-Filesystem";
+    version = "1.408";
+    src = fetchurl {
+      url = "mirror://cpan/authors/id/R/RE/REHSACK/Sys-Filesystem-${version}.tar.gz";
+      hash = "sha256-V34RByuJfXGMI0GBpcBZ+NwEtl/ZVGXwsSkstjWXTZc=";
+    };
+    propagatedBuildInputs = [
+      ModulePluggable
+      ParamsUtil
+    ];
+    meta = {
+      description = "Retrieve list of filesystems and their properties";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [
+        de11n
+        despsyched
+      ];
+    };
+  };
+
   SysMmap = buildPerlPackage {
     pname = "Sys-Mmap";
     version = "0.20";


### PR DESCRIPTION
- https://metacpan.org/dist/Config-Scoped
- https://metacpan.org/dist/Object-Destroyer
- https://metacpan.org/dist/Sys-Filesystem

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
