### PR TITLE
apache-airflow: 3.1.6 -> 3.1.7

### DIFF
--- a/pkgs/by-name/ap/apache-airflow/python-package.nix
+++ b/pkgs/by-name/ap/apache-airflow/python-package.nix
@@ -88,13 +88,13 @@
   enabledProviders,
 }:
 let
-  version = "3.1.6";
+  version = "3.1.7";
 
   src = fetchFromGitHub {
     owner = "apache";
     repo = "airflow";
     tag = version;
-    hash = "sha256-wC6C0jhCA76/+KhBQbe3WeSGqR6FwaudCT5xPV39Z6c=";
+    hash = "sha256-qFgI65wAttERPCHn7ezSdNGB0sclEV7zYIBqaC0Gs4A=";
   };
 
   airflowUi = stdenv.mkDerivation rec {
@@ -112,7 +112,7 @@ let
       pname = "airflow-ui";
       inherit sourceRoot src version;
       fetcherVersion = 1;
-      hash = "sha256-UcEFQkDZ9Ye+VfyJ9rdZKe0wilTgO4dMsULABWfL2Co=";
+      hash = "sha256-t39aatMfqyHtP+kdszyTQs+w7EojNGX0zVmlxqtY1jk=";
     };
 
     buildPhase = ''

--- a/pkgs/by-name/ap/apache-airflow/update.sh
+++ b/pkgs/by-name/ap/apache-airflow/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p common-updater-scripts curl jq nixfmt-tree
+#!nix-shell -i bash -p common-updater-scripts curl jq nixfmt-tree nix-update
 
 set -euo pipefail
 
@@ -40,7 +40,8 @@ echo "Latest tag found: $LATEST_TAG"
 # Update the version and hash in the package definition
 # This uses the standard nixpkgs script `update-source-version`.
 echo "Updating source version for $PACKAGE_NAME to $LATEST_TAG..."
-update-source-version "$PACKAGE_NAME" "$LATEST_TAG"
+nix-update --subpackage airflowUi --subpackage airflowSimpleAuthUi "$PACKAGE_NAME" \
+  --version "$LATEST_TAG"
 
 # After updating the main package, run the providers update script.
 # It will automatically pick up the new version from the nix file.

--- a/pkgs/development/python-modules/pyjwt/default.nix
+++ b/pkgs/development/python-modules/pyjwt/default.nix
@@ -13,14 +13,14 @@
 
 buildPythonPackage rec {
   pname = "pyjwt";
-  version = "2.10.1";
+  version = "2.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jpadilla";
     repo = "pyjwt";
     tag = version;
-    hash = "sha256-BPVythRLpglYtpLEoaC7+Q4l9izYXH2M9JEbxdyQZqU=";
+    hash = "sha256-Sves+/Mkk9O8rF/yRD6gID120diF1m+lt0exQ83LA1A=";
   };
 
   outputs = [


### PR DESCRIPTION
https://github.com/apache/airflow/releases/tag/3.1.7
also includes pyjwt update
https://github.com/jpadilla/pyjwt/releases/tag/2.11.0
built successfully against `master` but pyjwt triggers mass rebuild so this PR aims into `staging`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
