### PR TITLE
cd-hit: migrate to by-name, move override

### DIFF
--- a/pkgs/by-name/cd/cd-hit/package.nix
+++ b/pkgs/by-name/cd/cd-hit/package.nix
@@ -6,7 +6,7 @@
   zlib,
   perl,
   perlPackages,
-  openmp,
+  llvmPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     zlib
     makeWrapper
   ];
-  buildInputs = lib.optional stdenv.cc.isClang openmp;
+  buildInputs = lib.optional stdenv.cc.isClang llvmPackages.openmp;
 
   makeFlags = [
     "CC=${stdenv.cc.targetPrefix}c++" # remove once https://github.com/weizhongli/cdhit/pull/114 is merged

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12158,10 +12158,6 @@ with pkgs;
 
   ### SCIENCE/BIOLOGY
 
-  cd-hit = callPackage ../applications/science/biology/cd-hit {
-    inherit (llvmPackages) openmp;
-  };
-
   deepdiff = with python3Packages; toPythonApplication deepdiff;
 
   deep-translator = with python3Packages; toPythonApplication deep-translator;


### PR DESCRIPTION
This pull request refactors the packaging of the `cd-hit` bioinformatics tool to align with the new directory structure and improve compatibility with Clang toolchains. The main changes involve moving the package and updating how OpenMP is referenced for builds with Clang.

**Package relocation and build improvements:**

* Moved the `cd-hit` package from `pkgs/applications/science/biology/cd-hit/default.nix` to `pkgs/by-name/cd/cd-hit/package.nix` for better organization and discoverability.
* Updated the build to use `llvmPackages.openmp` instead of the previously used `openmp` when building with Clang, ensuring proper OpenMP support.

**Top-level package list cleanup:**

* Removed the old reference to `cd-hit` from `pkgs/top-level/all-packages.nix`, reflecting the new packaging location and build input handling.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
