### PR TITLE
nixos/llama-cpp: support model presets

### DIFF
--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -8,6 +8,12 @@
 
 let
   cfg = config.services.llama-cpp;
+
+  modelsPresetFile =
+    if cfg.modelsPreset != null then
+      pkgs.writeText "llama-models.ini" (lib.generators.toINI { } cfg.modelsPreset)
+    else
+      null;
 in
 {
 
@@ -30,6 +36,32 @@ in
         example = "/models/";
         description = "Models directory.";
         default = null;
+      };
+
+      modelsPreset = lib.mkOption {
+        type = lib.types.nullOr (lib.types.attrsOf lib.types.attrs);
+        default = null;
+        description = ''
+          Models preset configuration as a Nix attribute set.
+          This is converted to an INI file and passed to llama-server via --model-preset.
+          See llama-server documentation for available options.
+        '';
+        example = lib.literalExpression ''
+          {
+            "Qwen3-Coder-Next" = {
+              hf-repo = "unsloth/Qwen3-Coder-Next-GGUF";
+              hf-file = "Qwen3-Coder-Next-UD-Q4_K_XL.gguf";
+              alias = "unsloth/Qwen3-Coder-Next";
+              fit = "on";
+              seed = "3407";
+              temp = "1.0";
+              top-p = "0.95";
+              min-p = "0.01";
+              top-k = "40";
+              jinja = "on";
+            };
+          }
+        '';
       };
 
       extraFlags = lib.mkOption {
@@ -96,6 +128,10 @@ in
             ++ lib.optionals (cfg.modelsDir != null) [
               "--models-dir"
               cfg.modelsDir
+            ]
+            ++ lib.optionals (cfg.modelsPreset != null) [
+              "--models-preset"
+              modelsPresetFile
             ]
             ++ cfg.extraFlags;
           in

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -77,6 +77,10 @@ in
       serviceConfig = {
         Type = "idle";
         KillSignal = "SIGINT";
+        StateDirectory = "llama-cpp";
+        CacheDirectory = "llama-cpp";
+        WorkingDirectory = "/var/lib/llama-cpp";
+        Environment = [ "LLAMA_CACHE=/var/cache/llama-cpp" ];
         ExecStart =
           let
             args = [


### PR DESCRIPTION
Allows setting `--models-preset` via module option `modelsPreset`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
