### PR TITLE
python3Packages.fspath: init at 20230629; python3Packages.linuxdoc: init at 20240924

### DIFF
--- a/pkgs/development/python-modules/fspath/default.nix
+++ b/pkgs/development/python-modules/fspath/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  six,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fspath";
+  version = "20230629";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "return42";
+    repo = "fspath";
+    tag = finalAttrs.version;
+    hash = "sha256-OtJ6PODEYEiUnJriTAKTThSsEtiF7sjMFEu7wFqRR54=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    six
+  ];
+
+  pythonImportsCheck = [ "fspath" ];
+
+  meta = {
+    description = "Handling path names and executables more comfortable";
+    homepage = "https://github.com/return42/fspath";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ skohtv ];
+  };
+})

--- a/pkgs/development/python-modules/linuxdoc/default.nix
+++ b/pkgs/development/python-modules/linuxdoc/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  fspath,
+  docutils,
+  sphinx,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "linuxdoc";
+  version = "20240924";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "return42";
+    repo = "linuxdoc";
+    tag = finalAttrs.version;
+    hash = "sha256-UOOIl+HWI7bK6iWrADTgrGvom++178yPYmyI+qTwVlg=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    fspath
+    docutils
+    sphinx
+  ];
+
+  pythonImportsCheck = [ "linuxdoc" ];
+
+  meta = {
+    description = "Sphinx-doc extensions for sophisticated C developer";
+    homepage = "https://github.com/return42/linuxdoc";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ skohtv ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8838,6 +8838,8 @@ self: super: with self; {
 
   linode-metadata = callPackage ../development/python-modules/linode-metadata { };
 
+  linuxdoc = callPackage ../development/python-modules/linuxdoc { };
+
   linuxfd = callPackage ../development/python-modules/linuxfd { };
 
   linuxpy = callPackage ../development/python-modules/linuxpy { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5851,6 +5851,8 @@ self: super: with self; {
 
   fslpy = callPackage ../development/python-modules/fslpy { };
 
+  fspath = callPackage ../development/python-modules/fspath { };
+
   fsspec = callPackage ../development/python-modules/fsspec { };
 
   fsspec-xrootd = callPackage ../development/python-modules/fsspec-xrootd { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
We're looking to add a development `flake` to [bpfilter](https://github.com/facebook/bpfilter), however those 2 python dependencies are missing
Related https://github.com/facebook/bpfilter/pull/411

- https://github.com/return42/linuxdoc
- https://github.com/return42/fspath

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
