### PR TITLE
vampire: allow z3 override and add update script

### DIFF
--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -51,28 +51,33 @@ let
   # Isabelle uses a branch of vampire that is not in the normal release line
   # that adds support for higher order goals
   vampireStdenv = if stdenv.hostPlatform.isLinux then gcc14Stdenv else stdenv;
-  vampire' = (vampire.override { stdenv = vampireStdenv; }).overrideAttrs (_: {
-    pname = "vampire-for-isabelle";
-    version = "4.8";
+  vampire' =
+    (vampire.override {
+      stdenv = vampireStdenv;
+      z3' = null;
+    }).overrideAttrs
+      (_: {
+        pname = "vampire-for-isabelle";
+        version = "4.8";
 
-    src = fetchFromGitHub {
-      owner = "vprover";
-      repo = "vampire";
-      tag = "v4.8HO4Sledgahammer";
-      hash = "sha256-CmppaGa4M9tkE1b25cY1LSPFygJy5yV4kpHKbPqvcVE=";
-    };
+        src = fetchFromGitHub {
+          owner = "vprover";
+          repo = "vampire";
+          tag = "v4.8HO4Sledgahammer";
+          hash = "sha256-CmppaGa4M9tkE1b25cY1LSPFygJy5yV4kpHKbPqvcVE=";
+        };
 
-    patches = [ ./vampire-add-install-directive.patch ];
+        patches = [ ./vampire-add-install-directive.patch ];
 
-    postInstall = ''
-      mv $out/bin/vampire_rel $out/bin/vampire
-    '';
+        postInstall = ''
+          mv $out/bin/vampire_rel $out/bin/vampire
+        '';
 
-    cmakeFlags = [
-      (lib.cmakeFeature "CMAKE_BUILD_HOL" "On")
-      (lib.cmakeFeature "CMAKE_DISABLE_FIND_PACKAGE_Z3" "On")
-    ];
-  });
+        cmakeFlags = [
+          (lib.cmakeFeature "CMAKE_BUILD_HOL" "On")
+          (lib.cmakeFeature "CMAKE_DISABLE_FIND_PACKAGE_Z3" "On")
+        ];
+      });
 
   sha1 = stdenv.mkDerivation {
     pname = "isabelle-sha1";

--- a/pkgs/by-name/va/vampire/package.nix
+++ b/pkgs/by-name/va/vampire/package.nix
@@ -4,10 +4,7 @@
   fetchFromGitHub,
   cmake,
   z3,
-}:
-
-let
-  z3_4_14_0 = z3.overrideAttrs rec {
+  z3' ? z3.overrideAttrs rec {
     version = "4.14.0";
     src = fetchFromGitHub {
       owner = "Z3Prover";
@@ -15,8 +12,8 @@ let
       rev = "z3-${version}";
       hash = "sha256-Bv7+0J7ilJNFM5feYJqDpYsOjj7h7t1Bx/4OIar43EI=";
     };
-  };
-in
+  },
+}:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vampire";
   version = "5.0.1";
@@ -31,10 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
-    z3_4_14_0
+    z3'
   ];
 
-  cmakeFlags = [ (lib.cmakeFeature "Z3_DIR" "${z3_4_14_0.dev}/lib/cmake") ];
+  cmakeFlags = [ (lib.cmakeFeature "Z3_DIR" "${z3'.dev}/lib/cmake") ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/va/vampire/package.nix
+++ b/pkgs/by-name/va/vampire/package.nix
@@ -13,6 +13,7 @@
       hash = "sha256-Bv7+0J7ilJNFM5feYJqDpYsOjj7h7t1Bx/4OIar43EI=";
     };
   },
+  nix-update-script,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vampire";
@@ -38,6 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
   prePatch = ''
     rm -rf z3
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://vprover.github.io/";

--- a/pkgs/by-name/z3/z3/package.nix
+++ b/pkgs/by-name/z3/z3/package.nix
@@ -38,28 +38,31 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-eyF3ELv81xEgh9Km0Ehwos87e4VJ82cfsp53RCAtuTo=";
   };
 
-  patches = lib.optionals useCmakeBuild [
-    ./fix-pkg-config-paths.patch
-    # fix Segmentation fault. See https://github.com/Z3Prover/z3/pull/8264 and
-    # https://github.com/NixOS/nixpkgs/issues/486491
-    (fetchpatch2 {
-      name = "preserve-the-initial-state-of-the-solver.patch";
-      url = "https://github.com/Z3Prover/z3/commit/850a3236adab92f9f6f569ac66ffbb69be179f4c.patch?full_index=1";
-      hash = "sha256-C6p+dj3i3DpOnd2wr+R8ZwClHoMFfk5i5/+JRhTDNcs=";
-    })
-    # needs to include a cosmetic change to apply patch for memory corruption
-    (fetchpatch2 {
-      name = "cosmetic-changes-to-i.patch";
-      url = "https://github.com/Z3Prover/z3/commit/243694379475d983605f87578452a330f3e3b28f.patch?full_index=1";
-      includes = [ "src/api/api_polynomial.cpp" ];
-      hash = "sha256-huo5S73WrFrEEUcaP+1LDQwGwo+n2iYT4x/OjK5rmqQ=";
-    })
-    (fetchpatch2 {
-      name = "fix-memory-corruption.patch";
-      url = "https://github.com/Z3Prover/z3/commit/e7b6f3f33bcc6c88a0f2ace47ff2f09b59239433.patch?full_index=1";
-      hash = "sha256-kEEeod4s8i9SI2e2TFD2U4yd1qEPoGnJOfE0y+1Cq6M=";
-    })
-  ];
+  patches =
+    lib.optionals useCmakeBuild [
+      ./fix-pkg-config-paths.patch
+    ]
+    ++ lib.optionals (lib.versionAtLeast finalAttrs.version "4.15.4") [
+      # fix Segmentation fault. See https://github.com/Z3Prover/z3/pull/8264 and
+      # https://github.com/NixOS/nixpkgs/issues/486491
+      (fetchpatch2 {
+        name = "preserve-the-initial-state-of-the-solver.patch";
+        url = "https://github.com/Z3Prover/z3/commit/850a3236adab92f9f6f569ac66ffbb69be179f4c.patch?full_index=1";
+        hash = "sha256-C6p+dj3i3DpOnd2wr+R8ZwClHoMFfk5i5/+JRhTDNcs=";
+      })
+      # needs to include a cosmetic change to apply patch for memory corruption
+      (fetchpatch2 {
+        name = "cosmetic-changes-to-i.patch";
+        url = "https://github.com/Z3Prover/z3/commit/243694379475d983605f87578452a330f3e3b28f.patch?full_index=1";
+        includes = [ "src/api/api_polynomial.cpp" ];
+        hash = "sha256-huo5S73WrFrEEUcaP+1LDQwGwo+n2iYT4x/OjK5rmqQ=";
+      })
+      (fetchpatch2 {
+        name = "fix-memory-corruption.patch";
+        url = "https://github.com/Z3Prover/z3/commit/e7b6f3f33bcc6c88a0f2ace47ff2f09b59239433.patch?full_index=1";
+        hash = "sha256-kEEeod4s8i9SI2e2TFD2U4yd1qEPoGnJOfE0y+1Cq6M=";
+      })
+    ];
 
   strictDeps = true;
 


### PR DESCRIPTION
Fixes: #487162

Adds ability to override the pinned z3 version vampire uses, utilize this feature in isabelle derivation, and add update script to vampire. Also versions the patches z3 uses to fix the vampire build issues.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
