### PR TITLE
uiua: 0.17.3 -> 0.18.0; uiua-unstable: 0.18.0-dev.4 -> 0.18.0

### DIFF
--- a/pkgs/by-name/ui/uiua/stable.nix
+++ b/pkgs/by-name/ui/uiua/stable.nix
@@ -1,7 +1,7 @@
 rec {
-  version = "0.17.3";
+  version = "0.18.0";
   tag = version;
-  hash = "sha256-TiJAj+wBVb8Z9pnoscF65tB7flbk/XWW+7XrHlvIHeo=";
-  cargoHash = "sha256-smonKftOpGXy0WxI8Qqr0rTeI/pW6f+G4TxzoaEMsuc=";
+  hash = "sha256-049fEvLiRK2QfX6W0zCuL2QNACkBn0HmuGYjUGAWR1M=";
+  cargoHash = "sha256-rGWMhghlYaUupn2vqDxBEezgENH4GCXlf2RU3iRrmxo=";
   updateScript = ./update-stable.sh;
 }

--- a/pkgs/by-name/ui/uiua/unstable.nix
+++ b/pkgs/by-name/ui/uiua/unstable.nix
@@ -1,7 +1,7 @@
 rec {
-  version = "0.18.0-dev.4";
+  version = "0.18.0";
   tag = version;
-  hash = "sha256-/uM92x0jBgfbkBY5/NFPBDHgH+caISEtJiiXAFQj61A=";
-  cargoHash = "sha256-MsoLvwFlVBJnbWMA8Z7wCjQKJ9VHYhAV1HpNVmM+MEo=";
+  hash = "sha256-049fEvLiRK2QfX6W0zCuL2QNACkBn0HmuGYjUGAWR1M=";
+  cargoHash = "sha256-rGWMhghlYaUupn2vqDxBEezgENH4GCXlf2RU3iRrmxo=";
   updateScript = ./update-unstable.sh;
 }

--- a/pkgs/by-name/ui/uiua386/package.nix
+++ b/pkgs/by-name/ui/uiua386/package.nix
@@ -12,7 +12,7 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -Dm444 -t $out/share/fonts/truetype ./src/algorithm/Uiua386.ttf
+    install -Dm444 -t $out/share/fonts/truetype ./src/assets/Uiua386.ttf
 
     runHook postInstall
   '';


### PR DESCRIPTION
Changelog: https://github.com/uiua-lang/uiua/blob/refs/tags/0.18.0/changelog.md
Diff: https://github.com/uiua-lang/uiua/compare/0.18.0-dev.4...0.18.0

Supersedes #487698

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
