### PR TITLE
paqet: init at 1.0.0-alpha.13

### DIFF
--- a/pkgs/by-name/pa/paqet/package.nix
+++ b/pkgs/by-name/pa/paqet/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  libpcap,
+  installShellFiles,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "paqet";
+  version = "1.0.0-alpha.14";
+  src = fetchFromGitHub {
+    owner = "hanselime";
+    repo = "paqet";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-U5NBbXkyYcEemKgApNeDvxe3dKAt6HViUXlYcvvK0UU=";
+  };
+
+  vendorHash = "sha256-Vf3bKdhlM4vqzBv5RAwHeShGHudEh1VNTCFxAL/cwLw=";
+
+  nativeBuildInputs = [ installShellFiles ];
+  buildInputs = [ libpcap ];
+
+  postInstall = ''
+    mv $out/bin/cmd $out/bin/paqet
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd paqet \
+      --bash <($out/bin/paqet completion bash) \
+      --fish <($out/bin/paqet completion fish) \
+      --zsh  <($out/bin/paqet completion zsh)
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=unstable" ]; };
+
+  meta = {
+    description = "Bidirectional Packet-level proxy built using raw sockets in Go";
+    mainProgram = "paqet";
+    homepage = "https://github.com/hanselime/paqet";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nix-julia ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
