### PR TITLE
smithy-cli: init at version 1.67.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12925,6 +12925,12 @@
     github = "joshainglis";
     githubId = 1281131;
   };
+  joshgodsiff = {
+    name = "Josh Godsiff";
+    email = "josh.godsiff@gmail.com";
+    github = "joshgodsiff";
+    githubId = 145132;
+  };
   joshheinrichs-shopify = {
     name = "Josh Heinrichs";
     email = "josh.heinrichs@shopify.com";

--- a/pkgs/by-name/sm/smithy-cli/package.nix
+++ b/pkgs/by-name/sm/smithy-cli/package.nix
@@ -68,7 +68,7 @@ stdenvNoCC.mkDerivation {
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     mainProgram = "smithy";
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.joshgodsiff ];
     platforms = lib.attrNames sources;
   };
 }

--- a/pkgs/by-name/sm/smithy-cli/package.nix
+++ b/pkgs/by-name/sm/smithy-cli/package.nix
@@ -9,8 +9,6 @@
 }:
 
 let
-  version = "1.67.0";
-
   sources = {
     x86_64-linux = {
       platform = "linux-x86_64";
@@ -36,10 +34,10 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "smithy-cli";
-  inherit version;
+  version = "1.67.0";
 
   src = fetchzip {
-    url = "https://github.com/smithy-lang/smithy/releases/download/${version}/smithy-cli-${source.platform}.zip";
+    url = "https://github.com/smithy-lang/smithy/releases/download/${finalAttrs.version}/smithy-cli-${source.platform}.zip";
     hash = source.hash;
   };
 
@@ -105,7 +103,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   meta = {
     description = "CLI for the Smithy interface definition language (IDL)";
     homepage = "https://smithy.io/";
-    changelog = "https://github.com/smithy-lang/smithy/releases/tag/${version}";
+    changelog = "https://github.com/smithy-lang/smithy/releases/tag/${finalAttrs.version}";
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     license = lib.licenses.asl20;
     mainProgram = "smithy";

--- a/pkgs/by-name/sm/smithy-cli/package.nix
+++ b/pkgs/by-name/sm/smithy-cli/package.nix
@@ -8,38 +8,13 @@
   writeText,
 }:
 
-let
-  sources = {
-    x86_64-linux = {
-      platform = "linux-x86_64";
-      hash = "sha256-/qCxXC4uUfg10R5MeR7DrvUvAeTPJRt8z47SsAjN424=";
-    };
-    aarch64-linux = {
-      platform = "linux-aarch64";
-      hash = "sha256-8nat7tp9extvAU0VWIKQ88SGJC/lbt0G0NlIveteh1o=";
-    };
-    x86_64-darwin = {
-      platform = "darwin-x86_64";
-      hash = "sha256-K6v0o7xkRevwz47Y0PhQhFemzXvOp7Y0ggMRY9kS+iw=";
-    };
-    aarch64-darwin = {
-      platform = "darwin-aarch64";
-      hash = "sha256-XPFkVPpQjt2f6ifZxGbSTtmAltWpWdqPWlEkijvLio4=";
-    };
-  };
-
-  source =
-    sources.${stdenvNoCC.hostPlatform.system}
-      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
-in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "smithy-cli";
   version = "1.67.0";
 
-  src = fetchzip {
-    url = "https://github.com/smithy-lang/smithy/releases/download/${finalAttrs.version}/smithy-cli-${source.platform}.zip";
-    hash = source.hash;
-  };
+  src =
+    finalAttrs.passthru.sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
   dontConfigure = true;
   dontBuild = true;
@@ -62,13 +37,32 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = finalAttrs.finalPackage;
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchzip {
+        url = "https://github.com/smithy-lang/smithy/releases/download/${finalAttrs.version}/smithy-cli-linux-x86_64.zip";
+        hash = "sha256-/qCxXC4uUfg10R5MeR7DrvUvAeTPJRt8z47SsAjN424=";
+      };
+      "aarch64-linux" = fetchzip {
+        url = "https://github.com/smithy-lang/smithy/releases/download/${finalAttrs.version}/smithy-cli-linux-aarch64.zip";
+        hash = "sha256-8nat7tp9extvAU0VWIKQ88SGJC/lbt0G0NlIveteh1o=";
+      };
+      "x86_64-darwin" = fetchzip {
+        url = "https://github.com/smithy-lang/smithy/releases/download/${finalAttrs.version}/smithy-cli-darwin-x86_64.zip";
+        hash = "sha256-K6v0o7xkRevwz47Y0PhQhFemzXvOp7Y0ggMRY9kS+iw=";
+      };
+      "aarch64-darwin" = fetchzip {
+        url = "https://github.com/smithy-lang/smithy/releases/download/${finalAttrs.version}/smithy-cli-darwin-aarch64.zip";
+        hash = "sha256-XPFkVPpQjt2f6ifZxGbSTtmAltWpWdqPWlEkijvLio4=";
+      };
     };
-    validate =
-      let
-        sampleModel = writeText "example.smithy" ''
+
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+      validate = runCommand "smithy-cli-validate-test" { } ''
+        ${lib.getExe finalAttrs.finalPackage} validate ${writeText "example.smithy" ''
           $version: "2.0"
 
           namespace example
@@ -92,12 +86,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
               @required
               name: String
           }
-        '';
-      in
-      runCommand "smithy-cli-validate-test" { } ''
-        ${lib.getExe finalAttrs.finalPackage} validate ${sampleModel}
+        ''}
         touch $out
       '';
+    };
   };
 
   meta = {
@@ -108,6 +100,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     license = lib.licenses.asl20;
     mainProgram = "smithy";
     maintainers = [ lib.maintainers.joshgodsiff ];
-    platforms = lib.attrNames sources;
+    platforms = lib.attrNames finalAttrs.passthru.sources;
   };
 })

--- a/pkgs/by-name/sm/smithy-cli/package.nix
+++ b/pkgs/by-name/sm/smithy-cli/package.nix
@@ -3,6 +3,9 @@
   stdenvNoCC,
   fetchzip,
   jdk17,
+  testers,
+  runCommand,
+  writeText,
 }:
 
 let
@@ -31,7 +34,7 @@ let
     sources.${stdenvNoCC.hostPlatform.system}
       or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 in
-stdenvNoCC.mkDerivation {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "smithy-cli";
   inherit version;
 
@@ -61,6 +64,44 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
+  passthru.tests = {
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+    };
+    validate =
+      let
+        sampleModel = writeText "example.smithy" ''
+          $version: "2.0"
+
+          namespace example
+
+          service ExampleService {
+              version: "2023-01-01"
+              operations: [GetUser]
+          }
+
+          operation GetUser {
+              input: GetUserInput
+              output: GetUserOutput
+          }
+
+          structure GetUserInput {
+              @required
+              userId: String
+          }
+
+          structure GetUserOutput {
+              @required
+              name: String
+          }
+        '';
+      in
+      runCommand "smithy-cli-validate-test" { } ''
+        ${lib.getExe finalAttrs.finalPackage} validate ${sampleModel}
+        touch $out
+      '';
+  };
+
   meta = {
     description = "CLI for the Smithy interface definition language (IDL)";
     homepage = "https://smithy.io/";
@@ -71,4 +112,4 @@ stdenvNoCC.mkDerivation {
     maintainers = [ lib.maintainers.joshgodsiff ];
     platforms = lib.attrNames sources;
   };
-}
+})

--- a/pkgs/by-name/sm/smithy-cli/package.nix
+++ b/pkgs/by-name/sm/smithy-cli/package.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  jdk17,
+}:
+
+let
+  version = "1.67.0";
+
+  sources = {
+    x86_64-linux = {
+      platform = "linux-x86_64";
+      hash = "sha256-/qCxXC4uUfg10R5MeR7DrvUvAeTPJRt8z47SsAjN424=";
+    };
+    aarch64-linux = {
+      platform = "linux-aarch64";
+      hash = "sha256-8nat7tp9extvAU0VWIKQ88SGJC/lbt0G0NlIveteh1o=";
+    };
+    x86_64-darwin = {
+      platform = "darwin-x86_64";
+      hash = "sha256-K6v0o7xkRevwz47Y0PhQhFemzXvOp7Y0ggMRY9kS+iw=";
+    };
+    aarch64-darwin = {
+      platform = "darwin-aarch64";
+      hash = "sha256-XPFkVPpQjt2f6ifZxGbSTtmAltWpWdqPWlEkijvLio4=";
+    };
+  };
+
+  source =
+    sources.${stdenvNoCC.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "smithy-cli";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://github.com/smithy-lang/smithy/releases/download/${version}/smithy-cli-${source.platform}.zip";
+    hash = source.hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib
+
+    # Copy the launcher script
+    cp bin/smithy $out/bin/smithy
+    chmod +x $out/bin/smithy
+
+    # Copy lib directory (contains JARs and bundled JRE)
+    cp -r lib/* $out/lib/
+
+    # Replace the bundled java with system java
+    ln -sf ${jdk17}/bin/java $out/bin/java
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CLI for the Smithy interface definition language (IDL)";
+    homepage = "https://smithy.io/";
+    changelog = "https://github.com/smithy-lang/smithy/releases/tag/${version}";
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+    license = lib.licenses.asl20;
+    mainProgram = "smithy";
+    maintainers = [ ];
+    platforms = lib.attrNames sources;
+  };
+}


### PR DESCRIPTION
## Things done

Init smithy-cli at version 1.67.0

Homepage: https://smithy.io/index.html
Docs: https://smithy.io/2.0/quickstart.html

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
