### PR TITLE
rtl8761b-firmware: rtk1395 -> 162105963

### DIFF
--- a/pkgs/by-name/rt/rtl8761b-firmware/package.nix
+++ b/pkgs/by-name/rt/rtl8761b-firmware/package.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "Firmware for Realtek RTL8761b";
     license = lib.licenses.unfreeRedistributableFirmware;
-    maintainers = with lib.maintainers; [ milibopp ];
+    maintainers = with lib.maintainers; [ elfenermarcell ];
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
   };

--- a/pkgs/by-name/rt/rtl8761b-firmware/package.nix
+++ b/pkgs/by-name/rt/rtl8761b-firmware/package.nix
@@ -4,25 +4,23 @@
   fetchFromGitHub,
 }:
 
-stdenvNoCC.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation {
   pname = "rtl8761b-firmware";
-  version = "rtk1395";
+  version = "162105963";
 
   src = fetchFromGitHub {
-    owner = "Realtek-OpenSource";
-    repo = "android_hardware_realtek";
-    rev = finalAttrs.version;
-    hash = "sha256-vd9sZP7PGY+cmnqVty3sZibg01w8+UNinv8X85B+dzc=";
+    owner = "andrew-ld";
+    repo = "rtl8761b-firmware";
+    rev = "4b36bce18a5c9162d0c4f63ff70abcc5e9db9e28";
+    hash = "sha256-5DB7eGmKmnn2PQUHjDmKRPiNPZjC3pkSbEiE7rjdJOI=";
   };
 
   installPhase = ''
-    install -D -pm644 \
-      bt/rtkbt/Firmware/BT/rtl8761b_fw \
-      $out/lib/firmware/rtl_bt/rtl8761b_fw.bin
+    runHook preInstall
 
-    install -D -pm644 \
-      bt/rtkbt/Firmware/BT/rtl8761b_config \
-      $out/lib/firmware/rtl_bt/rtl8761b_config.bin
+    install -Dm444 -t $out/lib/firmware/rtl_bt/ *
+
+    runHook postInstall
   '';
 
   meta = {
@@ -32,4 +30,4 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     sourceProvenance = with lib.sourceTypes; [ binaryFirmware ];
   };
-})
+}


### PR DESCRIPTION
This firmware is a mess, there isn't really an "official" release, there are just a bunch of files floating around on the internet.

The previous version of this package was actually redundant, as those files (with what looks to be the same version, though the files differ) are already in the `linux-firmware` package.

This PR downgrades the firmware files in this package to an older version to resolve an issue with bluetooth devices (mostly xbox controllers, but I can also reproduce it with my headphones) randomly reconnecting.

It's also [packaged in the AUR](https://aur.archlinux.org/packages/rtl8761b-firmware), I chose to use the same version number, which is from the system log, converted to decimal:
```
kernel: Bluetooth: hci0: RTL: fw version 0x09a98a6b
```
(I have no idea how to extract the version any other way, but the prev version which is also in `linux-firmware` is `0xdfc6d922`)

I haven't found any reason to use the newer firmware (but again, there's no documentation or proper source for it)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
