### PR TITLE
tellico: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/te/tellico/package.nix
+++ b/pkgs/by-name/te/tellico/package.nix
@@ -4,26 +4,13 @@
   fetchFromGitLab,
   cmake,
   exempi,
-  extra-cmake-modules,
-  karchive,
-  kdoctools,
-  kfilemetadata,
-  kitemmodels,
-  knewstuff,
-  kxmlgui,
   libcdio,
-  libkcddb,
-  libksane,
   makeWrapper,
-  poppler,
-  qtcharts,
-  qtwebengine,
-  solid,
   taglib,
-  wrapQtAppsHook,
+  kdePackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tellico";
   version = "4.1.4";
 
@@ -31,32 +18,32 @@ stdenv.mkDerivation rec {
     domain = "invent.kde.org";
     owner = "office";
     repo = "tellico";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-eScAOd1da05fqXtbcz8oEJiObB7CUxiYReSrr3R7ybM=";
   };
 
   nativeBuildInputs = [
     cmake
-    extra-cmake-modules
-    kdoctools
+    kdePackages.extra-cmake-modules
+    kdePackages.kdoctools
     makeWrapper
-    wrapQtAppsHook
+    kdePackages.wrapQtAppsHook
   ];
 
   buildInputs = [
     exempi
-    karchive
-    kfilemetadata
-    kitemmodels
-    knewstuff
-    kxmlgui
+    kdePackages.karchive
+    kdePackages.kfilemetadata
+    kdePackages.kitemmodels
+    kdePackages.knewstuff
+    kdePackages.kxmlgui
     libcdio
-    libkcddb
-    libksane
-    poppler
-    qtcharts
-    qtwebengine
-    solid
+    kdePackages.libkcddb
+    kdePackages.libksane
+    kdePackages.poppler
+    kdePackages.qtcharts
+    kdePackages.qtwebengine
+    kdePackages.solid
     taglib
   ];
 
@@ -72,4 +59,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ numkem ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12788,8 +12788,6 @@ with pkgs;
     hasktags = haskellPackages.hasktags;
   };
 
-  tellico = kdePackages.callPackage ../applications/misc/tellico { };
-
   termpdfpy = python3Packages.callPackage ../applications/misc/termpdf.py { };
 
   inherit (callPackage ../applications/networking/cluster/terraform { })


### PR DESCRIPTION
This pull request reorganizes and modernizes the packaging of the `tellico` application. The package definition is moved to the new by-name directory structure, and dependencies are updated to use the `kdePackages` set for improved maintainability and consistency. The old reference in the top-level package list is removed.

**Package relocation and modernization:**

* Moved the `tellico` package definition from `pkgs/applications/misc/tellico/default.nix` to `pkgs/by-name/te/tellico/package.nix`, updating the file to follow the new by-name structure.
* Updated the package to use dependencies from the `kdePackages` set (e.g., `kdePackages.karchive`, `kdePackages.kdoctools`) instead of referencing them individually, simplifying maintenance and improving consistency.
* Changed the derivation style to use the `finalAttrs` pattern for improved Nixpkgs compatibility.

**Top-level package list cleanup:**

* Removed the old `tellico` entry from `pkgs/top-level/all-packages.nix`, as it is now managed through the new by-name packaging system.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
