### PR TITLE
n8n-nodes-carbonejs: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/by-name/n8/n8n-nodes-carbonejs/package.nix
+++ b/pkgs/by-name/n8/n8n-nodes-carbonejs/package.nix
@@ -8,16 +8,16 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "n8n-nodes-carbonejs";
-  version = "1.2.0";
+  version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "jreyesr";
     repo = "n8n-nodes-carbonejs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Dvl+Kc04i+hQ8rciT7n3oS4rtgke+HEqUszJnQa7UA0=";
+    hash = "sha256-QWErVquOEYCkoHIF6XSaDGzDbbkaNNoE70H/UvdZh6E=";
   };
 
-  npmDepsHash = "sha256-3VwejuSFGvJWNsitLKfVVpB8GnkTrrf/LLobNCpy8gU=";
+  npmDepsHash = "sha256-h780VxvDMUC5tv3JhDxYOZGJ+j40BAhmo4pRczlByKs=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
