### PR TITLE
adminneo: fix adminer devenv service when using adminneo pkg

### DIFF
--- a/pkgs/by-name/ad/adminneo/package.nix
+++ b/pkgs/by-name/ad/adminneo/package.nix
@@ -32,6 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp compiled/adminneo-${finalAttrs.version}.php $out/adminneo.php
     # for compatibility
     ln -s adminneo.php $out/index.php
+    ln -s adminneo.php $out/adminer.php
   ''
   + (lib.optionalString installPlugins ''
     cp -r compiled/adminneo-plugins $out/


### PR DESCRIPTION
This PR is a compatibility fix for https://devenv.sh/services/adminer/ when setting `services.adminer.package` to `pkgs.adminneo`. There is not a breaking change or similar.

You currently get the following error when running `devenv up` without the symlink: 

```
Warning: Unknown: Failed to open stream: No such file or directory in Unknown on line 0

Fatal error: Failed opening required '/nix/store/45nbm2lnc8jsrwrrpyp4pkdzhkrqdx20-adminneo-5.2.1/adminer.php' (include_path='.:/nix/store/xa439av7i5fxlbz53yj9xvgnhiz1vpm1-php-8.4.15/lib/php') in Unknown on line 0
```

The temporary fix on my local machine looked like this:

<img width="1134" height="709" alt="image" src="https://github.com/user-attachments/assets/9c2d4bac-ebfe-4733-89b5-398216ca851b" />

## how to reproduce

You can easily reproduce the compatibilty issue by just adding `package = pkgs.adminneo;` to

```nix
    adminer = {
      enable = true;
      listen = "127.0.0.1:8810"; # default is 127.0.0.1:8080
    };
```

between the lines 45 and 48 of this devenv.nix file: https://github.com/devloberto/laravel-devenv/blob/master/devenv.nix
<img width="659" height="282" alt="image" src="https://github.com/user-attachments/assets/04f7ffce-7032-49f0-8e4c-cd1d3265fce5" />
Then run `devenv up`, go to http://localhost:8810 in your browser and you will see the error.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
