### PR TITLE
vimPlugins.blink-cmp: 1.8.0 -> 1.9.0

### DIFF
--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/0001-pin-frizbee-0.6.0.patch
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/0001-pin-frizbee-0.6.0.patch
@@ -1,0 +1,29 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 35bb10e..71c79eb 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -144,9 +144,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+ [[package]]
+ name = "frizbee"
+-version = "0.7.0"
++version = "0.6.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "4d024031f1a5bc5f19917baa0b618f1067610e35ba23e9f105653fcb27e74f5c"
++checksum = "c3365720de81dac18e889afa72f5907aa061c975548da68e2400c056ebc94aec"
+ dependencies = [
+  "multiversion",
+  "rayon",
+diff --git a/Cargo.toml b/Cargo.toml
+index 392d1bb..c776c7d 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
+
+ [dependencies]
+ regex = "1.11.2"
+-frizbee = "0.7.0"
++frizbee = "0.6.0"
+ mlua = { version = "0.11.3", features = ["module", "luajit"] }
+ thiserror = "2.0.16"
+ blake3 = "1.8.2"

--- a/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/blink-cmp/default.nix
@@ -8,18 +8,24 @@
   gitMinimal,
 }:
 let
-  version = "1.8.0";
+  version = "1.9.0";
   src = fetchFromGitHub {
     owner = "Saghen";
     repo = "blink.cmp";
     tag = "v${version}";
-    hash = "sha256-JjlcPj7v9J+v1SDBYIub6jFEslLhZGHmsipV1atUAFo=";
+    hash = "sha256-fT3huB7R17/wdKjhpNHXYV/ngUX5X+wkHiGkC5HoY20=";
   };
   blink-fuzzy-lib = rustPlatform.buildRustPackage {
     inherit version src;
     pname = "blink-fuzzy-lib";
 
     cargoHash = "sha256-Qdt8O7IGj2HySb1jxsv3m33ZxJg96Ckw26oTEEyQjfs=";
+
+    # NOTE: The only change in frizbee 0.7.0 was nixpkgs incompatible rust semantic changes
+    # Patch just reverts https://github.com/saghen/blink.cmp/commit/cc824ec85b789a54d05241389993c6ab8c040810
+    cargoPatches = [
+      ./0001-pin-frizbee-0.6.0.patch
+    ];
 
     nativeBuildInputs = [ gitMinimal ];
 


### PR DESCRIPTION
Changelog: https://github.com/Saghen/blink.cmp/blob/v1.9.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

EDIT: Sorry, just ran updater and pushed branch during meeting. Looks like the rust lib build is failing. 
```
error[E0369]: no implementation for `Mask<i16, L> | Mask<i16, L>`
...
error[E0277]: the trait bound `LaneCount<L>: SupportedLaneCount` is not satisfied
...
```

~Assuming we are too far behind in rust toolchain for the recent frizbee  https://github.com/saghen/frizbee/pull/54 and need https://github.com/NixOS/nixpkgs/pull/483643~
Nvm... also get same errors on 1.93 version

Pinning `frizbee` to 0.6.0 which is the last version. Looks like we'll need a couple rust tooling updates before we can bump `frizbee`. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
