### PR TITLE
opentrack: 2026.1.0-unstable-2026-01-03 -> 2026.1.0-unstable-2026-01-24

### DIFF
--- a/pkgs/by-name/op/opentrack/package.nix
+++ b/pkgs/by-name/op/opentrack/package.nix
@@ -18,6 +18,7 @@
   wineWow64Packages,
   onnxruntime,
   nix-update-script,
+  v4l-utils,
   withWine ? stdenv.targetPlatform.isx86_64,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -90,7 +91,8 @@ stdenv.mkDerivation (finalAttrs: {
   # manually wrap just the main binary
   dontWrapQtApps = true;
   preFixup = ''
-    wrapQtApp $out/bin/opentrack
+    wrapQtApp $out/bin/opentrack \
+      --prefix PATH : ${lib.makeBinPath [ v4l-utils ]}
   '';
 
   desktopItems = [

--- a/pkgs/by-name/op/opentrack/package.nix
+++ b/pkgs/by-name/op/opentrack/package.nix
@@ -22,13 +22,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "opentrack";
-  version = "2026.1.0-unstable-2026-01-03";
+  version = "2026.1.0-unstable-2026-01-24";
 
   src = fetchFromGitHub {
     owner = "opentrack";
     repo = "opentrack";
-    rev = "0779d3ce9da19d46919e909d0a1a252d67122db9";
-    hash = "sha256-n7XCNNXgfwU4q27Q7ss9tgc2Z/tmzcRxUP4chwpPN38=";
+    rev = "2d3ab7a61d2514ce51c9656908d33465a788763e";
+    hash = "sha256-+Xb3zlybQrrc1AiTdYXxDhuFNN7g7u7ryM7da2EJpaY=";
   };
 
   aruco = callPackage ./aruco.nix { };
@@ -38,6 +38,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-zay5QrHJctllVFl+JhlyTDzH68h5UoxncEt+TpW3UgI=";
     # see license.txt inside the zip file
     meta.license = lib.licenses.free;
+  };
+
+  fusion = fetchFromGitHub {
+    owner = "xioTechnologies";
+    repo = "Fusion";
+    tag = "v1.2.11";
+    hash = "sha256-9bqqP+6kfdRWIRnnP+R0lXSQs6OmZoNlbCjqiJeJjpk=";
   };
 
   patches = [
@@ -69,6 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   cmakeFlags = [
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_AHRSFUSION" "${finalAttrs.fusion}")
     (lib.cmakeFeature "OPENTRACK_COMMIT" "opentrack-${finalAttrs.version}")
     (lib.cmakeBool "SDK_WINE" withWine)
     (lib.cmakeFeature "SDK_ARUCO_LIBPATH" "${finalAttrs.aruco}/lib/libaruco.a")


### PR DESCRIPTION
As mentioned in #486900, adding the new dependency which is currently tripping up nixpkgs-update: https://nixpkgs-update-logs.nix-community.org/opentrack/2026-01-31.log

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
