### PR TITLE
tmuxPlugins.fingers: 2.5.1 -> 2.6.1

### DIFF
--- a/pkgs/misc/tmux-plugins/tmux-fingers/default.nix
+++ b/pkgs/misc/tmux-plugins/tmux-fingers/default.nix
@@ -7,13 +7,13 @@
 let
   fingers = crystal.buildCrystalPackage rec {
     format = "shards";
-    version = "2.5.1";
+    version = "2.6.1";
     pname = "fingers";
     src = fetchFromGitHub {
       owner = "Morantron";
       repo = "tmux-fingers";
       rev = "${version}";
-      sha256 = "sha256-O5CfboFnl51OeOgqI2NB3MmELDeKykd5NO2d5FGXkII=";
+      sha256 = "sha256-f18y4Jq5Ab/5KZKv8woMTkFGEY2/f5KeRH0sf6R1l1U=";
     };
 
     shardsFile = ./shards.nix;

--- a/pkgs/misc/tmux-plugins/tmux-fingers/fix.patch
+++ b/pkgs/misc/tmux-plugins/tmux-fingers/fix.patch
@@ -1,8 +1,8 @@
 diff --git a/tmux-fingers.tmux b/tmux-fingers.tmux
-index f15b509..a14e312 100755
+index c62915a..eb065e7 100755
 --- a/tmux-fingers.tmux
 +++ b/tmux-fingers.tmux
-@@ -1,35 +1,4 @@
+@@ -1,36 +1,5 @@
  #!/usr/bin/env bash
  
 -CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -36,6 +36,13 @@ index f15b509..a14e312 100755
 -  fi
 -fi
 -
--tmux run "$FINGERS_BINARY load-config"
-+tmux run "@tmuxFingersDir@/tmux-fingers load-config"
+ if [[ "$TERM" == "dumb" ]]; then
+   # force term value to get proper colors in systemd and tmux 3.6a
+   # https://github.com/Morantron/tmux-fingers/issues/143
+@@ -39,5 +8,5 @@ else
+   FINGERS_TERM="$TERM"
+ fi
+ 
+-tmux run "TERM=$FINGERS_TERM $FINGERS_BINARY load-config"
++tmux run "TERM=$FINGERS_TERM @tmuxFingersDir@/tmux-fingers load-config"
  exit $?


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
