### PR TITLE
eclipses.plugins.*: set pname

### DIFF
--- a/doc/packages/eclipse.section.md
+++ b/doc/packages/eclipse.section.md
@@ -32,7 +32,7 @@ to your Nixpkgs configuration (`~/.config/nixpkgs/config.nix`) and install it by
 $ nix-env -f '<nixpkgs>' -qaP -A eclipses.plugins --description
 ```
 
-If there is a need to install plugins that are not available in Nixpkgs then it may be possible to define these plugins outside Nixpkgs using the `buildEclipseUpdateSite` and `buildEclipsePlugin` functions found in the `nixpkgs.eclipses.plugins` attribute set. Use the `buildEclipseUpdateSite` function to install a plugin distributed as an Eclipse update site. This function takes `{ name, src }` as argument, where `src` indicates the Eclipse update site archive. All Eclipse features and plugins within the downloaded update site will be installed. When an update site archive is not available, then the `buildEclipsePlugin` function can be used to install a plugin that consists of a pair of feature and plugin JARs. This function takes an argument `{ name, srcFeature, srcPlugin }` where `srcFeature` and `srcPlugin` are the feature and plugin JARs, respectively.
+If there is a need to install plugins that are not available in Nixpkgs then it may be possible to define these plugins outside Nixpkgs using the `buildEclipseUpdateSite` and `buildEclipsePlugin` functions found in the `nixpkgs.eclipses.plugins` attribute set. Use the `buildEclipseUpdateSite` function to install a plugin distributed as an Eclipse update site. This function takes `{ src }` and either `pname` or `name` + `version` as arguments, where `src` indicates the Eclipse update site archive. All Eclipse features and plugins within the downloaded update site will be installed. When an update site archive is not available, then the `buildEclipsePlugin` function can be used to install a plugin that consists of a pair of feature and plugin JARs. This function takes `{ srcFeature, srcPlugin }` and either `pname` or `name` + `version` as arguments, where `srcFeature` and `srcPlugin` are the feature and plugin JARs, respectively.
 
 Expanding the previous example with two plugins using the above functions, we have:
 
@@ -47,7 +47,8 @@ Expanding the previous example with two plugins using the above functions, we ha
         plugins = [
           plugins.color-theme
           (plugins.buildEclipsePlugin {
-            name = "myplugin1-1.0";
+            pname = "myplugin1";
+            version = "1.0";
             srcFeature = fetchurl {
               url = "http://…/features/myplugin1.jar";
               hash = "sha256-123…";
@@ -58,7 +59,8 @@ Expanding the previous example with two plugins using the above functions, we ha
             };
           })
           (plugins.buildEclipseUpdateSite {
-            name = "myplugin2-1.0";
+            pname = "myplugin2";
+            version = "1.0";
             src = fetchurl {
               stripRoot = false;
               url = "http://…/myplugin2.zip";

--- a/pkgs/applications/editors/eclipse/plugins.nix
+++ b/pkgs/applications/editors/eclipse/plugins.nix
@@ -13,7 +13,7 @@ rec {
   # to be used when building more advanced builders.
   buildEclipsePluginBase =
     {
-      name,
+      name ? "eclipse-plugin-${attrs.pname}-${attrs.version}",
       buildInputs ? [ ],
       passthru ? { },
       ...
@@ -21,7 +21,7 @@ rec {
     stdenv.mkDerivation (
       attrs
       // {
-        name = "eclipse-plugin-" + name;
+        inherit name;
 
         buildInputs = buildInputs ++ [ unzip ];
 
@@ -36,7 +36,7 @@ rec {
   # plugin JARs.
   buildEclipsePlugin =
     {
-      name,
+      name ? "eclipse-plugin-${attrs.pname}-${attrs.version}",
       srcFeature,
       srcPlugin ? null,
       srcPlugins ? [ ],
@@ -75,7 +75,10 @@ rec {
   # `features` and `plugins`. All features and plugins inside these
   # directories will be installed.
   buildEclipseUpdateSite =
-    { name, ... }@attrs:
+    {
+      name ? "eclipse-plugin-${attrs.pname}-${attrs.version}",
+      ...
+    }@attrs:
     buildEclipsePluginBase (
       attrs
       // {
@@ -119,7 +122,7 @@ rec {
     );
 
   acejump = buildEclipsePlugin rec {
-    name = "acejump-${version}";
+    pname = "acejump";
     version = "1.0.0.201610261941";
 
     srcFeature = fetchurl {
@@ -142,7 +145,7 @@ rec {
   };
 
   ansi-econsole = buildEclipsePlugin rec {
-    name = "ansi-econsole-${version}";
+    pname = "ansi-econsole";
     version = "1.3.5.201612301822";
 
     srcFeature = fetchurl {
@@ -165,17 +168,18 @@ rec {
   };
 
   antlr-runtime_4_5 = buildEclipsePluginBase rec {
-    name = "antlr-runtime-4.5.3";
+    pname = "antlr-runtime";
+    version = "4.5.3";
 
     src = fetchurl {
-      url = "https://www.antlr.org/download/${name}.jar";
+      url = "https://www.antlr.org/download/${pname}-${version}.jar";
       sha256 = "0lm78i2annlczlc2cg5xvby0g1dyl0sh1y5xc2pymjlmr67a1g4k";
     };
 
     buildCommand = ''
       dropinDir="$out/eclipse/dropins/"
       mkdir -p $dropinDir
-      cp -v $src $dropinDir/${name}.jar
+      cp -v $src $dropinDir/${pname}-${version}.jar
     '';
 
     meta = {
@@ -188,17 +192,18 @@ rec {
   };
 
   antlr-runtime_4_7 = buildEclipsePluginBase rec {
-    name = "antlr-runtime-4.7.1";
+    pname = "antlr-runtime";
+    version = "4.7.1";
 
     src = fetchurl {
-      url = "https://www.antlr.org/download/${name}.jar";
+      url = "https://www.antlr.org/download/${pname}-${version}.jar";
       sha256 = "07f91mjclacrvkl8a307w2abq5wcqp0gcsnh0jg90ddfpqcnsla3";
     };
 
     buildCommand = ''
       dropinDir="$out/eclipse/dropins/"
       mkdir -p $dropinDir
-      cp -v $src $dropinDir/${name}.jar
+      cp -v $src $dropinDir/${pname}-${version}.jar
     '';
 
     meta = {
@@ -211,7 +216,7 @@ rec {
   };
 
   anyedittools = buildEclipsePlugin rec {
-    name = "anyedit-${version}";
+    pname = "anyedit";
     version = "2.7.3.202502241151";
 
     srcFeature = fetchurl {
@@ -234,7 +239,7 @@ rec {
   };
 
   autodetect-encoding = buildEclipsePlugin rec {
-    name = "autodetect-encoding-${version}";
+    pname = "autodetect-encoding";
     version = "1.8.5.201801191359";
 
     srcFeature = fetchurl {
@@ -257,13 +262,13 @@ rec {
   };
 
   cdt = buildEclipseUpdateSite rec {
-    name = "cdt-${version}";
+    pname = "cdt";
     # find current version at https://github.com/eclipse-cdt/cdt/releases
     version = "11.4.0";
 
     src = fetchzip {
       stripRoot = false;
-      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/tools/cdt/releases/${lib.versions.majorMinor version}/${name}/${name}.zip";
+      url = "https://www.eclipse.org/downloads/download.php?r=1&nf=1&file=/tools/cdt/releases/${lib.versions.majorMinor version}/${pname}-${version}/${pname}-${version}.zip";
       hash = "sha256-39AoB5cKRQMFpRaOlrTEsyEKZYVqdTp1tMtlaDjjZ84=";
     };
 
@@ -278,7 +283,7 @@ rec {
   };
 
   checkstyle = buildEclipseUpdateSite rec {
-    name = "checkstyle-${version}";
+    pname = "checkstyle";
     version = "8.7.0.201801131309";
 
     src = fetchzip {
@@ -298,7 +303,7 @@ rec {
   };
 
   color-theme = buildEclipsePlugin rec {
-    name = "color-theme-${version}";
+    pname = "color-theme";
     version = "1.0.0.201410260308";
 
     srcFeature = fetchurl {
@@ -321,7 +326,7 @@ rec {
   };
 
   cup = buildEclipsePlugin rec {
-    name = "cup-${version}";
+    pname = "cup";
     version = "1.1.0.201604221613";
     version_ = "1.0.0.201604221613";
 
@@ -354,7 +359,7 @@ rec {
   };
 
   drools = buildEclipseUpdateSite rec {
-    name = "drools-${version}";
+    pname = "drools";
     version = "7.17.0.Final";
 
     src = fetchzip {
@@ -378,8 +383,8 @@ rec {
     };
   };
 
-  eclemma = buildEclipseUpdateSite rec {
-    name = "eclemma-${version}";
+  eclemma = buildEclipseUpdateSite {
+    pname = "eclemma";
     version = "2.3.2.201409141915";
 
     src = fetchzip {
@@ -398,7 +403,7 @@ rec {
   };
 
   findbugs = buildEclipsePlugin rec {
-    name = "findbugs-${version}";
+    pname = "findbugs";
     version = "3.0.1.20150306-5afe4d1";
 
     srcFeature = fetchurl {
@@ -421,7 +426,7 @@ rec {
   };
 
   freemarker = buildEclipseUpdateSite rec {
-    name = "freemarker-${version}";
+    pname = "freemarker";
     version = "1.5.305";
 
     src = fetchzip {
@@ -438,7 +443,7 @@ rec {
   };
 
   embed-cdt = buildEclipseUpdateSite rec {
-    name = "embed-cdt-${version}";
+    pname = "embed-cdt";
     version = "6.3.1";
 
     src = fetchzip {
@@ -459,7 +464,7 @@ rec {
   gnuarmeclipse = embed-cdt; # backward compat alias, added 2022-11-04
 
   jsonedit = buildEclipsePlugin rec {
-    name = "jsonedit-${version}";
+    pname = "jsonedit";
     version = "1.1.1";
 
     srcFeature = fetchurl {
@@ -519,7 +524,7 @@ rec {
   };
 
   jdt-codemining = buildEclipsePlugin rec {
-    name = "jdt-codemining-${version}";
+    pname = "jdt-codemining";
     version = "1.0.0.201806221018";
 
     srcFeature = fetchurl {
@@ -542,7 +547,7 @@ rec {
   };
 
   rustdt = buildEclipseUpdateSite rec {
-    name = "rustdt-${version}";
+    pname = "rustdt";
     version = "0.6.2";
     owner = "RustDT";
     repo = "rustdt.github.io";
@@ -567,7 +572,7 @@ rec {
   };
 
   spotbugs = buildEclipseUpdateSite rec {
-    name = "spotbugs-${version}";
+    pname = "spotbugs";
     version = "3.1.11";
 
     src = fetchzip {
@@ -586,7 +591,7 @@ rec {
   };
 
   testng = buildEclipsePlugin rec {
-    name = "testng-${version}";
+    pname = "testng";
     version = "6.9.13.201609291640";
 
     srcFeature = fetchurl {
@@ -609,7 +614,7 @@ rec {
   };
 
   vrapper = buildEclipseUpdateSite rec {
-    name = "vrapper-${version}";
+    pname = "vrapper";
     version = "0.72.0";
     owner = "vrapper";
     repo = "vrapper";
@@ -632,7 +637,7 @@ rec {
   };
 
   yedit = buildEclipsePlugin rec {
-    name = "yedit-${version}";
+    pname = "yedit";
     version = "1.0.20.201509041456";
 
     srcFeature = fetchurl {
@@ -655,11 +660,11 @@ rec {
   };
 
   zest = buildEclipseUpdateSite rec {
-    name = "zest-${version}";
+    pname = "zest";
     version = "3.9.101";
 
     src = fetchurl {
-      url = "http://archive.eclipse.org/tools/gef/downloads/drops/${version}/R201408150207/GEF-${name}.zip";
+      url = "http://archive.eclipse.org/tools/gef/downloads/drops/${version}/R201408150207/GEF-${pname}-${version}.zip";
       sha256 = "01scn7cmcrjcp387spjm8ifgwrwwi77ypildandbisfvhj3qqs7m";
     };
 


### PR DESCRIPTION
Part of #485742

I'm not really sure if this is the best solution, but I feel like it's a bit better than the current one. Leaving this as a draft for now for some comments or better ideas. If this solution is good this way, it's probably good to include it in the release-notes.

Another option would be to just use the `name` attribute and set it again to `name = "...-${name}-${version}"` so the name attribute doesn't have to get replaced by `pluginName`. The same how it is in #486595. This still would require a separate version to be set as the version is currently in the name attribute. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
