### PR TITLE
rke2: update all packages

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "3c30438a4eddeb831db2ac5f52f447b8848815c2fd0aa86d05764603689d39c6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "8d0c3980463addca09a3833d805472a3c7be5506821af44e06a5ea86a0886339"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "33c00385b8c3cec3ee5c1eff6f165284b4bf63ee53b1cbbe707fe3317706a7d2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "750f8ba9afb11c61d13ee5cd4e3126da5b6dab9f05b079934504665e84103c0f"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "0aa89b6a25f0d8ddcd32e7c1931d190d805cb79870a80593d8aa5ec797fc9f79"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "6b6bf994fda7fa6e128cdd8d43202da44a9cd573a4e6297cbf1943ce7c7db24f"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "e5c760962303fd6296842737be355cde7ee066f464ea550b55f1f6ba7dd95f2c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "b91c5d578d79132166706372210f215db3542bcd4c639ea4459af48364716bf7"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "a1a2f2fd90d92bbfdf0a77b77c4295e119e542021204a728cc42f618ab798622"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "6cdcdac6ac35650ad0baf654438bd16129810b110955c1f3571c174046b95a9c"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "a2b72764ab8f5e72169812ce875bbc861e1c2e341b167bef7d5e980b78dd9f6b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "66343e33391790e004829f41906db086b9dbefa08b5c7c554beb2d1e9d4b4095"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "a7163212bea884f76a6a2e3b62be7bf8086460f9149d9f2e5693edeaf0d7ad93"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "6d63a70fb0eb1b868e51c6660def5c28e4fbe88fcf2df8e32c7d1e25391426aa"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "3780c1220874f41028ba8f0a49209b090fb2947da23bff53bdc0953ed6e4db9e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "ba652613f19e1195e4a05f7538a9181565dc0a8d939b4717e55ea439dae4dcda"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "38dbc7f386c4fce06aa7a2c6051b4176113e1ff93f2da4beae66853e8ae582b1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "eb8ed504c28b0e7f6804a91aff8ff83d55c8ed4d3a9aa199d40629286c659726"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "75bd972ec8e3266ae01b4968b224a118e374b01c830def92a20dfcbf29cb20e8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "443b46e15b352da76faa0832e347915a6e8d74f6e5978e093e588fdf41cfb6f7"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "48d46a224df1ffe173b432b69f08249e98da31209de613b2ec06eb4476e8f4ff"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "52c2fad399e622209388e27f563d8d4fd1cd7dc3e4c690b13a82dfa2f5512e50"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "f71fb6f5e2b650958baff8133c61a1ad43c04ab7d222334cf54839de735e2897"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "63e4cebff2d8a2fc688dce5509f5a1eb1853f18dfe03341cf720eaed2f9c425c"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "375f0bf18da30f2f76aca8bbb065dda9ac75caca76a4704424c800917e351b42"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "3856334a4c01c6f3bf4edefdcf35c22934bb374247ec68f922c47d20df06a14b"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "c651e89aabdf77f4c90af42fd337b522691190600272f26059b8f1b48ac2f68c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "f262578106dd97865cfadf1844b8d4cb0f802684324dd4802e7d21a7691c5a5e"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "0161796116bab9afcfee91e9116b10516634254ec0771a08178761443eac2147"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "014252467ef853a76cdb6b3ca36cb9f02e0c87e432952f2a284924e9093bd828"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "53648ffc5b03c0aae262734bbe4c684a62a33a89fad4e8183957e57af4b5d65f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "533d173db72c3b470f588d34d9d0ea5d99d97bd95a3e1c84ce40e8f9c3c5a6fe"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "7683ea5abbf25b1af3a1fc6c1967fb65a05f2d927d1fe8b37fe3f30990c99907"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "6f2c18a776b7606eebba37a77a60c9af947277ec580a89ee0d78c3cdfdcee19a"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "99be4dff6a72d45c14ec4c7e2142a52eaac7e79e901d260b7b2a85c9463524f1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "e4dc998d92eaf65d64bc2a5d6e0de6aaa681e5472d299d24ae0839b62f76d0be"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "2157b8db3e36a598d266f475f359e78ea8f13ce759e865992fd52728de7f727e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "cf943bf7c49860e44f4495080b6a67c03254a66a14fd4c717d002b85a960d294"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "4413a6ec9305fb811eb99973f0b609ba4412b5a7ae6384146f7be647c8726851"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "4573fdf31346c635565c85df827890566be50a511d90430f6f6344822a57c840"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "5edf9c8e8b76e9ffd8accf30ab8d8e4d3edaf0aaf80d325c5cb7c0d319230f35"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "832c0c23264dd7465cdc9a5aaa15c08f4d3beae9f4cc340f22fde1b29f8df829"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "1ed7217d8e08947f03f96b482e095274d70a491286a8ffc58dfedad43958bcb8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "8cbb615444176d41b4b2a5c1e9c45bf790226557881f2f824a85870ce5411340"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "31e926524431667425d7f2120a25aca48ff4ae912e471a117a5d76c178002083"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "72c48dae8447f53098dd29929d0807dbcad35785ca5b947d4945352068d4fd21"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "e93b68f4123ae02bb62142468add0be45d98ed2667333421f26102ef01e06048"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "7aec3ca5df97a15a3fba6ad41b1c66ff0d89ce7566f2a77a67119fcc306aefd6"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "e642b17c843780f9961864a6a7ef6f5031a05c255cac62f7109a95870ecc46e7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "6e71cc84fa4db154a078b54dbc4c529343e239d2ee18a0c42182d78c42d235c5"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "7997ccf45051611f8c2ba6f0ac4ae59636aeec3e227fe2c31bd678a57396c813"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "11b14a77520d4a2d4576d29726a48df6099efbd3698acb9f21539f4aecd8cb07"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "0483706f7871c1965a0de7c63a011462aadf8f97f5a9fd28c5c16d914a0ca627"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "2c1a493889a2680107e3ddd243d51bf4b8cb39438f296ff1c5f67018f8a16f01"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "0a46e0ce765a01099eba369ff311a12fe2537ebaa32fdbe11248f47e6fe625b4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "e937a9f50c49e1ff9fee82701253eff96988c515a80b8ead262a0936749d117d"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "d58271f93c27bad3651b084357025ee5232044ef10c24f9e72c3f70a8fd5112c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "8cfc99966860bbc8ac394aaa742b849030fb34c76fad80f92ab01bfd61e439fa"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "c5170ab51f07f90da4972e6cda7186a042913a10064792529c3c292cd1c5b723"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "83fb940a35c030c0ada591b30929f891f313496759a3aa0bd5956d2fb5352d81"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "266398b100bd47ca86bb6ccd2edd0163f7606032a36780407dbb553c50705ea3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "2530f1eb0652d5a6ecef756762b313f3353d6248fca71f38fb4345c22a2ae6c3"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "1aedcb967b4203a54e247d90e3dfd054cd5de55281c0d9e4a6c7bbea45e0cd7e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "10d15dfa11d37bfa6818f50e143ee9747667412d87546c48c213d1f3ea592e94"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "90e37c8c8cbff0e23dee712821fd6d09302fe1064f8b87d53fae6e26800322c6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "e4ece48e2c1a7a300c7b8d3cf741274708bc6684a2c895eeb11125a56b00be89"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "341ec63cde711b4aa55f22e59d2238230ae703c70f67e74347755f5909c00b7b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "b2da9f611dbc21f9c084e294ca36e9d5028a31318b6692f25ef0b37079b4fc9f"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.32.11+rke2r1";
-  rke2Commit = "836ebdc75f3d96bbeed0373e1fee7de24d3798f7";
-  rke2TarballHash = "sha256-AErhQfpUyINPLNaCeXxl67EehB8aKrQUDWZKrFlrG4E=";
-  rke2VendorHash = "sha256-yiyMD4VPM592nwbKGEo380FX/B2NytKcw6ly2JSYx7E=";
-  k8sImageTag = "v1.32.11-rke2r1-build20251216";
-  etcdVersion = "v3.5.25-k3s1-build20251210";
+  rke2Version = "1.32.11+rke2r3";
+  rke2Commit = "17d79026f5b83f1ca4af3feadc4756cc0cce0ba1";
+  rke2TarballHash = "sha256-lu5Au09HF8Vhle/caMYIlrtxplbikzS4JpFvZwbm5Bg=";
+  rke2VendorHash = "sha256-wniGN8nRXo8GDKXG5wt/Ulv5A4IIIyVh6GFpfFfebRQ=";
+  k8sImageTag = "v1.32.11-rke2r3-build20260127";
+  etcdVersion = "v3.5.26-k3s1-build20260126";
   pauseVersion = "3.6";
   ccmVersion = "v1.32.11-0.20251210094421-ded016535487-build20251210";
-  dockerizedVersion = "v1.32.11-rke2r1";
+  dockerizedVersion = "v1.32.11-rke2r3";
   helmJobVersion = "v0.9.12-build20251215";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "8ffd0de3ae47590d6891b21c95a4bf718ba26b00acc72c3502e5b7a98cfeaebf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "cb42dab5e5d6b22a97f7c7b00bd366b0cb4d880faa4ea8471240010bf3fee06a"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "a3edff8cee5b147c736c11c2e074a8501ae82b5aca14d9149a04b14714312570"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "792fc6b5e017d22a7cc8ad15f90c848fa5f30fa2b70daf7da55942779209f1d1"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "d3e40d0c99a37419764bbd5be541fa1cc5469f8127aeb3297ab8f203194c916c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "1b03d015afa029e41c26bcf5a711a341be10500c13a38e7b595a7e5415db1705"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "d48b4a1d17c8befc174344dab58e5bda6a018d703ffc0cf17bddcfa94c538512"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "bfb9f3177f242ecf224146e92a1f3120b503a5ca27f9b7f98853de2e8d9b4d44"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "b779c59e5d18bd237eaa1664dd469943bbc98231fb471b3dea13c990c5d0c86b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "63a203c9503258029af30935856d27e71df3ac35f39f48d94a422db54ed3c077"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "f113b95fd2835db27570dc5525a5e8b86918b379a67aca12f6d547f5a3aaed23"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "b3b7091d62221ef06cecd4073404013d2e5428efb2b1bcbcf157ba4abca83ef9"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "507a46b8b160eb85c5d0833342bdc61a769bbcc7e5e0ee9ba4b90563b565e2a5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "2ba37d5f570aeec35084457f0cd95e319bc9049f893c3542721320601a3b01ee"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "9b542b33488d580223e161ba8d9bb11736eabddd3ed029d7a4a095d42b6e7122"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "59d2f4aff4e91135efcd6ea98e1d8d5e2464d5edbdcd1d21f6789158cb48c968"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "e11afea5475d8c87d078f6847b41167b682d2b59dcd717b50f57912a43544f7c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "639bd3f26fb9f710d4ca31ab53ce9c84484c20f08d078399ff39c5e74b05e00b"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "dd8a2be05ec194783058d3656a07a6b68b0ff7361fd4bc071cb2c61eee9d7803"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "7f9331159a77073291fcd5d3bbe739749f110e6b37b5d89c1c7a27aa1e2b97c0"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "7f3c01c545d101ca7b05efbb1d629433f914ad29e99d8d825372027f73b3a628"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "d46cdcc7f9966ed3da12d0ee6fa8573f9b9b5240b96d98dec182f56d73c2b497"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "f708c5275cb2a6ac390dcdeba1521da03b10e8812dcd4eef0a72bc7478f50aa7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "358c297f40be38aabca1d3fc23bd7fa75be38068592dbe9bb41fb25050694d06"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "c46fb5f1e71f33d30b3fdfad9bdb9cf45ed56172e99aa197db76e429e9c798b6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "3ae923d05c1cad4bda2b9c9485150b6a9d25b9df67868b0257ecb3a16d3536cf"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "4d45c42f2a676a69db2cfe61a661d07897dcaf6286e6edd7e0a0a13c4107f1ae"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "11d55e64e2cca2109f21f351f1f0f721f5bd6c66034bdf565b152e70b4aa173b"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "7312ad66a5ab852abc3365258520ac12ad1682e4d899ebe27c0852524eb7b8e0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "be0ca650fb5c02aa603c75fb121b90a42a3b238f4cca55779fd9706c5b275066"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "2e428e080ae979e7a253b1f8a8e0d9d045bbf37e3429a1e0cda7bfd816f9e5f8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "beac78c4a796e42f2416b7cefbcdd9b7806f49b59c2faa995632b8d8421c14b5"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "c42c70de2a03e024b2a215cf572c2043ad387e647b7f9c79f11f6c8f16169673"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "0da13ac23c3a5c3178383bb17fee989834a110e41ffe11780d3e7855445eebae"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "93136f61caf9b45dea0ab1d76473ebb880c56df404417d7706bab5677ce60ebb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "e4dc998d92eaf65d64bc2a5d6e0de6aaa681e5472d299d24ae0839b62f76d0be"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "4f32b6f1b4bd502c9622e79143e1f0bb1a5f57277bd496e0534415507094a57b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "5a4a349c2cfa222397ce2d937982f3247bfffe73807440851e0c41c721583693"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "46d14c3531e0fd14483fe148ebec5e14b14c28bf1049f258d06511051b167873"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "3e613cdb185cff68b8cb657cbe89f29858828cb5fec4763b25b0450f617f54ac"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "40829aff7709374b9d2d6b5cade000eb3f5dbcc91247364832cae8e1770b9749"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "d1b18a768857ad1f288b1d1db8065b5d668212a3270d08360fe7870bbf7593b3"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "fa712c7061cf6cc84c65e2d6aa86e4e98e862c17413d228677eedff2e32b500c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "493ff33611a271cb0e71642bd63d9b65d9032833fdd6f2a8e01e797624408e18"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "ac5ee84a05b4d9a8082ed58e3691305137f50dcd3de54a503905bd5943f5ada0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "118a8ede1ee0836ac1b891381a1211ede372d55c37f9edebe8060955f2a6ea9d"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "94a72b07d0cb69dd2406f52cf6b6d87be2aae2291d76370ded49f7f47197b631"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "aeccc7ede79366078b5fc964b41db6b579277a1170d62dc75de9f887262b9cac"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "b2f5875d3d9702b8778d609134a99cdbff720ea41ef7b490a0af2460e2e3ca8f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "b3411609c02fcac85c29fcfb251c0ab19896c6af65dcfc1fa539c696a73236e9"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "69ed710c8a64668d9fd59f1fa30601d26051389819753dcb27f46fc12192a884"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "e17c910d4609162de2416845fbd600711488566b4369e896e17249b1e2f00d4f"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "8917010380e3c2501af3b6cfc497b0d226aecf9a290b1a84090d62c549716564"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "d44e4f67971a2c2f9cea7a83777dba707a5c5bafef6cb9e7f45c0e84e8634f66"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "8c6164f34bff5253874fa7d5c18da79c5d2849bd874cf75eb6200bce79e4e342"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "e937a9f50c49e1ff9fee82701253eff96988c515a80b8ead262a0936749d117d"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "3af0e0aae8de0558602b278216f92d85bc976d1d44028900067b4e164b987f19"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "7831e03c29ff17d25131ef6982d7595f098af7abb99a2f040a186e9fbc5e094b"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "2bdec4a29e5660aeeb7789a12b48e0c92d1abb3d3533c779e1eb3a1859868895"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "83fb940a35c030c0ada591b30929f891f313496759a3aa0bd5956d2fb5352d81"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "d3c0a38066a85ee63d8363ed26ca511a2c94267ef48334e45d1abb756fc3d562"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "d7e6f2685bccd21af7abc539d8cdb72ebc6a69bad654308ecbc9a8d5d5d9de3d"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "02187f5f06231bb50c8ac0cd908669e7a7bd5c611f633eb119f8bc8458a5f24c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "10d15dfa11d37bfa6818f50e143ee9747667412d87546c48c213d1f3ea592e94"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "b492c8863e82f6223c8a8ff27d316d51c8931778921a16cab9b6861915ed7c45"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "3e40be7b6b4c22ba3e2c1bbb14d82002ef68ea6368633326fe8881251afc79c1"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "547cb03a489f2762e2d6de5693d91a17780113d88d3b6881fc4b182e864e7adb"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "3b7472d2058fa9a7c9285def8c30a32b8ccb0ffdae25ab94021d6cd7ea514066"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.33.7+rke2r1";
-  rke2Commit = "b0a4ec8463abd1e23e41f213fdb54ad8006c693b";
-  rke2TarballHash = "sha256-Dkr+rDsC3L9LSGuu6hBLuyWqWJLrpEi/p35wzP7P0uw=";
-  rke2VendorHash = "sha256-ybxWnzKjpH3sYeFIqUZyvV1KXB5zxpjMAzN6oC6MOXo=";
-  k8sImageTag = "v1.33.7-rke2r1-build20251210";
-  etcdVersion = "v3.5.25-k3s1-build20251210";
+  rke2Version = "1.33.7+rke2r3";
+  rke2Commit = "7e4fd1a82edf497cab91c220144619bbad659cf4";
+  rke2TarballHash = "sha256-kyTKacfVD93cwozXkjusR/eshibIyAPEmEyhRiAvppw=";
+  rke2VendorHash = "sha256-P6p//+38sM0dobc+Xx0Gd+A01cJsUUE+eblUtc3Cet4=";
+  k8sImageTag = "v1.33.7-rke2r3-build20260127";
+  etcdVersion = "v3.5.26-k3s1-build20260126";
   pauseVersion = "3.6";
   ccmVersion = "v1.33.7-0.20251210094413-291666bcc1a4-build20251210";
-  dockerizedVersion = "v1.33.7-rke2r1";
+  dockerizedVersion = "v1.33.7-rke2r3";
   helmJobVersion = "v0.9.12-build20251215";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "b85571d4e77831c90e5ab9169890177b472bb471ca4538335594109659239f32"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "3afe223e395bc988b49edd2d18293448dc267a31a9085250c54d13fb81a66c3d"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "94721c4576ea11ac7a53077f7b3b83e0da06d83bbe4ab7bf696085eee8d79bdf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "7e2aee7d34c13b088f9548764ec962233989749214ba906a7276729cede72e74"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "d5ea81e1b784d6631faf6c2dad980c2ab119a9d6bee3766e174c4ddd6afbd7d7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "4a2c4145e58c053239af5154402f8ccaffa4780bbd546a54ff725ad22eeb1dc4"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "1e6fac46a83442055666c2ab2aecbbbb8d8491c723fe6f587bd4af53423f5e23"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "237b907abf607a8319a6ce7e667ea479a9472e11f6ed23912830899cbe787600"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "17d5b245b9ed022c4eb806c0a974be672b87dd5d21491dcac17ba2fc6cf7b105"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "751fee624d7f58b6c7d408d17aefabafc55832b1935244add05e3cef566a20f1"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "20a8491b6a1c5ede6db6b2f8eb9c6dd2bccb1014193f50273b794d466f96b671"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "66343e33391790e004829f41906db086b9dbefa08b5c7c554beb2d1e9d4b4095"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "172691f696af33bec02fa560eb490fac5bba90ff206c3fe76f33ac48b3d89235"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "6b7280c45b1d0a6f46143d7a722dc20f5a08715dfd8955a7984e21f9e7c7e2c0"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "c6b4f18d5512159a783d8980b266eae0697e2eb9c9b6a87e845d8155ac3d10a7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "ba652613f19e1195e4a05f7538a9181565dc0a8d939b4717e55ea439dae4dcda"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "d0b3351896b2475d86b3db55a176300b13e5c29f7ce253895871181de6c554d5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "d93ed1d3f08889c94f194355c686cd170707cc10439a0794d4ac62813667871a"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "5eb9e750ccb966a5f65b294df586cadaa7988b84585c06538ba7e26a5e04ea31"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "8113765a4640591976507a4ff4403c516db0ebe214d538a1a3510bafcfad2216"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "473c179e121fa372118d8acf6d4042dcfbd78aa4180bde8f32a3686f6e67da0c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "acfe7b49804be0d410bf2e804f094bc8826e78502f4f9d0f2bc3d313cca7309d"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "9d60605d51e9adeae650731b1fcb06681140fe7ddff76178c3437f8bfc5876e8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "ecf563e46c8b6c0ac0ae29d05002255d22744bab89e5e17cf03a79758b8d68f0"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "cd62de26e53ff647b542782a539b2f5b4fadd9e34e8c84071fb1ac744b353af5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "164eef1322de2340e4af5e2451bcf2e72dcae002a983d3f1d51e27b95100daef"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "c19d06dcafbadd08bc46199a7f22d43ce70848191c242d3642313f17b4fe186f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "6a90ab3f9a9c1037a3c299afee21af063d69ee5b1a30d5fa09450e5ae5d302db"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "ed1650ffed4882821a833aaa86247038d386ab36a753726926de2346f228f240"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "5b5d5643d5106fda9e4eb54632cc18fe714611f557ccdfc75a5ff3966614978c"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "9df49d0786965a359e3ab70208e65632e7962befb46175e217d5b35e5a556f4b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "bdfd862680c1d3c5d4f0d35b390d63437d36e831fd7eccbec603b447e5874e2a"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "5642c999542e0e09b5b304f363b4612bc7e1d18ea209787c65015728a61d64f7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "b630aa6867bb8cd8074bdffc43c1a86793c1f266a7ae2d87365a31d45a3e6da3"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "e87d546dcbe16384fe163bf8d52cd41b36a106a6202ac0bf308e91085cc02c00"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "e4dc998d92eaf65d64bc2a5d6e0de6aaa681e5472d299d24ae0839b62f76d0be"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "6ff5df889ac61275f876c090476768cb0fde8d675300ac17ffa1bcab19c419a6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "637cada2e40ac5ea63779c870afdfd6a4d54b56e9ac692363b2a9d51e91870c5"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "9f33d2b63ae6c59e91e534a9f9908966116b3fec4880c3a13b522d3bbbddf207"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "3e613cdb185cff68b8cb657cbe89f29858828cb5fec4763b25b0450f617f54ac"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "a27f7c2ca33466cbf99d79648d30aa6b9cd8813bda40abf78f48315f7b038d2d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "83865ff5837bc7c4ca4b5355b0c4868df1e2d13f20119c89565ba01aada42f4e"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "8b83f60edc527b368bc412a1f2773387d8691f4e17b3a176cf2f648af9b4989b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "0919a88bc0d260f0fa17a1df0fe00964fc70b3b77f0080ce9797852841b91b7d"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "abe89abd5e5b09a00469e256cfcb0e4bd1b72f5ac01d8efecfef2c623c705454"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "4414e1eedaed610df4ced07da07ee7b0d0cacd890061d626bbaeb8282d69fbd1"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "cf1ff411e9acd0a78994e4d2fa52b63fc03ae30e59ecebf24609a65988fe877c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "4bf1d69a6fc62d953a481af4ec9f229ed8edce6343dd74a18bc2e9caa0aa4e9d"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "4472b330de3725c0135740da2c59e954c1f2cd3904b6bb22b2c764a2333c4a9a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "cdf7c04f270b83147ccd0a2fa05c09511852e40bc14d8ef65f018ac66a714621"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "aadd39289a95d0658cf8373aa896608d6ac62c654ed66f4edf1ff7f8e6a75881"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "7183250ff5fd40b8dbe21ce22b7eaee19dbc78a8986b935b4b8aeee1105ce098"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "b4447f161a0c86adea6050f298644fa42ef9b6eb0f315cd64d22b62ad20b3780"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "2c1a493889a2680107e3ddd243d51bf4b8cb39438f296ff1c5f67018f8a16f01"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "f1b91676d2517fa30afc36d077aef5568db8dcedfffce5f2081d35f6468620b2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "e937a9f50c49e1ff9fee82701253eff96988c515a80b8ead262a0936749d117d"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "52b6fdc13ba7ada02a1bf4a9e6044e2f1b53a864d53edeb1908f82a41e442c25"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "61a8cd4da4450b2196efcf4c210036dddc5496d233b4816212d8277a595f45d2"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "8c07f6491263873efbdf40795cf733a3a3da349e4bfc9d5edc59c50504347ebd"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "83fb940a35c030c0ada591b30929f891f313496759a3aa0bd5956d2fb5352d81"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "21d052162e50021c9d0efae0ad1c22e490dec2ac70d8d36dfe2975ab0d0105e3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "2530f1eb0652d5a6ecef756762b313f3353d6248fca71f38fb4345c22a2ae6c3"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "25a2c696e2ff8cfa508bf8cf7efdfe897018783dba92ff92c8aebcfcd1f2fb08"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "10d15dfa11d37bfa6818f50e143ee9747667412d87546c48c213d1f3ea592e94"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "9d37cc1e535d65a8f2d53ff35f35f3a0d0a09d5aa1fea474f47dc60900741e42"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "e6fba5a4ea6274527d9532782f5cab62b810cd2243ca17ebba7749d412c7ae4f"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "325587c90dbb2bbaf7aa5c2a42910b6110927031dc031535db779486c36e969d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "67372b6c334a4565361adb349a4f79bcf502c447c1333c48756cf7e7183b9b32"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.34.3+rke2r1";
-  rke2Commit = "1b103f296ab20fac6b32951c9efe59d28a5ed79f";
-  rke2TarballHash = "sha256-94wB6Dt06/evdQcW1K8blNBHwNR3ZGCZPLJyeyMbYAM=";
-  rke2VendorHash = "sha256-hVEIhaF5gabDKWX2VCTyKQa0cZktO9w+l2JtSNQIkg8=";
-  k8sImageTag = "v1.34.3-rke2r1-build20251210";
-  etcdVersion = "v3.6.6-k3s1-build20251210";
+  rke2Version = "1.34.3+rke2r3";
+  rke2Commit = "7598946e0086a9131564ccbb3c142b3fa54516ad";
+  rke2TarballHash = "sha256-qPpEcuW56RnOxnODAfaX/dVEW83axhVAEwiuBPg1wwU=";
+  rke2VendorHash = "sha256-RXvIbt98LuvH0HWKS0DYkrSxJYbb+XNBs+8Xr6EVwu4=";
+  k8sImageTag = "v1.34.3-rke2r3-build20260127";
+  etcdVersion = "v3.6.7-k3s1-build20260126";
   pauseVersion = "3.6";
   ccmVersion = "v1.34.3-0.20251210094406-1ff6ebef7028-build20251210";
-  dockerizedVersion = "v1.34.3-rke2r1";
+  dockerizedVersion = "v1.34.3-rke2r3";
   helmJobVersion = "v0.9.12-build20251215";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_35/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_35/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "d9184c1907c6a07328db80bc9787d9473874f99387997eb75712b3f109c28a95"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "72640113934fcea0ce39457b44ec5ac3b017e3b4b10e08e7fa889bc0acf12c9b"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "3b0fab246141f52418b0e8944ad0edac46e512ae837a6846d6685bd2ca934562"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "d191314d5d979cd63020d3a891ea9594922ffa580e1f1168e475e5889d2fdf1d"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "9ffb3e4607f44d5dde2e5fd17e4c317fb2f232174cd9b4fc1b5979ec8f0f0fa8"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "94f6294585471180d460ff25095df96223895f78356bca86cdb6b9ed120a27bd"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "c1531be737cb6dc2819f35e8e63d095b05db9dcd0698416a60b786a9e3d69bbf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "475ce43ee4cc09973cd6d7f00b84251525aa124d87732743015179b3ae79a403"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "dc6c2a3f22739fac02272372fc7eadb27809721ee921669203d46ec551fbb8a2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "dda02fecf29c0eee551822250f8b1aa6b5493515e8894889c16befefa49cea70"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "f039d8feabd264aa6a6d684560bd05e764e748292649736d436b28974b86668e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "ff61e91a44633b7d67b67ea9bd75f13a5388536f93c80897c2bcca2f7030bda3"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "6560ef5589c30afe63195d23a27ffcf4492a2e5135bb715c4c7818cd625a244e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "d0494bc8e7c1efcc1035b1527eae3b9a7bc4e23f1a2a3b944fa0134f5585ebce"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "8085686ffb57b508198916cd8ebdaec2a90b1e2f1592caeb0c4a55ae1ab4d223"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "d5977242482fbb89c52622813443f46fa44cd171695f53dedf8aa798cd861b6c"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "bf4fff99097f8bdf14d1ce51884e062140e311a08ad3661cd5455d966781d8ea"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "3f894c35461be717ddf06f3b41b7ac07ecaf81de71d838b680ef9663b4c50324"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "755338043246a0d167a16ff63ec53651ce9e837d39625d06bbbcd2c63004ec1c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "545690b3ff07522ae22fbdd522157cc81ef2e9f832feb18622be61e3470d0a18"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "f1b3dd87ee96aa022a73d535163bb066ae75b038188cd7937809e56d7896cd93"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "0c0819fedd53c077d349697c433d9c36005c9a9c3d286214d52d464684c1e439"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "decc80c50fd887ec299ff9b5ec5e7853be71c49f337cd5bb806c377e9e6f75ce"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "ee74ed3c7e0c69221153e378b5ed1034929a7836003210270586a59cb19b7c59"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "0fcbac0cfe2b7df25a677686408da84f960f292573d29341779191a981a1cd58"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "7f607ff9cc6a4b1c35db3cbdd1facf4057b3f7a55ee15fec69df5683652b72d8"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "4a715e8cc723a5b6b602b223c6609b1407ff837f6d31b203e23d2c53d9d7c85b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "7d12406770bc492304150df89d554ad92b3c522231567735c503f05ce5d14269"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "006b3603ca45d69897f47ac0e32b43eed3354a38fb3ed6d12b82f27c924f444d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "15e975a74fe89678df8e2825224a21aecdd2c8764e7f6a0a3f29ba3b5df06ad9"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "f2ee745a844902404623a4e45f0ecbcb7753547e199c93f87b750a9c3b7d32ff"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "74632fdb18512edf08f9369b7e1329436befd0833c7417ae77e7814265458a5e"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "63751fc22b0e35c44224c0ff053d6606ec63b885d1f8bde659e931b3de17815e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "f5966228ce3e52a3e7fbfc59d450885a3ee3c98a7219589771fbbabb62292ba7"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "1107c8a8c5aa90d5a8351340ac0a54862bd720f265f1b48742d55289d20c299f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "e4dc998d92eaf65d64bc2a5d6e0de6aaa681e5472d299d24ae0839b62f76d0be"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "337cdc528527e804e82cccdca4eb9d8a211b79b2a7839f280f285db1eabce22f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "f37509fde855af55bbb2054ce5c849f0c2411a612933aff51e330715bb646f5e"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "bbb4c7627e3d449284f20d79cf8392686fca7066043777092a455fabbaaf9ad7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "3e613cdb185cff68b8cb657cbe89f29858828cb5fec4763b25b0450f617f54ac"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "add464ba1af538d9ac0e4a5b739ede0ec5601e0fb380a07b6695d69fd95fa166"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "f3a6cb427ac9687ba81bdcfd77268ff96265e5b679c5b9d857e26bdb4f5f3593"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "3623423261a3db1d58750d98cc71950f21ebdab355103eab192f60db90834f29"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "abd5217c43cf1315054e900a3f326a301ba5e87579c1771ff649b6f5edd94d5e"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "d593f160508714b5d2e4c194c354daf16064d36505ae8e75b86fa9e8eae1c8ab"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "9ee5f7b09fe5b6646b969f4fcfd89479e3405457c86fc5bf74d30079712a0bb3"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "2d0ad2cb9bf5c0e6497e4a1f7602b7868653b303c249f2034fd6b3b95e0db194"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "53c468f8e56251ba7ff3f44e0ed00a4c4fe021d0cc8623ba8725addee066bd0b"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "2b4368fae7354431fbb66906a703f3c519bbcc71f46dd7e01d4874c911219990"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "16b8fef66fd39eb87f8b071fde864d2b81f903d3681ac831c9394b3327cc4cc1"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "778b48e8e451f3440fb02dda27e87a3a1c2fc8b5e1ae1386398e30fb698fc808"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "11b14a77520d4a2d4576d29726a48df6099efbd3698acb9f21539f4aecd8cb07"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "849f717627cc42919480bb35650e5e47c74fe39da40d1fe173f3b789abf5e3fc"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "d64d856bb555ef4a11df92a23eaa441db98c8f412feb412047da6d76fae76898"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "b570507f05e25379e0e3cd9f0bd9562d2fc87c8cba4eada865cfd22a94abab1b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "1c37eeadd82d49406ae3d554ac37b05e93a4648e82ffaedf7d43ae2e3ea5ea96"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "d28e86d1aba3274a7ed13278d9852956f454c4bc1da30a1df9c0b1184aa41ed1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "937eae561cef4f2a084268d02984393f6c963bbe6effb5b407ba73ee715d38df"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "d7364c02738d90b1f9aaf48c5dfd17d0393333fe1a67002e522fe4cf429118e7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "83fb940a35c030c0ada591b30929f891f313496759a3aa0bd5956d2fb5352d81"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "973358a62e4cbdd955097e9bdcbec7aacc439123486439aafcd1bb5af5828571"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "63cafab564b813e7275acfccf0da6e39520541900c59c43a25c3c128a5a739fd"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "aaee9b9bf92cf42bbcb2862dd0bfaa217730ebfe69947926a6fd624b9ba19dcf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "10d15dfa11d37bfa6818f50e143ee9747667412d87546c48c213d1f3ea592e94"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "4eeb361e1946f56d6fa2dd0a0beee094d0818a4f4278b1531c3a481c349ac4a1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "9c1d892ff927f82c5b403b0ef8f8e113dbd2515040fd24ea0556fc75de68bff7"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "be8b6a4d3823c2e4f22df991236227415a771794e3631ce228f89f9f3363cdaf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.35.0%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "49cc7202498496512f5320a70d544519bfbfe45e4893a678aebb2ab76a2dda6f"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_35/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_35/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.35.0+rke2r1";
-  rke2Commit = "233368982cc7242d3eb01e22112343839e8e8f2d";
-  rke2TarballHash = "sha256-spnfiv5butC6yh9h3uosS0M5jTbPAuy6N+jzdri9Ano=";
-  rke2VendorHash = "sha256-DSIhALF+Ic1zm52YntGoBbbJkeq0SX7QkpyOQ9z2+Qo=";
-  k8sImageTag = "v1.35.0-rke2r1-build20251218";
-  etcdVersion = "v3.6.6-k3s1-build20251210";
+  rke2Version = "1.35.0+rke2r3";
+  rke2Commit = "25ce2b8aa70af95611e0cd762079bbd1ee0006df";
+  rke2TarballHash = "sha256-HCdUc15OIQy+UBSXnaXift8KGbD2PfQCBuCacGKWjKw=";
+  rke2VendorHash = "sha256-gWb2rTpyAxhnl/OSzApsk/Ryo9tQud65a4TJC4d1eU4=";
+  k8sImageTag = "v1.35.0-rke2r3-build20260127";
+  etcdVersion = "v3.6.7-k3s1-build20260126";
   pauseVersion = "3.6";
   ccmVersion = "v1.35.0-rc1.0.20251218152248-a6c6cd15c0c4-build20251219";
-  dockerizedVersion = "v1.35.0-rke2r1";
+  dockerizedVersion = "v1.35.0-rke2r3";
   helmJobVersion = "v0.9.12-build20251215";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }


### PR DESCRIPTION
RKE2 counterpart to #487047, updates everything `rke2r1 -> rke2r3`:

https://github.com/rancher/rke2/releases/tag/v1.32.11%2Brke2r3
https://github.com/rancher/rke2/releases/tag/v1.33.7%2Brke2r3
https://github.com/rancher/rke2/releases/tag/v1.34.3%2Brke2r3
https://github.com/rancher/rke2/releases/tag/v1.35.0%2Brke2r3

The v1.34 upgrade warning from v1.32 & v1.33 also applies to RKE2, and is copied to the relevant commit messages. All tests passed locally.

cc @rorosen @zimbatm @stefan-bordei

PS: Should we be making one big PR like this if multiple versions update at once, or would it be better to make a separate one for each? Like this backports need to be manual if the newest minor version isn't on stable (like v1.35 right now).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
