### PR TITLE
nixos/firefly-iii-data-importer: create missing storage/import-jobs dir

### DIFF
--- a/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
+++ b/nixos/modules/services/web-apps/firefly-iii-data-importer.nix
@@ -267,6 +267,7 @@ in
           "${cfg.dataDir}/storage/framework/sessions"
           "${cfg.dataDir}/storage/framework/testing"
           "${cfg.dataDir}/storage/framework/views"
+          "${cfg.dataDir}/storage/import-jobs"
           "${cfg.dataDir}/storage/jobs"
           "${cfg.dataDir}/storage/logs"
           "${cfg.dataDir}/storage/submission-routines"


### PR DESCRIPTION
Data importer shows a warning if this directory does not exist since 2.0.0.

https://github.com/firefly-iii/data-importer/commit/b791a19b0c326b895fb962794633544ea5951d8d#diff-e1f5f65898d53a762d4676492d99c81863e1e30f61a1af2c06d0acccf28c513f

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
