### PR TITLE
opentrack: fix desktop icon & window title

### DIFF
--- a/pkgs/by-name/op/opentrack/desktop-filename.patch
+++ b/pkgs/by-name/op/opentrack/desktop-filename.patch
@@ -1,0 +1,15 @@
+diff --git a/gui/init.cpp b/gui/init.cpp
+index 1647b050db0efe76028000939a7ca8e4047116b7..9114c31c51a69294e0803c15008a824e18da7a09 100644
+--- a/gui/init.cpp
++++ b/gui/init.cpp
+@@ -315,6 +315,10 @@ int otr_main(int argc, char** argv, std::function<std::unique_ptr<QWidget>()> co
+     add_win32_path();
+ #endif
+ 
++#ifdef Q_OS_LINUX
++    app.setDesktopFileName("opentrack");
++#endif
++
+     QDir::setCurrent(OPENTRACK_BASE_PATH);
+ 
+     set_qt_style();

--- a/pkgs/by-name/op/opentrack/package.nix
+++ b/pkgs/by-name/op/opentrack/package.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation (finalAttrs: {
     meta.license = lib.licenses.free;
   };
 
+  patches = [
+    # calls `app.setDesktopFileName("opentrack");` - distros that don't wrap the binary apparently don't need this.
+    ./desktop-filename.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [
@@ -64,13 +69,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    (lib.cmakeFeature "OPENTRACK_COMMIT" "opentrack-${finalAttrs.version}")
     (lib.cmakeBool "SDK_WINE" withWine)
     (lib.cmakeFeature "SDK_ARUCO_LIBPATH" "${finalAttrs.aruco}/lib/libaruco.a")
     (lib.cmakeFeature "SDK_XPLANE" finalAttrs.xplaneSdk.outPath)
   ];
 
   postInstall = ''
-    install -Dt $out/share/icons/hicolor/256x256 $src/gui/images/opentrack.png
+    install -Dt $out/share/icons/hicolor/256x256/apps ../gui/images/opentrack.png
   '';
 
   # manually wrap just the main binary


### PR DESCRIPTION
Just realized I broke the desktop icon in c38cd91cbba253b965631f63f3c3212cf3bd326b and never noticed until now, sorry about that.

This now also fixes the app icon during runtime in Gnome on Wayland, previously it would show a generic icon, and the app id would never be set.
```console
$ WAYLAND_DEBUG=client opentrack |& grep app_id
[ ... ] {Default Queue}  -> xdg_toplevel#39.set_app_id("")
```

I first tried adding `startupWMClass` to the `makeDesktopIcon` helper, but that apparently doesn't work with wrapped Qt(6?) apps, because the binary (from my understanding) looks for `.opentrack-wrapped` which doesn't have an icon.

Lastly the title now shows `opentrack-${version} :: <profile>.ini` instead of ` :: <profile>.ini` by dealing with https://github.com/opentrack/opentrack/blob/2d3ab7a61d2514ce51c9656908d33465a788763e/cmake/opentrack-version.cmake#L4-L7

I also noticed that auto-updates currently fail: https://nixpkgs-update-logs.nix-community.org/opentrack/2026-01-31.log
I'll open a followup PR for that.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
