### PR TITLE
postgresqlPackages.{plperl,plpython3,pltcl}: set pname and version instead of name

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/plperl.nix
+++ b/pkgs/servers/sql/postgresql/ext/plperl.nix
@@ -11,7 +11,8 @@ let
     let
       perl' = perl.withPackages f;
       finalPackage = buildEnv {
-        name = "${postgresql.pname}-plperl-${postgresql.version}";
+        pname = "${postgresql.pname}-plperl";
+        inherit (postgresql) version;
         paths = [ postgresql.plperl ];
         passthru = {
           inherit withPackages;

--- a/pkgs/servers/sql/postgresql/ext/plpython3.nix
+++ b/pkgs/servers/sql/postgresql/ext/plpython3.nix
@@ -11,7 +11,8 @@ let
     let
       python = python3.withPackages f;
       finalPackage = buildEnv {
-        name = "${postgresql.pname}-plpython3-${postgresql.version}";
+        pname = "${postgresql.pname}-plpython3";
+        inherit (postgresql) version;
         paths = [ postgresql.plpython3 ];
         passthru = {
           inherit withPackages;

--- a/pkgs/servers/sql/postgresql/ext/pltcl.nix
+++ b/pkgs/servers/sql/postgresql/ext/pltcl.nix
@@ -13,7 +13,8 @@ let
       pkgs = f tclPackages;
       paths = lib.concatMapStringsSep " " (pkg: "${pkg}/lib") pkgs;
       finalPackage = buildEnv {
-        name = "${postgresql.pname}-pltcl-${postgresql.version}";
+        pname = "${postgresql.pname}-pltcl";
+        inherit (postgresql) version;
         paths = [ postgresql.pltcl ];
         passthru = {
           inherit withPackages;


### PR DESCRIPTION
#485742

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
