### PR TITLE
ndi-6 hash

### DIFF
--- a/pkgs/by-name/nd/ndi-6/version.json
+++ b/pkgs/by-name/nd/ndi-6/version.json
@@ -1,1 +1,1 @@
-{"hash": "sha256:0bdf66264527f8be37fa22eddd2b8514b9868a58a4d83f80a07dbeb479ee14d4", "version": "6.2.1.0"}
+{"hash": "sha256:bae544649fbda6bab8e7695d34ed171611b11e610c919da8fff673a67071fda8", "version": "6.2.1.0"}


### PR DESCRIPTION
changed the hash for ndi-6 as it errors out during updates for incorrect hash
## Things done
Changed the hash that is present in the hash version. It errored out as the hash changed and caused an error for plugins such as obs-studio.DistroAV.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] armv7l-linux
  - [x] i686-linux 
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
