### PR TITLE
linux: set CXX for consistency

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -32,6 +32,7 @@
   gnugrep ? null,
   expand-response-params,
   libcxx ? null,
+  cxxName ? cc.cxxName or null,
 
   # Whether or not to add `-B` and `-L` to `nix-support/cc-{c,ld}flags`
   useCcForLibs ?
@@ -523,32 +524,25 @@ stdenvNoCC.mkDerivation {
   # version.
   + ''
     export named_cc=${targetPrefix}cc
-    export named_cxx=${targetPrefix}c++
+    export named_cxx=${targetPrefix}${if cxxName != null then cxxName else "c++"}
 
     if [ -e $ccPath/${targetPrefix}gcc${exeSuffix} ]; then
       wrap ${targetPrefix}gcc $wrapper $ccPath/${targetPrefix}gcc${exeSuffix}
       ln -s ${targetPrefix}gcc $out/bin/${targetPrefix}cc
       export named_cc=${targetPrefix}gcc
-      export named_cxx=${targetPrefix}g++
     elif [ -e $ccPath/clang${exeSuffix} ]; then
       wrap ${targetPrefix}clang $wrapper $ccPath/clang${exeSuffix}
       ln -s ${targetPrefix}clang $out/bin/${targetPrefix}cc
       export named_cc=${targetPrefix}clang
-      export named_cxx=${targetPrefix}clang++
     elif [ -e $ccPath/arocc${exeSuffix} ]; then
       wrap ${targetPrefix}arocc $wrapper $ccPath/arocc${exeSuffix}
       ln -s ${targetPrefix}arocc $out/bin/${targetPrefix}cc
       export named_cc=${targetPrefix}arocc
     fi
-
-    if [ -e $ccPath/${targetPrefix}g++${exeSuffix} ]; then
-      wrap ${targetPrefix}g++ $wrapper $ccPath/${targetPrefix}g++${exeSuffix}
-      ln -s ${targetPrefix}g++ $out/bin/${targetPrefix}c++
-    elif [ -e $ccPath/clang++${exeSuffix} ]; then
-      wrap ${targetPrefix}clang++ $wrapper $ccPath/clang++${exeSuffix}
-      ln -s ${targetPrefix}clang++ $out/bin/${targetPrefix}c++
-    fi
-
+  '' + lib.optionalString (cxxName != null) ''
+      wrap ${targetPrefix}${cxxName} $wrapper $ccPath/${if isGNU then targetPrefix else ""}${cxxName}${exeSuffix}
+      ln -s ${targetPrefix}${cxxName} $out/bin/${targetPrefix}c++
+  '' + ''
     if [ -e $ccPath/${targetPrefix}cpp${exeSuffix} ]; then
       wrap ${targetPrefix}cpp $wrapper $ccPath/${targetPrefix}cpp${exeSuffix}
     elif [ -e $ccPath/cpp${exeSuffix} ]; then

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -408,6 +408,8 @@ pipe
             "fortify"
             "format"
           ];
+      } // lib.optionalAttrs langCC {
+        cxxName = "g++";
       };
 
       enableParallelBuilding = true;

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -188,6 +188,7 @@ stdenv.mkDerivation (
     passthru = {
       inherit libllvm;
       isClang = true;
+      cxxName = "clang++";
       hardeningUnsupportedFlagsByTargetPlatform =
         targetPlatform:
         [ "fortify3" ]

--- a/pkgs/os-specific/linux/kernel/common-flags.nix
+++ b/pkgs/os-specific/linux/kernel/common-flags.nix
@@ -6,9 +6,17 @@
 }:
 # Absolute paths for compilers avoid any PATH-clobbering issues.
 [
-  #
-  # We use the unwrapped compiler, because the clang-wrapper doesn't like -target.
+  # We use the unwrapped compiler, because the clang-wrapper doesn't
+  # like -target. For consistency, we also use it for GCC.
   "CC=${lib.getExe stdenv.cc.cc}"
+  # Avoid potential hard-to-debug linking issues by setting the C++
+  # compiler as well. It is not used by the Linux kernel, but can be
+  # used by modules. This avoids linking object files built with
+  # wrapped and unwrapped compilers.
+  #
+  # Besides clang, all C++ compilers we have, seem to offer g++, so we
+  # can simplify the check here.
+  "CXX=${lib.getExe' stdenv.cc.cc (if stdenv.cc.isClang then "clang++" else "g++")}"
   # The wrapper for ld.lld breaks linking the kernel. We use the unwrapped linker as workaround. See:
   # https://github.com/NixOS/nixpkgs/issues/321667
   "LD=${lib.getExe' stdenv.cc.bintools.bintools "${stdenv.cc.targetPrefix}ld"}"

--- a/pkgs/stdenv/linux/bootstrap-tools/glibc.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/glibc.nix
@@ -24,6 +24,7 @@ derivation (
     langC = true;
     langCC = true;
     isGNU = true;
+    cxxName = "g++";
     hardeningUnsupportedFlags = [
       "fortify3"
       "shadowstack"

--- a/pkgs/stdenv/linux/bootstrap-tools/musl.nix
+++ b/pkgs/stdenv/linux/bootstrap-tools/musl.nix
@@ -24,6 +24,7 @@ derivation (
     langC = true;
     langCC = true;
     isGNU = true;
+    cxxName = "g++";
     hardeningUnsupportedFlags = [
       "fortify3"
       "shadowstack"


### PR DESCRIPTION
We set CC but not CXX. This is not an issue for the Linux kernel itself, because it doesn't use C++. It does avoid a potential problem for modules that use C++, though.

For context, also see: https://github.com/NixOS/nixpkgs/issues/484935#issuecomment-3816382359


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
