### PR TITLE
linphonePackages.linphone-desktop-bin: init at 6.1.2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop-bin/default.nix
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop-bin/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  testers,
+  xvfb-run,
+  dbus,
+}:
+let
+  pname = "linphone-desktop-bin";
+  version = "6.1.2";
+
+  src = fetchurl {
+    url = "https://download.linphone.org/releases/linux/app/Linphone-${version}-x86_64.AppImage";
+    hash = "sha256-k9eizLZBVNKFaIOIWun9gN6mWQgbvqD6lW5PEBSetOQ=";
+  };
+
+  self = appimageTools.wrapType2 {
+    inherit pname version src;
+
+    extraInstallCommands =
+      let
+        appimageContents = appimageTools.extract { inherit pname version src; };
+      in
+      ''
+        install -m 444 -D ${appimageContents}/usr/share/applications/linphone.desktop $out/share/applications/${pname}.desktop
+        substituteInPlace $out/share/applications/${pname}.desktop \
+          --replace-fail "Name=Linphone" "Name=Linphone (AppImage)" \
+          --replace-fail "Exec=linphone" "Exec=${pname}"
+
+        install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/scalable/apps/linphone.svg \
+          $out/share/icons/hicolor/scalable/apps/linphone.svg
+      '';
+
+    passthru = {
+      updateScript = ./update.sh;
+      tests.version = testers.testVersion {
+        package = self;
+        command = ''
+          export PATH=${lib.makeBinPath [ dbus ]}:$PATH
+          export HOME=$TMPDIR
+          ${xvfb-run}/bin/xvfb-run dbus-run-session --config-file=${dbus}/share/dbus-1/session.conf -- ${pname} -v
+        '';
+        version = lib.head (lib.splitString "-" version);
+      };
+    };
+
+    meta = {
+      description = "Official Linphone desktop application (AppImage binary)";
+      homepage = "https://www.linphone.org/";
+      license = lib.licenses.gpl3Plus;
+      platforms = [ "x86_64-linux" ];
+      maintainers = with lib.maintainers; [ nivalux ];
+      mainProgram = "linphone-desktop-bin";
+    };
+  };
+in
+self

--- a/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop-bin/update.sh
+++ b/pkgs/applications/networking/instant-messengers/linphone/linphone-desktop-bin/update.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -euo pipefail
+
+URL="https://download.linphone.org/releases/linux/app/"
+version=$(curl -s "$URL" | grep -oP 'Linphone-\K\d+\.\d+\.\d+(?=-x86_64\.AppImage)' | sort -V | tail -n 1)
+
+if [[ -z "$version" ]]; then
+  echo "Error: version not found"
+  exit 1
+fi
+
+update-source-version linphonePackages.linphone-desktop-bin "$version"


### PR DESCRIPTION
Linphone is an app, that is difficult to build from source, since it is using many submodules and can have issues like this one:
https://github.com/NixOS/nixpkgs/issues/470112

Because I needed it to work and have a newer version that the current linphone package is in the nixpkgs I used the official AppImage version from linphone for the past half year.

That worked pretty well, so I wanted to add this package to the nixpkgs as well, so other users have an alternative path if they encounter issues with the one build from source.

If it is prefered to not have it as the AppImage version as well, please let me know.

@jluttine @Naxdy

PS: The reason I renamed even the desktop file to linphone-bin is because after launching linphone it creates a linphone.desktop file in the user home dir, with the wrong paths. Have not found a way to disable or prevent that so far.
Having the desktop file with a different name allows the app to be launched, even with the wrong .desktop file written by the app itself on launch.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
