### PR TITLE
yosys: 0.61 -> 0.62

### DIFF
--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -64,13 +64,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yosys";
-  version = "0.61";
+  version = "0.62";
 
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "yosys";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-p7QewbeJtJRRkqYqWW1QzIe71OR5LD+0qsHHgl/cq2w=";
+    hash = "sha256-FzvdjdAURB5iCkGwsYY6A2wP/Je/IW4AOd4kVOEOeVc=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Diff: https://github.com/YosysHQ/yosys/compare/v0.61...v0.62

Changelog: https://github.com/YosysHQ/yosys/releases/tag/v0.62

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
