### PR TITLE
nixos/limine: add settings autoGenerateKeys & autoEnrollKeys

### DIFF
--- a/nixos/modules/system/boot/loader/limine/limine-install.py
+++ b/nixos/modules/system/boot/loader/limine/limine-install.py
@@ -430,7 +430,7 @@ def install_bootloader() -> None:
             partition formatted as FAT.
         '''))
 
-    if config('secureBoot', 'enable') and not config('secureBoot', 'createAndEnrollKeys') and not os.path.exists("/var/lib/sbctl"):
+    if config('secureBoot', 'enable') and not config('secureBoot', 'autoGenerateKeys') and not os.path.exists("/var/lib/sbctl"):
         print("There are no sbctl secure boot keys present. Please generate some.")
         sys.exit(1)
 
@@ -557,18 +557,21 @@ def install_bootloader() -> None:
 
         if config('secureBoot', 'enable'):
             sbctl = os.path.join(str(config('secureBoot', 'sbctl')), 'bin', 'sbctl')
-            if config('secureBoot', 'createAndEnrollKeys'):
-                print("TEST MODE: creating and enrolling keys")
+            if not os.path.exists("/var/lib/sbctl") and config('secureBoot', 'autoGenerateKeys'):
+                print('auto generating keys')
                 try:
                     subprocess.run([sbctl, 'create-keys'])
                 except:
                     print('error: failed to create keys', file=sys.stderr)
                     sys.exit(1)
-                try:
-                    subprocess.run([sbctl, 'enroll-keys', '--yes-this-might-brick-my-machine'])
-                except:
-                    print('error: failed to enroll keys', file=sys.stderr)
-                    sys.exit(1)
+                if config('secureBoot', 'autoEnrollKeys', 'enable'):
+                    try:
+                        command = [sbctl, 'enroll-keys']
+                        command.extend(config('secureBoot', 'autoEnrollKeys', 'extraArgs'))
+                        subprocess.run(command)
+                    except:
+                        print('error: failed to enroll keys', file=sys.stderr)
+                        sys.exit(1)
 
             print('signing limine...')
             try:

--- a/nixos/modules/system/boot/loader/limine/limine.nix
+++ b/nixos/modules/system/boot/loader/limine/limine.nix
@@ -224,16 +224,22 @@ in
         '';
       };
 
-      createAndEnrollKeys = lib.mkEnableOption null // {
-        internal = true;
-        description = ''
-          Creates secure boot signing keys and enrolls them during bootloader installation.
+      autoGenerateKeys = lib.mkEnableOption null // {
+        description = "Generate keys automatically when none exists during bootloader installation";
+      };
 
-          ::: {.note}
-          This is used for automated nixos tests.
-          NOT INTENDED to be used on a real system.
-          :::
-        '';
+      autoEnrollKeys = {
+        enable = lib.mkEnableOption null // {
+          description = "Enroll automatically generated keys";
+        };
+        extraArgs = lib.mkOption {
+          default = [
+            "--microsoft"
+            "--firmware-builtin"
+          ];
+          type = lib.types.listOf lib.types.str;
+          description = "Extra arguments passed to sbctl";
+        };
       };
 
       sbctl = lib.mkPackageOption pkgs "sbctl" { };
@@ -484,6 +490,16 @@ in
       services.fwupd.uefiCapsuleSettings = {
         DisableShimForSecureBoot = true;
       };
+    })
+    (lib.mkIf (cfg.enable && cfg.secureBoot.enable && cfg.secureBoot.autoEnrollKeys.enable) {
+      assertions = [
+        {
+          assertion = cfg.secureBoot.autoGenerateKeys;
+          message = "autoEnrollKeys doesn't do anything without autoGenerateKeys.";
+        }
+      ];
+
+      boot.loader.limine.secureBoot.autoGenerateKeys = true;
     })
   ];
 }

--- a/nixos/tests/limine/secure-boot.nix
+++ b/nixos/tests/limine/secure-boot.nix
@@ -24,7 +24,9 @@
       boot.loader.limine.enable = true;
       boot.loader.limine.efiSupport = true;
       boot.loader.limine.secureBoot.enable = true;
-      boot.loader.limine.secureBoot.createAndEnrollKeys = true;
+      boot.loader.limine.secureBoot.autoGenerateKeys = true;
+      boot.loader.limine.secureBoot.autoEnrollKeys.enable = true;
+      boot.loader.limine.secureBoot.autoEnrollKeys.extraArgs = [ "--yes-this-might-brick-my-machine" ];
       boot.loader.timeout = 0;
 
       environment.systemPackages = [ pkgs.mokutil ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
add `secureBoot.autoGenerateKeys` and `secureBoot.autoEnrollKeys` to make system installation progress automatic

## Things done
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
