### PR TITLE
nushell: cleanup, skip failing test on darwin

### DIFF
--- a/pkgs/by-name/nu/nushell/package.nix
+++ b/pkgs/by-name/nu/nushell/package.nix
@@ -13,10 +13,9 @@
   libgit2,
   withDefaultFeatures ? true,
   additionalFeatures ? (p: p),
-  testers,
-  nushell,
   nix-update-script,
   curlMinimal,
+  versionCheckHook,
   writableTmpDirAsHomeHook,
 }:
 
@@ -91,6 +90,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
 
   nativeCheckInputs = [
+    versionCheckHook
     writableTmpDirAsHomeHook
   ];
   checkInputs =
@@ -99,9 +99,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     shellPath = "/bin/nu";
-    tests.version = testers.testVersion {
-      package = nushell;
-    };
     updateScript = nix-update-script { };
   };
 

--- a/pkgs/by-name/nu/nushell/package.nix
+++ b/pkgs/by-name/nu/nushell/package.nix
@@ -74,6 +74,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "plugins::stress_internals::test_exit_early_local_socket"
         "plugins::stress_internals::test_failing_local_socket_fallback"
         "plugins::stress_internals::test_local_socket"
+
+        # Error:   × I/O error: Operation not permitted (os error 1)
+        "shell::environment::env::path_is_a_list_in_repl"
       ];
 
       skippedTestsStr = lib.concatStringsSep " " (lib.map (testId: "--skip=${testId}") skippedTests);


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **nushell: cleanup**
- **nushell: skip failing test on darwin**

```
failures:

---- shell::environment::env::path_is_a_list_in_repl stdout ----
=== stderr
Error:   <C3><97> I/O error: Operation not permitted (os error 1)



thread 'shell::environment::env::path_is_a_list_in_repl' (16296812) panicked at tests/shell/environment/env.rs:281:5:
assertion failed: actual.out.ends_with("path:list<string>")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    shell::environment::env::path_is_a_list_in_repl

test result: FAILED. 1577 passed; 1 failed; 27 ignored; 0 measured; 8 filtered out; finished in 29.76s
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
