### PR TITLE
ultimate-doom-builder: init at 0-unstable-2026-02-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24948,6 +24948,12 @@
     githubId = 13762043;
     matrix = "@sophie:nue.soopy.moe";
   };
+  sophronesis = {
+    email = "oleksandr.buzynnyi@gmail.com";
+    github = "sophronesis";
+    githubId = 13190573;
+    name = "Oleksandr Buzynnyi";
+  };
   sophrosyne = {
     email = "joshuaortiz@tutanota.com";
     github = "sophrosyne97";

--- a/pkgs/by-name/ul/ultimate-doom-builder/package.nix
+++ b/pkgs/by-name/ul/ultimate-doom-builder/package.nix
@@ -1,0 +1,137 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeWrapper,
+  msbuild,
+  mono,
+  libGL,
+  libpng,
+  libx11,
+  gtk2-x11,
+  makeDesktopItem,
+  copyDesktopItems,
+  unstableGitUpdater,
+  autoPatchelfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ultimate-doom-builder";
+  version = "0-unstable-2026-02-01";
+
+  src = fetchFromGitHub {
+    owner = "jewalky";
+    repo = "UltimateDoomBuilder";
+    rev = "9d7a12b1164dc53964b594395f9d5d825a43ac12";
+    hash = "sha256-FwGfrvF+UrmEw1lvcU4qL9OOP0n/ZmQTsIjQIxRvkmg=";
+  };
+
+  nativeBuildInputs = [
+    msbuild
+    makeWrapper
+    copyDesktopItems
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    libGL
+    libpng
+    libx11
+    gtk2-x11
+  ];
+
+  postPatch =
+    let
+      gitCommitCount = "4291";
+      gitCommitHash = "9d7a12b";
+    in
+    ''
+      # Replace git-based version generation with static values since .git directory is not available.
+      # The build system runs git commands to get commit count and hash, then uses them in version strings.
+      # We disable the git Exec commands and set static PropertyGroup values instead.
+      for file in Source/Core/BuilderMono.csproj Source/Plugins/BuilderModes/BuilderModesMono.csproj; do
+        # Remove git Exec commands (they would fail without .git directory)
+        sed -i '/<Exec Command="git/,/<\/Exec>/d' "$file"
+        # Replace conditional defaults with static values
+        sed -i 's/>0<\/GitCommitCount>/>${gitCommitCount}<\/GitCommitCount>/g' "$file"
+        sed -i 's/>0<\/GitCommitHash>/>${gitCommitHash}<\/GitCommitHash>/g' "$file"
+      done
+    '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Won't compile without windows codepage identifier for UTF-8
+    msbuild /nologo /verbosity:minimal -p:Configuration=Release /p:codepage=65001 ./BuilderMono.sln
+
+    cp builder.sh Build/builder
+    chmod +x Build/builder
+
+    # Build native library with:
+    # - UDB_LINUX=1 for proper mouse input handling
+    # - NO_SSE=1 on aarch64 to disable SSE intrinsics
+    $CXX -std=c++14 -O2 -shared -o Build/libBuilderNative.so -fPIC \
+      -DUDB_LINUX=1 \
+      ${lib.optionalString stdenv.hostPlatform.isAarch64 "-DNO_SSE=1"} \
+      -I Source/Native \
+      Source/Native/*.cpp \
+      Source/Native/OpenGL/*.cpp \
+      Source/Native/OpenGL/gl_load/*.c \
+      -lX11 -ldl
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,opt,share/icons/hicolor/64x64/apps}
+
+    cp -r Build $out/opt/UltimateDoomBuilder
+
+    substituteInPlace $out/opt/UltimateDoomBuilder/builder --replace-fail mono ${mono}/bin/mono
+    substituteInPlace $out/opt/UltimateDoomBuilder/builder --replace-fail Builder.exe $out/opt/UltimateDoomBuilder/Builder.exe
+
+    # GTK is loaded dynamically by Mono at runtime
+    wrapProgram $out/opt/UltimateDoomBuilder/builder \
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk2-x11 ]}"
+
+    ln -s $out/opt/UltimateDoomBuilder/builder $out/bin/ultimate-doom-builder
+
+    cp flatpak/icons/64x64/io.github.ultimatedoombuilder.ultimatedoombuilder.png $out/share/icons/hicolor/64x64/apps/ultimate-doom-builder.png
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ultimate-doom-builder";
+      exec = "ultimate-doom-builder";
+      icon = "ultimate-doom-builder";
+      desktopName = "Ultimate Doom Builder";
+      comment = finalAttrs.meta.description;
+      categories = [
+        "Game"
+        "Development"
+        "Graphics"
+        "3DGraphics"
+      ];
+    })
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    homepage = "https://github.com/jewalky/UltimateDoomBuilder";
+    description = "Advanced Doom map editor based on Doom Builder 2 with Mono support";
+    mainProgram = "ultimate-doom-builder";
+    longDescription = ''
+      Ultimate Doom Builder is a map editor for Doom, Heretic, Hexen, and Strife.
+      It is a continuation of Doom Builder 2 with many new features and improvements,
+      including cross-platform support via Mono.
+    '';
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ sophronesis ];
+  };
+})


### PR DESCRIPTION
Ultimate Doom Builder is an advanced map editor for Doom, Heretic, Hexen, and Strife.
It's a continuation of Doom Builder 2 with many new features and cross-platform support via Mono.

   This package addresses the request in https://github.com/NixOS/nixpkgs/issues/211666

   ## Things done

   - Built on platform:
     - [x] x86_64-linux
     - [ ] aarch64-linux
     - [ ] x86_64-darwin
     - [ ] aarch64-darwin
   - Tested, as applicable:
     - [ ] [NixOS tests] in [nixos/tests] - N/A for this package
     - [ ] [Package tests] at `passthru.tests` - N/A
     - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality - N/A
   - [] Ran `nixpkgs-review` on this PR - Manual review completed (shallow clone issue)
   - [x] Tested basic functionality of all binary files, usually in `./result/bin/`
   - Nixpkgs Release Notes
     - [ ] Package update: when the change is major or breaking - N/A (new package)
   - NixOS Release Notes
     - [ ] Module addition: when adding a new NixOS module - N/A
     - [ ] Module update: when the change is significant - N/A
   - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs

   [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
   [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
   [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
   [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
   [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
   [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
   [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
   [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test"