### PR TITLE
kubectl-oidc-login: init at 1.35.2

### DIFF
--- a/pkgs/by-name/ku/kubectl-oidc-login/package.nix
+++ b/pkgs/by-name/ku/kubectl-oidc-login/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "kubectl-oidc-login";
+  version = "1.35.2";
+
+  src = fetchFromGitHub {
+    owner = "int128";
+    repo = "kubelogin";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-jSPNvr+spZvilTooK7s6l8CyvP5tzSWxqJzaoJCA5AM=";
+  };
+
+  vendorHash = "sha256-otzcOmW3mkiJrIv69wme5cHp5/iO2YSH+ecZgeX2aV0=";
+
+  ldflags = [
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  # Rename output binary to kubectl-<plugin-name> so kubectl recognizes it on $PATH.
+  postInstall = ''
+    mv $out/bin/{kubelogin,${finalAttrs.meta.mainProgram}}
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Kubernetes kubelogin plugin to add OpenID Connect authentication to kubectl. Run \"kubectl oidc-login ...\"";
+    # Quirk: we have to write "oidc_login" instead of "oidc-login"
+    # (at least on Mac "aarch64-darwin" and "x86_64_linux"), otherwise calling
+    # "kubectl oidc-login <subcommand>" fails that it can't find the underlying plugin in $PATH.
+    mainProgram = "kubectl-oidc_login";
+    homepage = "https://github.com/int128/kubelogin";
+    changelog = "https://github.com/int128/kubelogin/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.malteneuss ];
+  };
+})


### PR DESCRIPTION
A plugin for kubectl to login into a Kubernetes cluster via OAuth2, e.g. get an access token via a webpage login workflow. Useful for larger companies.
See https://github.com/int128/kubelogin

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
