### PR TITLE
irods: workaround for bug https://github.com/irods/irods/issues/8839

### DIFF
--- a/pkgs/by-name/ir/irods-icommands/package.nix
+++ b/pkgs/by-name/ir/irods-icommands/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  llvmPackages,
+  llvmPackages_19,
   fetchFromGitHub,
   cmake,
   ninja,
@@ -8,7 +8,9 @@
   irods,
 }:
 
-llvmPackages.stdenv.mkDerivation (finalAttrs: {
+# Using clang 19 because of: https://github.com/irods/irods/issues/8839
+# until 5.1 is out
+llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   pname = "irods-icommands";
   inherit (irods) version;
 

--- a/pkgs/by-name/ir/irods/package.nix
+++ b/pkgs/by-name/ir/irods/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  llvmPackages,
+  llvmPackages_19,
   fetchFromGitHub,
   cmake,
   ninja,
@@ -20,7 +20,9 @@
   spdlog,
 }:
 
-llvmPackages.stdenv.mkDerivation (finalAttrs: {
+# Using clang 19 because of: https://github.com/irods/irods/issues/8839
+# until 5.1 is out
+llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   pname = "irods";
   version = "5.0.2";
 


### PR DESCRIPTION
The current runtime binaries of this package are actually not functional due to a change in the way Clang  v20+ evaluates curly-brace initializing nlohmann:json objects

Discussion about the bug into the Nix package: 
https://groups.google.com/g/iROD-Chat/c/xNwrV2KnvVs

Upstream bug opened consequently:
https://github.com/irods/irods/issues/8839

So, we have to use llvmPackages_19 in place of llvmPackages until irods 5.1 is out

WARNING: this PR depends on #486840 ; tests will probably fail until #486840 is merged

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
