### PR TITLE
julec: 0.1.7 -> 0.2.0

### DIFF
--- a/pkgs/by-name/ju/julec/package.nix
+++ b/pkgs/by-name/ju/julec/package.nix
@@ -22,23 +22,23 @@ let
 in
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "julec";
-  version = "0.1.7";
+  version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "jule";
     tag = "jule${finalAttrs.version}";
     name = "jule-${finalAttrs.version}";
-    hash = "sha256-7py8QrNMX8LwpI7LCp5XgRFUzgltFP1rTbuzqw/1D8o=";
+    hash = "sha256-fwltqCmpCzWkCFGxGrhozW7LQmDwGT8nR9NO5s0nMfI=";
   };
 
   irSrc = fetchFromGitHub {
     owner = "julelang";
     repo = "julec-ir";
-    # revision determined by the upstream commit hash in julec-ir/README.md
-    rev = "81ddbed06a715428a90d3645f7242fa4e522ea16";
+    # revision determined by the upstream commit hash
+    rev = "e4134d89f34588e9fb5cc5698f27b0471918e057";
     name = "jule-ir-${finalAttrs.version}";
-    hash = "sha256-Az9RDrwRY2kuMgL/Lf/x6YctfySr96/imWZeOa+J/rM=";
+    hash = "sha256-hdS/q2/V/N97fM0r6jrj2SEGWdx9pFivGE4K4l8iVag=";
   };
 
   dontConfigure = true;
@@ -62,7 +62,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     echo "Building ${finalAttrs.meta.mainProgram}-bootstrap v${finalAttrs.version} for ${clangStdenv.hostPlatform.system}..."
     mkdir -p bin
     ${clangStdenv.cc.targetPrefix}c++ ir.cpp \
-      --std=c++17 \
+      --std=c++20 \
       -Wno-everything \
       -fwrapv \
       -ffloat-store \

--- a/pkgs/by-name/ju/juledoc/package.nix
+++ b/pkgs/by-name/ju/juledoc/package.nix
@@ -7,13 +7,13 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "juledoc";
-  version = "0.0.0-unstable-2025-09-09";
+  version = "0.0.0-unstable-2026-02-02";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "juledoc";
-    rev = "3461147f4630104999bb895bdd8e60f40ca23aaf";
-    hash = "sha256-0HuMWdoDoq2SgQhOnn6UnWXe2Js7/466cP2XpjvO5dw=";
+    rev = "e01e200293d134064c674f705c9babf6d23775e8";
+    hash = "sha256-JzIwIEd9kuVrBVo2H5bv3ROqpVUndBqLAZVYmoGbYuQ=";
   };
 
   nativeBuildInputs = [ julec.hook ];

--- a/pkgs/by-name/ju/julefmt/package.nix
+++ b/pkgs/by-name/ju/julefmt/package.nix
@@ -7,13 +7,13 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "julefmt";
-  version = "0.0.0-unstable-2025-09-08";
+  version = "0.0.0-unstable-2026-01-31";
 
   src = fetchFromGitHub {
     owner = "julelang";
     repo = "julefmt";
-    rev = "cc30781206d3d7b88599cc51b3f9d7d7936de527";
-    hash = "sha256-g3vN2Hz4BA5c0KqIbNKHg0W77xKGZQFHUIKWjg5/UTM=";
+    rev = "85b4aaca42e958fb33d6769879ec0a375913206c";
+    hash = "sha256-1UR5hsG5squzb2ADPMmHMKFSL4/fePlYsSlfx70nPSU=";
   };
 
   nativeBuildInputs = [ julec.hook ];


### PR DESCRIPTION
juledoc: 0.0.0-unstable-2025-09-09 -> 0.0.0-unstable-2026-02-02
julefmt: 0.0.0-unstable-2025-09-08 -> 0.0.0-unstable-2026-01-31

updating the jule toolkit to newest versions

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test