### PR TITLE
ev-cmd: init at 1.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5832,6 +5832,12 @@
     githubId = 24708079;
     name = "Dan Eads";
   };
+  danhab99 = {
+    email = "dan.habot@gmail.com";
+    github = "danhab99";
+    githubId = 13894263;
+    name = "Dan Habot";
+  };
   danid3v = {
     email = "sch220233@spengergasse.at";
     github = "DaniD3v";

--- a/pkgs/by-name/ev/ev-cmd/package.nix
+++ b/pkgs/by-name/ev/ev-cmd/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ev-cmd";
+  version = "1.0.1";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  src = fetchFromGitHub {
+    owner = "danhab99";
+    repo = "ev-cmd";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-zGawHgJx/KPbM8T5jKXAPOvhbNwzMa8acCgNaIyg1Fs=";
+  };
+
+  cargoHash = "sha256-YTVw1w+pr+G7c+1edKtul72n8q71R2+kheHIV/KTybg=";
+
+  meta = {
+    description = "Simple keyboard based command runner";
+    homepage = "https://github.com/danhab99/ev-cmd";
+    changelog = "https://github.com/danhab99/ev-cmd/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ danhab99 ];
+    mainProgram = "ev-cmd";
+  };
+})

--- a/pkgs/by-name/ev/ev-cmd/package.nix
+++ b/pkgs/by-name/ev/ev-cmd/package.nix
@@ -9,6 +9,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ev-cmd";
   version = "1.0.1";
 
+  __structuredAttrs = true;
+  strictDeps = true;
+
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds `ev-cmd`, a command-line tool that listens to Linux input events and executes shell commands on key presses, useful for devices like macropads.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
