### PR TITLE
platformio: 6.1.18 -> 6.1.19; meshtasticd regression fix

### DIFF
--- a/pkgs/by-name/me/meshtasticd/package.nix
+++ b/pkgs/by-name/me/meshtasticd/package.nix
@@ -81,6 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p platformio-deps-native
     cp -ar ${platformio-deps-native}/. platformio-deps-native
     chmod +w -R platformio-deps-native
+    rm -f platformio-deps-native/core/appstate.json
 
     export PLATFORMIO_CORE_DIR=platformio-deps-native/core
     export PLATFORMIO_LIBDEPS_DIR=platformio-deps-native/libdeps

--- a/pkgs/by-name/pl/platformio-core/package.nix
+++ b/pkgs/by-name/pl/platformio-core/package.nix
@@ -31,7 +31,7 @@ in
 with python3Packages;
 buildPythonApplication rec {
   pname = "platformio";
-  version = "6.1.18";
+  version = "6.1.19";
   pyproject = true;
 
   # pypi tarballs don't contain tests - https://github.com/platformio/platformio-core/issues/1964
@@ -39,7 +39,7 @@ buildPythonApplication rec {
     owner = "platformio";
     repo = "platformio-core";
     tag = "v${version}";
-    hash = "sha256-h9/xDWXCoGHQ9r2f/ZzAtwTAs4qzDrvVAQ2kuLS9Lk8=";
+    hash = "sha256-9pv2fbShddfYqBFxsQEj7nU1e772gUQEQINXRO/RMcQ=";
   };
 
   outputs = [
@@ -94,6 +94,7 @@ buildPythonApplication rec {
     intelhex
     lockfile
     marshmallow
+    packaging
     pip
     pyelftools
     pyparsing
@@ -130,6 +131,11 @@ buildPythonApplication rec {
   postInstall = ''
     mkdir -p $udev/lib/udev/rules.d
     cp platformio/assets/system/99-platformio-udev.rules $udev/lib/udev/rules.d/99-platformio-udev.rules
+
+    # Avoid platformio writing state into /build/.home when generating completions.
+    export HOME=$TMPDIR
+    export PLATFORMIO_CORE_DIR=$TMPDIR/platformio-core
+    mkdir -p "$PLATFORMIO_CORE_DIR"
 
     installShellCompletion --cmd platformio \
       --bash <(_PLATFORMIO_COMPLETE=bash_source $out/bin/platformio) \

--- a/pkgs/by-name/pl/platformio-core/use-local-spdx-license-list.patch
+++ b/pkgs/by-name/pl/platformio-core/use-local-spdx-license-list.patch
@@ -6,7 +6,7 @@ index 47efae59..6c2cfaed 100644
      @staticmethod
      @memoized(expire="1h")
      def load_spdx_licenses():
--        version = "3.26.0"
+-        version = "3.27.0"
 -        spdx_data_url = (
 -            "https://raw.githubusercontent.com/spdx/license-list-data/"
 -            f"v{version}/json/licenses.json"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
PlatformIO:
Release: https://github.com/platformio/platformio-core/releases/tag/v6.1.19
Diff: https://github.com/platformio/platformio-core/compare/v6.1.18...v6.1.19

meshtasticd: 
Fix: drop the bundled `appstate.json` so PlatformIO doesn’t try to auto-upgrade during the build (involves network access, which fails under sandboxing).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
