### PR TITLE
opaline move overrides

### DIFF
--- a/pkgs/by-name/op/opaline/package.nix
+++ b/pkgs/by-name/op/opaline/package.nix
@@ -1,20 +1,28 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchFromGitHub,
-  ocamlPackages,
 }:
-
-stdenv.mkDerivation rec {
+let
+  inherit (buildPackages) ocamlPackages;
+in
+stdenv.mkDerivation (finalAttrs: {
   version = "0.3.3";
   pname = "opaline";
 
   src = fetchFromGitHub {
     owner = "jaapb";
     repo = "opaline";
-    rev = "v${version}";
-    sha256 = "sha256-6htaiFIcRMUYWn0U7zTNfCyDaTgDEvPch2q57qzvND4=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6htaiFIcRMUYWn0U7zTNfCyDaTgDEvPch2q57qzvND4=";
   };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  # needed for pkgsStatic.opaline
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
 
   nativeBuildInputs = with ocamlPackages; [
     ocaml
@@ -32,7 +40,7 @@ stdenv.mkDerivation rec {
     mainProgram = "opaline";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.vbgl ];
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/jaapb/opaline";
     inherit (ocamlPackages.ocaml.meta) platforms;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1911,8 +1911,6 @@ with pkgs;
 
   online-judge-tools = with python3.pkgs; toPythonApplication online-judge-tools;
 
-  opaline = callPackage ../by-name/op/opaline/package.nix { inherit ocamlPackages; };
-
   inherit (ocamlPackages) patdiff;
 
   patool = with python3Packages; toPythonApplication patool;


### PR DESCRIPTION
- **kubie: 0.26.0 -> 0.26.1**
- **lnd: 0.19.3 -> 0.20.0**
- **lnd: set CGO_ENABLED=0**
- **swayosd: 0.2.1 -> 0.3.0**
- **ecm: set pname and version instead of name**
- **edopro: set pname instead of name**
- **feishu: 7.50.14 -> 7.58.14**
- **coq-kernel: set pname and version**
- **deadbeef-with-plugins: set pname and version instead of name**
- **go-task: 3.45.5 -> 3.48.0**
- **librewolf-bin-unwrapped: 147.0.1-3 -> 147.0.2-1**
- **xfsprogs: split man output**
- **abduco: split man output**
- **traefik: 3.6.4 -> 3.6.7**
- **nushell-plugin-skim: 0.22.0 -> 0.23.0**
- **bookstack: 25.12.1 -> 25.12.3**
- **lief: improve pkg-config integration**
- **hdrhistogram_c: improve pkg-config integration**
- **pike: 8.0.2040 -> 8.0.2042**
- **thunderbird: 146.0.1 -> 147.0.1**
- **libpng: migrate to pkgs/by-name**
- **libpng12: migrate to pkgs/by-name**
- **nezha-agent: 1.14.4 -> 1.15.0**
- **acli: 1.3.11-stable -> 1.3.13-stable**
- **lug-helper: 4.7 -> 4.9**
- **mfcl3770cdwdriver: set pname**
- **mfcl3770cdwcupswrapper: set pname**
- **binsider: 0.3.1 -> 0.3.2**
- **openlist: 4.1.9 -> 4.1.10**
- **bitrise: 2.36.5 -> 2.37.0**
- **python3Packages.pynmeagps: 1.0.57 -> 1.1.0**
- **python3Packages.hstspreload: 2025.12.3 -> 2026.2.1**
- **fleet: set __darwinAllowLocalNetworking**
- **helvetica-neue-lt-std: set pname**
- **ghostfolio: 2.233.0 -> 2.234.0**
- **python3Packages.aiocmd: use pname**
- **python3Packages.marqo: set pname**
- **quinze: set pname**
- **ramfetch: set pname**
- **raygui: set pname**
- **regal: set pname**
- **regal: use finalAttrs**
- **vacuum-tube: 1.5.5 -> 1.5.6**
- **termsonic: set pname**
- **liblogging: 1.0.6 -> 1.0.8**
- **nixos/xserver: use the requested drivers**
- **python314Packages.hstspreload: migrate to finalAttrs**
- **python314Packages.pynmeagps: migrate to finalAttrs**
- **vscode-extensions.sourcegraph.amp: 0.0.1769378769 -> 0.0.1769991964**
- **ducker: 0.5.7 -> 0.6.1**
- **python3Packages.swift: 2.36.0 -> 2.37.0**
- **hoppscotch: 25.12.1-0 -> 26.1.0-0**
- **llvmPackages_git: 23.0.0-unstable-2026-01-25 -> 23.0.0-unstable-2026-02-01**
- **vimPlugins.codediff-nvim: 2.13.1 -> 2.16.3**
- **python3Packages.dsinternals: 1.2.4 -> 1.2.5**
- **goverlay: 1.7.2 -> 1.7.3**
- **mas: 4.1.0 -> 5.1.0**
- **languagetool: fix src.url casing (make it reproducible)**
- **languagetool: set meta.mainProgram explicitly**
- **languagetool: use minimal jre**
- **terraform-providers.oracle_oci: 7.31.0 -> 7.32.0**
- **kdePackages.kwallet: use gpgmepp for GPG wallet support**
- **libpng: restore comment explaining the stdenv override**
- **python314Packages.dsinternals: modernize**
- **python313Packages.swift: migrate to finalAttrs**
- **weaviate: update homepage**
- **tuxguitar: build from source, add darwin support, update to 2.0.1**
- **libretro.beetle-psx: 0-unstable-2026-01-23 -> 0-unstable-2026-01-30**
- **clouddrive2: 0.9.23 -> 0.9.24**
- **moor: 2.10.2 -> 2.10.3**
- **lychee: 0.21.0 -> 0.22.0**
- **octave: move NIX_LDFLAGS into env for structuredAttrs**
- **opaline: remove top-level inherit, modernize**
