### PR TITLE
Revert "kdePackages.kdenlive: add workaround for broken shaderc pc file"

### DIFF
--- a/pkgs/kde/gear/kdenlive/default.nix
+++ b/pkgs/kde/gear/kdenlive/default.nix
@@ -16,7 +16,6 @@
   kio-extras,
   opentimelineio,
   frei0r,
-  shaderc,
 }:
 mkKdeDerivation {
   pname = "kdenlive";
@@ -31,9 +30,6 @@ mkKdeDerivation {
   extraCmakeFlags = [
     "-DFETCH_OTIO=0"
   ];
-
-  # Workaround until https://github.com/NixOS/nixpkgs/pull/480475 hits master
-  NIX_LDFLAGS = [ "-L${shaderc.lib}/lib -lshaderc_shared" ];
 
   extraNativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
This reverts commit e848373e2c049b8df7dd5d350e2d1ea32f850e4a.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
