### PR TITLE
netgen-vlsi: 1.5.315 -> 1.5.316

### DIFF
--- a/pkgs/by-name/ne/netgen-vlsi/package.nix
+++ b/pkgs/by-name/ne/netgen-vlsi/package.nix
@@ -5,17 +5,18 @@
   tcl,
   tk,
   m4,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "netgen";
-  version = "1.5.315";
+  version = "1.5.316";
 
   src = fetchFromGitHub {
     owner = "RTimothyEdwards";
     repo = "netgen";
     tag = finalAttrs.version;
-    hash = "sha256-dXCZm5zVwn23y7DLPSUrTKGMcu/FjdVKsyry59lEt7U=";
+    hash = "sha256-Cw/JZXzkvstfCD3oyWhZ3sWZcXtpGBkZhZIHjq2vQ6Q=";
   };
 
   strictDeps = true;
@@ -41,6 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
   postFixup = ''
     sed -i "1s|#!/bin/bash|#!${stdenv.shell}|" $out/bin/netgen
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "LVS tool for VLSI circuit netlists";


### PR DESCRIPTION
- Add passthru.updateScript for automated updates

https://github.com/RTimothyEdwards/netgen/releases/tag/1.5.316

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
