### PR TITLE
tuxedo-rs: remove mrcjkb from maintainers

### DIFF
--- a/nixos/modules/services/hardware/tuxedo-rs.nix
+++ b/nixos/modules/services/hardware/tuxedo-rs.nix
@@ -49,5 +49,7 @@ in
     ]
   );
 
-  meta.maintainers = with lib.maintainers; [ mrcjkb ];
+  meta.maintainers = with lib.maintainers; [
+    xaverdh
+  ];
 }

--- a/pkgs/by-name/ta/tailor-gui/package.nix
+++ b/pkgs/by-name/ta/tailor-gui/package.nix
@@ -66,7 +66,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/AaronErhardt/tuxedo-rs";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      mrcjkb
       xaverdh
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/tu/tuxedo-rs/package.nix
+++ b/pkgs/by-name/tu/tuxedo-rs/package.nix
@@ -43,7 +43,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/AaronErhardt/tuxedo-rs";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      mrcjkb
       xaverdh
     ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
I no longer own a Tuxedo device, so I can no longer maintain tuxedo-rs :disappointed:.

@xaverdh shall I add you as a maintainer for the NixOS module?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
