### PR TITLE
Kernel updates for 2026-02-06

### DIFF
--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -15,8 +15,8 @@
         "lts": true
     },
     "5.10": {
-        "version": "5.10.248",
-        "hash": "sha256:01g05n856c9q7m46dmn48pq7hfph4b1kpvrjvrykg8q4z7qy9rmm",
+        "version": "5.10.249",
+        "hash": "sha256:0ihh9pjnaz3lq9my6yhlikacadc5lldsypifjcpm8j8i4qsfv45r",
         "lts": true
     },
     "6.6": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -1,7 +1,7 @@
 {
     "testing": {
-        "version": "6.19-rc7",
-        "hash": "sha256:03isv8zwasq8shq06wryyzii1zvf1kqzs310mvyqbq22iifm71f7",
+        "version": "6.19-rc8",
+        "hash": "sha256:1vwlhsk3cry48p9v2kqqxkmrsw2sjgspfylv3c7r5430yk7fhyg1",
         "lts": false
     },
     "6.1": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -20,8 +20,8 @@
         "lts": true
     },
     "6.6": {
-        "version": "6.6.122",
-        "hash": "sha256:1mlrna10449cf7whz86wgj3bijlbahj03nqbfjwjzvsbw2fhv3nl",
+        "version": "6.6.123",
+        "hash": "sha256:1ca5x6ri5i8xcm4dc5hv6b0xyv9npb9dy0wfvzi9g44al6sx85m6",
         "lts": true
     },
     "6.12": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -10,8 +10,8 @@
         "lts": true
     },
     "5.15": {
-        "version": "5.15.198",
-        "hash": "sha256:0hwpwbvjh6y4dhbpp34x9j25nc6x48fbiz65zzavplqdb2a0jk2x",
+        "version": "5.15.199",
+        "hash": "sha256:0bmx5y10mbn05qv0cvh7w6zhgzar88vj2kdm3j4m32hk9jpd7h01",
         "lts": true
     },
     "5.10": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -5,8 +5,8 @@
         "lts": false
     },
     "6.1": {
-        "version": "6.1.161",
-        "hash": "sha256:0aasgrq6mv5nj7b8ashzx0pxlaah5y0f3sq7d8w00di2lyync5ml",
+        "version": "6.1.162",
+        "hash": "sha256:12fhqsz61g64wdx3hx637fx4zn7ks7kv9h7b26llx8mr94m44rlp",
         "lts": true
     },
     "5.15": {

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -30,8 +30,8 @@
         "lts": true
     },
     "6.18": {
-        "version": "6.18.8",
-        "hash": "sha256:1zwczw98ylqa3nhlqnvjbylaaqg8jn3z0j3xx02ddha2qbawbw1p",
+        "version": "6.18.9",
+        "hash": "sha256:0y05jg6126h946pac5mkl5myh573qgml1p29hinm7jxlizzia083",
         "lts": false
     }
 }

--- a/pkgs/os-specific/linux/kernel/kernels-org.json
+++ b/pkgs/os-specific/linux/kernel/kernels-org.json
@@ -25,8 +25,8 @@
         "lts": true
     },
     "6.12": {
-        "version": "6.12.68",
-        "hash": "sha256:1dr58bfp883g4dnxak5gr25hib6hs8jq3c0ys06m5nnl9d8cfryk",
+        "version": "6.12.69",
+        "hash": "sha256:0rbnbynhm7w4ig8snq97px4ljr5k4zq1a97jqhwk4w0qy9bkcjab",
         "lts": true
     },
     "6.18": {


### PR DESCRIPTION
https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.18.9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
