### PR TITLE
nixos/netbird: fixes login not working properly on first login

### DIFF
--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -760,35 +760,25 @@ in
             };
 
             environment.NB_SETUP_KEY_FILE = "%d/setup-key";
-            /*
-              might want to do something similar to the docker entrypoint (watching log messages) instead
-              see https://github.com/netbirdio/netbird/blob/dc30dcacce4c322502975f1f491e6774efd7e1e9/client/netbird-entrypoint.sh
-            */
+
             script = ''
               set -x
-              # uses a file on a `tmpfs`, because variable updates get lost in the loop
-              status_file="/tmp/status.txt"
 
-              refresh_status() {
-                '${lib.getExe client.wrapper}' status &>"$status_file" || :
-              }
-
-              print_short_setup_key() {
-                cut -b1-8 <"$NB_SETUP_KEY_FILE"
+              get_status() {
+                '${lib.getExe client.wrapper}' status 2>&1 || :
               }
 
               main() {
-                refresh_status
-                <"$status_file" sed 's/^/STATUS:PRE-CONNECT : /g'
-
-                until refresh_status && <"$status_file" grep --quiet 'Connected\|NeedsLogin' ; do
+                # grep for `: Connected` as well, as `Connected` appears other
+                # places even when not connected, and before NeedsLogin
+                until get_status | grep --quiet ': Connected\|NeedsLogin' ; do
                   sleep 1
                 done
-                <"$status_file" sed 's/^/STATUS:POST-CONNECT: /g'
 
-                if <"$status_file" grep --quiet 'NeedsLogin' ; then
-                  echo "Using Setup Key File with key: $(print_short_setup_key)" >&2
-                  '${lib.getExe client.wrapper}' up --setup-key-file="$NB_SETUP_KEY_FILE"
+                if get_status | grep --quiet 'NeedsLogin' ; then
+                  # setup key is in $NB_SETUP_KEY_FILE, and is
+                  # automatically picked up by the cli
+                  '${lib.getExe client.wrapper}' up
                 fi
               }
 


### PR DESCRIPTION


## Things done
When the netbird client is initially started, the first status command will return a seemingly normal output which contains `Peers 0/0 Connected`. This is treated as if already logged in, which is not the case, as a subsequent status command will display the `NeedsLogin` message. This PR fixes that, by checking for `: Connected`, which is used in e.g. `Managament: Connected`,

This also includes some cleanup of the script, as most things are not required/necessary.

The messages can be seen here

```
----- initial status, before needs login message
OS: linux/amd64
Daemon version: 0.64.4
CLI version: 0.64.4
Profile: default
Management: Disconnected
Signal: Disconnected
Relays: 0/0 Available
Nameservers: 0/0 Available
FQDN:
NetBird IP: N/A
Interface type: N/A
Quantum resistance: false
Lazy connection: false
SSH Server: Disabled
Networks: -
Peers count: 0/0 Connected

----- needs login
Daemon status: NeedsLogin
Run UP command to log in with SSO (interactive login):
 netbird up
If you are running a self-hosted version and no SSO provider has been configured in your Management Server,
you can use a setup-key:
 netbird up --management-url <YOUR_MANAGEMENT_URL> --setup-key <YOUR_SETUP_KEY>
More info: https://docs.netbird.io/how-to/register-machines-using-setup-keys

----- actually logged in
OS: linux/amd64
Daemon version: 0.64.4
CLI version: 0.64.4
Profile: default
Management: Connected
Signal: Connected
Relays: 2/2 Available
Nameservers: 0/0 Available
FQDN: chronos-98-42.nb.internal
NetBird IP: 100.65.98.42/16
Interface type: Kernel
Quantum resistance: false
Lazy connection: false
SSH Server: Enabled
Networks: -
Peers count: 0/3 Connected
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
