### PR TITLE
python3Packages.fastapi-users{,-db-sqlalchemy)}: init at 15.0.3, 7.0.0

### DIFF
--- a/pkgs/development/python-modules/fastapi-users-db-sqlalchemy/default.nix
+++ b/pkgs/development/python-modules/fastapi-users-db-sqlalchemy/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  hatch-regex-commit,
+
+  # dependencies
+  fastapi-users,
+  sqlalchemy,
+
+  # tests
+  aiosqlite,
+  pytest-asyncio,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fastapi-users-db-sqlalchemy";
+  version = "7.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fastapi-users";
+    repo = "fastapi-users-db-sqlalchemy";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VP//iYzyflqzCn/SkgeoSN+DjirLBWuH9yDJwtcCXCA=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-regex-commit
+  ];
+
+  dependencies = [
+    fastapi-users
+    sqlalchemy
+  ];
+
+  nativeCheckInputs = [
+    aiosqlite
+    pytest-asyncio
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "fastapi_users_db_sqlalchemy" ];
+
+  meta = {
+    changelog = "https://github.com/fastapi-users/fastapi-users-db-sqlalchemy/releases/tag/${finalAttrs.src.tag}";
+    description = "FastAPI Users database adapter for SQLAlchemy";
+    homepage = "https://github.com/fastapi-users/fastapi-users-db-sqlalchemy";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mulatta ];
+  };
+})

--- a/pkgs/development/python-modules/fastapi-users/default.nix
+++ b/pkgs/development/python-modules/fastapi-users/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  hatch-regex-commit,
+
+  # dependencies
+  email-validator,
+  fastapi,
+  makefun,
+  pyjwt,
+  pwdlib,
+  python-multipart,
+
+  # optional-dependencies
+  fastapi-users-db-sqlalchemy,
+  httpx-oauth,
+  redis,
+
+  # tests
+  asgi-lifespan,
+  cryptography,
+  httpx,
+  pytest-asyncio,
+  pytest-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fastapi-users";
+  version = "15.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fastapi-users";
+    repo = "fastapi-users";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0Lx7heqwLt7S8CIY5eG6R/76NuhUtbU6yicEnLhuu0Q=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-regex-commit
+  ];
+
+  pythonRelaxDeps = [ "python-multipart" ];
+
+  dependencies = [
+    email-validator
+    fastapi
+    makefun
+    pyjwt
+    pwdlib
+    python-multipart
+  ];
+
+  optional-dependencies = {
+    oauth = [ httpx-oauth ];
+    redis = [ redis ];
+    sqlalchemy = [ fastapi-users-db-sqlalchemy ];
+  };
+
+  nativeCheckInputs = [
+    asgi-lifespan
+    cryptography
+    httpx
+    httpx-oauth
+    pytest-asyncio
+    pytest-mock
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # Require database backends (sqlalchemy, beanie)
+    "tests/test_router_users.py"
+    "tests/test_router_auth.py"
+    "tests/test_router_register.py"
+    "tests/test_router_reset.py"
+    "tests/test_router_verify.py"
+    "tests/test_router_oauth.py"
+    # Requires redis
+    "tests/test_authentication_strategy_redis.py"
+  ];
+
+  pythonImportsCheck = [ "fastapi_users" ];
+
+  meta = {
+    changelog = "https://github.com/fastapi-users/fastapi-users/releases/tag/${finalAttrs.src.tag}";
+    description = "Ready-to-use and customizable users management for FastAPI";
+    homepage = "https://github.com/fastapi-users/fastapi-users";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mulatta ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5286,6 +5286,12 @@ self: super: with self; {
 
   fastapi-sso = callPackage ../development/python-modules/fastapi-sso { };
 
+  fastapi-users = callPackage ../development/python-modules/fastapi-users { };
+
+  fastapi-users-db-sqlalchemy =
+    callPackage ../development/python-modules/fastapi-users-db-sqlalchemy
+      { };
+
   fastapi-versionizer = callPackage ../development/python-modules/fastapi-versionizer { };
 
   fastavro = callPackage ../development/python-modules/fastavro { };


### PR DESCRIPTION
# python3Packages.fastapi-users{,-db-sqlalchemy}: init

## Description

Add fastapi-users and fastapi-users-db-sqlalchemy packages.

**fastapi-users** (v15.0.3) - Ready-to-use and customizable users management for FastAPI
- User registration, login, password reset, email verification
- Multiple authentication backends (JWT, cookie, etc.)
- Upstream: https://github.com/fastapi-users/fastapi-users

**fastapi-users-db-sqlalchemy** (v7.0.0) - SQLAlchemy database adapter for fastapi-users
- Upstream: https://github.com/fastapi-users/fastapi-users-db-sqlalchemy

Optional dependencies available via `optional-dependencies` passthru:
- `oauth`: OAuth2 support (httpx-oauth)
- `redis`: Redis token storage
- `sqlalchemy`: SQLAlchemy database adapter

Note: `pythonRelaxDeps` is used for `python-multipart` in fastapi-users (requires >=0.0.21, nixpkgs has 0.0.20).

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
