### PR TITLE
python3Packages.zammad-py: 3.2.0 -> 3.2.1

### DIFF
--- a/pkgs/development/python-modules/zammad-py/default.nix
+++ b/pkgs/development/python-modules/zammad-py/default.nix
@@ -7,16 +7,16 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "zammad-py";
-  version = "3.2.0";
+  version = "3.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "joeirimpan";
     repo = "zammad_py";
-    tag = "v${version}";
-    hash = "sha256-gU5OA5m8X03GM7ImXZZVLkEyoAXRCoFskfop8oXJFH0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-idPT3H2mlHoC8gHAQHOAcQJKciPZyagVEmojcKbj8ls=";
   };
 
   build-system = [
@@ -37,6 +37,9 @@ buildPythonPackage rec {
     "test_tickets"
     "test_groups"
     "test_pagination"
+    "test_knowledge_bases"
+    "test_knowledge_bases_answers"
+    "test_knowledge_bases_categories"
   ];
 
   pythonImportsCheck = [
@@ -44,10 +47,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://github.com/joeirimpan/zammad_py/blob/${src.tag}/HISTORY.rst";
+    changelog = "https://github.com/joeirimpan/zammad_py/blob/${finalAttrs.src.tag}/HISTORY.md";
     description = "Python API client for accessing zammad REST API";
     homepage = "https://github.com/joeirimpan/zammad_py";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ hexa ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/joeirimpan/zammad_py/blob/v3.2.1/HISTORY.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
