### PR TITLE
n8n-task-runner-launcher: init at 1.4.2

### DIFF
--- a/pkgs/by-name/n8/n8n-task-runner-launcher/package.nix
+++ b/pkgs/by-name/n8/n8n-task-runner-launcher/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "n8n-task-runner-launcher";
+  version = "1.4.2";
+
+  src = fetchFromGitHub {
+    owner = "n8n-io";
+    repo = "task-runner-launcher";
+    tag = finalAttrs.version;
+    hash = "sha256-kfwI3Qy0Zh4fQ+SYX9fvdDEV2Gdu4qGD3ZOb5Z10Bbc=";
+  };
+
+  vendorHash = "sha256-5dcIELsNFGB5qTmfpY/YRWeN2z9GdanysGw4Lqpfsi0=";
+
+  postInstall = ''
+    mv $out/bin/launcher $out/bin/n8n-task-runner-launcher
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Launcher for n8n task runners";
+    homepage = "https://github.com/n8n-io/task-runner-launcher";
+    changelog = "https://github.com/n8n-io/task-runner-launcher/releases/${finalAttrs.version}";
+    license = lib.licenses.sustainableUse;
+    maintainers = with lib.maintainers; [ sweenu ];
+    mainProgram = "n8n-task-runner-launcher";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
