### PR TITLE
vp: add update script, 1.8-unstable-2017-03-22 -> 1.8-unstable-2025-09-15; vpWithSixel: drop

### DIFF
--- a/pkgs/by-name/vp/vp/package.nix
+++ b/pkgs/by-name/vp/vp/package.nix
@@ -5,6 +5,7 @@
   autoreconfHook,
   fetchFromGitHub,
   stdenv,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -39,6 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-I${lib.getDev SDL}/include/SDL"
     "-I${lib.getDev SDL_image}/include/SDL"
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     homepage = "https://github.com/erikg/vp";

--- a/pkgs/by-name/vp/vp/package.nix
+++ b/pkgs/by-name/vp/vp/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
-  SDL,
-  SDL_image,
+  pkg-config,
+  SDL2,
+  SDL2_image,
+  libx11,
   autoreconfHook,
   fetchFromGitHub,
   stdenv,
@@ -10,23 +12,24 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vp";
-  version = "1.8-unstable-2017-03-22";
+  version = "1.8-unstable-2025-09-15";
 
   src = fetchFromGitHub {
     owner = "erikg";
     repo = "vp";
-    rev = "52bae15955dbd7270cc906af59bb0fe821a01f27";
-    hash = "sha256-AWRJ//0z97EwvQ00qWDjVeZrPrKnRMOXn4RagdVrcFc=";
+    rev = "12ab0c49a7d837af8370b91d3f6e4fa11789e57a";
+    hash = "sha256-Ea1p9NLk7tW3elU0zmlPAkobyv+yLYeKv5hscJTFJhs=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
-    SDL
+    pkg-config
   ];
 
   buildInputs = [
-    SDL
-    SDL_image
+    SDL2
+    SDL2_image
+    libx11
   ];
 
   outputs = [
@@ -36,10 +39,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-I${lib.getDev SDL}/include/SDL"
-    "-I${lib.getDev SDL_image}/include/SDL"
-  ];
+  # gcc15 build failure
+  env.NIX_CFLAGS_COMPILE = toString [ "-std=gnu17" ];
 
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];
@@ -51,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "vp";
     maintainers = [ ];
-    inherit (SDL.meta) platforms;
+    inherit (SDL2.meta) platforms;
     hydraPlatforms = lib.platforms.linux; # build hangs on both Darwin platforms, needs investigation
   };
 })

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1896,6 +1896,7 @@ mapAliases {
   volk_2 = throw "'volk_2' has been removed after not being used by any package for a long time"; # Added 2025-10-25
   volnoti = throw "'volnoti' has been removed due to lack of maintenance upstream. Consider using 'rumno' instead."; # Added 2024-12-04
   voxelands = throw "'voxelands' has been removed due to lack of upstream maintenance"; # Added 2025-08-30
+  vpWithSixel = throw "'vpWithSixel' has been removed as vp switched to SDL2 which does not support sixel"; # Added 2026-02-06
   vtk_9 = warnAlias "'vtk_9' has been renamed to 'vtk_9_5'" vtk_9_5; # Added 2025-07-18
   vtk_9_egl = warnAlias "'vtk_9_5' now build with egl support by default, so `vtk_9_egl` is deprecated, consider using 'vtk_9_5' instead." vtk_9_5; # Added 2025-07-18
   vtk_9_withQt5 = throw "'vtk_9_withQt5' has been removed, Consider using 'vtkWithQt6' instead."; # Added 2025-07-18

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3638,13 +3638,6 @@ with pkgs;
 
   vpn-slice = python3Packages.callPackage ../tools/networking/vpn-slice { };
 
-  vpWithSixel = vp.override {
-    # Enable next line for console graphics. Note that it requires `sixel`
-    # enabled terminals such as mlterm or xterm -ti 340
-    SDL = SDL_sixel;
-    SDL_image = SDL_image.override { SDL = SDL_sixel; };
-  };
-
   openconnectPackages = callPackage ../tools/networking/openconnect { };
 
   inherit (openconnectPackages) openconnect openconnect_openssl;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes: https://hydra.nixos.org/build/319841523
Part of: https://github.com/NixOS/nixpkgs/issues/475479

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
