### PR TITLE
open62541: 1.4.20 -> 1.5.8

### DIFF
--- a/pkgs/by-name/op/open62541/package.nix
+++ b/pkgs/by-name/op/open62541/package.nix
@@ -8,6 +8,7 @@
   libxcrypt,
   subunit,
   python3Packages,
+  libpcap,
   nix-update-script,
 
   withDoc ? false,
@@ -33,13 +34,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "open62541";
-  version = "1.4.16";
+  version = "1.5.4";
 
   src = fetchFromGitHub {
     owner = "open62541";
     repo = "open62541";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-PSY1GhaCaBkp1msjynOwHz0SzzoHliM5z5AWghG2ZU4=";
+    hash = "sha256-1Bv0i/BcPTrd/KVSgVlojEYva5g1+OIpu5oKg0IdY6g=";
     fetchSubmodules = true;
   };
 
@@ -48,9 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "UA_NAMESPACE_ZERO" "FULL")
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
 
-    # Note comment near doCheck
     (lib.cmakeBool "UA_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeBool "UA_ENABLE_ALLOW_REUSEADDR" finalAttrs.finalPackage.doCheck)
 
     (lib.cmakeBool "UA_BUILD_EXAMPLES" withExamples)
   ]
@@ -76,16 +75,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildFlags = [ "all" ] ++ lib.optional withDoc "doc";
 
-  # Tests must normally be disabled because they require
-  # -DUA_ENABLE_ALLOW_REUSEADDR=ON. The option must not be used in production,
-  # since it is a security risk.
-  # See https://github.com/open62541/open62541/issues/6407
-  doCheck = false;
+  doCheck = true;
 
   checkInputs = [
     check
     libxcrypt
     subunit
+    libpcap
   ];
 
   # Tests must run sequentially to avoid port collisions on localhost
@@ -110,6 +106,13 @@ stdenv.mkDerivation (finalAttrs: {
         "check_pubsub_multiple_subscribe_rt_levels"
         "check_pubsub_config_freeze"
         "check_pubsub_publish_rt_levels"
+        "check_pubsub_offset"
+        "check_pubsub_custom_state_machine"
+        "check_pubsub_subscribe_msgrcvtimeout"
+        "check_pubsub_encryption"
+        "check_pubsub_encryption_aes256"
+        "check_pubsub_decryption"
+        "check_pubsub_subscribe_encrypted"
 
         # Could not find the interface
         "check_pubsub_connection_ethernet"
@@ -156,20 +159,14 @@ stdenv.mkDerivation (finalAttrs: {
     let
       open62541Full =
         encBackend:
-        (open62541.overrideAttrs (_: {
-          doCheck = true;
-        })).override
-          {
-            withDoc = true;
-            # if withExamples, one of the example currently fails to build
-            #withExamples = true;
-            withEncryption = encBackend;
-          };
+        open62541.override {
+          withDoc = true;
+          # if withExamples, one of the example currently fails to build
+          #withExamples = true;
+          withEncryption = encBackend;
+        };
     in
     {
-      open62541WithTests = finalAttrs.finalPackage.overrideAttrs (_: {
-        doCheck = true;
-      });
       open62541Full = open62541Full false;
       open62541Full-openssl = open62541Full "openssl";
       open62541Full-mbedtls = open62541Full "mbedtls";

--- a/pkgs/by-name/op/open62541/package.nix
+++ b/pkgs/by-name/op/open62541/package.nix
@@ -8,6 +8,7 @@
   libxcrypt,
   subunit,
   python3Packages,
+  libpcap,
   nix-update-script,
 
   withDoc ? false,
@@ -33,13 +34,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "open62541";
-  version = "1.4.17";
+  version = "1.5.5";
 
   src = fetchFromGitHub {
     owner = "open62541";
     repo = "open62541";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-EUQ/wXv1dON7MzOKmnyNUY0mTC64qUEF1++YzPC2xIo=";
+    hash = "sha256-pbJaOcpidOBYkEH6Q0vJkFb4Na+qGRM4tmkwUS4uPYw=";
     fetchSubmodules = true;
   };
 
@@ -48,9 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeFeature "UA_NAMESPACE_ZERO" "FULL")
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
 
-    # Note comment near doCheck
     (lib.cmakeBool "UA_BUILD_UNIT_TESTS" finalAttrs.finalPackage.doCheck)
-    (lib.cmakeBool "UA_ENABLE_ALLOW_REUSEADDR" finalAttrs.finalPackage.doCheck)
 
     (lib.cmakeBool "UA_BUILD_EXAMPLES" withExamples)
   ]
@@ -76,16 +75,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildFlags = [ "all" ] ++ lib.optional withDoc "doc";
 
-  # Tests must normally be disabled because they require
-  # -DUA_ENABLE_ALLOW_REUSEADDR=ON. The option must not be used in production,
-  # since it is a security risk.
-  # See https://github.com/open62541/open62541/issues/6407
-  doCheck = false;
+  doCheck = true;
 
   checkInputs = [
     check
     libxcrypt
     subunit
+    libpcap
   ];
 
   # Tests must run sequentially to avoid port collisions on localhost
@@ -110,6 +106,13 @@ stdenv.mkDerivation (finalAttrs: {
         "check_pubsub_multiple_subscribe_rt_levels"
         "check_pubsub_config_freeze"
         "check_pubsub_publish_rt_levels"
+        "check_pubsub_offset"
+        "check_pubsub_custom_state_machine"
+        "check_pubsub_subscribe_msgrcvtimeout"
+        "check_pubsub_encryption"
+        "check_pubsub_encryption_aes256"
+        "check_pubsub_decryption"
+        "check_pubsub_subscribe_encrypted"
 
         # Could not find the interface
         "check_pubsub_connection_ethernet"
@@ -156,20 +159,14 @@ stdenv.mkDerivation (finalAttrs: {
     let
       open62541Full =
         encBackend:
-        (open62541.overrideAttrs (_: {
-          doCheck = true;
-        })).override
-          {
-            withDoc = true;
-            # if withExamples, one of the example currently fails to build
-            #withExamples = true;
-            withEncryption = encBackend;
-          };
+        open62541.override {
+          withDoc = true;
+          # if withExamples, one of the example currently fails to build
+          #withExamples = true;
+          withEncryption = encBackend;
+        };
     in
     {
-      open62541WithTests = finalAttrs.finalPackage.overrideAttrs (_: {
-        doCheck = true;
-      });
       open62541Full = open62541Full false;
       open62541Full-openssl = open62541Full "openssl";
       open62541Full-mbedtls = open62541Full "mbedtls";


### PR DESCRIPTION
## Things done

https://github.com/open62541/open62541/releases/tag/v1.5.0

* [x] Fixed ~Currently still failing because of https://github.com/open62541/open62541/issues/7700~
* [x] Merged ~For 1.4.14 -> 1.4.15, see #486426 (to be merged first, for backporting)~
* Downstream dependency `open62541pp` breaks because it is not yet ported to >= 1.5.0. I am unsure what to do, e.g. just break it or wait until it is ported to the new open62541.
* Closes #492482 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `cefe8e051ce89993e73dd52755dc1a587416e2fb`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>open62541pp</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>open62541</li>
  </ul>
</details>