### PR TITLE
magma: fix cuda 13 compatibility

### DIFF
--- a/pkgs/by-name/ma/magma/package.nix
+++ b/pkgs/by-name/ma/magma/package.nix
@@ -138,6 +138,16 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-Dfzq2gqoLSByCLWV5xvY/lXZeVa/yQ67lDSoIAa9jUU=";
     })
   ]
+  ++ lib.optionals cudaSupport [
+    # Fixes:
+    # error: 'struct cudaDeviceProp' has no member named 'clockRate'
+    # Context: https://github.com/icl-utk-edu/magma/issues/61
+    (fetchpatch {
+      name = "fix-cuda13-compat.patch";
+      url = "https://github.com/icl-utk-edu/magma/commit/235aefb7b064954fce09d035c69907ba8a87cbcd.patch";
+      hash = "sha256-i9InbxD5HtfonB/GyF9nQhFmok3jZ73RxGcIciGBGvU=";
+    })
+  ]
   ++ lib.optionals rocmSupport [
     # TODO: Drop both these patches on next magma release
     (fetchpatch {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is needed to push forward the migration to cuda 13.

Fixes:
```
FAILED: [code=1] CMakeFiles/magma.dir/interface_cuda/interface.cpp.o
/nix/store/73my2f2ah1yh6h9f7b95cca3vfifmqng-gfortran-wrapper-15.2.0/bin/g++  -I/build/source/build/include -I/build/source/include -I/build/source/control -I/build/source/magmablas -I/build/source/sparse/include -I/build/source/spa>
/build/source/interface_cuda/interface.cpp: In function 'void magma_print_environment()':
/build/source/interface_cuda/interface.cpp:457:22: error: 'struct cudaDeviceProp' has no member named 'clockRate'
  457 |                 prop.clockRate / 1000.,
      |                      ^~~~~~~~~
```
Reported upstream: https://github.com/icl-utk-edu/magma/issues/61
Fixed by: https://github.com/icl-utk-edu/magma/commit/235aefb7b064954fce09d035c69907ba8a87cbcd

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
