### PR TITLE
gnome-extensions-cli: migrate to by-name

### DIFF
--- a/pkgs/by-name/gn/gnome-extensions-cli/package.nix
+++ b/pkgs/by-name/gn/gnome-extensions-cli/package.nix
@@ -1,32 +1,24 @@
 {
   lib,
   fetchPypi,
-  buildPythonApplication,
-  poetry-core,
-  colorama,
-  packaging,
-  pydantic,
-  requests,
-  pygobject3,
-  tqdm,
+  python3Packages,
   gobject-introspection,
   wrapGAppsNoGuiHook,
 }:
 
-buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gnome-extensions-cli";
   version = "0.10.8";
   pyproject = true;
 
   src = fetchPypi {
     pname = "gnome_extensions_cli";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-Tnf8BbW9u7d19ZtGTdMVHa6azbKekYRGOPEPNiB+y00=";
   };
 
   nativeBuildInputs = [
     gobject-introspection
-    poetry-core
     wrapGAppsNoGuiHook
   ];
 
@@ -35,13 +27,17 @@ buildPythonApplication rec {
     "packaging"
   ];
 
-  propagatedBuildInputs = [
-    colorama
-    packaging
-    pydantic
-    requests
-    pygobject3
-    tqdm
+  build-system = [
+    python3Packages.poetry-core
+  ];
+
+  dependencies = [
+    python3Packages.colorama
+    python3Packages.packaging
+    python3Packages.pydantic
+    python3Packages.requests
+    python3Packages.pygobject3
+    python3Packages.tqdm
   ];
 
   pythonImportsCheck = [
@@ -55,4 +51,4 @@ buildPythonApplication rec {
     maintainers = with lib.maintainers; [ dylanmtaylor ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12067,8 +12067,6 @@ with pkgs;
     gnome49Extensions
     ;
 
-  gnome-extensions-cli = python3Packages.callPackage ../desktops/gnome/misc/gnome-extensions-cli { };
-
   gnome-session-ctl = callPackage ../by-name/gn/gnome-session/ctl.nix { };
 
   lomiri = recurseIntoAttrs (callPackage ../desktops/lomiri { });


### PR DESCRIPTION
This pull request reorganizes and improves the packaging of the `gnome-extensions-cli` Python application. The package has been moved to a new location and updated to use the standard `python3Packages` set for its dependencies, which improves maintainability and consistency with other Python packages.

**Package reorganization and dependency management:**

* Moved the `gnome-extensions-cli` package from `pkgs/desktops/gnome/misc/gnome-extensions-cli/default.nix` to `pkgs/by-name/gn/gnome-extensions-cli/package.nix` for better organization.
* Updated the package to use dependencies from `python3Packages` (such as `colorama`, `packaging`, `pydantic`, etc.) instead of referencing them directly, and switched to `python3Packages.buildPythonApplication` for building. 

* Updated `nativeBuildInputs` to use `python3Packages.poetry-core` instead of a direct reference.

**Top-level package list cleanup:**

* Removed the old reference to `gnome-extensions-cli` in `pkgs/top-level/all-packages.nix` to avoid duplication and ensure the new location is used.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
