### PR TITLE
apacheHttpd: make dependency on lynx optional

### DIFF
--- a/pkgs/servers/http/apache-httpd/2.4.nix
+++ b/pkgs/servers/http/apache-httpd/2.4.nix
@@ -10,6 +10,7 @@
   pcre2,
   libiconv,
   lynx,
+  withLynx ? false,
   which,
   libxcrypt,
   buildPackages,
@@ -82,7 +83,7 @@ stdenv.mkDerivation rec {
   postPatch = ''
     sed -i config.layout -e "s|installbuilddir:.*|installbuilddir: $dev/share/build|"
     sed -i configure -e 's|perlbin=.*|perlbin="/usr/bin/env perl"|'
-    sed -i support/apachectl.in -e 's|@LYNX_PATH@|${lynx}/bin/lynx|'
+    ${lib.optionalString withLynx "sed -i support/apachectl.in -e 's|@LYNX_PATH@|${lynx}/bin/lynx|'"}
   '';
 
   # Required for ‘pthread_cancel’.


### PR DESCRIPTION
currently, apache-httpd depends on lynx:

```
$> nix why-depends --derivation nixpkgs#apacheHttpd_2_4 nixpkgs#lynx
/nix/store/bb72xaaifzlixp80f8p4h73sif8wyxg2-apache-httpd-2.4.66.drv
└───/nix/store/0mxjndshcr2dijy30vzvl5hxa9gjsadg-lynx-2.9.2.drv
```

looking at the source (`support/apachectl.in`), it seems like this is only used in non-systemd environments to print the output of `http://localhost:@PORT@/server-status`:

```bash
# [...]

# a command that outputs a formatted text version of the HTML at the
# url given on the command line.  Designed for lynx, however other
# programs may work.  
LYNX="@LYNX_PATH@ -dump"
#
# the URL to your server's mod_status status page.  If you do not
# have one, then status and fullstatus will not work.
STATUSURL="http://localhost:@PORT@/server-status"

# [...]

case $ACMD in
start|stop|restart|graceful|graceful-stop)
    $HTTPD -k $ARGV
    ERROR=$?
    ;;
startssl|sslstart|start-SSL)
    echo The startssl option is no longer supported.
    echo Please edit httpd.conf to include the SSL configuration settings
    echo and then use "apachectl start".
    ERROR=2
    ;;
configtest)
    $HTTPD -t
    ERROR=$?
    ;;
status)
    $LYNX $STATUSURL | awk ' /process$/ { print; exit } { print } '
    ;;
fullstatus)
    $LYNX $STATUSURL
    ;;
*)
    $HTTPD "$@"
    ERROR=$?
esac

exit $ERROR
```

so I think it's safe to make this an opt-in dependency

built the package with and without `withLynx = true;`, as well as the tests

```
nix-build -E '((import <nixpkgs> {}).apacheHttpd.overrideAttrs {withLynx = true;}).tests'
nix-build -E '((import <nixpkgs> {}).apacheHttpd.overrideAttrs {withLynx = false;}).tests'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

