### PR TITLE
angular-language-server: 20.3.0 -> 21.1.1

### DIFF
--- a/pkgs/by-name/an/angular-language-server/package.nix
+++ b/pkgs/by-name/an/angular-language-server/package.nix
@@ -13,14 +13,13 @@
   unzip,
   typescript,
 }:
-
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "angular-language-server";
-  version = "20.3.0";
+  version = "21.1.1";
   src = fetchurl {
     name = "angular-language-server-${finalAttrs.version}.zip";
-    url = "https://github.com/angular/vscode-ng-language-service/releases/download/v${finalAttrs.version}/ng-template.vsix";
-    hash = "sha256-o3e2qVKw/sfnFHbHHdRlB9UjEx1KLD1KVoaAsnlYjmY=";
+    url = "https://github.com/angular/angular/releases/download/vsix-${finalAttrs.version}/ng-template-${finalAttrs.version}.vsix";
+    hash = "sha256-o8NOyQOFnW/sabwvyeIYcOxtOz9sKsIHqRImkT1Mbzs=";
   };
 
   nativeBuildInputs = [
@@ -70,8 +69,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
         LATEST_VERSION=$(curl -H "Accept: application/vnd.github+json" \
             ''${GITHUB_TOKEN:+-H "Authorization: bearer $GITHUB_TOKEN"} \
-          -Lsf https://api.github.com/repos/angular/vscode-ng-language-service/releases/latest | \
-          jq -r .tag_name | cut -c 2-)
+          -Lsf https://api.github.com/repos/angular/angular/releases | \
+          jq -r '.[] | select(.tag_name | startswith("vsix-")) | .tag_name' | \
+          sort | \
+          tail -n 1 | \
+          cut -d '"' -f 2 | \
+          cut -c 6-)
         update-source-version angular-language-server "$LATEST_VERSION"
       '';
     });
@@ -79,9 +82,9 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   meta = {
     description = "LSP for angular completions, AOT diagnostic, quick info and go to definitions";
-    homepage = "https://github.com/angular/vscode-ng-language-service";
+    homepage = "https://github.com/angular/angular";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
-    changelog = "https://github.com/angular/vscode-ng-language-service/blob/${finalAttrs.version}/CHANGELOG.md";
+    changelog = "https://github.com/angular/angular/blob/${finalAttrs.version}/vscode-ng-language-service/CHANGELOG.md";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     mainProgram = "ngserver";


### PR DESCRIPTION
Resolves #484020 

This PR updates the Angular Language Server to Version `21.1.1`.

For Version `21` of Angular, they moved the language server into the main Angular Monorepo. The normal releases of Angular don't include the `.vsix` file, so we have to use the `vsix-*` Version Tags from now own, that do include the `vsix` file.

I am not really happy with the way i get the next version number in the update script. I can't use the latest release as before because the main angular version is not necessarily the same as the language server version. For example, right now angular v21.1.2 is just released, but without the language server, so its latest version is v21.1.1. Also, the language server releases are prefixed with `vsix-*`. I am not a bash expert and would love to make changes to the way I extract the Version number and get the latest tag in the first place. How I did it now just *feels* a little hacky and brittle, but it works (tested it by manually setting the version back to 21.1.0 and running the update script).

CHANGELOG: https://github.com/angular/angular/blob/vsix-21.1.1/vscode-ng-language-service/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
