### PR TITLE
octoapp: init at 3.0.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -52,6 +52,8 @@
 
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
+- [OctoApp](https://octoapp.eu/), a companion service for Klipper/Moonraker providing push notifications, remote monitoring, and AI-powered print failure detection. Available as [services.octoapp](#opt-services.octoapp.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -903,6 +903,7 @@
   ./services/misc/ntfy-sh.nix
   ./services/misc/nzbget.nix
   ./services/misc/nzbhydra2.nix
+  ./services/misc/octoapp.nix
   ./services/misc/octoprint.nix
   ./services/misc/ollama.nix
   ./services/misc/ombi.nix

--- a/nixos/modules/services/misc/octoapp.nix
+++ b/nixos/modules/services/misc/octoapp.nix
@@ -1,0 +1,83 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.octoapp;
+  pkg = cfg.package;
+
+  moonrakerCfg = config.services.moonraker;
+  moonrakerStateDir = moonrakerCfg.stateDir;
+  configDir = "${moonrakerStateDir}/config";
+  logDir = "${moonrakerStateDir}/logs";
+
+  jsonConfig = builtins.toJSON {
+    ConfigFolder = configDir;
+    LogFolder = logDir;
+    LocalFileStoragePath = "/var/lib/octoapp";
+    ServiceName = "octoapp";
+    VirtualEnvPath = "/var/lib/octoapp/venv";
+    RepoRootFolder = "${pkg}/lib/octoapp";
+    IsCompanion = false;
+    MoonrakerConfigFile = "${configDir}/moonraker-temp.cfg";
+  };
+in
+{
+  options.services.octoapp = {
+    enable = lib.mkEnableOption "OctoApp, a companion service for Moonraker providing push notifications and remote monitoring via the OctoApp mobile app";
+
+    package = lib.mkPackageOption pkgs "octoapp" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = moonrakerCfg.user;
+      defaultText = lib.literalExpression "config.services.moonraker.user";
+      description = "User account under which OctoApp runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = moonrakerCfg.group;
+      defaultText = lib.literalExpression "config.services.moonraker.group";
+      description = "Group account under which OctoApp runs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = config.services.moonraker.enable;
+        message = "services.octoapp requires Moonraker to be enabled (services.moonraker.enable).";
+      }
+    ];
+
+    systemd.services.octoapp = {
+      description = "OctoApp Companion for Moonraker";
+      after = [
+        "network-online.target"
+        "moonraker.service"
+      ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = "${pkg}/lib/octoapp";
+        ExecStart = pkgs.writeShellScript "start-octoapp" ''
+          CONFIG_B64=$(echo -n '${jsonConfig}' | ${pkgs.coreutils}/bin/base64 -w0)
+          exec ${pkg}/bin/octoapp "$CONFIG_B64"
+        '';
+        Restart = "always";
+        RestartSec = 10;
+        StateDirectory = "octoapp";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ imadnyc ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1154,6 +1154,7 @@ in
   oci-containers = handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./oci-containers.nix { };
   ocis = runTest ./ocis.nix;
   ocsinventory-agent = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./ocsinventory-agent.nix { };
+  octoapp = runTest ./octoapp.nix;
   octoprint = runTest ./octoprint.nix;
   oddjobd = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./oddjobd.nix { };
   odoo = runTest ./odoo.nix;

--- a/nixos/tests/octoapp.nix
+++ b/nixos/tests/octoapp.nix
@@ -1,0 +1,42 @@
+{ pkgs, ... }:
+{
+  name = "octoapp";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [ imadnyc ];
+  };
+
+  nodes = {
+    printer =
+      { config, pkgs, ... }:
+      {
+        services.octoapp.enable = true;
+
+        services.moonraker = {
+          enable = true;
+          settings = {
+            authorization = {
+              trusted_clients = [
+                "127.0.0.0/8"
+                "::1/128"
+              ];
+            };
+          };
+        };
+
+        services.klipper = {
+          enable = true;
+          user = "moonraker";
+          group = "moonraker";
+          settings = { };
+        };
+      };
+  };
+
+  testScript = ''
+    printer.start()
+
+    printer.wait_for_unit("klipper.service")
+    printer.wait_for_unit("moonraker.service")
+    printer.wait_for_unit("octoapp.service")
+  '';
+}

--- a/pkgs/by-name/oc/octoapp/package.nix
+++ b/pkgs/by-name/oc/octoapp/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchPypi,
+  python3,
+  makeWrapper,
+  nixosTests,
+}:
+
+let
+  octowebsocket-client = python3.pkgs.buildPythonPackage rec {
+    pname = "octowebsocket-client";
+    version = "1.8.3";
+    format = "setuptools";
+
+    src = fetchPypi {
+      pname = "octowebsocket_client";
+      inherit version;
+      hash = "sha256-3oW25Mg1tm/N7D9qjHI7+6E3jR6bIWqYjqyvDyqP0jA=";
+    };
+
+    doCheck = false;
+
+    meta = {
+      description = "WebSocket client fork for OctoApp with CPU optimizations";
+      homepage = "https://github.com/OctoEverywhere/octowebsocket-client";
+      license = lib.licenses.asl20;
+    };
+  };
+
+  octoflatbuffers = python3.pkgs.buildPythonPackage rec {
+    pname = "octoflatbuffers";
+    version = "24.3.27";
+    format = "setuptools";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-5l3eWw73ZmWlek0JsYeZEiOTEuogPICF/THXzE4LFN4=";
+    };
+
+    doCheck = false;
+
+    meta = {
+      description = "FlatBuffers serialization fork for OctoApp";
+      homepage = "https://pypi.org/project/octoflatbuffers/";
+      license = lib.licenses.asl20;
+    };
+  };
+
+  pythonEnv = python3.withPackages (ps: [
+    octowebsocket-client
+    octoflatbuffers
+    ps.requests
+    ps.pillow
+    ps.certifi
+    ps.rsa
+    ps.dnspython
+    ps.httpx
+    ps.urllib3
+    ps.typing-extensions
+    ps.configparser
+    ps.qrcode
+    ps.pycryptodome
+  ]);
+in
+stdenvNoCC.mkDerivation {
+  pname = "octoapp";
+  version = "3.0.4";
+
+  src = fetchFromGitHub {
+    owner = "crysxd";
+    repo = "OctoApp-Plugin";
+    rev = "17dfd704160be61d0a53bf3ad3e366d376bb3cd6";
+    hash = "sha256-pX0F5tPAbCsMP583WQux6xwRuI0Xy/Ch225G/TqWOlk=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/octoapp
+    cp -r moonraker_octoapp $out/lib/octoapp/
+    cp -r octoapp $out/lib/octoapp/
+    cp -r linux_host $out/lib/octoapp/
+
+    mkdir -p $out/bin
+    makeWrapper ${pythonEnv}/bin/python3 $out/bin/octoapp \
+      --add-flags "-m moonraker_octoapp" \
+      --set PYTHONPATH "$out/lib/octoapp"
+
+    runHook postInstall
+  '';
+
+  passthru.tests = {
+    inherit (nixosTests) octoapp;
+  };
+
+  meta = {
+    description = "Companion service for Klipper/Moonraker providing push notifications and remote monitoring via the OctoApp mobile app";
+    homepage = "https://github.com/crysxd/OctoApp-Plugin";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ imadnyc ];
+    platforms = lib.platforms.linux;
+    mainProgram = "octoapp";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


## Things done
Adds a module and package for octoapp companion, which handles notification and stuff for the octoapp app on ios and android. Tested with klipper and octoprint, everything seems to work fine. https://github.com/crysxd/OctoApp-Plugin. Though it calls it a plugin, it's not -- it's it's own service, like how mainsail and fluidd are separate from klipper. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
