### PR TITLE
treewide: use nodejs-slim when accessing only `node`

### DIFF
--- a/nixos/modules/services/home-automation/deye-dummycloud.nix
+++ b/nixos/modules/services/home-automation/deye-dummycloud.nix
@@ -37,7 +37,7 @@ in
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         WorkingDirectory = "${pkgs.deye-dummycloud}/lib/node_modules/deye-dummycloud";
-        ExecStart = "${pkgs.nodejs}/bin/node app.js";
+        ExecStart = "${pkgs.lib.getExe pkgs.nodejs-slim} app.js";
         Restart = "always";
         User = "deye-dummycloud";
         DynamicUser = true;

--- a/nixos/modules/services/matrix/appservice-irc.nix
+++ b/nixos/modules/services/matrix/appservice-irc.nix
@@ -229,7 +229,7 @@ in
           sed -i "s/^as_token:.*$/$as_token/g" ${registrationFile}
         fi
         if ! [ -f "${cfg.settings.ircService.mediaProxy.signingKeyPath}" ]; then
-          ${lib.getExe pkgs.nodejs} ${pkg}/lib/generate-signing-key.js > "${cfg.settings.ircService.mediaProxy.signingKeyPath}"
+          ${lib.getExe pkgs.nodejs-slim} ${pkg}/lib/generate-signing-key.js > "${cfg.settings.ircService.mediaProxy.signingKeyPath}"
         fi
         # Allow synapse access to the registration
         if ${pkgs.getent}/bin/getent group matrix-synapse > /dev/null; then

--- a/nixos/modules/services/monitoring/uptime.nix
+++ b/nixos/modules/services/monitoring/uptime.nix
@@ -97,7 +97,7 @@ in
           NODE_PATH = "${pkgs.nodePackages.node-uptime}/lib/node_modules/node-uptime/node_modules";
         };
         preStart = "mkdir -p /var/lib/uptime";
-        serviceConfig.ExecStart = "${pkgs.nodejs}/bin/node ${pkgs.nodePackages.node-uptime}/lib/node_modules/node-uptime/app.js";
+        serviceConfig.ExecStart = "${pkgs.lib.getExe pkgs.nodejs-slim} ${pkgs.nodePackages.node-uptime}/lib/node_modules/node-uptime/app.js";
       };
 
       services.mongodb.enable = mkIf (!cfg.usesRemoteMongo) true;
@@ -115,7 +115,7 @@ in
         };
         # Ugh, need to wait for web service to be up
         preStart = if cfg.enableWebService then "sleep 1s" else "mkdir -p /var/lib/uptime";
-        serviceConfig.ExecStart = "${pkgs.nodejs}/bin/node ${pkgs.nodePackages.node-uptime}/lib/node_modules/node-uptime/monitor.js";
+        serviceConfig.ExecStart = "${pkgs.lib.getExe pkgs.nodejs-slim} ${pkgs.nodePackages.node-uptime}/lib/node_modules/node-uptime/monitor.js";
       };
     })
   ];

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -25,7 +25,7 @@ let
       userJson = pkgs.writeText "user.json" (builtins.toJSON userCfg);
     in
     (pkgs.runCommand "${varName}.js" { } ''
-      ${pkgs.nodejs}/bin/node ${extractor} ${source} ${varName} > default.json
+      ${pkgs.lib.getExe pkgs.nodejs-slim} ${extractor} ${source} ${varName} > default.json
       (
         echo "var ${varName} = "
         ${pkgs.jq}/bin/jq -s '.[0] * .[1]' default.json ${userJson}

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -377,7 +377,7 @@ in
         serviceConfig = {
           DynamicUser = true;
           WorkingDirectory = "${cfg.ui.package}";
-          ExecStart = "${pkgs.nodejs}/bin/node ${cfg.ui.package}/dist/js/server.js";
+          ExecStart = "${pkgs.lib.getExe pkgs.nodejs-slim} ${cfg.ui.package}/dist/js/server.js";
         };
       };
     };

--- a/nixos/tests/web-apps/sshwifty/default.nix
+++ b/nixos/tests/web-apps/sshwifty/default.nix
@@ -25,7 +25,7 @@
     machine.wait_for_unit("sshwifty.service")
     machine.wait_for_open_port(80)
     machine.wait_until_succeeds("curl --fail -6 http://localhost/", timeout=60)
-    machine.wait_until_succeeds("${lib.getExe pkgs.nodejs} ${./sshwifty-test.js}", timeout=60)
+    machine.wait_until_succeeds("${lib.getExe pkgs.nodejs-slim} ${./sshwifty-test.js}", timeout=60)
   '';
 
   meta.maintainers = [ lib.maintainers.ungeskriptet ];

--- a/pkgs/build-support/writers/scripts.nix
+++ b/pkgs/build-support/writers/scripts.nix
@@ -1086,7 +1086,7 @@ rec {
     in
     writeDash name ''
       export NODE_PATH=${node-env}/lib/node_modules
-      exec ${lib.getExe pkgs.nodejs} ${pkgs.writeText "js" content} "$@"
+      exec ${lib.getExe pkgs.nodejs-slim} ${pkgs.writeText "js" content} "$@"
     '';
 
   /**

--- a/pkgs/by-name/me/meshcentral/package.nix
+++ b/pkgs/by-name/me/meshcentral/package.nix
@@ -3,7 +3,7 @@
   fetchzip,
   fetchYarnDeps,
   yarn2nix-moretea,
-  nodejs_20,
+  nodejs-slim_20,
   dos2unix,
 }:
 
@@ -37,7 +37,7 @@ yarn2nix-moretea.mkYarnPackage {
   preFixup = ''
     mkdir -p $out/bin
     chmod a+x $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
-    sed -i '1i#!${nodejs_20}/bin/node' $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
+    sed -i '1i#!${lib.getExe nodejs-slim_20}' $out/libexec/meshcentral/deps/meshcentral/meshcentral.js
     ln -s $out/libexec/meshcentral/deps/meshcentral/meshcentral.js $out/bin/meshcentral
   '';
 

--- a/pkgs/top-level/emscripten-packages.nix
+++ b/pkgs/top-level/emscripten-packages.nix
@@ -35,7 +35,7 @@ rec {
             -o ./test1.js
 
           echo "Using node to execute the test which basically outputs an error on stderr which we grep for"
-          ${pkgs.nodejs}/bin/node ./test1.js
+          ${pkgs.lib.getExe pkgs.nodejs-slim} ./test1.js
 
           set +x
           if [ $? -ne 0 ]; then
@@ -77,7 +77,7 @@ rec {
           --embed-file ./test/xmlid/id_err1.xml
 
           echo "Using node to execute the test which basically outputs an error on stderr which we grep for"
-          ${pkgs.nodejs}/bin/node ./xmllint.test.js --noout test/xmlid/id_err1.xml 2>&1 | grep 0bar
+          ${pkgs.lib.getExe pkgs.nodejs-slim} ./xmllint.test.js --noout test/xmlid/id_err1.xml 2>&1 | grep 0bar
 
           set +x
           if [ $? -ne 0 ]; then
@@ -184,7 +184,7 @@ rec {
           -L. libz.a -I . -o example.js
 
           echo "Using node to execute the test"
-          ${pkgs.nodejs}/bin/node ./example.js
+          ${pkgs.lib.getExe pkgs.nodejs-slim} ./example.js
 
           set +x
           if [ $? -ne 0 ]; then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

With https://github.com/NixOS/nixpkgs/pull/481461 landed, there's an incentive to use the `-slim` varients when not using `npm`. I've searched for all the occurences where only the `node` binary is called.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
