### PR TITLE
gnome-{settings-daemon,shell,control-center}: fix duplicated sinks

### DIFF
--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -3,6 +3,7 @@
   lib,
   stdenv,
   replaceVars,
+  fetchpatch,
   accountsservice,
   adwaita-icon-theme,
   blueprint-compiler,
@@ -88,6 +89,15 @@ stdenv.mkDerivation (finalAttrs: {
       gcm = gnome-color-manager;
       inherit glibc tzdata shadow;
       inherit cups networkmanagerapplet;
+    })
+
+    # fix https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/issues/39
+    (fetchpatch {
+      name = "fix-duplicated-virtual-sinks.patch";
+      url = "https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/commit/3e68238ed7c9d3f26f8bfaf03780f79ce7c7043e.patch";
+      hash = "sha256-miOtI0Y/dUCLtTU5Wckp34k1JEJ87wyoDWAt8Cc1BOI=";
+      stripLen = 1;
+      extraPrefix = "subprojects/gvc/";
     })
   ];
 

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -66,6 +66,15 @@ stdenv.mkDerivation (finalAttrs: {
       stripLen = 1;
       extraPrefix = "subprojects/gvc/";
     })
+
+    # fix https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/issues/39
+    (fetchpatch {
+      name = "fix-duplicated-virtual-sinks.patch";
+      url = "https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/commit/3e68238ed7c9d3f26f8bfaf03780f79ce7c7043e.patch";
+      hash = "sha256-miOtI0Y/dUCLtTU5Wckp34k1JEJ87wyoDWAt8Cc1BOI=";
+      stripLen = 1;
+      extraPrefix = "subprojects/gvc/";
+    })
   ];
 
   depsBuildBuild = [

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -120,6 +120,15 @@ stdenv.mkDerivation (finalAttrs: {
       stripLen = 1;
       extraPrefix = "subprojects/gvc/";
     })
+
+    # fix https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/issues/39
+    (fetchpatch {
+      name = "fix-duplicated-virtual-sinks.patch";
+      url = "https://gitlab.gnome.org/GNOME/libgnome-volume-control/-/commit/3e68238ed7c9d3f26f8bfaf03780f79ce7c7043e.patch";
+      hash = "sha256-miOtI0Y/dUCLtTU5Wckp34k1JEJ87wyoDWAt8Cc1BOI=";
+      stripLen = 1;
+      extraPrefix = "subprojects/gvc/";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
This cherry-picks a commit to fix libgnome-volume-control#39.

A follow-up of #482791

My systems have been running with this patch for a few days.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
