### PR TITLE
nginx: 1.29.4 -> 1.29.5, 1.28.0 -> 1.28.2

### DIFF
--- a/pkgs/servers/http/nginx/mainline.nix
+++ b/pkgs/servers/http/nginx/mainline.nix
@@ -1,6 +1,6 @@
 { callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.29.4";
-  hash = "sha256-Wn037uUFhm+6tYEPqfeCR9bV2RV6WVxOenIEMUHdqyU=";
+  version = "1.29.5";
+  hash = "sha256-Z0R2ikEUiA83sToEQyROcxvLMTDAoGXX432P1Ymt43Q=";
 }

--- a/pkgs/servers/http/nginx/stable.nix
+++ b/pkgs/servers/http/nginx/stable.nix
@@ -1,13 +1,6 @@
-{ callPackage, fetchpatch, ... }@args:
+{ callPackage, ... }@args:
 
 callPackage ./generic.nix args {
-  version = "1.28.0";
-  hash = "sha256-xrXGsIbA3508o/9eCEwdDvkJ5gOCecccHD6YX1dv92o=";
-  extraPatches = [
-    (fetchpatch {
-      name = "CVE-2025-53859.patch";
-      url = "https://nginx.org/download/patch.2025.smtp.txt";
-      hash = "sha256-v49sLskFNMoKuG8HQISw8ST7ga6DS+ngJiL0D3sUyGk=";
-    })
-  ];
+  version = "1.28.2";
+  hash = "sha256-IOXg8skXrPtREg7sL7qaS6Th4Q/ShGUGfMh6fYGoKaM=";
 }


### PR DESCRIPTION
nginx update to latest releases [1.29.5](https://github.com/nginx/nginx/releases/tag/release-1.29.5), [1.28.2](https://github.com/nginx/nginx/releases/tag/release-1.28.2) fixing MitM injection CVE-2026-1642.

Changes: [1.29.4 -> 1.29.5](https://github.com/nginx/nginx/compare/release-1.29.4...release-1.29.5), [1.29.4 -> 1.29.5](https://github.com/nginx/nginx/compare/release-1.28.0...release-1.28.2)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
