### PR TITLE
nixos/regreet: fix extraCss store paths written as literal text

### DIFF
--- a/nixos/modules/programs/regreet.nix
+++ b/nixos/modules/programs/regreet.nix
@@ -159,7 +159,10 @@ in
 
     environment.etc = {
       "greetd/regreet.css" =
-        if lib.isPath cfg.extraCss then { source = cfg.extraCss; } else { text = cfg.extraCss; };
+        if lib.isPath cfg.extraCss || lib.isStorePath cfg.extraCss then
+          { source = cfg.extraCss; }
+        else
+          { text = cfg.extraCss; };
 
       "greetd/regreet.toml".source =
         if lib.isPath cfg.settings then


### PR DESCRIPTION
## Description

`lib.isPath` only matches Nix path literals, not strings containing store paths. When `extraCss` is set to a derivation's `.outPath` (a string like `"/nix/store/..."`), the condition falls through to the `text` branch, writing the store path as literal CSS content instead of using it as a file source.

This adds `lib.isStorePath` to the condition so string store paths are correctly handled via `source`.

Ref: https://github.com/nix-community/stylix/issues/2190

## Things done

- [x] Tested using sandboxing ([nix.settings.sandbox = true](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested via one or more NixOS test(s) if existing and applicable for rebuilds
- [x] Tested compilation of all pkgs that depend on this change using `nixpkgs-review`
- [x] Ensured that relevant tests are passing
- [x] Meets [Nixpkgs contribution standards](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)