### PR TITLE
nixos-rebuild-ng: get sudo args from NIX_SUDOOPTS env var

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -272,6 +272,9 @@ It must be one of the following:
 	When set, *nixos-rebuild* prefixes activation commands with sudo.
 	Setting this option allows deploying as a non-root user.
 
+	You can set sudo options by defining the NIX_SUDOOPTS environment
+	variable.
+
 *--ask-sudo-password*, *-S*
 	When set, *nixos-rebuild* will ask for sudo password for remote
 	activation (i.e.: on *--target-host*) at the start of the build process.
@@ -338,6 +341,9 @@ NIX_PATH
 
 NIX_SSHOPTS
 	Additional options to be passed to ssh on the command line.
+
+NIX_SUDOOPTS
+	Additional options to be passed to sudo on the command line.
 
 # FILES
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -142,7 +142,8 @@ def run_wrapper(
         if extra_env:
             env = os.environ | extra_env
         if sudo:
-            run_args = ["sudo", *run_args]
+            sudo_args = shlex.split(os.getenv("NIX_SUDOOPTS", ""))
+            run_args = ["sudo", *sudo_args, *run_args]
 
     logger.debug(
         "calling run with args=%r, kwargs=%r, extra_env=%r",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -160,3 +160,21 @@ def test_ssh_host() -> None:
         remote = m.Remote.from_arg(host_input, None, False)
         assert remote is not None
         assert remote.ssh_host() == expected
+
+
+@patch("subprocess.run", autospec=True)
+def test_custom_sudo_args(mock_run: Any) -> None:
+    with patch.dict(p.os.environ, {"NIX_SUDOOPTS": "--custom sudo --args"}):
+        p.run_wrapper(
+            ["test"],
+            check=False,
+            sudo=True,
+        )
+    mock_run.assert_called_with(
+        ["sudo", "--custom", "sudo", "--args", "test"],
+        check=False,
+        env=None,
+        input=None,
+        text=True,
+        errors="surrogateescape",
+    )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This is useful for making sudo send a terminal bell when it needs a password, for example (see https://github.com/NixOS/nixpkgs/pull/486109)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
