### PR TITLE
libxkbcommon: 1.11.0 -> 1.13.1

### DIFF
--- a/pkgs/by-name/li/libxkbcommon_8/disable-x11com.patch
+++ b/pkgs/by-name/li/libxkbcommon_8/disable-x11com.patch
@@ -2,13 +2,19 @@ On nixpkgs /tmp/.X11-unix is not compatible with Xvfb requirement and the
 test fails.
 --- a/meson.build
 +++ b/meson.build
-@@ -775,12 +775,6 @@ if get_option('enable-x11')
+@@ -1229,18 +1229,6 @@ if get_option('enable-x11')
          env: test_env,
          is_parallel : false,
      )
 -    test(
 -        'x11comp',
--        executable('test-x11comp', 'test/x11comp.c', dependencies: x11_xvfb_test_dep),
+-        executable(
+-            'test-x11comp',
+-            'test/x11comp.c',
+-            'test/utils-text.c',
+-            'test/utils-text.h',
+-            dependencies: x11_xvfb_test_dep
+-        ),
 -        env: test_env,
 -        is_parallel : false,
 -    )

--- a/pkgs/by-name/li/libxkbcommon_8/package.nix
+++ b/pkgs/by-name/li/libxkbcommon_8/package.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libxkbcommon";
-  version = "1.11.0";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "xkbcommon";
     repo = "libxkbcommon";
     tag = "xkbcommon-${finalAttrs.version}";
-    hash = "sha256-IV1dgGM8z44OQCQYQ5PiUUw/zAvG5IIxiBywYVw2ius=";
+    hash = "sha256-wUsxsM0xXTg7nbvFMXrrnHherOepj0YI77eferjRgJA=";
   };
 
   patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Resolves https://github.com/NixOS/nixpkgs/issues/487667

Update patch to align with upstream change: https://github.com/xkbcommon/libxkbcommon/commit/1bbd317f81c17685b86f14ebb884d5ebeec73d42