### PR TITLE
yaziPlugins.drag: init at 0-unstable-2025-08-29

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9550,6 +9550,12 @@
     githubId = 127353;
     name = "Geoffrey Huntley";
   };
+  gibbert = {
+    email = "gbjgms@gmail.com";
+    github = "zgibberish";
+    githubId = 67570424;
+    name = "gibbert";
+  };
   gigahawk = {
     email = "Jasper Chan";
     name = "jasperchan515@gmail.com";

--- a/pkgs/by-name/ya/yazi/plugins/drag/default.nix
+++ b/pkgs/by-name/ya/yazi/plugins/drag/default.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  fetchFromGitHub,
+  mkYaziPlugin,
+}:
+mkYaziPlugin {
+  pname = "drag.yazi";
+  version = "0-unstable-2025-08-29";
+
+  src = fetchFromGitHub {
+    owner = "Joao-Queiroga";
+    repo = "drag.yazi";
+    rev = "27606689cb82c56a19c052a7b7935cd9b1466bab";
+    hash = "sha256-ITkZjpwWXni4tQpDhUiVvtPrEkAo6RISgCH594NgpYE=";
+  };
+
+  meta = {
+    description = "Yazi plugin to drag and drop files using ripdrag";
+    homepage = "https://github.com/Joao-Queiroga/drag.yazi";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gibbert ];
+  };
+}


### PR DESCRIPTION
(This is my first contribution, I've also added myself to maintainer-list.nix)

Added the drag.yazi plugin to yaziPlugins

Upstream: <https://github.com/Joao-Queiroga/drag.yazi/>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
