### PR TITLE
mathematica: add pname

### DIFF
--- a/pkgs/by-name/ma/mathematica/generic.nix
+++ b/pkgs/by-name/ma/mathematica/generic.nix
@@ -10,7 +10,7 @@
   # arguments from default.nix
   lang,
   meta,
-  name,
+  pname,
   src,
   version,
   # dependencies
@@ -89,7 +89,7 @@ in
 stdenv.mkDerivation {
   inherit
     meta
-    name
+    pname
     src
     version
     ;

--- a/pkgs/by-name/ma/mathematica/package.nix
+++ b/pkgs/by-name/ma/mathematica/package.nix
@@ -62,14 +62,13 @@ in
 
 callPackage ./generic.nix {
   inherit cudaSupport cudaPackages;
-  inherit (found-version) version lang;
+  inherit (found-version) lang;
   src = if source == null then found-version.src else source;
-  name = (
-    "mathematica"
+  pname = "mathematica";
+  version =
+    found-version.version
     + lib.optionalString cudaSupport "-cuda"
-    + "-${found-version.version}"
-    + lib.optionalString (lang != "en") "-${lang}"
-  );
+    + lib.optionalString (lang != "en") "-${lang}";
   meta = {
     description = "Wolfram Mathematica computational software system";
     homepage = "https://www.wolfram.com/mathematica/";


### PR DESCRIPTION
Part of #485742

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
