### PR TITLE
ci/github-script/check-target-branch: fix kernel exemption logic

### DIFF
--- a/ci/github-script/check-target-branch.js
+++ b/ci/github-script/check-target-branch.js
@@ -122,7 +122,11 @@ async function checkTargetBranch({ github, context, core, dry }) {
     ].join('\n'),
   )
 
-  if (maxRebuildCount >= 1000 && !isExemptHomeAssistantUpdate) {
+  if (
+    maxRebuildCount >= 1000 &&
+    !isExemptHomeAssistantUpdate &&
+    !isExemptKernelUpdate
+  ) {
     const desiredBranch =
       base === 'master' ? 'staging' : `staging-${split(base).version}`
     const body = [


### PR DESCRIPTION
In #487700, this check erroneously failed to exempt the kernel update, because I failed to check for an exemption in one if condition.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
