### PR TITLE
nixos-container: add --refresh option

### DIFF
--- a/pkgs/by-name/ni/nixos-container/nixos-container.pl
+++ b/pkgs/by-name/ni/nixos-container/nixos-container.pl
@@ -55,6 +55,7 @@ Usage: nixos-container list
          [--config-file <path>]
          [--flake <flakeref>]
          [--nixos-path <path>]
+         [--refresh]
        nixos-container login <container-name>
        nixos-container root-login <container-name>
        nixos-container run <container-name> -- args...
@@ -122,6 +123,7 @@ GetOptions(
     "no-write-lock-file" => \&copyNixFlags0,
     "no-allow-dirty" => \&copyNixFlags0,
     "recreate-lock-file" => \&copyNixFlags0,
+    "refresh" => \&copyNixFlags0,
     ) or exit 1;
 
 push @nixFlags, @nixFlags2;


### PR DESCRIPTION
This adds the `--refresh` option to the `nixos-container update` command, which is useful if you have a container based on a remote flake that you want to redownload, e.g. a flake referencing a branch in a Git repository. `nix build --refresh`  will cause the newest version of such a flake to be downloaded.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
