### PR TITLE
tuxguitar: fix launch on darwin when app bundle path contains space

### DIFF
--- a/pkgs/by-name/tu/tuxguitar/package.nix
+++ b/pkgs/by-name/tu/tuxguitar/package.nix
@@ -187,10 +187,10 @@ maven.buildMavenPackage {
     # Ensure the main executable has execute permissions
     chmod +x $out/Applications/TuxGuitar.app/Contents/MacOS/tuxguitar.sh
 
-    # Symlink doesn't work. We have to create a wrapper script instead
     mkdir -p $out/bin
-    makeWrapper "$out/Applications/TuxGuitar.app/Contents/MacOS/tuxguitar.sh" \
-      "$out/bin/tuxguitar"
+    # the script depends on $0 to work. We wrap it to give it a stable $0 without space. The script doesn't handle $0 containing space correctly.
+    wrapProgram "$out/Applications/TuxGuitar.app/Contents/MacOS/tuxguitar.sh"
+    ln -s $out/Applications/TuxGuitar.app/Contents/MacOS/tuxguitar.sh $out/bin/tuxguitar
   ''
   # Linux: Install traditional layout
   + lib.optionalString stdenv.hostPlatform.isLinux ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Currently on darwin only `tuxguitar` command work reliably. When launching the application from gui the `tuxguitar.sh` from upstream  is called directly. With nix-darwin when tuxguitar is installed to /Applications/Nix\ Apps the `tuxguitar.sh` from upstream doesn't handle space correctly

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
