### PR TITLE
vrcx: 2026.01.04 -> 2026.01.28

### DIFF
--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -1,15 +1,15 @@
 {
   lib,
-  fetchFromGitHub,
-  buildDotnetModule,
-  dotnetCorePackages,
-  buildNpmPackage,
+  stdenv,
   nodejs_22,
   electron_39,
   makeWrapper,
-  copyDesktopItems,
+  fetchFromGitHub,
+  buildNpmPackage,
   makeDesktopItem,
-  stdenv,
+  copyDesktopItems,
+  buildDotnetModule,
+  dotnetCorePackages,
 }:
 let
   node = nodejs_22;
@@ -78,11 +78,11 @@ buildNpmPackage (finalAttrs: {
   desktopItems = [
     (makeDesktopItem {
       name = "vrcx";
-      desktopName = "VRCX";
-      comment = "Friendship management tool for VRChat";
       icon = "vrcx";
       exec = "vrcx";
       terminal = false;
+      desktopName = "VRCX";
+      comment = "Friendship management tool for VRChat";
       categories = [
         "Utility"
         "Application"
@@ -93,8 +93,8 @@ buildNpmPackage (finalAttrs: {
 
   passthru = {
     backend = buildDotnetModule {
-      pname = "${finalAttrs.pname}-backend";
       inherit (finalAttrs) version src;
+      pname = "${finalAttrs.pname}-backend";
 
       dotnet-sdk = dotnet.sdk;
       dotnet-runtime = dotnet.runtime;

--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -4,6 +4,7 @@
   buildDotnetModule,
   dotnetCorePackages,
   buildNpmPackage,
+  nodejs_22,
   electron_39,
   makeWrapper,
   copyDesktopItems,
@@ -11,23 +12,25 @@
   stdenv,
 }:
 let
+  node = nodejs_22;
   electron = electron_39;
   dotnet = dotnetCorePackages.dotnet_9;
 in
 buildNpmPackage (finalAttrs: {
   pname = "vrcx";
-  version = "2026.01.04";
+  version = "2026.01.28";
 
   src = fetchFromGitHub {
     repo = "VRCX";
     owner = "vrcx-team";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ibsmlNfW64mzJOhIkJydpJ9ys2PbPfyj2XBGwY5xuww=";
+    hash = "sha256-D6KYKKDaWk7OMKVNOsA8K2j+kilAtLcRmMz4Xmt5pms=";
   };
 
+  nodejs = node;
   makeCacheWritable = true;
   npmFlags = [ "--ignore-scripts" ];
-  npmDepsHash = "sha256-TUdzrEa2dW4rKA/9HGgF6c9JTMiBmNWvc/9R0kIKSls=";
+  npmDepsHash = "sha256-qa9056EljXLxcrArECf41vygueAAwrbeuA20yoMcYPA=";
 
   nativeBuildInputs = [
     makeWrapper


### PR DESCRIPTION
https://github.com/vrcx-team/VRCX/releases/tag/v2026.01.28
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
