### PR TITLE
czkawka: Fix Krokiet GUI startup on Wayland

### DIFF
--- a/pkgs/by-name/cz/czkawka/package.nix
+++ b/pkgs/by-name/cz/czkawka/package.nix
@@ -4,15 +4,19 @@
   cairo,
   callPackage,
   fetchFromGitHub,
+  fontconfig,
   gdk-pixbuf,
   glib,
   gobject-introspection,
   gtk4,
+  libglvnd,
+  libxkbcommon,
   pango,
   pkg-config,
   rustPlatform,
   stdenv,
   testers,
+  wayland,
   wrapGAppsHook4,
   xvfb-run,
   versionCheckHook,
@@ -41,10 +45,14 @@ let
     buildInputs = [
       atk
       cairo
+      fontconfig
       gdk-pixbuf
       glib
       gtk4
+      libglvnd
+      libxkbcommon
       pango
+      wayland
     ];
 
     nativeCheckInputs = [ xvfb-run ];
@@ -65,6 +73,20 @@ let
       install -Dm444 -t $out/share/icons/hicolor/scalable/apps data/icons/com.github.qarmin.czkawka.svg
       install -Dm444 -t $out/share/icons/hicolor/scalable/apps data/icons/com.github.qarmin.czkawka-symbolic.svg
       install -Dm444 -t $out/share/metainfo data/com.github.qarmin.czkawka.metainfo.xml
+    '';
+    dontWrapGApps = true;
+
+    postFixup = ''
+      wrapGApp $out/bin/czkawka_gui
+
+      patchelf --add-rpath "${
+        lib.makeLibraryPath [
+          fontconfig
+          libglvnd
+          libxkbcommon
+          wayland
+        ]
+      }" $out/bin/krokiet
     '';
 
     nativeInstallCheckInputs = [


### PR DESCRIPTION
Krokiet, the Slint-based GUI for czkawka, failed to launch on Wayland due to missing runtime dependencies.
This commit addresses the issue by:
- Adding `wayland`, `libxkbcommon`, `fontconfig.lib`, and `libglvnd` to the package's `buildInputs`.
- Ensuring these libraries are available in `LD_LIBRARY_PATH` for both `czkawka_gui` and `krokiet` by extending the `gappsWrapperArgs` in `preFixup`.

This resolves the "Could not initialize backend. The wayland library could not be loaded" panic.

Error:
```
krokiet
19:04:32.418 [INFO] czkawka_core::common::logger: Logging to file "/home/initsnow/.cache/czkawka/krokiet.log" and terminal
19:04:32.423 [INFO] czkawka_core::common::logger: Krokiet version: 10.0.0, release mode, rust 1.91.1 (2025-11-07), os NixOS 25.11.0 (x86_64 64-bit), 20 cpu/threads, features(0): [], app cpu version: x86-64-v1 (SSE2), os cpu version: x86-64-v3 (AVX2)
19:04:32.423 [INFO] czkawka_core::common::config_cache_path: Config folder set to "/home/initsnow/.config/krokiet" and cache folder set to "/home/initsnow/.cache/czkawka"
19:04:32.423 [INFO] krokiet: Krokiet features(2): [winit_femtovg, winit_software]
19:04:32.431 [ERROR] log_panics: thread 'main' panicked at 'Failed to create main window: Could not initialize backend.
Error from Winit backend: Error initializing winit event loop: os error at /build/czkawka-10.0.0-vendor/winit-0.30.12/src/platform_impl/linux/wayland/event_loop/mod.rs:89: The wayland library could not be loaded
No backends configured.': krokiet/src/main.rs:77
   0: log_panics::Config::install_panic_hook::{{closure}}
   1: std::panicking::panic_with_hook
   2: std::panicking::panic_handler::{{closure}}
   3: std::sys::backtrace::__rust_end_short_backtrace
   4: __rustc::rust_begin_unwind
   5: core::panicking::panic_fmt
   6: core::result::unwrap_failed
   7: krokiet::main
   8: std::sys::backtrace::__rust_begin_short_backtrace
   9: std::rt::lang_start::{{closure}}
  10: std::rt::lang_start_internal
  11: main
  12: __libc_start_call_main
  13: __libc_start_main_alias_1
  14: _start
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
