### PR TITLE
arti: 1.9.0 -> 2.0.0, add self as maintainer

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -65,6 +65,8 @@
 
 - `nodePackages.wavedrom-cli` has been removed, as it was unmaintained within nixpkgs.
 
+- `arti` has been updated to major version 2, which removed the long-deprecated `proxy.socks_port` and `proxy.dns_port` and the legacy syntax for specifying directory authorities. For more information, see the [changelog for 2.0.0](https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.0.0/CHANGELOG.md).
+
 - `kanata` now requires `karabiner-dk` version 6.0+ or later.
   The package has been updated to use the new `karabiner-dk` package and the `darwinDriver` output stays at the version defined in the package.
 

--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -12,7 +12,7 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "arti";
-  version = "1.9.0";
+  version = "2.0.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.torproject.org";
@@ -20,10 +20,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "core";
     repo = "arti";
     tag = "arti-v${finalAttrs.version}";
-    hash = "sha256-b5DWu38/iKwKcmp4BNgkeE5F522YRZZiev9gUZ/Rb1E=";
+    hash = "sha256-eqCQwBP/QLxBwjGvksFwNwNSCng/pf19DiBQ+tA4a7M=";
   };
 
-  cargoHash = "sha256-SGxSZaY8//FHhySbarfgleafF5YEWJW/fUAwo3576NI=";
+  cargoHash = "sha256-0CxlvTetxXM+xe6r98T6hzoD/IGfYkI9TqqUe+u1U2I=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 

--- a/pkgs/by-name/ar/arti/package.nix
+++ b/pkgs/by-name/ar/arti/package.nix
@@ -79,6 +79,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ rapiteanu ];
+    maintainers = with lib.maintainers; [
+      rapiteanu
+      whispersofthedawn
+    ];
   };
 })


### PR DESCRIPTION
Release announcement: https://blog.torproject.org/arti_2_0_0_released/
Changelog: https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.0.0/CHANGELOG.md

I've also added myself as a maintainer, as I'm interested in this package and use it regularly. I also made the last few package updates, in addition to this one: #460918 and #467316.

Tested:
- With Tor Browser to connect to clearnet sites and onion services. (x86_64-linux)
  - command: `arti proxy -p 9150` and then `TOR_PROVIDER=none TOR_SOCKS_PORT=9150 tor-browser`
- `curl` with Arti as a SOCKS5 proxy for clearnet access (x86_64-linux)
  - command: `arti proxy -p 9052` and then `curl --socks5-hostname localhost:9052 https://check.torproject.org/api/ip`
- `curl` with Arti as a SOCKS5 proxy for onion service access (x86_64-linux)
  - command: `arti proxy -p 9052` and then `curl --socks5-hostname localhost:9052 http://2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion/`
- Running a regular onion service (aarch64-linux)
- Running an onion service with restricted discovery/client authorization (aarch64-linux)

**Backporting:** I'm not entirely sure if this can be backported. The biggest breakages are to users of `arti` as a library, which we don't support in Nixpkgs; we only ship the binary. However, there are a few removals of long-deprecated (notably, well before the release of 25.11) behavior:

>  - Removed the long-deprecated `proxy.socks_port` and `proxy.dns_port` configuration options. Use `proxy.socks_listen` and `dns_listen` instead. ([!3622](https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/3622))
>  - Removed legacy syntax for specifying directory authorities. The current syntax is documented in the [example configuration](https://gitlab.torproject.org/tpo/core/arti/-/blob/df5fba75c61001b07115776518f95bcb4d51681c/crates/arti/src/arti-example-config.toml#L449-484). ([!3597](https://gitlab.torproject.org/tpo/core/arti/-/merge_requests/3597))

Thus, if we did want to backport it (e.g. to make potential future security update backports easier), I think it's probably fine for us to do so. However, I'll leave this up to the judgement of the package maintainers/committers who are more familiar with the policy.

~~Either way, #486454 should be merged, which backports the v1.7.0 → v1.9.0 update (and a minor test improvement) to release-25.11.~~ EDIT: done 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
