### PR TITLE
python3Packages.llm-anthropic: 0.20 -> 0.23, adopt

### DIFF
--- a/pkgs/development/python-modules/llm-anthropic/default.nix
+++ b/pkgs/development/python-modules/llm-anthropic/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   setuptools,
+  json-schema-to-pydantic,
   llm,
   llm-anthropic,
   anthropic,
@@ -12,16 +13,16 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "llm-anthropic";
-  version = "0.20";
+  version = "0.23";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "llm-anthropic";
-    tag = version;
-    hash = "sha256-tZCFbrsACJl1hC5tSbxJzBBLY8mdcCNjshZilSCAslM=";
+    tag = finalAttrs.version;
+    hash = "sha256-ZO9hoDv3YLl8ZCcd5UEDdD5VNPa83N639z1ZxJaFt7Y=";
   };
 
   build-system = [
@@ -30,6 +31,7 @@ buildPythonPackage rec {
 
   dependencies = [
     anthropic
+    json-schema-to-pydantic
     llm
   ];
 
@@ -40,6 +42,15 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ];
 
+  disabledTests = [
+    # Need to be run as a passthru test
+    "test_async_prompt"
+    "test_image_prompt"
+    "test_prompt"
+    "test_schema_prompt"
+    "test_thinking_prompt"
+  ];
+
   pythonImportsCheck = [ "llm_anthropic" ];
 
   passthru.tests = llm.mkPluginTest llm-anthropic;
@@ -47,8 +58,8 @@ buildPythonPackage rec {
   meta = {
     description = "LLM access to models by Anthropic, including the Claude series";
     homepage = "https://github.com/simonw/llm-anthropic";
-    changelog = "https://github.com/simonw/llm-anthropic/releases/tag/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/simonw/llm-anthropic/releases/tag/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ aos ];
   };
-}
+})

--- a/pkgs/development/python-modules/llm-anthropic/default.nix
+++ b/pkgs/development/python-modules/llm-anthropic/default.nix
@@ -60,6 +60,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/simonw/llm-anthropic";
     changelog = "https://github.com/simonw/llm-anthropic/releases/tag/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ aos ];
+    maintainers = with lib.maintainers; [
+      aos
+      sarahec
+    ];
   };
 })


### PR DESCRIPTION
1. `llm-anthropic` update (includes `finalAttrs` migration, add self as maintainer)
2. Prerequisite package `python3Packages.json-schema-to-pydantic` init at 0.4.9, adopt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
