### PR TITLE
python3Packages.mmcv: cleanup, skip crashing test on x86_64-darwin

### DIFF
--- a/pkgs/development/python-modules/mmcv/default.nix
+++ b/pkgs/development/python-modules/mmcv/default.nix
@@ -140,6 +140,10 @@ buildPythonPackage (finalAttrs: {
     "test_ycbcr2rgb"
     "test_ycbcr2bgr"
     "test_tensor2imgs"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+    # Fatal Python error: Segmentation fault
+    "test_transform"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/mmcv/default.nix
+++ b/pkgs/development/python-modules/mmcv/default.nix
@@ -36,7 +36,7 @@ let
   inherit (torch) cudaCapabilities cudaPackages cudaSupport;
   inherit (cudaPackages) backendStdenv;
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mmcv";
   version = "2.2.0";
   pyproject = true;
@@ -44,7 +44,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "open-mmlab";
     repo = "mmcv";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-NNF9sLJWV1q6uBE73LUW4UWwYm4TBMTBJjJkFArBmsc=";
   };
 
@@ -57,7 +57,7 @@ buildPythonPackage rec {
     ''
       substituteInPlace setup.py \
         --replace-fail "cpu_use = 4" "cpu_use = $NIX_BUILD_CORES" \
-        --replace-fail "return locals()['__version__']" "return '${version}'"
+        --replace-fail "return locals()['__version__']" "return '${finalAttrs.version}'"
     '';
 
   nativeBuildInputs = [
@@ -93,17 +93,16 @@ buildPythonPackage rec {
     # torch
   ];
 
-  env.CUDA_HOME = lib.optionalString cudaSupport (lib.getDev cudaPackages.cuda_nvcc);
-
-  preConfigure = ''
-    export MMCV_WITH_OPS=1
-  ''
-  + lib.optionalString cudaSupport ''
-    export CC=${lib.getExe' backendStdenv.cc "cc"}
-    export CXX=${lib.getExe' backendStdenv.cc "c++"}
-    export TORCH_CUDA_ARCH_LIST="${lib.concatStringsSep ";" cudaCapabilities}"
-    export FORCE_CUDA=1
-  '';
+  env = {
+    CUDA_HOME = lib.optionalString cudaSupport (lib.getDev cudaPackages.cuda_nvcc);
+    MMCV_WITH_OPS = 1;
+  }
+  // lib.optionalAttrs cudaSupport {
+    CC = lib.getExe' backendStdenv.cc "cc";
+    CXX = lib.getExe' backendStdenv.cc "c++";
+    TORCH_CUDA_ARCH_LIST = lib.concatStringsSep ";" cudaCapabilities;
+    FORCE_CUDA = 1;
+  };
 
   pythonImportsCheck = [ "mmcv" ];
 
@@ -146,8 +145,8 @@ buildPythonPackage rec {
   meta = {
     description = "Foundational Library for Computer Vision Research";
     homepage = "https://github.com/open-mmlab/mmcv";
-    changelog = "https://github.com/open-mmlab/mmcv/releases/tag/v${version}";
+    changelog = "https://github.com/open-mmlab/mmcv/releases/tag/${finalAttrs.src.tag}";
     license = with lib.licenses; [ asl20 ];
     maintainers = with lib.maintainers; [ rxiao ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.mmcv: cleanup**
- **python3Packages.mmcv: skip crashing test on x86_64-darwin**

cc @benxiao

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
