### PR TITLE
goofcord: 1.7.1 -> 2.2.0

### DIFF
--- a/pkgs/by-name/go/goofcord/node-modules.nix
+++ b/pkgs/by-name/go/goofcord/node-modules.nix
@@ -1,0 +1,65 @@
+# fixed output derivation for node_modules
+{
+  lib,
+  stdenv,
+  goofcord,
+  bun,
+  nodejs,
+  writableTmpDirAsHomeHook,
+}:
+stdenv.mkDerivation {
+  inherit (goofcord) version src;
+  pname = goofcord.pname + "-modules";
+
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [
+    "GIT_PROXY_COMMAND"
+    "SOCKS_SERVER"
+  ];
+
+  nativeBuildInputs = [
+    bun
+    nodejs
+    writableTmpDirAsHomeHook
+  ];
+
+  dontConfigure = true;
+  dontFixup = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
+    export npm_config_build_from_source=true
+    export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+
+    bun install \
+      --frozen-lockfile \
+      --linker=hoisted \
+      --no-progress
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -R ./node_modules $out
+
+    runHook postInstall
+  '';
+
+  outputHash =
+    {
+      x86_64-linux = "sha256-EEl+hrdMR6z1PAy+uIhl2UYtajXWiUQMQxIfYpMRw6Y=";
+      aarch64-linux = "sha256-ba+j8FGKNH3Mpql7xvLgHHuJxDGVlZ+TeZ3Oxsw3ot4=";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system ${stdenv.hostPlatform.system}");
+  outputHashAlgo = "sha256";
+  outputHashMode = "recursive";
+
+  meta = {
+    description = "Node modules for GoofCord";
+    license = lib.licenses.osl3;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -1,68 +1,84 @@
 {
   lib,
   stdenv,
+  callPackage,
   fetchFromGitHub,
-  pnpm_9,
-  fetchPnpmDeps,
-  pnpmConfigHook,
-  nodejs_22,
-  nix-update-script,
+  bun,
+  nodejs_24,
   electron,
-  pipewire,
-  libpulseaudio,
+  nix-update-script,
+  libxkbcommon,
+  libx11,
+  libxcb,
+  libxtst,
   makeShellWrapper,
   makeDesktopItem,
   copyDesktopItems,
 }:
-
 let
-  pnpm = pnpm_9.override { nodejs = nodejs_22; };
+  patchcordAddon = callPackage ./patchcord-addon.nix { };
+  venbindAddon = callPackage ./venbind-addon.nix { };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "goofcord";
-  version = "1.7.1";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "Milkshiift";
     repo = "GoofCord";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-fx/RKnUhXhaWVd/KYPVxr19/Q8o1ovm2TgMTcTYjE3Q=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BnaPw9edaI1nKAu421JBkI9dAV3Xu3Yr5VQILN0QUTM=";
   };
 
   nativeBuildInputs = [
-    pnpmConfigHook
-    pnpm
-    nodejs_22
+    bun
+    nodejs_24
     makeShellWrapper
     copyDesktopItems
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    libpulseaudio
-    pipewire
+    libxkbcommon
+    libx11
+    libxcb
+    libxtst
     (lib.getLib stdenv.cc.cc)
   ];
 
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs) pname version src;
-    inherit pnpm;
-    fetcherVersion = 3;
-    hash = "sha256-NKind57XDW7I5XNmjAu4cqkK5UVNAaKewpfOTNzF2BM=";
-  };
+  node-modules = callPackage ./node-modules.nix { nodejs = nodejs_24; };
 
   env = {
     ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+    GOOFCORD_PATCHCORD_PATH = "${patchcordAddon}/bin/patchcord";
+    GOOFCORD_VENBIND_PATH = "${venbindAddon}/lib/libvenbind.so";
   };
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cp -R ${finalAttrs.node-modules} node_modules
+    chmod -R u+w node_modules
+    patchShebangs node_modules/.bin
+    patchShebangs node_modules/@typescript/native-preview/bin
+
+    runHook postConfigure
+  '';
+
+  preBuild = lib.optionalString stdenv.hostPlatform.isLinux ''
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+  '';
 
   buildPhase = ''
     runHook preBuild
 
-    pnpm build
+    bun run build -- --skipTypecheck
 
-    npm exec electron-builder -- \
+    node node_modules/electron-builder/out/cli/cli.js \
       --dir \
-      -c.electronDist="${electron.dist}" \
-      -c.electronVersion="${electron.version}"
+      -c.electronDist="${if stdenv.hostPlatform.isLinux then "electron-dist" else electron.dist}" \
+      -c.electronVersion="${electron.version}" \
+      -c.npmRebuild=false
 
     runHook postBuild
   '';
@@ -73,13 +89,21 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/share/lib/goofcord"
     cp -r ./dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/goofcord"
 
-    install -Dm644 "build/icon.png" "$out/share/icons/hicolor/256x256/apps/goofcord.png"
+    install -Dm644 "assets/gf_icon.png" "$out/share/icons/hicolor/256x256/apps/goofcord.png"
 
     # use makeShellWrapper (instead of the makeBinaryWrapper provided by wrapGAppsHook3) for proper shell variable expansion
     # see https://github.com/NixOS/nixpkgs/issues/172583
     makeShellWrapper "${lib.getExe electron}" "$out/bin/goofcord" \
       --add-flags "$out/share/lib/goofcord/resources/app.asar" \
       "''${gappsWrapperArgs[@]}" \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libxkbcommon
+          libx11
+          libxcb
+          libxtst
+        ]
+      }" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer --enable-wayland-ime=true}}" \
       --set-default ELECTRON_IS_DEV 0 \
       --inherit-argv0
@@ -120,11 +144,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/Milkshiift/GoofCord";
     downloadPage = "https://github.com/Milkshiift/GoofCord";
     license = lib.licenses.osl3;
-    maintainers = with lib.maintainers; [ nyabinary ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
+    maintainers = with lib.maintainers; [
+      nyabinary
     ];
+    platforms = lib.platforms.linux;
     mainProgram = "goofcord";
   };
 })

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -146,6 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.osl3;
     maintainers = with lib.maintainers; [
       nyabinary
+      miniharinn
     ];
     platforms = lib.platforms.linux;
     mainProgram = "goofcord";

--- a/pkgs/by-name/go/goofcord/patchcord-addon.nix
+++ b/pkgs/by-name/go/goofcord/patchcord-addon.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage {
+  pname = "patchcord";
+  version = "0-unstable-2026-03-29";
+
+  src = fetchFromGitHub {
+    owner = "Milkshiift";
+    repo = "patchcord";
+    rev = "f2611630f143a53b46514d4916af0971d7aab2b5";
+    hash = "sha256-VTHS5psVqg4RjSrAs9vPkixsVwwIYE2E4o0vXVN58tE=";
+  };
+
+  cargoHash = "sha256-/IbHvs9SEuulNcWkihwFwaFcqMM0rdFBVjCWgUu7dys=";
+
+  doCheck = false;
+
+  meta = {
+    description = "Patcher for GoofCord";
+    homepage = "https://github.com/Milkshiift/patchcord";
+    license = lib.licenses.osl3;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/go/goofcord/venbind-addon.nix
+++ b/pkgs/by-name/go/goofcord/venbind-addon.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  libx11,
+  libxtst,
+  libxdmcp,
+  libxkbfile,
+  libxkbcommon,
+  libxcb,
+  wayland,
+  xorgproto,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "venbind";
+  version = "0.1.7";
+
+  src = fetchFromGitHub {
+    owner = "tuxinal";
+    repo = "venbind";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6gPyQ6JjqvM2AUuIxCfO0nOLJfyQTX5bbsbKDzlNSqo=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-FZTXj8f+ezRhElovKhF3khWc5SqC+22tDHlFe9IHuwo=";
+
+  nativeBuildInputs = [
+    rustPlatform.bindgenHook
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    libx11
+    libxtst
+    libxdmcp
+    libxkbfile
+    libxkbcommon
+    libxcb
+    wayland
+    xorgproto
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Native module for Vencord";
+    homepage = "https://github.com/tuxinal/venbind";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Release: https://github.com/Milkshiift/GoofCord/releases/tag/v2.0.1
Diff: https://github.com/Milkshiift/GoofCord/compare/v1.7.1...v2.0.1

Changes:
- Switched goofcord to Bun-based builds (removed pnpm/fetchPnpmDeps, build now uses `bun run build` and electron-builder from `node_modules` with `-c.npmRebuild=false`).
- Added a fixed-output `node-modules` derivation and wired it into the package via `callPackage`.
- Added a `configurePhase` to copy the prebuilt `node_modules` into the build tree.
- Patched shebangs for Bun/tsgo (`node_modules/.bin` and `node_modules/@typescript/native-preview/bin`) to avoid `/usr/bin/env` failures.
- Bumped Node to `nodejs_24`.
- Made Electron fuses work by copying `electron.dist` to a writable `electron-dist` and pointing electron-builder at it on Linux.
- Fixed icon install path to `assets/gf_icon.png`.
- Added runtime deps for venbind (`libxkbcommon`, `libX11`, `libxcb`, `libXtst`) and prefixed `LD_LIBRARY_PATH` in the wrapper.
- Switched `platforms` to `lib.platforms.linux`.

I’ve also noticed that this package hasn’t been updated for quite some time, and I’d be happy to help maintain it in the future. If the situation allows, I will open a follow-up PR to update the maintainer metadata (I currently have a pending PR that modifies `maintainer-list.nix`, which needs to be merged before my handle becomes available).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
