### PR TITLE
wine: Get rid of overcomplicated `overrride` dance in `default.nix`

### DIFF
--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -49,10 +49,10 @@
 
 let
   wine-build =
-    build: release:
+    build:
     lib.getAttr build (
       callPackage ./packages.nix {
-        wineRelease = release;
+        inherit wineRelease;
         supportFlags = {
           inherit
             alsaSupport
@@ -91,18 +91,5 @@ let
         inherit moltenvk;
       }
     );
-
-  baseRelease =
-    {
-      staging = "unstable";
-      yabridge = "yabridge";
-    }
-    .${wineRelease} or null;
 in
-if baseRelease != null then
-  (wine-build wineBuild baseRelease).override {
-    inherit wineRelease;
-    useStaging = true;
-  }
-else
-  wine-build wineBuild wineRelease
+wine-build wineBuild

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -18,9 +18,27 @@
 }:
 
 let
-  src = lib.getAttr wineRelease (callPackage ./sources.nix { });
+  sources = callPackage ./sources.nix { };
+
+  # "staging" of course enables staging, but for "yabridge" we do too
+  # --- we are not interested in yabridge without the staging patches
+  # applied.
+  useStaging = wineRelease == "staging" || wineRelease == "yabridge";
+
+  # Map wineRelease to actual source. Many versions have a "staging"
+  # variant, but when we say "staging", the version we want to use is
+  # "unstable".
+  baseRelease = if wineRelease == "staging" then "unstable" else wineRelease;
+
+  src = lib.getAttr baseRelease (callPackage ./sources.nix { });
+  inherit (src)
+    version
+    patches
+    gecko32
+    gecko64
+    mono
+    ;
 in
-with src;
 {
   wine32 = pkgsi686Linux.callPackage ./base.nix {
     pname = "wine";
@@ -31,6 +49,7 @@ with src;
       patches
       moltenvk
       wineRelease
+      useStaging
       # Forcing these `nativeBuildInputs` used in the `staging` to come
       # from ambient `pkgs`, rather than being provided by
       # `pkgsi686Linux.callPackage` for that platform.
@@ -58,6 +77,7 @@ with src;
       patches
       moltenvk
       wineRelease
+      useStaging
       ;
     pkgArches = [ pkgs ];
     mingwGccs = with pkgsCross; [ mingwW64.buildPackages.gcc ];
@@ -79,6 +99,7 @@ with src;
       patches
       moltenvk
       wineRelease
+      useStaging
       ;
     stdenv = stdenv_32bit;
     pkgArches = [
@@ -112,6 +133,7 @@ with src;
       patches
       moltenvk
       wineRelease
+      useStaging
       ;
     supportFlags = supportFlags // {
       mingwSupport = true;


### PR DESCRIPTION
The new logic is much easier to read, and (I hope!) better documented.

As an added bonus, replace with the `with src` with a more targeted `let inherit`.

Split out from #486997.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
