### PR TITLE
x16-emulator, x16-rom: disable nixpkgs-update

### DIFF
--- a/pkgs/by-name/x1/x16/package.nix
+++ b/pkgs/by-name/x1/x16/package.nix
@@ -12,6 +12,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "x16-emulator";
   version = "48";
+  # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "X16Community";

--- a/pkgs/by-name/x1/x16/rom.nix
+++ b/pkgs/by-name/x1/x16/rom.nix
@@ -11,6 +11,7 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "x16-rom";
   version = "48";
+  # nixpkgs-update: no auto update
 
   src = fetchFromGitHub {
     owner = "X16Community";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Prevent the bot from sending broken PRs, these packages have an assert that prevents them from being updated separately.

https://github.com/NixOS/nixpkgs/pull/464498, https://github.com/NixOS/nixpkgs/pull/486533

Closes https://github.com/NixOS/nixpkgs/pull/486533

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
