### PR TITLE
synergy: fix missing include to <cstdint>

### DIFF
--- a/pkgs/by-name/sy/synergy/include_cstdint.patch
+++ b/pkgs/by-name/sy/synergy/include_cstdint.patch
@@ -1,0 +1,12 @@
+diff --git a/src/lib/server/InputFilter.cpp b/src/lib/server/InputFilter.cpp
+index da29f5b..65c500f 100755
+--- a/src/lib/server/InputFilter.cpp
++++ b/src/lib/server/InputFilter.cpp
+@@ -26,6 +26,7 @@
+
+ #include <cstdlib>
+ #include <cstring>
++#include <cstdint>
+
+ // -----------------------------------------------------------------------------
+ // Input Filter Condition Classes

--- a/pkgs/by-name/sy/synergy/package.nix
+++ b/pkgs/by-name/sy/synergy/package.nix
@@ -42,6 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Without this OpenSSL from nixpkgs is not detected
     ./darwin-non-static-openssl.patch
+
+    # This missing include broke the build on GCC 15
+    # This can be removed once we switch to a newer version
+    ./include_cstdint.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
The upgrade to GCC 15 broke the build because `cstdint` isn't getting transitively included via some other headers anymore [1].

This has been fixed in newer 1.x versions of synergy, but those include some more drastic changes that would need to be addressed in Nixpkgs (such as, at least, in the NixOS and nix-darwin synergy modules).

I've opened a PR for the update here [2], but this patch is a simpler quick fix we can implement before that's sorted out.

[1]: https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes
[2]: https://github.com/NixOS/nixpkgs/pull/486784


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
