### PR TITLE
python3Packages.uv-build: 0.9.26 -> 0.10.0

### DIFF
--- a/pkgs/development/python-modules/cryptography/vectors.nix
+++ b/pkgs/development/python-modules/cryptography/vectors.nix
@@ -14,16 +14,10 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/vectors";
 
-  patches = [
-    # https://github.com/NixOS/nixpkgs/pull/449568
-    (fetchpatch2 {
-      name = "uv-build.patch";
-      url = "https://github.com/pyca/cryptography/commit/5f311c1cbe09ddea6136b0bb737fb7df6df1b923.patch?full_index=1";
-      stripLen = 1;
-      includes = [ "pyproject.toml" ];
-      hash = "sha256-OdHK0OGrvOi3mS0q+v8keDLvKxtgQkDkHQSYnmC/vd4=";
-    })
-  ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.7.19,<0.9.0" "uv_build>=0.7.19,<0.11.0"
+  '';
 
   build-system = [ uv-build ];
 

--- a/pkgs/development/python-modules/uv-build/built-by-uv.nix
+++ b/pkgs/development/python-modules/uv-build/built-by-uv.nix
@@ -1,6 +1,5 @@
 {
   buildPythonPackage,
-  uv,
   uv-build,
   anyio,
   pytestCheckHook,
@@ -10,7 +9,7 @@ buildPythonPackage {
   version = "0.1.0";
   pyproject = true;
 
-  src = "${uv.src}/scripts/packages/built-by-uv";
+  src = "${uv-build.src}/test/packages/built-by-uv";
 
   build-system = [ uv-build ];
 

--- a/pkgs/development/python-modules/uv-build/default.nix
+++ b/pkgs/development/python-modules/uv-build/default.nix
@@ -9,14 +9,14 @@
 
 buildPythonPackage rec {
   pname = "uv-build";
-  version = "0.9.26";
+  version = "0.10.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
     tag = version;
-    hash = "sha256-qvfMB62/0Hvc7m5h+QitvUcS6YZWAV1uGPg8JpCKPNU=";
+    hash = "sha256-nD26zqKMK5LNkeYdqVYteeYL4mYaQQ/QlyjbMDDhLAY=";
   };
 
   nativeBuildInputs = [
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-3ncKhauappl1MR3EG1bwYVrwhM7gCFRcRyRvYrsDaok=";
+    hash = "sha256-lEynVemQHCI7ZKD2+1n4K/AtEYRld2+aRLkDMSX8ejM=";
   };
 
   buildAndTestSubdir = "crates/uv-build";
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   # Run the tests of a package built by `uv_build`.
   passthru = {
-    tests.built-by-uv = callPackage ./built-by-uv.nix { inherit (pkgs) uv; };
+    tests.built-by-uv = callPackage ./built-by-uv.nix { };
 
     # updateScript is not needed here, as updating is done on staging
   };

--- a/pkgs/development/python-modules/uv-build/default.nix
+++ b/pkgs/development/python-modules/uv-build/default.nix
@@ -7,7 +7,7 @@
   callPackage,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "uv-build";
   version = "0.10.0";
   pyproject = true;
@@ -15,7 +15,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "astral-sh";
     repo = "uv";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-nD26zqKMK5LNkeYdqVYteeYL4mYaQQ/QlyjbMDDhLAY=";
   };
 
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-lEynVemQHCI7ZKD2+1n4K/AtEYRld2+aRLkDMSX8ejM=";
   };
 
@@ -52,4 +52,4 @@ buildPythonPackage rec {
     inherit (pkgs.uv.meta) changelog license;
     maintainers = with lib.maintainers; [ bengsparks ];
   };
-}
+})


### PR DESCRIPTION
Changelog: https://github.com/astral-sh/uv/releases/tag/0.10.0

Built `python3Packages.uv-build`, as well as its passthru package `built-by-uv` on master, which also builds `cryptography(-vectors)` along the way.
PR is therefore ready, unless a `fetchpatch(2)` from a PR in the `cryptography` repository is desired for `cryptography-vectors`.

This PR is also an opportunity to migrate `uv-build`'s package to finalAttrs, so it has been done.

```console
$ git checkout 96bc8fec15133d6056410ed3abae2fb9419fb545

$ git cherry-pick 0cb3a504cbdaec18f53b94ab63ba2f9b7a924b77..uv-build-update -Xtheirs
Auto-merging pkgs/development/python-modules/uv-build/default.nix
[master 20fd8c08eb3d] python3Packages.uv-build: 0.9.26 -> 0.10.0
 Date: Fri Feb 6 01:16:21 2026 +0100
 2 files changed, 5 insertions(+), 6 deletions(-)
[master 3f119692bbf2] python3Packages.uv-build: migrate to finalAttrs
 Date: Fri Feb 6 01:25:58 2026 +0100
 1 file changed, 4 insertions(+), 4 deletions(-)
[master 33dd901c32cf] python3Packages.cryptography-vectors: tweak uv-build version constraint
 Date: Fri Feb 6 01:54:19 2026 +0100
 1 file changed, 4 insertions(+), 10 deletions(-)
 
$ nom-build -A python3Packages.uv-build -A python3Packages.cryptography -A python3Packages.uv-build.passthru.tests.built-by-uv 
Finished at 02:26:18 after 6s
/nix/store/k1aqwm7104hqfxfyzygwp1847cnw9wks-python3.13-uv-build-0.10.0
/nix/store/37x4n6hn571bwpgqnjy1m0a8h18j2kx7-python3.13-cryptography-46.0.3
/nix/store/8jh2rgij7qmyb4i0y19dv8qxcbd7b00m-python3.13-built-by-uv-0.1.0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
