### PR TITLE
rpi-imager: 2.0.2 -> 2.0.6

### DIFF
--- a/pkgs/by-name/rp/rpi-imager/package.nix
+++ b/pkgs/by-name/rp/rpi-imager/package.nix
@@ -4,29 +4,31 @@
   cmake,
   curl,
   fetchFromGitHub,
+  gnutls,
   libarchive,
+  libtasn1,
+  liburing,
   nix-update-script,
   pkg-config,
   qt6,
-  wrapGAppsHook4,
   testers,
+  wrapGAppsHook4,
   writeShellScriptBin,
   xz,
-  gnutls,
   zstd,
-  libtasn1,
   enableTelemetry ? false,
+  enableUring ? stdenv.hostPlatform.isLinux,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "rpi-imager";
-  version = "2.0.2";
+  version = "2.0.6";
 
   src = fetchFromGitHub {
     owner = "raspberrypi";
     repo = "rpi-imager";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dfzWVmRthoLzI//jfeY6P1W/sfT0cNjhp5EiNQQy8zA=";
+    hash = "sha256-YbPGxc6EWE3B+7MWgtwTDRdjin9FM7KpWfw38FqKXYA=";
   };
 
   patches = [ ./remove-vendoring.patch ];
@@ -43,34 +45,41 @@ stdenv.mkDerivation (finalAttrs: {
     cd src
   '';
 
-  nativeBuildInputs = [
-    cmake
-    pkg-config
-    qt6.wrapQtAppsHook
-    wrapGAppsHook4
-    # Fool upstream's cmake lsblk check a bit
-    (writeShellScriptBin "lsblk" ''
-      echo "our lsblk has --json support but it doesn't work in our sandbox"
-    '')
-    # Upstream uses `git describe` to define a `IMAGER_VERSION` CMake variable,
-    # and we fool it to take a version from a fake `git` executable.
-    (writeShellScriptBin "git" ''
-      echo "v${finalAttrs.version}"
-    '')
-  ];
+  nativeBuildInputs =
+    let
+      # Fool upstream's cmake lsblk check a bit
+      fake-lsblk = writeShellScriptBin "lsblk" ''
+        echo "our lsblk has --json support but it doesn't work in our sandbox"
+      '';
+
+      # Upstream uses `git describe` to define a `IMAGER_VERSION` CMake variable,
+      # and we fool it to take a version from a fake `git` executable.
+      fake-git = writeShellScriptBin "git" ''
+        echo "v${finalAttrs.version}"
+      '';
+    in
+    [
+      cmake
+      fake-git
+      fake-lsblk
+      pkg-config
+      qt6.wrapQtAppsHook
+      wrapGAppsHook4
+    ];
 
   buildInputs = [
     curl
+    gnutls
     libarchive
+    libtasn1
     qt6.qtbase
     qt6.qtdeclarative
     qt6.qtsvg
     qt6.qttools
     xz
-    gnutls
     zstd
-    libtasn1
   ]
+  ++ lib.optional enableUring liburing
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     qt6.qtwayland
   ];
@@ -79,21 +88,30 @@ stdenv.mkDerivation (finalAttrs: {
     # Isn't relevant for Nix
     (lib.cmakeBool "ENABLE_CHECK_VERSION" false)
     (lib.cmakeBool "ENABLE_TELEMETRY" enableTelemetry)
+    # Disable fetching external data files
+    (lib.cmakeBool "GENERATE_CAPITAL_CITIES" false)
+    (lib.cmakeBool "GENERATE_COUNTRIES_FROM_REGDB" false)
+    (lib.cmakeBool "GENERATE_TIMEZONES_FROM_IANA" false)
   ];
 
   qtWrapperArgs = [
     "--unset QT_QPA_PLATFORMTHEME"
     "--unset QT_STYLE_OVERRIDE"
   ];
+
   dontWrapGApps = true;
+
   preFixup = ''
     qtWrapperArgs+=("''${gappsWrapperArgs[@]}")
   '';
+
+  env.LANG = "C.UTF-8";
 
   passthru = {
     tests.version = testers.testVersion {
       package = finalAttrs.finalPackage;
       command = "QT_QPA_PLATFORM=offscreen rpi-imager --version";
+      version = "v${finalAttrs.version}";
     };
     updateScript = nix-update-script { };
   };


### PR DESCRIPTION
Diff: https://github.com/raspberrypi/rpi-imager/compare/v2.0.2...v2.0.6

Changelog: https://github.com/raspberrypi/rpi-imager/releases/tag/v2.0.6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
