### PR TITLE
soundshow: init at 2026.02.04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27238,6 +27238,12 @@
     github = "Tungsten842";
     githubId = 24614168;
   };
+  tunnelmaker = {
+    email = "nix@finnrut.is";
+    github = "Multipixelone";
+    githubId = 505116;
+    name = "Finn Rutis";
+  };
   turbomack = {
     email = "marek.faj@gmail.com";
     github = "turboMaCk";

--- a/pkgs/by-name/so/soundshow/package.nix
+++ b/pkgs/by-name/so/soundshow/package.nix
@@ -1,0 +1,217 @@
+{
+  lib,
+  stdenv,
+  nix-update-script,
+  fetchzip,
+  autoPatchelfHook,
+  makeWrapper,
+  gtk3,
+  zlib,
+  alsa-lib,
+  dbus,
+  libGL,
+  libxcursor,
+  libxext,
+  libxi,
+  libxinerama,
+  libxkbcommon,
+  libxrandr,
+  libxscrnsaver,
+  libxxf86vm,
+  libxcb,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxfixes,
+  udev,
+  vulkan-loader,
+  wayland,
+  makeDesktopItem,
+  # Additional dependencies for SoundShowDisplay (CEF/Chromium-based)
+  at-spi2-atk,
+  at-spi2-core,
+  cups,
+  expat,
+  glib,
+  libdrm,
+  libxshmfence,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  libpulseaudio,
+  # Fix file browser: invisible text, oversized icons, and Wayland drag-and-drop
+  adwaita-icon-theme,
+  hicolor-icon-theme,
+  gsettings-desktop-schemas,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "soundshow";
+  version = "2026.02.05";
+
+  src = fetchzip {
+    url = "https://github.com/soundshow-app/soundshow-downloads/releases/download/v${finalAttrs.version}/SoundShow-linux-x64.zip";
+    hash = "sha256-AzrLQIvGvG2RPntnw/LspL/sN40ncp7dzI5JtazHgn8=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    # Load-time libraries (loaded from DT_NEEDED section in ELF binary)
+    alsa-lib
+    gtk3
+    stdenv.cc.cc.lib
+    zlib
+
+    # Run-time libraries (loaded with dlopen)
+    dbus
+    libGL
+    libxcursor
+    libxext
+    libxi
+    libxinerama
+    libxkbcommon
+    libxrandr
+    libxscrnsaver
+    libxxf86vm
+    udev
+    vulkan-loader
+    wayland
+    libpulseaudio
+
+    # CEF/Chromium dependencies for SoundShowDisplay
+    at-spi2-atk
+    at-spi2-core
+    cups
+    expat
+    glib
+    libdrm
+    libxshmfence
+    mesa
+    nspr
+    nss
+    pango
+    libxcb
+    libx11
+    libxcomposite
+    libxdamage
+    libxfixes
+
+    # Icon themes and schemas for file browser
+    adwaita-icon-theme
+    hicolor-icon-theme
+    gsettings-desktop-schemas
+  ];
+
+  desktopItem = makeDesktopItem {
+    name = "soundshow";
+    desktopName = "SoundShow";
+    comment = finalAttrs.meta.description;
+    icon = "soundshow";
+    exec = "soundshow";
+    categories = [ "Audio" ];
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install main SoundShow application
+    # The executable needs UnityPlayer.so and SoundShow_Data in the same directory
+    mkdir -p "$out/libexec/soundshow"
+    install -Dm755 SoundShow.x86_64 "$out/libexec/soundshow/SoundShow.x86_64"
+    install -Dm644 UnityPlayer.so "$out/libexec/soundshow/UnityPlayer.so"
+    install -Dm644 libdecor-0.so.0 "$out/libexec/soundshow/libdecor-0.so.0"
+    install -Dm644 libdecor-cairo.so "$out/libexec/soundshow/libdecor-cairo.so"
+    cp -r SoundShow_Data "$out/libexec/soundshow/"
+
+    # Install SoundShowDisplay application
+    mkdir -p "$out/libexec/soundshow-display"
+    install -Dm755 Display/SoundShowDisplay.x86_64 "$out/libexec/soundshow-display/SoundShowDisplay.x86_64"
+    install -Dm644 Display/UnityPlayer.so "$out/libexec/soundshow-display/UnityPlayer.so"
+    install -Dm644 Display/libdecor-0.so.0 "$out/libexec/soundshow-display/libdecor-0.so.0"
+    install -Dm644 Display/libdecor-cairo.so "$out/libexec/soundshow-display/libdecor-cairo.so"
+    cp -r Display/SoundShowDisplay_Data "$out/libexec/soundshow-display/"
+
+    # Create wrapper scripts
+    mkdir -p "$out/bin"
+    makeWrapper "$out/libexec/soundshow/SoundShow.x86_64" "$out/bin/soundshow" \
+      --chdir "$out/libexec/soundshow" \
+      --unset WAYLAND_DISPLAY \
+      --set GTK_THEME Adwaita \
+      --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS" \
+      --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
+    makeWrapper "$out/libexec/soundshow-display/SoundShowDisplay.x86_64" "$out/bin/soundshow-display" \
+      --chdir "$out/libexec/soundshow-display"
+
+    install -Dm644 "$desktopItem/share/applications/soundshow.desktop" "$out/share/applications/soundshow.desktop"
+
+    runHook postInstall
+  '';
+
+  # Patch required run-time libraries as load-time libraries
+  #
+  # Libraries found with:
+  # > strings UnityPlayer.so | grep '\.so'
+  postFixup = ''
+    # Patch the main SoundShow UnityPlayer.so
+    patchelf \
+      --add-needed libasound.so.2 \
+      --add-needed libdbus-1.so.3 \
+      --add-needed libGL.so.1 \
+      --add-needed libpthread.so.0 \
+      --add-needed libudev.so.1 \
+      --add-needed libvulkan.so.1 \
+      --add-needed libwayland-client.so.0 \
+      --add-needed libwayland-cursor.so.0 \
+      --add-needed libwayland-egl.so.1 \
+      --add-needed libX11.so.6 \
+      --add-needed libXcursor.so.1 \
+      --add-needed libXext.so.6 \
+      --add-needed libXi.so.6 \
+      --add-needed libXinerama.so.1 \
+      --add-needed libxkbcommon.so.0 \
+      --add-needed libXrandr.so.2 \
+      --add-needed libXss.so.1 \
+      --add-needed libXxf86vm.so.1 \
+      "$out/libexec/soundshow/UnityPlayer.so"
+
+    # Patch the SoundShowDisplay UnityPlayer.so
+    patchelf \
+      --add-needed libasound.so.2 \
+      --add-needed libdbus-1.so.3 \
+      --add-needed libGL.so.1 \
+      --add-needed libpthread.so.0 \
+      --add-needed libudev.so.1 \
+      --add-needed libvulkan.so.1 \
+      --add-needed libwayland-client.so.0 \
+      --add-needed libwayland-cursor.so.0 \
+      --add-needed libwayland-egl.so.1 \
+      --add-needed libX11.so.6 \
+      --add-needed libXcursor.so.1 \
+      --add-needed libXext.so.6 \
+      --add-needed libXi.so.6 \
+      --add-needed libXinerama.so.1 \
+      --add-needed libxkbcommon.so.0 \
+      --add-needed libXrandr.so.2 \
+      --add-needed libXss.so.1 \
+      --add-needed libXxf86vm.so.1 \
+      "$out/libexec/soundshow-display/UnityPlayer.so"
+  '';
+
+  passthru.updateScript = nix-update-script { };
+  meta = with lib; {
+    description = "Soundboard and multimedia player for live triggering audio cues";
+    homepage = "https://soundshow.app";
+    mainProgram = "soundshow";
+    license = licenses.unfree;
+    maintainers = with lib.maintainers; [
+      tunnelmaker
+    ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Add soundshow, a live soundboard application.

This is a Unity binary application, so I based my package off of the clonehero package.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
