### PR TITLE
nootka: Add updateScript and other clean ups

### DIFF
--- a/pkgs/by-name/no/nootka/package.nix
+++ b/pkgs/by-name/no/nootka/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   cmake,
   alsa-lib,
   fftwSinglePrec,
@@ -10,15 +10,19 @@
   libvorbis,
   soundtouch,
   qt5,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nootka";
+  # drop patch when updating to next release
   version = "2.0.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/nootka/nootka-${finalAttrs.version}-source.tar.bz2";
-    hash = "sha256-ZHdyLZ3+TCpQ77tcNuDlN2124qLDZu9DdH5x7RI1HIs=";
+  src = fetchFromGitHub {
+    owner = "SeeLook";
+    repo = "nootka";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-lRgFCPeIBefwsHMsE8eHLxT9GQUT0iUCyIrJz+mltp0=";
   };
 
   nativeBuildInputs = [
@@ -50,13 +54,15 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "cmake_minimum_required(VERSION 3.1.0)" "cmake_minimum_required(VERSION 3.10)"
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Application for practicing playing musical scores and ear training";
     mainProgram = "nootka";
     homepage = "https://nootka.sourceforge.io/";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [
-      mmlb
+    maintainers = [
+      lib.maintainers.mmlb
     ];
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
* Add updateScript
* Change to fetchFromGitHub, looks like development moved to GitHub
* Drop with lib.maintainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
