### PR TITLE
python3Packages.ansible-core: patch cli stub

### DIFF
--- a/pkgs/development/python-modules/ansible/core.nix
+++ b/pkgs/development/python-modules/ansible/core.nix
@@ -44,9 +44,6 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-WLfLbQYYJOdMHApNnFZYiET4es3z2SeeLP0jbrFqxrU=";
   };
 
-  # ansible_connection is already wrapped, so don't pass it through
-  # the python interpreter again, as it would break execution of
-  # connection plugins.
   postPatch = ''
     patchShebangs --build packaging/cli-doc/build.py
 
@@ -96,6 +93,10 @@ buildPythonPackage (finalAttrs: {
     export HOME="$(mktemp -d)"
     packaging/cli-doc/build.py man --output-dir=man
     installManPage man/*
+  '';
+
+  postFixup = ''
+    patchPythonScript $out/${python.sitePackages}/ansible/cli/scripts/ansible_connection_cli_stub.py
   '';
 
   # internal import errors, missing dependencies


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Ansible calls this stub via `sys.executable` (see [here](https://github.com/ansible/ansible/blob/29086acfa61f32a9e5b087abdaf4336330ab5456/lib/ansible/executor/task_executor.py#L1238-L1241)), which means that the Python dependencies are not available in this stub. This affects modules using the Ansible `network_cli` connection plugin and leads to errors such as:

```
TASK [Gathering Facts] ************************************************************************************
[ERROR]: Task failed: Traceback (most recent call last):
  File "/nix/store/ldqvz4jmyv5x9hbgi4zckyi39w06a309-python3.13-ansible-core-2.19.4/lib/python3.13/site-packages/ansible/cli/scripts/ansible_connection_cli_stub.py", line 19, in <module>
    from ansible import constants as C
ModuleNotFoundError: No module named 'ansible'

fatal: [host.name]: FAILED! => {
    "changed": false
}

MSG:

Task failed: Traceback (most recent call last):
  File "/nix/store/ldqvz4jmyv5x9hbgi4zckyi39w06a309-python3.13-ansible-core-2.19.4/lib/python3.13/site-packages/ansible/cli/scripts/ansible_connection_cli_stub.py", line 19, in <module>
    from ansible import constants as C
ModuleNotFoundError: No module named 'ansible'
```

With playbook:
```yaml
- name: Apply router configuration
  hosts: all
  vars:
    ansible_connection: network_cli
    ansible_network_os: vyos
    ansible_command_timeout: 180
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
