### PR TITLE
ifupdown-ng: init at unstable-2025-09-12

### DIFF
--- a/pkgs/by-name/if/ifupdown-ng/package.nix
+++ b/pkgs/by-name/if/ifupdown-ng/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libbsd,
+  pkg-config,
+  coreutils,
+  iproute2,
+}:
+
+stdenv.mkDerivation {
+  pname = "ifupdown-ng";
+  version = "unstable-2025-09-12";
+
+  src = fetchFromGitHub {
+    owner = "ifupdown-ng";
+    repo = "ifupdown-ng";
+    rev = "fb07d0824b20d178e7acca9e85296822ac2539ac";
+    hash = "sha256-c06NbF0LpyK3hTMxCeWyQcUP9dL17hOm3993wjW/OzQ=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ libbsd ];
+
+  postPatch = ''
+    # The Makefile hardcodes -static; remove it to build dynamically.
+    substituteInPlace Makefile \
+      --replace-fail ' -static ' ' '
+
+    # replace _PATH_STDPATH with a path that includes nix store locations.
+    # ifupdown-ng sets PATH to this value before running executor scripts.
+    substituteInPlace libifupdown/lifecycle.c \
+      --replace-fail '_PATH_STDPATH' '"${
+        lib.makeBinPath [
+          iproute2
+          coreutils
+        ]
+      }:/usr/bin:/bin"'
+
+    # remove hardcoded FHS paths from executor scripts so they use PATH lookup.
+    substituteInPlace executors/linux/dhcp \
+      --replace-fail '/sbin/dhcpcd' 'dhcpcd' \
+      --replace-fail '/usr/sbin/dhclient' 'dhclient' \
+      --replace-fail '/sbin/udhcpc' 'udhcpc'
+    substituteInPlace executors/linux/vrf \
+      --replace-fail '/sbin/ip' 'ip'
+    substituteInPlace executors/linux/wifi \
+      --replace-fail '/sbin/wpa_passphrase' 'wpa_passphrase' \
+      --replace-fail '/sbin/wpa_supplicant' 'wpa_supplicant' \
+      --replace-fail '/usr/sbin/iwconfig' 'iwconfig'
+  '';
+
+  makeFlags = [
+    "SBINDIR=/bin"
+    "EXECUTOR_PATH=/libexec/ifupdown-ng"
+  ];
+
+  installFlags = [
+    "DESTDIR=${placeholder "out"}"
+  ];
+
+  meta = {
+    description = "Next-generation network interface configuration tool";
+    longDescription = ''
+      ifupdown-ng is a network device manager that is largely compatible
+      with Debian ifupdown, BusyBox ifupdown, and other implementations.
+      It is used by Alpine Linux as its network management solution.
+    '';
+    homepage = "https://github.com/ifupdown-ng/ifupdown-ng";
+    license = lib.licenses.isc;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ aanderse ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

i've been running this on my home server for a while and i find it a nice solution

`alpine`, `debian`, and `void` provide this package, so i think that justifies `nixpkgs` providing it as well

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
