### PR TITLE
[Backport release-25.11] z3: version macos compat patches

### DIFF
--- a/pkgs/by-name/z3/z3/package.nix
+++ b/pkgs/by-name/z3/z3/package.nix
@@ -38,28 +38,31 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-eyF3ELv81xEgh9Km0Ehwos87e4VJ82cfsp53RCAtuTo=";
   };
 
-  patches = lib.optionals useCmakeBuild [
-    ./fix-pkg-config-paths.patch
-    # fix Segmentation fault. See https://github.com/Z3Prover/z3/pull/8264 and
-    # https://github.com/NixOS/nixpkgs/issues/486491
-    (fetchpatch2 {
-      name = "preserve-the-initial-state-of-the-solver.patch";
-      url = "https://github.com/Z3Prover/z3/commit/850a3236adab92f9f6f569ac66ffbb69be179f4c.patch?full_index=1";
-      hash = "sha256-C6p+dj3i3DpOnd2wr+R8ZwClHoMFfk5i5/+JRhTDNcs=";
-    })
-    # needs to include a cosmetic change to apply patch for memory corruption
-    (fetchpatch2 {
-      name = "cosmetic-changes-to-i.patch";
-      url = "https://github.com/Z3Prover/z3/commit/243694379475d983605f87578452a330f3e3b28f.patch?full_index=1";
-      includes = [ "src/api/api_polynomial.cpp" ];
-      hash = "sha256-huo5S73WrFrEEUcaP+1LDQwGwo+n2iYT4x/OjK5rmqQ=";
-    })
-    (fetchpatch2 {
-      name = "fix-memory-corruption.patch";
-      url = "https://github.com/Z3Prover/z3/commit/e7b6f3f33bcc6c88a0f2ace47ff2f09b59239433.patch?full_index=1";
-      hash = "sha256-kEEeod4s8i9SI2e2TFD2U4yd1qEPoGnJOfE0y+1Cq6M=";
-    })
-  ];
+  patches =
+    lib.optionals useCmakeBuild [
+      ./fix-pkg-config-paths.patch
+    ]
+    ++ lib.optionals (lib.versionAtLeast finalAttrs.version "4.15.4") [
+      # fix Segmentation fault. See https://github.com/Z3Prover/z3/pull/8264 and
+      # https://github.com/NixOS/nixpkgs/issues/486491
+      (fetchpatch2 {
+        name = "preserve-the-initial-state-of-the-solver.patch";
+        url = "https://github.com/Z3Prover/z3/commit/850a3236adab92f9f6f569ac66ffbb69be179f4c.patch?full_index=1";
+        hash = "sha256-C6p+dj3i3DpOnd2wr+R8ZwClHoMFfk5i5/+JRhTDNcs=";
+      })
+      # needs to include a cosmetic change to apply patch for memory corruption
+      (fetchpatch2 {
+        name = "cosmetic-changes-to-i.patch";
+        url = "https://github.com/Z3Prover/z3/commit/243694379475d983605f87578452a330f3e3b28f.patch?full_index=1";
+        includes = [ "src/api/api_polynomial.cpp" ];
+        hash = "sha256-huo5S73WrFrEEUcaP+1LDQwGwo+n2iYT4x/OjK5rmqQ=";
+      })
+      (fetchpatch2 {
+        name = "fix-memory-corruption.patch";
+        url = "https://github.com/Z3Prover/z3/commit/e7b6f3f33bcc6c88a0f2ace47ff2f09b59239433.patch?full_index=1";
+        hash = "sha256-kEEeod4s8i9SI2e2TFD2U4yd1qEPoGnJOfE0y+1Cq6M=";
+      })
+    ];
 
   strictDeps = true;
 


### PR DESCRIPTION
patches fix a bug only present in the latest versions of z3 fixes the vampire build, which requires an older version of z3

(cherry picked from commit ee06439c43fdcafbecf098e7d7f8ce1e06da09ac)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
