### PR TITLE
Revert "slurp: 1.5.0 -> 1.6.0"

### DIFF
--- a/pkgs/by-name/sl/slurp/package.nix
+++ b/pkgs/by-name/sl/slurp/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "slurp";
-  version = "1.6.0";
+  version = "1.5.0";
 
   src = fetchFromGitHub {
     owner = "emersion";
     repo = "slurp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-kH7K/ttTNYQ5im7YsJ28bLi8yKfWZ3HGEDOfTs22UR0=";
+    hash = "sha256-2M8f3kN6tihwKlUCp2Qowv5xD6Ufb71AURXqwQShlXI=";
   };
 
   depsBuildBuild = [ pkg-config ];


### PR DESCRIPTION
Reverts NixOS/nixpkgs#483629

Release has been retracted by upstream.