### PR TITLE
nixos/test-driver: Add required attributes to package call

### DIFF
--- a/nixos/lib/test-driver/shell.nix
+++ b/nixos/lib/test-driver/shell.nix
@@ -1,4 +1,4 @@
 {
   pkgs ? import ../../.. { },
 }:
-pkgs.callPackage ./default.nix { }
+pkgs.python3Packages.callPackage ./default.nix { }


### PR DESCRIPTION
When trying to run `nix-shell` in `nixpkgs/nixos/lib/test-driver` it complains:

> error: evaluation aborted with the following error message: 'lib.customisation.callPackageWith: Function called without required argument "buildPythonApplication" at […]/nixos/lib/test-driver/default.nix:4'

I'm uncertain whether this shell is meant to be used like this, or at all, but this change at least enables entering it using the standard `nix-shell` command.

@tfc

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
