### PR TITLE
python3Packages.xsdata-pydantic: cleanup, disable failing test

### DIFF
--- a/pkgs/development/python-modules/xsdata-pydantic/default.nix
+++ b/pkgs/development/python-modules/xsdata-pydantic/default.nix
@@ -2,18 +2,24 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   setuptools,
-  pytestCheckHook,
-  xsdata,
+
+  # dependencies
   pydantic,
+  xsdata,
+
+  # tests
   click,
   click-default-group,
-  jinja2,
   docformatter,
+  jinja2,
+  pytestCheckHook,
   toposort,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "xsdata-pydantic";
   version = "24.5";
   pyproject = true;
@@ -21,15 +27,15 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "tefra";
     repo = "xsdata-pydantic";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ExgAXQRNfGQRSZdMuWc8ldJPqz+3c4Imgu75KXLXHNk=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
-    xsdata
     pydantic
+    xsdata
   ];
 
   nativeCheckInputs = [
@@ -37,19 +43,18 @@ buildPythonPackage rec {
     click-default-group
     docformatter
     jinja2
-    toposort
     pytestCheckHook
+    toposort
   ];
 
-  pythonImportsCheck = [
-    "xsdata_pydantic"
-  ];
+  pythonImportsCheck = [ "xsdata_pydantic" ];
 
   meta = {
-    description = "Naive XML & JSON Bindings for python pydantic classes!";
+    description = "Naive XML & JSON Bindings for python pydantic classes";
     homepage = "https://github.com/tefra/xsdata-pydantic";
+    changelog = "https://github.com/tefra/xsdata-pydantic/blob/${finalAttrs.src.tag}/CHANGES.md";
     maintainers = with lib.maintainers; [ berrij ];
     license = lib.licenses.mit;
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/development/python-modules/xsdata-pydantic/default.nix
+++ b/pkgs/development/python-modules/xsdata-pydantic/default.nix
@@ -49,6 +49,11 @@ buildPythonPackage (finalAttrs: {
 
   pythonImportsCheck = [ "xsdata_pydantic" ];
 
+  disabledTests = [
+    # AssertionError: SystemExit(2) is not None
+    "test_complete"
+  ];
+
   meta = {
     description = "Naive XML & JSON Bindings for python pydantic classes";
     homepage = "https://github.com/tefra/xsdata-pydantic";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- **python3Packages.xsdata-pydantic: cleanup**
- **python3Packages.xsdata-pydantic: disable failing test**

cc @BerriJ

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
