### PR TITLE
libv4l: don't pull qtbase into cross-compiled builds

### DIFF
--- a/pkgs/by-name/v4/v4l-utils/package.nix
+++ b/pkgs/by-name/v4/v4l-utils/package.nix
@@ -30,7 +30,7 @@
 
 let
   withQt = withUtils && withGUI;
-
+  isCrossBuild = !(lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform);
 in
 # we need to use stdenv.mkDerivation in order not to pollute the libv4l’s closure with Qt
 stdenv.mkDerivation (finalAttrs: {
@@ -112,7 +112,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Meson unable to find moc/uic/rcc in case of cross-compilation
   # https://github.com/mesonbuild/meson/issues/13018
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (isCrossBuild && withQt) ''
     export PATH=${buildPackages.qt6Packages.qtbase}/libexec:$PATH
   '';
 


### PR DESCRIPTION
`libv4l` definition explicitly disables `withUtils` which in its turn disables `withQt`, but without this change the cross-compiled version still pulls in `qtbase` as a build-time dependency:
```
/nix/store/4d39hzhiafjd9a7bhwgx71pf107jam7f-qtwebengine-aarch64-unknown-linux-gnu-5.15.19.drv
└───/nix/store/vqipnyd68wllhxm06aa0a1a57rs4vrsk-ffmpeg-aarch64-unknown-linux-gnu-7.1.3.drv
    └───/nix/store/yp8hidwx2mx1ih08aqqp7pah0dgs3r5h-v4l-utils-aarch64-unknown-linux-gnu-1.32.0.drv
        └───/nix/store/s2bqx6qwch94g60axz84zs6d3cp9sjx2-qtbase-6.10.1.drv
            └───/nix/store/vkw73c46w1lkcx5vl5wa0519scahnadq-qttranslations-6.10.1.drv
                └───/nix/store/5wpq717cais7avynrwvx2p7hhcn51b9w-qttools-6.10.1.drv
                    └───/nix/store/48w6gal7n8r59bnkwiqg8n94l81zvs8x-qtbase-6.10.1.drv
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
