### PR TITLE
tirith: init at 0.1.2

### DIFF
--- a/pkgs/by-name/ti/tirith/package.nix
+++ b/pkgs/by-name/ti/tirith/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  fetchFromGitHub,
+  installShellFiles,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "tirith";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "sheeki03";
+    repo = "tirith";
+    rev = "v${version}";
+    hash = "sha256-WpaHsGDHBQaU8umNN8tWsDmraqo38wnOTCrcA18ss9A=";
+  };
+
+  cargoHash = "sha256-im/KpQyPlzqvKgItwMVbLscppArU0Z57r2pdOW3bn88=";
+
+  # Skip failing shell init tests in sandbox environment
+  checkFlags = [
+    "--skip=init_bash_output"
+    "--skip=init_zsh_output"
+  ];
+
+  nativeBuildInputs = lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    installShellFiles
+  ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd tirith \
+      --bash <("$out/bin/tirith" completions bash) \
+      --zsh <("$out/bin/tirith" completions zsh) \
+      --fish <("$out/bin/tirith" completions fish)
+  '';
+
+  meta = {
+    description = "Terminal security tool that guards against homograph attacks, pipe-to-shell exploits, and other command-line threats";
+    homepage = "https://github.com/sheeki03/tirith";
+    changelog = "https://github.com/sheeki03/tirith/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ];
+    mainProgram = "tirith";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add `tirith`, a terminal security tool that guards against homograph attacks, pipe-to-shell exploits, and other command-line threats.

Tirith provides real-time protection for shell environments by analyzing commands before execution. It's particularly useful for preventing supply chain attacks through malicious install scripts.

Users activate it by adding `eval "$(tirith init)"` to their shell config.
                                                                                                                                                                                                                                      
**Homepage**: https://github.com/sheeki03/tirith

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
