### PR TITLE
frescobaldi: 3.3.0 -> 4.0.4, switch to qt6

### DIFF
--- a/pkgs/by-name/fr/frescobaldi/package.nix
+++ b/pkgs/by-name/fr/frescobaldi/package.nix
@@ -4,38 +4,37 @@
   fetchFromGitHub,
   python3Packages,
   lilypond,
+  qt6,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "frescobaldi";
-  version = "3.3.0";
-  format = "setuptools";
+  version = "4.0.4";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "wbsoft";
     repo = "frescobaldi";
     tag = "v${version}";
-    sha256 = "sha256-Q6ruthNcpjLlYydUetkuTECiCIzu055bw40O8BPGq/A=";
+    hash = "sha256-J0QC+VwNdA24vAW5Fx+cz5IFajkB8GmR4Rae0Q+2zw8=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
+  dependencies = with python3Packages; [
     qpageview
     lilypond
-    pygame
+    pygame-ce
+    pyqt6-sip
     python-ly
-    sip4
-    pyqt5
-    poppler-qt5
-    pyqtwebengine
+    pyqt6
+    pyqt6-webengine
   ];
 
-  nativeBuildInputs = [ python3Packages.pyqtwebengine.wrapQtAppsHook ];
+  buildInputs = [ qt6.qtbase ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
 
-  # Needed because source is fetched from git
-  preBuild = ''
-    make -C i18n
-    make -C linux
-  '';
+  build-system = with python3Packages; [
+    hatchling
+  ];
 
   # no tests in shipped with upstream
   doCheck = false;

--- a/pkgs/development/python-modules/pyqt/6.x.nix
+++ b/pkgs/development/python-modules/pyqt/6.x.nix
@@ -21,6 +21,7 @@
   withSerialPort ? false,
   cups,
   withSpeech ? true,
+  withPdf ? true,
 }:
 
 buildPythonPackage rec {
@@ -104,7 +105,8 @@ buildPythonPackage rec {
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
     ++ lib.optional withSerialPort qtserialport
-    ++ lib.optional withSpeech qtspeech;
+    ++ lib.optional withSpeech qtspeech
+    ++ lib.optional withPdf qtwebengine;
 
   buildInputs =
     with qt6Packages;
@@ -121,7 +123,8 @@ buildPythonPackage rec {
     ++ lib.optional withWebSockets qtwebsockets
     ++ lib.optional withLocation qtlocation
     ++ lib.optional withSerialPort qtserialport
-    ++ lib.optional withSpeech qtspeech;
+    ++ lib.optional withSpeech qtspeech
+    ++ lib.optional withPdf qtwebengine;
 
   propagatedBuildInputs =
     # ld: library not found for -lcups
@@ -151,7 +154,8 @@ buildPythonPackage rec {
   # ++ lib.optional withConnectivity "PyQt6.QtConnectivity"
   ++ lib.optional withLocation "PyQt6.QtPositioning"
   ++ lib.optional withSerialPort "PyQt6.QtSerialPort"
-  ++ lib.optional withSpeech "PyQt6.QtTextToSpeech";
+  ++ lib.optional withSpeech "PyQt6.QtTextToSpeech"
+  ++ lib.optional withPdf "PyQt6.QtPdf";
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-address-of-temporary";
 

--- a/pkgs/development/python-modules/qpageview/default.nix
+++ b/pkgs/development/python-modules/qpageview/default.nix
@@ -4,7 +4,6 @@
   buildPythonPackage,
   hatchling,
   pyqt6,
-  poppler-qt5,
   pycups,
 }:
 
@@ -24,7 +23,6 @@ buildPythonPackage rec {
 
   dependencies = [
     pyqt6
-    poppler-qt5
     pycups
   ];
 
@@ -33,7 +31,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "qpageview" ];
 
   meta = {
-    description = "Page-based viewer widget for Qt5/PyQt5";
+    description = "Page-based viewer widget for Qt6/PyQt6";
     homepage = "https://github.com/frescobaldi/qpageview";
     changelog = "https://github.com/frescobaldi/qpageview/blob/${src.tag}/ChangeLog";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
Updates and unbreaks frescobaldi. This includes a migration to qt6, which removes yet another dependency on qt5 webengine.
Part of #480196

<img width="1916" height="524" alt="image" src="https://github.com/user-attachments/assets/031154be-4e8b-48fa-9bad-9fdc1bcc07be" />

Runs and can display the music sheet PDFs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
