### PR TITLE
cockpit-zfs: use Python from cockpit, drop firewalld dependency

### DIFF
--- a/pkgs/by-name/co/cockpit-zfs/package.nix
+++ b/pkgs/by-name/co/cockpit-zfs/package.nix
@@ -1,9 +1,9 @@
 {
   acl,
   bash,
+  cockpit,
   coreutils,
   fetchFromGitHub,
-  firewalld,
   getent,
   glibc,
   iproute2,
@@ -15,7 +15,6 @@
   msmtp,
   nodejs,
   openssh,
-  python312,
   samba,
   shadow,
   smartmontools,
@@ -27,15 +26,6 @@
   zfs,
 }:
 
-let
-  # Using python312 because py-libzfs is not compatible with newer versions
-  python = (
-    python312.withPackages (ps: [
-      ps.pyudev
-      ps.py-libzfs
-    ])
-  );
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "cockpit-zfs";
   version = "1.2.12-2";
@@ -67,7 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     acl
     bash
     coreutils
-    firewalld
     getent
     glibc
     iproute2
@@ -76,7 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     msmtp
     nodejs
     openssh
-    python
     samba
     shadow
     smartmontools
@@ -84,6 +72,8 @@ stdenv.mkDerivation (finalAttrs: {
     systemd
     util-linux
     zfs
+    cockpit.passthru.python3Packages.pyudev
+    cockpit.passthru.python3Packages.py-libzfs
   ];
 
   env = {
@@ -151,11 +141,12 @@ stdenv.mkDerivation (finalAttrs: {
     for script in $out/etc/zfs/zed.d/*; do
       if [ -f "$script" ]; then
         wrapProgram "$script" \
+          --set PYTHONPATH "/etc/cockpit/${cockpit.passthru.python3Packages.python.sitePackages}" \
           --set PATH "${
             lib.makeBinPath [
+              "/etc/cockpit"
               coreutils
               bash
-              python
               jq
             ]
           }"

--- a/pkgs/by-name/co/cockpit/package.nix
+++ b/pkgs/by-name/co/cockpit/package.nix
@@ -33,7 +33,7 @@
   pam,
   pkg-config,
   polkit,
-  python3Packages,
+  python312Packages,
   sscg,
   systemd,
   udev,
@@ -43,6 +43,12 @@
   withBranding ? true,
   nixos-icons,
 }:
+
+let
+  # Pinned to 3.12 due to cockpit-zfs dependency py-libzfs not being compatible
+  # with 3.13+
+  python3Packages = python312Packages;
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cockpit";
@@ -166,6 +172,11 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail "/usr/lib/polkit-1/polkit-agent-helper-1" "/run/wrappers/bin/polkit-agent-helper-1"
   '';
 
+  preConfigure = ''
+    # Make sure our Python comes before any other Python (e.g. from asciidoc)
+    export PATH="${lib.makeBinPath [ python3Packages.python ]}:$PATH"
+  '';
+
   configureFlags = [
     "--enable-prefix-only=yes"
     "--disable-pcp" # TODO: figure out how to package its dependency
@@ -270,6 +281,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    inherit python3Packages;
     tests = { inherit (nixosTests) cockpit; };
     updateScript = nix-update-script { };
     cockpitPath = [


### PR DESCRIPTION
Closes #486590

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
