### PR TITLE
quake3e: use SDL; 2024-09-02-dev -> 2025-10-14

### DIFF
--- a/pkgs/by-name/qu/quake3e/package.nix
+++ b/pkgs/by-name/qu/quake3e/package.nix
@@ -60,12 +60,6 @@ stdenv.mkDerivation {
     sed -i -e 's#"libcurl.so.4"#"${curl.out}/lib/libcurl.so.4"#' code/client/cl_curl.h
   '';
 
-  # Default value for `USE_SDL` changed (from 0 to 1) in 5f8ce6d (2020-12-26)
-  # Setting `USE_SDL=0` in `makeFlags` doesn't work
-  preConfigure = ''
-    sed -i 's/USE_SDL *= 1/USE_SDL = 0/' Makefile
-  '';
-
   installPhase = ''
     runHook preInstall
     make install DESTDIR=$out/lib

--- a/pkgs/by-name/qu/quake3e/package.nix
+++ b/pkgs/by-name/qu/quake3e/package.nix
@@ -19,15 +19,15 @@
 let
   arch = if stdenv.hostPlatform.isx86_64 then "x64" else stdenv.hostPlatform.parsed.cpu.name;
 in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "Quake3e";
-  version = "2024-09-02-dev";
+  version = "2025-10-14";
 
   src = fetchFromGitHub {
     owner = "ec-";
     repo = "Quake3e";
-    rev = "b6e7ce4f78711e1c9d2924044a9a9d8a9db7020f";
-    sha256 = "sha256-tQgrHiP+QhBzcUnHRwzaDe38Th0uDt450fra8O3Vjqc=";
+    tag = finalAttrs.version;
+    sha256 = "sha256-3Ij0GEPXdl7Lhp9o1Zdwg1tcLgFEay686QjhSlh8iAo=";
   };
 
   nativeBuildInputs = [
@@ -87,4 +87,4 @@ stdenv.mkDerivation {
       alx
     ];
   };
-}
+})


### PR DESCRIPTION
This PR, in addition to updating the package, enables SDL, which is the default configuration for Quake3e. Without SDL, keyboard input does not work on some systems (e.g. on Cosmic).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
