### PR TITLE
maintainers: drop kiloreux

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13806,12 +13806,6 @@
     githubId = 20063;
     name = "Pascal Hertleif";
   };
-  kiloreux = {
-    email = "kiloreux@gmail.com";
-    github = "kiloreux";
-    githubId = 6282557;
-    name = "Kiloreux Emperex";
-  };
   kim0 = {
     email = "email.ahmedkamal@googlemail.com";
     github = "kim0";

--- a/pkgs/by-name/li/libaom/package.nix
+++ b/pkgs/by-name/li/libaom/package.nix
@@ -125,7 +125,6 @@ stdenv.mkDerivation rec {
     homepage = "https://aomedia.org/av1-features/get-started/";
     changelog = "https://aomedia.googlesource.com/aom/+/refs/tags/v${version}/CHANGELOG";
     maintainers = with lib.maintainers; [
-      kiloreux
       dandellion
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/op/opencore-amr/package.nix
+++ b/pkgs/by-name/op/opencore-amr/package.nix
@@ -17,6 +17,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Library of OpenCORE Framework implementation of Adaptive Multi Rate Narrowband and Wideband (AMR-NB and AMR-WB) speech codec.
     Library of VisualOn implementation of Adaptive Multi Rate Wideband (AMR-WB)";
     license = lib.licenses.asl20;
-    maintainers = [ lib.maintainers.kiloreux ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/perl-modules/ImageExifTool/default.nix
+++ b/pkgs/development/perl-modules/ImageExifTool/default.nix
@@ -60,7 +60,6 @@ buildPerlPackage rec {
       artistic2
     ];
     maintainers = with lib.maintainers; [
-      kiloreux
       anthonyroussel
     ];
     mainProgram = "exiftool";


### PR DESCRIPTION
No [PRs](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+author%3Akiloreux) or [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Akiloreux) since 2021 despite [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+-commenter%3Akiloreux+user-review-requested%3Akiloreux++created%3A%3E%3D2022-01-01). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@kiloreux if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
