### PR TITLE
simplenote: init at version 2.27.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -209,6 +209,12 @@
     github = "2hexed";
     githubId = 54501296;
   };
+  _2zqa = {
+    name = "Marijn Kok";
+    email = "hkju4b4ds@mozmail.com";
+    github = "2zqa";
+    githubId = 25235249;
+  };
   _30350n = {
     name = "Max Schlecht";
     github = "30350n";

--- a/pkgs/by-name/si/simplenote/package.nix
+++ b/pkgs/by-name/si/simplenote/package.nix
@@ -1,0 +1,64 @@
+{
+  appimageTools,
+  lib,
+  fetchurl,
+  nix-update-script,
+  makeDesktopItem,
+}:
+
+let
+  pname = "simplenote";
+  version = "2.27.1";
+
+  src = fetchurl {
+    url = "https://github.com/Automattic/simplenote-electron/releases/download/v${version}/Simplenote-linux-${version}-x86_64.AppImage";
+    hash = "sha512-jf9mnmf+5Xcowxgx7uizWVmv88gPdYwojQ2f+xhbqnXaHD3dSbcW2YdxiV3qjmFsRzUgwZvBVOGpOMvnSHuQDA==";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      libsecret
+      libnotify
+      libappindicator-gtk3
+    ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = pname;
+      exec = pname;
+      icon = "simplenote";
+      genericName = "Note Taking Application";
+      comment = "Simplenote for Linux";
+      categories = [ "Utility" ];
+      startupNotify = true;
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "simplenote";
+    description = "The simplest way to keep notes";
+    homepage = "https://github.com/Automattic/simplenote-electron";
+    license = lib.licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ _2zqa ];
+    changelog = "https://github.com/Automattic/simplenote-electron/releases/tag/v${version}/RELEASE-NOTES.md";
+  };
+}


### PR DESCRIPTION
This pull request adds Simplenote, an open source, cross-platform note-taking application by Automattic, the company behind WordPress.com, featuring automatic note synchronization across devices.

Sadly, building from source is not possible because Automattic only allows use of the production database in official production builds. https://github.com/Automattic/simplenote-electron/issues/1208

App homepage: https://simplenote.com/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
