### PR TITLE
libngspice: fix build on Darwin with Clang

### DIFF
--- a/pkgs/by-name/li/libngspice/package.nix
+++ b/pkgs/by-name/li/libngspice/package.nix
@@ -21,6 +21,24 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-8arYq6woKKe3HaZkEd6OQGUk518wZuRnVUOcSQRC1zQ=";
   };
 
+  patches = [
+    (builtins.toFile "fix-cppduals.patch" ''
+      --- a/src/include/cppduals/duals/dual
+      +++ b/src/include/cppduals/duals/dual
+      @@ -485,10 +485,6 @@ struct is_arithmetic<duals::dual<T>> : is_arithmetic<T> {};
+
+       #endif // CPPDUALS_ENABLE_IS_ARITHMETIC
+
+      -/// Duals are compound types.
+      -template <class T>
+      -struct is_compound<duals::dual<T>> : true_type {};
+      -
+       // Modification of std::numeric_limits<> per
+       // C++03 17.4.3.1/1, and C++11 18.3.2.3/1.
+       template <class T>
+    '')
+  ];
+
   nativeBuildInputs = [
     flex
     bison


### PR DESCRIPTION
Apply patch to remove redundant is_compound specialization in cppduals. This resolves a compilation error on macOS where the specialization conflicts with the standard library's type traits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

Also reported upstream:
https://sourceforge.net/p/ngspice/bugs/826/
https://gitlab.com/tesch1/cppduals/-/issues/14