### PR TITLE
librelane: 3.0.0.dev49 -> 3.0.0.dev50

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -22,14 +22,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.0.dev49";
+  version = "3.0.0.dev50";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
     tag = finalAttrs.version;
-    hash = "sha256-g6bQMg9W0gbvJzVvO4ESeAtswbBoUVY3NXLK4UdOcGs=";
+    hash = "sha256-YDLX/aZEutoJ9Nu0aLvvDLwGH3HEGP+vtHdPFDbjEEU=";
   };
 
   build-system = [


### PR DESCRIPTION
Diff: https://github.com/librelane/librelane/compare/3.0.0.dev49...3.0.0.dev50

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

librelane --smoke-test passes:

```
* Antenna
Passed ✅

* LVS
Passed ✅

* DRC
Passed ✅

[14:24:23] INFO     Saving views to '/tmp/tmpz3d3661llibrelane/smoke_test_design/runs/RUN_2026-02-04_14-23-06/final'…                               state.py:209
[14:24:23] INFO     Flow complete.                                                                                                             sequential.py:413
Classic - Stage 79 - Report Manufacturability ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79/79 0:01:17
[14:24:23] WARNING  The following warnings were generated by the flow:                                                                               flow.py:699
[14:24:23] WARNING  [Odb.CustomIOPlacement] Overriding minimum distance 0.1 with 0.42 for pins on side N to avoid overlap.                           flow.py:701
[14:24:23] WARNING  [OpenROAD.RepairDesignPostGPL] [STA-1140]                                                                                        flow.py:701
                    /home/gonsolo/.ciel/ciel/sky130/versions/8afc8346a57fe1ab7934ba5a6056ea8b43078e71/sky130A/libs.ref/sky130_fd_sc_hd/lib/sky130_fd            
                    _sc_hd__tt_025C_1v80.lib line 1, library sky130_fd_sc_hd__tt_025C_1v80 already exists. (and 17 similar warnings)                            
[14:24:23] WARNING  [OpenROAD.RepairDesignPostGPL] [RSZ-0020] found 2 floating nets.                                                                 flow.py:701
[14:24:23] WARNING  [OpenROAD.DetailedRouting] [DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon (and 9 similar  flow.py:701
                    warnings)                                                                                                                                   
[14:24:23] WARNING  [Checker.WireLength] Threshold for Threshold-surpassing long wires is not set. The checker will be skipped.                      flow.py:701
[14:24:23] WARNING  [OpenROAD.IRDropReport] 'VSRC_LOC_FILES' was not given a value, which may make the results of IR drop analysis inaccurate. If    flow.py:701
                    you are not integrating a top-level chip for manufacture, you may ignore this warning, otherwise, see the documentation for                 
                    'VSRC_LOC_FILES'.                                                                                                                           
[14:24:23] INFO     Smoke test passed.                   
```