### PR TITLE
tcat: Add updateScript, convert to finalAttrs, drop with lib.maintainers

### DIFF
--- a/pkgs/by-name/tc/tcat/package.nix
+++ b/pkgs/by-name/tc/tcat/package.nix
@@ -2,25 +2,30 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "tcat";
   version = "1.0.0";
   src = fetchFromGitHub {
     owner = "rsc";
     repo = "tcat";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "1szzfz5xsx9l8gjikfncgp86hydzpvsi0y5zvikd621xkp7g7l21";
   };
   vendorHash = null;
   subPackages = ".";
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Table cat";
     homepage = "https://github.com/rsc/tcat";
-    maintainers = with lib.maintainers; [ mmlb ];
+    maintainers = [
+      lib.maintainers.mmlb
+    ];
     license = lib.licenses.bsd3;
     mainProgram = "tcat";
   };
-}
+})


### PR DESCRIPTION
Just some clean ups to the derivation.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
