### PR TITLE
hyprwhspr-rs: init at 0.3.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5183,6 +5183,13 @@
     email = "codenil@proton.me";
     name = "Dan Lock";
   };
+  CodeF53 = {
+    github = "CodeF53";
+    githubId = 37855219;
+    matrix = "@codef53:matrix.org";
+    email = "fseusb@gmail.com";
+    name = "cassie";
+  };
   CodeLongAndProsper90 = {
     github = "CodeLongAndProsper90";
     githubId = 50145141;

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -38,6 +38,8 @@
 
 - [bentopdf](https://github.com/alam00000/bentopdf), a privacy-first PDF toolkit running completely in-browser. Available as [services.bentopdf](#opt-services.bentopdf.enable).
 
+- [hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs), a keybind activated speech-to-text voice dictation utility built for use with Hyprland. Available as `services.hyprwhspr-rs`
+
 - [DankMaterialShell](https://danklinux.com), a complete desktop shell for Wayland compositors built with Quickshell. Available as [programs.dms-shell](#opt-programs.dms-shell.enable).
 
 - [dms-greeter](https://danklinux.com), a modern display manager greeter for DankMaterialShell that works with greetd and supports multiple Wayland compositors. Available as [services.displayManager.dms-greeter](#opt-services.displayManager.dms-greeter.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -873,6 +873,7 @@
   ./services/misc/headphones.nix
   ./services/misc/heisenbridge.nix
   ./services/misc/homepage-dashboard.nix
+  ./services/misc/hyprwhspr-rs.nix
   ./services/misc/ihaskell.nix
   ./services/misc/iio-niri.nix
   ./services/misc/input-remapper.nix

--- a/nixos/modules/services/misc/hyprwhspr-rs.nix
+++ b/nixos/modules/services/misc/hyprwhspr-rs.nix
@@ -1,0 +1,47 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    ;
+  cfg = config.services.hyprwhspr-rs;
+in
+{
+  options.services.hyprwhspr-rs = {
+    enable = mkEnableOption "hyprwhspr-rs";
+    package = mkPackageOption pkgs "hyprwhspr-rs" { };
+
+    environmentFile = mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "/path/to/hyprwhspr_secret_file";
+      description = "File containing API keys (GROQ_API_KEY, GEMINI_API_KEY) for remote transcription.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.hyprwhspr-rs = {
+      description = "Native speech-to-text voice dictation for Hyprland";
+
+      after = [
+        "graphical-session.target"
+        "pipewire.service"
+      ];
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+
+      serviceConfig = {
+        ExecStart = lib.getExe cfg.package;
+        Restart = "on-failure";
+        LoadCredential = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/hy/hyprwhspr-rs/package.nix
+++ b/pkgs/by-name/hy/hyprwhspr-rs/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  openssl,
+  pkg-config,
+  alsa-lib,
+  systemdLibs,
+  libxkbcommon,
+  makeWrapper,
+  versionCheckHook,
+  # hardware acceleration can be enabled by overriding whisper-cpp/onnxruntime or by editing config.cudaSupport/config.rocmSupport globals
+  whisper-cpp,
+  onnxruntime,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hyprwhspr-rs";
+  version = "0.3.20";
+
+  src = fetchFromGitHub {
+    owner = "better-slop";
+    repo = "hyprwhspr-rs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QCOzTbLBoygOLLN90840HHHFEaHdorf0CQOCuGpCIfo=";
+  };
+
+  cargoHash = "sha256-hLjWHMY2wpEfPfLIdfxDI21FrrC1QOWGRkTezkmzmGY=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    openssl
+    alsa-lib
+    onnxruntime
+    systemdLibs
+    libxkbcommon
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/hyprwhspr-rs \
+      --prefix PATH : ${lib.makeBinPath [ whisper-cpp ]}
+    # default voice activation sounds
+    install -Dm644 assets/* -t $out/share/assets
+  '';
+
+  # provide onnx runtime libraries to prevent default behavior of downloading them during the build step
+  env = {
+    ORT_STRATEGY = "system";
+    ORT_LIB_LOCATION = "${lib.getLib onnxruntime}/lib";
+    ORT_PREFER_DYNAMIC_LINK = "1";
+  };
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Native speech-to-text voice dictation for Hyprland";
+    homepage = "https://github.com/better-slop/hyprwhspr-rs";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    mainProgram = "hyprwhspr-rs";
+    maintainers = with lib.maintainers; [ CodeF53 ];
+  };
+})


### PR DESCRIPTION
[hyprwhspr-rs](https://github.com/better-slop/hyprwhspr-rs) is a keybind activated speech-to-text voice dictation utility built for use with Hyprland.

I have included a NixOS Module `services.hyprwhspr-rs` (user service) to run the utility in the background.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
