### PR TITLE
sprite: init at 0.0.1-rc41

### DIFF
--- a/pkgs/by-name/sp/sprite/package.nix
+++ b/pkgs/by-name/sp/sprite/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  versionCheckHook,
+  autoPatchelfHook,
+  writableTmpDirAsHomeHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sprite";
+  version = "0.0.1-rc41";
+
+  src = fetchurl {
+    url = "https://sprites-binaries.t3.storage.dev/client/v${finalAttrs.version}/sprite-${
+      if stdenv.hostPlatform.isLinux then "linux" else "darwin"
+    }-${if stdenv.hostPlatform.isx86_64 then "amd64" else "arm64"}.tar.gz";
+    hash =
+      {
+        aarch64-darwin = "sha256-WVEa0NjpoeHZtn8p8k5AJLifIZWgPchpyrj5ikRupoI=";
+        x86_64-darwin = "sha256-zwCgZSFeFFk49blOjzH5PEv5fuFUlnP/Bre0uJpz78c=";
+        aarch64-linux = "sha256-PjL4usgcx3ybLB7ZLPfKHaqygWVfiuCNrERbYrDRZYk=";
+        x86_64-linux = "sha256-PAnnP5M9lLwC3Qhydz3Bo0uLtX6uE5cJF4lDOGfsiDk=";
+      }
+      .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -m 755 sprite $out/bin/
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = "HOME";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Command Line Interactive for sprites, stateful sandbox environments with checkpoint & restore";
+    homepage = "https://sprites.dev";
+    license = lib.licenses.unfree;
+    mainProgram = "sprite";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ drawbu ];
+  };
+})

--- a/pkgs/by-name/sp/sprite/update.sh
+++ b/pkgs/by-name/sp/sprite/update.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl gnused nix-prefetch
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+dirname="$(dirname "$0")"
+
+updateHash()
+{
+    version=$1
+    archHash=$2
+    filetype=$3
+
+    url="https://sprites-binaries.t3.storage.dev/client/v$version/sprite-$filetype.tar.gz"
+    hash=$(nix-prefetch-url --type sha256 "$url")
+    sriHash="$(nix hash convert sha256:"$hash")"
+
+    sed -i "s|$archHash = \"[a-zA-Z0-9\/+-=]*\";|$archHash = \"$sriHash\";|g" "$dirname/package.nix"
+}
+
+updateVersion()
+{
+    sed -i "s/version = \".*\";/version = \"$1\";/g" "$dirname/package.nix"
+}
+
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; sprite.version" | tr -d '"')
+
+# right now, the release channel returns an error, because no "stable" version
+# has been released; we have to rely on the release candidate for now.
+# TODO: drop /rc.txt when a release hits stable
+latestTag=$(curl -f https://sprites-binaries.t3.storage.dev/client/release.txt \
+         || curl -f https://sprites-binaries.t3.storage.dev/client/rc.txt)
+latestVersion="$(expr "$latestTag" : 'v\(.*\)')"
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "sprite is up-to-date: ${currentVersion}"
+    exit 0
+fi
+
+updateVersion "$latestVersion"
+
+updateHash "$latestVersion" x86_64-linux   linux-amd64
+updateHash "$latestVersion" aarch64-linux  linux-arm64
+updateHash "$latestVersion" x86_64-darwin  darwin-amd64
+updateHash "$latestVersion" aarch64-darwin darwin-arm64


### PR DESCRIPTION
Adding the `sprite` CLI from [sprites.dev](https://sprites.dev). Right now, it uses the release candidate channel, as no "stable" version has been released yet. But... the cli is the only way to use the project, and I highly doubt anyone using Nix would want to run their bash installer. 

This is not an open-source software, so I assumed the license was unfree, and I added `update.sh` script that should follow releases and update the hash of the various binaries (although it will have to be edited because it is targeted towards rc channel for now).

I included an update script so that we can switch to the `release` channel as soon as it releases.
<!-- I might let this PR as a draft until the package hits a real release. -->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
