### PR TITLE
iptsd: build all debug tools

### DIFF
--- a/pkgs/by-name/ip/iptsd/package.nix
+++ b/pkgs/by-name/ip/iptsd/package.nix
@@ -6,11 +6,13 @@
   meson,
   ninja,
   pkg-config,
+  cairomm,
   cli11,
   eigen,
   hidrd,
   inih,
   microsoft-gsl,
+  sdl2-compat,
   spdlog,
   systemd,
   udevCheckHook,
@@ -38,11 +40,13 @@ stdenv.mkDerivation (finalAttrs: {
   dontUseCmakeConfigure = true;
 
   buildInputs = [
+    cairomm
     cli11
     eigen
     hidrd
     inih
     microsoft-gsl
+    sdl2-compat
     spdlog
     systemd
   ];
@@ -63,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "-Dservice_manager=systemd"
     "-Dsample_config=false"
-    "-Ddebug_tools="
     "-Db_lto=false" # plugin needed to handle lto object -> undefined reference to ...
   ];
 


### PR DESCRIPTION
I wanted to calibrate the touch screen on my Surface Pro 8 running nixos. I had to build iptsd myself to access these tools that [the documentation page](https://github.com/linux-surface/iptsd/wiki/Calibrating-iptsd) assumes is available.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


Below is a record of running each additional tool as built with nix-build. The driver itself functions as normally.

```
[nix-shell:~/Documents/nix_dev/nixpkgs]$ sudo ./result/bin/iptsd-calibrate /dev/hidraw0
[19:45:19.311] [info] Loading config /etc/iptsd.conf.
[19:45:19.311] [info] Connected to device 045E:0C37
[19:45:19.311] [info] Running in Touchscreen mode
[19:45:21.586] [info] Samples: 127
[19:45:21.586] [info] Size:    0.882 (Min: 0.882; Max: 0.882)
[19:45:21.586] [info] Aspect:  1.125 (Min: 1.125; Max: 1.125)
^C[19:45:21.588] [warning] core: linux: Reading from file failed: Interrupted system call
[19:45:21.688] [info] 
[19:45:21.688] [info] To finish the calibration process, apply the determined values to iptsd.
[19:45:21.688] [info] Three config snippets have been generated for you in the current directory.
[19:45:21.688] [info] Run the displayed to command to install them, and restart iptsd.
[19:45:21.688] [info] 
[19:45:21.688] [info] Recommended:
[19:45:21.688] [info]     sudo cp iptsd_calib_045E_0C37_1770435921_2mm.conf /etc/iptsd.d/91-calibration-045E-0C37.conf
[19:45:21.688] [info] 
[19:45:21.688] [info] If iptsd misses inputs:
[19:45:21.688] [info]     sudo cp iptsd_calib_045E_0C37_1770435921_10mm.conf /etc/iptsd.d/91-calibration-045E-0C37.conf
[19:45:21.688] [info] 
[19:45:21.688] [info] For manual finetuning:
[19:45:21.688] [info]     sudo cp iptsd_calib_045E_0C37_1770435921_0mm.conf /etc/iptsd.d/91-calibration-045E-0C37.conf
[19:45:21.688] [info] 
[19:45:21.688] [warning] Running these commands can permanently overwrite a previous calibration!

[nix-shell:~/Documents/nix_dev/nixpkgs]$ sudo ./result/bin/iptsd-check-device /dev/hidraw0
[19:45:38.021] [info] Loading config /etc/iptsd.conf.
[19:45:38.021] [info] Connected to device 045E:0C37
[19:45:38.021] [info] Running in Touchscreen mode
[19:45:38.021] [info] /dev/hidraw0 is an IPTS device!

[nix-shell:~/Documents/nix_dev/nixpkgs]$ sudo ./result/bin/iptsd-find-hidraw 
[19:45:45.007] [warning] iptsd-find-hidraw is deprecated, please use iptsd-foreach
/dev/hidraw0

[nix-shell:~/Documents/nix_dev/nixpkgs]$ sudo ./result/bin/iptsd-find-service 
[19:45:51.781] [warning] iptsd-find-service is deprecated, please use iptsd-systemd
iptsd@dev-hidraw0.service

[nix-shell:~/Documents/nix_dev/nixpkgs]$ sudo ./result/bin/iptsd-foreach echo {}
/dev/hidraw0

[nix-shell:~/Documents/nix_dev/nixpkgs]$ sudo ./result/bin/iptsd-show /dev/hidraw0
[19:46:54.502] [info] Loading config /etc/iptsd.conf.
error: XDG_RUNTIME_DIR is invalid or not set in the environment.
[19:46:54.656] [info] Connected to device 045E:0C37
[19:46:54.656] [info] Running in Touchscreen mode
^C[19:47:00.148] [warning] core: linux: Reading from file failed: Interrupted system call
```
