### PR TITLE
tokendiff: init at v0.1.1

### DIFF
--- a/pkgs/by-name/to/tokendiff/package.nix
+++ b/pkgs/by-name/to/tokendiff/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "tokendiff";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "dacharyc";
+    repo = "tokendiff";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-r0o3KViGTHlIcEcgFZO/PwYU4/s7+wGPuk6Crn/y9PU=";
+  };
+
+  vendorHash = "sha256-qGINKmwu0GttbYVMz8CLf9MAOBJZtcSFXsbq392cXBc=";
+
+  passthru.updateScript = nix-update-script { };
+  meta = {
+    description = "Go library/CLI for human-readable diffs";
+    mainProgram = "tokendiff";
+    homepage = "https://github.com/dacharyc/tokendiff";
+    maintainers = [
+      lib.maintainers.mmlb
+    ];
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
Add new package, https://github.com/dacharyc/tokendiff:

Go library/CLI for human-readable diffs - token-level comparison with configurable delimiters 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
