### PR TITLE
burpsuite: fix wordlists not available in file picker

### DIFF
--- a/pkgs/by-name/bu/burpsuite/package.nix
+++ b/pkgs/by-name/bu/burpsuite/package.nix
@@ -85,6 +85,16 @@ buildFHSEnv {
       libxrandr
     ];
 
+  extraBuildCommands = ''
+    mkdir -p $out/usr/share/wordlists
+    mkdir -p $out/usr/share/seclists
+  '';
+
+  extraBwrapArgs = [
+    "--ro-bind-try /usr/share/wordlists /usr/share/wordlists"
+    "--ro-bind-try /usr/share/seclists /usr/share/seclists"
+  ];
+
   extraInstallCommands = ''
     mkdir -p "$out/share/pixmaps"
     ${lib.getBin unzip}/bin/unzip -p ${src} resources/Media/icon64${product.productName}.png > "$out/share/pixmaps/burpsuite.png"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR adds support for using wordlists directly in Burp Suite’s Intruder via the file picker.
Previously, users had to manually copy and paste wordlist contents into Intruder.

The patch updates the Burp Suite FHS environment wrapper to expose external wordlists inside the sandbox without merging the entire `/usr/share` directory.
It achieves this by read-only binding `/usr/share/wordlists` and `/usr/share/seclists` into the FHS environment’s `/usr/share` using `extraBwrapArgs`.

Related to https://github.com/NixOS/nixpkgs/issues/81418


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
