### PR TITLE
nixos/netbird-dashboard: fixes 404.html not being served

### DIFF
--- a/nixos/modules/services/networking/netbird/dashboard.nix
+++ b/nixos/modules/services/networking/netbird/dashboard.nix
@@ -168,13 +168,12 @@ in
       enable = true;
 
       virtualHosts.${cfg.domain} = {
-        locations = {
-          "/" = {
-            root = cfg.finalDrv;
-            tryFiles = "$uri $uri.html $uri/ =404";
-          };
+        root = cfg.finalDrv;
 
-          "/404.html".extraConfig = ''
+        locations = {
+          "/".tryFiles = "$uri $uri.html $uri/ =404";
+
+          "= /404.html".extraConfig = ''
             internal;
           '';
         };


### PR DESCRIPTION
## Things done
Specified root at the virtualhost level, instead of under the catch-all location, like upstream does [here](https://github.com/netbirdio/dashboard/blob/750f660bcc9325b251ceeae7ac951c24c3b35dcd/docker/default.conf#L5).

The current configuration will not show the `404.html`, as there is no root specified for it, and will default to nginx `404.html`.
This is problematic when configuring netbird, as the `404.html` page seems to be somewhat part of the auth process?

At least, this patch allows to use different `AUTH_REDIRECT_URI` and `AUTH_SILENT_REDIRECT_URI`, and works great.

I've applied the config to my own setup, and it works https://git.fricloud.dk/fricloud/server-configs/commit/18dbff65588538a5e4f33b2d1670f0f50dd1f7a6

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
