### PR TITLE
anydesk: 7.1.1 -> 7.1.3

### DIFF
--- a/pkgs/by-name/an/anydesk/package.nix
+++ b/pkgs/by-name/an/anydesk/package.nix
@@ -32,6 +32,7 @@
   libxkbfile,
   libxcb,
   minizip,
+  net-tools,
   lsb-release,
   freetype,
   fontconfig,
@@ -40,21 +41,29 @@
   pciutils,
   copyDesktopItems,
   pulseaudio,
+  udev,
 }:
 
 let
   description = "Desktop sharing application, providing remote support and online meetings";
+  pin = lib.importJSON ./pin.json;
+  inherit (pin) version;
+  inherit (stdenv.hostPlatform) system;
+  url =
+    if system == "x86_64-linux" then
+      "https://download.anydesk.com/linux/anydesk-${version}-amd64.tar.gz"
+    else if system == "aarch64-linux" then
+      "https://download.anydesk.com/rpi/anydesk-${version}-arm64.tar.gz"
+    else
+      throw "cannot install AnyDesk on ${system}";
+  hash = pin.${system};
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "anydesk";
-  version = "7.1.1";
+  inherit version;
 
   src = fetchurl {
-    urls = [
-      "https://download.anydesk.com/linux/anydesk-${finalAttrs.version}-amd64.tar.gz"
-      "https://download.anydesk.com/linux/generic-linux/anydesk-${finalAttrs.version}-amd64.tar.gz"
-    ];
-    hash = "sha256-pGzU4dBeWlACAOvshBzTPN6PcNdQkQXAjGFnK+yrKA4=";
+    inherit url hash;
   };
 
   buildInputs = [
@@ -90,6 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
     libice
     libsm
     libxrender
+    udev
   ];
 
   nativeBuildInputs = [
@@ -139,17 +149,32 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       } \
       --prefix GDK_BACKEND : x11 \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          net-tools
+        ]
+      } \
       --set GTK_THEME Adwaita
   '';
 
   passthru = {
     updateScript = genericUpdater {
-      versionLister = writeShellScript "anydesk-versionLister" ''
-        curl -s https://anydesk.com/en/downloads/linux \
-          | grep "https://[a-z0-9._/-]*-amd64.tar.gz" -o \
-          | uniq \
-          | sed 's,.*/anydesk-\(.*\)-amd64.tar.gz,\1,g'
-      '';
+      versionLister =
+        let
+          arch =
+            if system == "x86_64-linux" then
+              "amd64"
+            else if system == "aarch64-linux" then
+              "arm64"
+            else
+              throw "cannot update AnyDesk on ${system}";
+        in
+        writeShellScript "anydesk-versionLister" ''
+          curl -s https://anydesk.com/en/downloads/linux \
+            | grep "https://[a-z0-9._/-]*-${arch}.tar.gz" -o \
+            | uniq \
+            | sed 's,.*/anydesk-\(.*\)-${arch}.tar.gz,\1,g'
+        '';
     };
   };
 
@@ -158,7 +183,11 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.anydesk.com";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "anydesk";
     maintainers = [ ];
   };
 })

--- a/pkgs/by-name/an/anydesk/pin.json
+++ b/pkgs/by-name/an/anydesk/pin.json
@@ -1,0 +1,5 @@
+{
+  "version": "7.1.3",
+  "x86_64-linux": "sha256-b1WSQMRlFaqhECCBKoPjUIww5Fj3yfN8wxwACuO7RR4=",
+  "aarch64-linux": "sha256-Yb5Jnjxs8AmMeFvWY+VYGTovpLwW1PRPBEJZUF63gA0="
+}


### PR DESCRIPTION
This patch to the AnyDesk package adds a missing runtime dependency on `domainname` (via `net-tools`) and updates it to the latest version, while also adding support for aarch64-linux.

https://anydesk.com/en/changelog/linux
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
