### PR TITLE
nixd: fix the build against `boost-1.89`

### DIFF
--- a/pkgs/development/tools/language-servers/nixd/default.nix
+++ b/pkgs/development/tools/language-servers/nixd/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   boost,
   gtest,
@@ -132,6 +133,17 @@ in
     common
     // {
       pname = "nixd";
+
+      patches = [
+        # Pull upstream fix for boost-1.89 & boost 1.87 support:
+        #   https://github.com/nix-community/nixd/pull/783
+        (fetchpatch {
+          name = "boost-1.89.patch";
+          url = "https://github.com/nix-community/nixd/commit/11dfdf5f2db2e0fc1fea0349fb68739a9c747a41.patch";
+          hash = "sha256-aCb9wRKqZSuUXmamzjpYe0vRqEQh4tenwoScv+juYK8=";
+          stripLen = 1;
+        })
+      ];
 
       sourceRoot = "${common.src.name}/nixd";
 


### PR DESCRIPTION
Without the change the build in` staging` fails as:

    In file included from ../lib/Controller/DocumentHighlight.cpp:10:
    ../include/nixd/Controller/Controller.h:139:48: error: 'default_thread_pool_size' is not a member of 'boost::asio::detail'
      139 |       static_cast<size_t>(boost::asio::detail::default_thread_pool_size())};
          |                                                ^~~~~~~~~~~~~~~~~~~~~~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
