### PR TITLE
keyfinder-cli: 1.1.2 -> 1.2.0

### DIFF
--- a/pkgs/by-name/ke/keyfinder-cli/package.nix
+++ b/pkgs/by-name/ke/keyfinder-cli/package.nix
@@ -5,28 +5,31 @@
   ffmpeg,
   libkeyfinder,
   fftw,
+  cmake,
+  pkg-config,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "keyfinder-cli";
-  version = "1.1.2";
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     repo = "keyfinder-cli";
     owner = "EvanPurkhiser";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-9/+wzPTaQ5PfPiqTZ5EuHdswXJgfgnvAul/FeeDbbJA=";
+    hash = "sha256-WdZ5jiq5bfwiq1RK4XDRhqh2gAukq3hLCA56K/f+84g=";
   };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
 
   buildInputs = [
     ffmpeg
     libkeyfinder
     fftw
   ];
-
-  makeFlags = [ "PREFIX=$(out)" ];
-
-  enableParallelBuilding = true;
 
   meta = {
     inherit (finalAttrs.src.meta) homepage;


### PR DESCRIPTION
https://github.com/evanpurkhiser/keyfinder-cli/releases/tag/v1.2.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
