### PR TITLE
Update download references for `ngrok` | no longer user equinox.io and instead use ngrok.com

### DIFF
--- a/pkgs/by-name/ng/ngrok/update.sh
+++ b/pkgs/by-name/ng/ngrok/update.sh
@@ -7,7 +7,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 get_download_info() {
     xh --json \
-        https://update.equinox.io/check \
+        https://update.ngrok-agent.com/check \
         'Accept:application/json; q=1; version=1; charset=utf-8' \
         'Content-Type:application/json; charset=utf-8' \
         app_id=app_c3U4eZcDbjV \

--- a/pkgs/by-name/ng/ngrok/versions.json
+++ b/pkgs/by-name/ng/ngrok/versions.json
@@ -1,37 +1,37 @@
 {
   "linux-386": {
     "sys": "linux-386",
-    "url": "https://bin.equinox.io/a/nNTqdX4Ydi/ngrok-v3-3.31.0-linux-386",
+    "url": "https://bin.ngrok.com/a/nNTqdX4Ydi/ngrok-v3-3.31.0-linux-386",
     "sha256": "df57220616e209b18fad5db27ebab459b79d79431845a9f35e39f5f7b482646d",
     "version": "3.31.0"
   },
   "linux-amd64": {
     "sys": "linux-amd64",
-    "url": "https://bin.equinox.io/a/mWtsD5CQpnc/ngrok-v3-3.31.0-linux-amd64",
+    "url": "https://bin.ngrok.com/a/mWtsD5CQpnc/ngrok-v3-3.31.0-linux-amd64",
     "sha256": "1dab42535428db2a55f44abb0d14f6d9fec7f930f9346c9bd69f0cf5b6529dca",
     "version": "3.31.0"
   },
   "linux-arm": {
     "sys": "linux-arm",
-    "url": "https://bin.equinox.io/a/dDdHR6qWaFy/ngrok-v3-3.31.0-linux-arm",
+    "url": "https://bin.ngrok.com/a/dDdHR6qWaFy/ngrok-v3-3.31.0-linux-arm",
     "sha256": "e713bfc77f2fe0a1225215ce5651a3beefb27773b01f1cce442a271512ee60bd",
     "version": "3.31.0"
   },
   "linux-arm64": {
     "sys": "linux-arm64",
-    "url": "https://bin.equinox.io/a/2SEt27vYGV3/ngrok-v3-3.31.0-linux-arm64",
+    "url": "https://bin.ngrok.com/a/2SEt27vYGV3/ngrok-v3-3.31.0-linux-arm64",
     "sha256": "4bd600d663bcdec42a7d1a6f0c5a042042fecd529b9867b532bd794e62fdb9b4",
     "version": "3.31.0"
   },
   "darwin-amd64": {
     "sys": "darwin-amd64",
-    "url": "https://bin.equinox.io/a/8YrgUfMJ8FH/ngrok-v3-3.31.0-darwin-amd64",
+    "url": "https://bin.ngrok.com/a/8YrgUfMJ8FH/ngrok-v3-3.31.0-darwin-amd64",
     "sha256": "b4855f6d9b170ffe9a77393e43d1e40a4a5ce66a6906fa2cfcddaf5e05938b98",
     "version": "3.31.0"
   },
   "darwin-arm64": {
     "sys": "darwin-arm64",
-    "url": "https://bin.equinox.io/a/9XVR1UCtCce/ngrok-v3-3.31.0-darwin-arm64",
+    "url": "https://bin.ngrok.com/a/9XVR1UCtCce/ngrok-v3-3.31.0-darwin-arm64",
     "sha256": "407f7e88a57f93536d0981544d4132cdf100aa2799a5b56640ec13726febc970",
     "version": "3.31.0"
   }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Here at ngrok, we are retiring our use of `equinox.io` and moving our hosted binaries/downloads to `ngrok.com`.

## Things done
Updated `versions.json` and `update.json` to reference new URLs.

(I sanity checked the URLs in the updated files work as expected and have not tested this another way).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
