### PR TITLE
plezy: 1.14.1 -> 1.15.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17394,6 +17394,12 @@
     githubId = 66798382;
     name = "Sebastian Maximilian Scherthan";
   };
+  miniharinn = {
+    name = "Harinn";
+    github = "MiniHarinn";
+    githubId = 52773156;
+    email = "prinn.dev@pm.me";
+  };
   minijackson = {
     email = "minijackson@riseup.net";
     github = "minijackson";

--- a/pkgs/by-name/pl/plezy/git-hashes.json
+++ b/pkgs/by-name/pl/plezy/git-hashes.json
@@ -1,3 +1,3 @@
 {
-  "os_media_controls": "sha256-xfn4gzYTDe7sIsL4cqvX756+ZI9vR40Hr4FCyJXkGfs="
+  "os_media_controls": "sha256-6aM7C9KuF7we//yMUQ0SZ8o+5KQ9EP5sjkzwdghM4EQ="
 }

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -154,7 +154,10 @@ flutter338.buildFlutterApplication rec {
     homepage = "https://github.com/edde746/plezy";
     mainProgram = "plezy";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ mio ];
+    maintainers = with lib.maintainers; [
+      mio
+      miniharinn
+    ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/pl/plezy/package.nix
+++ b/pkgs/by-name/pl/plezy/package.nix
@@ -38,13 +38,13 @@ let
 in
 flutter338.buildFlutterApplication rec {
   pname = "plezy";
-  version = "1.14.1";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "edde746";
     repo = "plezy";
     tag = version;
-    hash = "sha256-KQahdzrn7Fu+rkp7uFpX6ZaA7mou4g1ZYLl7lWBzN/8=";
+    hash = "sha256-tFVaLfGANkcNYqwOJEQXQya52rMNMC4rJlqmrP7VhJ0=";
   };
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;

--- a/pkgs/by-name/pl/plezy/pubspec.lock.json
+++ b/pkgs/by-name/pl/plezy/pubspec.lock.json
@@ -576,6 +576,12 @@
       "source": "hosted",
       "version": "5.0.0"
     },
+    "flutter_localizations": {
+      "dependency": "transitive",
+      "description": "flutter",
+      "source": "sdk",
+      "version": "0.0.0"
+    },
     "flutter_plugin_android_lifecycle": {
       "dependency": "transitive",
       "description": {
@@ -838,6 +844,16 @@
       "source": "hosted",
       "version": "2.0.5"
     },
+    "intl": {
+      "dependency": "direct main",
+      "description": {
+        "name": "intl",
+        "sha256": "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5",
+        "url": "https://pub.dev"
+      },
+      "source": "hosted",
+      "version": "0.20.2"
+    },
     "io": {
       "dependency": "transitive",
       "description": {
@@ -867,16 +883,6 @@
       },
       "source": "hosted",
       "version": "0.0.1"
-    },
-    "json2yaml": {
-      "dependency": "transitive",
-      "description": {
-        "name": "json2yaml",
-        "sha256": "da94630fbc56079426fdd167ae58373286f603371075b69bf46d848d63ba3e51",
-        "url": "https://pub.dev"
-      },
-      "source": "hosted",
-      "version": "3.0.1"
     },
     "json_annotation": {
       "dependency": "direct main",
@@ -1042,8 +1048,8 @@
       "dependency": "direct main",
       "description": {
         "path": ".",
-        "ref": "60b3bbbe16773d3862253c97df4b1e0a3b1cd0d4",
-        "resolved-ref": "60b3bbbe16773d3862253c97df4b1e0a3b1cd0d4",
+        "ref": "6463fd18875ead347e739189b9687307f629f090",
+        "resolved-ref": "6463fd18875ead347e739189b9687307f629f090",
         "url": "https://github.com/edde746/os-media-controls"
       },
       "source": "git",
@@ -1479,31 +1485,31 @@
       "dependency": "direct main",
       "description": {
         "name": "slang",
-        "sha256": "a466773de768eb95bdf681e0a92e7c8010d44bb247b62130426c83ece33aeaed",
+        "sha256": "13e3b6f07adc51ab751e7889647774d294cbce7a3382f81d9e5029acfe9c37b2",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.32.0"
+      "version": "4.12.0"
     },
     "slang_build_runner": {
       "dependency": "direct dev",
       "description": {
         "name": "slang_build_runner",
-        "sha256": "b2e0c63f3c801a4aa70b4ca43173893d6eb7d5a421fc9d97ad983527397631b3",
+        "sha256": "453d74b5430153a3c4150d5ba8f6380e0785f3939f7511f10ac5b6cf9bb7d2a7",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.32.0"
+      "version": "4.12.0"
     },
     "slang_flutter": {
       "dependency": "direct main",
       "description": {
         "name": "slang_flutter",
-        "sha256": "1a98e878673996902fa5ef0b61ce5c245e41e4d25640d18af061c6aab917b0c7",
+        "sha256": "0a4545cca5404d6b7487cf61cf1fe56c52daeb08de56a7574ee8381fbad035a0",
         "url": "https://pub.dev"
       },
       "source": "hosted",
-      "version": "3.32.0"
+      "version": "4.12.0"
     },
     "source_gen": {
       "dependency": "transitive",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Release: https://github.com/edde746/plezy/releases/tag/1.15.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
