### PR TITLE
golazo: init at 0.18.0

### DIFF
--- a/pkgs/by-name/go/golazo/package.nix
+++ b/pkgs/by-name/go/golazo/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  gitUpdater,
+  libnotify,
+}:
+buildGoModule (finalAttrs: {
+  pname = "golazo";
+  version = "0.21.0";
+
+  src = fetchFromGitHub {
+    owner = "0xjuanma";
+    repo = "golazo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TWpaW8MTkYEOp+7dd3LiDs05tCB3riUPmFRzhMiAeZI=";
+  };
+
+  vendorHash = "sha256-M2gfqU5rOfuiVSZnH/Dr8OVmDhyU2jYkgW7RuIUTd+E=";
+
+  subPackages = [ "." ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ libnotify ];
+
+  ldflags = [
+    "-X github.com/0xjuanma/golazo/cmd.Version=v${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = gitUpdater {
+    rev-prefix = "v";
+  };
+
+  meta = {
+    description = "Minimal TUI app to keep up with live & recent football/soccer matches written in Go";
+    homepage = "https://github.com/0xjuanma/golazo";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    mainProgram = "golazo";
+    maintainers = with lib.maintainers; [ rafaelrc ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/0xjuanma/golazo

A TUI app written in go to follow football matches in real time.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
