### PR TITLE
abc-verifier, yosys, openroad: use external abc-verifier

### DIFF
--- a/pkgs/by-name/ab/abc-verifier/package.nix
+++ b/pkgs/by-name/ab/abc-verifier/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   readline,
-  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -17,21 +16,36 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-T6Hj8zrr3XuI3Eh0I5rJI3+DAsuQIMtWEsaBJ8a5Cag=";
   };
 
-  nativeBuildInputs = [ cmake ];
   buildInputs = [ readline ];
 
-  cmakeFlags = [
-    # This prevents CMake from trying to download googletest during the build
-    (lib.cmakeBool "ABC_SKIP_TESTS" true)
+  # Defining the namespace is still required for OpenROAD
+  env.NIX_CFLAGS_COMPILE = "-DABC_NAMESPACE=abc";
+
+  makeFlags = [
+    "ABC_USE_LIBSTDCXX=1"
+    "ABC_USE_NAMESPACE=abc"
+    "CC=${stdenv.cc.targetPrefix}gcc"
+    "CXX=${stdenv.cc.targetPrefix}g++"
   ];
+
+  buildPhase = ''
+    runHook preBuild
+    # Build both the 'abc' executable and the 'libabc.a' static library
+    make -j$NIX_BUILD_CORES $makeFlags abc libabc.a
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
-    install -Dm755 'abc' "$out/bin/abc"
+    install -Dm755 abc $out/bin/abc
+    install -Dm644 libabc.a $out/lib/libabc.a
+
+    pushd src
+    find . -name "*.h" -exec install -Dm644 {} $out/include/{} \;
+    popd
     runHook postInstall
   '';
 
-  # needed by yosys
   passthru.rev = finalAttrs.src.rev;
 
   meta = {
@@ -42,6 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
       thoughtpolice
       Luflosi
     ];
+
     mainProgram = "abc";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/op/openroad/package.nix
+++ b/pkgs/by-name/op/openroad/package.nix
@@ -17,6 +17,7 @@
   versionCheckHook,
 
   # buildInputs
+  abc-verifier,
   boost,
   cbc,
   cimg,
@@ -66,6 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    abc-verifier
     boost
     cbc
     cimg
@@ -95,6 +97,13 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals stdenv.hostPlatform.isLinux [ libx11 ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
 
+  # This activates the namespace logic found in abc_namespaces.h
+  env.NIX_CFLAGS_COMPILE = "-DABC_NAMESPACE=abc";
+
+  # Linker flags for transitive dependencies of the static libabc.a
+  # This avoids passing spaces/flags directly into CMake's ABC_LIBRARY variable
+  env.NIX_LDFLAGS = "-lreadline -lrt";
+
   postPatch = ''
     patchShebangs etc/
 
@@ -111,10 +120,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    # Disable tests on Darwin to avoid discovery timeouts during build
     (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
     (lib.cmakeBool "USE_SYSTEM_BOOST" true)
-    (lib.cmakeBool "USE_SYSTEM_ABC" false)
+    (lib.cmakeBool "USE_SYSTEM_ABC" true)
+    (lib.cmakeFeature "ABC_INCLUDE_DIR" "${abc-verifier}/include")
+    (lib.cmakeFeature "ABC_LIBRARY" "${abc-verifier}/lib/libabc.a")
+
     (lib.cmakeBool "ABC_SKIP_TESTS" true)
     (lib.cmakeBool "USE_SYSTEM_OPENSTA" false)
     (lib.cmakeFeature "OPENROAD_VERSION" finalAttrs.version)

--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -7,6 +7,7 @@
   bison,
   flex,
   pkg-config,
+  makeWrapper,
 
   # propagatedBuildInputs
   libffi,
@@ -14,6 +15,7 @@
   readline,
   tcl,
   zlib,
+  abc-verifier,
 
   # tests
   gtkwave,
@@ -22,12 +24,11 @@
   # passthru
   symlinkJoin,
   yosys,
-  makeWrapper,
   yosys-bluespec,
   yosys-ghdl,
   yosys-symbiflow,
   nix-update-script,
-  enablePython ? true, # enable python binding
+  enablePython ? true,
 }:
 
 let
@@ -71,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "yosys";
     tag = "v${finalAttrs.version}";
     hash = "sha256-FzvdjdAURB5iCkGwsYY6A2wP/Je/IW4AOd4kVOEOeVc=";
-    fetchSubmodules = true;
+    fetchSubmodules = false; # ABC is now external
   };
 
   enableParallelBuilding = true;
@@ -80,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     bison
     flex
     pkg-config
+    makeWrapper
   ];
 
   propagatedBuildInputs = [
@@ -102,22 +104,29 @@ stdenv.mkDerivation (finalAttrs: {
   makeFlags = [
     "PREFIX=${placeholder "out"}"
     "YOSYS_VER=${finalAttrs.version}"
+    "ABCEXTERNAL=${lib.getExe abc-verifier}"
   ];
 
   postPatch = ''
+    patchShebangs tests ./misc/yosys-config.in
+
     substituteInPlace Makefile \
       --replace-fail 'GIT_REV := $(shell GIT_DIR=$(YOSYS_SRC)/.git git rev-parse --short=9 HEAD || echo UNKNOWN)' 'GIT_REV := v${finalAttrs.version}' \
       --replace-fail 'GIT_DIRTY := $(shell GIT_DIR=$(YOSYS_SRC)/.git git diff --exit-code --quiet 2>/dev/null; if [ $$? -ne 0 ]; then echo "-dirty"; fi)' 'GIT_DIRTY := ""'
 
+    # Remove internal ABC build checks and submodule requirements
     substituteInPlace Makefile \
-      --replace-fail "| check-git-abc" ""
-
-    substituteInPlace Makefile \
+      --replace-fail "| check-git-abc" "" \
       --replace-fail 'new=$$(cd abc 2>/dev/null && git rev-parse HEAD 2>/dev/null || echo none)' 'new=none'
 
+    # Ensure the version is correctly set in the Makefile
     sed -i 's/^YOSYS_VER :=.*/YOSYS_VER := ${finalAttrs.version}/' Makefile
 
-    patchShebangs tests ./misc/yosys-config.in
+    # Patch setup.py for Pyosys to use external ABC
+    if [ -e setup.py ]; then
+      substituteInPlace setup.py \
+        --replace-fail '"ABCEXTERNAL=",' '"ABCEXTERNAL=${lib.getExe abc-verifier}",'
+    fi
   '';
 
   preBuild = ''
@@ -134,6 +143,11 @@ stdenv.mkDerivation (finalAttrs: {
     echo "ENABLE_PYOSYS := 1" >> Makefile.conf
     echo "PYTHON_DESTDIR := $out/${python3.sitePackages}" >> Makefile.conf
     echo "BOOST_PYTHON_LIB := -lboost_python${lib.versions.major python3.version}${lib.versions.minor python3.version}" >> Makefile.conf
+  '';
+
+  postInstall = ''
+    # Create the symlink that sby and internal scripts expect
+    ln -s ${lib.getExe abc-verifier} $out/bin/yosys-abc
   '';
 
   preCheck = ''


### PR DESCRIPTION
There is already abc-verifier in Nix, no need to duplicate it here.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
