### PR TITLE
various: migrate from rev to tag and check build outputs #1

### DIFF
--- a/pkgs/by-name/am/amd-debug-tools/package.nix
+++ b/pkgs/by-name/am/amd-debug-tools/package.nix
@@ -14,7 +14,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   src = fetchgit {
     url = "https://git.kernel.org/pub/scm/linux/kernel/git/superm1/amd-debug-tools.git";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-748K4Ee9HVYWQ7/DVz7F2nZNjau5v4OGvgHwJZ4vYpM=";
   };
 

--- a/pkgs/by-name/an/anki/package.nix
+++ b/pkgs/by-name/an/anki/package.nix
@@ -104,7 +104,7 @@ let
   src = fetchFromGitHub {
     owner = "ankitects";
     repo = "anki";
-    rev = version;
+    tag = version;
     hash = srcHash;
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ar/archisteamfarm/package.nix
+++ b/pkgs/by-name/ar/archisteamfarm/package.nix
@@ -26,7 +26,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "JustArchiNET";
     repo = "ArchiSteamFarm";
-    rev = version;
+    tag = version;
     hash = "sha256-xLS9YUDY54nzt3MjOQv5TvT6TCNpiFo+goKMtiv+jjs=";
   };
 

--- a/pkgs/by-name/ar/archisteamfarm/web-ui/default.nix
+++ b/pkgs/by-name/ar/archisteamfarm/web-ui/default.nix
@@ -14,7 +14,7 @@ buildNpmPackage rec {
     repo = "ASF-ui";
     # updated by the update script
     # this is always the commit that should be used with asf-ui from the latest asf version
-    rev = version;
+    tag = version;
     hash = "sha256-PP9VT1F8EX5AgNr3OGsirDkUSVAzKHbBpJi6XBlEWeg=";
   };
 

--- a/pkgs/by-name/as/asciidoc/package.nix
+++ b/pkgs/by-name/as/asciidoc/package.nix
@@ -151,7 +151,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "asciidoc-py";
     repo = "asciidoc-py";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-td3C7xTWfSzdo9Bbz0dHW2oPaCQYmUE9H2sUFfg5HH0=";
   };
 

--- a/pkgs/by-name/aw/aws-mfa/package.nix
+++ b/pkgs/by-name/aw/aws-mfa/package.nix
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "broamski";
     repo = "aws-mfa";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-XhnDri7QV8esKtx0SttWAvevE3SH2Yj2YMq/P4K6jK4=";
   };
 

--- a/pkgs/by-name/ca/castor/package.nix
+++ b/pkgs/by-name/ca/castor/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromSourcehut {
     owner = "~julienxx";
     repo = "castor";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-yYLDbxmUR86fdpbHQQTiHVUbicnOD75cl3Vhofw5qr0=";
   };
 

--- a/pkgs/by-name/cd/cdist/package.nix
+++ b/pkgs/by-name/cd/cdist/package.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     domain = "code.ungleich.ch";
     owner = "ungleich-public";
     repo = "cdist";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-lIx0RtGQJdY2e00azI9yS6TV+5pCegpKOOD0dQmgMqA=";
   };
 

--- a/pkgs/by-name/cf/cf-tool/package.nix
+++ b/pkgs/by-name/cf/cf-tool/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "sempr";
     repo = "cf-tool";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-D+mJJw1+ImCrFpsv8HmaAwWqjYvUWouh8mgQ7hJxMrc=";
   };
 

--- a/pkgs/by-name/cf/cf-vault/package.nix
+++ b/pkgs/by-name/cf/cf-vault/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jacobbednarz";
     repo = "cf-vault";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-vp9ufjNZabY/ck2lIT+QpD6IgaVj1BkBRTjPxkb6IjQ=";
   };
 

--- a/pkgs/by-name/cf/cfs-zen-tweaks/package.nix
+++ b/pkgs/by-name/cf/cfs-zen-tweaks/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "igo95862";
     repo = "cfs-zen-tweaks";
-    rev = version;
+    tag = version;
     hash = "sha256-E3sNWWXm0NEqLCzFccd/nfYby+/b/MVjIHeGlDxV1W4=";
   };
 

--- a/pkgs/by-name/ch/choose-gui/package.nix
+++ b/pkgs/by-name/ch/choose-gui/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "chipsenkbeil";
     repo = "choose";
-    rev = version;
+    tag = version;
     hash = "sha256-ewXZpP3XmOuV/MA3fK4BwZnNb2jkE727Sse6oAd4HJk=";
   };
 

--- a/pkgs/by-name/cl/claws/package.nix
+++ b/pkgs/by-name/cl/claws/package.nix
@@ -9,7 +9,7 @@ buildGoModule (finalAttrs: {
   version = "0.4.1";
 
   src = fetchFromGitHub {
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     owner = "thehowl";
     repo = "claws";
     hash = "sha256-3zzUBeYfu9x3vRGX1DionLnAs1e44tFj8Z1dpVwjdCg=";

--- a/pkgs/by-name/cl/clever-tools/package.nix
+++ b/pkgs/by-name/cl/clever-tools/package.nix
@@ -18,7 +18,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "CleverCloud";
     repo = "clever-tools";
-    rev = version;
+    tag = version;
     hash = "sha256-W7SE6ZdoFArKmnKiHNDRTuIMvchG/QTFahacUKkzYTI=";
   };
 

--- a/pkgs/by-name/cl/cli53/package.nix
+++ b/pkgs/by-name/cl/cli53/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "barnybug";
     repo = "cli53";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-wfb3lK/WB/B8gd4BOqh+Ol10cNZdsoCoQ+hM33+goM8=";
   };
 

--- a/pkgs/by-name/cl/cliam/package.nix
+++ b/pkgs/by-name/cl/cliam/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "securisec";
     repo = "cliam";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-59nPoH0+k1umMwFg95hQHOr/SRGKqr1URFG7xtVRiTs=";
   };
 

--- a/pkgs/by-name/cl/clipmenu/package.nix
+++ b/pkgs/by-name/cl/clipmenu/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "cdown";
     repo = "clipmenu";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-nvctEwyho6kl4+NXi76jT2kG7nchmI2a7mgxlgjXA5A=";
   };
 

--- a/pkgs/by-name/cl/clipster/package.nix
+++ b/pkgs/by-name/cl/clipster/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mrichar1";
     repo = "clipster";
-    rev = version;
+    tag = version;
     sha256 = "sha256-MLLkFsBBQtb7RFQN+uoEmuCn5bnbkYsqoyWGZtTCI2U=";
   };
 

--- a/pkgs/by-name/cl/cloudlog/package.nix
+++ b/pkgs/by-name/cl/cloudlog/package.nix
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "magicbug";
     repo = "Cloudlog";
-    rev = version;
+    tag = version;
     hash = "sha256-Mr5418UTU44glFSvo1abKcjHQJRMQCgHcWsh/Kabr9Y=";
   };
 

--- a/pkgs/by-name/cl/cloudmonkey/package.nix
+++ b/pkgs/by-name/cl/cloudmonkey/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "apache";
     repo = "cloudstack-cloudmonkey";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-CdqKaKUVqeAujrWh7u0npZ6ON/nmL/8uIBIljAPPUv0=";
   };
 

--- a/pkgs/by-name/cm/cmark/package.nix
+++ b/pkgs/by-name/cm/cmark/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "commonmark";
     repo = "cmark";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-+JLw7zCjjozjq1RhRQGFqHj/MTUTq3t7A0V3T2U2PQk=";
   };
 

--- a/pkgs/by-name/cn/cntr/package.nix
+++ b/pkgs/by-name/cn/cntr/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Mic92";
     repo = "cntr";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-4HBOUx9086nn3hRBLA4zuH0Dq+qDZHgo3DivmiEMh3w=";
   };
 

--- a/pkgs/by-name/co/cockatrice/package.nix
+++ b/pkgs/by-name/co/cockatrice/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Cockatrice";
     repo = "Cockatrice";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-GQVdn6vUW0B9vSk7ZvSDqMNhLNe86C+/gE1n6wfQIMw=";
   };
 

--- a/pkgs/by-name/cp/cpp-hocon/package.nix
+++ b/pkgs/by-name/cp/cpp-hocon/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchFromGitHub {
     sha256 = "0b24anpwkmvbsn5klnr58vxksw00ci9pjhwzx7a61kplyhsaiydw";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     repo = "cpp-hocon";
     owner = "puppetlabs";
   };

--- a/pkgs/by-name/cr/crate2nix/package.nix
+++ b/pkgs/by-name/cr/crate2nix/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "crate2nix";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-SUuruvw1/moNzCZosHaa60QMTL+L9huWdsCBN6XZIic=";
   };
 

--- a/pkgs/by-name/cr/crawl/package.nix
+++ b/pkgs/by-name/cr/crawl/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "crawl";
     repo = "crawl";
-    rev = version;
+    tag = version;
     hash = "sha256-GXrYLGoQ1UwDHs+kLLcaBNpJ2BVMv4NhmpyfNFxPmg8=";
   };
 

--- a/pkgs/by-name/cr/credhub-cli/package.nix
+++ b/pkgs/by-name/cr/credhub-cli/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "cloudfoundry-incubator";
     repo = "credhub-cli";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-qp7Oj207uu2P/Jt9O5tZM0ra9fMx+DfuHPaKr5z+ef0=";
   };
 

--- a/pkgs/by-name/cr/critcmp/package.nix
+++ b/pkgs/by-name/cr/critcmp/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "critcmp";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-cf78R9siH0RFbx+vXTs71VblpsQokL6Uo32N3X4lV2I=";
   };
 

--- a/pkgs/by-name/cr/cryfs/package.nix
+++ b/pkgs/by-name/cr/cryfs/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "cryfs";
     repo = "cryfs";
-    rev = version;
+    tag = version;
     hash = "sha256-bBe//AjA9QmdSDlb0xiOboE5F4g6LJ03cHQZpfOk+Y4=";
   };
 

--- a/pkgs/by-name/cs/csvs-to-sqlite/package.nix
+++ b/pkgs/by-name/cs/csvs-to-sqlite/package.nix
@@ -13,7 +13,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "simonw";
     repo = "csvs-to-sqlite";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-wV6htULG3lg2IhG2bXmc/9vjcK8/+WA7jm3iJu4ZoOE=";
   };
 

--- a/pkgs/by-name/cu/cups-filters/package.nix
+++ b/pkgs/by-name/cu/cups-filters/package.nix
@@ -59,7 +59,7 @@
       src = fetchFromGitHub {
         owner = "OpenPrinting";
         repo = "cups-filters";
-        rev = version;
+        tag = version;
         hash = "sha256-bLOl64bdeZ10JLcQ7GbU+VffJu3Lzo0ves7O7GQIOWY=";
       };
 

--- a/pkgs/by-name/da/dashing/package.nix
+++ b/pkgs/by-name/da/dashing/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "technosophos";
     repo = "dashing";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-CcEgGPnJGrTXrgo82u5dxQTB/YjFBhHdsv7uggsHG1Y=";
   };
 

--- a/pkgs/by-name/da/dav1d/package.nix
+++ b/pkgs/by-name/da/dav1d/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "videolan";
     repo = "dav1d";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-E3da/LJ8HNy1osExmupovqnL8JHgVNzPUCG5F8TJKXQ=";
   };
 

--- a/pkgs/by-name/db/db-rest/package.nix
+++ b/pkgs/by-name/db/db-rest/package.nix
@@ -15,7 +15,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "derhuerst";
     repo = "db-rest";
-    rev = version;
+    tag = version;
     hash = "sha256-1iJ26l6C6GevNkoDVMztPHiH3YsutJa3xWAsfYvgR9U=";
   };
 

--- a/pkgs/by-name/dd/ddh/package.nix
+++ b/pkgs/by-name/dd/ddh/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "darakian";
     repo = "ddh";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "XFfTpX4c821pcTAJZFUjdqM940fRoBwkJC6KTknXtCw=";
   };
 

--- a/pkgs/by-name/de/denaro/package.nix
+++ b/pkgs/by-name/de/denaro/package.nix
@@ -20,7 +20,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "NickvisionApps";
     repo = "Denaro";
-    rev = version;
+    tag = version;
     hash = "sha256-fEhwup8SiYvKH2FtzruEFsj8axG5g3YJ917aqc8dn/8=";
   };
 

--- a/pkgs/by-name/de/dependency-track/package.nix
+++ b/pkgs/by-name/de/dependency-track/package.nix
@@ -24,7 +24,7 @@ let
     src = fetchFromGitHub {
       owner = "DependencyTrack";
       repo = "frontend";
-      rev = version;
+      tag = version;
       hash = "sha256-SSnbmAFXQwxAZQzMZeDzf/ebbWUVRICAs1msFXMMi98=";
     };
 
@@ -49,7 +49,7 @@ maven.buildMavenPackage rec {
   src = fetchFromGitHub {
     owner = "DependencyTrack";
     repo = "dependency-track";
-    rev = version;
+    tag = version;
     hash = "sha256-EL0Yd8pfTG8/DlY9A3F0lRuPl/wU2/LyACclzttrsjw=";
   };
 

--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -33,7 +33,7 @@ buildPythonApplication (finalAttrs: {
   src = fetchFromGitLab {
     owner = "rastersoft";
     repo = "devedeng";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-sLJkIKw0ciX6spugbdO0eZ1dIkoHfuu5e/f2XwA70a0=";
   };
 

--- a/pkgs/by-name/df/dfrs/package.nix
+++ b/pkgs/by-name/df/dfrs/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "anthraxx";
     repo = "dfrs";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "01h00328kbw83q11yrsvcly69p0hql3kw49b4jx6gwkrdm8c2amk";
   };
 

--- a/pkgs/by-name/di/diopser/package.nix
+++ b/pkgs/by-name/di/diopser/package.nix
@@ -23,7 +23,7 @@ let
     src = fetchFromGitHub {
       owner = "Naios";
       repo = "function2";
-      rev = version;
+      tag = version;
       hash = "sha256-JceZU8ZvtYhFheh8BjMvjjZty4hcYxHEK+IIo5X4eSk=";
     };
   };

--- a/pkgs/by-name/di/dirstalk/package.nix
+++ b/pkgs/by-name/di/dirstalk/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "stefanoj3";
     repo = "dirstalk";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-gSMkTGzMDI+scG3FQ0u0liUDL4qOPPW2UWLlAQcmmaA=";
   };
 

--- a/pkgs/by-name/di/discordchatexporter-cli/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-cli/package.nix
@@ -14,7 +14,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "tyrrrz";
     repo = "discordchatexporter";
-    rev = version;
+    tag = version;
     hash = "sha256-r9bvTgqKQY605BoUlysSz4WJMxn2ibNh3EhoMYCfV3c=";
   };
 

--- a/pkgs/by-name/di/discordchatexporter-desktop/package.nix
+++ b/pkgs/by-name/di/discordchatexporter-desktop/package.nix
@@ -14,7 +14,7 @@ buildDotnetModule rec {
   src = fetchFromGitHub {
     owner = "tyrrrz";
     repo = "discordchatexporter";
-    rev = version;
+    tag = version;
     hash = "sha256-Dc6OSWUTFftP2tyRFoxHm+TsnSMDfx627DhmYnPie9w=";
   };
 

--- a/pkgs/by-name/dn/dnscrypt-proxy/package.nix
+++ b/pkgs/by-name/dn/dnscrypt-proxy/package.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "DNSCrypt";
     repo = "dnscrypt-proxy";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-o6XZR3w1LfyCGOcF6Gzp39neMp5QjbTxQdL8A81AakM=";
   };
 

--- a/pkgs/by-name/do/do-agent/package.nix
+++ b/pkgs/by-name/do/do-agent/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "digitalocean";
     repo = "do-agent";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-uOZTiP+2r5wTPuYXcPc3bShfTIlQMkcfwiuBqUeLxPA=";
   };
 

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -21,7 +21,7 @@ ocamlPackages.buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "darrenldl";
     repo = "docfd";
-    rev = version;
+    tag = version;
     hash = "sha256-d7c72jXadwBtUqarfdGnEDo9yFwCAeEX0GGVqCe70Ak=";
   };
 

--- a/pkgs/by-name/do/dockbarx/package.nix
+++ b/pkgs/by-name/do/dockbarx/package.nix
@@ -18,7 +18,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "xuzhen";
     repo = "dockbarx";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-J/5KpHptGzgRF1qIGrgjkRR3in5pE0ffkiYVTR3iZKY=";
   };
 

--- a/pkgs/by-name/do/docker-slim/package.nix
+++ b/pkgs/by-name/do/docker-slim/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "slimtoolkit";
     repo = "slim";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-X+1euWp4W53axbiBpL82bUPfod/JNhGVGWgOqKyhz6A=";
   };
 

--- a/pkgs/by-name/do/doppler/package.nix
+++ b/pkgs/by-name/do/doppler/package.nix
@@ -15,7 +15,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dopplerhq";
     repo = "cli";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-4OvU0Hy2uBjeyQibODi9WqdM0adUW2vTS9SCL+O2RFA=";
   };
 

--- a/pkgs/by-name/do/dorkscout/package.nix
+++ b/pkgs/by-name/do/dorkscout/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "R4yGM";
     repo = "dorkscout";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-v0OgEfl6L92ux+2GbSPHEgkmA/ZobQHB66O2LlEhVUA=";
   };
 

--- a/pkgs/by-name/do/dotool/package.nix
+++ b/pkgs/by-name/do/dotool/package.nix
@@ -15,7 +15,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromSourcehut {
     owner = "~geb";
     repo = "dotool";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-KI3vA45/MvFRV8Fr3Q4yd/argDy1PpFHCT3KA9VDP80=";
   };
 

--- a/pkgs/by-name/dr/drawpile/package.nix
+++ b/pkgs/by-name/dr/drawpile/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "drawpile";
     repo = "drawpile";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-0paLKxAEvlbExq426xTekBt+Dkphx7Wg/AtpYN3f/4w=";
   };
 

--- a/pkgs/by-name/dr/drill/package.nix
+++ b/pkgs/by-name/dr/drill/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fcsonline";
     repo = "drill";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-jBnRVTnrSfEpN7xgMrlAsCwl62kZpHMI4IeT0rPb+zg=";
   };
 

--- a/pkgs/by-name/dt/dtrx/package.nix
+++ b/pkgs/by-name/dt/dtrx/package.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dtrx-py";
     repo = "dtrx";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-FNSFEGIK0vDNlvqc8BKDCB/0hoxrITfeh59JcyzX3jY=";
   };
 

--- a/pkgs/by-name/dy/dynamic-wallpaper/package.nix
+++ b/pkgs/by-name/dy/dynamic-wallpaper/package.nix
@@ -23,7 +23,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dusansimic";
     repo = "dynamic-wallpaper";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-DAdx34EYO8ysQzbWrAIPoghhibwFtoqCi8oyDVyO5lk=";
   };
 

--- a/pkgs/by-name/ea/ea/package.nix
+++ b/pkgs/by-name/ea/ea/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "dduan";
     repo = "ea";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-VXSSe5d7VO3LfjumzN9a7rrKRedOtOzTdLVQWgV1ED8=";
   };
 

--- a/pkgs/by-name/ea/ear2ctl/package.nix
+++ b/pkgs/by-name/ea/ear2ctl/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitLab {
     owner = "bharadwaj-raju";
     repo = "ear2ctl";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-xaxl4opLMw9KEDpmNcgR1fBGUqO4BP5a/U52Kz+GAvc=";
   };
 

--- a/pkgs/by-name/ea/eartag/package.nix
+++ b/pkgs/by-name/ea/eartag/package.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "eartag";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-Iwfk0SqxYF2bzkKZNqGonJh8MQ2c+K1wN0o4GECR/Rw=";
   };
 

--- a/pkgs/by-name/ea/earthlyls/package.nix
+++ b/pkgs/by-name/ea/earthlyls/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "glehmann";
     repo = "earthlyls";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-GnFzfCjT4kjb9WViKIFDkIU7zVpiI6HDuUeddgHGQuc=";
   };
 

--- a/pkgs/by-name/ea/easyrpg-player/package.nix
+++ b/pkgs/by-name/ea/easyrpg-player/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "EasyRPG";
     repo = "Player";
-    rev = version;
+    tag = version;
     hash = "sha256-fYSpFhqETkQhRK1/Uws0fWWdCr35+1J4vCPX9ZiQ3ZA=";
   };
 

--- a/pkgs/by-name/eb/ebusd/package.nix
+++ b/pkgs/by-name/eb/ebusd/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "john30";
     repo = "ebusd";
-    rev = version;
+    tag = version;
     sha256 = "sha256-CmArhkJfxf8lL6FoHRQKjk/8ObfEy3Xef9DUtOVKRas=";
   };
 

--- a/pkgs/by-name/ed/eduvpn-client/package.nix
+++ b/pkgs/by-name/ed/eduvpn-client/package.nix
@@ -19,7 +19,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromCodeberg {
     owner = "eduVPN";
     repo = "linux-app";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-oI/hc1XAddXGtwaLY6+zFoshs82lDTRESF4+xUmi+jc=";
   };
 

--- a/pkgs/by-name/ef/effitask/package.nix
+++ b/pkgs/by-name/ef/effitask/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "sanpii";
     repo = "effitask";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-6BA/TCCqVh5rtgGkUgk8nIqUzozipC5rrkbXMDWYpdQ=";
   };
 

--- a/pkgs/by-name/ef/efmt/package.nix
+++ b/pkgs/by-name/ef/efmt/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "sile";
     repo = "efmt";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-Qk33fKOQmBnT0D3/VEF8txm0GIPLziISkqxGjn2gWdM=";
   };
 

--- a/pkgs/by-name/ek/eksctl/package.nix
+++ b/pkgs/by-name/ek/eksctl/package.nix
@@ -13,7 +13,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "weaveworks";
     repo = "eksctl";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-VjrR5jm4tpUz5mrW4dyTqkzPvJ0Z+zTuwSofddN3aD0=";
   };
 

--- a/pkgs/by-name/el/element-desktop/seshat/default.nix
+++ b/pkgs/by-name/el/element-desktop/seshat/default.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "matrix-org";
     repo = "seshat";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = pinData.srcHash;
   };
 

--- a/pkgs/by-name/el/elfcat/package.nix
+++ b/pkgs/by-name/el/elfcat/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ruslashev";
     repo = "elfcat";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-8jyOYV455APlf8F6HmgyvgfNGddMzrcGhj7yFQT6qvg=";
   };
 

--- a/pkgs/by-name/el/elfinfo/package.nix
+++ b/pkgs/by-name/el/elfinfo/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "xyproto";
     repo = "elfinfo";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-HnjHOjanStqmDXnc6Z9w0beCMJFf/ndWbYxoDEaOws4=";
   };
 

--- a/pkgs/by-name/en/enc/package.nix
+++ b/pkgs/by-name/en/enc/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "life4";
     repo = "enc";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-VBtjULav6ks2BYMVnUmOn/bAvonGDPia0eO7pJ1P5+Q=";
   };
 

--- a/pkgs/by-name/en/endlessh-go/package.nix
+++ b/pkgs/by-name/en/endlessh-go/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "shizunge";
     repo = "endlessh-go";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-ABrmvP8xfH1DWzepnzrIsNJDE9sDoXPQteA/ToyRtoo=";
   };
 

--- a/pkgs/by-name/er/errbot/package.nix
+++ b/pkgs/by-name/er/errbot/package.nix
@@ -13,7 +13,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "errbotio";
     repo = "errbot";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-UdqzBrlcb9NkuVo8ChADJmaKevadoGLyZUrckStb5ko=";
   };
 

--- a/pkgs/by-name/es/escambo/package.nix
+++ b/pkgs/by-name/es/escambo/package.nix
@@ -21,7 +21,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "CleoMenezesJr";
     repo = "escambo";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-jMlix8nlCaVLZEhqzb6LRNrD3DUZMTIjqrRKo6nFbQA=";
   };
 

--- a/pkgs/by-name/ev/evebox/package.nix
+++ b/pkgs/by-name/ev/evebox/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "jasonish";
     repo = "evebox";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-vakCBDyL/Su55tkn/SJ5ShZcYC8l+p2acpve/fTN0uI=";
   };
 

--- a/pkgs/by-name/ex/extest/package.nix
+++ b/pkgs/by-name/ex/extest/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "Supreeeme";
     repo = "extest";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-qdTF4n3uhkl3WFT+7bAlwCjxBx3ggTN6i3WzFg+8Jrw=";
   };
 

--- a/pkgs/by-name/fa/faas-cli/package.nix
+++ b/pkgs/by-name/fa/faas-cli/package.nix
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "openfaas";
     repo = "faas-cli";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-zPgSmkegq7LsdOk5MQBmv2jAMI4FIwu5jBMWiQSZxL8=";
   };
 

--- a/pkgs/by-name/fa/faircamp/package.nix
+++ b/pkgs/by-name/fa/faircamp/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromCodeberg {
     owner = "simonrepp";
     repo = "faircamp";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-r5r7vfTbMPjAqMg5f7L/YfSzlxZgrSFjO6WHO64wfIo=";
   };
 

--- a/pkgs/by-name/ff/ff2mpv-rust/package.nix
+++ b/pkgs/by-name/ff/ff2mpv-rust/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ryze312";
     repo = "ff2mpv-rust";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-kJpKcwwwGjFYE7R4ZhkEGK44QqxsUEB/Scj0RoySta4=";
   };
 

--- a/pkgs/by-name/ff/ffizer/package.nix
+++ b/pkgs/by-name/ff/ffizer/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ffizer";
     repo = "ffizer";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-r4jaqjHYDZxftU7J6hGMXW/Oq+8biy9bFoHIOt33ta8=";
   };
 

--- a/pkgs/by-name/fi/fido2luks/package.nix
+++ b/pkgs/by-name/fi/fido2luks/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "shimunn";
     repo = "fido2luks";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-bXwaFiRHURvS5KtTqIj+3GlGNbEulDgMDP51ZiO1w9o=";
   };
 

--- a/pkgs/by-name/fi/finalfusion-utils/package.nix
+++ b/pkgs/by-name/fi/finalfusion-utils/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "finalfusion";
     repo = "finalfusion-utils";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-suzivynlgk4VvDOC2dQR40n5IJHoJ736+ObdrM9dIqE=";
   };
 

--- a/pkgs/by-name/fn/fn-cli/package.nix
+++ b/pkgs/by-name/fn/fn-cli/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "fnproject";
     repo = "cli";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-TTGZoCvhJXRsGY5pGiURpHVhlCacDYiLTnyjVJHJLno=";
   };
 

--- a/pkgs/by-name/fr/fragments/package.nix
+++ b/pkgs/by-name/fr/fragments/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "World";
     repo = "Fragments";
-    rev = version;
+    tag = version;
     hash = "sha256-lTOO6ZQWImaFqYZ3qerYYHWj/eOLYU/2k2Wh/ju9Njw=";
   };
 

--- a/pkgs/by-name/fs/fsarchiver/package.nix
+++ b/pkgs/by-name/fs/fsarchiver/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "fdupoux";
     repo = "fsarchiver";
-    rev = version;
+    tag = version;
     sha256 = "sha256-eJ+25wfOZ7qYL5zi2kz0+03xg6gnKmLG+xjC7wEJ2HM=";
   };
 

--- a/pkgs/by-name/fs/fscan/package.nix
+++ b/pkgs/by-name/fs/fscan/package.nix
@@ -11,7 +11,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "shadow1ng";
     repo = "fscan";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-OFlwL7PXKOPKIW2YCirCGCXRCGIWYMmYHMmSU2he/tw=";
   };
 

--- a/pkgs/by-name/fu/fusioninventory-agent/package.nix
+++ b/pkgs/by-name/fu/fusioninventory-agent/package.nix
@@ -18,7 +18,7 @@ perlPackages.buildPerlPackage rec {
   src = fetchFromGitHub {
     owner = "fusioninventory";
     repo = "fusioninventory-agent";
-    rev = version;
+    tag = version;
     sha256 = "1hbp5a9m03n6a80xc8z640zs71qhqk4ifafr6fp0vvzzvq097ip2";
   };
 

--- a/pkgs/by-name/fw/fwanalyzer/package.nix
+++ b/pkgs/by-name/fw/fwanalyzer/package.nix
@@ -14,7 +14,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "cruise-automation";
     repo = "fwanalyzer";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     sha256 = "sha256-fcqtyfpxdjD+1GsYl05RSJaFDoLSYQDdWcQV6a+vNGA=";
   };
 

--- a/pkgs/by-name/fy/fypp/package.nix
+++ b/pkgs/by-name/fy/fypp/package.nix
@@ -12,7 +12,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "aradi";
     repo = "fypp";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-MgGVlOqOIrIVoDfBMVpFLT26mhYndxans2hfo/+jdoA=";
   };
 

--- a/pkgs/by-name/fz/fzf-obc/package.nix
+++ b/pkgs/by-name/fz/fzf-obc/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "rockandska";
     repo = "fzf-obc";
-    rev = version;
+    tag = version;
     sha256 = "sha256-KIAlDpt1Udl+RLp3728utgQ9FCjZz/OyoG92MOJmgPI=";
   };
 

--- a/pkgs/by-name/gd/gdrive/package.nix
+++ b/pkgs/by-name/gd/gdrive/package.nix
@@ -12,7 +12,7 @@ buildGoModule (finalAttrs: {
   src = fetchFromGitHub {
     owner = "prasmussen";
     repo = "gdrive";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-2dJmGFHfGSroucn4WgiV2NExBs5wtMDe2kX1jDBwbRs=";
   };
 

--- a/pkgs/by-name/gd/gdrive3/package.nix
+++ b/pkgs/by-name/gd/gdrive3/package.nix
@@ -11,7 +11,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "glotlabs";
     repo = "gdrive";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-1yJg+rEhKTGXC7mlHxnWGUuAm9/RwhD6/Xg/GBKyQMw=";
   };
 

--- a/pkgs/by-name/gd/gdtoolkit_4/package.nix
+++ b/pkgs/by-name/gd/gdtoolkit_4/package.nix
@@ -16,7 +16,7 @@ let
         src = fetchFromGitHub {
           owner = "lark-parser";
           repo = "lark";
-          rev = version;
+          tag = version;
           hash = "sha256-Dc7wbMBY8CSeP4JE3hBk5m1lwzmCnNTkVoLdIukRw1Q=";
           fetchSubmodules = true;
         };

--- a/pkgs/by-name/ge/geticons/package.nix
+++ b/pkgs/by-name/ge/geticons/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromSourcehut {
     owner = "~zethra";
     repo = "geticons";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-HEnUfOLeRTi2dRRqjDPVwVVHo/GN9wE28x5qv3qOpCY=";
   };
 

--- a/pkgs/by-name/gi/gifski/package.nix
+++ b/pkgs/by-name/gi/gifski/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "ImageOptim";
     repo = "gifski";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-8EAC8YH3AIbvYdTL7HtqTL7WqztzCwvDwIVkhiqvtrQ=";
   };
 


### PR DESCRIPTION
This pull request standardizes the way source versions are referenced across multiple package definitions in the repository. Specifically, it replaces the use of the `rev` attribute with the `tag` attribute in various `fetchFromGitHub`, `fetchgit`, and other fetchers. This change ensures that package builds consistently reference tags rather than raw commits or revisions, which improves clarity and maintainability.

Changes to source version referencing:

* Updated `fetchFromGitHub`, `fetchgit`, `fetchFromSourcehut`, and similar fetchers to use the `tag` attribute instead of `rev` for specifying the source version in package definitions.

These changes are purely related to how the source version is referenced and do not affect the functionality of the packages themselves.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
