### PR TITLE
torcs: make it build on hydra, clean up derivation

### DIFF
--- a/pkgs/by-name/to/torcs/package.nix
+++ b/pkgs/by-name/to/torcs/package.nix
@@ -1,84 +1,51 @@
 {
-  fetchpatch,
-  fetchurl,
-  lib,
   stdenv,
-  libGLU,
-  libglut,
-  libX11,
-  plib,
-  openal,
-  freealut,
-  libXrandr,
-  xorgproto,
-  libXext,
-  libsm,
-  libice,
-  libXi,
-  libXt,
-  libXrender,
-  libXxf86vm,
-  libvorbis,
-  libpng,
-  zlib,
-  makeWrapper,
+  symlinkJoin,
+  torcs-without-data,
 }:
+let
+  # This package is split into two parts because the complete package includes
+  # the game data, which takes up a lot of space and is not worth serving from
+  # the official cache. The compiled program gets built by Hydra and cached,
+  # while the game data does not and gets handled locally instead.
+  torcs-data = stdenv.mkDerivation (finalAttrs: {
+    pname = "torcs-data";
+    inherit (torcs-without-data)
+      version
+      src
+      buildInputs
+      ;
 
-stdenv.mkDerivation (finalAttrs: {
+    dontBuild = true;
+
+    installTargets = "export datainstall";
+    postInstall = ''
+      install -D -m644 Ticon.png $out/share/pixmaps/torcs.png
+      install -D -m644 torcs.desktop $out/share/applications/torcs.desktop
+    '';
+
+    meta.hydraPlatforms = [ ];
+  });
+in
+symlinkJoin {
   pname = "torcs";
-  version = "1.3.8";
+  inherit (torcs-without-data)
+    version
+    ;
 
-  src = fetchurl {
-    url = "mirror://sourceforge/torcs/torcs-${finalAttrs.version}.tar.bz2";
-    sha256 = "sha256-S5Z3NUX7NkEZgqbziXIF64/VciedTOVp8s4HsI6Jp68=";
-  };
-
-  patches = [
-    (fetchpatch {
-      url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/format-argument.patch";
-      sha256 = "04advcx88yh23ww767iysydzhp370x7cqp2wf9hk2y1qvw7mxsja";
-    })
+  paths = [
+    torcs-without-data
+    torcs-data
   ];
 
-  postInstall = ''
-    install -D -m644 Ticon.png $out/share/pixmaps/torcs.png
-    install -D -m644 torcs.desktop $out/share/applications/torcs.desktop
+  postBuild = ''
+    cp --remove-destination $(realpath $out/bin/torcs) $out/bin/torcs
+    substituteInPlace $out/bin/torcs \
+      --replace-fail "${torcs-without-data}" "$out"
   '';
 
-  postPatch = ''
-    sed -i -e s,/bin/bash,`type -P bash`, src/linux/torcs.in
-  '';
-
-  nativeBuildInputs = [ makeWrapper ];
-  buildInputs = [
-    libGLU
-    libglut
-    libX11
-    plib
-    openal
-    freealut
-    libXrandr
-    xorgproto
-    libXext
-    libsm
-    libice
-    libXi
-    libXt
-    libXrender
-    libXxf86vm
-    libpng
-    zlib
-    libvorbis
-  ];
-
-  installTargets = "install datainstall";
-
-  meta = {
+  meta = torcs-without-data.meta // {
     description = "Car racing game";
-    homepage = "https://torcs.sourceforge.net/";
-    license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ pixel-87 ];
-    platforms = lib.platforms.linux;
     hydraPlatforms = [ ];
   };
-})
+}

--- a/pkgs/by-name/to/torcs/without-data.nix
+++ b/pkgs/by-name/to/torcs/without-data.nix
@@ -1,0 +1,74 @@
+{
+  fetchpatch,
+  fetchurl,
+  lib,
+  stdenv,
+  libGLU,
+  libglut,
+  libX11,
+  plib,
+  openal,
+  freealut,
+  libXrandr,
+  xorgproto,
+  libXext,
+  libsm,
+  libice,
+  libXi,
+  libXt,
+  libXrender,
+  libXxf86vm,
+  libvorbis,
+  libpng,
+  zlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "torcs-without-data";
+  version = "1.3.8";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/torcs/torcs-${finalAttrs.version}.tar.bz2";
+    sha256 = "sha256-S5Z3NUX7NkEZgqbziXIF64/VciedTOVp8s4HsI6Jp68=";
+  };
+
+  patches = [
+    (fetchpatch {
+      url = "https://salsa.debian.org/games-team/torcs/raw/fb0711c171b38c4648dc7c048249ec20f79eb8e2/debian/patches/format-argument.patch";
+      sha256 = "04advcx88yh23ww767iysydzhp370x7cqp2wf9hk2y1qvw7mxsja";
+    })
+  ];
+
+  postPatch = ''
+    sed -i -e s,/bin/bash,`type -P bash`, src/linux/torcs.in
+  '';
+
+  buildInputs = [
+    libGLU
+    libglut
+    libX11
+    plib
+    openal
+    freealut
+    libXrandr
+    xorgproto
+    libXext
+    libsm
+    libice
+    libXi
+    libXt
+    libXrender
+    libXxf86vm
+    libpng
+    zlib
+    libvorbis
+  ];
+
+  meta = {
+    description = "Car racing game (does not come with the game data required to run)";
+    homepage = "https://torcs.sourceforge.net/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ pixel-87 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12983,6 +12983,8 @@ with pkgs;
 
   tora = libsForQt5.callPackage ../development/tools/tora { };
 
+  torcs-without-data = callPackage ../../pkgs/by-name/to/torcs/without-data.nix { };
+
   nitrokey-app = libsForQt5.callPackage ../tools/security/nitrokey-app { };
 
   nitrokey-app2 = python3Packages.callPackage ../tools/security/nitrokey-app2 { };


### PR DESCRIPTION
Split `torcs` into two packages -- `torcs-without-data`, which includes the result of running the build on the source, and `torcs`, which wraps the aforementioned derivation by adding the game data that is required to run the game.

Old PR message:
> The main point of this PR is to remove the empty `meta.hydraPlatforms`, which
> causes it to not build on Hydra and therefore not be cached.
> 
> Also removes the redundant makeWrapper dependency and reorder the derivation
> attributes content to follow the order of the build process. This part can be
> dropped if desired.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
