### PR TITLE
python3Packages.{autopage,python-openstackclient}: fixes (including python 3.14)

### DIFF
--- a/pkgs/development/python-modules/autopage/default.nix
+++ b/pkgs/development/python-modules/autopage/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
@@ -28,6 +29,11 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
   ]
   ++ fixtures.optional-dependencies.streams;
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # https://github.com/zaneb/autopage/issues/7
+    "test_end_to_end"
+  ];
 
   pythonImportsCheck = [ "autopage" ];
 

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   ddt,
   openstackdocstheme,
   osc-lib,
@@ -37,12 +37,14 @@ buildPythonPackage rec {
   version = "8.3.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "python_openstackclient";
-    inherit version;
-    hash = "sha256-zHsy5F8Lju2SFeAhiuoCUmYZpeewaCsngXaRNK/Xb/g=";
+  src = fetchFromGitHub {
+    owner = "openstack";
+    repo = "python-openstackclient";
+    tag = version;
+    hash = "sha256-CEz1v4e4NadSZ+qhotFtLB4y/KdhDZbDOohN8D9FB30=";
   };
 
+  env.PBR_VERSION = version;
   build-system = [
     openstackdocstheme
     setuptools
@@ -107,7 +109,8 @@ buildPythonPackage rec {
   meta = {
     description = "OpenStack Command-line Client";
     mainProgram = "openstack";
-    homepage = "https://github.com/openstack/python-openstackclient";
+    homepage = "https://opendev.org/openstack/python-openstackclient";
+    downloadPage = "https://github.com/openstack/python-openstackclient";
     license = lib.licenses.asl20;
     teams = [ lib.teams.openstack ];
   };

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -45,6 +45,7 @@ buildPythonPackage rec {
   };
 
   env.PBR_VERSION = version;
+
   build-system = [
     openstackdocstheme
     setuptools
@@ -70,10 +71,11 @@ buildPythonPackage rec {
     stestr
   ];
 
+  # test_module failures under python 3.14: https://bugs.launchpad.net/python-openstackclient/+bug/2137223
   checkPhase = ''
     runHook preCheck
     stestr run -E \
-      "openstackclient.tests.unit.volume.v3.test_volume.(TestVolumeCreate|TestVolumeShow)"
+      "openstackclient.tests.unit.(volume.v3.test_volume.(TestVolumeCreate|TestVolumeShow)|common.test_module.TestModuleList)"
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -111,7 +111,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "OpenStack Command-line Client";
     mainProgram = "openstack";
-    homepage = "https://opendev.org/openstack/python-openstackclient";
+    homepage = "https://docs.openstack.org/python-openstackclient/latest/";
     downloadPage = "https://github.com/openstack/python-openstackclient/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     teams = [ lib.teams.openstack ];

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -32,7 +32,7 @@
   testers,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-openstackclient";
   version = "8.3.0";
   pyproject = true;
@@ -40,11 +40,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "openstack";
     repo = "python-openstackclient";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-CEz1v4e4NadSZ+qhotFtLB4y/KdhDZbDOohN8D9FB30=";
   };
 
-  env.PBR_VERSION = version;
+  env.PBR_VERSION = finalAttrs.version;
 
   build-system = [
     openstackdocstheme
@@ -112,8 +112,8 @@ buildPythonPackage rec {
     description = "OpenStack Command-line Client";
     mainProgram = "openstack";
     homepage = "https://opendev.org/openstack/python-openstackclient";
-    downloadPage = "https://github.com/openstack/python-openstackclient";
+    downloadPage = "https://github.com/openstack/python-openstackclient/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     teams = [ lib.teams.openstack ];
   };
-}
+})


### PR DESCRIPTION
### python-openstackclient

ref: https://github.com/NixOS/nixpkgs/issues/475732#issuecomment-3841121849

1. Build from Github source
2. Disable broken tests on Pythonn 3.14, see https://bugs.launchpad.net/python-openstackclient/+bug/2137223
3. Migrate to `finalAttrs`

### autopage

Disable broken test on Darwin, see https://github.com/zaneb/autopage/issues/7

Tracking: #475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
