### PR TITLE
turntable: 0.4.0 -> 0.5.1, add updateScript

### DIFF
--- a/pkgs/by-name/tu/turntable/package.nix
+++ b/pkgs/by-name/tu/turntable/package.nix
@@ -14,8 +14,11 @@
   libsecret,
   libglycin,
   libglycin-gtk4,
+  libportal,
+  libportal-gtk4,
   glib-networking,
   glycin-loaders,
+  nix-update-script,
 
   # Per the upstream request. Key owned by Aleksana
   lastfmKey ? "b5027c5178ca2abfcc31bd04397c3c0e",
@@ -24,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "turntable";
-  version = "0.4.0";
+  version = "0.5.1";
 
   src = fetchFromCodeberg {
     owner = "GeopJr";
     repo = "Turntable";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Rvkzh2Cila6ZhQZyX5zzUrWane6nLAjrwnKk0LPWKuE=";
+    hash = "sha256-OXZjCkVf1XOh1joDE5SBKaQmblfu+zNr+EXaqWP7HhM=";
   };
 
   nativeBuildInputs = [
@@ -51,6 +54,8 @@ stdenv.mkDerivation (finalAttrs: {
     libglycin-gtk4
     glycin-loaders
     glib-networking
+    libportal
+    libportal-gtk4
   ];
 
   mesonFlags = [
@@ -59,6 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   strictDeps = true;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Scrobbles your music to multiple services with playback controls for MPRIS players";


### PR DESCRIPTION
0.5.0 requires the libportal dependency for running in the background.
https://codeberg.org/GeopJr/Turntable/releases/tag/v0.5.0
https://codeberg.org/GeopJr/Turntable/releases/tag/v0.5.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
