### PR TITLE
bogofilter: split into bogofilter-db and bogofilter-sqlite; fix bogoupgrade

### DIFF
--- a/pkgs/by-name/bo/bogofilter/package.nix
+++ b/pkgs/by-name/bo/bogofilter/package.nix
@@ -7,10 +7,14 @@
   makeWrapper,
   pax,
   perl,
+  database ? db,
 }:
 
+let
+  dbName = lib.getName database;
+in
 stdenv.mkDerivation (finalAttrs: {
-  pname = "bogofilter";
+  pname = "bogofilter-${dbName}";
   version = "1.2.5";
 
   src = fetchurl {
@@ -22,14 +26,23 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     flex
-    db
-    perl # required by bogoupgrade
+    database
+  ]
+  ++ lib.optional (dbName == "db") perl; # required by bogoupgrade
+
+  configureFlags = [
+    "--with-database=${dbName}"
   ];
 
   doCheck = false; # needs "y" tool
 
   postInstall = ''
     wrapProgram "$out/bin/bf_tar" --prefix PATH : "${lib.makeBinPath [ pax ]}"
+  ''
+  # Only supports upgrading through various db versions, not useful for
+  # other database types.
+  + lib.optionalString (dbName != "db") ''
+    rm "$out/bin/bogoupgrade"
   '';
 
   meta = {
@@ -42,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
       filter.
     '';
     license = lib.licenses.gpl2Plus;
+    mainProgram = "bogofilter";
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/bo/bogofilter/package.nix
+++ b/pkgs/by-name/bo/bogofilter/package.nix
@@ -6,6 +6,7 @@
   db,
   makeWrapper,
   pax,
+  perl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -22,6 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     flex
     db
+    perl # required by bogoupgrade
   ];
 
   doCheck = false; # needs "y" tool

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1590,6 +1590,9 @@ with pkgs;
 
   blockdiag = with python3Packages; toPythonApplication blockdiag;
 
+  bogofilter-sqlite = bogofilter.override { database = sqlite; };
+  bogofilter-db = bogofilter.override { database = db; };
+
   boomerang = libsForQt5.callPackage ../development/tools/boomerang { };
 
   bozohttpd-minimal = bozohttpd.override { minimal = true; };


### PR DESCRIPTION
Split the `bogofilter` package into `bogofilter-db` and `bogofilter-sqlite`, aliasing `bogofilter` to `bogofilter-db`. Users may also build with any of the supported databases (`kyotocabinet`, `lmdb`, `sqlite`, or `db`) by passing their preferred database as an override.

The next release (1.3.0) will switch to the sqlite backend by default so splitting now:

1. Gives users a chance to upgrade at their leisure before the default switches.
2. Gives users a way to explicitly stick with Berkeley DB (by switching to `bogofilter-db`.

For context, see the 1.3.0.rc1 [release announcement](https://www.bogofilter.org/pipermail/bogofilter-announce/2025/000191.html).

Additionally, this PR fixes bogoupgrade by adding a dependency on `perl`. It also _removes_ `bogoupgrade` from non-Berkley DB builds because it only supports upgrading Berkley DB databases.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
