### PR TITLE
gitstatus: Add updateScript and drop with lib.maintainers

### DIFF
--- a/pkgs/by-name/gi/gitstatus/package.nix
+++ b/pkgs/by-name/gi/gitstatus/package.nix
@@ -7,6 +7,7 @@
   zsh,
   zlib,
   runtimeShell,
+  nix-update-script,
 }:
 let
   romkatv_libgit2 = callPackage ./romkatv_libgit2.nix { };
@@ -120,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     inherit romkatv_libgit2;
+    updateScript = nix-update-script { };
   };
 
   meta = {
@@ -133,9 +135,9 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/romkatv/gitstatus";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [
-      mmlb
-      SuperSandro2000
+    maintainers = [
+      lib.maintainers.mmlb
+      lib.maintainers.SuperSandro2000
     ];
     platforms = lib.platforms.all;
     mainProgram = "gitstatusd";


### PR DESCRIPTION
Just some light clean ups to the derivation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
