### PR TITLE
make-minimal-bootstrap-sources: fix build

### DIFF
--- a/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/make-bootstrap-sources.nix
+++ b/pkgs/os-specific/linux/minimal-bootstrap/stage0-posix/make-bootstrap-sources.nix
@@ -27,6 +27,7 @@ fetchFromGitHub {
   owner = "oriansj";
   repo = "stage0-posix";
   sha256 = expected.outputHash;
+  deepClone = true;
   fetchSubmodules = true;
   postFetch = ''
     # Seed binaries will be fetched separately
@@ -40,6 +41,9 @@ fetchFromGitHub {
       $out/M2-Planet/M2libc \
       $out/mescc-tools/M2libc \
       $out/mescc-tools-extra/M2libc
+
+    # deepClone causes .git to be present, remove
+    rm -rf $out/*/.git $out/.git
   '';
 
   meta = {


### PR DESCRIPTION
The GitHub repository we fetch in make-minimal-bootstrap-sources references a submodule (mescc-tools) which is located in GNU Savannah. Shallow-fetching mescc-tools is broken since some time ago, but a deep clone seems to work.

Thankfully this leaves the FOD output unchanged (verified with diffoscope).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
