### PR TITLE
k3s: update all packages

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_32/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_32/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-37.1.1+up37.1.0.tgz";
-    sha256 = "0q568ffjhxmw87fzwafxlxrzx2lgcqlqbwj87pbc2xszh9pyakyd";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-38.0.201+up38.0.2.tgz";
+    sha256 = "1fxkdmk859nwn0x9iq0abdwb16njsang7257ppaj9s1if06fsncd";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-37.1.1+up37.1.0.tgz";
-    sha256 = "0gpcr6zfbncvp2sjjwzg732k4xfr5ba0pbc5x08lgwvibqpp4r27";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-38.0.201+up38.0.2.tgz";
+    sha256 = "16kzjy8dgswn4jfx62dn2ihmgpkzcfvjv6ync9zdi397fz32mqjv";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "6dfe83a7d8984a5fe6be63a429698ce3fc61761ce68e3f4f2c6f3ff96a349f37"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "572f512cc0bdf89213d2c532e6182d4a291663bb38a51beb57197bf3fb67dd47"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "9b6a7ea64b7b14a6c43613e4e170902e99c600857265875282f8d4b9dfefa6f4"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "a65a1ed1cf081285d4c32ed3989d95cb0a4d90209e99a8765b65d41b02ea059d"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "cbda428d59a8593267343fb32ad985bf2125f45860425f9b7b31bbea9d305046"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm.tar.gz",
+    "sha256": "ffaee35854e9bfa6f34fae0a7a2ff81e8909cfb2d5a5bd65df89c03a1ceb1b3a"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "b1a253aab260beabea305517d8d57cce4594d2e071320d5700d389b29eb3c196"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm.tar.zst",
+    "sha256": "b92568a2fa8683a5abd29c151d12f2737bf7ac961dfa615a2fa891a66f2d23cf"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "0f6e598bf90b9ced4f1f758db6b0d7f8afbf9b5973d801d8a743c5b27ac3b748"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "cc99b0211110b8dc14c47cde0fe9b93b7e36c2ead64286412a896f6aa8a722cf"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "297beda34a0a2a7ff727fced94dba6f999636a4e9b2cdd6e30840cc0e746a4ee"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "a7ab99f7e2a6cf6ecc833c8ba67ba154b3ff186c58d574fa4bbda2e70dcb55f7"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
@@ -1,20 +1,20 @@
 {
-  k3sVersion = "1.32.11+k3s1";
-  k3sCommit = "8119508834f2503e3c7bace3125f5db6b038d377";
-  k3sRepoSha256 = "0fni4sh3a5flyrli7xxd9zxj9sh75kv79msy3zkfbgjxqz7rg4v9";
-  k3sVendorHash = "sha256-8gzvad5Cpkatc8158m9FBGnkGEbajn30alSPlzhor0E=";
+  k3sVersion = "1.32.11+k3s3";
+  k3sCommit = "c9aa1d2889a003715698542826c2af94160ac2e5";
+  k3sRepoSha256 = "0fi634dnsghjwnp07h6jhknccqlr9n5g3l34sipc41vvfmn4b0k8";
+  k3sVendorHash = "sha256-qbmqzsd8oMQSFCh7HvjDiYds5gLEIGjjcv4EJbgxfJI=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
   k3sRootSha256 = "008n8xx7x36y9y4r24hx39xagf1dxbp3pqq2j53s9zkaiqc62hd0";
-  k3sCNIVersion = "1.8.0-k3s1";
-  k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
+  k3sCNIVersion = "1.9.0-k3s1";
+  k3sCNISha256 = "0naqf3jkxz3rd9ljd40wbm8walgi2bx6d1l9wr6mcvrgj7d5g28c";
   containerdVersion = "2.1.5-k3s1.32";
   containerdSha256 = "1fzld9q0ycfg9b3054qg70mif1p6i7xqikcbabrmxapk81fy83kn";
   containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.31.0-k3s2";
-  flannelVersion = "v0.27.4";
-  flannelPluginVersion = "v1.8.0-flannel1";
+  flannelVersion = "v0.28.0";
+  flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s2.32";
   helmJobVersion = "v0.9.12-build20251215";

--- a/pkgs/applications/networking/cluster/k3s/1_33/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-37.1.1+up37.1.0.tgz";
-    sha256 = "0q568ffjhxmw87fzwafxlxrzx2lgcqlqbwj87pbc2xszh9pyakyd";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-38.0.201+up38.0.2.tgz";
+    sha256 = "1fxkdmk859nwn0x9iq0abdwb16njsang7257ppaj9s1if06fsncd";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-37.1.1+up37.1.0.tgz";
-    sha256 = "0gpcr6zfbncvp2sjjwzg732k4xfr5ba0pbc5x08lgwvibqpp4r27";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-38.0.201+up38.0.2.tgz";
+    sha256 = "16kzjy8dgswn4jfx62dn2ihmgpkzcfvjv6ync9zdi397fz32mqjv";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "47644f3141878535a1951fdaf03bc485001b50a58b8fb58d97c75c49ea38a1f0"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "130a3b3e51947b7a0beffca422b85c2d3fbe78b1163a0fc069871877021123d3"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "9b6a7ea64b7b14a6c43613e4e170902e99c600857265875282f8d4b9dfefa6f4"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "b0d7062008fa7fcad9ad7c6b60f74ae1c561927dbb5a4105433f5afbd091361b"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "ee76f65f39a0ca12bbaa6bf9fdd5dc161b553b15a5746d47795cf0113916c063"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm.tar.gz",
+    "sha256": "6451f4bd29b4ab76dcbfa520d907425976a04e9d5044b969e81fa2dfdc085c20"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "b1a253aab260beabea305517d8d57cce4594d2e071320d5700d389b29eb3c196"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm.tar.zst",
+    "sha256": "03a165ad40d022616281fbf329bcfa546b9245a9f431d1c362b86faff72d83dd"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "a2f534291abd4d6491dc669b46e437df1fe0cd7b573485ec30aa813510b22635"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "6243a503de28c17f4b1b16018237a5008bc99983dc3b3b87ed2a1fe790d9e211"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "87db88828e43179ef30a17ba66b416a3e398c4a00673908bd8d39ae4996ce300"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "74713adf726f6b407330b93e252b7a8e0a85204137c8a6f61b66f681b5761c42"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
@@ -1,20 +1,20 @@
 {
-  k3sVersion = "1.33.7+k3s1";
-  k3sCommit = "0b396d3f7f26e0c2ae5b6a114383830f533938c2";
-  k3sRepoSha256 = "0jkvm7c333zazabsxrjl6wkdsni1m5g5gamriyyf53lly9935wsf";
-  k3sVendorHash = "sha256-HpgcO/mUo64mkH38sAURnLOmXdXmHh3o6iDKtQeUt/E=";
+  k3sVersion = "1.33.7+k3s3";
+  k3sCommit = "1288e778af2a8ae295c47c213a3d13abd2969cde";
+  k3sRepoSha256 = "07274x0d0q7cn6x5g8d0zbyf67axrmchhngsjsp3plskyr313hcy";
+  k3sVendorHash = "sha256-XlZFYEGqoDGFlLJYRJDDoRPWuptFYkZT6axergChFN4=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
   k3sRootSha256 = "008n8xx7x36y9y4r24hx39xagf1dxbp3pqq2j53s9zkaiqc62hd0";
-  k3sCNIVersion = "1.8.0-k3s1";
-  k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
+  k3sCNIVersion = "1.9.0-k3s1";
+  k3sCNISha256 = "0naqf3jkxz3rd9ljd40wbm8walgi2bx6d1l9wr6mcvrgj7d5g28c";
   containerdVersion = "2.1.5-k3s1.33";
   containerdSha256 = "15iw6px3710rlsx7j933i07qd4a2r7caagfjbhhfcp33m9k19v7h";
   containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.33.0-k3s2";
-  flannelVersion = "v0.27.4";
-  flannelPluginVersion = "v1.8.0-flannel1";
+  flannelVersion = "v0.28.0";
+  flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s2";
   helmJobVersion = "v0.9.12-build20251215";

--- a/pkgs/applications/networking/cluster/k3s/1_34/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-37.1.1+up37.1.0.tgz";
-    sha256 = "0q568ffjhxmw87fzwafxlxrzx2lgcqlqbwj87pbc2xszh9pyakyd";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-38.0.201+up38.0.2.tgz";
+    sha256 = "1fxkdmk859nwn0x9iq0abdwb16njsang7257ppaj9s1if06fsncd";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-37.1.1+up37.1.0.tgz";
-    sha256 = "0gpcr6zfbncvp2sjjwzg732k4xfr5ba0pbc5x08lgwvibqpp4r27";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-38.0.201+up38.0.2.tgz";
+    sha256 = "16kzjy8dgswn4jfx62dn2ihmgpkzcfvjv6ync9zdi397fz32mqjv";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "499d7fb0b2eab200e9bf9b3935ce787a7fa0597933dce25ad091703933d6ecc8"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "696c2e10f511295f5e0e6281a2f22eec60b33962d45bc9117703db1ac887e981"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "b8dff3265568e1be66ab72ac0ded68bd266fa37a32c010f1253dba6547a49ce8"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "4805a6c4bfdfd20d3ad42bc14c79e00662739aca275e6a37cd8f3a406fae0f0a"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "170db25228c873741f895fced05f0e5bdbbddb8ffeb5e0342a5b8e44f3c28757"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm.tar.gz",
+    "sha256": "a4bc850fcf9b73bf0f45d4a1f50bd612e52d77daa5de5020589e7f99e5d1a3e6"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "27407fd1553c89b8ccd3b45ad0fbdcd483c1a010e7b28b60b24a8e73b58aa783"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm.tar.zst",
+    "sha256": "a1b0ac3a00f409fa51e196ea9db5f2282efff00a282ab797bf49b29453bb1379"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "e67cddf839571cd489aef44acb2aca82285a9789a170c1a44d51b7f8b6129883"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "ceea4427499fb39be0bff18f840cf80a091f63e88421bc89fdfceb8017aab59b"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "b6cb3c06f19859d3a5fba54b305097e89d2a86b5bce9e8360a46b9d2e67da565"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "e0cec00a1c19c8c6f7fde7005e325d285f23ff43752cce9ce0796ccb10e9582a"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
@@ -1,20 +1,20 @@
 {
-  k3sVersion = "1.34.3+k3s1";
-  k3sCommit = "48ffa7b6893f21b919b3029d54c9d9838ae426a1";
-  k3sRepoSha256 = "1177kzbhp6ihb7dzfdi1a0idgp69y1hwh6wnwvdx1fnivg2gj7aw";
-  k3sVendorHash = "sha256-dp8SU24nuy3WmG1Zln/J2nVHnVQmVyN78FBOSxNjbF8=";
+  k3sVersion = "1.34.3+k3s3";
+  k3sCommit = "2975fb0973ca47f54b1aa2a8c3a976a779f52349";
+  k3sRepoSha256 = "0bvccp573xihzbnkd3n6xldcxpnlwiz9b5p0fw6sxv69m7jaac2f";
+  k3sVendorHash = "sha256-R8QXwXmTKsONsbWaedFNDPdYZ82jaQ/T8S9sllqKPjk=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
   k3sRootSha256 = "008n8xx7x36y9y4r24hx39xagf1dxbp3pqq2j53s9zkaiqc62hd0";
-  k3sCNIVersion = "1.8.0-k3s1";
-  k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
+  k3sCNIVersion = "1.9.0-k3s1";
+  k3sCNISha256 = "0naqf3jkxz3rd9ljd40wbm8walgi2bx6d1l9wr6mcvrgj7d5g28c";
   containerdVersion = "2.1.5-k3s1";
   containerdSha256 = "0n0g58d352i8wz0bqn87vgrd7z54j268cbmbp19fz68wmifm7fl8";
   containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.34.0-k3s2";
-  flannelVersion = "v0.27.4";
-  flannelPluginVersion = "v1.8.0-flannel1";
+  flannelVersion = "v0.28.0";
+  flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s3";
   helmJobVersion = "v0.9.12-build20251215";

--- a/pkgs/applications/networking/cluster/k3s/1_35/chart-versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_35/chart-versions.nix
@@ -1,10 +1,10 @@
 {
   traefik-crd = {
-    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-37.1.1+up37.1.0.tgz";
-    sha256 = "0q568ffjhxmw87fzwafxlxrzx2lgcqlqbwj87pbc2xszh9pyakyd";
+    url = "https://k3s.io/k3s-charts/assets/traefik-crd/traefik-crd-38.0.201+up38.0.2.tgz";
+    sha256 = "1fxkdmk859nwn0x9iq0abdwb16njsang7257ppaj9s1if06fsncd";
   };
   traefik = {
-    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-37.1.1+up37.1.0.tgz";
-    sha256 = "0gpcr6zfbncvp2sjjwzg732k4xfr5ba0pbc5x08lgwvibqpp4r27";
+    url = "https://k3s.io/k3s-charts/assets/traefik/traefik-38.0.201+up38.0.2.tgz";
+    sha256 = "16kzjy8dgswn4jfx62dn2ihmgpkzcfvjv6ync9zdi397fz32mqjv";
   };
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_35/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "af7ce67f0a8c457618a492ba995cc645d8ad13512008b88db97719941c39389a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s3/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "8a1c1f25d62d3395fbb2b37d55cf3d836ca4bc68e6358d21b6573f42d295c6f0"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "2e3d6d14bbbeb8c16f1849cca8da48887c5a7ddceb1cc2bf60be63e4fa8c63f3"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s3/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "4805a6c4bfdfd20d3ad42bc14c79e00662739aca275e6a37cd8f3a406fae0f0a"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s1/k3s-airgap-images-arm.tar.gz",
-    "sha256": "82cf1310db1bfac5733c5c16864034c6c7c7affc60c39be610ce7cf169631ef5"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s3/k3s-airgap-images-arm.tar.gz",
+    "sha256": "8659dda950ab0ddff37b2c8d59f527489e1accde30f652b6c3b434385825b8b5"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "27407fd1553c89b8ccd3b45ad0fbdcd483c1a010e7b28b60b24a8e73b58aa783"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s3/k3s-airgap-images-arm.tar.zst",
+    "sha256": "fab2006d48153f278332504c1aa8b03e5683c14924f66ecbd5eeb7db3a5dedd9"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "cb3d24f44c9f29da3421e99db0801f2a30b3e16c7032c423a9b631c0fc66a5fa"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s3/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "ec9a3d8b04445afe24093dd0f4e65a1da6b3a5d73f3c739746aaa8ec0aaa03cb"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "b6cb3c06f19859d3a5fba54b305097e89d2a86b5bce9e8360a46b9d2e67da565"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.35.0%2Bk3s3/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "4c6a31ffa5bc267986f47f36396c51232f55b5db22253630bf7e8b48ea41084f"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_35/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_35/versions.nix
@@ -1,20 +1,20 @@
 {
-  k3sVersion = "1.35.0+k3s1";
-  k3sCommit = "a6c6cd15c0c42ec9fce21f8ad5f42aa74fddb4f2";
-  k3sRepoSha256 = "0033m0vbysy2bcjfmam387580j1cmq6cys8diismgf8m5s64nivb";
-  k3sVendorHash = "sha256-S9GkT87C8qbuefH93Y6d0Y95NNuT6paNdDkmSDllFIY=";
+  k3sVersion = "1.35.0+k3s3";
+  k3sCommit = "323b95245012f0d56a863d8c23964399814191c2";
+  k3sRepoSha256 = "1h6az9xj074pj8s60p2yw9gbqz2dabrxvrq41igcw0nq7ymcwaaz";
+  k3sVendorHash = "sha256-4Qs03mrOJBxsyQe4RrDG9vvS23JwjUPhPec/TebS4Yw=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
   k3sRootSha256 = "008n8xx7x36y9y4r24hx39xagf1dxbp3pqq2j53s9zkaiqc62hd0";
-  k3sCNIVersion = "1.8.0-k3s1";
-  k3sCNISha256 = "04xig5spp81l81781ixmk99ghiz8lk0p16zhcbja5mslfdjmc7vg";
+  k3sCNIVersion = "1.9.0-k3s1";
+  k3sCNISha256 = "0naqf3jkxz3rd9ljd40wbm8walgi2bx6d1l9wr6mcvrgj7d5g28c";
   containerdVersion = "2.1.5-k3s1";
   containerdSha256 = "0n0g58d352i8wz0bqn87vgrd7z54j268cbmbp19fz68wmifm7fl8";
   containerdPackage = "github.com/k3s-io/containerd/v2";
   criCtlVersion = "1.35.0-k3s2";
-  flannelVersion = "v0.27.4";
-  flannelPluginVersion = "v1.8.0-flannel1";
+  flannelVersion = "v0.28.0";
+  flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s3";
   helmJobVersion = "v0.9.12-build20251215";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Updates all k3s packages to the latest versions:

- `k3s_1_32`: https://github.com/k3s-io/k3s/releases/tag/v1.32.11%2Bk3s3
- `k3s_1_33`: https://github.com/k3s-io/k3s/releases/tag/v1.33.7%2Bk3s3
- `k3s_1_34`: https://github.com/k3s-io/k3s/releases/tag/v1.34.3%2Bk3s3
- `k3s_1_35`: https://github.com/k3s-io/k3s/releases/tag/v1.35.0%2Bk3s3

For the  `k3s_1_32` and `k3s_1_33` packages exists an upstream upgrade warning:

## K3s v1.34 Upgrade Warning

This warning targets users who perform upgrades by adding new nodes to the cluster, and removing old ones. If your etcd cluster membership is and has been consistent across versions, you should NOT be affected by this issue.

K3s v1.34 and higher include etcd 3.6. Maintainers of the etcd project have indicated that there no safe path from etcd 3.5 to 3.6 except by upgrading to v3.5.26 first.

In mid December, the project [released an announcement](https://etcd.io/blog/2025/zombie_members_upgrade/) indicating that there is NO safe path from etcd 3.5 to 3.6 except by upgrading to v3.5.26 first. Failure to do so can cause the cluster to report “zombie members” (etcd nodes that were removed from the cluster some time ago) re-appearing and joining database consensus, ultimately causing the cluster to lose quorum. This updated blog post contradicts [previous announcements on this topic](https://etcd.io/blog/2025/upgrade_from_3.5_to_3.6_issue_followup/), which indicated that it was safe to upgrade from v3.5.20+ as long as nodes had been restarted at least once, to reconcile membership lists across internal storage layers.

The January releases of K3s v1.32 and v1.33 will include etcd v3.5.26. All users should plan on upgrading to this patch release, prior to upgrading to v1.34 and v1.35.


All tests pass locally

@NixOS/k3s 

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
