### PR TITLE
[Backport release-25.11] discordo: 0-unstable-2025-11-17 -> 0-unstable-2026-01-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24356,6 +24356,12 @@
     github = "siph";
     githubId = 6619112;
   };
+  siphc = {
+    name = "siphc";
+    github = "siphc";
+    githubId = 42943030;
+    email = "ayfpan@ucla.edu";
+  };
   sir4ur0n = {
     github = "sir4ur0n";
     githubId = 1204125;

--- a/pkgs/by-name/di/discordo/package.nix
+++ b/pkgs/by-name/di/discordo/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "discordo";
-  version = "0-unstable-2025-11-24";
+  version = "0-unstable-2025-11-30";
 
   src = fetchFromGitHub {
     owner = "ayn2op";
     repo = "discordo";
-    rev = "ac1436b4d4e132f92b48b3afdf3f430e2846b41a";
-    hash = "sha256-qf7DPl/ZZlrjyX1dV9SP7wBiysqvZKNb+awYk6V+Lj8=";
+    rev = "845485595fbe5df8ff800ce068ea5e051f896dd5";
+    hash = "sha256-8GUVPt8GalNe5CzAmgJaf0eOM7+WqNt7qchrQGZ/zCo=";
   };
 
   vendorHash = "sha256-b5ilZPU6+KwiTj8aC0gqZvgGI+V69gF8LNxCpxwUy7c=";

--- a/pkgs/by-name/di/discordo/package.nix
+++ b/pkgs/by-name/di/discordo/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "discordo";
-  version = "0-unstable-2025-11-17";
+  version = "0-unstable-2025-11-24";
 
   src = fetchFromGitHub {
     owner = "ayn2op";
     repo = "discordo";
-    rev = "9aa853fa6cf29653815fadae7be4c876b5c1cfdb";
-    hash = "sha256-eu9QorEPjlLMahAnZ+c3P8oTvjAvsanocmoKlKwJUFE=";
+    rev = "ac1436b4d4e132f92b48b3afdf3f430e2846b41a";
+    hash = "sha256-qf7DPl/ZZlrjyX1dV9SP7wBiysqvZKNb+awYk6V+Lj8=";
   };
 
-  vendorHash = "sha256-nudvu36jBlDrRPvukNuDtv/+XrVZKChn2NHFm0uzUSQ=";
+  vendorHash = "sha256-b5ilZPU6+KwiTj8aC0gqZvgGI+V69gF8LNxCpxwUy7c=";
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/di/discordo/package.nix
+++ b/pkgs/by-name/di/discordo/package.nix
@@ -55,7 +55,10 @@ buildGoModule (finalAttrs: {
     description = "Lightweight, secure, and feature-rich Discord terminal client";
     homepage = "https://github.com/ayn2op/discordo";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ arian-d ];
+    maintainers = with lib.maintainers; [
+      arian-d
+      siphc
+    ];
     mainProgram = "discordo";
   };
 })

--- a/pkgs/by-name/di/discordo/package.nix
+++ b/pkgs/by-name/di/discordo/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "discordo";
-  version = "0-unstable-2026-01-23";
+  version = "0-unstable-2026-01-28";
 
   src = fetchFromGitHub {
     owner = "ayn2op";
     repo = "discordo";
-    rev = "08bda9e40541d32e9313405824550cff41f60912";
-    hash = "sha256-80ZG1lQV4/kf4zqW2ANkRIJSZbjwCKsV0TTwSZuoMGk=";
+    rev = "415c534674064305625f97a8ba42c4da0ad8f2e9";
+    hash = "sha256-epodX3renaAdzqKsYux65LX671M6u3uHvh/EViQqAQg=";
   };
 
-  vendorHash = "sha256-quRRGf9eVCK7OYgPhBn+qM6WTUGra9I2eUxkRbCXxB8=";
+  vendorHash = "sha256-2Y+IBDklxro75rFImKjMecr/eK6jSquKidy4hfpguYY=";
 
   env.CGO_ENABLED = 1;
 

--- a/pkgs/by-name/di/discordo/package.nix
+++ b/pkgs/by-name/di/discordo/package.nix
@@ -4,31 +4,36 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  libx11,
   makeWrapper,
-  xsel,
   wl-clipboard,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "discordo";
-  version = "0-unstable-2025-12-06";
+  version = "0-unstable-2026-01-23";
 
   src = fetchFromGitHub {
     owner = "ayn2op";
     repo = "discordo";
-    rev = "a9359209369cf816bdab76d4feeb8270a5410040";
-    hash = "sha256-Dudlghaz3RGZaHSExyzmeVUZufU8w1ONSE3nh/GINHQ=";
+    rev = "08bda9e40541d32e9313405824550cff41f60912";
+    hash = "sha256-80ZG1lQV4/kf4zqW2ANkRIJSZbjwCKsV0TTwSZuoMGk=";
   };
 
-  vendorHash = "sha256-IFZcBq58qLRmU0eDrPNh/vEL3L+FZX1AHS09vtWmRaQ=";
+  vendorHash = "sha256-quRRGf9eVCK7OYgPhBn+qM6WTUGra9I2eUxkRbCXxB8=";
 
-  env.CGO_ENABLED = 0;
+  env.CGO_ENABLED = 1;
 
   ldflags = [
     "-s"
   ];
 
-  # Clipboard support on X11 and Wayland
+  # Clipboard support on X11
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libx11
+  ];
+
+  # Clipboard support on Wayland
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     makeWrapper
   ];
@@ -37,7 +42,6 @@ buildGoModule (finalAttrs: {
     wrapProgram $out/bin/discordo \
       --prefix PATH : ${
         lib.makeBinPath [
-          xsel
           wl-clipboard
         ]
       }

--- a/pkgs/by-name/di/discordo/package.nix
+++ b/pkgs/by-name/di/discordo/package.nix
@@ -11,16 +11,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "discordo";
-  version = "0-unstable-2025-11-30";
+  version = "0-unstable-2025-12-06";
 
   src = fetchFromGitHub {
     owner = "ayn2op";
     repo = "discordo";
-    rev = "845485595fbe5df8ff800ce068ea5e051f896dd5";
-    hash = "sha256-8GUVPt8GalNe5CzAmgJaf0eOM7+WqNt7qchrQGZ/zCo=";
+    rev = "a9359209369cf816bdab76d4feeb8270a5410040";
+    hash = "sha256-Dudlghaz3RGZaHSExyzmeVUZufU8w1ONSE3nh/GINHQ=";
   };
 
-  vendorHash = "sha256-b5ilZPU6+KwiTj8aC0gqZvgGI+V69gF8LNxCpxwUy7c=";
+  vendorHash = "sha256-IFZcBq58qLRmU0eDrPNh/vEL3L+FZX1AHS09vtWmRaQ=";
 
   env.CGO_ENABLED = 0;
 


### PR DESCRIPTION
The automatic backport failed; this manual backport PR updates the package `discordo` to the unstable version (#476153).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
