### PR TITLE
mdbook-plantuml: 0.8.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/md/mdbook-plantuml/package.nix
+++ b/pkgs/by-name/md/mdbook-plantuml/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "mdbook-plantuml";
-  version = "0.8.0-unstable-2022-12-28";
+  version = "v2.0.0";
 
   src = fetchFromGitHub {
     owner = "sytsereitsma";
     repo = "mdbook-plantuml";
-    rev = "c156b53aad6d7bce8479e5406a4a3465c12714ef";
-    hash = "sha256-5/6NQO++MsV7GS69jGkdpkiRhadtQyYZeHreft4h6hQ=";
+    rev = "dae70cfd3deb8438127cc369a92ecefe24acb6a2";
+    hash = "sha256-PNVWeXbYDX/PYFCSPKKeqdbhLl9hmDOK7i7lWQlbEK0=";
   };
 
-  cargoHash = "sha256-LzzAaWLDODbqGNVeEULLOgrpyLGKzaknIbLjKyF2zBw=";
+  cargoHash = "sha256-8DKnINclcX0WwRtCTv7DUBx/6omRvda3qg3a1g1lyFA=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
Diff: https://github.com/sytsereitsma/mdbook-plantuml/compare/v0.8.0...v2.0.0
Changelog: https://github.com/sytsereitsma/mdbook-plantuml/releases/tag/v2.0.0


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
