### PR TITLE
hyprselect: init at 0.53.0

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprselect.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprselect.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  mkHyprlandPlugin,
+  fetchFromGitHub,
+}:
+
+mkHyprlandPlugin (finalAttrs: {
+  pluginName = "hyprselect";
+  version = "0.53.1";
+
+  src = fetchFromGitHub {
+    owner = "jmanc3";
+    repo = "hyprselect";
+    rev = "f9651b5fd64c730ee164a6fee6a08d0398dcbe0a";
+    hash = "sha256-tY8EdfsjlUOuQ9v/POqpyLlkRO5wqEVSE9UeHfXuaGk=";
+  };
+
+  inherit (hyprland) nativeBuildInputs;
+
+  meta = with lib; {
+    homepage = "https://github.com/jmanc3/hyprselect";
+    description = "A plugin that adds a completely useless desktop selection box to Hyprland";
+    license = licenses.unlicense;
+    platforms = platforms.linux;
+  };
+})


### PR DESCRIPTION
Adds [hyprselect](https://github.com/jmanc3/hyprselect)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
