### PR TITLE
qt5: facelift

### DIFF
--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -16,17 +16,7 @@
   fetchpatch,
   fetchFromGitHub,
   makeSetupHook,
-  makeWrapper,
-  bison,
-  cups ? null,
-  harfbuzz,
-  libGL,
-  perl,
   python3,
-  gstreamer,
-  gst-plugins-base,
-  gtk3,
-  dconf,
   llvmPackages_19,
   darwin,
 
@@ -282,14 +272,7 @@ let
       qtbase = callPackage ../modules/qtbase.nix {
         inherit (srcs.qtbase) src version;
         patches = patches.qtbase;
-        inherit
-          bison
-          cups
-          harfbuzz
-          libGL
-          ;
         withGtk3 = !stdenv.hostPlatform.isDarwin;
-        inherit dconf gtk3;
         inherit developerBuild decryptSslTraffic;
       };
 
@@ -305,9 +288,7 @@ let
       qtlocation = callPackage ../modules/qtlocation.nix { };
       qtlottie = callPackage ../modules/qtlottie.nix { };
       qtmacextras = callPackage ../modules/qtmacextras.nix { };
-      qtmultimedia = callPackage ../modules/qtmultimedia.nix {
-        inherit gstreamer gst-plugins-base;
-      };
+      qtmultimedia = callPackage ../modules/qtmultimedia.nix { };
       qtnetworkauth = callPackage ../modules/qtnetworkauth.nix { };
       qtpim = callPackage ../modules/qtpim.nix { };
       qtpositioning = callPackage ../modules/qtpositioning.nix { };

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -49,6 +49,10 @@ let
         url = "https://gitlab.alpinelinux.org/alpine/aports/-/raw/81b14ae4eed038662b53cd20786fd5e0816279ec/community/qt5-qtbase/loongarch64.patch";
         hash = "sha256-BnpejF6/L73kVVts0R0/OMbVN8G4DXVFwBMJPLU9QbE=";
       })
+      (fetchpatch {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtbase/-/raw/6910758e1141f8ea65a8f2359ac30163d65bf6e2/debian/patches/cross_build_mysql.diff";
+        hash = "sha256-tzmmLmMXmeDwRVjdpWekDJvSkrIIlslC12HP7XPcm3E=";
+      })
     ];
     qtdeclarative = [
       ./qtdeclarative.patch

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -10,7 +10,6 @@
   generateSplicesForMkScope,
   lib,
   stdenv,
-  gcc14Stdenv,
   fetchurl,
   fetchgit,
   fetchpatch,
@@ -254,15 +253,12 @@ let
   addPackages =
     self:
     let
-      qtModuleWithStdenv =
-        stdenv:
-        callPackage ../qtModule.nix {
-          inherit patches;
-          # Use a variant of mkDerivation that does not include wrapQtApplications
-          # to avoid cyclic dependencies between Qt modules.
-          mkDerivation = (callPackage ../mkDerivation.nix { wrapQtAppsHook = null; }) stdenv.mkDerivation;
-        };
-      qtModule = qtModuleWithStdenv stdenv;
+      qtModule = callPackage ../qtModule.nix {
+        inherit patches;
+        # Use a variant of mkDerivation that does not include wrapQtApplications
+        # to avoid cyclic dependencies between Qt modules.
+        mkDerivation = (callPackage ../mkDerivation.nix { wrapQtAppsHook = null; }) stdenv.mkDerivation;
+      };
 
       callPackage = self.newScope {
         inherit
@@ -328,22 +324,14 @@ let
       qtvirtualkeyboard = callPackage ../modules/qtvirtualkeyboard.nix { };
       qtwayland = callPackage ../modules/qtwayland.nix { };
       qtwebchannel = callPackage ../modules/qtwebchannel.nix { };
-      qtwebengine =
-        # Actually propagating stdenv change
-        let
-          # Won’t build with Clang 20, as `-Wenum-constexpr-conversion`
-          # was made a hard error.
-          # qt5webengine no longer maintained, FTBFS with GCC 15
-          stdenv' = if stdenv.cc.isClang then llvmPackages_19.stdenv else gcc14Stdenv;
-          qtModule' = qtModuleWithStdenv stdenv';
-        in
-        callPackage ../modules/qtwebengine.nix {
-          inherit (srcs.qtwebengine) version;
-          inherit (darwin) bootstrap_cmds;
-          stdenv = stdenv';
-          qtModule = qtModule';
-          python = python3;
-        };
+      qtwebengine = callPackage ../modules/qtwebengine.nix {
+        # Won’t build with Clang 20, as `-Wenum-constexpr-conversion`
+        # was made a hard error.
+        stdenv = if stdenv.cc.isClang then llvmPackages_19.stdenv else stdenv;
+        inherit (srcs.qtwebengine) version;
+        inherit (darwin) bootstrap_cmds;
+        python = python3;
+      };
       qtwebglplugin = callPackage ../modules/qtwebglplugin.nix { };
       qtwebkit = callPackage ../modules/qtwebkit.nix { };
       qtwebsockets = callPackage ../modules/qtwebsockets.nix { };

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -60,6 +60,7 @@ let
       ./qtdeclarative-default-disable-qmlcache.patch
       # add version specific QML import path
       ./qtdeclarative-qml-paths.patch
+      ./qtdeclarative-gcc15.patch
     ];
     qtlocation = lib.optionals stdenv.cc.isClang [
       # Fix build with Clang 16

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -231,6 +231,18 @@ let
       ./qtwebkit.patch
       ./qtwebkit-icu68.patch
       ./qtwebkit-cstdint.patch
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/84f3c61c46bce99bfbd70d8c202e022d62f2ea9a/f/qtwebkit-icu76.patch";
+        sha256 = "sha256-Z+ot7R5Dy+F08FbcXzN4MB2ttxLg0I0P8uVErpbFiu4=";
+      })
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/84f3c61c46bce99bfbd70d8c202e022d62f2ea9a/f/webkit-offlineasm-warnings-ruby27.patch";
+        sha256 = "sha256-g+qkAJD78lPdZzZZ910SZqk0yJlJIBZh9ue4ClRD5L4=";
+      })
+      (fetchpatch {
+        url = "https://src.fedoraproject.org/rpms/qt5-qtwebkit/raw/84f3c61c46bce99bfbd70d8c202e022d62f2ea9a/f/qtwebkit-fix-build-gcc14.patch";
+        sha256 = "sha256-K7TgGux34dMN0Mnm4EsJhNKLdy1VdKTAE3HGRD8KARU=";
+      })
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       ./qtwebkit-darwin-no-readline.patch

--- a/pkgs/development/libraries/qt-5/5.15/qtdeclarative-gcc15.patch
+++ b/pkgs/development/libraries/qt-5/5.15/qtdeclarative-gcc15.patch
@@ -1,0 +1,12 @@
+diff --git a/src/qml/compiler/qv4compiler.cpp b/src/qml/compiler/qv4compiler.cpp
+index 18e19cf01c..13934eebb5 100644
+--- a/src/qml/compiler/qv4compiler.cpp
++++ b/src/qml/compiler/qv4compiler.cpp
+@@ -47,6 +47,7 @@
+ #include <private/qml_compile_hash_p.h>
+ #include <private/qqmlirbuilder_p.h>
+ #include <QCryptographicHash>
++#include <cstdint>
+ 
+ // Efficient implementation that takes advantage of powers of two.
+ static inline size_t roundUpToMultipleOf(size_t divisor, size_t x)

--- a/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qmake-hook.sh
@@ -1,5 +1,15 @@
 . @fix_qmake_libtool@
 
+# Split qmakeFlags if it's not an array already (i.e. comes from a derivation
+# with __structuredAttrs disabled). This will be important later when we pass
+# it to qmake: qmakeFlags can contain file names and other options that must
+# be separate words in the command.
+local type=$(declare -p qmakeFlags)
+local typeArray='declare -a'
+if [[ "${type:0:${#typeArray}}" == "$typeArray" ]]; then
+    qmakeFlags=( ${qmakeFlags-} )
+fi
+
 qmakePrePhase() {
     # These flags must be added _before_ the flags specified in the derivation.
     prependToVar qmakeFlags \

--- a/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-5/hooks/qtbase-setup-hook.sh
@@ -41,9 +41,6 @@ export QMAKE
 QMAKEPATH=
 export QMAKEPATH
 
-QMAKEMODULES=
-export QMAKEMODULES
-
 declare -Ag qmakePathSeen=()
 qmakePathHook() {
     # Skip this path if we have seen it before.
@@ -52,7 +49,6 @@ qmakePathHook() {
     qmakePathSeen[$1]=1
     if [ -d "$1/mkspecs" ]
     then
-        QMAKEMODULES="${QMAKEMODULES}${QMAKEMODULES:+:}/mkspecs"
         QMAKEPATH="${QMAKEPATH}${QMAKEPATH:+:}$1"
     fi
 }

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -56,7 +56,6 @@
   withGtk3 ? false,
   dconf,
   gtk3,
-  withQttranslation ? true,
   qttranslations ? null,
   withLibinput ? false,
   libinput,
@@ -492,8 +491,7 @@ stdenv.mkDerivation (
             "-I"
             "${libmysqlclient}/include"
           ]
-          ++ lib.optional (withQttranslation && (qttranslations != null)) [
-            # depends on x11
+          ++ lib.optional (qttranslations != null) [
             "-translationdir"
             "${qttranslations}/translations"
           ]

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -63,8 +63,7 @@
   # options
   libGLSupported ? !stdenv.hostPlatform.isDarwin,
   libGL,
-  # qmake detection for libmysqlclient does not seem to work when cross compiling
-  mysqlSupport ? stdenv.hostPlatform == stdenv.buildPlatform,
+  mysqlSupport ? true,
   libmysqlclient,
   buildExamples ? false,
   buildTests ? false,
@@ -487,9 +486,9 @@ stdenv.mkDerivation (
           ]
           ++ lib.optionals mysqlSupport [
             "-L"
-            "${libmysqlclient}/lib"
+            "${libmysqlclient}/lib/mysql"
             "-I"
-            "${libmysqlclient}/include"
+            "${libmysqlclient}/include/mysql"
           ]
           ++ lib.optional (qttranslations != null) [
             "-translationdir"

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -159,7 +159,6 @@ stdenv.mkDerivation (
         pkg-config
         which
       ]
-      ++ lib.optionals mysqlSupport [ libmysqlclient ]
       ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
 
     }

--- a/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtdeclarative.nix
@@ -2,14 +2,12 @@
   qtModule,
   python3,
   qtbase,
-  qtsvg,
 }:
 
 qtModule {
   pname = "qtdeclarative";
   propagatedBuildInputs = [
     qtbase
-    qtsvg
   ];
   nativeBuildInputs = [ python3 ];
   outputs = [

--- a/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtmultimedia.nix
@@ -6,8 +6,7 @@
   qtdeclarative,
   pkg-config,
   alsa-lib,
-  gstreamer,
-  gst-plugins-base,
+  gst_all_1,
   libpulseaudio,
   wayland,
 }:
@@ -19,16 +18,18 @@ qtModule {
     qtdeclarative
   ];
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    gstreamer
-    gst-plugins-base
-  ]
-  # https://github.com/NixOS/nixpkgs/pull/169336 regarding libpulseaudio
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libpulseaudio
-    alsa-lib
-    wayland
-  ];
+  buildInputs =
+    with gst_all_1;
+    [
+      gstreamer
+      gst-plugins-base
+    ]
+    # https://github.com/NixOS/nixpkgs/pull/169336 regarding libpulseaudio
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libpulseaudio
+      alsa-lib
+      wayland
+    ];
   outputs = [
     "bin"
     "dev"

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -38,17 +38,19 @@
   zlib,
   minizip,
   libjpeg,
+  openjpeg,
   libpng,
   libtiff,
   libwebp,
   libopus,
-  jsoncpp,
-  protobuf,
   libvpx,
   srtp,
   snappy,
   nss,
   libevent,
+  lcms2,
+  libxml2,
+  libxslt,
   alsa-lib,
   pulseaudio,
   libcap,
@@ -224,21 +226,42 @@ qtModule (
 
       # Fix the build with gperf ≥ 3.2 and Clang 19.
       ./qtwebengine-gperf-3.2.patch
+
+      # Support building with gcc15
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/451b2e7a6a0ac2c6eb409b4e2c03dada141bcd7f/debian/patches/gcc-15.patch";
+        hash = "sha256-nOGntSYDwyYXZYb1/VQMJQDfvn2KbN5/Ok4rs/ZabdQ=";
+      })
+
+      # support for building with python 3.12
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/python3.12-six.patch";
+        hash = "sha256-gjc9sOPbcyHtJWnSHpkpupY6dIAODO20tiaTEtAfFr0=";
+      })
+
+      # Build with C++17, which is required by ICU 75
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/build-with-c++17.patch";
+        hash = "sha256-1fhkj50radAc3uG386UnS735+LRe0Xs8jQOJtMqE7hQ=";
+      })
+
+      # Use system openjpeg
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/system-openjpeg2.patch";
+        hash = "sha256-H3WwC40t0FRMGf1K2aXucrQjynMU/U/14goB4HK9/KM=";
+      })
+
+      # Use system lcms2
+      (fetchpatch2 {
+        url = "https://salsa.debian.org/qt-kde-team/qt/qtwebengine/-/raw/313423e0178cee6eb9419c5803b982df2a71d689/debian/patches/system-lcms2.patch";
+        hash = "sha256-ccEbt5T54uXTV1pJnHI12NfYJ+QdUSUJFj0xcKcmtIA=";
+      })
     ];
 
     postPatch = ''
       # Patch Chromium build tools
       (
         cd src/3rdparty/chromium;
-
-        patch -p1 < ${
-          (fetchpatch {
-            # support for building with python 3.12
-            name = "python312-six.patch";
-            url = "https://gitlab.archlinux.org/archlinux/packaging/packages/qt5-webengine/-/raw/6b0c0e76e0934db2f84be40cb5978cee47266e78/python3.12-six.patch";
-            hash = "sha256-YgP9Sq5+zTC+U7+0hQjZokwb+fytk0UEIJztUXFhTkI=";
-          })
-        }
 
         # Manually fix unsupported shebangs
         substituteInPlace third_party/harfbuzz-ng/src/src/update-unicode-tables.make \
@@ -327,11 +350,12 @@ qtModule (
 
     qmakeFlags = [
       "--"
-      "-system-ffmpeg"
+      "-webengine-icu"
     ]
     ++ lib.optional (
       pipewireSupport && stdenv.buildPlatform == stdenv.hostPlatform
     ) "-webengine-webrtc-pipewire"
+    ++ lib.optional (ffmpeg_7 != null) "-webengine-ffmpeg"
     ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
 
     propagatedBuildInputs = [
@@ -339,9 +363,14 @@ qtModule (
       qtquickcontrols
       qtlocation
       qtwebchannel
+    ];
 
+    # Optional dependency on system-provided re2 library is not used here because it activates
+    # some broken code paths in chromium.
+    buildInputs = [
       # Image formats
       libjpeg
+      openjpeg
       libpng
       libtiff
       libwebp
@@ -356,18 +385,20 @@ qtModule (
       # Text rendering
       harfbuzz
       icu
+      freetype
 
       libevent
       ffmpeg_7
+
+      lcms2
+
+      snappy
+      minizip
+      zlib
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       dbus
-      zlib
-      minizip
-      snappy
       nss
-      protobuf
-      jsoncpp
 
       # Audio formats
       alsa-lib
@@ -375,10 +406,16 @@ qtModule (
 
       # Text rendering
       fontconfig
-      freetype
 
       libcap
       pciutils
+
+      # there's an explicit check for LIBXML_ICU_ENABLED at configuraion time
+      # FIXME: still doesn't work because of the propagation of non-icu libxml2
+      # from qtbase. Not sure what is the right move here.
+      # FIXME: those could also be used on Darwin if we fix https://github.com/NixOS/nixpkgs/issues/272383
+      (libxml2.override { icuSupport = true; })
+      libxslt
 
       # X11 libs
       xrandr

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -397,12 +397,11 @@ qtModule (
       # Pipewire
       pipewire
     ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # FIXME This dependency shouldn't be needed but can't find a way
+      # around it. Chromium pulls this in while bootstrapping GN.
+      cctools.libtool
 
-    # FIXME These dependencies shouldn't be needed but can't find a way
-    # around it. Chromium pulls this in while bootstrapping GN.
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools.libtool ];
-
-    buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
       cups
 
       # `sw_vers` is used by `src/3rdparty/chromium/build/config/mac/sdk_info.py`

--- a/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebkit.nix
@@ -26,22 +26,10 @@
   pkg-config,
   python3,
   ruby,
+  hyphen,
+  woff2,
 }:
 
-let
-  hyphen = stdenv.mkDerivation rec {
-    pname = "hyphen";
-    version = "2.8.8";
-    src = fetchurl {
-      url = "http://dev-www.libreoffice.org/src/5ade6ae2a99bc1e9e57031ca88d36dad-hyphen-${version}.tar.gz";
-      sha256 = "304636d4eccd81a14b6914d07b84c79ebb815288c76fe027b9ebff6ff24d5705";
-    };
-    postPatch = ''
-      patchShebangs tests
-    '';
-    buildInputs = [ perl ];
-  };
-in
 qtModule {
   pname = "qtwebkit";
   propagatedBuildInputs = [
@@ -62,6 +50,7 @@ qtModule {
     gst_all_1.gstreamer
     gst_all_1.gst-plugins-base
     hyphen
+    woff2
   ];
   nativeBuildInputs = [
     bison

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7484,35 +7484,7 @@ with pkgs;
     python3 = null;
   };
 
-  qt5 = recurseIntoAttrs (
-    makeOverridable (import ../development/libraries/qt-5/5.15) {
-      inherit (__splicedPackages)
-        makeScopeWithSplicing'
-        generateSplicesForMkScope
-        lib
-        stdenv
-        gcc14Stdenv
-        fetchurl
-        fetchpatch
-        fetchgit
-        fetchFromGitHub
-        makeSetupHook
-        makeWrapper
-        bison
-        cups
-        dconf
-        harfbuzz
-        libGL
-        perl
-        gtk3
-        python3
-        llvmPackages_19
-        darwin
-        ;
-      inherit (__splicedPackages.gst_all_1) gstreamer gst-plugins-base;
-      inherit config;
-    }
-  );
+  qt5 = recurseIntoAttrs (__splicedPackages.callPackage ../development/libraries/qt-5/5.15 { });
 
   libsForQt5 = recurseIntoAttrs (
     import ./qt5-packages.nix {


### PR DESCRIPTION
These are various fixes, improvements, and cleanups that I've accumulated over the past 2+ years of trying to keep my out-of-tree cross compilation changes working. Most of these commits are applicable to native builds too and nothing here depends on the scary cross changes.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
