### PR TITLE
snappy-switcher: init at 2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19839,6 +19839,12 @@
     name = "Oops418";
     githubId = 93655215;
   };
+  OpalAayan = {
+    email = "YougurtMyFace@proton.me";
+    github = "OpalAayan";
+    githubId = 169937134;
+    name = "OpalAayan";
+  };
   opeik = {
     email = "sandro@stikic.com";
     github = "opeik";

--- a/pkgs/by-name/sn/snappy-switcher/package.nix
+++ b/pkgs/by-name/sn/snappy-switcher/package.nix
@@ -63,11 +63,23 @@ stdenv.mkDerivation (finalAttrs: {
     # Install and wrap scripts
     install -m 755 scripts/snappy-wrapper.sh $out/bin/snappy-wrapper
     wrapProgram $out/bin/snappy-wrapper \
-      --prefix PATH : ${lib.makeBinPath [ coreutils gnugrep gnused ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
 
     install -m 755 scripts/install-config.sh $out/bin/snappy-install-config
     wrapProgram $out/bin/snappy-install-config \
-      --prefix PATH : ${lib.makeBinPath [ coreutils gnugrep gnused ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          gnugrep
+          gnused
+        ]
+      }
 
     runHook postInstall
   '';
@@ -77,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/OpalAayan/snappy-switcher";
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [OpalAayan];
+    maintainers = with lib.maintainers; [ OpalAayan ];
     mainProgram = "snappy-switcher";
   };
 })

--- a/pkgs/by-name/sn/snappy-switcher/package.nix
+++ b/pkgs/by-name/sn/snappy-switcher/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  wayland-scanner,
+  makeWrapper,
+  wayland,
+  wayland-protocols,
+  cairo,
+  pango,
+  json_c,
+  libxkbcommon,
+  glib,
+  librsvg,
+  gdk-pixbuf,
+  coreutils,
+  gnugrep,
+  gnused,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "snappy-switcher";
+  version = "2.0";
+
+  src = fetchFromGitHub {
+    owner = "OpalAayan";
+    repo = "snappy-switcher";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-yc9oQcEqbnx9GJhNiuvNT9ueUxFAYzQu4WKB9F+ywkE=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+    wayland-scanner
+    makeWrapper
+  ];
+
+  buildInputs = [
+    wayland
+    wayland-protocols
+    cairo
+    pango
+    json_c
+    libxkbcommon
+    glib
+    librsvg
+    gdk-pixbuf
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    mkdir -p $out/share/snappy-switcher/themes
+    mkdir -p $out/share/doc/snappy-switcher
+
+    install -m 755 snappy-switcher $out/bin/
+    install -m 644 themes/*.ini $out/share/snappy-switcher/themes/
+    install -m 644 config.ini.example $out/share/doc/snappy-switcher/
+    install -m 644 README.md $out/share/doc/snappy-switcher/
+
+    # Install and wrap scripts
+    install -m 755 scripts/snappy-wrapper.sh $out/bin/snappy-wrapper
+    wrapProgram $out/bin/snappy-wrapper \
+      --prefix PATH : ${lib.makeBinPath [ coreutils gnugrep gnused ]}
+
+    install -m 755 scripts/install-config.sh $out/bin/snappy-install-config
+    wrapProgram $out/bin/snappy-install-config \
+      --prefix PATH : ${lib.makeBinPath [ coreutils gnugrep gnused ]}
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Fast, animated Alt+Tab window switcher for Hyprland";
+    homepage = "https://github.com/OpalAayan/snappy-switcher";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [OpalAayan];
+    mainProgram = "snappy-switcher";
+  };
+})


### PR DESCRIPTION
snappy-switcher: init at 2.0

This PR introduces `snappy-switcher` version 2.0, a new Wayland-native window switcher designed primarily for the Hyprland compositor.

**Package Description:**
Snappy Switcher is a fast, keyboard-driven Alt+Tab replacement written in C. It features Most Recently Used (MRU) sorting, context-aware window grouping (by workspace and class), and custom styling via INI themes. It relies on standard Wayland protocols (`wlr-layer-shell`, `wlr-foreign-toplevel`) and Hyprland IPC.

**Homepage:** https://github.com/OpalAayan/snappy-switcher

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test