### PR TITLE
py-libzfs: fix build by using zfs_2_3 instead of default zfs

### DIFF
--- a/pkgs/development/python-modules/py-libzfs/default.nix
+++ b/pkgs/development/python-modules/py-libzfs/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchpatch2,
   cython_0,
-  zfs,
+  zfs_2_3,
 }:
 
 buildPythonPackage rec {
@@ -30,14 +30,14 @@ buildPythonPackage rec {
   ];
 
   build-system = [ cython_0 ];
-  buildInputs = [ zfs ];
+  buildInputs = [ zfs_2_3 ];
 
   # Passing CFLAGS in configureFlags does not work, see https://github.com/truenas/py-libzfs/issues/107
   postPatch = lib.optionalString stdenv.hostPlatform.isLinux ''
     substituteInPlace configure \
       --replace-fail \
         'CFLAGS="-DCYTHON_FALLTHROUGH"' \
-        'CFLAGS="-DCYTHON_FALLTHROUGH -I${zfs.dev}/include/libzfs -I${zfs.dev}/include/libspl"' \
+        'CFLAGS="-DCYTHON_FALLTHROUGH -I${zfs_2_3.dev}/include/libzfs -I${zfs_2_3.dev}/include/libspl"' \
       --replace-fail 'zof=false' 'zof=true'
   '';
 


### PR DESCRIPTION
Since PR #485460 `python312Packages.py-libzfs` fail to build.
This PR forces the use of zfs_2_3 for py-libzfs to fix the build process.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
