### PR TITLE
noogle-search: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2157,6 +2157,12 @@
     githubId = 58516559;
     name = "Alexander Rezvov";
   };
+  argos_nothing = {
+    email = "argosnothing@gmail.com";
+    github = "argosnothing";
+    githubId = 225423001;
+    name = "Argos Nothing";
+  };
   argrat = {
     email = "n.bertazzo@protonmail.com";
     github = "brtz-cs";

--- a/pkgs/by-name/no/noogle-search/package.nix
+++ b/pkgs/by-name/no/noogle-search/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  makeWrapper,
+  bat,
+  fzf,
+  xdg-utils,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "noogle-search";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "argosnothing";
+    repo = "noogle-search";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-js3jBZsyukleQW2BwggfYUvKCdS8pBTjD6ysWyMUtpI=";
+  };
+
+  cargoHash = "sha256-axqFE5ZEiVP8PzFTtW5mbyyYcR4q9g3LX/0i6y+cgy8=";
+
+  nativeBuildInputs = [
+    makeWrapper
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/noogle-search \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bat
+          fzf
+          xdg-utils
+        ]
+      }
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Search Noogle functions with fzf";
+    homepage = "https://github.com/argosnothing/noogle-search";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "noogle-search";
+    maintainers = with lib.maintainers; [ argos_nothing ];
+  };
+})


### PR DESCRIPTION
Added argos_nothing as maintainer

Added package [noogle-search](https://github.com/argosnothing/noogle-search), A terminal fzf-frontend for noogle.dev

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: noogle-search.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
