### PR TITLE
desync: enable tests (take 2)

### DIFF
--- a/pkgs/by-name/de/desync/package.nix
+++ b/pkgs/by-name/de/desync/package.nix
@@ -21,8 +21,29 @@ buildGoModule rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  # nix builder doesn't have access to test data; tests fail for reasons unrelated to binary being bad.
-  doCheck = false;
+  # required for TestHTTPHandlerReadWrite and other tests
+  __darwinAllowLocalNetworking = true;
+
+  checkFlags =
+    let
+      skippedTests = [
+        "TestExtract" # block cloning fails on ZFS
+        "TestExtractCommand/extract_while_regenerating_the_corrupted_seed" # block cloning fails on ZFS
+        "TestExtractCommand/extract_with_seed_directory" # block cloning fails on ZFS
+        "TestExtractCommand/extract_with_single_seed" # block cloning fails on ZFS
+        "TestExtractCommand/extract_with_single_seed,_explicit_data_directory_and_unexpected_seed_options" # block cloning fails on ZFS
+        "TestExtractCommand/extract_with_single_seed_and_explicit_data_directory" # block cloning fails on ZFS
+        "TestExtractWithNonStaticSeeds" # block cloning fails on ZFS
+        "TestMountIndex" # FUSE does not work in sandbox
+        "TestSeed/extract_repetitive_file" # block cloning fails on ZFS
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        # sendfile is not permitted in Darwin sandbox
+        "TestS3StoreGetChunk/fail"
+        "TestS3StoreGetChunk/recover"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd desync \


### PR DESCRIPTION
#469469 reapplied, but now with fixes of problems mentioned in #469904. There were some tests that passed locally but failed on Hydra and ofborg because they use ZFS and it has more limitations on block cloning than btrfs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
