### PR TITLE
electron.wrapElectronHook: init

### DIFF
--- a/doc/hooks/electron-wrap.section.md
+++ b/doc/hooks/electron-wrap.section.md
@@ -1,0 +1,149 @@
+# electron.electronWrapHook {#electron-wrap-hook}
+
+Hook for wrapping Electron-based packages.
+
+## Examples {#electron-wrap-hook-example}
+
+:::{.example #electron-wrap-hook-example-snippet}
+
+# Using `electronWrapHook`
+
+Note that how Electron packages are built can vary widely between packages.
+
+```nix
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm,
+  electron,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "electron-project";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "JaneElectron";
+    repo = "ElectronProject";
+    tag = finalAttrs.version;
+    hash = "...";
+  };
+
+  npmDeps = null;
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "...";
+  };
+
+  npmConfigHook = pnpmConfigHook;
+
+  # Must be in buildInputs since the Electron is the
+  # Electron running on the host machine
+  buildInputs = [
+    electron.electronWrapHook
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  postBuild = ''
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    npm_config_nodedir=${electron.headers} \
+    npm exec electron-builder -- \
+      --config electron-builder.json \
+      --dir \
+      -c.electronDist=electron-dist
+      -c.electronVersion=${electron.version}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share"
+
+    cp -r dist/resources $out/share/electron-program
+
+    runHook postInstall
+  '';
+
+  meta = {
+    mainProgram = "electronProject";
+    description = "electron project";
+  };
+})
+```
+:::
+
+## Variables controlling `electronWrapHook` {#electron-wrap-hook-variables}
+
+### `electronWrapHook` Exclusive Variables {#electron-wrap-hook-exclusive-variables}
+
+#### `electronWrapPath` {#electron-wrap-hook-path}
+
+Controls the path that is wrapped by Electron.
+Most often this is a `*.asar` archive that is automatically found by the hook.
+But in some cases this will need to be manually provided:
+
+1. If there are multiple `*.asar` archives in one package
+2. If a `*.asar` archive was not generated
+
+Archives are not always generated, often in cases when `asar=false` is passed to `electron-builder` (if used),
+or if `electron-pacakger` is used and `asar=true` is not passed. In that case the path that is wrapped will be
+a directory, not an archive file.
+
+#### `electronWrapperName` {#electron-wrap-hook-name}
+
+Controls the name of the wrapper program.
+This will be output to `{!outputBin}/bin/$name`, which is either `$bin` or `$out` in that order of precedence.
+Often does not need to be set, and `meta.mainProgram` should be set instead.
+Only set this if the Electron program is not the *main* program of the package.
+
+#### `electronWrapperArgs` {#electron-wrap-hook-args}
+
+Controls the arguments to `makeWrapper`.
+
+Default flags:
+- `--inherit-argv0`
+- `--set-default ELECTRON_FORCE_IS_PACKAGED 1`
+- The `*.asar` file to wrap
+
+If for example this Electron program requires arguments from other toolkits, those flags can be appended like so:
+
+```nix
+{
+  #...
+  dontWrapGApps = true;
+  preInstall = ''
+    electronWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+  #...
+}
+```
+#### `dontElectronWrap` {#electron-wrap-hook-dont}
+
+Control whether the hook is ran or not. Defaults to `true`.
+
+If set to false, the hook will not do any detection.
+This is useful for manually wrapping paths using the wrapper manually.
+
+The wrapper as two required arguments, and then optional arguments.
+
+1. The path to wrap, generally a `*.asar` file
+2. The path to place the wrapper.
+3. All other argument will be appended to the `makeWrapper` call.
+
+```nix
+{
+  dontElectronWrap = true;
+  postInstall = ''
+    mkdir -p "$out/bin"
+    electronWrap "$out/share/myApp/app.asar" "$out/bin/myApp" --set SOME_ENV 1
+  '';
+}
+```

--- a/doc/hooks/electron-wrap.section.md
+++ b/doc/hooks/electron-wrap.section.md
@@ -1,0 +1,166 @@
+# electron.wrapElectronHook {#electron-wrap-hook}
+
+Hook for wrapping Electron-based packages.
+
+## Examples {#electron-wrap-hook-example}
+
+:::{.example #electron-wrap-hook-example-snippet}
+
+# Using `wrapElectronHook`
+
+This hook is only for Linux hosts.
+
+Note that how Electron packages are built can vary widely between packages.
+
+```nix
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm,
+  electron,
+}:
+buildNpmPackage (finalAttrs: {
+  pname = "electron-project";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "JaneElectron";
+    repo = "ElectronProject";
+    tag = finalAttrs.version;
+    hash = "...";
+  };
+
+  npmDeps = null;
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    inherit pnpm;
+    fetcherVersion = 3;
+    hash = "...";
+  };
+
+  npmConfigHook = pnpmConfigHook;
+
+  # Must be in buildInputs since the Electron is the
+  # Electron running on the host machine
+  buildInputs = [
+    electron.wrapElectronHook
+  ];
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  };
+
+  postBuild = ''
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    npm_config_nodedir=${electron.headers} \
+    npm exec electron-builder -- \
+      --config electron-builder.json \
+      --dir \
+      -c.electronDist=electron-dist
+      -c.electronVersion=${electron.version}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share"
+
+    cp -r dist/resources $out/share/electron-program
+
+    runHook postInstall
+  '';
+
+  meta = {
+    mainProgram = "electronProject";
+    description = "electron project";
+  };
+})
+```
+:::
+
+## Variables controlling `wrapElectronHook` {#electron-wrap-hook-variables}
+
+### `wrapElectronHook` Exclusive Variables {#electron-wrap-hook-exclusive-variables}
+
+#### `wrapElectronPath` {#electron-wrap-hook-path}
+
+Controls the path that is wrapped by Electron.
+Most often this is a `*.asar` archive that is automatically found by the hook.
+But in some cases this will need to be manually provided:
+
+1. If there are multiple `*.asar` archives in one package
+2. If a `*.asar` archive was not generated
+
+Archives are not always generated, often in cases when `asar=false` is passed to `electron-builder` (if used),
+or if `electron-pacakger` is used and `asar=true` is not passed. In that case the path that is wrapped will be
+a directory, not an archive file.
+
+#### `electronWrapperName` {#electron-wrap-hook-name}
+
+Controls the name of the wrapper program.
+This will be output to `{!outputBin}/bin/$name`, which is either `$bin` or `$out` in that order of precedence.
+Often does not need to be set, and `meta.mainProgram` should be set instead.
+
+Only set this if the Electron program is not the *main* program of the package, as by default it reads the value set in
+`meta.mainProgram`.
+
+#### `electronWrapperArgs` {#electron-wrap-hook-args}
+
+Controls the arguments to `makeWrapper`.
+
+Default flags:
+- The `*.asar` file to wrap
+- `--set-default ELECTRON_FORCE_IS_PACKAGED 1`
+
+If for example this Electron program requires arguments from other toolkits, those flags can be appended like so:
+
+```nix
+{
+  #...
+  dontWrapGApps = true;
+  preInstall = ''
+    electronWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+  #...
+}
+```
+#### `dontWrapElectron` {#electron-wrap-hook-dont}
+
+Control whether the hook is ran or not. Defaults to `false`.
+
+If set to false, the hook will not do any detection.
+This is useful for manually wrapping paths using the wrapper manually.
+
+The wrapper as two required arguments, and then optional arguments.
+
+1. The path to wrap, generally a `*.asar` file
+2. The path to place the wrapper.
+3. All other argument will be appended to the `makeWrapper` call.
+
+```nix
+{
+  dontWrapElectron = true;
+  postInstall = ''
+    mkdir -p "$out/bin"
+    wrapElectron "$out/share/myApp/app.asar" "$out/bin/myApp" --set SOME_ENV 1
+  '';
+}
+```
+
+#### `wrapElectronForcePackaged` {#electron-wrap-hook-is-packaged}
+
+Controls whether the Electron package is told it is in a production package.
+This variable is defaulted to `true`, so if the attribute is not set, it is assumed that
+the app is told to run in production mode.
+
+If the app breaks under these conditions, it can be disabled by setting this attribute to false.
+
+```nix
+{
+  wrapElectronForcePackaged = false;
+}
+```

--- a/doc/hooks/index.md
+++ b/doc/hooks/index.md
@@ -15,6 +15,7 @@ breakpoint.section.md
 cernlib.section.md
 cmake.section.md
 desktop-file-utils.section.md
+electron-wrap.section.md
 gdk-pixbuf.section.md
 ghc.section.md
 gnome.section.md

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -102,6 +102,33 @@
   "cuda-writing-tests": [
     "index.html#cuda-writing-tests"
   ],
+  "electron-wrap-hook": [
+    "index.html#electron-wrap-hook"
+  ],
+  "electron-wrap-hook-args": [
+    "index.html#electron-wrap-hook-args"
+  ],
+  "electron-wrap-hook-dont": [
+    "index.html#electron-wrap-hook-dont"
+  ],
+  "electron-wrap-hook-path": [
+    "index.html#electron-wrap-hook-path"
+  ],
+  "electron-wrap-hook-example": [
+    "index.html#electron-wrap-hook-example"
+  ],
+  "electron-wrap-hook-example-snippet": [
+    "index.html#electron-wrap-hook-example-snippet"
+  ],
+  "electron-wrap-hook-exclusive-variables": [
+    "index.html#electron-wrap-hook-exclusive-variables"
+  ],
+  "electron-wrap-hook-name": [
+    "index.html#electron-wrap-hook-name"
+  ],
+  "electron-wrap-hook-variables": [
+    "index.html#electron-wrap-hook-variables"
+  ],
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -102,6 +102,36 @@
   "cuda-writing-tests": [
     "index.html#cuda-writing-tests"
   ],
+  "electron-wrap-hook": [
+    "index.html#electron-wrap-hook"
+  ],
+  "electron-wrap-hook-args": [
+    "index.html#electron-wrap-hook-args"
+  ],
+  "electron-wrap-hook-dont": [
+    "index.html#electron-wrap-hook-dont"
+  ],
+  "electron-wrap-hook-path": [
+    "index.html#electron-wrap-hook-path"
+  ],
+  "electron-wrap-hook-example": [
+    "index.html#electron-wrap-hook-example"
+  ],
+  "electron-wrap-hook-example-snippet": [
+    "index.html#electron-wrap-hook-example-snippet"
+  ],
+  "electron-wrap-hook-exclusive-variables": [
+    "index.html#electron-wrap-hook-exclusive-variables"
+  ],
+  "electron-wrap-hook-name": [
+    "index.html#electron-wrap-hook-name"
+  ],
+  "electron-wrap-hook-variables": [
+    "index.html#electron-wrap-hook-variables"
+  ],
+  "electron-wrap-hook-is-packaged": [
+    "index.html#electron-wrap-hook-is-packaged"
+  ],
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   buildNpmPackage,
   electron_40,
-  makeWrapper,
   testers,
   mattermost-desktop,
   nix-update-script,
@@ -28,7 +27,9 @@ buildNpmPackage rec {
   npmBuildScript = "build-prod";
   makeCacheWritable = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [
+    electron.electronWrapHook
+  ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -73,11 +74,6 @@ buildNpmPackage rec {
       --replace-fail /build/source/$dist/ $out/bin/
 
     cp src/assets/linux/app_icon.png $out/share/icons/hicolor/512x512/apps/${pname}.png
-
-    makeWrapper '${lib.getExe electron}' $out/bin/${pname} \
-      --set-default ELECTRON_IS_DEV 0 \
-      --add-flags $out/share/${pname}/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -3,7 +3,6 @@
   fetchFromGitHub,
   buildNpmPackage,
   electron_40,
-  makeWrapper,
   testers,
   mattermost-desktop,
   nix-update-script,
@@ -28,7 +27,9 @@ buildNpmPackage rec {
   npmBuildScript = "build-prod";
   makeCacheWritable = true;
 
-  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [
+    electron.wrapElectronHook
+  ];
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
@@ -73,11 +74,6 @@ buildNpmPackage rec {
       --replace-fail /build/source/$dist/ $out/bin/
 
     cp src/assets/linux/app_icon.png $out/share/icons/hicolor/512x512/apps/${pname}.png
-
-    makeWrapper '${lib.getExe electron}' $out/bin/${pname} \
-      --set-default ELECTRON_IS_DEV 0 \
-      --add-flags $out/share/${pname}/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ro/rocketchat-desktop/package.nix
+++ b/pkgs/by-name/ro/rocketchat-desktop/package.nix
@@ -55,6 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     vips
+    electron.electronWrapHook
   ];
 
   postPatch = ''
@@ -126,11 +127,6 @@ stdenv.mkDerivation (finalAttrs: {
     do
       install -Dm644 $icon $out/share/icons/hicolor/$(basename ''${icon%.png})/apps/rocketchat-desktop.png
     done
-
-    makeWrapper '${lib.getExe electron}' $out/bin/rocketchat-desktop \
-      --set-default ELECTRON_IS_DEV 0 \
-      --add-flags $out/share/rocketchat-desktop/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ro/rocketchat-desktop/package.nix
+++ b/pkgs/by-name/ro/rocketchat-desktop/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     vips
+    electron.wrapElectronHook
   ];
 
   postPatch = ''
@@ -132,11 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     do
       install -Dm644 $icon $out/share/icons/hicolor/$(basename ''${icon%.png})/apps/rocketchat-desktop.png
     done
-
-    makeWrapper '${lib.getExe electron}' $out/bin/rocketchat-desktop \
-      --set-default ELECTRON_IS_DEV 0 \
-      --add-flags $out/share/rocketchat-desktop/app.asar \
-      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
 
     runHook postInstall
   '';

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -8,7 +8,6 @@
   pnpmConfigHook,
   electron_41,
   python3,
-  makeWrapper,
   callPackage,
   fetchFromGitHub,
   jq,
@@ -110,7 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     pnpmConfigHook
     pnpm
-    makeWrapper
     python3
     jq
   ]
@@ -119,6 +117,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
+  ];
+
+  buildInputs = [
+    electron.electronWrapHook
   ];
 
   patches = [
@@ -269,6 +271,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
+  electronWrapperArgs = lib.optionalString (commandLineArgs != "") "--add-flags ${commandLineArgs}";
+
   installPhase = ''
     runHook preInstall
   ''
@@ -287,11 +291,6 @@ stdenv.mkDerivation (finalAttrs: {
     do
       install -Dm644 $icon $out/share/icons/hicolor/`basename ''${icon%.png}`/apps/signal-desktop.png
     done
-
-    makeWrapper '${lib.getExe electron}' "$out/bin/signal-desktop" \
-      --add-flags "$out/share/signal-desktop/app.asar" \
-      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
-      --add-flags ${lib.escapeShellArg commandLineArgs}
   ''
   + ''
     runHook postInstall

--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -8,7 +8,6 @@
   pnpmConfigHook,
   electron_41,
   python3,
-  makeWrapper,
   callPackage,
   fetchFromGitHub,
   fetchpatch,
@@ -102,7 +101,6 @@ stdenv.mkDerivation (finalAttrs: {
     nodejs
     pnpmConfigHook
     pnpm
-    makeWrapper
     python3
     jq
   ]
@@ -111,6 +109,10 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     copyDesktopItems
+  ];
+
+  buildInputs = [
+    electron.wrapElectronHook
   ];
 
   patches = [
@@ -268,6 +270,10 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postBuild
   '';
 
+  electronWrapperArgs = lib.optionalString (
+    commandLineArgs != ""
+  ) "--add-flags ${lib.escapeShellArg commandLineArgs}";
+
   installPhase = ''
     runHook preInstall
   ''
@@ -286,11 +292,6 @@ stdenv.mkDerivation (finalAttrs: {
     do
       install -Dm644 $icon $out/share/icons/hicolor/`basename ''${icon%.png}`/apps/signal-desktop.png
     done
-
-    makeWrapper '${lib.getExe electron}' "$out/bin/signal-desktop" \
-      --add-flags "$out/share/signal-desktop/app.asar" \
-      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
-      --add-flags ${lib.escapeShellArg commandLineArgs}
   ''
   + ''
     runHook postInstall

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  callPackage,
   makeWrapper,
   fetchurl,
   fetchzip,
@@ -92,7 +93,10 @@ let
   common = platform: {
     inherit pname version meta;
     src = fetcher version (get tags platform) (get hashes platform);
-    passthru.headers = headersFetcher version hashes.headers;
+    passthru = {
+      headers = headersFetcher version hashes.headers;
+    }
+    // (callPackage ../hooks { });
   };
 
   electronLibPath = lib.makeLibraryPath [

--- a/pkgs/development/tools/electron/binary/generic.nix
+++ b/pkgs/development/tools/electron/binary/generic.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  callPackage,
   makeWrapper,
   fetchurl,
   fetchzip,
@@ -89,10 +90,13 @@ let
 
   get = as: platform: as.${platform.system} or (throw "Unsupported system: ${platform.system}");
 
-  common = platform: {
+  common = platform: finalAttrs: {
     inherit pname version meta;
     src = fetcher version (get tags platform) (get hashes platform);
-    passthru.headers = headersFetcher version hashes.headers;
+    passthru = {
+      headers = headersFetcher finalAttrs.version hashes.headers;
+    }
+    // (callPackage ../hooks { electron = finalAttrs.finalPackage; });
   };
 
   electronLibPath = lib.makeLibraryPath [
@@ -211,7 +215,7 @@ let
 in
 stdenv.mkDerivation (
   finalAttrs:
-  lib.recursiveUpdate (common stdenv.hostPlatform) (
+  lib.recursiveUpdate (common stdenv.hostPlatform finalAttrs) (
     (if stdenv.hostPlatform.isDarwin then darwin else linux) finalAttrs
   )
 )

--- a/pkgs/development/tools/electron/hooks/default.nix
+++ b/pkgs/development/tools/electron/hooks/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  makeSetupHook,
+  replaceVars,
+  targetPackages,
+  makeBinaryWrapper,
+  electron,
+  # Test packages
+  mattermost-desktop,
+  rocketchat-desktop,
+  signal-desktop,
+}:
+# These must be in buildInputs so that the correct Electron is used, which is the
+# Electron for the host, not the Electron for the build machine, which would be the
+# one passed if this hook was in `nativeBuildInputs`. This is similar to how shebangs
+# are only patched if a dependency is in `buildInputs`
+#
+# We could pull Electron out of targetPackages, but it would be nice to support
+# overriding Electron and using the hook on the overidden electron.
+{
+  electronWrapHook =
+    makeSetupHook
+      {
+        name = "electron-wrap-hook";
+        # Has to be in nativeBuildInputs so that it
+        # goes back 1 offset from buildInputs to nativeBuildInputs since the
+        # wrapper must be build->host
+        propagatedNativeBuildInputs = [
+          makeBinaryWrapper
+        ];
+
+        passthru.tests = {
+          inherit mattermost-desktop rocketchat-desktop signal-desktop;
+        };
+      }
+      (
+        replaceVars ./electron-wrap-hook.sh {
+          ELECTRON_PACKAGE = electron;
+        }
+      );
+}

--- a/pkgs/development/tools/electron/hooks/default.nix
+++ b/pkgs/development/tools/electron/hooks/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  makeSetupHook,
+  replaceVars,
+  targetPackages,
+  makeBinaryWrapper,
+  electron,
+  # Test packages
+  mattermost-desktop,
+  rocketchat-desktop,
+  signal-desktop,
+}:
+# These must be in buildInputs so that the correct Electron is used, which is the
+# Electron for the host, not the Electron for the build machine, which would be the
+# one passed if this hook was in `nativeBuildInputs`. This is similar to how shebangs
+# are only patched if a dependency is in `buildInputs`
+#
+# We could pull Electron out of targetPackages, but it would be nice to support
+# overriding Electron and using the hook on the overidden electron.
+{
+  wrapElectronHook =
+    makeSetupHook
+      {
+        name = "wrap-electron-hook";
+        # Has to be in nativeBuildInputs so that it
+        # goes back 1 offset from buildInputs to nativeBuildInputs since the
+        # wrapper must be build->host
+        propagatedNativeBuildInputs = [
+          makeBinaryWrapper
+        ];
+
+        passthru.tests = {
+          inherit mattermost-desktop rocketchat-desktop signal-desktop;
+        };
+      }
+      (
+        replaceVars ./electron-wrap-hook.sh {
+          ELECTRON_PACKAGE = electron;
+        }
+      );
+}

--- a/pkgs/development/tools/electron/hooks/electron-wrap-hook.sh
+++ b/pkgs/development/tools/electron/hooks/electron-wrap-hook.sh
@@ -1,0 +1,106 @@
+# shellcheck shell=bash
+
+electronWrap() {
+  if (( $# < 2 )); then
+    echo "Usage: electronWrap pathToWrap wrapperPath [electronWrapperArgs]"
+    echo ""
+    echo "  Required:"
+    echo "    pathToWrap: Path that Electron will execute"
+    echo "    wrapperPath: The path that the wrapper will be placed"
+    echo ""
+    echo "  Optional:"
+    echo "    electronWrapperArgs: Addtional arguments that will be appended to the wrapper"
+    echo ""
+    echo "  Example:"
+    echo '    electronWrap "$out/share/app.asar" "$out/bin/myApp" --set COOL_ENV 1'
+    exit 1
+  fi
+
+  # Required args
+  local -r pathToWrap="$1"
+  local -r wrapperPath="$2"
+
+  # Pack the rest into the arg array
+  local -ar electronWrapperArgs=("${@:3}")
+
+  local -a electronWrapperArgsArray=(
+    # Actually launch the Electron program
+    "--add-flag" "$pathToWrap"
+    # This is generally desired for `top` purposes, and node will
+    # doesn't look adjacent to argv0, which is to say that it will
+    # not look around the argv0 argument for other executables or files.
+    "--inherit-argv0"
+    # Tell Electron that it is being used in production reglardless of how it was built
+    # electron-is-dev also supports this var.
+    "--set-default" "ELECTRON_FORCE_IS_PACKAGED" "1"
+  )
+
+  # Concat user args to the flags array
+  concatTo electronWrapperArgsArray electronWrapperArgs
+
+  makeWrapper "@ELECTRON_PACKAGE@/bin/electron" \
+    "$wrapperPath" \
+    "${electronWrapperArgsArray[@]}"
+
+  echo "wrapped $pathToWrap with Electron using:"
+
+  local -ra tmp=("$wrapperPath" "${electronWrapperArgsArray[@]}")
+  echoCmd "makeWrapper" "${tmp[@]}"
+}
+
+electronWrapHook() {
+  echo "Running electronWrapHook..."
+
+  local pathToWrap findResult cmdProgram
+
+  # Check if the var is set, if so just use it.
+  if [[ -v electronWrapPath ]]; then
+    # Use the user input
+    pathToWrap="$electronWrapPath"
+  else
+    # If electronWrapPath is not set...
+    #
+    # Look for files named "app.asar", output results as null-terminated string, and store each string to an array
+    mapfile -t -d $'\0' findResult < <(find "${!outputBin:?}" -type f -a -name "app.asar" -print0)
+
+    # Ensure only one is found
+    if [[ ${#findResult[@]} -eq 0 ]]; then
+      echo "electronWrapHook: did not find 'app.asar' in the bin output. Please supply the path to it with 'electronWrapPath'"
+      exit 1
+    elif [[ ${#findResult[@]} -gt 1 ]]; then
+      echo "electronWrapHook: found multiple 'app.asar' files:"
+      echo "${findResult[*]}"
+      echo "Please supply the path to wrap with 'electronWrapPath'"
+      exit 1
+    else
+      # If there is only exactly one result, use it.
+      pathToWrap="${findResult[0]}"
+    fi
+  fi
+
+  # Check if electronWrapperName is set, and use that unconditionally if so.
+  if [[ -v electronWrapperName ]]; then
+    # User input
+    cmdProgram="$electronWrapperName"
+  elif [[ -v NIX_MAIN_PROGRAM ]]; then
+    # If not, check if meta.mainProgram has been set.
+    cmdProgram="$NIX_MAIN_PROGRAM"
+  else
+    # If neither...
+    echo "electronWrapHook: \$mainProgram is not set so we don't know how to set the binary name."
+    echo "  To fix this set \`meta.mainProgram\` or \`electronWrapperName\`"
+    exit 1
+  fi
+
+  local -a electronWrapperArgsArray=()
+  concatTo electronWrapperArgsArray electronWrapperArgs
+
+  mkdir -p "${!outputBin}/bin"
+  electronWrap "$pathToWrap" "${!outputBin}/bin/${cmdProgram}" "${electronWrapperArgsArray[@]}"
+
+  echo "electronWrapHook finished."
+}
+
+if [[ -z "${dontElectronWrap-}" ]]; then
+  postInstall+=(electronWrapHook)
+fi

--- a/pkgs/development/tools/electron/hooks/electron-wrap-hook.sh
+++ b/pkgs/development/tools/electron/hooks/electron-wrap-hook.sh
@@ -1,0 +1,107 @@
+# shellcheck shell=bash
+
+wrapElectron() {
+  if (( $# < 2 )); then
+    echo "Usage: wrapElectron pathToWrap wrapperPath [electronWrapperArgs]"
+    echo ""
+    echo "  Required:"
+    echo "    pathToWrap: Path that Electron will execute"
+    echo "    wrapperPath: The path that the wrapper will be placed"
+    echo ""
+    echo "  Optional:"
+    echo "    electronWrapperArgs: Addtional arguments that will be appended to the wrapper"
+    echo ""
+    echo "  Example:"
+    echo '    wrapElectron "$out/share/app.asar" "$out/bin/myApp" --set COOL_ENV 1'
+    exit 1
+  fi
+
+  # Required args
+  local -r pathToWrap="$1"
+  local -r wrapperPath="$2"
+
+  # Pack the rest into the arg array
+  local -ar electronWrapperArgs=("${@:3}")
+
+  local -a electronWrapperArgsArray=(
+    # Actually launch the Electron program
+    "--add-flag" "$pathToWrap"
+  )
+
+  if [[ ! -v electronWrapPackaged || "$electronWrapPackaged" == "1" ]]; then
+    # This branch executes if the attribute is not defined, or is set to true.
+    #
+    # Tell Electron that it is being used in production regardless of how it was built
+    # electron-is-dev also supports this var.
+    electronWrapperArgsArray+=( "--set-default" "ELECTRON_FORCE_IS_PACKAGED" "1" )
+  fi
+
+  # Concat user args to the flags array
+  concatTo electronWrapperArgsArray electronWrapperArgs
+
+  makeWrapper "@ELECTRON_PACKAGE@/bin/electron" \
+    "$wrapperPath" \
+    "${electronWrapperArgsArray[@]}"
+
+  echo "wrapElectron: wrapped $pathToWrap with Electron using:"
+
+  local -ra tmp=("$wrapperPath" "${electronWrapperArgsArray[@]}")
+  echoCmd "makeWrapper" "${tmp[@]}"
+}
+
+wrapElectronHook() {
+  echo "Running wrapElectronHook..."
+
+  local pathToWrap findResult cmdProgram
+
+  # Check if the var is set, if so just use it.
+  if [[ -v wrapElectronPath ]]; then
+    # Use the user input
+    pathToWrap="$wrapElectronPath"
+  else
+    # If electronWrapPath is not set...
+    #
+    # Look for files named "app.asar", output results as null-terminated string, and store each string to an array
+    mapfile -t -d $'\0' findResult < <(find "${!outputBin:?}" -type f -a -name "app.asar" -print0)
+
+    # Ensure only one is found
+    if [[ ${#findResult[@]} -eq 0 ]]; then
+      echo "wrapElectronHook: did not find 'app.asar' in the bin output. Please supply the path to it with 'wrapElectronPath'"
+      exit 1
+    elif [[ ${#findResult[@]} -gt 1 ]]; then
+      echo "wrapElectronHook: found multiple 'app.asar' files:"
+      echo "${findResult[*]}"
+      echo "Please supply the path to wrap with 'wrapElectronPath'"
+      exit 1
+    else
+      # If there is only exactly one result, use it.
+      pathToWrap="${findResult[0]}"
+    fi
+  fi
+
+  # Check if electronWrapperName is set, and use that unconditionally if so.
+  if [[ -v electronWrapperName ]]; then
+    # User input
+    cmdProgram="$electronWrapperName"
+  elif [[ -v NIX_MAIN_PROGRAM ]]; then
+    # If not, check if meta.mainProgram has been set.
+    cmdProgram="$NIX_MAIN_PROGRAM"
+  else
+    # If neither...
+    echo "wrapElectronHook: \$mainProgram is not set so we don't know how to set the binary name."
+    echo "  To fix this set \`meta.mainProgram\` or \`electronWrapperName\`"
+    exit 1
+  fi
+
+  local -a electronWrapperArgsArray=()
+  concatTo electronWrapperArgsArray electronWrapperArgs
+
+  mkdir -p "${!outputBin}/bin"
+  wrapElectron "$pathToWrap" "${!outputBin}/bin/${cmdProgram}" "${electronWrapperArgsArray[@]}"
+
+  echo "wrapElectronHook finished."
+}
+
+if [[ -z "${dontWrapElectron-}" ]]; then
+  postInstallHooks+=(wrapElectronHook)
+fi

--- a/pkgs/development/tools/electron/wrapper.nix
+++ b/pkgs/development/tools/electron/wrapper.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  callPackage,
   electron-unwrapped,
   wrapGAppsHook3,
   makeWrapper,
@@ -9,7 +10,7 @@
   gtk4,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "electron";
   inherit (electron-unwrapped) version;
 
@@ -39,6 +40,8 @@ stdenv.mkDerivation {
   passthru = {
     unwrapped = electron-unwrapped;
     inherit (electron-unwrapped) headers dist;
-  };
+  }
+  // (callPackage ./hooks { electron = finalAttrs.finalPackage; });
+
   inherit (electron-unwrapped) meta;
-}
+})

--- a/pkgs/development/tools/electron/wrapper.nix
+++ b/pkgs/development/tools/electron/wrapper.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  callPackage,
   electron-unwrapped,
   wrapGAppsHook3,
   makeWrapper,
@@ -9,7 +10,7 @@
   gtk4,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "electron";
   inherit (electron-unwrapped) version;
 
@@ -39,10 +40,11 @@ stdenv.mkDerivation {
   passthru = {
     unwrapped = electron-unwrapped;
     inherit (electron-unwrapped) headers dist;
-  };
+  }
+  // (callPackage ./hooks { electron = finalAttrs.finalPackage; });
 
   __structuredAttrs = true;
   strictDeps = true;
 
   inherit (electron-unwrapped) meta;
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. Create a hook for wrapping Electron project
2. Migrate a few projects

This hook should work with different electron versions, and with binary electron builds as well.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
