### PR TITLE
doc/doc-support/options-doc: use resolveDefaultNix in declStr

### DIFF
--- a/doc/doc-support/options-doc.nix
+++ b/doc/doc-support/options-doc.nix
@@ -12,10 +12,10 @@ let
   transformDeclaration =
     decl:
     let
-      declStr = toString decl;
-      subpath = lib.removePrefix "/" (lib.removePrefix root declStr);
+      resolvedDeclStr = toString (lib.filesystem.resolveDefaultNix decl);
+      subpath = lib.removePrefix "/" (lib.removePrefix root resolvedDeclStr);
     in
-    assert lib.hasPrefix root declStr;
+    assert lib.hasPrefix root resolvedDeclStr;
     {
       url = "https://github.com/NixOS/nixpkgs/blob/master/${subpath}";
       name = subpath;


### PR DESCRIPTION
Append "default.nix" to `declStr` when it points to a directory. Some options are declared inside "default.nix" files but imported by referencing their directory rather than the full file path, which previously caused those declarations to be not transformed correctly.


The full list of incorrect declaration references that I found at https://nixos.org/manual/nixos/unstable/options:

<details>
<summary>134 items</summary>

<details>
<summary>script</summary>

```js
const anchors = Array.from(document.querySelectorAll('a.filename[target="_top"]'));

const items = anchors
  .filter(a => !a.href.endsWith(".nix"))
  .map(a => {
    const container = a.parentElement.parentElement.parentElement.parentElement.parentElement.parentElement;
    const prevElement = container?.previousElementSibling;
    const path = prevElement ? prevElement.textContent.trim() : "unknown path";

    return `- \${a.href} (${path})`;
  });

const markdown = items.join("\n");

const spoilerBlock = `<details>\n<summary>...</summary>\n\n${markdown}\n\n</details>`;

console.log(spoilerBlock);
```

</details>

- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/system/boot/loader/generic-extlinux-compatible (boot.loader.generic-extlinux-compatible.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/system/boot/loader/generic-extlinux-compatible (boot.loader.generic-extlinux-compatible.configurationLimit)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/system/boot/loader/generic-extlinux-compatible (boot.loader.generic-extlinux-compatible.mirroredBoots)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/system/boot/loader/generic-extlinux-compatible (boot.loader.generic-extlinux-compatible.mirroredBoots.*.path)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/system/boot/loader/generic-extlinux-compatible (boot.loader.generic-extlinux-compatible.populateCmd)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/system/boot/loader/generic-extlinux-compatible (boot.loader.generic-extlinux-compatible.useGenerationDeviceTree)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/hardware/facter/graphics (hardware.facter.detected.boot.graphics.kernelModules)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/hardware/facter/networking (hardware.facter.detected.dhcp.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/hardware/facter/networking (hardware.facter.detected.dhcp.interfaces)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/hardware/facter/fingerprint (hardware.facter.detected.fingerprint.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/hardware/facter/graphics (hardware.facter.detected.graphics.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/hardware/facter (hardware.facter.report)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/hardware/facter (hardware.facter.reportPath)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.enable-hooks)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.csv-files)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.device-name-strategy)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.disable-hooks)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.discovery-mode)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.extraArgs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.mount-nvidia-docker-1-directories)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.mount-nvidia-executables)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.mounts)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.mounts.*.containerPath)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.mounts.*.hostPath)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.mounts.*.mountOptions)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/hardware/nvidia-container-toolkit (hardware.nvidia-container-toolkit.suppressNvidiaDriverAssertion)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/programs/foot (programs.foot.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/programs/foot (programs.foot.enableBashIntegration)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/programs/foot (programs.foot.enableFishIntegration)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/programs/foot (programs.foot.enableZshIntegration)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/programs/foot (programs.foot.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/programs/foot (programs.foot.settings)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/programs/foot (programs.foot.theme)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.acceptTerms)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.enableDebugLogs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.credentialFiles)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.csr)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.csrKey)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.directory)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.dnsPropagationCheck)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.dnsProvider)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.dnsResolver)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.domain)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.email)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.environmentFile)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.extraDomainNames)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.extraLegoFlags)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.extraLegoRenewFlags)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.extraLegoRunFlags)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.group)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.inheritDefaults)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.keyType)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.listenHTTP)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.ocspMustStaple)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.postRun)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.profile)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.reloadServices)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.renewInterval)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.s3Bucket)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.server)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.validMinDays)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.certs.\<name>.webroot)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.enableDebugLogs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.credentialFiles)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.dnsPropagationCheck)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.dnsProvider)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.dnsResolver)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.email)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.environmentFile)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.extraLegoFlags)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.extraLegoRenewFlags)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.extraLegoRunFlags)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.group)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.keyType)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.listenHTTP)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.ocspMustStaple)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.postRun)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.profile)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.reloadServices)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.renewInterval)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.server)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.validMinDays)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.defaults.webroot)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.maxConcurrentRenewals)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/acme (security.acme.useRoot)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/krb5 (security.krb5.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/krb5 (security.krb5.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/krb5 (security.krb5.settings)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/krb5 (security.krb5.settings.include)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/krb5 (security.krb5.settings.includedir)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/security/krb5 (security.krb5.settings.module)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/firewalld (services.firewalld.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/firewalld (services.firewalld.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/firewalld (services.firewalld.packages)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/firewalld (services.firewalld.extraArgs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.extraArgs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.gc.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.gc.dates)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.gc.extraArgs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.group)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.nrBuildUsers)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.publish.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.publish.extraArgs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.publish.generateKeyPair)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.publish.port)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.publish.user)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.stateDir)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.storeDir)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.substituters.authorizedKeys)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/guix (services.guix.substituters.urls)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/security/howdy (services.howdy.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/security/howdy (services.howdy.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/security/howdy (services.howdy.control)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/security/howdy (services.howdy.settings)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.bundle.appName)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.bundle.domain)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.bundle.executable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.bundle.publicScript)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.bundle.secretScript)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.globalKeterConfig)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.globalKeterConfig.ip-from-header)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.globalKeterConfig.listeners)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.globalKeterConfig.listeners.*.host)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.globalKeterConfig.listeners.*.port)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.globalKeterConfig.rotate-logs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/web-servers/keter (services.keter.root)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.allowConfigWrite)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.configFile)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.group)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.openFirewall)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.secretFiles)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.enable_https)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.bandwidth_max)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.bandwidth_perc)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.cache_limit)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.email_endjob)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.email_from)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.email_full)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.email_rss)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.email_server)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.email_to)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.host)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.html_login)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.https_cert)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.https_key)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.inet_exposure)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.misc.port)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.ntfosd)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.ntfosd.ntfosd_enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.connections)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.displayname)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.expire_date)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.host)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.name)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.optional)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.port)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.priority)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.required)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.ssl)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.ssl_verify)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.settings.servers.\<name>.timeout)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.stateDir)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/networking/sabnzbd (services.sabnzbd.user)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.allowedClientIDs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.ciphers)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.config)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.confirmation)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.dataDir)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.debug)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.disallowedClientIDs)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.extensions)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.fqdn)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.group)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.ipLog)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.listenHost)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.listenPort)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.openFirewall)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.organisations)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.organisations.\<name>.groups)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.organisations.\<name>.users)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.auto.bits)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.auto.expiration.ca)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.auto.expiration.client)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.auto.expiration.crl)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.auto.expiration.server)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.manual.ca.cert)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.manual.server.cert)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.manual.server.crl)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.pki.manual.server.key)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.queueSize)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.requestLimit)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.trust)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/taskserver (services.taskserver.user)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/tee-supplicant (services.tee-supplicant.enable)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/tee-supplicant (services.tee-supplicant.package)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/tee-supplicant (services.tee-supplicant.pluginPath)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/tee-supplicant (services.tee-supplicant.reeFsParentPath)
- https://github.com/NixOS/nixpkgs/blob/release-26.05/nixos/modules/services/misc/tee-supplicant (services.tee-supplicant.trustedApplications)

</details>

Should I make similar changes in https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/tr/treefmt/options-doc.nix ?

---

This means that for these 134 items the declaration path is broken without this change, as shown in the screenshot:
<img width="1511" height="409" alt="image" src="https://github.com/user-attachments/assets/f398df11-de79-4f38-ac11-2261ebb160c8" />
