### PR TITLE
tracearr: init at 1.4.27

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8118,6 +8118,12 @@
     githubId = 965612;
     name = "York Wong";
   };
+  ethnt = {
+    email = "ethan@turkeltaub.dev";
+    github = "ethnt";
+    githubId = 137037;
+    name = "Ethan Turkeltaub";
+  };
   Etjean = {
     email = "et.jean@outlook.fr";
     github = "Etjean";

--- a/pkgs/by-name/tr/tracearr/package.nix
+++ b/pkgs/by-name/tr/tracearr/package.nix
@@ -1,0 +1,102 @@
+{
+  lib,
+  stdenv,
+  pnpm_10,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  makeWrapper,
+  nix-update-script,
+  nodejs,
+  fetchFromGitHub,
+  turbo,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tracearr";
+  version = "1.4.27";
+
+  src = fetchFromGitHub {
+    owner = "connorgallopo";
+    repo = "Tracearr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-AIybXQFRrD5H5aF77ykL0xpYs/UftAAJVyo84LTdTdw=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-mBo2+Gy91MQEplMDSkExb9eKmOGeDYk8c4uHMzjDv64=";
+  };
+
+  strictDeps = true;
+
+  env.NODE_ENV = "production";
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpmConfigHook
+    pnpm_10
+    turbo
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm run build
+    runHook postBuild
+  '';
+
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+
+    pnpm test
+
+    runHook postCheck
+  '';
+
+  preInstall = ''
+    rm node_modules/.modules.yaml
+
+    CI=true pnpm prune --prod --ignore-scripts
+
+    find -type f \( -name "*.d.ts" -o -name "*.map" \) -exec rm -rf {} +
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{lib/tracearr,bin}
+    mkdir -p $out/lib/tracearr/apps
+
+    cp -r {node_modules,packages,data} $out/lib/tracearr
+    cp -r apps/{server,web} $out/lib/tracearr/apps
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/tracearr \
+      --add-flags $out/lib/tracearr/apps/server/dist/index.js \
+      --set NODE_PATH "$out/lib/tracearr/node_modules:$out/lib/tracearr/apps/server/node_modules:$out/lib/tracearr/apps/web/node_modules" \
+      --set-default APP_VERSION ${finalAttrs.version} \
+      --set-default APP_TAG v${finalAttrs.version} \
+      --set-default NODE_ENV production
+
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    find $out/lib -xtype l -delete
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Real-time monitoring for Plex, Jellyfin, and Emby servers. Track streams, analyze playback, and detect account sharing from a single dashboard.";
+    mainProgram = "tracearr";
+    homepage = "https://tracearr.com";
+    license = lib.licenses.unfree; # Marked unfree due to licensing issues upstream: https://github.com/connorgallopo/Tracearr/issues/702
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    maintainers = with lib.maintainers; [ ethnt ];
+  };
+})


### PR DESCRIPTION
- Adds package `tracearr` v.1.4.27 ([homepage](https://www.tracearr.com/))
- Adds `ethnt` as maintainer

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
