### PR TITLE
flatpak: Fix segfault in NixOS custom font mounting code

### DIFF
--- a/pkgs/by-name/fl/flatpak/fix-fonts-icons.patch
+++ b/pkgs/by-name/fl/flatpak/fix-fonts-icons.patch
@@ -15,7 +15,7 @@ index 94ad013..5c9f55e 100644
 +      realpath(source_path, path);
 +      if (g_str_has_prefix(path, "/nix/store/"))
 +        {
-+          *strchr(path + strlen("/nix/store/"), '/') = 0;
++          char * const p = strchr(path + strlen("/nix/store/"), '/'); if (p != 0) *p = 0;
 +          g_hash_table_add(closure, g_steal_pointer (&path));
 +        }
 +    }


### PR DESCRIPTION
On my systems there is a path in the fonts list that looks like /nix/store/<hash>-<font>.ttf. The previous code assumed that every font path contains at least one more slash which isn't the case here.

The code matched on the / after the $out path of the derivation:
```
/nix/store/<hash>-<name>/share/X11/fonts/...
                        ^
```
That slash only exists if the font lives in a subdirectory, which isn't strictly required. In my case I've a few font files that are located at /nix/store/<hash>-<name>.ttf and are assembled into a folder as symlinks. (See example below)

Any attempt at calling realpath(3) on them (potentially recursively) will result in the single file entry in the store being returned.

Whenever that font is being loaded flatpak segfaulted like so:

```
(gdb) bt
#0  0x00005583b3673763 in get_nix_closure ()
#1  0x00005583b3673711 in get_nix_closure ()
#2  0x00005583b36737dc in add_nix_store_symlink_targets ()
#3  0x00005583b36749a8 in add_font_path_args ()
#4  0x00005583b367b3f4 in flatpak_run_app ()
#5  0x00005583b35e4f08 in flatpak_builtin_run ()
#6  0x00005583b35a5970 in main ()
(gdb) x/5i $rip
=> 0x5583b3673763 <get_nix_closure+307>:	movb   $0x0,(%rax)
   0x5583b3673766 <get_nix_closure+310>:	call   0x5583b35a46a0 <g_hash_table_add@plt>
   0x5583b367376b <get_nix_closure+315>:	jmp    0x5583b3673699 <get_nix_closure+105>
   0x5583b3673770 <get_nix_closure+320>:	xor    %edi,%edi
   0x5583b3673772 <get_nix_closure+322>:	lea    0x30475(%rip),%rsi        # 0x5583b36a3bee
(gdb) x/s $rsi
0x5583e92d2180:	"/nix/store/<hash>-A.ttf"
(gdb) print $rax
$1 = 0
```

RAX pointing to 0 here corresponds to the pointer `p` in the source code. So the code attempted to dereference a null pointer as no further slash (the return value of strchr(3)) could be found.

The modification in this commit ensures that we check for `p != 0` so we don't run into this situation again.

Adding the path to the closure will still be done, even if no further slash can be found, as that still points to a valid store path.

----

Nix code for custom fonts:

```nix
let
  files = [
    ./A.ttf
    ./B.ttf
  ];
in
runCommandNoCC "custom-fonts" {} ''
  mkdir -p $out/share/fonts/truetype
  cd $out/share/fonts/truetype
  ${ lib.concatStringsSep "\n" (map (file: "ln -s ${file} ${baseNameOf file}") files)}
''
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  	-> NixOS test is currently broken as `installedTests` aren't buildable of the `flatpak` package.
  - [x] [Package tests] at `passthru.tests`.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
