### PR TITLE
knot-resolver-manager_6: 6.1.0 -> 6.2.0

### DIFF
--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -15,13 +15,15 @@
   libuv,
   gnutls,
   lmdb,
+  # optionals, in principle
   jemalloc,
   systemdMinimal,
   libcap_ng,
   dns-root-data,
-  nghttp2, # optionals, in principle
+  nghttp2,
+  ngtcp2-gnutls,
   fstrm,
-  protobufc, # more optionals
+  protobufc,
   # test-only deps.
   cmocka,
   which,
@@ -34,11 +36,11 @@ let
   # TODO: we could cut the `let` short here, but it would de-indent everything.
   unwrapped = stdenv.mkDerivation (finalAttrs: {
     pname = "knot-resolver_6";
-    version = "6.1.0";
+    version = "6.2.0";
 
     src = fetchurl {
       url = "https://secure.nic.cz/files/knot-resolver/knot-resolver-${finalAttrs.version}.tar.xz";
-      hash = "sha256-eSHfdQcobZBXS79a5mSopTeAXOQLX6ixX10NM+LEONA=";
+      hash = "sha256-tEYzvIQxgMC8fHfPexX+VxJDrpkrTdt0r97kz6gDcBs=";
     };
 
     outputs = [
@@ -92,6 +94,7 @@ let
     ++ [
       jemalloc
       nghttp2
+      ngtcp2-gnutls
       # dnstap support
       fstrm
       protobufc


### PR DESCRIPTION
https://gitlab.nic.cz/knot/knot-resolver/-/releases/v6.2.0
The enablement of DoQ costs us only 48 KiB of runtime closure increase, thanks to sharing the costs with knot-dns libs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
