### PR TITLE
nixos/netbird: add client options for DNS, routing, SSH, rosenpass an…

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25089,6 +25089,12 @@
     github = "shunueda";
     githubId = 62182668;
   };
+  shuuri-labs = {
+    name = "Ashley Mensah";
+    email = "ashley@netbird.io";
+    github = "shuuri-labs";
+    githubId = 61762328;
+  };
   shved = {
     name = "Yury Shvedov";
     email = "mestofel13@gmail.com";

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1202,6 +1202,27 @@
   "module-services-netbird-customization": [
     "index.html#module-services-netbird-customization"
   ],
+  "module-services-netbird-client-configuration": [
+    "index.html#module-services-netbird-client-configuration"
+  ],
+  "module-services-netbird-dns": [
+    "index.html#module-services-netbird-dns"
+  ],
+  "module-services-netbird-routing": [
+    "index.html#module-services-netbird-routing"
+  ],
+  "module-services-netbird-rosenpass": [
+    "index.html#module-services-netbird-rosenpass"
+  ],
+  "module-services-netbird-ssh": [
+    "index.html#module-services-netbird-ssh"
+  ],
+  "module-services-netbird-connection": [
+    "index.html#module-services-netbird-connection"
+  ],
+  "module-services-netbird-selfhosted": [
+    "index.html#module-services-netbird-selfhosted"
+  ],
   "module-services-mosquitto": [
     "index.html#module-services-mosquitto"
   ],

--- a/nixos/modules/services/networking/netbird.md
+++ b/nixos/modules/services/networking/netbird.md
@@ -86,6 +86,117 @@ Each Netbird client service by default:
 on demand, for example to connect to work-related or otherwise conflicting network only when required.
 See the option description for more information.
 
-[environment](#opt-services.netbird.clients._name_.environment) allows you to pass additional configurations
-through environment variables, but special care needs to be taken for overriding config location and
-daemon address due [hardened](#opt-services.netbird.clients._name_.hardened) option.
+## Client configuration {#module-services-netbird-client-configuration}
+
+Following [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md), the NetBird
+client module provides two escape hatches for configuring upstream settings instead of individual typed
+options:
+
+- [`extraEnvironment`](#opt-services.netbird.clients._name_.extraEnvironment) — set `NB_*` environment
+  variables that the NetBird client reads at startup. Values set here take precedence over the
+  module's computed defaults.
+- [`config`](#opt-services.netbird.clients._name_.config) — set keys in `config.json` (merged via
+  `preStart`). This is useful for settings that are not exposed as environment variables.
+
+See the
+[NetBird environment variable reference](https://docs.netbird.io/how-to/cli/environment-variables)
+for the full list of supported `NB_*` variables.
+
+### DNS {#module-services-netbird-dns}
+
+```nix
+{
+  services.netbird.clients.work = {
+    port = 51820;
+    extraEnvironment = {
+      NB_DISABLE_DNS = "true";
+      NB_EXTRA_DNS_LABELS = "myserver=10.0.0.5";
+      NB_DNS_ROUTER_INTERVAL = "5000";
+    };
+  };
+}
+```
+
+### Routing and firewall {#module-services-netbird-routing}
+
+```nix
+{
+  services.netbird.clients.restricted = {
+    port = 51820;
+    extraEnvironment = {
+      NB_DISABLE_CLIENT_ROUTES = "true";
+      NB_DISABLE_SERVER_ROUTES = "true";
+      NB_BLOCK_LAN_ACCESS = "true";
+      NB_BLOCK_INBOUND = "true";
+      NB_DISABLE_FIREWALL = "true";
+    };
+  };
+}
+```
+
+### Rosenpass (post-quantum cryptography) {#module-services-netbird-rosenpass}
+
+```nix
+{
+  services.netbird.clients.secure = {
+    port = 51820;
+    extraEnvironment = {
+      NB_ENABLE_ROSENPASS = "true";
+      NB_ROSENPASS_PERMISSIVE = "true"; # allow connections with non-Rosenpass peers
+    };
+  };
+}
+```
+
+See [the NetBird docs](https://docs.netbird.io/how-to/enable-post-quantum-cryptography) for more information.
+
+### SSH {#module-services-netbird-ssh}
+
+```nix
+{
+  services.netbird.clients.withSsh = {
+    port = 51820;
+    extraEnvironment = {
+      NB_ALLOW_SERVER_SSH = "true";
+      NB_SSH_ALLOW_SFTP = "true";
+      NB_SSH_ALLOW_LOCAL_PORT_FORWARDING = "true";
+    };
+  };
+}
+```
+
+### Connection and hostname {#module-services-netbird-connection}
+
+```nix
+{
+  services.netbird.clients.lazy = {
+    port = 51820;
+    extraEnvironment = {
+      NB_ENABLE_LAZY_CONNECTION = "true";
+      NB_DISABLE_NETWORK_MONITOR = "true";
+      NB_HOSTNAME = "my-custom-hostname";
+      NB_ANONYMIZE = "true";
+    };
+  };
+}
+```
+
+### Self-hosted deployments (config.json) {#module-services-netbird-selfhosted}
+
+For self-hosted NetBird deployments, use the `config` option to set `config.json` keys:
+
+```nix
+{
+  services.netbird.clients.selfhosted = {
+    port = 51820;
+    config = {
+      ManagementURL = "https://management.example.com:443";
+      AdminURL = "https://admin.example.com:443";
+      Mtu = 1280;
+    };
+  };
+}
+```
+
+Consult [the source code](https://github.com/netbirdio/netbird/blob/88747e3e0191abc64f1e8c7ecc65e5e50a1527fd/client/internal/config.go#L49-L82)
+or inspect an existing `config.json` for a complete list of available keys.

--- a/nixos/modules/services/networking/netbird.nix
+++ b/nixos/modules/services/networking/netbird.nix
@@ -74,7 +74,7 @@ let
 in
 {
   meta.maintainers = with maintainers; [
-    nazarewk
+    shuuri-labs
   ];
   meta.doc = ./netbird.md;
 
@@ -180,6 +180,17 @@ in
                 '';
               };
 
+              extraEnvironment = mkOption {
+                type = attrsOf str;
+                default = { };
+                description = ''
+                  Additional environment variables to pass to the NetBird service.
+
+                  These are merged with the computed environment variables, with
+                  values from this option taking precedence on conflicts.
+                '';
+              };
+
               interface = mkOption {
                 type = str;
                 default = "nb-${client.name}";
@@ -208,6 +219,7 @@ in
                   } // optionalAttrs (client.dns-resolver.address != null) {
                     NB_DNS_RESOLVER_ADDRESS = "''${client.dns-resolver.address}:''${toString client.dns-resolver.port}";
                   }
+                  // client.extraEnvironment
                 '';
                 description = ''
                   Environment for the netbird service, used to pass configuration options.
@@ -275,10 +287,9 @@ in
                   - `CAP_NET_RAW`, `CAP_NET_ADMIN` and `CAP_BPF` still give unlimited network manipulation possibilites,
                   - older kernels don't have `CAP_BPF` and use `CAP_SYS_ADMIN` instead,
 
-                  Known security features that are not (yet) integrated into the module:
-                  - 2024-02-14: `rosenpass` is an experimental feature configurable solely
-                    through `--enable-rosenpass` flag on the `netbird up` command,
-                    see [the docs](https://docs.netbird.io/how-to/enable-post-quantum-cryptography)
+                  For post-quantum cryptography, set `NB_ENABLE_ROSENPASS = "true"` in
+                  [`extraEnvironment`](#opt-services.netbird.clients._name_.extraEnvironment).
+                  See [the docs](https://docs.netbird.io/how-to/enable-post-quantum-cryptography).
                 '';
               };
 
@@ -447,7 +458,8 @@ in
             }
             // optionalAttrs (client.dns-resolver.address != null) {
               NB_DNS_RESOLVER_ADDRESS = "${client.dns-resolver.address}:${toString client.dns-resolver.port}";
-            };
+            }
+            // client.extraEnvironment;
 
             config.config = {
               DisableAutoConnect = !client.autoStart;

--- a/nixos/tests/netbird.nix
+++ b/nixos/tests/netbird.nix
@@ -12,6 +12,24 @@
         enable = true;
         clients.custom.port = 51819;
         ui.enable = true;
+
+        # Test extraEnvironment escape hatch
+        clients.envtest = {
+          port = 51830;
+          extraEnvironment = {
+            NB_DISABLE_DNS = "true";
+            NB_HOSTNAME = "test-peer";
+          };
+        };
+
+        # Test config escape hatch
+        clients.configtest = {
+          port = 51831;
+          config = {
+            ManagementURL = "https://management.example.com:443";
+            Mtu = 1280;
+          };
+        };
       };
     };
   };
@@ -79,7 +97,7 @@
           retry(check_success, retries)
           return output
 
-    instances = ["netbird", "netbird-custom"]
+    instances = ["netbird", "netbird-custom", "netbird-envtest", "netbird-configtest"]
 
     for name in instances:
       node.wait_for_unit(f"{name}.service")
@@ -87,6 +105,15 @@
 
     for name in instances:
       wait_until_rcode(node, f"{name} status |& grep -C20 Disconnected", 0, retries=5)
+
+    # Verify extraEnvironment variables are set correctly
+    node.succeed("systemctl show netbird-envtest.service --property=Environment | grep -q NB_DISABLE_DNS=true")
+    node.succeed("systemctl show netbird-envtest.service --property=Environment | grep -q NB_HOSTNAME=test-peer")
+
+    # Verify config.json contains ManagementURL and Mtu
+    node.succeed("cat /etc/netbird-configtest/config.d/50-nixos.json | grep -q 'ManagementURL'")
+    node.succeed("cat /etc/netbird-configtest/config.d/50-nixos.json | grep -q 'management.example.com'")
+    node.succeed("cat /etc/netbird-configtest/config.d/50-nixos.json | grep -q '\"Mtu\": 1280'")
   ''
   # The status used to turn into `NeedsLogin`, but recently started crashing instead.
   # leaving the snippets in here, in case some update goes back to the old behavior and can be tested again


### PR DESCRIPTION
…d connection

## Motivation

The NetBird client module currently requires users to manually set NB_* environment variables via the environment option to configure features like DNS, routing, SSH, Rosenpass, and self-hosted server URLs. However, environment uses NixOS module merging, which rejects conflicts with module-computed keys (like NB_STATE_DIR), making it awkward to use as an escape hatch.

Rather than adding individual typed options for every upstream setting  (which RFC 0042 recommends against) this adds a proper extraEnvironment escape hatch and documents how to use it alongside the existing config option.

## Changes

- extraEnvironment option: New attrsOf str option that merges with computed environment variables using //, so user values cleanly override module defaults. This is the RFC 0042 "structural escape hatch" pattern.
- Documentation rewrite (netbird.md): Replaces the minimal docs with categorized examples showing how to configure DNS, routing, firewall, Rosenpass, SSH, connection behavior, hostname/debug, and self-hosted deployments using extraEnvironment and config. Links to the upstream env var reference.
- Redirects (redirects.json): Adds entries for the new documentation sections.
- Tests (nixos/tests/netbird.nix): Adds test clients exercising both escape hatches - envtest verifies NB_* vars from extraEnvironment appear in the systemd service environment, configtest verifies config values appear in config.d/50-nixos.json.
- Hardened option description: Updates the rosenpass cross-reference to point at extraEnvironment instead of a non-existent typed option.

## How to test

```bash
nix build .#checks.x86_64-linux.nixosTests.netbird -L
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
