### PR TITLE
skywalking-eyes: init at 0.8.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11786,6 +11786,12 @@
     githubId = 1358764;
     name = "Jamie Magee";
   };
+  janezp = {
+    name = "Janez Podhostnik";
+    email = "janez.podhostnik@ourplace.is";
+    github = "janezpodhostnik";
+    githubId = 67895329;
+  };
   janhencic = {
     name = "Jan Hencic";
     email = "jan@hencic.com";

--- a/pkgs/by-name/sk/skywalking-eyes/package.nix
+++ b/pkgs/by-name/sk/skywalking-eyes/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "skywalking-eyes";
+  version = "0.8.0";
+
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "skywalking-eyes";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uk/tX1AfYfy4ARzyd9IZijFYBEsfrx/DX+QsTVg3Jc4=";
+  };
+
+  vendorHash = "sha256-sH9zV99XX7f8q7guBDkLAJ7Lr3eiQXSQ2+CGd2zphLk=";
+
+  subPackages = [ "cmd/license-eye" ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/apache/skywalking-eyes/commands.version=${finalAttrs.version}"
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd license-eye \
+      --bash <($out/bin/license-eye completion bash) \
+      --zsh <($out/bin/license-eye completion zsh) \
+      --fish <($out/bin/license-eye completion fish)
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Check and fix license headers and resolve dependencies' licenses";
+    homepage = "https://github.com/apache/skywalking-eyes";
+    changelog = "https://github.com/apache/skywalking-eyes/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ janezp ];
+    mainProgram = "license-eye";
+  };
+})


### PR DESCRIPTION
Add [Apache SkyWalking Eyes](https://github.com/apache/skywalking-eyes) - a full-featured license tool to check and fix license headers and resolve dependencies' licenses.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

