### PR TITLE
tonearm: init at 1.2.0

### DIFF
--- a/pkgs/by-name/to/tonearm/package.nix
+++ b/pkgs/by-name/to/tonearm/package.nix
@@ -1,0 +1,120 @@
+{
+  buildGoModule,
+  cairo,
+  copyDesktopItems,
+  fetchFromGitea,
+  gdk-pixbuf,
+  glib,
+  glib-networking,
+  gobject-introspection,
+  graphene,
+  gst_all_1,
+  gtk4,
+  lib,
+  libadwaita,
+  libsecret,
+  librsvg,
+  makeDesktopItem,
+  makeWrapper,
+  pango,
+  pkg-config,
+  symlinkJoin,
+  wrapGAppsHook4,
+}:
+let
+  libraryPath = symlinkJoin {
+    name = "tonearm-puregotk-lib-folder";
+    paths = [
+      cairo
+      gdk-pixbuf
+      glib.out
+      graphene
+      pango.out
+      gtk4
+      libadwaita
+      libsecret
+      gobject-introspection
+      librsvg
+    ];
+  };
+in
+buildGoModule (finalAttrs: {
+  pname = "tonearm";
+  version = "1.2.0";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "dergs";
+    repo = "Tonearm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2on27z3BRf63gjs3NKmF9H0Le7hBdaHRUp8WQgFs3QU=";
+  };
+  vendorHash = "sha256-j+7cobxVGNuZFYeRn5ad7XT4um8WNWE1byFo7qo9zK0=";
+
+  ldflags = [
+    "-X \"codeberg.org/dergs/tonearm/internal/ui.Version=${finalAttrs.version}\""
+  ];
+
+  buildInputs = [
+    glib-networking
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    gtk4
+    libsecret
+  ];
+  doCheck = false;
+  nativeBuildInputs = [
+    pkg-config
+    copyDesktopItems
+    makeWrapper
+    wrapGAppsHook4
+  ];
+
+  subPackages = [
+    "cmd/tonearm"
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "dev.dergs.Tonearm";
+      exec = "tonearm %u";
+      icon = "dev.dergs.Tonearm";
+      comment = "Tonearm is a GTK client for TIDAL written in GoLang.";
+      desktopName = "Tonearm";
+      mimeTypes = [
+        "x-scheme-handler/tidal"
+      ];
+      categories = [
+        "Audio"
+        "AudioVideo"
+        "Music"
+        "GNOME"
+        "GTK"
+      ];
+    })
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/tonearm \
+      --prefix GST_PLUGIN_PATH : "$GST_PLUGIN_SYSTEM_PATH_1_0" \
+      --set-default PUREGOTK_LIB_FOLDER ${libraryPath}/lib \
+      ''${gappsWrapperArgs[@]}
+    install -Dm444 internal/icons/hicolor/scalable/apps/dev.dergs.Tonearm.svg -t $out/share/icons/hicolor/scalable/apps
+    install -Dm444 internal/icons/hicolor/128x128/apps/dev.dergs.Tonearm.png -t $out/share/icons/hicolor/128x128/apps
+    install -Dm444 internal/icons/hicolor/symbolic/apps/dev.dergs.Tonearm-symbolic.svg -t $out/share/icons/hicolor/symbolic/apps
+    install -Dm444 internal/settings/dev.dergs.Tonearm.gschema.xml -t $out/share/glib-2.0/schemas
+    glib-compile-schemas $out/share/glib-2.0/schemas
+  '';
+
+  meta = {
+    description = "GTK client for TIDAL written in Golang";
+    homepage = "https://codeberg.org/dergs/Tonearm";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      drafolin
+      nilathedragon
+    ];
+    mainProgram = "tonearm";
+  };
+})


### PR DESCRIPTION
Added tonearm to nix packages

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
