### PR TITLE
tg-timer: Use strictDeps, structuredAttrs, wrapGApps

### DIFF
--- a/pkgs/by-name/tg/tg-timer/package.nix
+++ b/pkgs/by-name/tg/tg-timer/package.nix
@@ -6,6 +6,7 @@
   autoreconfHook,
   # Build binaries
   pkg-config,
+  wrapGAppsHook3,
   # Build libraries
   gtk3,
   portaudio,
@@ -30,9 +31,19 @@ stdenv.mkDerivation (finalAttrs: {
     ./audio.patch
   ];
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   nativeBuildInputs = [
+    wrapGAppsHook3
     autoreconfHook
     pkg-config
+    (python3.pythonOnBuildForHost.withPackages (p: [
+      p.numpy
+      p.matplotlib
+      p.libtfr
+      p.scipy
+    ]))
   ];
 
   buildInputs = [
@@ -40,12 +51,6 @@ stdenv.mkDerivation (finalAttrs: {
     portaudio
     fftwFloat
     libjack2
-    (python3.withPackages (p: [
-      p.numpy
-      p.matplotlib
-      p.libtfr
-      p.scipy
-    ]))
   ];
 
   enableParallelBuilding = true;
@@ -68,7 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/xyzzy42/tg";
     changelog = "https://github.com/xyzzy42/tg/releases/tag/v${finalAttrs.version}-tpiepho";
     license = lib.licenses.gpl2Plus;
-    mainProgram = "tg";
+    mainProgram = "tg-timer";
     maintainers = with lib.maintainers; [ RossSmyth ];
   };
 })


### PR DESCRIPTION
Also fix the mainProgram


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
