### PR TITLE
python314Packages.apify-fingerprint-datapoints: init at 0.10.0, python314Packages.browserforge: 1.2.3 -> 1.2.4

### DIFF
--- a/pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
+++ b/pkgs/development/python-modules/apify-fingerprint-datapoints/default.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "apify-fingerprint-datapoints";
+  version = "0.10.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "apify_fingerprint_datapoints";
+    inherit (finalAttrs) version;
+    hash = "sha256-FObB0yFu/t1RtnCYyDuzIzgm4mHu8mC+cATzciGd2VA=";
+  };
+
+  build-system = [ hatchling ];
+
+  pythonImportsCheck = [ "apify_fingerprint_datapoints" ];
+
+  # Module has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Browser fingerprint datapoints collected by Apify";
+    homepage = "https://pypi.org/project/apify-fingerprint-datapoints/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/development/python-modules/browserforge/default.nix
+++ b/pkgs/development/python-modules/browserforge/default.nix
@@ -1,34 +1,33 @@
 {
   lib,
   aiofiles,
+  apify-fingerprint-datapoints,
   buildPythonPackage,
   click,
   fetchFromGitHub,
   httpx,
   orjson,
   poetry-core,
-  pythonOlder,
   rich,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "browserforge";
-  version = "1.2.3";
+  version = "1.2.4";
   pyproject = true;
-
-  disabled = pythonOlder "3.11";
 
   src = fetchFromGitHub {
     owner = "daijro";
     repo = "browserforge";
-    tag = "v${version}";
-    hash = "sha256-D5GlUZ4KT6kqPQVcpli8T++xoXl1YUVGZu8rePJQ44A=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8mh1Wok96rwUNAdnaoI1VYkyNr50JX/K7o04n/epuMo=";
   };
 
   build-system = [ poetry-core ];
 
   dependencies = [
     aiofiles
+    apify-fingerprint-datapoints
     click
     httpx
     orjson
@@ -46,4 +45,4 @@ buildPythonPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -816,6 +816,10 @@ self: super: with self; {
 
   apiflask = callPackage ../development/python-modules/apiflask { };
 
+  apify-fingerprint-datapoints =
+    callPackage ../development/python-modules/apify-fingerprint-datapoints
+      { };
+
   apipkg = callPackage ../development/python-modules/apipkg { };
 
   apischema = callPackage ../development/python-modules/apischema { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
