### PR TITLE
python3Packages.mistral-inference: init at 1.6.0

### DIFF
--- a/pkgs/by-name/mi/mistral-inference/package.nix
+++ b/pkgs/by-name/mi/mistral-inference/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication mistral-inference

--- a/pkgs/development/python-modules/mistral-inference/default.nix
+++ b/pkgs/development/python-modules/mistral-inference/default.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  config,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonAtLeast,
+
+  # build-system
+  poetry-core,
+
+  # dependencies
+  fire,
+  mistral-common,
+  pillow,
+  safetensors,
+  simple-parsing,
+  xformers,
+
+  # tests
+  mamba-ssm,
+  pycountry,
+  pytestCheckHook,
+  writableTmpDirAsHomeHook,
+
+  # passthu
+  mistral-inference,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "mistral-inference";
+  version = "1.6.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mistralai";
+    repo = "mistral-inference";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dcBlZWrgQn7eiNsjTS8882X9quHbgTfXxTK7HLpbLM8=";
+  };
+
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    fire
+    mistral-common
+    pillow
+    pycountry
+    safetensors
+    simple-parsing
+    xformers
+  ];
+
+  nativeCheckInputs = [
+    mamba-ssm
+    pytestCheckHook
+    writableTmpDirAsHomeHook
+  ];
+
+  # Tests require GPU access in the sandbox
+  doCheck = false;
+
+  disabledTests = lib.optionals (pythonAtLeast "3.14") [
+    # AttributeError("module 'ast' has no attribute 'Num'")
+    "test_generation_mamba"
+  ];
+
+  passthru.gpuCheck = mistral-inference.overridePythonAttrs {
+    requiredSystemFeatures = [ "cuda" ];
+    doCheck = true;
+  };
+
+  pythonImportsCheck = [ "mistral_inference" ];
+
+  meta = {
+    description = "High-performance library for running Mistral AI models on local hardware";
+    homepage = "https://github.com/mistralai/mistral-inference";
+    changelog = "https://github.com/mistralai/mistral-inference/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      mana-byte
+    ];
+    mainProgram = "mistral-chat";
+    # Explicitly requires an NVIDIA GPU to work
+    broken = !config.cudaSupport;
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9764,6 +9764,8 @@ self: super: with self; {
 
   mistral-common = callPackage ../development/python-modules/mistral-common { };
 
+  mistral-inference = callPackage ../development/python-modules/mistral-inference { };
+
   mistralai = callPackage ../development/python-modules/mistralai { };
 
   mistune = callPackage ../development/python-modules/mistune { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Mistral inference is a python package built to run Mistralai opensource models. See: https://github.com/mistralai/mistral-inference

Note : It needs a GPU to run. Tests only run with CUDA.
https://github.com/mistralai/mistral-inference#installation

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
