### PR TITLE
tirith: init at 0.1.8

### DIFF
--- a/pkgs/by-name/ti/tirith/package.nix
+++ b/pkgs/by-name/ti/tirith/package.nix
@@ -1,0 +1,54 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  installShellFiles,
+  versionCheckHook,
+}:
+rustPlatform.buildRustPackage (final: {
+  pname = "tirith";
+  version = "0.1.8";
+  src = fetchFromGitHub {
+    owner = "sheeki03";
+    repo = "tirith";
+    tag = "v${final.version}";
+    hash = "sha256-B/NiA7tag66wCvJMCX8oNeDiJDZVdPgOg8dhSaIGAJs=";
+  };
+
+  cargoHash = "sha256-DKVuZuBQ1RAfcuwSdaTq4ke6qjTXe99kPcbPz25SCPM=";
+
+  cargoBuildFlags = [
+    "-p"
+    "tirith"
+  ];
+
+  checkFlags = [
+    # requires a fully functional shell environment, generating init scripts needs a patch under nix to work at build time
+    "--skip=init_bash_output"
+    "--skip=init_zsh_output"
+  ];
+
+  nativeBuildInputs = lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    installShellFiles
+  ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd tirith \
+      --bash <("$out/bin/tirith" completions bash) \
+      --zsh <("$out/bin/tirith" completions zsh) \
+      --fish <("$out/bin/tirith" completions fish)
+  '';
+
+  meta = {
+    description = "Shell security tool that guards against homograph URL attacks, pipe-to-shell exploits, and other command-line threats before they execute";
+    homepage = "https://github.com/sheeki03/tirith";
+    changelog = "https://github.com/sheeki03/tirith/blob/${final.src.tag}/CHANGELOG.md";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ toasteruwu ];
+    platforms = lib.platforms.unix;
+    mainProgram = "tirith";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added a new package for [tirtih](https://github.com/sheeki03/tirith)

2 tests require a patch to work at build time. The init scripts get created fine when the program is installed and used, but within the nix sandbox used for building they fail because they cant find the location to cache their init scripts at because they want write access to some location to save it, there is no subcommand to generate the init scripts without saving them via tirith itself.
This does not affect actual functionality, just the convenience of completions and the ability to run two tests.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
