### PR TITLE
Init plasmazones at 1.3.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20109,6 +20109,12 @@
     githubId = 17091659;
     name = "Pablo Andres Dealbera";
   };
+  pacjo = {
+    email = "korycinski.kam@gmail.com";
+    github = "pacjo";
+    githubId = 56438628;
+    name = "pacjo";
+  };
   pacman99 = {
     email = "pachum99@gmail.com";
     matrix = "@pachumicchu:myrdd.info";

--- a/pkgs/by-name/pl/plasmazones/package.nix
+++ b/pkgs/by-name/pl/plasmazones/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  kdePackages,
+  qt6,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "plasmazones";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "fuddlesworth";
+    repo = "PlasmaZones";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-fqs11tv8ejRBszWKhNHo1lozI00lsk7aNdOBwqxCG5Y=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+    kdePackages.extra-cmake-modules
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+  ]
+  ++ (with kdePackages; [
+    kconfig
+    kconfigwidgets
+    kcoreaddons
+    kdbusaddons
+    ki18n
+    kcmutils
+    kwindowsystem
+    kglobalaccel
+    knotifications
+    kcolorscheme
+    layer-shell-qt
+    kwin
+  ]);
+
+  cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Release" ];
+
+  postInstall = ''
+    substituteInPlace $out/share/systemd/user/plasmazones.service \
+      --replace-fail "/usr/bin/plasmazonesd" "$out/bin/plasmazonesd"
+  '';
+
+  meta = {
+    description = "FancyZones-style window tiling for KDE Plasma";
+    homepage = "https://github.com/fuddlesworth/PlasmaZones";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ pacjo ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This packages the current version of [PlasmaZones](https://github.com/fuddlesworth/PlasmaZones), which is a FancyZones-like tiling system/helper.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
