### PR TITLE
[Backport release-25.11] alcove: 1.4.1 -> 1.5.1

### DIFF
--- a/pkgs/by-name/al/alcove/package.nix
+++ b/pkgs/by-name/al/alcove/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "alcove";
-  version = "1.4.1";
+  version = "1.5.1";
 
   src = fetchurl {
     url = "https://github.com/henrikruscon/alcove-releases/releases/download/${finalAttrs.version}/Alcove.zip";
-    hash = "sha256-9SYqvJqLC4h4AcK/F86S7H15PiW+tcmaF83ILdc/ejE=";
+    hash = "sha256-MhwtQDuDKP4vLPvOxSe9pY2W//dHplHlu6YvxfswNOg=";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
This PR is a back port of https://github.com/NixOS/nixpkgs/pull/485362 to the current Nix release.