### PR TITLE
element-desktop: fix darwin build

### DIFF
--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -18,6 +18,7 @@
   asar,
   copyDesktopItems,
   darwin,
+  apple-sdk_26,
 }:
 
 let
@@ -46,6 +47,10 @@ stdenv.mkDerivation (
     };
 
     env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+    buildInputs = [
+      apple-sdk_26
+    ];
 
     nativeBuildInputs = [
       asar


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/485589

Error message:
```
>   ⨯ Failed to check actool version. Is Xcode 26 or higher installed? See output of the `actool --version` CLI command for more details.  failedTask=build stackTrace=Error: Failed to check actool version. Is Xcode 26 or higher installed? See output of the `actool --version` CLI command for more details.
>     at Object.<anonymous> (/nix/var/nix/builds/nix-build-element-desktop-1.12.9.drv-0/b/source/node_modules/app-builder-lib/src/util/macosIconComposer.ts:15:38)
>     at Module._compile (node:internal/modules/cjs/loader:1761:14)
>     at Object..js (node:internal/modules/cjs/loader:1893:10)
>     at Module.load (node:internal/modules/cjs/loader:1481:32)
>     at Module._load (node:internal/modules/cjs/loader:1300:12)
>     at TracingChannel.traceSync (node:diagnostics_channel:328:14)
>     at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
>     at Module.require (node:internal/modules/cjs/loader:1504:12)
>     at require (node:internal/modules/helpers:152:16)
>     at Object.<anonymous> (/nix/var/nix/builds/nix-build-element-desktop-1.12.9.drv-0/b/source/node_modules/app-builder-lib/src/platformPackager.ts:51:1)
> error Command failed with exit code 1.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
