### PR TITLE
pacu: 1.6.0 -> 1.6.1

### DIFF
--- a/pkgs/by-name/pa/pacu/package.nix
+++ b/pkgs/by-name/pa/pacu/package.nix
@@ -13,7 +13,7 @@ let
 in
 python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "pacu";
-  version = "1.6.0";
+  version = "1.6.1";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -52,6 +52,7 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     sqlalchemy
     sqlalchemy-utils
     toml
+    types-urllib3
     typing-extensions
     urllib3
   ]);
@@ -71,6 +72,10 @@ python.pkgs.buildPythonApplication (finalAttrs: {
     # sAttributeError: module 'moto' has no attribute 'mock_s3'
     "test_update"
     "test_update_second_time"
+
+    # AttributeError: module 'moto' has no attribute 'mock_cognitoidp'
+    "test_cognito__attack_minimal"
+    "test_cognito__attack_sanity"
   ];
 
   meta = {


### PR DESCRIPTION
Updates `pacu` from 1.6.0 to 1.6.1.

Changelog: https://github.com/RhinoSecurityLabs/pacu/releases/tag/v1.6.1

This update keeps `doCheck` enabled. Some upstream tests are disabled because they rely on the pre-moto-v5 service-specific mocks (e.g. `moto.mock_s3`), which were removed in moto >= 5 and replaced by `mock_aws`. The affected tests are tracked via `disabledTests` with an explanatory comment.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

  Commands run:
  - `nix build -L .#pacu`
  - `./result/bin/pacu --help`

- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
