### PR TITLE
[Backport release-25.11] wine: Make `base.nix` and `package.nix` not know about `wineRelease`

### DIFF
--- a/pkgs/applications/emulators/wine/base.nix
+++ b/pkgs/applications/emulators/wine/base.nix
@@ -18,7 +18,7 @@
   pkg-config,
   nixosTests,
   supportFlags,
-  wineRelease,
+  pnameSuffix ? "",
   patches,
   moltenvk,
   buildScript ? null,
@@ -95,9 +95,7 @@ stdenv.mkDerivation (
   // {
     inherit version src;
 
-    pname =
-      prevName
-      + lib.optionalString (wineRelease != "stable" && wineRelease != "unstable") "-${wineRelease}";
+    pname = prevName + pnameSuffix;
 
     # Fixes "Compiler cannot create executables" building wineWow with mingwSupport
     strictDeps = true;

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -47,49 +47,44 @@
   moltenvk, # Allow users to override MoltenVK easily
 }:
 
-let
-  wine-build =
-    build:
-    lib.getAttr build (
-      callPackage ./packages.nix {
-        inherit wineRelease;
-        supportFlags = {
-          inherit
-            alsaSupport
-            cairoSupport
-            cupsSupport
-            cursesSupport
-            dbusSupport
-            embedInstallers
-            fontconfigSupport
-            gettextSupport
-            gphoto2Support
-            gstreamerSupport
-            gtkSupport
-            krb5Support
-            mingwSupport
-            netapiSupport
-            odbcSupport
-            openclSupport
-            openglSupport
-            pcapSupport
-            pulseaudioSupport
-            saneSupport
-            sdlSupport
-            tlsSupport
-            udevSupport
-            usbSupport
-            v4lSupport
-            vaSupport
-            vulkanSupport
-            waylandSupport
-            x11Support
-            ffmpegSupport
-            xineramaSupport
-            ;
-        };
-        inherit moltenvk;
-      }
-    );
-in
-wine-build wineBuild
+lib.getAttr wineBuild (
+  callPackage ./packages.nix {
+    inherit wineRelease;
+    supportFlags = {
+      inherit
+        alsaSupport
+        cairoSupport
+        cupsSupport
+        cursesSupport
+        dbusSupport
+        embedInstallers
+        fontconfigSupport
+        gettextSupport
+        gphoto2Support
+        gstreamerSupport
+        gtkSupport
+        krb5Support
+        mingwSupport
+        netapiSupport
+        odbcSupport
+        openclSupport
+        openglSupport
+        pcapSupport
+        pulseaudioSupport
+        saneSupport
+        sdlSupport
+        tlsSupport
+        udevSupport
+        usbSupport
+        v4lSupport
+        vaSupport
+        vulkanSupport
+        waylandSupport
+        x11Support
+        ffmpegSupport
+        xineramaSupport
+        ;
+    };
+    inherit moltenvk;
+  }
+)

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -47,44 +47,77 @@
   moltenvk, # Allow users to override MoltenVK easily
 }:
 
-lib.getAttr wineBuild (
-  callPackage ./packages.nix {
-    inherit wineRelease;
-    supportFlags = {
-      inherit
-        alsaSupport
-        cairoSupport
-        cupsSupport
-        cursesSupport
-        dbusSupport
-        embedInstallers
-        fontconfigSupport
-        gettextSupport
-        gphoto2Support
-        gstreamerSupport
-        gtkSupport
-        krb5Support
-        mingwSupport
-        netapiSupport
-        odbcSupport
-        openclSupport
-        openglSupport
-        pcapSupport
-        pulseaudioSupport
-        saneSupport
-        sdlSupport
-        tlsSupport
-        udevSupport
-        usbSupport
-        v4lSupport
-        vaSupport
-        vulkanSupport
-        waylandSupport
-        x11Support
-        ffmpegSupport
-        xineramaSupport
-        ;
+let
+  sources = callPackage ./sources.nix { };
+
+  # Map user-facing release names to sources, pname suffix, and staging flag
+  releaseInfo = {
+    stable = {
+      src = sources.stable;
+      useStaging = false;
     };
-    inherit moltenvk;
-  }
+    unstable = {
+      src = sources.unstable;
+      useStaging = false;
+    };
+    # Many versions have a "staging" variant, but when we say "staging",
+    # the version we want to use is "unstable".
+    staging = {
+      src = sources.unstable;
+      pnameSuffix = "-staging";
+      useStaging = true;
+    };
+    # "yabridge" enables staging too --- we are not interested in
+    # yabridge without the staging patches applied.
+    yabridge = {
+      src = sources.yabridge;
+      pnameSuffix = "-yabridge";
+      useStaging = true;
+    };
+  };
+
+in
+
+lib.getAttr wineBuild (
+  callPackage ./packages.nix (
+    releaseInfo.${wineRelease}
+    // {
+      supportFlags = {
+        inherit
+          alsaSupport
+          cairoSupport
+          cupsSupport
+          cursesSupport
+          dbusSupport
+          embedInstallers
+          fontconfigSupport
+          gettextSupport
+          gphoto2Support
+          gstreamerSupport
+          gtkSupport
+          krb5Support
+          mingwSupport
+          netapiSupport
+          odbcSupport
+          openclSupport
+          openglSupport
+          pcapSupport
+          pulseaudioSupport
+          saneSupport
+          sdlSupport
+          tlsSupport
+          udevSupport
+          usbSupport
+          v4lSupport
+          vaSupport
+          vulkanSupport
+          waylandSupport
+          x11Support
+          ffmpegSupport
+          xineramaSupport
+          ;
+      };
+      inherit moltenvk;
+    }
+  )
 )

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -7,7 +7,9 @@
   callPackage,
   replaceVars,
   moltenvk,
-  wineRelease ? "stable",
+  src,
+  pnameSuffix ? "",
+  useStaging ? false,
   supportFlags,
   # Staging native build deps
   autoconf,
@@ -18,19 +20,6 @@
 }:
 
 let
-  sources = callPackage ./sources.nix { };
-
-  # "staging" of course enables staging, but for "yabridge" we do too
-  # --- we are not interested in yabridge without the staging patches
-  # applied.
-  useStaging = wineRelease == "staging" || wineRelease == "yabridge";
-
-  # Map wineRelease to actual source. Many versions have a "staging"
-  # variant, but when we say "staging", the version we want to use is
-  # "unstable".
-  baseRelease = if wineRelease == "staging" then "unstable" else wineRelease;
-
-  src = lib.getAttr baseRelease (callPackage ./sources.nix { });
   inherit (src)
     version
     patches
@@ -48,7 +37,7 @@ in
       supportFlags
       patches
       moltenvk
-      wineRelease
+      pnameSuffix
       useStaging
       # Forcing these `nativeBuildInputs` used in the `staging` to come
       # from ambient `pkgs`, rather than being provided by
@@ -76,7 +65,7 @@ in
       supportFlags
       patches
       moltenvk
-      wineRelease
+      pnameSuffix
       useStaging
       ;
     pkgArches = [ pkgs ];
@@ -98,7 +87,7 @@ in
       supportFlags
       patches
       moltenvk
-      wineRelease
+      pnameSuffix
       useStaging
       ;
     stdenv = stdenv_32bit;
@@ -132,7 +121,7 @@ in
       version
       patches
       moltenvk
-      wineRelease
+      pnameSuffix
       useStaging
       ;
     supportFlags = supportFlags // {


### PR DESCRIPTION
Manual backport of #487421

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
