### PR TITLE
python313Packages.mcpadapt: 0.1.17 -> 0.1.20

### DIFF
--- a/pkgs/development/python-modules/mcpadapt/default.nix
+++ b/pkgs/development/python-modules/mcpadapt/default.nix
@@ -18,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "mcpadapt";
-  version = "0.1.17";
+  version = "0.1.20";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "grll";
     repo = "mcpadapt";
     tag = "v${version}";
-    hash = "sha256-pnMtCvspfrKwqhNyCelesBSxuPh9Ruc26pzqfWElvsE=";
+    hash = "sha256-mUwGKr+QBkqMKhfEEIlF/jZDW7enKYdngNIoxG5hMU4=";
   };
 
   build-system = [ hatchling ];

--- a/pkgs/development/python-modules/mcpadapt/default.nix
+++ b/pkgs/development/python-modules/mcpadapt/default.nix
@@ -16,7 +16,7 @@
   torchaudio,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "mcpadapt";
   version = "0.1.20";
   pyproject = true;
@@ -24,7 +24,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "grll";
     repo = "mcpadapt";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-mUwGKr+QBkqMKhfEEIlF/jZDW7enKYdngNIoxG5hMU4=";
   };
 
@@ -59,8 +59,8 @@ buildPythonPackage rec {
   meta = {
     description = "MCP servers tool";
     homepage = "https://github.com/grll/mcpadapt";
-    changelog = "https://github.com/grll/mcpadapt/releases/tag/${src.tag}";
+    changelog = "https://github.com/grll/mcpadapt/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/mcpadapt/default.nix
+++ b/pkgs/development/python-modules/mcpadapt/default.nix
@@ -6,6 +6,7 @@
   hatchling,
   jsonref,
   langchain,
+  langchain-anthropic,
   langgraph,
   llama-index,
   mcp,
@@ -45,7 +46,7 @@ buildPythonPackage (finalAttrs: {
     crewai = [ crewai ];
     langchain = [
       langchain
-      # langchain-anthropic
+      langchain-anthropic
       langgraph
     ];
     llamaindex = [ llama-index ];

--- a/pkgs/development/python-modules/mcpadapt/default.nix
+++ b/pkgs/development/python-modules/mcpadapt/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  crewai,
   fetchFromGitHub,
   hatchling,
   jsonref,
@@ -41,7 +42,7 @@ buildPythonPackage (finalAttrs: {
       torchaudio
       soundfile
     ];
-    # crewai = [ crewai ];
+    crewai = [ crewai ];
     langchain = [
       langchain
       # langchain-anthropic


### PR DESCRIPTION
Diff: https://github.com/grll/mcpadapt/compare/v0.1.17...v0.1.20

Changelog: https://github.com/grll/mcpadapt/releases/tag/v0.1.20


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
