### PR TITLE
nixos/grub: add setting keepBootedSystemEntry

### DIFF
--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -104,6 +104,7 @@ let
           extraEntriesBeforeNixOS
           extraPrepareConfig
           configurationLimit
+          keepBootedSystemEntry
           copyKernels
           default
           fsIdentifier
@@ -638,6 +639,20 @@ in
         description = ''
           Maximum of configurations in boot menu. GRUB has problems when
           there are too many entries.
+        '';
+      };
+
+      keepBootedSystemEntry = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to include the currently booted system (from `/run/booted-system`) as a
+          in the GRUB menu. This ensures that a system known to have booted successfully is
+          always available as a fallback even if it is not included within
+          `boot.loader.grub.configurationLimit` generations or if the system profile
+          link has been removed by a command line `sudo nixos-collect-garbage -d`.
+          (`/run/booted-system` has a separate GC root so it will normally stay around until
+          at least the next successful boot.)
         '';
       };
 

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -74,6 +74,7 @@ my $entryOptions = get("entryOptions");
 my $subEntryOptions = get("subEntryOptions");
 my $backgroundColor = get("backgroundColor");
 my $configurationLimit = int(get("configurationLimit"));
+my $keepBootedSystemEntry = get("keepBootedSystemEntry") eq "true";
 my $copyKernels = get("copyKernels") eq "true";
 my $timeout = int(get("timeout"));
 my $timeoutStyle = get("timeoutStyle");
@@ -566,6 +567,17 @@ $conf .= "$extraEntries\n" if $extraEntriesBeforeNixOS;
 
 addGeneration("@distroName@", "", $defaultConfig, $entryOptions, 1);
 
+if ($keepBootedSystemEntry && -e "/run/booted-system") {
+    my $link = "/run/booted-system";
+    if (! -e "$link/nixos-version") {
+        warn "skipping unrecognized booted system ‘$link’\n";
+    } else {
+      my $date = strftime("%F", localtime(lstat($link)->mtime));
+      my $version = readFile("$link/nixos-version");
+      addGeneration("@distroName@ - Last Booted", " (booted $date - $version)", $link, $entryOptions, 0);
+    }
+}
+
 $conf .= "$extraEntries\n" unless $extraEntriesBeforeNixOS;
 
 my $grubBootPath = $grubBoot->path;
@@ -593,10 +605,7 @@ sub addProfile {
             next;
         }
         my $date = strftime("%F", localtime(lstat($link)->mtime));
-        my $version =
-            -e "$link/nixos-version"
-            ? readFile("$link/nixos-version")
-            : basename((glob(dirname(Cwd::abs_path("$link/kernel")) . "/lib/modules/*"))[0]);
+        my $version = readFile("$link/nixos-version");
         addGeneration("@distroName@ - Configuration " . nrFromGen($link), " ($date - $version)", $link, $subEntryOptions, 0);
     }
 


### PR DESCRIPTION
This adds a boolean `boot.loader.grub.keepBootedSystemEntry` option. If true, this option adds the currently booted system to the list of grub menu items, even if the system has been rebuilt more than configurationLimit times or the system profile link has been removed. This is useful because any subsequent profile may be non-bootable, so it provides a more reliable fallback than even a large number of recent generations.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (In this case, by enabling and using the option, garbage collecting, rebooting etc.)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
