### PR TITLE
equibop: fix EROFS when settings.json is a Nix store symlink & Disable speech-dispatcher by default to avoid SIGTRAP

### DIFF
--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -146,7 +146,6 @@ stdenv.mkDerivation (finalAttrs: {
       ' \
       --add-flags $out/opt/Equibop/resources/app.asar \
       ${lib.strings.optionalString withTTS ''
-        --run 'if [[ "''${NIXOS_SPEECH:-default}" != "False" ]]; then NIXOS_SPEECH=True; else unset NIXOS_SPEECH; fi' \
         --add-flags "\''${NIXOS_SPEECH:+--enable-speech-dispatcher}" \
       ''} \
       ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \

--- a/pkgs/by-name/eq/equibop/package.nix
+++ b/pkgs/by-name/eq/equibop/package.nix
@@ -6,6 +6,7 @@
   makeWrapper,
   makeDesktopItem,
   copyDesktopItems,
+  coreutils,
   electron,
   python3Packages,
   pipewire,
@@ -13,6 +14,7 @@
   autoPatchelfHook,
   bun,
   nodejs,
+  speechd,
   withTTS ? true,
   withMiddleClickScroll ? false,
 }:
@@ -118,8 +120,35 @@ stdenv.mkDerivation (finalAttrs: {
 
   postFixup = ''
     makeWrapper ${electron}/bin/electron $out/bin/equibop \
+      --prefix PATH : ${lib.makeBinPath ([ coreutils ] ++ lib.optionals withTTS [ speechd ])} \
+      --run '
+        cfg_home="''${XDG_CONFIG_HOME:-$HOME/.config}"
+        cfg_file="$cfg_home/equibop/settings/settings.json"
+
+        # Home Manager (and similar tooling) may symlink config files into the
+        # Nix store, which is read-only. Equibop expects to mutate this file at
+        # runtime, so replace a read-only symlink with a writable copy.
+        if [[ -L "$cfg_file" && ! -w "$cfg_file" ]]; then
+          target="$(readlink -f "$cfg_file" 2>/dev/null || true)"
+          if [[ "$target" == /nix/store/* ]]; then
+            cfg_dir="''${cfg_file%/*}"
+            mkdir -p "$cfg_dir"
+            tmp="$(mktemp -p "$cfg_dir" settings.json.XXXXXX)"
+            if cp -L "$cfg_file" "$tmp" 2>/dev/null; then
+              rm -f "$cfg_file"
+              mv -f "$tmp" "$cfg_file"
+            else
+              rm -f "$tmp"
+              rm -f "$cfg_file"
+            fi
+          fi
+        fi
+      ' \
       --add-flags $out/opt/Equibop/resources/app.asar \
-      ${lib.optionalString withTTS "--add-flags \"--enable-speech-dispatcher\""} \
+      ${lib.strings.optionalString withTTS ''
+        --run 'if [[ "''${NIXOS_SPEECH:-default}" != "False" ]]; then NIXOS_SPEECH=True; else unset NIXOS_SPEECH; fi' \
+        --add-flags "\''${NIXOS_SPEECH:+--enable-speech-dispatcher}" \
+      ''} \
       ${lib.optionalString withMiddleClickScroll "--add-flags \"--enable-blink-features=MiddleClickAutoscroll\""} \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
   '';


### PR DESCRIPTION
Equibop writes to `~/.config/equibop/settings/settings.json` at runtime. When that file is managed by Home Manager (e.g. via nixcord or similar) it can be a symlink into `/nix/store`, which is read-only, causing EROFS errors and (in some cases) a crash on startup.

This change wraps the launcher to detect a read-only `/nix/store` symlink at that path and replace it with a writable copy in place before starting Equibop.

Example trace of the issue:
```bash
Failed to write renderer settings Error: EROFS: read-only file system, open '/home/user/.config/equibop/settings/settings.json'
    at writeFileSync (node:fs:2425:20)
    at file:///VencordDesktopMain:7:4416
    at file:///VencordDesktopMain:7:3366
    at Set.forEach (<anonymous>)
    at Se.markAsChanged (file:///VencordDesktopMain:7:3355)
    at Se.setData (file:///VencordDesktopMain:7:2740)
    at file:///VencordDesktopMain:7:4678
    at Session.<anonymous> (node:electron/js2c/browser_init:2:107303)
    at Session.emit (node:events:519:28) {
  errno: -30,
  code: 'EROFS',
  syscall: 'open',
  path: '/home/user/.config/equibop/settings/settings.json'
}
```
Related: similar issue/approach for Vesktop: https://github.com/NixOS/nixpkgs/pull/368221

<br>

Additionally, this PR avoids enabling Chromium's `--enable-speech-dispatcher` by default, because doing so can trigger a startup crash (SIGTRAP) on some systems. TTS remains opt-in via `NIXOS_SPEECH=1`.

Example trace of the SIGTRAP:
```bash
Stack trace of thread 15165:
#0  0x00005637019881e5 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x71091e5)
#1  0x0000563701988193 close (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x7109193)
#2  0x0000563701b1a107 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x729b107)
#3  0x0000563701b1a2e1 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x729b2e1)
#4  0x00005637019a173e n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x712273e)
#5  0x00005637019a15d2 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x71225d2)
#6  0x00005637019881e4 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x71091e4)
#7  0x0000563701988193 close (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x7109193)
#8  0x00007f213c92e454 write_err_and_exit (libglib-2.0.so.0 + 0xc7454)
#9  0x00007f213c92e9cf do_exec (libglib-2.0.so.0 + 0xc79cf)
#10 0x00007f213c93097b fork_exec (libglib-2.0.so.0 + 0xc997b)
#11 0x00007f213c930af7 g_spawn_sync_impl (libglib-2.0.so.0 + 0xc9af7)
#12 0x00007f2093754755 spd_open2 (libspeechd.so.2 + 0x7755)
#13 0x00007f2093754c98 spd_open (libspeechd.so.2 + 0x7c98)
#14 0x00005637007ba8c5 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x5f3b8c5)
#15 0x00005637007ba15b n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x5f3b15b)
#16 0x0000563701933b89 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70b4b89)
#17 0x0000563701958fdf n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70d9fdf)
#18 0x0000563701959091 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70da091)
#19 0x0000563701958951 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70d9951)
#20 0x00005637019583fd n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70d93fd)
#21 0x000056370196c26e n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70ed26e)
#22 0x000056370196be9d n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70ece9d)
#23 0x000056370196bd98 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x70ecd98)
#24 0x0000563701987e85 n/a (/nix/store/6ppl38w30hiygnhzkxagm6yrw9jdl15x-electron-unwrapped-38.7.2/libexec/electron/electron + 0x7108e85)
#25 0x00007f213ae8cd53 start_thread (libc.so.6 + 0x9dd53)
#26 0x00007f213af145fc __clone3 (libc.so.6 + 0x1255fc)
ELF object binary architecture: AMD x86-64
```

## Things done
  - Built on platform:
      - [x] x86_64-linux
      - [ ] aarch64-linux
      - [ ] x86_64-darwin
      - [ ] aarch64-darwin
  - Tested, as applicable:
      - [ ] [NixOS tests] in [nixos/tests].
      - [ ] [Package tests] at passthru.tests.
      - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran nixpkgs-review on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in ./result/bin/.
  - Nixpkgs Release Notes
      - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
      - [ ] Module addition: when adding a new NixOS module.
      - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test