### PR TITLE
discord: quote client mods on darwin

### DIFF
--- a/pkgs/applications/networking/instant-messengers/discord/darwin.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/darwin.nix
@@ -82,25 +82,25 @@ stdenv.mkDerivation {
 
   postInstall =
     lib.strings.optionalString withOpenASAR ''
-      cp -f ${openasar} $out/Applications/${desktopName}.app/Contents/Resources/app.asar
+      cp -f ${openasar} "$out/Applications/${desktopName}.app/Contents/Resources/app.asar"
     ''
     + lib.strings.optionalString withVencord ''
-      mv $out/Applications/${desktopName}.app/Contents/Resources/app.asar $out/Applications/${desktopName}.app/Contents/Resources/_app.asar
-      mkdir $out/Applications/${desktopName}.app/Contents/Resources/app.asar
-      echo '{"name":"discord","main":"index.js"}' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json
-      echo 'require("${vencord}/patcher.js")' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js
+      mv "$out/Applications/${desktopName}.app/Contents/Resources/app.asar" "$out/Applications/${desktopName}.app/Contents/Resources/_app.asar"
+      mkdir "$out/Applications/${desktopName}.app/Contents/Resources/app.asar"
+      echo '{"name":"discord","main":"index.js"}' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json"
+      echo 'require("${vencord}/patcher.js")' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js"
     ''
     + lib.strings.optionalString withEquicord ''
-      mv $out/Applications/${desktopName}.app/Contents/Resources/app.asar $out/Applications/${desktopName}.app/Contents/Resources/_app.asar
-      mkdir $out/Applications/${desktopName}.app/Contents/Resources/app.asar
-      echo '{"name":"discord","main":"index.js"}' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json
-      echo 'require("${equicord}/desktop/patcher.js")' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js
+      mv "$out/Applications/${desktopName}.app/Contents/Resources/app.asar" "$out/Applications/${desktopName}.app/Contents/Resources/_app.asar"
+      mkdir "$out/Applications/${desktopName}.app/Contents/Resources/app.asar"
+      echo '{"name":"discord","main":"index.js"}' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json"
+      echo 'require("${equicord}/desktop/patcher.js")' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/index.js"
     ''
     + lib.strings.optionalString withMoonlight ''
-      mv $out/Applications/${desktopName}.app/Contents/Resources/app.asar $out/Applications/${desktopName}.app/Contents/Resources/_app.asar
-      mkdir $out/Applications/${desktopName}.app/Contents/Resources/app.asar
-      echo '{"name":"discord","main":"injector.js","private": true}' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json
-      echo 'require("${moonlight}/injector.js").inject(require("path").join(__dirname, "../_app.asar"));' > $out/Applications/${desktopName}.app/Contents/Resources/app.asar/injector.js
+      mv "$out/Applications/${desktopName}.app/Contents/Resources/app.asar" "$out/Applications/${desktopName}.app/Contents/Resources/_app.asar"
+      mkdir "$out/Applications/${desktopName}.app/Contents/Resources/app.asar"
+      echo '{"name":"discord","main":"injector.js","private": true}' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/package.json"
+      echo 'require("${moonlight}/injector.js").inject(require("path").join(__dirname, "../_app.asar"));' > "$out/Applications/${desktopName}.app/Contents/Resources/app.asar/injector.js"
     '';
 
   passthru = {


### PR DESCRIPTION
The `desktopName` field can contain spaces (e.g. 'Discord PTB.app') and therefore the paths in postInstall should be quoted.

Fixes the following error:

```
error: Cannot build '/nix/store/x3l3kq8fyk29arz3z8mxxmdnlq3ax22f-discord-ptb-0.0.205.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/qp3jljcfyl4bpf09i7d2xchv61mk9kq7-discord-ptb-0.0.205
       Last 11 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/srd3hq7jmsipi64kyr4fc1ij53s1b883-DiscordPTB.dmg
       > source root is .
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > no Makefile or custom buildPhase, doing nothing
       > Running phase: installPhase
       > mv: target 'PTB.app/Contents/Resources/_app.asar': No such file or directory
       For full logs, run:
         nix log /nix/store/x3l3kq8fyk29arz3z8mxxmdnlq3ax22f-discord-ptb-0.0.205.drv
```

To verify the change, I ran `NIXPKGS_ALLOW_UNFREE=1 nix build --impure --expr "(builtins.getFlake (toString ./.)).legacyPackages.aarch64-darwin.discord-ptb.override { withVencord = true; }"` and verified Vencord being present when running `open ./result/Applications/Discord\ PTB.app/`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
