### PR TITLE
jfrog-cli: 2.78.10 -> 2.98.0

### DIFF
--- a/pkgs/by-name/jf/jfrog-cli/package.nix
+++ b/pkgs/by-name/jf/jfrog-cli/package.nix
@@ -4,21 +4,22 @@
   fetchFromGitHub,
   nodejs,
   nix-update-script,
+  curl,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "jfrog-cli";
-  version = "2.78.10";
+  version = "2.98.0";
 
   src = fetchFromGitHub {
     owner = "jfrog";
     repo = "jfrog-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-o3H+onnvGFGxUtFRYFHmrEQ5EqQCGP8n/NdqdEHNj84=";
+    hash = "sha256-ADVjR2l03p1/lGzThIeFNZbMGAQ2r5IwOJ7l/2JUbTc=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-jzjYFnctUwQUVC59JIsrHTIWCqYiZTurNFLn9zuM+18=";
+  vendorHash = "sha256-etxagQWxKlYmJCuvwa7VXKUfkK4EaDR2R4YPzfUx8ug=";
 
   checkFlags = "-skip=^TestReleaseBundle";
 
@@ -30,7 +31,10 @@ buildGoModule (finalAttrs: {
   # Some of the tests require a writable $HOME
   preCheck = "export HOME=$TMPDIR";
 
-  nativeCheckInputs = [ nodejs ];
+  nativeCheckInputs = [
+    nodejs
+    curl
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
https://github.com/jfrog/jfrog-cli/releases/tag/v2.98.0

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
