### PR TITLE
sympa: Fix build with gettext 0.25 and strictDeps

### DIFF
--- a/pkgs/by-name/sy/sympa/gettext-0.25.patch
+++ b/pkgs/by-name/sy/sympa/gettext-0.25.patch
@@ -1,0 +1,21 @@
+diff --git a/configure.ac b/configure.ac
+index 2182b31..6292827 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -23,12 +23,14 @@
+ # You should have received a copy of the GNU General Public License
+ # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
++AC_CONFIG_MACRO_DIRS([m4])
++
+ AC_PREREQ(2.60)
+ AC_INIT(sympa, 6.2.76, devel@sympa.community)
+ AM_INIT_AUTOMAKE([foreign -Wall -Werror 1.9 tar-pax])
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+-AM_PO_SUBDIRS
+-GETTEXT_MACRO_VERSION=0.19
++AM_GNU_GETTEXT([external])
++AM_GNU_GETTEXT_VERSION([0.25])
+ 
+ AC_PREFIX_DEFAULT(/home/sympa)
+ 

--- a/pkgs/by-name/sy/sympa/package.nix
+++ b/pkgs/by-name/sy/sympa/package.nix
@@ -93,13 +93,15 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-spooldir=${dataDir}/spool"
     "--with-expldir=${dataDir}/list_data"
   ];
-  nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = [ perlEnv ];
-  patches = [ ./make-docs.patch ];
-
-  prePatch = ''
-    patchShebangs po/sympa/add-lang.pl
-  '';
+  nativeBuildInputs = [
+    autoreconfHook
+    perlEnv
+  ];
+  strictDeps = true;
+  patches = [
+    ./make-docs.patch
+    ./gettext-0.25.patch
+  ];
 
   preInstall = ''
     mkdir "$TMP/bin"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
