### PR TITLE
buildDubPackage: fix flag arrays not being expanded correctly

### DIFF
--- a/pkgs/build-support/dlang/builddubpackage/hooks/dub-build-hook.sh
+++ b/pkgs/build-support/dlang/builddubpackage/hooks/dub-build-hook.sh
@@ -2,7 +2,14 @@ dubBuildHook() {
     runHook preBuild
     echo "Executing dubBuildHook"
 
-    dub build --skip-registry=all --build="${dubBuildType-"release"}" "${dubBuildFlags[@]}" "${dubFlags[@]}"
+    local flagsArray=(
+        --skip-registry=all
+        "--build=${dubBuildType-release}"
+    )
+    concatTo flagsArray dubBuildFlags dubFlags
+
+    echoCmd 'dubBuildHook flags' "${flagsArray[@]}"
+    dub build "${flagsArray[@]}"
 
     echo "Finished dubBuildHook"
     runHook postBuild

--- a/pkgs/build-support/dlang/builddubpackage/hooks/dub-check-hook.sh
+++ b/pkgs/build-support/dlang/builddubpackage/hooks/dub-check-hook.sh
@@ -2,7 +2,13 @@ dubCheckHook() {
     runHook preCheck
     echo "Executing dubCheckHook"
 
-    dub test --skip-registry=all "${dubTestFlags[@]}" "${dubFlags[@]}"
+    local flagsArray=(
+        --skip-registry=all
+    )
+    concatTo flagsArray dubTestFlags dubFlags
+
+    echoCmd 'dubCheckHook flags' "${flagsArray[@]}"
+    dub test "${flagsArray[@]}"
 
     echo "Finished dubCheckHook"
     runHook postCheck


### PR DESCRIPTION
Use concatTo to properly handle dubBuildFlags, dubTestFlags, and dubFlags. Previously these were used as "${var[@]}" but Nix lists become space-separated strings, not bash arrays, causing all flags to be concatenated into a single argument.

Motivating example:

```nix
          dubBuildFlags = [ "--config=mysql-integration" "-d=ASOCKETS_DEBUG_IDLE" ];
```

became:

```
            > Error Unknown build configuration: mysql-integration -d=ASOCKETS_DEBUG_IDLE                                                                                          
```

CC @TomaSajt 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
