### PR TITLE
tabbyapi: init at 0-unstable-2026-01-20

### DIFF
--- a/pkgs/by-name/ta/tabbyapi/package.nix
+++ b/pkgs/by-name/ta/tabbyapi/package.nix
@@ -1,0 +1,115 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  nix-update-script,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication {
+  pname = "tabbyapi";
+  version = "0-unstable-2026-01-20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "theroyallab";
+    repo = "tabbyAPI";
+    rev = "54e3ea1fb30c48217f82dcb4ab1359f4784da4c8";
+    hash = "sha256-cwxpW4s8LKxS+2A2Grfhx8XaxbfT8U1LG59yhbu1lD8=";
+  };
+
+  build-system = with python3Packages; [
+    packaging
+    setuptools
+    wheel
+  ];
+
+  nativeBuildInputs = with python3Packages; [
+    pythonRelaxDepsHook
+  ];
+
+  pythonRelaxDeps = [
+    "pydantic"
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      fastapi # fastapi-slim
+      pydantic
+      ruamel-yaml
+      rich
+      uvicorn
+      jinja2
+      loguru
+      sse-starlette
+      packaging
+      tokenizers
+      formatron
+      kbnf
+      aiofiles
+      aiohttp
+      async-lru
+      huggingface-hub
+      psutil
+      httptools
+      pillow
+      numpy
+      setuptools
+
+      exllamav2
+      exllamav3
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      uvloop
+    ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail 'fastapi-slim' 'fastapi'
+  '';
+
+  optional-dependencies = with python3Packages; {
+    amd = [
+      pytorch-triton-rocm
+      torch
+    ];
+    cu118 = [
+      torch
+    ];
+    cu121 = [
+      flash-attn
+      torch
+    ];
+    dev = [
+      ruff
+    ];
+    extras = [
+      infinity-emb
+      sentence-transformers
+    ];
+  };
+
+  postInstall = ''
+    cp *.py $out/${python3Packages.python.sitePackages}/
+    cp -r {common,endpoints,backends,templates} $out/${python3Packages.python.sitePackages}/
+  '';
+
+  postFixup = ''
+    makeWrapper ${python3Packages.python.interpreter} $out/bin/tabbyapi \
+      --prefix PYTHONPATH : "$PYTHONPATH" \
+      --add-flags "$out/${python3Packages.python.sitePackages}/main.py"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Official API server for Exllama";
+    homepage = "https://github.com/theroyallab/tabbyAPI";
+    license = lib.licenses.agpl3Only;
+    platforms = [
+      "x86_64-windows"
+      "x86_64-linux"
+    ];
+    mainProgram = "tabbyapi";
+    maintainers = with lib.maintainers; [ BatteredBunny ];
+  };
+}


### PR DESCRIPTION
Upstreams tabbyapi package from https://github.com/BatteredBunny/nix-ai-stuff
Related https://github.com/NixOS/nixpkgs/issues/353718

Tested with

```
nix run .#pkgsCuda.tabbyapi --impure
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
