### PR TITLE
gradle: Check that mitmCache.updateScript is run from a valid location

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/update-deps.nix
+++ b/pkgs/development/tools/build-managers/gradle/update-deps.nix
@@ -101,6 +101,12 @@ lib.makeOverridable (
           "${dirOf pkg.meta.position}/${data}"
       }"
 
+      # Check that the parent directory exists before running more costly tasks
+      if [ ! -d $(dirname "$outPath") ]; then
+        echo "Directory \"$(dirname "$outPath")\" does not exist, aborting as the next steps would fail anyway"
+        exit 1
+      fi
+
       pushd "$(mktemp -d)" >/dev/null
       MITM_CACHE_DIR="$PWD"
       trap "rm -rf '$MITM_CACHE_DIR'" SIGINT SIGTERM ERR EXIT


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
I frequently fall into the trap of generating+running update scripts from the package subfolder (e.g. `pkgs/by-name/pr/processing`), which will trigger a lengthy build process and then ultimately fails to save the result.

Instead, perform a quick smoke check before triggering potentially long-running tasks.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - (applied + tested this for the processing package)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
