### PR TITLE
gitu: patch unit tests

### DIFF
--- a/pkgs/by-name/gi/gitu/package.nix
+++ b/pkgs/by-name/gi/gitu/package.nix
@@ -20,6 +20,10 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-JNa9foW5z0NrXk5r/Oep20+u7YRhkzMIZQPHlZVifGI=";
   };
 
+  patches = [
+    ./unit-tests-compile.patch
+  ];
+
   cargoHash = "sha256-mQ5xXYVmadmNx57nnJGICZ2dhll+V3PkYK+hwTTfdVE=";
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gi/gitu/unit-tests-compile.patch
+++ b/pkgs/by-name/gi/gitu/unit-tests-compile.patch
@@ -1,0 +1,31 @@
+diff --git i/src/git/parse/status/mod.rs w/src/git/parse/status/mod.rs
+index 5595ca1..8929d79 100644
+--- i/src/git/parse/status/mod.rs
++++ w/src/git/parse/status/mod.rs
+@@ -703,10 +703,12 @@ R  old.rs -> new.rs
+             for c2 in &status_chars {
+                 input.push(*c1);
+                 input.push(*c2);
++                let c1_str = c1.to_string();
++                let c2_str = c2.to_string();
+                 input.push_str(&format!(
+                     " file_{}_{}.txt\n",
+-                    if *c1 == ' ' { "space" } else { &c1.to_string() },
+-                    if *c2 == ' ' { "space" } else { &c2.to_string() }
++                    if *c1 == ' ' { "space" } else { &c1_str },
++                    if *c2 == ' ' { "space" } else { &c2_str }
+                 ));
+                 count += 1;
+             }
+diff --git i/src/tests/remote.rs w/src/tests/remote.rs
+index 7a81a50..0ac14f5 100644
+--- i/src/tests/remote.rs
++++ w/src/tests/remote.rs
+@@ -1,6 +1,6 @@
+ use git2::{Buf, Error, Repository};
+ 
+-use crate::{git::remote::*, repo_setup_clone, setup_clone, tests::helpers::RepoTestContext};
++use crate::{git::remote::*, repo_setup_clone, tests::helpers::RepoTestContext};
+ 
+ use super::*;
+ 


### PR DESCRIPTION
fixes #486623

I guess unstable has a more strict rustc version than 25.11 that catches a temporary value error in unit tests, so this fixes the error (and a warning that would not have blocked the build). So we just have to patch the unit test code.

This is fixed upstream in https://github.com/altsem/gitu/commit/eca03217c09cd6317047bc422d6790f8738562bf but that commit also introduces non-test changes, so I only included the necessary fix to test code.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
