### PR TITLE
lima: mark as insecure if older than version 2.x

### DIFF
--- a/pkgs/by-name/li/lima/additional-guestagents.nix
+++ b/pkgs/by-name/li/lima/additional-guestagents.nix
@@ -7,12 +7,15 @@
   findutils,
 }:
 
+let
+  source = callPackage ./source.nix { };
+in
 buildGoModule (finalAttrs: {
   pname = "lima-additional-guestagents";
 
   # Because agents must use the same version as lima, lima's updateScript should also update the shared src.
   # nixpkgs-update: no auto update
-  inherit (callPackage ./source.nix { }) version src vendorHash;
+  inherit (source) version src vendorHash;
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     apple-sdk_15
@@ -56,8 +59,7 @@ buildGoModule (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  meta = {
-    homepage = "https://github.com/lima-vm/lima";
+  meta = source.meta // {
     description = "Lima Guest Agents for emulating non-native architectures";
     longDescription = ''
       This package should only be used when your guest's architecture differs from the host's.
@@ -71,8 +73,5 @@ buildGoModule (finalAttrs: {
 
       Typically, you won't need to directly add this package to your *.nix files.
     '';
-    changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.asl20;
-    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/li/lima/package.nix
+++ b/pkgs/by-name/li/lima/package.nix
@@ -20,10 +20,13 @@
   jq,
 }:
 
+let
+  source = callPackage ./source.nix { };
+in
 buildGoModule (finalAttrs: {
   pname = "lima";
 
-  inherit (callPackage ./source.nix { }) version src vendorHash;
+  inherit (source) version src vendorHash;
 
   nativeBuildInputs = [
     makeWrapper
@@ -158,13 +161,7 @@ buildGoModule (finalAttrs: {
     };
   };
 
-  meta = {
-    homepage = "https://github.com/lima-vm/lima";
+  meta = source.meta // {
     description = "Linux virtual machines with automatic file sharing and port forwarding";
-    changelog = "https://github.com/lima-vm/lima/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [
-      anhduy
-    ];
   };
 })

--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -21,6 +21,7 @@ in
   meta = {
     homepage = "https://github.com/lima-vm/lima";
     changelog = "https://github.com/lima-vm/lima/releases/tag/v${version}";
+    knownVulnerabilities = lib.optional (lib.versionOlder version "2") "Lima version ${version} is EOL. See https://lima-vm.io/docs/releases/.";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       anhduy

--- a/pkgs/by-name/li/lima/source.nix
+++ b/pkgs/by-name/li/lima/source.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   fetchFromGitHub,
 }:
 
@@ -16,4 +17,13 @@ in
   };
 
   vendorHash = "sha256-SeLYVQI+ZIbR9qVaNyF89VUvXdfv1M5iM+Cbas6e2E0=";
+
+  meta = {
+    homepage = "https://github.com/lima-vm/lima";
+    changelog = "https://github.com/lima-vm/lima/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      anhduy
+    ];
+  };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Lima 1.x reaches EOL at 2026-02-06.
I think we can merge this PR into `master`(Lima 2.x) now. But we should wait for the EOL date to merge the backport to `release-25.11`(Lima 1.x).

- https://github.com/NixOS/nixpkgs/pull/461178#issuecomment-3544386822
- https://lima-vm.io/docs/releases/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

cc: @voanhduy1512, @msgilligan