### PR TITLE
vdrPlugins: set pname

### DIFF
--- a/pkgs/applications/video/vdr/plugins.nix
+++ b/pkgs/applications/video/vdr/plugins.nix
@@ -13,8 +13,9 @@ let
   mkPlugin =
     name:
     stdenv.mkDerivation {
-      name = "vdr-${name}-${vdr.version}";
-      inherit (vdr) src;
+      pname = name;
+      inherit (vdr) src version;
+
       buildInputs = [ vdr ];
       preConfigure = "cd PLUGINS/src/${name}";
       installFlags = [ "DESTDIR=$(out)" ];


### PR DESCRIPTION
- #485742
Some vdrPlugins seems to already be using pname, but the one within `mkPlugin` aren't yet

```nix
nix-repl> builtins.mapAttrs (attr: value: if lib.isDerivation value then value.pname else null) vdrPlugins
{
  epgsearch = "vdr-epgsearch";
  epgtableid0 = "epgtableid0";
  femon = "vdr-femon";
  fritzbox = "vdr-fritzbox";
  hello = "hello";
  markad = "vdr-markad";
  nopacity = "vdr-skin-nopacity";
  osddemo = "osddemo";
  override = null;
  overrideDerivation = null;
  pictures = "pictures";
  recurseForDerivations = null;
  servicedemo = "servicedemo";
  skincurses = "skincurses";
  softhddevice = "vdr-softhddevice";
  status = "status";
  streamdev = "vdr-streamdev";
  svdrpdemo = "svdrpdemo";
  text2skin = "vdr-text2skin";
  vnsiserver = "vdr-vnsiserver";
  xineliboutput = "vdr-xineliboutput";
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
