### PR TITLE
morphe-cli: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10467,6 +10467,11 @@
     githubId = 69494718;
     name = "Herschenglime";
   };
+  hetraeus = {
+    github = "hetraeus";
+    githubId = 4652857;
+    name = "Hetraeus";
+  };
   hexa = {
     email = "hexa@darmstadt.ccc.de";
     matrix = "@hexa:lossy.network";

--- a/pkgs/by-name/mo/morphe-cli/package.nix
+++ b/pkgs/by-name/mo/morphe-cli/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  jre,
+  libGL,
+  unzip,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttr: {
+  pname = "morphe-cli";
+  version = "1.8.0";
+
+  src = fetchurl {
+    url = "https://github.com/MorpheApp/morphe-cli/releases/download/v${finalAttr.version}/morphe-cli-${finalAttr.version}-all.jar";
+    hash = "sha256-4cqYKiBWJWuQg+UkuBMYRFS7SkEq1Dw+wMPihkuKVwQ=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    unzip
+    wrapGAppsHook3
+  ];
+  buildInputs = [
+    jre
+    libGL
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$prefix/bin" "$out/share/doc/${finalAttr.pname}"
+
+    makeWrapper ${jre}/bin/java $out/bin/morphe-cli \
+      --add-flags "-jar $src" \
+      --prefix PATH : "$PATH" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
+
+    unzip -p "$src" NOTICE > "$out/share/doc/${finalAttr.pname}/NOTICE"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command-line application that uses Morphe Patcher to patch Android apps";
+    homepage = "https://github.com/MorpheApp/morphe-cli";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    maintainers = [ lib.maintainers.hetraeus ];
+    mainProgram = "morphe-cli";
+  };
+})

--- a/pkgs/by-name/mo/morphe-cli/package.nix
+++ b/pkgs/by-name/mo/morphe-cli/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  jre,
+  libGL,
+  unzip,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttr: {
+  pname = "morphe-cli";
+  version = "1.9.0";
+
+  src = fetchurl {
+    url = "https://github.com/MorpheApp/morphe-cli/releases/download/v${finalAttr.version}/morphe-cli-${finalAttr.version}-all.jar";
+    hash = "sha256-cHxWaqqEqMY6Log6ccsep/VeHjwIjEJs0Gss0fl9Pmk=";
+  };
+
+  __structuredAttrs = true;
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+    unzip
+    wrapGAppsHook3
+  ];
+  buildInputs = [
+    jre
+    libGL
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$prefix/bin" "$out/share/doc/morphe-cli" "$out/share/morphe-cli"
+    install -Dm644 "$src" $out/share/morphe-cli.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/morphe-cli \
+      --add-flags "-jar $out/share/morphe-cli.jar" \
+      --prefix PATH : "${lib.makeBinPath [ ]}" \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ libGL ]}" \
+
+    unzip -p "$src" NOTICE > "$out/share/doc/morphe-cli/NOTICE"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Command-line application that uses Morphe Patcher to patch Android apps";
+    homepage = "https://github.com/MorpheApp/morphe-cli";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    maintainers = [ lib.maintainers.hetraeus ];
+    mainProgram = "morphe-cli";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

package.nix copied from revanced-cli. morphe-cli is a more vital revanced-cli fork.

- Built on platform:
  - [ x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ x ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
