### PR TITLE
ticket: init at 0.3.2

### DIFF
--- a/pkgs/by-name/ti/ticket/package.nix
+++ b/pkgs/by-name/ti/ticket/package.nix
@@ -1,0 +1,89 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  bash,
+  coreutils,
+  gnused,
+  gawk,
+  findutils,
+  gnugrep,
+  jq,
+  ripgrep,
+}:
+
+stdenvNoCC.mkDerivation (final: {
+  pname = "ticket";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "wedow";
+    repo = "ticket";
+    rev = "v${final.version}";
+    hash = "sha256-orxqAwJBL+LHe+I9M+djYGa/yfvH67HdR/VVy8fdg90=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  patches = [ ./progname.patch ];
+
+  postPatch = ''
+    sed -i 's/^readonly PROGNAME=.*$/readonly PROGNAME=tk/' ticket
+  '';
+
+  dontBuild = true;
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    # Verify that tk prints "tk" as the program name, not ".tk-wrapped", based
+    # on the local progname.patch that we apply.
+    if ! $out/bin/tk --help 2>&1 | grep -q "^tk - minimal ticket system"; then
+      echo "ERROR: tk --help does not show correct program name" 1>&2
+      $out/bin/tk --help 1>&2 | head -5
+      exit 1
+    fi
+
+    runHook postInstallCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 ticket $out/bin/tk
+
+    wrapProgram $out/bin/tk \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bash
+          coreutils
+          gnused
+          gawk
+          findutils
+          gnugrep
+          jq
+          ripgrep
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Git-backed issue tracker for AI agents";
+    longDescription = ''
+      The git-backed issue tracker for AI agents. Rooted in the Unix Philosophy,
+      tk is a minimal ticket system with dependency tracking. Tickets are markdown
+      files with YAML frontmatter in .tickets/.
+    '';
+    homepage = "https://github.com/wedow/ticket";
+    changelog = "https://github.com/wedow/ticket/blob/v${final.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jmmv ];
+    mainProgram = "tk";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/ti/ticket/progname.patch
+++ b/pkgs/by-name/ti/ticket/progname.patch
@@ -1,0 +1,71 @@
+--- a/ticket
++++ b/ticket
+@@ -4,6 +4,8 @@
+ # ticket - minimal ticket system with dependency tracking
+ # Stores markdown files with YAML frontmatter in .tickets/
+ 
++readonly PROGNAME="$(basename "$0")"
++
+ # Find .tickets directory by walking parent directories
+ find_tickets_dir() {
+     # Explicit env var takes priority
+@@ -247,7 +249,7 @@
+ 
+ cmd_status() {
+     if [[ $# -lt 2 ]]; then
+-        echo "Usage: $(basename "$0") status <id> <status>" >&2
++        echo "Usage: $PROGNAME status <id> <status>" >&2
+         echo "Valid statuses: $VALID_STATUSES" >&2
+         return 1
+     fi
+@@ -266,7 +268,7 @@
+ 
+ cmd_start() {
+     if [[ $# -lt 1 ]]; then
+-        echo "Usage: $(basename "$0") start <id>" >&2
++        echo "Usage: $PROGNAME start <id>" >&2
+         return 1
+     fi
+     cmd_status "$1" "in_progress"
+@@ -274,7 +276,7 @@
+ 
+ cmd_close() {
+     if [[ $# -lt 1 ]]; then
+-        echo "Usage: $(basename "$0") close <id>" >&2
++        echo "Usage: $PROGNAME close <id>" >&2
+         return 1
+     fi
+     cmd_status "$1" "closed"
+@@ -282,7 +284,7 @@
+ 
+ cmd_reopen() {
+     if [[ $# -lt 1 ]]; then
+-        echo "Usage: $(basename "$0") reopen <id>" >&2
++        echo "Usage: $PROGNAME reopen <id>" >&2
+         return 1
+     fi
+     cmd_status "$1" "open"
+@@ -1432,12 +1434,10 @@
+ }
+ 
+ cmd_help() {
+-    local cmd
+-    cmd=$(basename "$0")
+     cat << EOF
+-$cmd - minimal ticket system with dependency tracking
++$PROGNAME - minimal ticket system with dependency tracking
+ 
+-Usage: $cmd <command> [args]
++Usage: $PROGNAME <command> [args]
+ 
+ Commands:
+   create [title] [options] Create ticket, prints ID
+@@ -1471,7 +1471,7 @@
+   migrate-beads            Import tickets from .beads/issues.jsonl
+ 
+ Tickets stored as markdown files in .tickets/
+-Supports partial ID matching (e.g., '$cmd show 5c4' matches 'nw-5c46')
++Supports partial ID matching (e.g., '$PROGNAME show 5c4' matches 'nw-5c46')
+ EOF
+ }
+ 


### PR DESCRIPTION
This adds a new package for "ticket", a Git-backed issue tracker for AI agents.

According to its homepage: The git-backed issue tracker for AI agents. Rooted in the Unix Philosophy, tk is a minimal ticket system with dependency tracking. Tickets are markdown files with YAML frontmatter in .tickets/.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
