### PR TITLE
badgemagic-rs: change meta.mainProgram

### DIFF
--- a/pkgs/by-name/ba/badgemagic-rs/package.nix
+++ b/pkgs/by-name/ba/badgemagic-rs/package.nix
@@ -36,6 +36,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/fossasia/badgemagic-rs";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ matthewcroughan ];
-    mainProgram = "badgemagic-rs";
+    mainProgram = "badgemagic";
   };
 }


### PR DESCRIPTION
The executable should be (according to upstream) and is (as evident by the program not running on current nixpkgs) called `badgemagic`, without the `-rs` suffix.
There is, however, a problem with this: The BadgeMagic app (also in Nixpkgs) also calls its binary `badgemagic` They could either be made incompatible or both applications should have their executables renamed. I don't know if anything relies on them being called exactly `badgemagic`.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
