### PR TITLE
boost177: add patch to fix a typo

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -170,7 +170,16 @@ stdenv.mkDerivation {
     ++ lib.optional (
       lib.versionOlder version "1.88" && stdenv.hostPlatform.isDarwin
     ) ./darwin-no-system-python.patch
-    ++ lib.optional (lib.versionOlder version "1.88") ./cmake-paths-173.patch
+    ++ lib.optionals (lib.versionOlder version "1.88") [
+      ./cmake-paths-173.patch
+      # A typo in a template fails with clang >= 19 and gcc >= 15
+      (fetchpatch {
+        url = "https://github.com/boostorg/thread/commit/49ccf9c30a0ca556873dbf64b12b0d741d1b3e66.patch";
+        relative = "include";
+        sha256 = "sha256-O1dH8H1kPZvj4ol47TvlW7+MIejy7uggcIOnZ2t8/UI=";
+      })
+    ]
+
     ++ lib.optional (lib.versionAtLeast version "1.88") ./cmake-paths-188.patch
     ++ lib.optional (version == "1.77.0") (fetchpatch {
       url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";


### PR DESCRIPTION
## Things done

All boost releases since 1.60.0 contain a typo in a template (`that_=x.that` but should be `that_=x.that_`). At that time it was apparently not a big problem, but since clang 19 and gcc 15 even un-instantiated templates are checked more thoroughly and builds may fail. The typo was fixed in boost 1.88.0.

The error would look like:

```
> /nix/store/sh7jvmnv1j8prxsy4p72vk6x4z5zfbk1-boost-1.86.0-dev/include/boost/thread/future.hpp: In member function ‘boost::detail::run_it<FutureExecutorContinuationSharedState>& boost::detail::run_it<FutureExecutorContinuationSharedState>::operator=(boost::detail::run_it<FutureExecutorContinuationSharedState>&&)’:
> /nix/store/sh7jvmnv1j8prxsy4p72vk6x4z5zfbk1-boost-1.86.0-dev/include/boost/thread/future.hpp:4671:19: error: ‘struct boost::detail::run_it<FutureExecutorContinuationSharedState>’ has no member named ‘that’; did you mean ‘that_’? [-Wtemplate-body]
>  4671 |           that_=x.that;
>       |                   ^~~~
>       |                   that_
```

The oldest supported boost in nixpkgs seems to be 1.77, so I put that in the commit msg.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
