### PR TITLE
cxxtest: migrate to by-name, fix no module named cxxtest

### DIFF
--- a/pkgs/by-name/cx/cxxtest/package.nix
+++ b/pkgs/by-name/cx/cxxtest/package.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  ply,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "cxxtest";
   version = "4.4";
   format = "setuptools";
@@ -19,7 +18,7 @@ buildPythonApplication rec {
 
   sourceRoot = "${src.name}/python";
 
-  nativeCheckInputs = [ ply ];
+  nativeCheckInputs = [ python3Packages.ply ];
 
   preCheck = ''
     cd ../
@@ -40,8 +39,6 @@ buildPythonApplication rec {
     mkdir -p "$out/include"
     cp -r ../../cxxtest "$out/include"
   '';
-
-  dontWrapPythonPrograms = true;
 
   meta = {
     homepage = "https://github.com/CxxTest/cxxtest";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6366,8 +6366,6 @@ with pkgs;
     ssl_implementation = mbedtls_2;
   };
 
-  cxxtest = python3Packages.callPackage ../development/libraries/cxxtest { };
-
   # Make bdb5 the default as it is the last release under the custom
   # bsd-like license
   db = db5;


### PR DESCRIPTION
This pull request updates the packaging of the `cxxtest` Python application to use the standardized `by-name` directory structure and modernizes its dependencies. The changes ensure better maintainability and consistency with current Nixpkgs conventions.

**Migration and packaging improvements:**

* Renamed and relocated the package definition from `pkgs/development/libraries/cxxtest/default.nix` to `pkgs/by-name/cx/cxxtest/package.nix`, aligning with the new `by-name` directory structure.

* Updated the build process to use `python3Packages.buildPythonApplication` instead of the generic `buildPythonApplication`, and replaced the direct `ply` dependency with `python3Packages.ply` for consistency with Python packaging best practices. 

**Top-level package configuration:**

* Removed the old `cxxtest` entry from `pkgs/top-level/all-packages.nix`, reflecting the migration to the new packaging approach.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
