### PR TITLE
esphome: allow user to configure state dir

### DIFF
--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -17,7 +17,9 @@ let
 
   cfg = config.services.esphome;
 
-  stateDir = "/var/lib/esphome";
+  defaultStateDir = "/var/lib/esphome";
+  stateDirIsDefault = cfg.stateDir == defaultStateDir; # use DynamicUser only if using default stateDir
+  stateDirInHome = lib.hasPrefix "/home/" cfg.stateDir; # disable ProtectHome if stateDir is in /home
 
   esphomeParams =
     if cfg.enableUnixSocket then
@@ -49,6 +51,13 @@ in
       type = types.port;
       default = 6052;
       description = "esphome port";
+    };
+
+    stateDir = mkOption {
+      type = types.path;
+      default = defaultStateDir;
+      example = "/persist/esphome";
+      description = "Directory which ESPHome uses for its project files and working state.";
     };
 
     openFirewall = mkOption {
@@ -92,18 +101,17 @@ in
 
       environment = {
         # platformio fails to determine the home directory when using DynamicUser
-        PLATFORMIO_CORE_DIR = "${stateDir}/.platformio";
+        PLATFORMIO_CORE_DIR = "${cfg.stateDir}/.platformio";
       }
       // lib.optionalAttrs cfg.usePing { ESPHOME_DASHBOARD_USE_PING = "true"; };
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} ${stateDir}";
-        DynamicUser = true;
+        ExecStart = "${cfg.package}/bin/esphome dashboard ${esphomeParams} ${cfg.stateDir}";
+        DynamicUser = stateDirIsDefault;
         User = "esphome";
         Group = "esphome";
-        WorkingDirectory = stateDir;
-        StateDirectory = "esphome";
-        StateDirectoryMode = "0750";
+        WorkingDirectory = cfg.stateDir;
+        ReadWritePaths = [ cfg.stateDir ];
         Restart = "on-failure";
         RuntimeDirectory = mkIf cfg.enableUnixSocket "esphome";
         RuntimeDirectoryMode = "0750";
@@ -120,7 +128,6 @@ in
         #PrivateTmp = true; # Implied by DynamicUser
         ProtectClock = true;
         ProtectControlGroups = true;
-        ProtectHome = true;
         ProtectHostname = false; # breaks bwrap
         ProtectKernelLogs = false; # breaks bwrap
         ProtectKernelModules = true;
@@ -144,7 +151,30 @@ in
           "@mount" # Required by platformio for chroot
         ];
         UMask = "0077";
+      }
+      // lib.optionalAttrs stateDirIsDefault {
+        StateDirectory = "esphome";
+        StateDirectoryMode = "0750";
+      }
+      // lib.optionalAttrs (!stateDirIsDefault) {
+        NoNewPrivileges = true;
+        RemoveIPC = true;
+      }
+      // lib.optionalAttrs (!stateDirInHome) {
+        ProtectHome = true;
       };
     };
+
+    users.groups.esphome = lib.mkIf (!stateDirIsDefault) { };
+    users.users.esphome = lib.mkIf (!stateDirIsDefault) {
+      isSystemUser = true;
+      group = "esphome";
+      home = cfg.stateDir;
+      description = "ESPHome dashboard user";
+    };
+
+    systemd.tmpfiles.rules = lib.mkIf (!stateDirIsDefault) [
+      "d '${cfg.stateDir}' 0750 esphome esphome - -"
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Hi!

I wanted to [erase my darlings](https://grahamc.com/blog/erase-your-darlings/) and noticed esphome used a hardcoded state dir. I changed this and added an option to the esphome service that allows the user to set a custom stateDir. I tested it with my esphome setup, it is backwards-compatible and I also added a condition to disable ProtectHome when the state dir is under `/home`. DynamicUser needs to be disabled for a different state dir than the default, and is conditionally disabled if the user changes this option. Otherwise, the behaviour stays as it was.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
