### PR TITLE
obsidian-cli: init at 0.2.2

### DIFF
--- a/pkgs/by-name/ob/obsidian-cli/package.nix
+++ b/pkgs/by-name/ob/obsidian-cli/package.nix
@@ -1,25 +1,27 @@
-{ lib, buildGoModule, fetchFromGitHub }:
+{ lib, buildGoModule, fetchFromGitHub, testers }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "obsidian-cli";
   version = "0.2.2";
 
   src = fetchFromGitHub {
     owner = "Yakitrak";
     repo = "obsidian-cli";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-H7Nm+QwpAD5K1Ltl4irvSI/z3Ct7g3rh2w0Rbka7LwE=";
   };
 
-  vendorHash = null;          # repo includes vendor/
-  subPackages = [ "." ];      # change to [ "cmd/obsidian-cli" ] if needed
+  vendorHash = null;
+  subPackages = [ "." ];
 
-  meta = with lib; {
+  passthru.tests.version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+  meta = {
     description = "Interact with an Obsidian vault from the terminal";
     homepage = "https://github.com/Yakitrak/obsidian-cli";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "obsidian-cli";
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
+    maintainers = [ ];
   };
-}
-
+})

--- a/pkgs/by-name/ob/obsidian-cli/package.nix
+++ b/pkgs/by-name/ob/obsidian-cli/package.nix
@@ -1,0 +1,25 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "obsidian-cli";
+  version = "0.2.2";
+
+  src = fetchFromGitHub {
+    owner = "Yakitrak";
+    repo = "obsidian-cli";
+    rev = "v${version}";
+    hash = "sha256-H7Nm+QwpAD5K1Ltl4irvSI/z3Ct7g3rh2w0Rbka7LwE=";
+  };
+
+  vendorHash = null;          # repo includes vendor/
+  subPackages = [ "." ];      # change to [ "cmd/obsidian-cli" ] if needed
+
+  meta = with lib; {
+    description = "Interact with an Obsidian vault from the terminal";
+    homepage = "https://github.com/Yakitrak/obsidian-cli";
+    license = licenses.mit;
+    mainProgram = "obsidian-cli";
+    platforms = platforms.unix;
+  };
+}
+


### PR DESCRIPTION
obsidian-cli is a command-line tool to interact with Obsidian vaults
from the terminal. It provides functionality for searching, creating,
and managing notes in Obsidian markdown-based knowledge base.
Features:
 - Search notes in your vault
 - Create new notes
 - Query vault metadata
 - Terminal-based note management
Homepage: https://github.com/Yakitrak/obsidian-cli
License: MIT

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
