### PR TITLE
cryptsetup: make systemd token modules discoverable

### DIFF
--- a/pkgs/by-name/cr/cryptsetup/package.nix
+++ b/pkgs/by-name/cr/cryptsetup/package.nix
@@ -11,6 +11,8 @@
   popt,
   nixosTests,
   libargon2,
+  systemd,
+  withSystemdTokens ? !stdenv.hostPlatform.isStatic,
   withInternalArgon2 ? false,
 
   # Programs enabled by default upstream are implicitly enabled unless
@@ -78,6 +80,9 @@ stdenv.mkDerivation (finalAttrs: {
     # though it isn't used.
     "--with-luks2-external-tokens-path=/"
   ]
+  ++ lib.optionals (!stdenv.hostPlatform.isStatic && withSystemdTokens) [
+    "--with-luks2-external-tokens-path=${systemd}/lib/cryptsetup"
+  ]
   ++ (lib.mapAttrsToList (lib.flip lib.enableFeature)) programs;
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals rebuildMan [ asciidoctor ];
@@ -91,6 +96,10 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (!withInternalArgon2) libargon2;
 
   enableParallelBuilding = true;
+
+  postFixup = lib.optionalString withSystemdTokens ''
+    patchelf --add-rpath ${systemd}/lib/cryptsetup $out/lib/libcryptsetup.so
+  '';
 
   # The test [7] header backup in compat-test fails with a mysterious
   # "out of memory" error, even though tons of memory is available.

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -353,7 +353,7 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
   ]
   ++ lib.optional withCoredump elfutils
-  ++ lib.optional withCryptsetup cryptsetup
+  ++ lib.optional withCryptsetup (cryptsetup.override { withSystemdTokens = false; })
   ++ lib.optional withKexectools kexec-tools
   ++ lib.optional withKmod kmod
   ++ lib.optional withLibidn2 libidn2


### PR DESCRIPTION
Fix: https://github.com/NixOS/nixpkgs/issues/265366

Make systemd-provided cryptsetup token modules (TPM2 / FIDO2 / PKCS11) discoverable when invoking cryptsetup directly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
