### PR TITLE
python3Packages.redbaron: disable failing test

### DIFF
--- a/pkgs/development/python-modules/redbaron/default.nix
+++ b/pkgs/development/python-modules/redbaron/default.nix
@@ -23,6 +23,8 @@ buildPythonPackage rec {
     rm tests/test_bounding_box.py
   ''; # error about fixtures
 
+  disabledTests = [ "test_no_pygments" ]; # some tests about formatting of the help message
+
   nativeCheckInputs = [ pytestCheckHook ];
 
   meta = {


### PR DESCRIPTION
redbaron was failing since some time, causing portmod to fail to compile.

This disable the failing and fix portmod, its sole dependent..

## Things done

disabled a test from redbaron. It appear to be related to the formatting of an help message, in regard to coloration.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (tested portmod)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Should close both https://github.com/NixOS/nixpkgs/issues/456892 and https://github.com/NixOS/nixpkgs/issues/456894