### PR TITLE
nixos/n8n: refactor env partitioning for reusability

### DIFF
--- a/nixos/modules/services/misc/n8n.nix
+++ b/nixos/modules/services/misc/n8n.nix
@@ -7,11 +7,22 @@
 let
   cfg = config.services.n8n;
 
-  envVarToCredName = varName: lib.toLower varName;
-
   # Partition environment variables into regular and file-based (_FILE suffix)
-  regularEnv = lib.filterAttrs (name: _value: !(lib.hasSuffix "_FILE" name)) cfg.environment;
-  fileBasedEnv = lib.filterAttrs (name: _value: lib.hasSuffix "_FILE" name) cfg.environment;
+  envVarToCredName = varName: lib.toLower varName;
+  partitionEnv =
+    env:
+    let
+      regular = lib.filterAttrs (name: _value: !(lib.hasSuffix "_FILE" name)) env;
+      fileBased = lib.filterAttrs (name: _value: lib.hasSuffix "_FILE" name) env;
+      fileBasedTransformed = lib.mapAttrs' (
+        varName: _secretPath: lib.nameValuePair varName "%d/${envVarToCredName varName}"
+      ) fileBased;
+    in
+    {
+      inherit regular fileBased fileBasedTransformed;
+    };
+
+  n8nEnv = partitionEnv cfg.environment;
 
   customNodesDir = pkgs.linkFarm "n8n-custom-nodes" (
     map (pkg: {
@@ -19,12 +30,6 @@ let
       path = "${pkg}/lib/node_modules/${pkg.pname}";
     }) cfg.customNodes
   );
-
-  # Transform file-based env vars to point to credentials directory
-  fileBasedEnvTransformed = lib.mapAttrs' (
-    varName: _secretPath: lib.nameValuePair varName "%d/${envVarToCredName varName}"
-  ) fileBasedEnv;
-
 in
 {
   imports = [
@@ -135,14 +140,14 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
       environment =
-        regularEnv
+        n8nEnv.regular
         // {
-          HOME = config.services.n8n.environment.N8N_USER_FOLDER;
+          HOME = cfg.environment.N8N_USER_FOLDER;
         }
         // lib.optionalAttrs (cfg.customNodes != [ ]) {
           N8N_CUSTOM_EXTENSIONS = toString customNodesDir;
         }
-        // fileBasedEnvTransformed;
+        // n8nEnv.fileBasedTransformed;
       serviceConfig = {
         Type = "simple";
         ExecStart = lib.getExe cfg.package;
@@ -151,7 +156,7 @@ in
 
         LoadCredential = lib.mapAttrsToList (
           varName: secretPath: "${envVarToCredName varName}:${secretPath}"
-        ) fileBasedEnv;
+        ) n8nEnv.fileBased;
 
         # Basic Hardening
         NoNewPrivileges = "yes";


### PR DESCRIPTION
Prepares the way for runners.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
