### PR TITLE
brewtarget: fix wrapper for non-gnome environments, add ilkecan to maintainers

### DIFF
--- a/pkgs/by-name/br/brewtarget/package.nix
+++ b/pkgs/by-name/br/brewtarget/package.nix
@@ -71,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       avnik
       mmahut
+      ilkecan
     ];
   };
 })

--- a/pkgs/by-name/br/brewtarget/package.nix
+++ b/pkgs/by-name/br/brewtarget/package.nix
@@ -10,7 +10,8 @@
   pkg-config,
   xercesc,
   xalanc,
-  qt6Packages,
+  qt6,
+  wrapGAppsHook3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,24 +41,33 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     ninja
     pkg-config
-    qt6Packages.wrapQtAppsHook
+    qt6.wrapQtAppsHook
+    wrapGAppsHook3
     pandoc
   ];
+
   buildInputs = [
     boost
-    qt6Packages.qtbase
-    qt6Packages.qttools
-    qt6Packages.qtmultimedia
-    qt6Packages.qtsvg
+    qt6.qtbase
+    qt6.qtmultimedia
+    qt6.qtsvg
+    qt6.qttools
     xercesc
     xalanc
   ];
 
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
   meta = {
     description = "Open source beer recipe creation tool";
     mainProgram = "brewtarget";
-    homepage = "http://www.brewtarget.org/";
+    homepage = "https://www.brewtarget.beer";
     license = lib.licenses.gpl3;
+    platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       avnik
       mmahut


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Without adding the `wrapGAppsHook3` hook, the program fails to start with the error:
```
...
(brewtarget:108700): GLib-GIO-ERROR **: 20:30:28.162: No GSettings schemas are installed on the system
```

See https://github.com/NixOS/nixpkgs/pull/341222, https://github.com/NixOS/nixpkgs/issues/181500, https://github.com/NixOS/nixpkgs/issues/263383 for the same problem with different packages.

---

Additionally I updated the `meta.homePage` according to the description of the source repository:
```
*** Please note that the up-to-date Brewtarget website is [www.brewtarget.beer](https://www.brewtarget.beer/). Latest Brewtarget releases are always here on [GitHub](https://github.com/Brewtarget/brewtarget/releases/latest). ***
```
and set `meta.platforms` (According to https://github.com/Brewtarget/brewtarget/wiki/Development:-Getting-Started, the program additionally supports Darwin and Windows).

Lastly I have added myself as another maintainer to help keep this package up to date. (see [this PR](https://github.com/NixOS/nixpkgs/pull/476845) for a version update that has been waiting for a month.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
