### PR TITLE
maintainers: drop andrewrk

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1744,12 +1744,6 @@
     matrix = "@andrew:kvalhe.im";
     name = "Andrew Kvalheim";
   };
-  andrewrk = {
-    email = "superjoe30@gmail.com";
-    github = "andrewrk";
-    githubId = 106511;
-    name = "Andrew Kelley";
-  };
   andrewzah = {
     name = "Andrew Zah";
     github = "andrewzah";

--- a/pkgs/by-name/li/libebur128/package.nix
+++ b/pkgs/by-name/li/libebur128/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Implementation of the EBU R128 loudness standard";
     homepage = "https://github.com/jiixyj/libebur128";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.andrewrk ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/li/liblaxjson/package.nix
+++ b/pkgs/by-name/li/liblaxjson/package.nix
@@ -29,6 +29,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
-    maintainers = [ lib.maintainers.andrewrk ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/li/libsoundio/package.nix
+++ b/pkgs/by-name/li/libsoundio/package.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://libsound.io/";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
-    maintainers = [ lib.maintainers.andrewrk ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/rh/rhash/package.nix
+++ b/pkgs/by-name/rh/rhash/package.nix
@@ -55,6 +55,6 @@ stdenv.mkDerivation rec {
     description = "Console utility and library for computing and verifying hash sums of files";
     license = lib.licenses.bsd0;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ andrewrk ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/wo/wolfebin/package.nix
+++ b/pkgs/by-name/wo/wolfebin/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/thejoshwolfe/wolfebin";
     description = "Quick and easy file sharing";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ andrewrk ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -175,7 +175,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://ziglang.org/";
     changelog = "https://ziglang.org/download/${finalAttrs.version}/release-notes.html";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ andrewrk ];
+    maintainers = [ ];
     teams = [ lib.teams.zig ];
     mainProgram = "zig";
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Aandrewrk) since 2024 despite [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+-commenter%3Aandrewrk+user-review-requested%3Aandrewrk++created%3A%3E%3D2025-01-01). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@andrewrk if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
