### PR TITLE
pgread: init at 0-unstable-2026-01-18

### DIFF
--- a/pkgs/by-name/pg/pgread/package.nix
+++ b/pkgs/by-name/pg/pgread/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pgread";
+  version = "0-unstable-2026-01-18";
+
+  src = fetchFromGitHub {
+    owner = "Chocapikk";
+    repo = "pgread";
+    rev = "48a71943fd1fed407a2bf6c9e0afaefabb7e26fc";
+    hash = "sha256-Z9fXFygc7ftP3+6K8JMmaVjoMw1+dgHRvzM2TUhySwM=";
+  };
+
+  vendorHash = "sha256-rF9neBKy8HZQBKAaNiA0uAmVLtX93oblkZTowbfnUzs=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=github.com/Chocapikk/pgread/pgdump.Version=${finalAttrs.version}"
+  ];
+
+  meta = {
+    description = "Tools to read PostgreSQL data files without credentials";
+    homepage = "https://github.com/Chocapikk/pgread";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "pgread";
+  };
+})


### PR DESCRIPTION
Tools to read PostgreSQL data files without credentials

https://github.com/Chocapikk/pgread


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
