### PR TITLE
acltoolkit: update to use python3Packages and enable pyproject support

### DIFF
--- a/pkgs/by-name/ac/acltoolkit/package.nix
+++ b/pkgs/by-name/ac/acltoolkit/package.nix
@@ -1,15 +1,15 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonPackage {
+python3Packages.buildPythonPackage {
   pname = "acltoolkit";
-  version = "0-unstable-2023-02-03";
+  version = "0.2.2-unstable-2023-02-03";
   pyproject = true;
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
   src = fetchFromGitHub {
     owner = "zblurx";
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonPackage {
     sed -i -e "s/==[0-9.]*//" setup.py
   '';
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     asn1crypto
     dnspython
     impacket

--- a/pkgs/by-name/ac/acltoolkit/package.nix
+++ b/pkgs/by-name/ac/acltoolkit/package.nix
@@ -4,16 +4,15 @@
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonPackage {
+python3Packages.buildPythonPackage (finalAttrs: {
   pname = "acltoolkit";
   version = "0.2.2-unstable-2023-02-03";
   pyproject = true;
 
-  build-system = with python3Packages; [ setuptools ];
-
   src = fetchFromGitHub {
     owner = "zblurx";
     repo = "acltoolkit";
+    # https://github.com/zblurx/acltoolkit/issues/6
     rev = "a5219946aa445c0a3b4a406baea67b33f78bca7c";
     hash = "sha256-97cbkGyIkq2Pk1hydMcViXWoh+Ipi3m0YvEYiaV4zcM=";
   };
@@ -22,6 +21,8 @@ python3Packages.buildPythonPackage {
     # Ignore pinned versions
     sed -i -e "s/==[0-9.]*//" setup.py
   '';
+
+  build-system = with python3Packages; [ setuptools ];
 
   dependencies = with python3Packages; [
     asn1crypto
@@ -35,15 +36,13 @@ python3Packages.buildPythonPackage {
   # Project has no tests
   doCheck = false;
 
-  pythonImportsCheck = [
-    "acltoolkit"
-  ];
+  pythonImportsCheck = [ "acltoolkit" ];
 
   meta = {
     description = "ACL abuse swiss-knife";
-    mainProgram = "acltoolkit";
     homepage = "https://github.com/zblurx/acltoolkit";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "acltoolkit";
   };
-}
+})

--- a/pkgs/by-name/ac/acltoolkit/package.nix
+++ b/pkgs/by-name/ac/acltoolkit/package.nix
@@ -1,13 +1,13 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
 }:
 
-python3.pkgs.buildPythonPackage {
+python3Packages.buildPythonPackage {
   pname = "acltoolkit";
-  version = "0-unstable-2023-02-03";
-  format = "setuptools";
+  version = "0.2.2-unstable-2023-02-03";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zblurx";
@@ -21,7 +21,11 @@ python3.pkgs.buildPythonPackage {
     sed -i -e "s/==[0-9.]*//" setup.py
   '';
 
-  propagatedBuildInputs = with python3.pkgs; [
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = with python3Packages; [
     asn1crypto
     dnspython
     impacket


### PR DESCRIPTION
This pull request updates the packaging for `acltoolkit` in `pkgs/by-name/ac/acltoolkit/package.nix` to use modern Python packaging conventions and improves dependency management.

**Packaging modernization:**

* Switched from using `python3.pkgs.buildPythonPackage` to `python3Packages.buildPythonPackage`, and enabled PEP 517 build backend with `pyproject = true`.
* Replaced the deprecated `format = "setuptools"` with explicit `build-system` declaration using `python3Packages.setuptools`.

**Dependency management improvements:**

* Migrated from `propagatedBuildInputs` to the new `dependencies` attribute for runtime dependencies, using the updated `python3Packages` namespace.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
