### PR TITLE
sail-riscv: migrate to by-name, modernize derivation

### DIFF
--- a/pkgs/by-name/sa/sail-riscv/package.nix
+++ b/pkgs/by-name/sa/sail-riscv/package.nix
@@ -5,19 +5,19 @@
   cmake,
   gmp,
   pkg-config,
-  sail,
+  ocamlPackages,
   ninja,
   z3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sail-riscv";
   version = "0.8";
 
   src = fetchFromGitHub {
     owner = "riscv";
     repo = "sail-riscv";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-50ATe3DQcdyNOqP85mEMyEwxzpBOplzRN9ulaJNo9zo=";
   };
 
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     cmake
     pkg-config
     ninja
-    sail
+    ocamlPackages.sail
   ];
   buildInputs = [
     gmp
@@ -42,4 +42,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     license = lib.licenses.bsd2;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12758,10 +12758,6 @@ with pkgs;
     waylandSupport = true;
   };
 
-  sail-riscv = callPackage ../applications/virtualization/sail-riscv {
-    inherit (ocamlPackages) sail;
-  };
-
   mfcj470dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj470dwlpr { };
 
   mfcj6510dwlpr = pkgsi686Linux.callPackage ../misc/cups/drivers/mfcj6510dwlpr { };


### PR DESCRIPTION
This pull request reorganizes the `sail-riscv` package in the Nixpkgs repository and updates its dependencies and packaging approach. The main changes include moving the package to a new location, updating its dependency handling to use `ocamlPackages.sail`, and refactoring the packaging code to modern standards.

**Package relocation and refactoring:**

* Moved the `sail-riscv` package from `pkgs/applications/virtualization/sail-riscv/default.nix` to `pkgs/by-name/sa/sail-riscv/package.nix`, aligning with the new by-name directory structure.
* Refactored the package definition to use the `finalAttrs` argument style in `stdenv.mkDerivation` for improved maintainability and consistency.

**Dependency and build improvements:**

* Updated the dependency from `sail` to `ocamlPackages.sail`, and adjusted the input handling to use `ocamlPackages` directly, ensuring more robust dependency management.

* Changed the source fetch method to use the `tag` attribute instead of `rev`, improving clarity and correctness in version referencing.

**Repository-wide updates:**

* Removed the old `sail-riscv` package entry from `pkgs/top-level/all-packages.nix`, as the package is now managed in the new location and format.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
