### PR TITLE
[25.11] luaPackages.image-nvim: 1.3.0-1 -> 1.4.0 

### DIFF
--- a/maintainers/scripts/luarocks-packages.csv
+++ b/maintainers/scripts/luarocks-packages.csv
@@ -29,7 +29,6 @@ gitsigns.nvim,https://raw.githubusercontent.com/lewis6991/gitsigns.nvim/main/git
 grug-far.nvim,,,,,,teto
 haskell-tools.nvim,,,,,,mrcjkb
 http,,,,0.4-0,,vcunat
-image.nvim,,,,,,teto
 inspect,,,,,,
 jsregexp,,,,,,
 ldbus,,,http://luarocks.org/dev,,,

--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -1007,39 +1007,6 @@ final: prev: {
     }
   ) { };
 
-  image-nvim = callPackage (
-    {
-      buildLuarocksPackage,
-      fetchurl,
-      fetchzip,
-      luaOlder,
-      magick,
-    }:
-    buildLuarocksPackage {
-      pname = "image.nvim";
-      version = "1.3.0-1";
-      knownRockspec =
-        (fetchurl {
-          url = "mirror://luarocks/image.nvim-1.3.0-1.rockspec";
-          sha256 = "1ls3v5xcgmqmscqk5prpj0q9sy0946rfb2dfva5f1axb5x4jbvj9";
-        }).outPath;
-      src = fetchzip {
-        url = "https://github.com/3rd/image.nvim/archive/v1.3.0.zip";
-        sha256 = "0fbc3wvzsck8bbz8jz5piy68w1xmq5cnhaj1lw91d8hkyjryrznr";
-      };
-
-      disabled = luaOlder "5.1";
-      propagatedBuildInputs = [ magick ];
-
-      meta = {
-        homepage = "https://github.com/3rd/image.nvim";
-        description = "🖼️ Bringing images to Neovim.";
-        maintainers = with lib.maintainers; [ teto ];
-        license.fullName = "MIT";
-      };
-    }
-  ) { };
-
   inspect = callPackage (
     {
       buildLuarocksPackage,

--- a/pkgs/development/lua-modules/image-nvim/default.nix
+++ b/pkgs/development/lua-modules/image-nvim/default.nix
@@ -29,7 +29,7 @@ buildLuarocksPackage rec {
   meta = {
     homepage = "https://github.com/3rd/image.nvim";
     description = "🖼️ Bringing images to Neovim.";
-    maintainers = with lib.maintainers; [ teto ];
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
     license.fullName = "MIT";
   };
 }

--- a/pkgs/development/lua-modules/image-nvim/default.nix
+++ b/pkgs/development/lua-modules/image-nvim/default.nix
@@ -1,0 +1,35 @@
+{
+  buildLuarocksPackage,
+  fetchFromGitHub,
+  lib,
+  lua,
+  luaOlder,
+  luajitPackages,
+}:
+buildLuarocksPackage rec {
+  pname = "image.nvim";
+  version = "1.4.0";
+
+  disabled = luaOlder "5.1";
+  knownRockspec = "image.nvim-scm-1.rockspec";
+  rockspecVersion = "scm-1";
+
+  src = fetchFromGitHub {
+    owner = "3rd";
+    repo = "image.nvim";
+    tag = "v${version}";
+    hash = "sha256-EaDeY8aP41xHTw5epqYjaBqPYs6Z2DABzSaVOnG6D6I=";
+  };
+
+  propagatedBuildInputs = [
+    lua
+    luajitPackages.magick
+  ];
+
+  meta = {
+    homepage = "https://github.com/3rd/image.nvim";
+    description = "🖼️ Bringing images to Neovim.";
+    maintainers = with lib.maintainers; [ teto ];
+    license.fullName = "MIT";
+  };
+}

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -35,7 +35,6 @@
   libxcrypt,
   libyaml,
   lua-language-server,
-  luajitPackages,
   mariadb,
   mpfr,
   neovim-unwrapped,
@@ -249,13 +248,6 @@ in
       busted --lua=nlua
       runHook postCheck
     '';
-  };
-
-  image-nvim = prev.image-nvim.overrideAttrs {
-    propagatedBuildInputs = [
-      lua
-      luajitPackages.magick
-    ];
   };
 
   ldbus = prev.ldbus.overrideAttrs (oa: {

--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -922,53 +922,6 @@ in
     '';
   };
 
-  readline = final.callPackage (
-    {
-      buildLuarocksPackage,
-      fetchurl,
-      luaAtLeast,
-      luaOlder,
-      luaposix,
-    }:
-    # upstream broken, can't be generated, so moved out from the generated set
-    buildLuarocksPackage {
-      pname = "readline";
-      version = "3.2-0";
-      knownRockspec =
-        (fetchurl {
-          url = "mirror://luarocks/readline-3.2-0.rockspec";
-          sha256 = "1r0sgisxm4xd1r6i053iibxh30j7j3rcj4wwkd8rzkj8nln20z24";
-        }).outPath;
-      src = fetchurl {
-        # the rockspec url doesn't work because 'www.' is not covered by the certificate so
-        # I manually removed the 'www' prefix here
-        url = "http://pjb.com.au/comp/lua/readline-3.2.tar.gz";
-        sha256 = "1mk9algpsvyqwhnq7jlw4cgmfzj30l7n2r6ak4qxgdxgc39f48k4";
-      };
-
-      luarocksConfig.variables = rec {
-        READLINE_INCDIR = "${readline.dev}/include";
-        HISTORY_INCDIR = READLINE_INCDIR;
-      };
-      unpackCmd = ''
-        unzip "$curSrc"
-        tar xf *.tar.gz
-      '';
-
-      propagatedBuildInputs = [
-        luaposix
-        readline.out
-      ];
-
-      meta = {
-        homepage = "https://pjb.com.au/comp/lua/readline.html";
-        description = "Interface to the readline library";
-        license.fullName = "MIT/X11";
-        broken = (luaOlder "5.1") || (luaAtLeast "5.5");
-      };
-    }
-  ) { };
-
   rocks-dev-nvim = prev.rocks-dev-nvim.overrideAttrs {
 
     # E5113: Error while calling lua chunk [...] pl.path requires LuaFileSystem

--- a/pkgs/development/lua-modules/readline/default.nix
+++ b/pkgs/development/lua-modules/readline/default.nix
@@ -1,0 +1,45 @@
+{
+  buildLuarocksPackage,
+  fetchurl,
+  luaAtLeast,
+  luaOlder,
+  luaposix,
+  readline,
+}:
+# upstream broken, can't be generated, so moved out from the generated set
+buildLuarocksPackage {
+  pname = "readline";
+  version = "3.2-0";
+  knownRockspec =
+    (fetchurl {
+      url = "mirror://luarocks/readline-3.2-0.rockspec";
+      sha256 = "1r0sgisxm4xd1r6i053iibxh30j7j3rcj4wwkd8rzkj8nln20z24";
+    }).outPath;
+  src = fetchurl {
+    # the rockspec url doesn't work because 'www.' is not covered by the certificate so
+    # I manually removed the 'www' prefix here
+    url = "http://pjb.com.au/comp/lua/readline-3.2.tar.gz";
+    sha256 = "1mk9algpsvyqwhnq7jlw4cgmfzj30l7n2r6ak4qxgdxgc39f48k4";
+  };
+
+  luarocksConfig.variables = rec {
+    READLINE_INCDIR = "${readline.dev}/include";
+    HISTORY_INCDIR = READLINE_INCDIR;
+  };
+  unpackCmd = ''
+    unzip "$curSrc"
+    tar xf *.tar.gz
+  '';
+
+  propagatedBuildInputs = [
+    luaposix
+    readline.out
+  ];
+
+  meta = {
+    homepage = "https://pjb.com.au/comp/lua/readline.html";
+    description = "Interface to the readline library";
+    license.fullName = "MIT/X11";
+    broken = (luaOlder "5.1") || (luaAtLeast "5.5");
+  };
+}

--- a/pkgs/development/lua-modules/updater/.flake8
+++ b/pkgs/development/lua-modules/updater/.flake8
@@ -1,8 +1,0 @@
-[flake8]
-# E111 => 4 spaces tabs
-# don't let spaces else it is not recognized
-# E123 buggy
-ignore =
-	E501,E265,E402
-
-max-line-length = 120

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -255,6 +255,8 @@ rec {
     inherit (pkgs) zenity;
   };
 
+  readline = callPackage ../development/lua-modules/readline { inherit (pkgs) readline; };
+
   vicious = callPackage (
     { fetchFromGitHub }:
     stdenv.mkDerivation rec {

--- a/pkgs/top-level/lua-packages.nix
+++ b/pkgs/top-level/lua-packages.nix
@@ -112,6 +112,8 @@ rec {
     }
   ) { };
 
+  image-nvim = callPackage ../development/lua-modules/image-nvim { };
+
   lua-pam = callPackage (
     {
       fetchFromGitHub,


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
