### PR TITLE
variety: install missing desktop file

### DIFF
--- a/pkgs/by-name/va/variety/package.nix
+++ b/pkgs/by-name/va/variety/package.nix
@@ -89,6 +89,11 @@ python3Packages.buildPythonApplication rec {
       --replace-fail "{VARIETY_PATH}" "variety"
   '';
 
+  postInstall = ''
+    mkdir -p $out/share/applications
+    intltool-merge --desktop-style po variety.desktop.in $out/share/applications/variety.desktop
+  '';
+
   pythonImportsCheck = [ "variety" ];
 
   meta = {

--- a/pkgs/by-name/va/variety/package.nix
+++ b/pkgs/by-name/va/variety/package.nix
@@ -92,6 +92,9 @@ python3Packages.buildPythonApplication rec {
   postInstall = ''
     mkdir -p $out/share/applications
     intltool-merge --desktop-style po variety.desktop.in $out/share/applications/variety.desktop
+
+    mkdir -p $out/share/icons/hicolor/scalable/apps
+    cp variety/data/icons/scalable/apps/variety.svg $out/share/icons/hicolor/scalable/apps/variety.svg
   '';
 
   pythonImportsCheck = [ "variety" ];


### PR DESCRIPTION
The 0.9.0-b1 update (#477721) moved variety from `DistUtilsExtra.auto` to plain `setuptools` + `setuptools-gettext`. The old build system automatically processed and installed `variety.desktop.in` to `share/applications/`, but the new `setup.py` only installs `variety.appdata.xml` via `data_files` — the desktop file was dropped.

This adds a `postInstall` step that uses `intltool-merge` (already in `nativeBuildInputs`) to process `variety.desktop.in` and install the resulting `variety.desktop` to `$out/share/applications/`.

Fixes the issue reported by @linsui in https://github.com/NixOS/nixpkgs/pull/477721#issuecomment-3772159216.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test