### PR TITLE
nixos: plumb crossOverlays through to nixpkgs

### DIFF
--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -90,7 +90,7 @@ let
       in
       import ../../.. (
         {
-          inherit (cfg) config overlays;
+          inherit (cfg) config crossOverlays overlays;
         }
         // systemArgs
       )
@@ -98,6 +98,7 @@ let
       import ../../.. {
         inherit (cfg)
           config
+          crossOverlays
           overlays
           localSystem
           crossSystem
@@ -172,6 +173,12 @@ in
 
         Ignored when {option}`nixpkgs.pkgs` is set.
       '';
+    };
+
+    crossOverlays = lib.mkOption {
+      default = [ ];
+      description = "Like overlays, but applied only in cross-compilation";
+      type = lib.types.listOf overlayType;
     };
 
     overlays = lib.mkOption {


### PR DESCRIPTION
Teach `nixos/modules/misc/nixpkgs.nix` about the `crossOverlays` argument to `pkgs/top-level/default.nix` (and its wrappers, including `pkgs/top-level/impure.nix`).

I am not sure this is the preferred way to do things -- at this point should I be trying to use `nixpkgs.pkgs` instead? -- but it seemed easily done and arguably not wrong. :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] powerpc64le-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
