### PR TITLE
k2pdfopt: init at 2.55 (again/fix build)

### DIFF
--- a/pkgs/by-name/k2/k2pdfopt/0001-Fix-CMakeLists.patch
+++ b/pkgs/by-name/k2/k2pdfopt/0001-Fix-CMakeLists.patch
@@ -1,0 +1,37 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 365b835..4341de9 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -57,6 +57,7 @@ endif(JPEG_FOUND)
+ include(FindJasper)
+ if(JASPER_FOUND)
+   set(HAVE_JASPER_LIB 1)
++  set(K2PDFOPT_LIB ${K2PDFOPT_LIB} ${JASPER_LIBRARY})
+ endif(JASPER_FOUND)
+ 
+ # paths from willuslib/wgs.c
+@@ -71,9 +72,12 @@ else()
+   message(STATUS "Could NOT find ghostscript executable")
+ endif(GHOSTSCRIPT_EXECUTABLE)
+ 
+-# willus.h
+-# HAVE_GSL_LIB
+-
++pkg_check_modules(GSL gsl)
++if(GSL_FOUND)
++  set(HAVE_GSL_LIB 1)
++  include_directories(SYSTEM ${GSL_INCLUDEDIR})
++  set(K2PDFOPT_LIB ${K2PDFOPT_LIB} ${GSL_LDFLAGS})
++endif(GSL_FOUND)
+ 
+ # libfreetype6 (>= 2.3.9), libjbig2dec0, libjpeg8 (>= 8c), libx11-6, libxext6, zlib1g (>= 1:1.2.0)
+ # MUPDF_STATIC_LDFLAGS misses mupdf-js-none, and doubles libs ...
+@@ -85,7 +89,7 @@ if(MUPDF_FOUND)
+   include_directories(SYSTEM ${MUPDF_INCLUDEDIR})
+   message(STATUS "mupdf libraries: ${MUPDF_LDFLAGS}")
+   set(K2PDFOPT_LIB ${K2PDFOPT_LIB} ${MUPDF_LDFLAGS} 
+-    -lmupdf-js-none -lopenjpeg -ljbig2dec -ljpeg -lfreetype -llcms -lgumbo
++
+   )
+ endif(MUPDF_FOUND)
+ 

--- a/pkgs/by-name/k2/k2pdfopt/package.nix
+++ b/pkgs/by-name/k2/k2pdfopt/package.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  stdenv,
+  runCommand,
+  fetchzip,
+  fetchurl,
+  fetchpatch,
+  fetchFromGitHub,
+  cmake,
+  jbig2dec,
+  libjpeg_turbo,
+  libpng,
+  makeWrapper,
+  pkg-config,
+  zlib,
+  enableGSL ? true,
+  gsl,
+  enableGhostScript ? true,
+  ghostscript,
+  enableMuPDF ? true,
+  mupdf,
+  enableDJVU ? true,
+  djvulibre,
+  enableLeptonica ? true,
+  leptonica,
+  # Tesseract support is broken
+  # See: https://github.com/NixOS/nixpkgs/issues/368349
+  # Making GOCR work without Tesseract support is non-trivial
+  fetchDebianPatch,
+}:
+
+# k2pdfopt requires modified versions of mupdf, leptonica, and tesseract.
+# However, Debian just uses system versions with minimal fixes to k2pdfopt's
+# willuslib; some fixes to mupdf and leptoanica have since been upstreamed,
+# some are not relevant on Linux
+# Applying the upstream changes to fresh tesseract with our glibc leads to
+# k2pdfopt that crashes on launch, so we can drop tesseract or use the old
+# version that k2pdfopt wants
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "k2pdfopt";
+  version = "2.55";
+  src = fetchzip {
+    url = "http://www.willus.com/k2pdfopt/src/k2pdfopt_v${finalAttrs.version}_src.zip";
+    hash = "sha256-orQNDXQkkcCtlA8wndss6SiJk4+ImiFCG8XRLEg963k=";
+  };
+
+  patches = [
+    ./0001-Fix-CMakeLists.patch
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname;
+      version = "${finalAttrs.version}+ds";
+      debianRevision = "3.1";
+      patch = "0007-k2pdfoptlib-k2ocr.c-conditionally-enable-tesseract-r.patch";
+      hash = "sha256-uJ9Gpyq64n/HKqo0hkQ2dnkSLCKNN4DedItPGzHfqR8=";
+    })
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname;
+      version = "${finalAttrs.version}+ds";
+      debianRevision = "3.1";
+      patch = "0009-willuslib-CMakeLists.txt-conditionally-add-source-fi.patch";
+      hash = "sha256-cBSlcuhsw4YgAJtBJkKLW6u8tK5gFwWw7pZEJzVMJDE=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace willuslib/bmpdjvu.c \
+      --replace-fail "<djvu.h>" "<libdjvu/ddjvuapi.h>"
+
+    # Parts of Debian patches
+    substituteInPlace CMakeLists.txt */CMakeLists.txt \
+      --replace-fail 'cmake_minimum_required(VERSION 2.6)' \
+      'cmake_minimum_required(VERSION 3.31)'
+    substituteInPlace willuslib/bmpmupdf.c \
+      --replace-fail 'void pdf_install_load_system_font_funcs(fz_context *ctx);' \
+      'void pdf_install_load_system_font_funcs(fz_context *ctx) {};'
+    substituteInPlace willuslib/wleptonica.c \
+      --replace-fail 'dewarpBuildPageModel_ex(dew1,debug,fit_order);' \
+      'dewarpBuildPageModel(dew1,debug);'
+
+    # Potential memory corruption under benign use, and cheap to fix
+    substituteInPlace willuslib/wfile.c \
+      --replace-fail 'char cmd[MAXFILENAMELEN];' \
+      'char cmd[4*MAXFILENAMELEN];'
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = [
+    jbig2dec
+    libjpeg_turbo
+    libpng
+    zlib
+  ]
+  ++ lib.optional enableGSL gsl
+  ++ lib.optional enableGhostScript ghostscript
+  ++ lib.optional enableMuPDF mupdf
+  ++ lib.optional enableDJVU djvulibre
+  ++ lib.optional enableLeptonica leptonica;
+
+  cmakeFlags = [ (lib.cmakeFeature "CMAKE_C_FLAGS" "-I${finalAttrs.src}/include_mod") ];
+
+  installPhase = ''
+    install -D -m 755 k2pdfopt $out/bin/k2pdfopt
+  '';
+
+  meta = {
+    description = "Optimizes PDF/DJVU files for mobile e-readers (e.g. the Kindle) and smartphones";
+    homepage = "http://www.willus.com/k2pdfopt";
+    changelog = "https://www.willus.com/k2pdfopt/k2pdfopt_version.txt";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      raskin
+    ];
+  };
+})

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -887,7 +887,6 @@ mapAliases {
   jsduck = throw "jsduck has been removed, as it was broken and and unmaintained upstream."; # Added 2025-12-02
   julia_19 = throw "Julia 1.9 has reached its end of life and 'julia_19' has been removed. Please use a supported version."; # Added 2025-10-29
   julia_19-bin = throw "Julia 1.9 has reached its end of life and 'julia_19-bin' has been removed. Please use a supported version."; # Added 2025-10-29
-  k2pdfopt = throw "'k2pdfopt' has been removed from nixpkgs as it was broken"; # Added 2025-09-27
   k3s_1_30 = throw "'k3s_1_30' has been removed from nixpkgs as it has reached end of life"; # Added 2025-09-01
   k3s_1_31 = throw "'k3s_1_31' has been removed from nixpkgs as it has reached end of life"; # Added 2025-12-08
   kak-lsp = throw "'kak-lsp' has been renamed to/replaced by 'kakoune-lsp'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
@bosu @danielfullmer Should I keep you as maintainers or not? (I have added little but dropped quite a bit of code)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
