### PR TITLE
lingeling: 708beb26 -> 1.0.0

### DIFF
--- a/pkgs/by-name/li/lingeling/package.nix
+++ b/pkgs/by-name/li/lingeling/package.nix
@@ -5,16 +5,15 @@
   aiger,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation rec {
   pname = "lingeling";
-  # This is the version used in satcomp2020
-  version = "pre1_708beb26";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "arminbiere";
     repo = "lingeling";
-    rev = "708beb26a7d5b5d5e7abd88d6f552fb1946b07c1";
-    sha256 = "1lb2g37nd8qq5hw5g6l691nx5095336yb2zlbaw43mg56hkj8357";
+    tag = "rel-${version}";
+    hash = "sha256-gVFznoptP9Ukux+1jbUpXZDPbc45EAdQ4UyeaD2cX0M=";
   };
 
   patches = [


### PR DESCRIPTION
This upgrades to a post-satcomp2022 version, with an actual release even!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
