### PR TITLE
sequoia-octopus-librnp: init at 1.11.1

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/librnp-flavor.patch
+++ b/pkgs/applications/networking/mailreaders/thunderbird/librnp-flavor.patch
@@ -1,0 +1,15 @@
+diff --git a/comm/mail/extensions/openpgp/content/modules/RNPLib.sys.mjs b/comm/mail/extensions/openpgp/content/modules/RNPLib.sys.mjs
+index 102e608..0a972ae 100644
+--- a/comm/mail/extensions/openpgp/content/modules/RNPLib.sys.mjs
++++ b/comm/mail/extensions/openpgp/content/modules/RNPLib.sys.mjs
+@@ -41,8 +41,9 @@ function tryLoadRNP(name, suffix) {
+ 
+ function loadExternalRNPLib() {
+   if (!librnp) {
++    const rnpFlavor = Services.env.get("MOZ_RNP_FLAVOR") || "rnp";
+     // Try loading librnp.so, librnp.dylib, or rnp.dll first
+-    tryLoadRNP("rnp", "");
++    tryLoadRNP(rnpFlavor, "");
+   }
+ 
+   if (!librnp && (systemOS === "winnt" || systemOS === "darwin")) {

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -8,6 +8,7 @@
   icu78,
   fetchpatch2,
   config,
+  sequoia-octopus-librnp,
 }:
 
 let
@@ -47,7 +48,14 @@ let
       extraPatches = [
         # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.
         (if lib.versionOlder version "140" then ./no-buildconfig.patch else ./no-buildconfig-tb140.patch)
+        # Allow changing between librnp.so and sequoia-octopus-librnp.so at runtime
+        ./librnp-flavor.patch
       ];
+      extraPostInstall = if stdenv.hostPlatform.isLinux then ''
+        ln -s ${lib.getLib sequoia-octopus-librnp}/lib/libsequoia_octopus_librnp.so $out/lib/
+      '' else ''
+        ln -s ${lib.getLib sequoia-octopus-librnp}/lib/libsequoia_octopus_librnp.dylib $out/Applications/Thunderbird.app/Contents/MacOS/
+      '';
       extraPassthru = {
         icu77 = icu77';
         icu78 = icu78';

--- a/pkgs/build-support/build-mozilla-mach/default.nix
+++ b/pkgs/build-support/build-mozilla-mach/default.nix
@@ -14,6 +14,7 @@
   unpackPhase ? null,
   extraPatches ? [ ],
   extraPostPatch ? "",
+  extraPostInstall ? "",
   extraNativeBuildInputs ? [ ],
   extraConfigureFlags ? [ ],
   extraBuildInputs ? [ ],
@@ -694,7 +695,8 @@ buildStdenv.mkDerivation {
       install -Dvm644 ${defaultPrefsFile} "$resourceDir/browser/defaults/preferences/nixos-default-prefs.js"
 
       cd ..
-    '';
+    ''
+    + extraPostInstall;
 
   postFixup = lib.optionalString (crashreporterSupport && buildStdenv.hostPlatform.isLinux) ''
     patchelf --add-rpath "${lib.makeLibraryPath [ curl ]}" $out/lib/${binaryName}/crashreporter

--- a/pkgs/by-name/se/sequoia-octopus-librnp/package.nix
+++ b/pkgs/by-name/se/sequoia-octopus-librnp/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitLab,
+  pkg-config,
+  bzip2,
+  libgit2,
+  nettle,
+  openssl,
+  sqlite,
+  zlib,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sequoia-octopus-librnp";
+  version = "1.11.1";
+
+  src = fetchFromGitLab {
+    owner = "sequoia-pgp";
+    repo = "sequoia-octopus-librnp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D10Nt+fV/zGt5YBEBoFI3z0TbLSnRWgzTO+MmLtfQe0=";
+  };
+
+  cargoHash = "sha256-o+3urC4k1gjfm35027KABAotV5HrBp6qJUNPM5kM8Vs=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    bzip2
+    libgit2
+    nettle
+    openssl
+    sqlite
+    zlib
+  ];
+
+  meta = {
+    description = "";
+    homepage = "https://gitlab.com/sequoia-pgp/sequoia-octopus-librnp";
+    changelog = "https://gitlab.com/sequoia-pgp/sequoia-octopus-librnp/-/blob/${finalAttrs.src.tag}/NEWS";
+    license = lib.licenses.lgpl2Only;
+    maintainers = with lib.maintainers; [ hexa ];
+  };
+})


### PR DESCRIPTION
Sequoia backend for Thunderbird OpenPGP integration.

The current version doesn't seem to be compatible, so I'm leaving this here as a draft.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
