### PR TITLE
nodejs: add a `corepack` output

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -143,7 +143,7 @@
 
 - `services.openssh.settings.AcceptEnv` now explicitly defined as an option that takes a list of strings, to facilitate option merging. Setting it to a string value is no longer supported.
 
-- `nodejs-slim` has a `npm` output, and `nodejs` no longer has a `libv8` output.
+- `nodejs-slim` has a `npm` and a `corepack` outputs, and `nodejs` no longer has a `libv8` output.
 
 - All Xfce packages have been moved to top level (e.g. if you previously added `pkgs.xfce.xfce4-whiskermenu-plugin` to `environment.systemPackages`, you will need to change it to `pkgs.xfce4-whiskermenu-plugin`). The `xfce` scope will be removed in NixOS 26.11.
 

--- a/pkgs/development/web/nodejs/corepack.nix
+++ b/pkgs/development/web/nodejs/corepack.nix
@@ -8,7 +8,8 @@ stdenv.mkDerivation {
   pname = "corepack-nodejs";
   inherit (nodejs) version;
 
-  nativeBuildInputs = [ nodejs ];
+  nativeBuildInputs = [ nodejs.corepack ];
+  buildInputs = [ nodejs ];
 
   dontUnpack = true;
 

--- a/pkgs/development/web/nodejs/symlink.nix
+++ b/pkgs/development/web/nodejs/symlink.nix
@@ -1,0 +1,14 @@
+{
+  lib,
+  nodejs-slim,
+  symlinkJoin,
+}:
+symlinkJoin {
+  pname = "nodejs";
+  inherit (nodejs-slim) version passthru meta;
+  paths = [
+    nodejs-slim
+    nodejs-slim.npm
+  ]
+  ++ lib.optional (builtins.hasAttr "corepack" nodejs-slim) nodejs-slim.corepack;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2876,47 +2876,19 @@ with pkgs;
   nodejs-slim = nodejs-slim_24;
 
   nodejs-slim_20 = callPackage ../development/web/nodejs/v20.nix { };
-  nodejs_20 = symlinkJoin {
-    pname = "nodejs";
-    inherit (nodejs-slim_20) version passthru meta;
-    paths = [
-      nodejs-slim_20
-      nodejs-slim_20.npm
-    ];
-  };
+  nodejs_20 = callPackage ../development/web/nodejs/symlink.nix { nodejs-slim = nodejs-slim_20; };
   corepack_20 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs-slim_20; };
 
   nodejs-slim_22 = callPackage ../development/web/nodejs/v22.nix { };
-  nodejs_22 = symlinkJoin {
-    pname = "nodejs";
-    inherit (nodejs-slim_22) version passthru meta;
-    paths = [
-      nodejs-slim_22
-      nodejs-slim_22.npm
-    ];
-  };
+  nodejs_22 = callPackage ../development/web/nodejs/symlink.nix { nodejs-slim = nodejs-slim_22; };
   corepack_22 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs-slim_22; };
 
   nodejs-slim_24 = callPackage ../development/web/nodejs/v24.nix { };
-  nodejs_24 = symlinkJoin {
-    pname = "nodejs";
-    inherit (nodejs-slim_24) version passthru meta;
-    paths = [
-      nodejs-slim_24
-      nodejs-slim_24.npm
-    ];
-  };
+  nodejs_24 = callPackage ../development/web/nodejs/symlink.nix { nodejs-slim = nodejs-slim_24; };
   corepack_24 = callPackage ../development/web/nodejs/corepack.nix { nodejs = nodejs-slim_24; };
 
   nodejs-slim_25 = callPackage ../development/web/nodejs/v25.nix { };
-  nodejs_25 = symlinkJoin {
-    pname = "nodejs";
-    inherit (nodejs-slim_25) version passthru meta;
-    paths = [
-      nodejs-slim_25
-      nodejs-slim_25.npm
-    ];
-  };
+  nodejs_25 = callPackage ../development/web/nodejs/symlink.nix { nodejs-slim = nodejs-slim_25; };
 
   # Update this when adding the newest nodejs major version!
   nodejs_latest = nodejs_25;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Similar to https://github.com/NixOS/nixpkgs/pull/481461, we can decouple `corepack` to its own output.
Fixes: https://github.com/NixOS/nixpkgs/issues/482918

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
