### PR TITLE
dcnnt: use PEP517, modernize 

### DIFF
--- a/pkgs/by-name/dc/dcnnt/package.nix
+++ b/pkgs/by-name/dc/dcnnt/package.nix
@@ -7,14 +7,18 @@
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "dcnnt";
   version = "0.10.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit (finalAttrs) pname version;
     hash = "sha256-73ZLgb5YcXlAOjbKLVv8oqgS6pstBdJxa7LFUgIHpUE=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = with python3Packages; [
     pycryptodome
   ];
 


### PR DESCRIPTION
This pull request refactors the packaging for the `dcnnt` Python application to align with modern Nix packaging standards and improve maintainability. The main changes include moving the package to a new location, updating its build process to use `pyproject`, and switching to the `python3Packages` namespace for dependencies.

**Packaging refactor:**
* Renamed and relocated the `dcnnt` package from `pkgs/servers/dcnnt/default.nix` to `pkgs/by-name/dc/dcnnt/package.nix` for better organization.
* Updated the build process to use `python3Packages.buildPythonApplication` with `pyproject = true` and explicitly specified `build-system` and `dependencies` using the `python3Packages` namespace.
* Changed the function signature to use `finalAttrs` and updated the inheritance of `pname` and `version` accordingly.

**Nixpkgs maintenance:**
* Removed the old reference to `dcnnt` from `pkgs/top-level/all-packages.nix` to reflect the new package location and setup.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
