### PR TITLE
polysh: init at 1.0.4

### DIFF
--- a/pkgs/by-name/po/polysh/package.nix
+++ b/pkgs/by-name/po/polysh/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "polysh";
+  version = "1.0.4";
+  pyproject = true;
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "innogames";
+    repo = "polysh";
+    tag = "polysh-${finalAttrs.version}";
+    hash = "sha256-fmcu3lWSV5aft+gX5QjypdK5pyfdVd0HDNekiFVdlBI=";
+  };
+
+  build-system = with python3Packages; [
+    hatchling
+  ];
+
+  meta = {
+    description = "Remote shell multiplexer for executing commands on multiple hosts";
+    homepage = "https://github.com/innogames/polysh";
+    changelog = "https://github.com/innogames/polysh/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ seqizz ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Looks like this was [removed](https://github.com/NixOS/nixpkgs/pull/153151/commits/7409e5411b384f60184671cd51a5c4535fceafe9) before. Not abandoned anymore, personally using for a while so I wanted to contribute to upstream. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
