### PR TITLE
[Backport release-25.11] blocky: build time config checking, finalAttrs, add kuflierl as maintainer

### DIFF
--- a/nixos/modules/services/networking/blocky.nix
+++ b/nixos/modules/services/networking/blocky.nix
@@ -16,6 +16,10 @@ in
 
     package = lib.mkPackageOption pkgs "blocky" { };
 
+    enableConfigCheck = lib.mkEnableOption "checking the config during build time" // {
+      default = true;
+    };
+
     settings = lib.mkOption {
       type = format.type;
       default = { };
@@ -80,6 +84,14 @@ in
         ];
       };
     };
+    system.checks = lib.mkIf cfg.enableConfigCheck [
+      (pkgs.runCommand "check-blocky-config" { } ''
+        ${lib.getExe cfg.package} --config ${configFile} validate && touch $out
+      '')
+    ];
   };
-  meta.maintainers = with lib.maintainers; [ paepcke ];
+  meta.maintainers = with lib.maintainers; [
+    paepcke
+    kuflierl
+  ];
 }

--- a/nixos/tests/blocky.nix
+++ b/nixos/tests/blocky.nix
@@ -15,15 +15,17 @@
                 "printer.lan" = "192.168.178.3,2001:0db8:85a3:08d3:1319:8a2e:0370:7344";
               };
             };
-            upstream = {
+            upstreams.groups = {
               default = [
                 "8.8.8.8"
                 "1.1.1.1"
               ];
             };
-            port = 53;
-            httpPort = 5000;
-            logLevel = "info";
+            ports = {
+              dns = 53;
+              http = 5000;
+            };
+            log.level = "info";
           };
         };
       };

--- a/pkgs/by-name/bl/blocky/package.nix
+++ b/pkgs/by-name/bl/blocky/package.nix
@@ -5,14 +5,14 @@
   nixosTests,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "blocky";
   version = "0.27.0";
 
   src = fetchFromGitHub {
     owner = "0xERR0R";
     repo = "blocky";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-N0zQb30PHTbTsQQgljuIW/We1i9ITLFdonOX4L+vk+o=";
   };
 
@@ -25,7 +25,7 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/0xERR0R/blocky/util.Version=${version}"
+    "-X github.com/0xERR0R/blocky/util.Version=${finalAttrs.version}"
   ];
 
   passthru.tests = { inherit (nixosTests) blocky; };
@@ -35,7 +35,10 @@ buildGoModule rec {
     homepage = "https://0xerr0r.github.io/blocky";
     changelog = "https://github.com/0xERR0R/blocky/releases";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ ratsclub ];
+    maintainers = with lib.maintainers; [
+      ratsclub
+      kuflierl
+    ];
     mainProgram = "blocky";
   };
-}
+})


### PR DESCRIPTION
This PR is a back port of https://github.com/NixOS/nixpkgs/pull/480908 to the current Nix release.