### PR TITLE
luarocks-packages-updater: remove nix-commands dependency

### DIFF
--- a/pkgs/by-name/lu/luarocks-packages-updater/package.nix
+++ b/pkgs/by-name/lu/luarocks-packages-updater/package.nix
@@ -1,5 +1,6 @@
 {
   nix,
+  nixfmt,
   makeWrapper,
   python3Packages,
   lib,
@@ -15,6 +16,7 @@ let
 
   path = lib.makeBinPath [
     nix
+    nixfmt
     nix-prefetch-scripts
     luarocks-nix
     lua5_1

--- a/pkgs/by-name/lu/luarocks-packages-updater/updater.py
+++ b/pkgs/by-name/lu/luarocks-packages-updater/updater.py
@@ -161,8 +161,8 @@ class LuaEditor(nixpkgs_plugin_update.Editor):
 
         print(f"updated {outfilename}")
 
-        # Format the generated file with nix fmt
-        subprocess.run(["nix", "fmt", outfilename], check=True)
+        # Format the generated file with nixfmt
+        subprocess.run(["nixfmt", outfilename], check=True)
 
     @property
     def attr_path(self):


### PR DESCRIPTION
Make it functional without experimental features.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
