### PR TITLE
gnuplot: Add info output

### DIFF
--- a/pkgs/by-name/gn/gnuplot/package.nix
+++ b/pkgs/by-name/gn/gnuplot/package.nix
@@ -29,6 +29,7 @@
   coreutils,
   withQt ? false,
   qt5,
+  emacs,
 }:
 
 let
@@ -43,10 +44,16 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-RY2UdpYl5z1fYjJQD0nLrcsrGDOA1D0iZqD5cBrrnFs=";
   };
 
+  outputs = [
+    "out"
+    "info"
+  ];
+
   nativeBuildInputs = [
     makeWrapper
     pkg-config
     texinfo
+    emacs
   ]
   ++ lib.optionals withQt [
     qt5.qttools
@@ -119,6 +126,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+
+  installTargets = [
+    "install"
+    "install-info"
+  ];
 
   meta = {
     homepage = "http://www.gnuplot.info/";


### PR DESCRIPTION
This adds the info version of the Gnuplot manual to derivation outputs. Replaces #271418, which targeted `master` branch, while this PR targets `staging`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
