### PR TITLE
libgourou: 0.8.7 -> 0.8.8

### DIFF
--- a/pkgs/by-name/li/libgourou/package.nix
+++ b/pkgs/by-name/li/libgourou/package.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libgourou";
-  version = "0.8.7";
+  version = "0.8.8";
 
   src = fetchFromGitea {
     domain = "forge.soutade.fr";
     owner = "soutade";
     repo = "libgourou";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Tkft/pe3lH07pmyVibTEutIIvconUWDH1ZVN3qV4sSY=";
+    hash = "sha256-WQOlanavMy1z3ze+c8d1a7ZkAU60/GjEFS5JJfyNHMg=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Changes to Adobe servers causes `adept_activate` to fail sometime in version 0.8.7.

See this issue : [https://forge.soutade.fr/soutade/libgourou/issues/16](https://forge.soutade.fr/soutade/libgourou/issues/16)

I encountered this on the KUbuntu of a family member and had the same problem again on February 5th 2026 on my unstable NixOS so I propose this update. Tested that everything (most crucially `adept_activate`) is now working on my computer.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
