### PR TITLE
tinyxxd: 1.3.8 -> 1.3.10

### DIFF
--- a/pkgs/by-name/ti/tinyxxd/package.nix
+++ b/pkgs/by-name/ti/tinyxxd/package.nix
@@ -2,29 +2,20 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch2,
   installShellFiles,
   vim,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tinyxxd";
-  version = "1.3.8";
+  version = "1.3.10";
 
   src = fetchFromGitHub {
     repo = "tinyxxd";
     owner = "xyproto";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ePLqbcwlqBK/x645Yf5pgHSCtBSd3mqktAHhomxU3dM=";
+    hash = "sha256-DrAwUwaiEnaOCo0YLXSaAJDEyBJ4t7mVxEarDSO6XeU=";
   };
-
-  patches = [
-    # Darwin fails to build due to the warning from the unused `-fno-plt` being turned into an error.
-    (fetchpatch2 {
-      url = "https://github.com/xyproto/tinyxxd/commit/63ee0f4a03b06ded1eb531129240a4f0880a41dc.patch?full_index=1";
-      hash = "sha256-sZG7hZUmF0PK2TYcUfHXTz2VCwe5Ba6cm3CVJ9aA2SQ=";
-    })
-  ];
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Changes: https://github.com/xyproto/tinyxxd/compare/v1.3.8...v1.3.10


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
