### PR TITLE
idescriptor: 0.1.2 -> 0.2.0

### DIFF
--- a/pkgs/by-name/id/idescriptor/package.nix
+++ b/pkgs/by-name/id/idescriptor/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   buildGoModule,
+  nix-update-script,
   copyDesktopItems,
   makeDesktopItem,
   cmake,
@@ -114,6 +115,12 @@ stdenv.mkDerivation (finalAttrs: {
       ];
     })
   ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    goModules = finalAttrs.ipatool-go-modules;
+  };
 
   meta = {
     homepage = "https://github.com/iDescriptor/iDescriptor";

--- a/pkgs/by-name/id/idescriptor/package.nix
+++ b/pkgs/by-name/id/idescriptor/package.nix
@@ -28,13 +28,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "idescriptor";
-  version = "0.1.2";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "iDescriptor";
     repo = "iDescriptor";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pj/8PCZUTPu28MQd3zL8ceDsQy4+55348ZOCpiQaiEo=";
+    hash = "sha256-p6iJP4duesUiYEH8pgGgX5GOdaOhaAegPPphBaXU4VM=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Changelog: https://github.com/iDescriptor/iDescriptor/releases/tag/v0.2.0

nixpkgs-update was failing, so I have added the passthru to fix it and also manually bumped it. https://r.ryantm.com/log/idescriptor/2026-02-01.log

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
