### PR TITLE
dms-greeter: inherit package defaults from dms-shell

### DIFF
--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -12,8 +12,6 @@ let
     mkOption
     mkIf
     mkDefault
-    mkPackageOption
-    mkRemovedOptionModule
     literalExpression
     getExe
     makeBinPath
@@ -22,6 +20,7 @@ let
     ;
 
   cfg = config.services.displayManager.dms-greeter;
+  cfgDms = config.programs.dms-shell;
   cfgAutoLogin = config.services.displayManager.autoLogin;
 
   cacheDir = "/var/lib/dms-greeter";
@@ -69,7 +68,21 @@ in
   options.services.displayManager.dms-greeter = {
     enable = mkEnableOption "DankMaterialShell greeter";
 
-    package = mkPackageOption pkgs "dms-shell" { };
+    package = mkOption {
+      type = types.package;
+      default = if cfgDms.enable then cfgDms.package else pkgs.dms-shell;
+      defaultText = literalExpression ''
+        if config.programs.dms-shell.enable
+        then config.programs.dms-shell.package
+        else pkgs.dms-shell;
+      '';
+      description = ''
+        The DankMaterialShell package to use for the greeter.
+
+        Defaults to the package from `programs.dms-shell` if it is enabled,
+        otherwise defaults to `pkgs.dms-shell`.
+      '';
+    };
 
     compositor = {
       name = mkOption {
@@ -159,7 +172,21 @@ in
     };
 
     quickshell = {
-      package = mkPackageOption pkgs "quickshell" { };
+      package = mkOption {
+        type = types.package;
+        default = if cfgDms.enable then cfgDms.quickshell.package else pkgs.quickshell;
+        defaultText = literalExpression ''
+          if config.programs.dms-shell.enable
+          then config.programs.dms-shell.quickshell.package
+          else pkgs.quickshell;
+        '';
+        description = ''
+          The Quickshell package to use for the greeter.
+
+          Defaults to the quickshell package from `programs.dms-shell` if it is enabled,
+          otherwise defaults to `pkgs.quickshell`.
+        '';
+      };
     };
 
     logs = {


### PR DESCRIPTION
When `programs.dms-shell.enable` is true, the greeter now automatically uses the dms-shell package and its quickshell dependency from the main program module. This ensures version consistency between the desktop shell and the display manager greeter.

The defaults fall back to pkgs.dms-shell and pkgs.quickshell respectively when the main program module is not enabled.


## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.