### PR TITLE
yaziPlugins: update on 2026-02-04

### DIFF
--- a/pkgs/by-name/ya/yazi/plugins/mount/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/mount/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "mount.yazi";
-  version = "25.12.29-unstable-2026-01-26";
+  version = "25.12.29-unstable-2026-01-31";
 
   src = fetchFromGitHub {
     owner = "yazi-rs";
     repo = "plugins";
-    rev = "0c95a0dac882e652f70c6fbc79655658c0cb6e74";
-    hash = "sha256-DwHTpEIuING9cajq+O61OmHR93/tpKqgU+cM0//5TZ8=";
+    rev = "d078b01ecbdb0f85f6ea8836a851c6bf72f9f865";
+    hash = "sha256-aPe1AntPE76xq0VA/4FtBtRXmj+tfDjdMlQ9B9MkM+U=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/nord/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/nord/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "nord.yazi";
-  version = "0-unstable-2025-05-20";
+  version = "0-unstable-2026-02-03";
 
   src = fetchFromGitHub {
     owner = "stepbrobd";
     repo = "nord.yazi";
-    rev = "c9a58b4361ac82d5ddc91e6e27b620bb096d0bee";
-    hash = "sha256-yjxdoZlOPFliNbp+SwNFd+PPWlD7j8edXC8urQo7WZA=";
+    rev = "891f0b3048c21ce48cd73948971ebde7a73b7260";
+    hash = "sha256-EcHFLYNfK4pOMxZ0anWSDUPmTQoYdAohnVAtn0XSoO8=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/yatline-catppuccin/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline-catppuccin/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline-catppuccin.yazi";
-  version = "0-unstable-2025-03-05";
+  version = "0-unstable-2026-02-01";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline-catppuccin.yazi";
-    rev = "8cc4773ecab8ee8995485d53897e1c46991a7fea";
-    hash = "sha256-Wz53zjwFyflnxCIMjAv+nzcgDriJwVYBX81pFXJUzc4=";
+    rev = "6c3f166231d054bd500585b83280258f3941e3af";
+    hash = "sha256-NRmXzgRMnjCKbg8V+TuppBRLbP1NAz7taRtYv8C7kqY=";
   };
 
   meta = {

--- a/pkgs/by-name/ya/yazi/plugins/yatline-githead/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/yatline-githead/default.nix
@@ -5,13 +5,13 @@
 }:
 mkYaziPlugin {
   pname = "yatline-githead.yazi";
-  version = "0-unstable-2026-01-30";
+  version = "0-unstable-2026-01-31";
 
   src = fetchFromGitHub {
     owner = "imsi32";
     repo = "yatline-githead.yazi";
-    rev = "25a068d78838e463a7c34f3674a6f3b986756968";
-    hash = "sha256-1BrqMwFff3wH+RntYSQkeuRZiBMdgK5v1c9h+QQ8XF8=";
+    rev = "929e52cd6ff9ef0130756260ee5f0af69ce5debe";
+    hash = "sha256-1r7AY0Yzr32YZl2g74ylx+1vGoNg04PMkDXnaB0X+lk=";
   };
 
   meta = {


### PR DESCRIPTION
- mount: 25.12.29-unstable-2026-01-26 → 25.12.29-unstable-2026-01-31
  Compare: https://github.com/yazi-rs/plugins/compare/0c95a0dac882e652f70c6fbc79655658c0cb6e74...d078b01ecbdb0f85f6ea8836a851c6bf72f9f865
- nord: 0-unstable-2025-05-20 → 0-unstable-2026-02-03
  Compare: https://github.com/stepbrobd/nord.yazi/compare/c9a58b4361ac82d5ddc91e6e27b620bb096d0bee...891f0b3048c21ce48cd73948971ebde7a73b7260
- yatline-catppuccin: 0-unstable-2025-03-05 → 0-unstable-2026-02-01
  Compare: https://github.com/imsi32/yatline-catppuccin.yazi/compare/8cc4773ecab8ee8995485d53897e1c46991a7fea...6c3f166231d054bd500585b83280258f3941e3af
- yatline-githead: 0-unstable-2026-01-30 → 0-unstable-2026-01-31
  Compare: https://github.com/imsi32/yatline-githead.yazi/compare/25a068d78838e463a7c34f3674a6f3b986756968...929e52cd6ff9ef0130756260ee5f0af69ce5debe


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
