### PR TITLE
nodejs-repackaged: init at 24.13.1

### DIFF
--- a/pkgs/development/web/nodejs/pubring.nix
+++ b/pkgs/development/web/nodejs/pubring.nix
@@ -1,0 +1,9 @@
+{ fetchurl }:
+
+let
+  rev = "b362bd15f2ac7ce350d7563fc03e0c625e455e5f"; # should be the HEAD of nodejs/release-keys
+in
+fetchurl {
+  url = "https://github.com/nodejs/release-keys/raw/${rev}/gpg-only-active-keys/pubring.kbx";
+  hash = "sha256-ZnapJ9YmGnq2u03caWFII1Z0Jruax3ruSEz7XWb0oUg=";
+}

--- a/pkgs/development/web/nodejs/repackaged.nix
+++ b/pkgs/development/web/nodejs/repackaged.nix
@@ -1,0 +1,132 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  versionCheckHook,
+
+  common-updater-scripts,
+  curl,
+  gawk,
+  gnugrep,
+  gnupg,
+  jq,
+  writeShellScript,
+}:
+
+let
+  pubring = import ./pubring.nix { inherit fetchurl; };
+  # Node.js and Nix projects use different conventions to refer to the same platforms.
+  platformMap = {
+    aarch64-darwin = "darwin-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-linux = "linux-arm64";
+    powerpc64le-linux = "linux-ppc64le";
+    s390x-linux = "linux-s390x";
+    x86_64-linux = "linux-x64";
+  };
+  hashes = {
+    aarch64-darwin = "d82a321541d65109c696505135be3b7dd46e3358f0f04d664f50f0d1e1ccb8a6";
+    x86_64-darwin = "013a8f786a022ad1729cf435e3675e097a77d5a42eaf139a2d5d1d5309a027d4";
+    aarch64-linux = "c827d3d301e2eed1a51f36d0116b71b9e3d9e3b728f081615270ea40faac34c1";
+    powerpc64le-linux = "fb712a08d317655dbf776c90f60ac2105109d802e33811df6c9ed33d12f801c6";
+    s390x-linux = "8e2c0d9b5545c3db22623e8cb8d6f0c28fcd470f29d32dbeabf9432dda289de2";
+    x86_64-linux = "30215f90ea3cd04dfbc06e762c021393fa173a1d392974298bbc871a8e461089";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nodejs-repackaged";
+  version = "24.13.1";
+
+  src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system};
+
+  dontBuild = true;
+
+  # 4. Define how to install it
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 bin/* -t $out/bin
+    cp -R include lib share $out/.
+
+    mkdir -p $out/share/bash-completion/completions
+    ln -s $out/lib/node_modules/npm/lib/utils/completion.sh \
+      $out/share/bash-completion/completions/npm
+
+    for dir in "$out/lib/node_modules/npm/man/"*; do
+      mkdir -p $out/share/man/$(basename "$dir")
+      for page in "$dir"/*; do
+        ln -rs $page $out/share/man/$(basename "$dir")
+      done
+    done
+
+    runHook postInstall
+  '';
+
+  dontPatchShebangs = true;
+  postFixup = ''
+    HOST_PATH=$out/bin patchShebangs --host $out
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru = {
+    sources =
+      let
+        inherit (finalAttrs) version;
+        downloadDir = if lib.strings.hasInfix "-rc." version then "download/rc" else "dist";
+      in
+      lib.listToAttrs (
+        map (platform: {
+          name = platform;
+          value = fetchurl {
+            url = "https://nodejs.org/${downloadDir}/v${version}/node-v${version}-${platformMap.${platform}}.tar.xz";
+            sha256 = hashes.${platform};
+          };
+        }) (builtins.attrNames hashes)
+      );
+    updateScript = writeShellScript "nodejs-repackaged-update-script" ''
+      set -o errexit
+      PATH=${
+        lib.makeBinPath [
+          common-updater-scripts
+          curl
+          gawk
+          gnugrep
+          gnupg
+          jq
+        ]
+      }
+      version=$(
+        curl --silent https://nodejs.org/download/release/index.json \
+        | jq -r 'map(select(.lts)) | first | .version[1:]'
+      )
+
+      hashes=$(
+        curl --silent "https://nodejs.org/dist/v''${version}/SHASUMS256.txt.asc" \
+        | gpgv --keyring="${pubring}" --output -
+      )
+
+      ${builtins.concatStringsSep "\n" (
+        map (nix_platform: ''
+          update-source-version nodejs-repackaged "$version" "$(
+            echo "$hashes" | awk '/${platformMap.${nix_platform}}.tar.xz/{ print $1 }'
+          )" --ignore-same-version --source-key="sources.${nix_platform}"
+        '') (builtins.attrNames platformMap)
+      )}
+    '';
+  };
+
+  meta = {
+    description = "Repackage of the Node.js official binaries";
+    homepage = "https://nodejs.org";
+    changelog = "https://github.com/nodejs/node/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.aduh95 ];
+    platforms = builtins.attrNames hashes;
+    mainProgram = "node";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/development/web/nodejs/update.nix
+++ b/pkgs/development/web/nodejs/update.nix
@@ -13,11 +13,7 @@
 }:
 
 let
-  rev = "b362bd15f2ac7ce350d7563fc03e0c625e455e5f"; # should be the HEAD of nodejs/release-keys
-  pubring = fetchurl {
-    url = "https://github.com/nodejs/release-keys/raw/${rev}/gpg-only-active-keys/pubring.kbx";
-    hash = "sha256-ZnapJ9YmGnq2u03caWFII1Z0Jruax3ruSEz7XWb0oUg=";
-  };
+  pubring = import ./pubring.nix { inherit fetchurl; };
 in
 writeScript "update-nodejs" ''
   #!${runtimeShell}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2854,6 +2854,7 @@ with pkgs;
 
   nodejs = nodejs_24;
   nodejs-slim = nodejs-slim_24;
+  nodejs-repackaged = callPackage ../development/web/nodejs/repackaged.nix { };
 
   nodejs_20 = callPackage ../development/web/nodejs/v20.nix { };
   nodejs-slim_20 = callPackage ../development/web/nodejs/v20.nix { enableNpm = false; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A feedback I have gotten is that using Nix to manage Node.js can result in using an outdated version for a few weeks (because of the mass rebuild, the `nodejs` changes go to the `staging` branch first, which is merged into `master` every once in a while). Maybe a solution would be to offer an alternative repackage of Node.js that downloads the official binaries which can land on `master` independently from the Nix pure `nodejs` package and is fairly trivial to build.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
