### PR TITLE
npmHooks: Use concatTo for improved structuredAttrs handling

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-build-hook.sh
@@ -14,7 +14,10 @@ npmBuildHook() {
         exit 1
     fi
 
-    if ! npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" $npmBuildFlags "${npmBuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    local -a buildArray
+    concatTo buildArray npmBuildFlags npmBuildFlagsArray npmFlags npmFlagsArray
+
+    if ! npm run ${npmWorkspace+--workspace=$npmWorkspace} "$npmBuildScript" "${buildArray[@]}"; then
         echo
         echo 'ERROR: `npm build` failed'
         echo

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -122,7 +122,10 @@ npmConfigHook() {
 
     echo "Installing dependencies"
 
-    if ! npm ci --ignore-scripts $npmInstallFlags "${npmInstallFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+    local -a ciFlagsArray
+    concatTo ciFlagsArray npmInstallFlags npmInstallFlagsArray npmFlags npmFlagsArray
+
+    if ! npm ci --ignore-scripts "${ciFlagsArray[@]}"; then
         echo
         echo "ERROR: npm failed to install dependencies"
         echo
@@ -138,7 +141,10 @@ npmConfigHook() {
 
     patchShebangs node_modules
 
-    npm rebuild $npmRebuildFlags "${npmRebuildFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"
+    local -a rebuildFlagsArray
+    concatTo rebuildFlagsArray npmRebuildFlagsArray npmFlags npmCiFlagsArray
+
+    npm rebuild "${rebuildFlagsArray[@]}"
 
     patchShebangs node_modules
 

--- a/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-install-hook.sh
@@ -22,7 +22,10 @@ npmInstallHook() {
 
     if [ ! -d "$nodeModulesPath" ]; then
         if [ -z "${dontNpmPrune-}" ]; then
-            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} $npmPruneFlags "${npmPruneFlagsArray[@]}" $npmFlags "${npmFlagsArray[@]}"; then
+            local -a pruneFlagsArray
+            concatTo pruneFlagsArray npmPruneFlags npmPruneFlagsArray npmFlags npmFlagsArray
+
+            if ! npm prune --omit=dev --no-save ${npmWorkspace+--workspace=$npmWorkspace} "${pruneFlagsArray[@]}"; then
               echo
               echo
               echo "ERROR: npm prune step failed"

--- a/pkgs/by-name/no/nodejsInstallExecutables/hook.sh
+++ b/pkgs/by-name/no/nodejsInstallExecutables/hook.sh
@@ -5,15 +5,10 @@ nodejsInstallExecutables() {
 
     local -r packageOut="$out/lib/node_modules/$(@jq@ --raw-output '.name' package.json)"
 
-    # Based on code from Python's buildPythonPackage wrap.sh script, for
-    # supporting both the case when makeWrapperArgs is an array and a
-    # IFS-separated string.
-    #
-    # TODO: remove the string branch when __structuredAttrs are used.
-    if [[ "${makeWrapperArgs+defined}" == "defined" && "$(declare -p makeWrapperArgs)" =~ ^'declare -a makeWrapperArgs=' ]]; then
-        local -a user_args=("${makeWrapperArgs[@]}")
-    else
-        local -a user_args="(${makeWrapperArgs:-})"
+    local -a user_args=()
+
+    if [[ -v makeWrapperArgs ]]; then
+      concatTo user_args makeWrapperArgs
     fi
 
     while IFS=" " read -ra bin; do


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Part of #205690

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
