### PR TITLE
ungoogled-chromium: 144.0.7559.109-1 -> 144.0.7559.132-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -558,9 +558,10 @@ let
       # https://chromium-review.googlesource.com/c/chromium/src/+/7022369
       ./patches/chromium-144-rustc_nightly_capability.patch
     ]
-    ++ lib.optionals (chromiumVersionAtLeast "144.0.7559.132") [
+    ++ lib.optionals (chromiumVersionAtLeast "144.0.7559.132" && !ungoogled) [
       # Rollup was swapped with esbuild because of compile failures on Windows,
       # which is not compatible with our build yet. So let's revert it for now.
+      # Ungoogled ships its own variant of this patch upstream.
       # https://issues.chromium.org/issues/461602362
       (fetchpatch {
         name = "revert-devtools-frontend-esbuild-instead-of-rollup.patch";

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -813,7 +813,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "144.0.7559.109",
+    "version": "144.0.7559.132",
     "deps": {
       "depot_tools": {
         "rev": "2e88a3f08bd8c4a0014eae82729beca935f7f188",
@@ -825,16 +825,16 @@
         "hash": "sha256-04h38X/hqWwMiAOVsVu4OUrt8N+S7yS/JXc5yvRGo1I="
       },
       "ungoogled-patches": {
-        "rev": "144.0.7559.109-1",
-        "hash": "sha256-PPZ87jk8zISyWcoI3cf5/Z11uA15+cb+K9EKxT93u0M="
+        "rev": "144.0.7559.132-1",
+        "hash": "sha256-QEVnXEzjdJoulTB2yCA8DkmeHwGyksjQhumycsW9HV8="
       },
       "npmHash": "sha256-13sgV/5BD7QvDLBAEmoLN5vongw+S5v5znvZcctxhWc="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "6a8d5e49388fcc8a7d56d2a275e4ef424eb10960",
-        "hash": "sha256-3Wwc7Vb8dM2VGqQs6GOPehsTVBgcZ9in+kC1vN9S1FI=",
+        "rev": "8990ccf77859863f68a0d18957786bd7cb29ff76",
+        "hash": "sha256-USPpPF6BcxrUiRwwGKRo+bGN2NPuLLqBYSN3q1D2f0A=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1069,8 +1069,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "a3064782146fc247c488d44c1ad3496b29d55ec4",
-        "hash": "sha256-vLkWH/EiDHxl/dz4soKybQF1hgud/7MlnDhVPicYJGY="
+        "rev": "f130475580017f9f87502343dbcfc0c76dccefe8",
+        "hash": "sha256-6osYh+ijcH7LEg1v7xGEf0zC36HZGMfqXP9Eq6g5WdU="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -1344,8 +1344,8 @@
       },
       "src/third_party/libvpx/source/libvpx": {
         "url": "https://chromium.googlesource.com/webm/libvpx.git",
-        "rev": "9a7674e1a83d1261a49776c8794b87c9bccc85d7",
-        "hash": "sha256-PdRZyXurQkw3UWOH1MkkuzggJkt9Uxq472L4LkxaYtw="
+        "rev": "14cd170a941f88e6fb145ebb873a3c8f87645834",
+        "hash": "sha256-5+TQo0qRaH1QnAgdQkJcGkKWYGPJO3hVIqqGEtHpwqk="
       },
       "src/third_party/libwebm/source": {
         "url": "https://chromium.googlesource.com/webm/libwebm.git",
@@ -1619,8 +1619,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "d75d178c137447df1a3e8830eae86b0bd72b9ac6",
-        "hash": "sha256-5oQP3+kpnKfUInGBYcTvL/uLK9UlcWCz1mDFGeXBnmM="
+        "rev": "0f9ccaeb4a88dbff7a7c86e998ceea7d6f947950",
+        "hash": "sha256-7jQ1WrY2+8s0tDjl4qzaZz/xdWrePiVvuJDI00YLd9k="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #486940

https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop.html

This update includes 2 security fixes.

CVEs:
CVE-2026-1861 CVE-2026-1862

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
