### PR TITLE
python3Packages.lunatone-rest-api-client: 0.6.0 -> 0.6.3

### DIFF
--- a/pkgs/development/python-modules/lunatone-rest-api-client/default.nix
+++ b/pkgs/development/python-modules/lunatone-rest-api-client/default.nix
@@ -12,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "lunatone-rest-api-client";
-  version = "0.6.0";
+  version = "0.6.3";
   pyproject = true;
 
   src = fetchFromGitLab {
     owner = "lunatone-public";
     repo = "lunatone-rest-api-client";
     tag = "v${version}";
-    hash = "sha256-kPvHyabiT+Vl+/yCGQxyD16HPoOKsL7ij3c0LO3qNe8=";
+    hash = "sha256-KP+i5TmvCkdyIiuGiP9H8GmRC2+/r7QCqmzD+/2+tU8=";
   };
 
   build-system = [ hatchling ];
@@ -27,7 +27,8 @@ buildPythonPackage rec {
   dependencies = [
     aiohttp
     pydantic
-  ];
+  ]
+  ++ aiohttp.optional-dependencies.speedups;
 
   pythonImportsCheck = [ "lunatone_rest_api_client" ];
 


### PR DESCRIPTION
Diff: https://gitlab.com/lunatone-public/lunatone-rest-api-client/-/compare/v0.6.0...0.6.3

Changelog: https://gitlab.com/lunatone-public/lunatone-rest-api-client/-/blob/v0.6.3/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
