### PR TITLE
chore(inkscape): move tutorials to its own output

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -78,6 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
   outputs = [
     "out"
     "man"
+    "tutorials"
   ];
 
   src = fetchurl {
@@ -177,11 +178,18 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Make sure PyXML modules can be found at run-time.
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    for f in $out/lib/inkscape/*.dylib; do
-      ln -s $f $out/lib/$(basename $f)
-    done
-  '';
+  postInstall =
+    lib.optionalString stdenv.hostPlatform.isDarwin ''
+      for f in $out/lib/inkscape/*.dylib; do
+        ln -s $f $out/lib/$(basename $f)
+      done
+    ''
+    +
+    # Move tutorials to their own output
+    ''
+      mkdir -p $tutorials/share/inkscape/
+      mv $out/share/inkscape/tutorials $tutorials/share/inkscape/
+    '';
 
   passthru = {
     tests = {


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
