### PR TITLE
python313Packages.atomic-red-team: init at 0.1.0-unstable-2026-01-20

### DIFF
--- a/pkgs/development/python-modules/atomic-red-team/default.nix
+++ b/pkgs/development/python-modules/atomic-red-team/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hypothesis,
+  jsonschema,
+  poetry-core,
+  pydantic,
+  pytestCheckHook,
+  pyyaml,
+  requests,
+  ruamel-yaml,
+  typer,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "atomic-red-team";
+  version = "0.1.0-unstable-2026-01-20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "redcanaryco";
+    repo = "atomic-red-team";
+    rev = "a1e6fd545421d6acf4e97d9c6737de31512cb41a";
+    hash = "sha256-ZOmQ5NEn4ZTUQ3/fytGfWYqpHluWc8BwC7wBnYysyLU=";
+  };
+
+  pythonRelaxDeps = [
+    "hypothesis"
+    "jsonschema"
+    "pydantic"
+    "pytest"
+  ];
+
+  build-system = [ poetry-core ];
+
+  dependencies = [
+    hypothesis
+    jsonschema
+    pydantic
+    pyyaml
+    requests
+    ruamel-yaml
+    typer
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "atomic_red_team" ];
+
+  meta = {
+    description = "Detection tests based on MITRE's ATT&CK";
+    homepage = "https://github.com/redcanaryco/atomic-red-team";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1140,6 +1140,8 @@ self: super: with self; {
 
   atom = callPackage ../development/python-modules/atom { };
 
+  atomic-red-team = callPackage ../development/python-modules/atomic-red-team { };
+
   atomiclong = callPackage ../development/python-modules/atomiclong { };
 
   atomicwrites = callPackage ../development/python-modules/atomicwrites { };


### PR DESCRIPTION
Detection tests based on MITRE's ATT&CK

https://github.com/redcanaryco/atomic-red-team


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
