### PR TITLE
python3Packages.redbaron: fix tests

### DIFF
--- a/pkgs/development/python-modules/redbaron/default.nix
+++ b/pkgs/development/python-modules/redbaron/default.nix
@@ -16,6 +16,8 @@ buildPythonPackage rec {
     sha256 = "0bqkq0wn20cc3qrcd1ifq74p4m570j345bkq4axl08kbr8whfba7";
   };
 
+  patches = [ ./fix-pygments-test.patch ];
+
   propagatedBuildInputs = [ baron ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/redbaron/fix-pygments-test.patch
+++ b/pkgs/development/python-modules/redbaron/fix-pygments-test.patch
@@ -1,0 +1,30 @@
+diff --git a/tests/test_no_pygments.py b/tests/test_no_pygments.py
+index 1064653c23..f536bcca4b 100644
+--- a/tests/test_no_pygments.py
++++ b/tests/test_no_pygments.py
+@@ -55,15 +55,15 @@
+         out = captured.out
+     assert out == """\
+ 0 -----------------------------------------------------
+-\x1b[38;5;148mAssignmentNode\x1b[39m\x1b[38;5;197m(\x1b[39m\x1b[38;5;197m)\x1b[39m
+-\x1b[38;5;15m  \x1b[39m\x1b[38;5;242m# identifiers: assign, assignment, assignment_, assignmentnode\x1b[39m
+-\x1b[38;5;15m  \x1b[39m\x1b[38;5;15moperator\x1b[39m\x1b[38;5;197m=\x1b[39m\x1b[38;5;186m''\x1b[39m
+-\x1b[38;5;15m  \x1b[39m\x1b[38;5;15mtarget\x1b[39m\x1b[38;5;15m \x1b[39m\x1b[38;5;197m->\x1b[39m
+-\x1b[38;5;15m    \x1b[39m\x1b[38;5;148mNameNode\x1b[39m\x1b[38;5;197m(\x1b[39m\x1b[38;5;197m)\x1b[39m
+-\x1b[38;5;15m      \x1b[39m\x1b[38;5;242m# identifiers: name, name_, namenode\x1b[39m
+-\x1b[38;5;15m      \x1b[39m\x1b[38;5;15mvalue\x1b[39m\x1b[38;5;197m=\x1b[39m\x1b[38;5;186m'a'\x1b[39m
+-\x1b[38;5;15m  \x1b[39m\x1b[38;5;15mannotation\x1b[39m\x1b[38;5;15m \x1b[39m\x1b[38;5;197m->\x1b[39m
++\x1b[38;5;148mAssignmentNode\x1b[39m\x1b[38;5;204m(\x1b[39m\x1b[38;5;204m)\x1b[39m
++\x1b[38;5;15m  \x1b[39m\x1b[38;5;245m# identifiers: assign, assignment, assignment_, assignmentnode\x1b[39m
++\x1b[38;5;15m  \x1b[39m\x1b[38;5;15moperator\x1b[39m\x1b[38;5;204m=\x1b[39m\x1b[38;5;186m''\x1b[39m
++\x1b[38;5;15m  \x1b[39m\x1b[38;5;15mtarget\x1b[39m\x1b[38;5;15m \x1b[39m\x1b[38;5;204m->\x1b[39m
++\x1b[38;5;15m    \x1b[39m\x1b[38;5;148mNameNode\x1b[39m\x1b[38;5;204m(\x1b[39m\x1b[38;5;204m)\x1b[39m
++\x1b[38;5;15m      \x1b[39m\x1b[38;5;245m# identifiers: name, name_, namenode\x1b[39m
++\x1b[38;5;15m      \x1b[39m\x1b[38;5;15mvalue\x1b[39m\x1b[38;5;204m=\x1b[39m\x1b[38;5;186m'a'\x1b[39m
++\x1b[38;5;15m  \x1b[39m\x1b[38;5;15mannotation\x1b[39m\x1b[38;5;15m \x1b[39m\x1b[38;5;204m->\x1b[39m
+ \x1b[38;5;15m    \x1b[39m\x1b[38;5;186mNone\x1b[39m
+-\x1b[38;5;15m  \x1b[39m\x1b[38;5;15mvalue\x1b[39m\x1b[38;5;15m \x1b[39m\x1b[38;5;197m->\x1b[39m
+-\x1b[38;5;15m    \x1b[39m\x1b[38;5;15m[\x1b[39m\x1b[38;5;15m]\x1b[39m
++\x1b[38;5;15m  \x1b[39m\x1b[38;5;15mvalue\x1b[39m\x1b[38;5;15m \x1b[39m\x1b[38;5;204m->\x1b[39m
++\x1b[38;5;15m    \x1b[39m\x1b[38;5;15m\x1b[38;5;15m[\x1b[39m\x1b[39m\x1b[38;5;15m\x1b[38;5;15m]\x1b[39m\x1b[39m
+ """


### PR DESCRIPTION
I've come across this broken package a couple of times while updating `python-sat` now, so I decided to just look into fixing it.
However, nobody seems to have minded this being broken for more than half a year now, so one could also vote for removing it (at `portmod`, which depends on it).

The pygments test seems to have broken due to some color changes in styling.
Updates the expected styled text.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
