### PR TITLE
doc: update references to `nixfmt-rfc-style` to `treefmt`

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -2136,7 +2136,7 @@ The following rules are desired to be respected:
 * `pythonImportsCheck` is set. This is still a good smoke test even if `pytestCheckHook` is set.
 * `meta.platforms` takes the default value in many cases.
   It does not need to be set explicitly unless the package requires a specific platform.
-* The file is formatted with `nixfmt-rfc-style`.
+* The file is formatted correctly (e.g., `nix-shell --run treefmt`).
 * Commit names of Python libraries must reflect that they are Python
   libraries (e.g. `python3Packages.numpy: 1.11 -> 1.12` rather than `numpy: 1.11 -> 1.12`).
   See also [`pkgs/README.md`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#commit-conventions).

--- a/pkgs/applications/editors/vscode/extensions/README.md
+++ b/pkgs/applications/editors/vscode/extensions/README.md
@@ -7,7 +7,7 @@
 
 * When adding a new extension, place its definition in a `default.nix` file in a directory with the extension's ID (e.g. `publisher.extension-name/default.nix`) and refer to it in `./default.nix`, e.g. `publisher.extension-name = callPackage ./publisher.extension-name { };`.
 
-* Currently `nixfmt-rfc-style` formatter is being used to format the VSCode extensions.
+* Use `nix-shell --run treefmt` to format the VSCode extensions.
 
 * Respect `alphabetical order` whenever adding extensions. If out of order, please kindly open a PR re-establishing the order.
 

--- a/pkgs/by-name/ni/nixfmt-tree/package.nix
+++ b/pkgs/by-name/ni/nixfmt-tree/package.nix
@@ -95,7 +95,7 @@ treefmtWithConfig.overrideAttrs {
       You can achieve similar results by manually configuring `treefmt`:
       ```nix
       pkgs.treefmt.withConfig {
-        runtimeInputs = [ pkgs.nixfmt-rfc-style ];
+        runtimeInputs = [ pkgs.nixfmt ];
 
         settings = {
           # Log level for files treefmt won't format

--- a/pkgs/development/lisp-modules/import/main.lisp
+++ b/pkgs/development/lisp-modules/import/main.lisp
@@ -49,7 +49,7 @@
           (truename "imported.nix")))
 
 (defun run-nix-formatter ()
-  (uiop:run-program '("nixfmt" "imported.nix")))
+  (uiop:run-program '("treefmt" "imported.nix")))
 
 (defun main ()
   (format t "~%")

--- a/pkgs/development/lisp-modules/shell.nix
+++ b/pkgs/development/lisp-modules/shell.nix
@@ -1,10 +1,12 @@
 let
-  pkgs = import ../../../. { };
-  inherit (pkgs) mkShellNoCC sbcl nixfmt-rfc-style;
+  # Use CI-pinned (Hydra-cached) packages and formatter,
+  # rather than the local nixpkgs checkout.
+  inherit (import ../../../ci { }) pkgs fmt;
+  inherit (pkgs) mkShellNoCC sbcl;
 in
 mkShellNoCC {
   packages = [
-    nixfmt-rfc-style
+    fmt.pkg
     (sbcl.withPackages (
       ps:
       builtins.attrValues {


### PR DESCRIPTION
This completes https://github.com/NixOS/nixpkgs/issues/425583.

Rather than putting `nixfmt` everywhere, I opted to teach people to use `treefmt` instead. This is more correct, as we have formatting rules for non-nix files, and also may invoke `nixfmt` with non-default options.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
