### PR TITLE
pay-respects: 0.7.9 -> 0.7.10

### DIFF
--- a/pkgs/by-name/pa/pay-respects/package.nix
+++ b/pkgs/by-name/pa/pay-respects/package.nix
@@ -6,16 +6,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pay-respects";
-  version = "0.7.9";
+  version = "0.7.10";
 
   src = fetchFromCodeberg {
     owner = "iff";
     repo = "pay-respects";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qKej29kM0Kq5RRHo+lu9cGeTjnjUvpmIqSxq5yHuCKc=";
+    hash = "sha256-HRSSJPiHILV3YsyXw0vRNDNV6gR1wB2W0H396yU2wko=";
   };
 
-  cargoHash = "sha256-2MEbUBTZ/zsPLhHTnQCrWQManqUQ3V3xta5NT9gu38A=";
+  cargoHash = "sha256-jgeypBPHffZPu8mEJPn8d6eh691K7Jh5OvXdVBeuwF0=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;


### PR DESCRIPTION
https://codeberg.org/iff/pay-respects/src/branch/main/CHANGELOG.md#0-7-10-2026-02-03

https://codeberg.org/iff/pay-respects/releases/tag/v0.7.10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
