### PR TITLE
qutebrowser-qt5: drop

### DIFF
--- a/pkgs/by-name/qu/qutebrowser/package.nix
+++ b/pkgs/by-name/qu/qutebrowser/package.nix
@@ -24,7 +24,6 @@
 }:
 
 let
-  isQt6 = lib.versions.major qt6Packages.qtbase.version == "6";
   pdfjs =
     let
       version = "5.4.394";
@@ -39,7 +38,7 @@ let
 in
 
 python3.pkgs.buildPythonApplication {
-  pname = "qutebrowser" + lib.optionalString (!isQt6) "-qt5";
+  pname = "qutebrowser";
   inherit version;
   pyproject = true;
 
@@ -76,7 +75,7 @@ python3.pkgs.buildPythonApplication {
   dependencies = with python3.pkgs; [
     colorama
     pyyaml
-    (if isQt6 then pyqt6-webengine else pyqtwebengine)
+    pyqt6-webengine
     jinja2
     pygments
     # scripts and userscripts libs
@@ -138,7 +137,7 @@ python3.pkgs.buildPythonApplication {
     let
       libPath = lib.makeLibraryPath [ pipewire ];
       resourcesPath =
-        if (isQt6 && stdenv.hostPlatform.isDarwin) then
+        if stdenv.hostPlatform.isDarwin then
           "${qt6Packages.qtwebengine}/lib/QtWebEngineCore.framework/Resources"
         else
           "${qt6Packages.qtwebengine}/resources";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1546,6 +1546,7 @@ mapAliases {
   quicksynergy = throw "'quicksynergy' has been removed due to lack of maintenance upstream. Consider using 'deskflow' instead."; # Added 2025-06-18
   quictls = throw "'quictls' has been removed. QUIC support is now available in `openssl`.";
   quorum = throw "'quorum' has been removed as it was broken and unmaintained upstream"; # Added 2025-11-07
+  qutebrowser-qt5 = lib.warnOnInstantiate "'qutebrowser-qt5' has been removed as it depended on vulnerable and outdated qt5 webengine" qutebrowser; # Added 2026-01-14
   qv2ray = throw "'qv2ray' has been removed as it was unmaintained"; # Added 2025-06-03
   ra-multiplex = lib.warnOnInstantiate "'ra-multiplex' has been renamed to/replaced by 'lspmux'" lspmux; # Added 2025-10-27
   radiance = throw "'radiance' has been removed as it was broken for a long time"; # Added 2026-01-02

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10970,10 +10970,6 @@ with pkgs;
     withXineBackend = true;
   };
 
-  qutebrowser-qt5 = qutebrowser.override {
-    qt6Packages = libsForQt5;
-  };
-
   rakarrack = callPackage ../applications/audio/rakarrack {
     fltk = fltk_1_3;
   };


### PR DESCRIPTION
drops browsers doing qt5 webengine
part of #480196
morph is done in #467662, ideally. That one is not yet ready.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
