### PR TITLE
pnpmBuildHook: init and migrate some packages

### DIFF
--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -37,6 +37,7 @@ npm-install-hook.section.md
 patch-rc-path-hooks.section.md
 perl.section.md
 pkg-config.section.md
+pnpm.section.md
 postgresql-test-hook.section.md
 premake.section.md
 python.section.md

--- a/doc/hooks/pnpm.section.md
+++ b/doc/hooks/pnpm.section.md
@@ -1,0 +1,142 @@
+# pnpmBuildHook {#pnpm-build-hook}
+
+[pnpm](https://pnpm.io/) is a an NPM-compatible package manager focused on increasing managment speeds, and reducing disk space.
+
+The `pnpmBuildHook` in Nixpkgs overrides the default build phase for building packages that use pnpm.
+
+:::{.example #ex-pnpm-build-hook}
+## pnpmBuildHook example code snippet {#pnpm-build-hook-code-snippet}
+
+```
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpmBuildHook,
+  makeBinaryWrapper,
+  pnpm_10,
+}:
+let
+  pnpm = pnpm_10;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "coolPackages";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "JaneCool";
+    repo = "coolpackage";
+    tag = finalAttrs.version;
+    hash = lib.fakeHash;
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherversion = 4;
+    hash = lib.fakeHash;
+  };
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpmBuildHook
+    makeBinaryWrapper
+  ];
+
+  pnpmBuildScript = "build";
+  pnpmBuildFlags = [
+    "--mode"
+    "production"
+  ];
+  pnpmWorkspaces = [
+    "test"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir "$out"
+    cp -r dist/. "$out"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "very cool package that does cool things";
+    mainProgram = "cool";
+  };
+})
+```
+:::
+
+## Variables controlling pnpmBuildHook {#pnpm-build-hook-variables}
+
+### pnpm Exclusive Variables {#pnpm-build-hook-exclusive-variables}
+
+#### `pnpmBuildScript` {#pnpm-build-hook-script}
+
+Controls the script ran to build the package, by default the script is `build`.
+
+#### `pnpmFlags` {#pnpm-build-hook-flags}
+
+Controls flags used for all invocations of pnpm across all hooks local to this derivation.
+
+#### `pnpmBuildFlags` {#pnpm-build-hook-build-flags}
+
+Controls the flags pass only to the pnpm build script invocation.
+
+#### `dontPnpmBuild` {#pnpm-build-hook-dont}
+
+Disables automatically running `pnpmBuildHook`. The build can still be run manually if needed, for example:
+
+```
+{
+  lib,
+  rustPlatform,
+  pnpmBuildHook,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+  emptyDirectory,
+  pnpm_10,
+}:
+let
+  pnpm = pnpm_10;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "super-fast-application";
+  version = "1.0";
+
+  src = emptyDirectory;
+
+  cargoHash = lib.fakeHash;
+
+  nativeBuildInputs = [
+    pnpmBuildHook
+    pnpmConfigHook
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherversion = 3;
+    hash = lib.fakeHash;
+  }
+
+  dontPnpmBuild = true;
+  postBuild = ''
+    pnpmBuildHook
+  '';
+})
+```
+
+### Honored Variables {#pnpm-build-hook-honored-variables}
+
+The following variables are honored by `pnpmBuildHook`.
+
+* [`pnpmRoot`](#javascript-pnpm-sourceRoot)
+* [`pnpmWorkspaces`](#javascript-pnpm-workspaces)

--- a/doc/languages-frameworks/javascript.section.md
+++ b/doc/languages-frameworks/javascript.section.md
@@ -309,6 +309,8 @@ pnpm is available as the top-level package `pnpm`. Additionally, there are varia
 
 When packaging an application that includes a `pnpm-lock.yaml`, you need to fetch the pnpm store for that project using a fixed-output-derivation. The function `fetchPnpmDeps` can create this pnpm store derivation. In conjunction, the setup hook `pnpmConfigHook` will prepare the build environment to install the pre-fetched dependencies store. Here is an example for a package that contains `package.json` and a `pnpm-lock.yaml` files using the fetcher and setup hook above:
 
+There is also the [`pnpmBuildHook`](#pnpm-build-hook) for building packages with `pnpm`, as seen in [](#ex-pnpm-build-hook).
+
 ```nix
 {
   fetchPnpmDeps,

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -113,6 +113,9 @@
   "ex-pkgs-replace-vars-with": [
     "index.html#ex-pkgs-replace-vars-with"
   ],
+  "ex-pnpm-build-hook": [
+    "index.html#ex-pnpm-build-hook"
+  ],
   "ex-shfmt": [
     "index.html#ex-shfmt"
   ],
@@ -345,6 +348,33 @@
   ],
   "pkgs.treefmt.withConfig": [
     "index.html#pkgs.treefmt.withConfig"
+  ],
+  "pnpm-build-hook": [
+    "index.html#pnpm-build-hook"
+  ],
+  "pnpm-build-hook-build-flags": [
+    "index.html#pnpm-build-hook-build-flags"
+  ],
+  "pnpm-build-hook-code-snippet": [
+    "index.html#pnpm-build-hook-code-snippet"
+  ],
+  "pnpm-build-hook-dont": [
+    "index.html#pnpm-build-hook-dont"
+  ],
+  "pnpm-build-hook-exclusive-variables": [
+    "index.html#pnpm-build-hook-exclusive-variables"
+  ],
+  "pnpm-build-hook-flags": [
+    "index.html#pnpm-build-hook-flags"
+  ],
+  "pnpm-build-hook-script": [
+    "index.html#pnpm-build-hook-script"
+  ],
+  "pnpm-build-hook-variables": [
+    "index.html#pnpm-build-hook-variables"
+  ],
+  "pnpm-build-hook-honored-variables": [
+    "index.html#pnpm-build-hook-honored-variables"
   ],
   "preface": [
     "index.html#preface"

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -723,6 +723,7 @@ rec {
       meta ? { },
       passthru ? { },
       substitutions ? { },
+      __structuredAttrs ? false,
     }@args:
     script:
     runCommand name
@@ -735,7 +736,7 @@ rec {
           # TODO(@Artturin:) substitutions should be inside the env attrset
           # but users are likely passing non-substitution arguments through substitutions
           # turn off __structuredAttrs to unbreak substituteAll
-          __structuredAttrs = false;
+          inherit __structuredAttrs;
           pname = name;
           version = "26.05pre-git";
           inherit meta;

--- a/pkgs/by-name/oc/ocis/web.nix
+++ b/pkgs/by-name/oc/ocis/web.nix
@@ -5,6 +5,7 @@
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   fetchFromGitHub,
 }:
 stdenvNoCC.mkDerivation rec {
@@ -21,14 +22,9 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
+    pnpmBuildHook
     pnpm_9
   ];
-
-  buildPhase = ''
-    runHook preBuild
-    pnpm build
-    runHook postBuild
-  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/op/opencloud/idp-web.nix
+++ b/pkgs/by-name/op/opencloud/idp-web.nix
@@ -5,6 +5,7 @@
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   nodejs,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -25,19 +26,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     nodejs
     pnpmConfigHook
+    pnpmBuildHook
     pnpm_9
   ];
 
-  buildPhase = ''
-    runHook preBuild
-
-    cd $pnpmRoot
-    pnpm build
+  postBuild = ''
     mkdir -p assets/identifier/static
     cp -v src/images/favicon.svg assets/identifier/static/favicon.svg
     cp -v src/images/icon-lilac.svg assets/identifier/static/icon-lilac.svg
-
-    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/by-name/pn/pnpmBuildHook/package.nix
+++ b/pkgs/by-name/pn/pnpmBuildHook/package.nix
@@ -1,0 +1,10 @@
+{
+  makeSetupHook,
+}:
+makeSetupHook {
+  # Shouldn't need to propagate anything because for this to do anything useful,
+  # the config hook must also be used.
+  name = "pnpm-build-hook";
+
+  __structuredAttrs = true;
+} ./pnpm-build-hook.sh

--- a/pkgs/by-name/pn/pnpmBuildHook/pnpm-build-hook.sh
+++ b/pkgs/by-name/pn/pnpmBuildHook/pnpm-build-hook.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=bash
+
+pnpmBuildHook() {
+    echo "Executing pnpmBuildHook"
+
+    if [[ $pnpmRoot ]]; then
+      pushd "$pnpmRoot"
+    fi
+
+    # Add workspace flags before the other flags
+    local -a pnpmWorkspacesArray
+    concatTo pnpmWorkspacesArray pnpmWorkspaces
+
+    local -a pnpmBuildFlagsArray
+    concatTo pnpmBuildFlagsArray pnpmFlags pnpmBuildFlags
+
+
+    echo
+    echo "Running"
+    echo "pnpm run ${pnpmWorkspacesArray[*]/#/--filter=} ${pnpmBuildScript:-build} ${pnpmBuildFlagsArray[*]}"
+    echo
+
+    if ! pnpm run "${pnpmWorkspacesArray[@]/#/--filter=}" "${pnpmBuildScript:-build}" "${pnpmBuildFlagsArray[@]}"; then
+        echo
+        echo "ERROR: 'pnpm run ${pnpmBuildScript:-build}' failed"
+        echo
+        echo "Here are a few things you can try, depending on the error:"
+        echo "1. Make sure your build script (${pnpmBuildScript:-build}) exists"
+        echo '   If there isnt one, set `dontPnpmBuild = true`.'
+        echo
+
+        exit 1
+    fi
+
+    if [[ $pnpmRoot ]]; then
+      popd
+    fi
+
+    echo "Finished pnpmBuildHook"
+}
+
+pnpmBuildPhase() {
+  runHook preBuild
+
+  pnpmBuildHook
+
+  runHook postBuild
+}
+
+if [ -z "${dontPnpmBuild-}" ] && [ -z "${buildPhase-}" ]; then
+    buildPhase=pnpmBuildPhase
+fi

--- a/pkgs/by-name/si/siyuan/package.nix
+++ b/pkgs/by-name/si/siyuan/package.nix
@@ -9,6 +9,7 @@
   pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   electron,
   makeWrapper,
   makeDesktopItem,
@@ -84,6 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm
   ]
   ++ lib.optionals isLinux [
+    pnpmBuildHook
     makeWrapper
     copyDesktopItems
   ]
@@ -120,11 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     chmod -R u+w electron-dist
   '';
 
-  buildPhase = ''
-    runHook preBuild
-
-    pnpm build
-
+  postBuild = ''
     electronBuilderArgs=(
       --dir
       --config electron-builder-${platformId}.yml
@@ -134,8 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
     )
 
     npm exec electron-builder -- "''${electronBuilderArgs[@]}"
-
-    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -9,6 +9,7 @@
   nodejs,
   fetchPnpmDeps,
   pnpmConfigHook,
+  pnpmBuildHook,
   pnpm_10,
   prisma_7,
   prisma-engines_7,
@@ -83,6 +84,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper
     nodejs
     pnpmConfigHook
+    pnpmBuildHook
     pnpm
   ];
 
@@ -134,14 +136,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   # Only needed at build time for `prisma generate`.
   env.PRISMA_QUERY_ENGINE_LIBRARY = "${finalAttrs.passthru.prisma-engines}/lib/libquery_engine.node";
   env.PRISMA_SCHEMA_ENGINE_BINARY = "${finalAttrs.passthru.prisma-engines}/bin/schema-engine";
-
-  buildPhase = ''
-    runHook preBuild
-
-    pnpm build
-
-    runHook postBuild
-  '';
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

re: #317927

This adds the pnpm build hook. This allows one to use structured attributes and a unified interface for building pnpm packages. This does not use a builder. If this is desired a builder can be created later.

I migrated a few packages to this new hook. It's mostly a straight-forward process. The most complicated was `umami`, which also seems to be the most complex one that calls `pnpm build` in Nixpkgs I am aware of. 

Once this is merged I plan on making a corresponding `pnpmInstallHook` as well. That hook is actually where the real meat and potatoes will lie, this is just an initial one to get cooking. 

Needed a simple fix for `makeSetupHook` so that it could be added to `by-name`. This is backward compatible since that attr would be rejected previously. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
