### PR TITLE
krita: 5.2.14 -> 6.0.0, switch to Qt6

### DIFF
--- a/pkgs/by-name/kr/krita-plugin-gmic/package.nix
+++ b/pkgs/by-name/kr/krita-plugin-gmic/package.nix
@@ -1,23 +1,27 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   cmake,
-  extra-cmake-modules,
+  curl,
   fftw,
   krita-unwrapped,
-  libsForQt5,
+  kdePackages,
+  qt6,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "krita-plugin-gmic";
-  version = "3.6.4.1";
+  version = "3.7.4.1";
 
-  src = fetchurl {
-    url = "https://files.kde.org/krita/build/dependencies/gmic-${finalAttrs.version}.tar.gz";
-    hash = "sha256-prbGkwFWC+LqK1WDqOwZvX5Q5LQal3dFUXzpILwF+v4=";
+  src = fetchFromGitHub {
+    owner = "vanyossi";
+    repo = "gmic";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xyln60z9r4spPtN3r2+3a1e5yzd8+B7d9UAR3VsRZ78=";
   };
-  sourceRoot = "gmic-v${finalAttrs.version}/gmic-qt";
+
+  sourceRoot = "${finalAttrs.src.name}/gmic-qt";
   dontWrapQtApps = true;
 
   postPatch = ''
@@ -28,14 +32,16 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    libsForQt5.qttools
+    kdePackages.extra-cmake-modules
+    qt6.qttools
   ];
 
   buildInputs = [
+    curl
     fftw
     krita-unwrapped
-    libsForQt5.kcoreaddons
+    kdePackages.kcoreaddons
+    qt6.qtbase
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/kr/krita-unwrapped/package.nix
+++ b/pkgs/by-name/kr/krita-unwrapped/package.nix
@@ -4,10 +4,8 @@
   boost,
   cmake,
   curl,
-  eigen,
+  eigen_5,
   exiv2,
-  extra-cmake-modules,
-  fetchpatch,
   fetchurl,
   fftw,
   fribidi,
@@ -24,7 +22,8 @@
   libjxl,
   libmypaint,
   libraw,
-  libsForQt5,
+  qt6,
+  kdePackages,
   libunibreak,
   libwebp,
   opencolorio,
@@ -39,34 +38,25 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "krita-unwrapped";
 
-  version = "5.2.15";
+  version = "6.0.0";
   src = fetchurl {
     url = "mirror://kde/stable/krita/${finalAttrs.version}/krita-${finalAttrs.version}.tar.gz";
-    hash = "sha256-m5T4Qh2XZ8KU3vWY+xBwfd5usje67KJZBmn7DUuQOzk=";
+    hash = "sha256-kytodhJvfGKeQn7j0BIwDIKGsFoYQnc1S0FK9kGg8e0=";
   };
-
-  patches = [
-    # Fixes build with SIP 6.8
-    (fetchpatch {
-      name = "bump-SIP-ABI-version-to-12.8.patch";
-      url = "https://invent.kde.org/graphics/krita/-/commit/2d71c47661d43a4e3c1ab0c27803de980bdf2bb2.diff";
-      hash = "sha256-U3E44nj4vra++PJV20h4YHjES78kgrJtr4ktNeQfOdA=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
+    kdePackages.extra-cmake-modules
     pkg-config
     python3Packages.sip
-    libsForQt5.wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
     boost
     libraw
     fftw
-    eigen
+    eigen_5
     exiv2
     fribidi
     lcms2
@@ -90,9 +80,12 @@ stdenv.mkDerivation (finalAttrs: {
     libwebp
     SDL2
     zug
-    python3Packages.pyqt5
+    python3Packages.pyqt6
+
+    qt6.qtmultimedia
+    qt6.qttools
   ]
-  ++ (with libsForQt5; [
+  ++ (with kdePackages; [
     breeze-icons
     karchive
     kcompletion
@@ -108,15 +101,9 @@ stdenv.mkDerivation (finalAttrs: {
     kwindowsystem
     mlt
     poppler
-    qtmultimedia
-    qtx11extras
     quazip
-
-    # TODO: reenable libkdcraw when migrating to Qt6, see #430298
-    # libkdcraw
+    libkdcraw
   ]);
-
-  env.NIX_CFLAGS_COMPILE = toString (lib.optional stdenv.cc.isGNU "-Wno-deprecated-copy");
 
   # Krita runs custom python scripts in CMake with custom PYTHONPATH which krita determined in their CMake script.
   # Patch the PYTHONPATH so python scripts can import sip successfully.
@@ -143,8 +130,9 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeBuildType = "RelWithDebInfo";
 
   cmakeFlags = [
-    "-DPYQT5_SIP_DIR=${python3Packages.pyqt5}/${python3Packages.python.sitePackages}/PyQt5/bindings"
-    "-DPYQT_SIP_DIR_OVERRIDE=${python3Packages.pyqt5}/${python3Packages.python.sitePackages}/PyQt5/bindings"
+    "-DBUILD_WITH_QT6=ON"
+    "-DALLOW_UNSTABLE=QT6"
+    "-DENABLE_UPDATERS=OFF"
     "-DBUILD_KRITA_QT_DESIGNER_PLUGINS=ON"
   ];
 

--- a/pkgs/by-name/kr/krita/package.nix
+++ b/pkgs/by-name/kr/krita/package.nix
@@ -1,6 +1,4 @@
 {
-  lib,
-  libsForQt5,
   symlinkJoin,
   krita-plugin-gmic,
   binaryPlugins ? [

--- a/pkgs/by-name/ks/kseexpr/package.nix
+++ b/pkgs/by-name/ks/kseexpr/package.nix
@@ -3,39 +3,41 @@
   stdenv,
   fetchFromGitLab,
   cmake,
-  extra-cmake-modules,
-  qt5,
-  libsForQt5,
+  qt6,
+  kdePackages,
   bison,
   flex,
-  llvm,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kseexpr";
-  version = "4.0.4.0";
+  version = "6.0.0.0";
   src = fetchFromGitLab {
     domain = "invent.kde.org";
     owner = "graphics";
     repo = "kseexpr";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XjFGAN7kK2b0bLouYG3OhajhOQk4AgC4EQRzseccGCE=";
+    hash = "sha256-Z3CjQdKHeZ/6He43qVYQj8Fo0y88v/ldJJD8bPYOaEo=";
   };
+
   patches = [
     # see https://github.com/NixOS/nixpkgs/issues/144170
     ./cmake_libdir.patch
   ];
+
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    qt5.wrapQtAppsHook
+    kdePackages.extra-cmake-modules
   ];
+
+  dontWrapQtApps = true;
+
   buildInputs = [
     bison
     flex
-    libsForQt5.ki18n
-    llvm
-    qt5.qtbase
+    kdePackages.ki18n
+    qt6.qtbase
+    qt6.qttools
   ];
 
   meta = {


### PR DESCRIPTION
<img width="2559" height="1599" alt="image" src="https://github.com/user-attachments/assets/a003dc80-399e-45ef-b9a0-d5dc2e038555" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
