### PR TITLE
python3Packages.slither-analyzer: cleanup, fix on darwin

### DIFF
--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -52,6 +52,7 @@ buildPythonPackage (finalAttrs: {
     versionCheckHook
     writableTmpDirAsHomeHook
   ];
+  versionCheckKeepEnvironment = [ "HOME" ];
 
   postFixup = lib.optionalString withSolc ''
     wrapProgram $out/bin/slither \

--- a/pkgs/development/python-modules/slither-analyzer/default.nix
+++ b/pkgs/development/python-modules/slither-analyzer/default.nix
@@ -1,16 +1,27 @@
 {
   lib,
   buildPythonPackage,
-  crytic-compile,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
+
+  # nativeBuildInputs
   makeWrapper,
+
+  # dependencies
+  crytic-compile,
   packaging,
   prettytable,
-  solc,
-  testers,
-  versionCheckHook,
   web3,
+
+  # tests
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+
+  # postFixup
+  solc,
+
   withSolc ? false,
 }:
 
@@ -37,16 +48,14 @@ buildPythonPackage (finalAttrs: {
     web3
   ];
 
-  nativeInstallCheckInputs = [ versionCheckHook ];
+  nativeCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
 
   postFixup = lib.optionalString withSolc ''
     wrapProgram $out/bin/slither \
       --prefix PATH : "${lib.makeBinPath [ solc ]}"
-  '';
-
-  # required for pythonImportsCheck
-  postInstall = ''
-    export HOME="$TEMP"
   '';
 
   pythonImportsCheck = [
@@ -65,8 +74,6 @@ buildPythonPackage (finalAttrs: {
     "slither.visitors"
     "slither.vyper_parsing"
   ];
-
-  doInstallCheck = true;
 
   meta = {
     description = "Static Analyzer for Solidity";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.slither-analyzer: cleanup**
- **python3Packages.slither-analyzer: fix on darwin**

cc @arcz @fabaff @hellwolf

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
