### PR TITLE
python3Packages.keyboard: 0.13.5 -> 0.13.5-unstable-2023-01-31

### DIFF
--- a/pkgs/development/python-modules/keyboard/default.nix
+++ b/pkgs/development/python-modules/keyboard/default.nix
@@ -2,19 +2,24 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "keyboard";
-  version = "0.13.5";
-  format = "setuptools";
+  # the commit tagged v0.13.5 on github actually has version 0.13.4,
+  # and fetchPypi reports 404 error; very strange!
+  version = "0.13.5-unstable-2023-01-31";
 
   src = fetchFromGitHub {
     owner = "boppreh";
     repo = "keyboard";
-    rev = "v${version}";
-    hash = "sha256-U4GWhPp28azBE3Jn9xpLxudOKx0PjnYO77EM2HsJ9lM=";
+    rev = "d232de09bda50ecb5211ebcc59b85bc6da6aaa24";
+    hash = "sha256-Xk419Zvx9pDgMcaWZn52WD41cFaXXzJlvmPGxaWdR0k=";
   };
+
+  pyproject = true;
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "keyboard" ];
 
@@ -26,6 +31,7 @@ buildPythonPackage rec {
   meta = {
     description = "Hook and simulate keyboard events on Windows and Linux";
     homepage = "https://github.com/boppreh/keyboard";
+    changelog = "https://github.com/boppreh/keyboard/releases";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ulysseszhan ];
     platforms = lib.platforms.linux;

--- a/pkgs/development/python-modules/keyboard/default.nix
+++ b/pkgs/development/python-modules/keyboard/default.nix
@@ -27,7 +27,7 @@ buildPythonPackage rec {
     description = "Hook and simulate keyboard events on Windows and Linux";
     homepage = "https://github.com/boppreh/keyboard";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
The commit tagged v0.13.5 on github actually has version 0.13.4, and fetchPypi reports 404 error; very strange!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
