### PR TITLE
colloid-cursors: init at 2025-07-19

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29312,6 +29312,12 @@
     githubId = 36407913;
     name = "Uli Baum";
   };
+  xelacodes = {
+    name = "Alex";
+    github = "itzTheMeow";
+    githubId = 50887230;
+    email = "nixpkgs@xela.codes";
+  };
   xelden = {
     email = "anpiz@protonmail.com";
     github = "Xelden";

--- a/pkgs/by-name/co/colloid-cursors/package.nix
+++ b/pkgs/by-name/co/colloid-cursors/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  gitUpdater,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "colloid-cursors";
+  version = "2025-07-19";
+
+  src = fetchFromGitHub {
+    owner = "vinceliuice";
+    repo = "Colloid-icon-theme";
+    tag = finalAttrs.version;
+    hash = "sha256-x2SSaIkKm1415avO7R6TPkpghM30HmMdjMFUUyPWZsk=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    # Loosely based on the install script: https://github.com/vinceliuice/Colloid-icon-theme/blob/main/cursors/install.sh
+    mkdir -p $out/share/icons
+    cp -r cursors/dist $out/share/icons/Colloid-cursors
+    cp -r cursors/dist-dark $out/share/icons/Colloid-dark-cursors
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Colloid cursor theme";
+    homepage = "https://github.com/vinceliuice/Colloid-icon-theme/tree/main/cursors#readme";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ xelacodes ];
+  };
+})


### PR DESCRIPTION
Adds the cursors from the colloid icon theme. Loosely based on the `colloid-icon-theme` package.
The cursors are in the same repo, but not included in the icon theme itself.
https://github.com/vinceliuice/Colloid-icon-theme/tree/main/cursors#readme
There are "dark" and "light" variants.

I tested both variants on an x86_64-linux NixOS machine using KDE Plasma.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
