### PR TITLE
elasticsearchPlugins.analysis-lemmagen: remove broken plugin

### DIFF
--- a/pkgs/servers/search/elasticsearch/plugins.nix
+++ b/pkgs/servers/search/elasticsearch/plugins.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  config,
   stdenv,
   fetchurl,
   unzip,
@@ -74,25 +75,6 @@ in
       homepage = "https://github.com/elastic/elasticsearch/tree/master/plugins/analysis-kuromoji";
       description = "Japanese (kuromoji) Analysis plugin integrates Lucene kuromoji analysis module into Elasticsearch";
       license = lib.licenses.asl20;
-    };
-  };
-
-  analysis-lemmagen = esPlugin rec {
-    pluginName = "analysis-lemmagen";
-    version = esVersion;
-    src = fetchurl {
-      url = "https://github.com/vhyza/elasticsearch-${pluginName}/releases/download/v${version}/elasticsearch-${pluginName}-${version}-plugin.zip";
-      hash =
-        if version == "7.17.9" then
-          "sha256-iY25apDkS6s0RoR9dVL2o/hFuUo6XhMzLjl8wDSFejk="
-        else
-          throw "unsupported version ${version} for plugin ${pluginName}";
-    };
-    meta = {
-      homepage = "https://github.com/vhyza/elasticsearch-analysis-lemmagen";
-      description = "LemmaGen Analysis plugin provides jLemmaGen lemmatizer as Elasticsearch token filter";
-      license = lib.licenses.asl20;
-      broken = true; # Not released yet for ES 7.17.10
     };
   };
 
@@ -230,4 +212,7 @@ in
         license = lib.licenses.asl20;
       };
     };
+}
+// lib.optionalAttrs config.allowAliases {
+  analysis-lemmagen = throw "elasticsearchPlugins.analysis-lemmagen has been removed due to being broken for more than a year; see RFC 180"; # Added 2026-02-05
 }


### PR DESCRIPTION
analysis-lemmagen has been marked broken since NixOS 24.05 and remains unfixed. The upstream plugin hasn't been updated for ES 7.17.10+.

Per RFC 180, packages broken for a full release cycle are subject to removal.

https://github.com/NixOS/rfcs/pull/180


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
