### PR TITLE
fritzing: fix wrapper for non-gnome environments

### DIFF
--- a/pkgs/by-name/fr/fritzing/package.nix
+++ b/pkgs/by-name/fr/fritzing/package.nix
@@ -9,6 +9,7 @@
   libngspice,
   libgit2,
   clipper,
+  wrapGAppsHook3,
 }:
 
 let
@@ -53,6 +54,7 @@ stdenv.mkDerivation {
     pkg-config
     qt6.qttools
     kdePackages.wrapQtAppsHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [
@@ -112,6 +114,12 @@ stdenv.mkDerivation {
     mv $out/bin/Fritzing.app $out/Applications/Fritzing.app
     cp FritzingInfo.plist $out/Applications/Fritzing.app/Contents/Info.plist
     makeWrapper $out/Applications/Fritzing.app/Contents/MacOS/Fritzing $out/bin/Fritzing
+  '';
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
 
   postFixup = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Without this change, clicking the "File -> Open" results in the following error:
```
(Fritzing:117857): GLib-GIO-ERROR **: 21:00:44.654: No GSettings schemas are installed on the system
```
See https://discourse.nixos.org/t/fritzing-no-gsettings-schemas-are-installed-on-the-system/64603 for more detail.

I encountered that Discourse topic while trying to fix the same problem for `brewtarget` and after finding the solutions (#486616), I decided to apply it for `fritzing` too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
