### PR TITLE
apksigcopier: update apksigcopier to use python3Packages, use finalAttrs

### DIFF
--- a/pkgs/by-name/ap/apksigcopier/package.nix
+++ b/pkgs/by-name/ap/apksigcopier/package.nix
@@ -5,10 +5,10 @@
   fetchFromGitHub,
   installShellFiles,
   pandoc,
-  python3,
+  python3Packages,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "apksigcopier";
   version = "1.1.1";
   pyproject = true;
@@ -16,8 +16,8 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "obfusk";
     repo = "apksigcopier";
-    tag = "v${version}";
-    sha256 = "sha256-VuwSaoTv5qq1jKwgBTKd1y9RKUzz89n86Z4UBv7Q51o=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VuwSaoTv5qq1jKwgBTKd1y9RKUzz89n86Z4UBv7Q51o=";
   };
 
   nativeBuildInputs = [
@@ -25,11 +25,11 @@ python3.pkgs.buildPythonApplication rec {
     pandoc
   ];
 
-  build-system = with python3.pkgs; [
+  build-system = with python3Packages; [
     setuptools
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     click
   ];
 
@@ -46,18 +46,18 @@ python3.pkgs.buildPythonApplication rec {
   '';
 
   postBuild = ''
-    make ${pname}.1
+    make apksigcopier.1
   '';
 
   postInstall = ''
-    installManPage ${pname}.1
+    installManPage apksigcopier.1
   '';
 
   doInstallCheck = true;
 
   installCheckPhase = ''
     runHook preInstallCheck
-    $out/bin/apksigcopier --version | grep "${version}"
+    $out/bin/apksigcopier --version | grep "${finalAttrs.version}"
     runHook postInstallCheck
   '';
 
@@ -79,4 +79,4 @@ python3.pkgs.buildPythonApplication rec {
     license = with lib.licenses; [ gpl3Plus ];
     maintainers = with lib.maintainers; [ obfusk ];
   };
-}
+})


### PR DESCRIPTION
This pull request refactors the `package.nix` file for the `apksigcopier` package to modernize its usage of Python packaging in Nix and improve maintainability. The main changes involve switching to `python3Packages`, updating function syntax, and making variable usage more explicit and robust.

**Python packaging modernization:**
* Switched from using `python3.pkgs.buildPythonApplication rec { ... }` to the more modern `python3Packages.buildPythonApplication (finalAttrs: { ... })` function syntax, improving clarity and maintainability.

* Replaced all references to `python3.pkgs` with `python3Packages` for consistency with current Nixpkgs best practices. 

**Variable handling improvements:**
* Updated usage of variables such as `version` and `pname` to use `finalAttrs.version` and hardcoded `apksigcopier` where appropriate, ensuring correctness in build and install scripts.

**Build and install script fixes:**
* Fixed the man page build and install steps to use the correct file name `apksigcopier.1` directly rather than relying on the `pname` variable.
* Updated the install check phase to reference `finalAttrs.version` for more robust version checking.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
