### PR TITLE
pam_xdg: init at 0.8.5

### DIFF
--- a/pkgs/by-name/pa/pam_xdg/package.nix
+++ b/pkgs/by-name/pa/pam_xdg/package.nix
@@ -1,0 +1,37 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  pam,
+  coreutils,
+}:
+stdenv.mkDerivation rec {
+  pname = "pam_xdg";
+  version = "0.8.5";
+
+  src = fetchurl {
+    url = "https://ftp.sdaoden.eu/pam_xdg-${version}.tar.gz";
+    sha256 = "sha256-o4Fol6LouBQVLiGMAszEB+zBkBj8C1xMp057AvH3nl4=";
+  };
+
+  buildInputs = [
+    pam
+  ];
+
+  postPatch = ''
+    substituteInPlace pam_xdg.c \
+      --replace-fail '"/usr/bin/rm"' '"${coreutils}/bin/rm"'
+  '';
+
+  makeFlags = [
+    "PREFIX=$(out)"
+  ];
+
+  meta = {
+    homepage = "https://www.sdaoden.eu/code-pam_xdg.html";
+    description = "PAM module that manages XDG Base Directories";
+    license = lib.licenses.isc;
+    platforms = lib.platforms.unix;
+    maintainers = with lib; [ maintainers.aanderse ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

i've been using this on my system for a bit now and i like it - i think it can be useful to anyone running `seatd` without `logind`, including our `nix` using friends on `void` linux, for example

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
