### PR TITLE
chiaki: 2.2.0 -> 2.2.0-unstable-2026-01-04

### DIFF
--- a/pkgs/by-name/ch/chiaki/package.nix
+++ b/pkgs/by-name/ch/chiaki/package.nix
@@ -4,7 +4,7 @@
   fetchgit,
   cmake,
   pkg-config,
-  ffmpeg_7,
+  ffmpeg,
   libopus,
   SDL2,
   libevdev,
@@ -15,13 +15,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "chiaki";
-  version = "2.2.0";
+  version = "2.2.0-unstable-2026-01-04";
 
   src = fetchgit {
     url = "https://git.sr.ht/~thestr4ng3r/chiaki";
-    tag = "v${finalAttrs.version}";
+    rev = "ab55cf4c95f7723faae08a546fbe14e0f6bddf45";
     fetchSubmodules = true;
-    hash = "sha256-mLx2ygMlIuDJt9iT4nIj/dcLGjMvvmneKd49L7C3BQk=";
+    hash = "sha256-GYhbq3QCyykMu5K1ITJ+XqNU593Gn3eBTM9coKmh/Vk=";
   };
 
   nativeBuildInputs = [
@@ -30,14 +30,8 @@ stdenv.mkDerivation (finalAttrs: {
     libsForQt5.wrapQtAppsHook
   ];
 
-  postPatch = ''
-    substituteInPlace CMakeLists.txt --replace-fail \
-    'cmake_minimum_required(VERSION 3.2)' \
-    'cmake_minimum_required(VERSION 3.5)'
-  '';
-
   buildInputs = [
-    ffmpeg_7 # needs avcodec_close which was removed in ffmpeg 8
+    ffmpeg
     libopus
     libsForQt5.qtbase
     libsForQt5.qtmultimedia


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes: https://hydra.nixos.org/build/319702508
Part of: https://github.com/NixOS/nixpkgs/issues/475479

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
