### PR TITLE
wigglypaint: init at 1.4

### DIFF
--- a/pkgs/by-name/wi/wigglypaint/package.nix
+++ b/pkgs/by-name/wi/wigglypaint/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  decker,
+  makeWrapper,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "wigglypaint";
+  version = "1.4";
+
+  src = fetchurl {
+    url = "https://web.archive.org/web/20260207010416if_/https://itchio-mirror.cb031a832f44726753d6267436f3b414.r2.cloudflarestorage.com/upload2/game/2398889/15143914?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=3edfcce40115d057d0b5606758e7e9ee%2F20260207%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260207T010330Z&X-Amz-Expires=60&X-Amz-SignedHeaders=host&X-Amz-Signature=48f3a1889c8898ad615ea14c12ceb216ae61ae334a612b06da658b08c96b4d37";
+    hash = "sha256-7Yoe0/QSDqOiOsuBmEeYpX2pV4NGCQDLZI5H0VQtPMY=";
+  };
+
+  dontUnpack = true;
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/bin"
+    install -Dm0644 "$src" "$out/share/wigglypaint/WigglyPaint.deck"
+    makeWrapper ${decker}/bin/decker "$out/bin/wigglypaint" \
+      --add-flags "$out/share/wigglypaint/WigglyPaint.deck"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Juicy, jiggly drawing program built with Decker";
+    homepage = "https://internet-janitor.itch.io/wigglypaint";
+    downloadPage = "https://internet-janitor.itch.io/wigglypaint";
+    license = lib.licenses.unfree;
+    inherit (decker.meta) platforms;
+    mainProgram = "wigglypaint";
+    maintainers = with lib.maintainers; [ mio ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
