### PR TITLE
python314Packages.cyvest: 5.1.4 -> 5.2.0

### DIFF
--- a/pkgs/development/python-modules/cyvest/default.nix
+++ b/pkgs/development/python-modules/cyvest/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "cyvest";
-  version = "5.1.4";
+  version = "5.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "PakitoSec";
     repo = "cyvest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OvAnhasc4iZtfi8olQ4rLaokcaC/b5rYdPPMn2pVYTA=";
+    hash = "sha256-AfTeZj7GFLoaLRImGbiFqbaw4AxjHUZSBDwGFY9sA1s=";
   };
 
   pythonRelaxDeps = [ "pydantic" ];

--- a/pkgs/development/python-modules/cyvest/default.nix
+++ b/pkgs/development/python-modules/cyvest/default.nix
@@ -53,7 +53,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Cybersecurity Investigation Model";
     homepage = "https://github.com/PakitoSec/cyvest";
-    changelog = "https://github.com/PakitoSec/cyvest/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/PakitoSec/cyvest/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
Diff: https://github.com/PakitoSec/cyvest/compare/v5.1.4...v5.2.0

Changelog: https://github.com/PakitoSec/cyvest/releases/tag/vv5.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
