### PR TITLE
python3Packages.pylance: 1.0.4 -> 2.0.0; python3Packages.lancedb: 0.26.1 -> 0.27.1 

### DIFF
--- a/pkgs/development/python-modules/lancedb/default.nix
+++ b/pkgs/development/python-modules/lancedb/default.nix
@@ -42,21 +42,21 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "lancedb";
-  version = "0.26.1";
+  version = "0.27.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lancedb";
     repo = "lancedb";
     tag = "python-v${finalAttrs.version}";
-    hash = "sha256-yx4cwO7qRH9/1rW0UFz17HkvJ8utJynYoAHnN+wPpKw=";
+    hash = "sha256-pWrwv3VtfkfOKnkiiu26yRDrDrsNxb+0r/kcNHwzmhU=";
   };
 
   buildAndTestSubdir = "python";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-ymoA/KKL7oLgp5u/NcXxbYfOueiKH+bpLxLcO+mn0Eo=";
+    hash = "sha256-U1Od4lhaaGdYF3TISfRWY7sRmyyniZqLofBCnYAo1ew=";
   };
 
   build-system = [ rustPlatform.maturinBuildHook ];
@@ -106,18 +106,26 @@ buildPythonPackage (finalAttrs: {
 
   disabledTestMarks = [ "slow" ];
 
-  disabledTests =
-    lib.optionals (pythonAtLeast "3.14") [
-      # TypeError: Converting Pydantic type to Arrow Type: unsupported type
-      # <class 'test_pydantic.test_optional_nested_model.<locals>.WALocation'>.
-      "test_optional_nested_model"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Flaky (even when the sandbox is disabled):
-      # FileNotFoundError: [Errno 2] Cannot delete directory '/nix/var/nix/builds/nix-41395-654732360/.../test.lance/_indices/fts':
-      # Cannot get information for path '/nix/var/nix/builds/nix-41395-654732360/.../test.lance/_indices/fts/.tmppyKXfw'
-      "test_create_index_from_table"
-    ];
+  disabledTests = [
+    # Requires internet access
+    # RuntimeError: lance error: LanceError(IO): Generic S3 error
+    "test_bucket_without_dots_passes"
+  ]
+  ++ lib.optionals (pythonAtLeast "3.14") [
+    # TypeError: Converting Pydantic type to Arrow Type: unsupported type
+    # <class 'test_pydantic.test_optional_nested_model.<locals>.WALocation'>.
+    "test_optional_nested_model"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Flaky (even when the sandbox is disabled):
+    # FileNotFoundError: [Errno 2] Cannot delete directory '/nix/var/nix/builds/nix-41395-654732360/.../test.lance/_indices/fts':
+    # Cannot get information for path '/nix/var/nix/builds/nix-41395-654732360/.../test.lance/_indices/fts/.tmppyKXfw'
+    "test_create_index_from_table"
+  ]
+  ++ lib.optionals ((pythonAtLeast "3.14") && stdenv.hostPlatform.isDarwin) [
+    # Failed: DID NOT RAISE <class 'Exception'>
+    "test_merge_insert"
+  ];
 
   disabledTestPaths = [
     # touch the network

--- a/pkgs/development/python-modules/pylance/default.nix
+++ b/pkgs/development/python-modules/pylance/default.nix
@@ -34,14 +34,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "pylance";
-  version = "1.0.4";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lancedb";
     repo = "lance";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SAV4mowG8wcK22ZXJUT9UffKz8lcICipSDC5FR0Z2lY=";
+    hash = "sha256-VxhRdyPhVVRRiYu2h7ospxLSpXCz0a6LgjJCGcqJVcU=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/python";
@@ -53,7 +53,7 @@ buildPythonPackage (finalAttrs: {
       src
       sourceRoot
       ;
-    hash = "sha256-qDfN4iH/FSqklUC58O4ot7SxBRSKWebYkh1X1T5JXUs=";
+    hash = "sha256-toIyApf/v0h45rZjfJRAStU9TZGmB+cCChObzjVr1Hs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Things done

- **python3Packages.pylance: 1.0.4 -> 2.0.0**
  - Diff: https://github.com/lancedb/lance/compare/v1.0.4...v2.0.0
  - Changelog: https://github.com/lancedb/lance/releases/tag/v2.0.0
- **python3Packages.lancedb: 0.26.1 -> 0.27.1**
  - Diff: https://github.com/lance-format/lance/compare/v1.0.4...v2.0.0
  - Changelog: https://github.com/lancedb/lance/releases/tag/v2.0.0

cc @natsukium

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test