### PR TITLE
m-cli: 2.0.5 -> 2.0.7

### DIFF
--- a/pkgs/by-name/m-/m-cli/package.nix
+++ b/pkgs/by-name/m-/m-cli/package.nix
@@ -2,17 +2,18 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
   pname = "m-cli";
-  version = "2.0.5";
+  version = "2.0.7";
 
   src = fetchFromGitHub {
     owner = "rgcr";
     repo = "m-cli";
-    rev = "v${version}";
-    sha256 = "sha256-41o7RoRlHwAmzSREDhQpq2Lchkz8QPxJRqN42ShUJb8=";
+    tag = "v${version}";
+    sha256 = "sha256-a/X7HaShb8mXJIYtTDxEPN4DcskUDourRFgHnOXksYM=";
   };
 
   dontBuild = true;
@@ -37,6 +38,8 @@ stdenv.mkDerivation rec {
     install -Dt "$out/share/zsh/site-functions/" -m444 completions/zsh/_m
   '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Swiss Army Knife for macOS";
     inherit (src.meta) homepage;
@@ -44,7 +47,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
 
     platforms = lib.platforms.darwin;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ anish ];
     mainProgram = "m";
   };
 }


### PR DESCRIPTION
Added `nix-update-script` and updated

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
