### PR TITLE
abc-verifier: 0.61 -> 0.62

### DIFF
--- a/pkgs/by-name/ab/abc-verifier/package.nix
+++ b/pkgs/by-name/ab/abc-verifier/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "abc-verifier";
-  version = "0.61";
+  version = "0.62";
 
   src = fetchFromGitHub {
     owner = "yosyshq";
     repo = "abc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-j/JmEJa29mT/XQmVL/adVbj4S+AAgpga1jbEinCN16w=";
+    hash = "sha256-T6Hj8zrr3XuI3Eh0I5rJI3+DAsuQIMtWEsaBJ8a5Cag=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     # The upstream fix for the input-files macro regression
     (fetchpatch {
       url = "https://github.com/acl2/acl2/commit/be39e7835f1c68008c17188d2f65eeaef61632fa.patch";
-      sha256 = "sha256-pZ/r0vlyJz7ymYfrVtHDxsLdw0M/MJStBH42ZLO7Fs4=";
+      hash = "sha256-pZ/r0vlyJz7ymYfrVtHDxsLdw0M/MJStBH42ZLO7Fs4=";
     })
 
     (replaceVars ./0001-path-changes-for-nix.patch {


### PR DESCRIPTION
https://github.com/YosysHQ/abc/releases/tag/v0.62

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
