### PR TITLE
kea: backport boost-1.89 fix

### DIFF
--- a/pkgs/by-name/ke/kea/boost-1.89.patch
+++ b/pkgs/by-name/ke/kea/boost-1.89.patch
@@ -1,0 +1,61 @@
+https://gitlab.isc.org/isc-projects/kea/-/commit/b03071ba6912a08e4cc4cb4db50d9624ce86f41e
+
+From b03071ba6912a08e4cc4cb4db50d9624ce86f41e Mon Sep 17 00:00:00 2001
+From: Francis Dupont <fdupont@isc.org>
+Date: Fri, 29 Aug 2025 00:40:03 +0200
+Subject: [PATCH] [#4085] Proposed update
+
+---
+ meson.build                       | 3 ++-
+ src/lib/asiodns/io_fetch.h        | 1 +
+ src/lib/asiolink/interval_timer.h | 1 +
+ 3 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index 434abf58313..fbd76dce5e5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -189,7 +189,7 @@ message(f'Detected system "@SYSTEM@".')
+ 
+ #### Dependencies
+ 
+-boost_dep = dependency('boost', version: '>=1.66', modules: ['system'])
++boost_dep = dependency('boost', version: '>=1.66')
+ dl_dep = dependency('dl')
+ threads_dep = dependency('threads')
+ add_project_dependencies(boost_dep, dl_dep, threads_dep, language: ['cpp'])
+@@ -200,6 +200,7 @@ boost_headers = [
+     'boost/asio/coroutine.hpp',
+     'boost/asio/io_context.hpp',
+     'boost/asio/ip/address.hpp',
++    'boost/asio/deadline_timer.hpp',
+     'boost/asio/signal_set.hpp',
+     'boost/circular_buffer.hpp',
+     'boost/date_time/posix_time/posix_time_types.hpp',
+diff --git a/src/lib/asiodns/io_fetch.h b/src/lib/asiodns/io_fetch.h
+index 6fcbb78abb0..3053cc2e0a2 100644
+--- a/src/lib/asiodns/io_fetch.h
++++ b/src/lib/asiodns/io_fetch.h
+@@ -16,6 +16,7 @@
+ #include <util/buffer.h>
+ 
+ #include <boost/asio/coroutine.hpp>
++#include <boost/asio/deadline_timer.hpp>
+ #include <boost/shared_array.hpp>
+ #include <boost/shared_ptr.hpp>
+ #include <boost/date_time/posix_time/posix_time_types.hpp>
+diff --git a/src/lib/asiolink/interval_timer.h b/src/lib/asiolink/interval_timer.h
+index 0b1c10c7882..790d132b42a 100644
+--- a/src/lib/asiolink/interval_timer.h
++++ b/src/lib/asiolink/interval_timer.h
+@@ -7,6 +7,7 @@
+ #ifndef ASIOLINK_INTERVAL_TIMER_H
+ #define ASIOLINK_INTERVAL_TIMER_H 1
+ 
++#include <boost/asio/deadline_timer.hpp>
+ #include <boost/shared_ptr.hpp>
+ #include <functional>
+ 
+-- 
+GitLab
+

--- a/pkgs/by-name/ke/kea/package.nix
+++ b/pkgs/by-name/ke/kea/package.nix
@@ -38,6 +38,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./dont-create-system-paths.patch
+    # backport of an upstream fix for boost-1.89:
+    #   https://gitlab.isc.org/isc-projects/kea/-/merge_requests/2771
+    ./boost-1.89.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Without the chnage `kea` fails the build on `staging` as:

    kea> ../src/lib/asiolink/interval_timer.cc:91:18: error: 'deadline_timer' in namespace 'boost::asio' does not name a type
    kea>    91 |     boost::asio::deadline_timer timer_;
    kea>       |                  ^~~~~~~~~~~~~~

Can't download the patch as is at it fails to fetch over http/2 as:

    $ curl -L https://gitlab.isc.org/isc-projects/kea/-/commit/b03071ba6912a08e4cc4cb4db50d9624ce86f41e.patch
    curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
