### PR TITLE
gnujump: fix build with gcc15

### DIFF
--- a/pkgs/by-name/gn/gnujump/fix-c23-prototypes.patch
+++ b/pkgs/by-name/gn/gnujump/fix-c23-prototypes.patch
@@ -1,0 +1,16 @@
+diff --git a/src/game.h b/src/game.h
+index fc75acc..fd511a8 100644
+--- a/src/game.h
++++ b/src/game.h
+@@ -207,9 +207,9 @@ void continueTimer (L_timer * time);
+ 
+ int yesNoQuestion (data_t * gfx, game_t * game, char *text);
+ 
+-int updateInput ();
++int updateInput (game_t * game);
+ 
+-void freeGame ();
++void freeGame (game_t * game);
+ 
+ void drawGame (data_t * gfx, game_t * game);
+ 

--- a/pkgs/by-name/gn/gnujump/package.nix
+++ b/pkgs/by-name/gn/gnujump/package.nix
@@ -28,6 +28,8 @@ stdenv.mkDerivation (finalAttrs: {
     SDL_mixer
   ];
 
+  patches = [ ./fix-c23-prototypes.patch ];
+
   env.NIX_LDFLAGS = "-lm";
 
   desktopItems = [


### PR DESCRIPTION
Tracking: https://github.com/NixOS/nixpkgs/issues/475479


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
