### PR TITLE
fetchCrate: make overridable

### DIFF
--- a/pkgs/build-support/rust/fetchcrate.nix
+++ b/pkgs/build-support/rust/fetchcrate.nix
@@ -3,35 +3,36 @@
   fetchzip,
   fetchurl,
 }:
-
-{
-  crateName ? args.pname,
-  pname ? null,
-  # The `dl` field of the registry's index configuration
-  # https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
-  registryDl ? "https://crates.io/api/v1/crates",
-  version,
-  unpack ? true,
-  ...
-}@args:
-
-assert pname == null || pname == crateName;
-
-(if unpack then fetchzip else fetchurl) (
+lib.makeOverridable (
   {
-    name = "${crateName}-${version}.tar.gz";
-    url = "${registryDl}/${crateName}/${version}/download";
+    crateName ? args.pname,
+    pname ? null,
+    # The `dl` field of the registry's index configuration
+    # https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
+    registryDl ? "https://crates.io/api/v1/crates",
+    version,
+    unpack ? true,
+    ...
+  }@args:
 
-    passthru = { inherit pname version; };
-  }
-  // lib.optionalAttrs unpack {
-    extension = "tar.gz";
-  }
-  // removeAttrs args [
-    "crateName"
-    "pname"
-    "registryDl"
-    "version"
-    "unpack"
-  ]
+  assert pname == null || pname == crateName;
+
+  (if unpack then fetchzip else fetchurl) (
+    {
+      name = "${crateName}-${version}.tar.gz";
+      url = "${registryDl}/${crateName}/${version}/download";
+
+      passthru = { inherit pname version; };
+    }
+    // lib.optionalAttrs unpack {
+      extension = "tar.gz";
+    }
+    // removeAttrs args [
+      "crateName"
+      "pname"
+      "registryDl"
+      "version"
+      "unpack"
+    ]
+  )
 )

--- a/pkgs/build-support/rust/fetchcrate.nix
+++ b/pkgs/build-support/rust/fetchcrate.nix
@@ -3,35 +3,36 @@
   fetchzip,
   fetchurl,
 }:
-
-{
-  crateName ? args.pname,
-  pname ? null,
-  # The `dl` field of the registry's index configuration
-  # https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
-  registryDl ? "https://static.crates.io/crates",
-  version,
-  unpack ? true,
-  ...
-}@args:
-
-assert pname == null || pname == crateName;
-
-(if unpack then fetchzip else fetchurl) (
+lib.makeOverridable (
   {
-    name = "${crateName}-${version}.tar.gz";
-    url = "${registryDl}/${crateName}/${version}/download";
+    crateName ? args.pname,
+    pname ? null,
+    # The `dl` field of the registry's index configuration
+    # https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
+    registryDl ? "https://static.crates.io/crates",
+    version,
+    unpack ? true,
+    ...
+  }@args:
 
-    passthru = { inherit pname version; };
-  }
-  // lib.optionalAttrs unpack {
-    extension = "tar.gz";
-  }
-  // removeAttrs args [
-    "crateName"
-    "pname"
-    "registryDl"
-    "version"
-    "unpack"
-  ]
+  assert pname == null || pname == crateName;
+
+  (if unpack then fetchzip else fetchurl) (
+    {
+      name = "${crateName}-${version}.tar.gz";
+      url = "${registryDl}/${crateName}/${version}/download";
+
+      passthru = { inherit pname version; };
+    }
+    // lib.optionalAttrs unpack {
+      extension = "tar.gz";
+    }
+    // removeAttrs args [
+      "crateName"
+      "pname"
+      "registryDl"
+      "version"
+      "unpack"
+    ]
+  )
 )


### PR DESCRIPTION
Allows overriding input attributes.

This should make overriding Rust derivations a little easier.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
