### PR TITLE
chickenPackages_4.egg2nix: set pname instead of name

### DIFF
--- a/pkgs/development/compilers/chicken/4/egg2nix.nix
+++ b/pkgs/development/compilers/chicken/4/egg2nix.nix
@@ -3,6 +3,7 @@
   eggDerivation,
   fetchFromGitHub,
   chickenEggs,
+  fetchpatch,
 }:
 
 # Note: This mostly reimplements the default.nix already contained in
@@ -18,6 +19,13 @@ eggDerivation rec {
     rev = version;
     sha256 = "sha256-5ov2SWVyTUQ6NHnZNPRywd9e7oIxHlVWv4uWbsNaj/s=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/the-kenny/egg2nix/commit/7d20ed520b8fe4debeefc78271c8c836015f95dc.patch";
+      hash = "sha256-emMnxu6HnpcDWcO7rAe0VOy2ZPfPhqj5bQv9foOkjY0=";
+    })
+  ];
 
   buildInputs = with chickenEggs; [
     matchable

--- a/pkgs/development/compilers/chicken/4/egg2nix.nix
+++ b/pkgs/development/compilers/chicken/4/egg2nix.nix
@@ -9,7 +9,7 @@
 # the tarball. Is there a nicer way than duplicating code?
 
 eggDerivation rec {
-  name = "egg2nix-${version}";
+  pname = "egg2nix";
   version = "0.5";
 
   src = fetchFromGitHub {

--- a/pkgs/development/compilers/chicken/4/eggDerivation.nix
+++ b/pkgs/development/compilers/chicken/4/eggDerivation.nix
@@ -5,7 +5,7 @@
   makeWrapper,
 }:
 {
-  name,
+  name ? "${args.pname}-${args.version}",
   src,
   buildInputs ? [ ],
   chickenInstallFlags ? [ ],

--- a/pkgs/development/compilers/chicken/4/eggs.nix
+++ b/pkgs/development/compilers/chicken/4/eggs.nix
@@ -1,9 +1,10 @@
-{ pkgs }:
+{ pkgs, stdenv }:
 rec {
   inherit (pkgs) eggDerivation fetchegg;
 
   base64 = eggDerivation {
-    name = "base64-3.3.1";
+    pname = "base64";
+    version = "3.3.1";
 
     src = fetchegg {
       name = "base64";
@@ -17,12 +18,13 @@ rec {
   };
 
   defstruct = eggDerivation {
-    name = "defstruct-1.6";
+    pname = "defstruct";
+    version = "1.7";
 
     src = fetchegg {
       name = "defstruct";
-      version = "1.6";
-      sha256 = "0lsgl32nmb5hxqiii4r3292cx5vqh50kp6v062nfiyid9lhrj0li";
+      version = "1.7";
+      sha256 = "1rkqk9jxd6vnlvkwzqg8mc7bsw050fgmxfj84y66lf0a14n5r5dg";
     };
 
     buildInputs = [
@@ -31,7 +33,8 @@ rec {
   };
 
   http-client = eggDerivation {
-    name = "http-client-0.18";
+    pname = "http-client";
+    version = "0.18";
 
     src = fetchegg {
       name = "http-client";
@@ -48,12 +51,13 @@ rec {
   };
 
   intarweb = eggDerivation {
-    name = "intarweb-1.7";
+    pname = "intarweb";
+    version = "1.7.1";
 
     src = fetchegg {
       name = "intarweb";
-      version = "1.7";
-      sha256 = "1arjgn5g4jfdzj3nlrhxk235qwf6k6jxr14yhnncnfbgdb820xp8";
+      version = "1.7.1";
+      sha256 = "0pqgwgy4jynlsr3l52qsiwm75qgs7n86kwssaawzp9y34y80awpg";
     };
 
     buildInputs = [
@@ -64,7 +68,8 @@ rec {
   };
 
   matchable = eggDerivation {
-    name = "matchable-3.7";
+    pname = "matchable";
+    version = "3.7";
 
     src = fetchegg {
       name = "matchable";
@@ -78,12 +83,13 @@ rec {
   };
 
   sendfile = eggDerivation {
-    name = "sendfile-1.8.3";
+    pname = "sendfile";
+    version = "1.11";
 
     src = fetchegg {
       name = "sendfile";
-      version = "1.8.3";
-      sha256 = "036x4xdndx7qly94afnag5b9idd1yymdm8d832w2cy054y7lxqsi";
+      version = "1.11";
+      sha256 = "15gm380asvj87f3bqb7rz4mz6znnk6r00rdy3njx9ay0qkxi3q9y";
     };
 
     buildInputs = [
@@ -92,7 +98,8 @@ rec {
   };
 
   simple-md5 = eggDerivation {
-    name = "simple-md5-0.0.1";
+    pname = "simple-md5";
+    version = "0.0.1";
 
     src = fetchegg {
       name = "simple-md5";
@@ -106,7 +113,8 @@ rec {
   };
 
   uri-common = eggDerivation {
-    name = "uri-common-1.4";
+    pname = "uri-common";
+    version = "1.4";
 
     src = fetchegg {
       name = "uri-common";
@@ -122,7 +130,8 @@ rec {
   };
 
   uri-generic = eggDerivation {
-    name = "uri-generic-2.46";
+    pname = "uri-generic";
+    version = "2.46";
 
     src = fetchegg {
       name = "uri-generic";


### PR DESCRIPTION
#485742
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
