### PR TITLE
python3Packages.urwid: 3.0.4 -> 3.0.5

### DIFF
--- a/pkgs/by-name/to/todoman/package.nix
+++ b/pkgs/by-name/to/todoman/package.nix
@@ -90,8 +90,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "test_xdg_existant"
     # Tests are sensitive to performance
     "test_sorting_fields"
-    # Test fails with urwid 3.0.4, but should work with 3.0.5 again
-    "test_todo_editor_list"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/urwid/default.nix
+++ b/pkgs/development/python-modules/urwid/default.nix
@@ -7,6 +7,7 @@
   pygobject3,
   pyserial,
   pytestCheckHook,
+  pythonOlder,
   pyzmq,
   setuptools,
   setuptools-scm,
@@ -19,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "urwid";
-  version = "3.0.4";
+  version = "3.0.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "urwid";
     repo = "urwid";
     tag = version;
-    hash = "sha256-mKBLAoEBiqr//1Gl8DAmpUJ9woq6Zf2HhbYEirAoi2M=";
+    hash = "sha256-9ajcpyQTSASz8A4eM78vPjL+9Rk07Q30JmIrSx0Crpo=";
   };
 
   postPatch = ''
@@ -44,12 +45,10 @@ buildPythonPackage rec {
   ];
 
   optional-dependencies = {
+    curses = [ ];
     glib = [ pygobject3 ];
     tornado = [ tornado ];
-    trio = [
-      exceptiongroup
-      trio
-    ];
+    trio = [ trio ] ++ lib.optionals (pythonOlder "3.11") [ exceptiongroup ];
     twisted = [ twisted ];
     zmq = [ pyzmq ];
     serial = [ pyserial ];


### PR DESCRIPTION
Diff: https://github.com/urwid/urwid/compare/3.0.4...3.0.5

Changelog: https://github.com/urwid/urwid/releases/tag/3.0.5


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
