### PR TITLE
merve: init at 1.0.1

### DIFF
--- a/pkgs/by-name/me/merve/package.nix
+++ b/pkgs/by-name/me/merve/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  cmake,
+  fetchFromGitHub,
+  simdutf,
+  gtest,
+  nix-update-script,
+  stdenv,
+  testers,
+  validatePkgConfig,
+  static ? stdenv.hostPlatform.isStatic,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "merve";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "nodejs";
+    repo = "merve";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IqUpvnrbnsXlI//xRLbcseMFVLQrwdDCyW1oud3+Ekk=";
+  };
+
+  doCheck = true;
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!static))
+    (lib.cmakeBool "MERVE_TESTING" finalAttrs.finalPackage.doCheck)
+    (lib.cmakeBool "MERVE_USE_SIMDUTF" true)
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    validatePkgConfig
+  ];
+  buildInputs = [
+    simdutf
+  ];
+  checkInputs = [
+    gtest
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
+      versionCheck = true;
+    };
+  };
+
+  meta = {
+    description = "Lexer to extract named exports via analysis from CommonJS modules";
+    homepage = "https://github.com/nodejs/merve";
+    changelog = "https://github.com/nodejs/merve/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aduh95 ];
+    platforms = lib.platforms.all;
+    pkgConfigModules = [ "merve" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

https://github.com/nodejs/merve/releases/tag/v1.0.1

This is a new Node.js dependency.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
