### PR TITLE
fetchFrom{GitHub, Codeberg, Gitea}: allow overriding function name 

### DIFF
--- a/pkgs/build-support/fetchcodeberg/default.nix
+++ b/pkgs/build-support/fetchcodeberg/default.nix
@@ -1,2 +1,11 @@
 { lib, fetchFromGitea }:
-lib.makeOverridable (args: fetchFromGitea ({ domain = "codeberg.org"; } // args))
+lib.makeOverridable (
+  args:
+  fetchFromGitea (
+    {
+      domain = "codeberg.org";
+      functionName = "fetchFromCodeberg";
+    }
+    // args
+  )
+)

--- a/pkgs/build-support/fetchgitea/default.nix
+++ b/pkgs/build-support/fetchgitea/default.nix
@@ -3,7 +3,20 @@
 { lib, fetchFromGitHub }:
 
 lib.makeOverridable (
-  { domain, ... }@args:
+  {
+    domain,
+    functionName ? "fetchFromGitea",
+    ...
+  }@args:
 
-  fetchFromGitHub ((removeAttrs args [ "domain" ]) // { githubBase = domain; })
+  fetchFromGitHub (
+    (removeAttrs args [
+      "domain"
+      "functionName"
+    ])
+    // {
+      inherit functionName;
+      githubBase = domain;
+    }
+  )
 )

--- a/pkgs/build-support/fetchgithub/default.nix
+++ b/pkgs/build-support/fetchgithub/default.nix
@@ -48,6 +48,7 @@ decorate (
     repo,
     tag ? null,
     rev ? null,
+    functionName ? "fetchFromGitHub",
     # TODO(@ShamrockLee): Add back after reconstruction with lib.extendMkDerivation
     # name ? repoRevToNameMaybe finalAttrs.repo (lib.revOrTag finalAttrs.revCustom finalAttrs.tag) "github",
     private ? false,
@@ -60,7 +61,7 @@ decorate (
 
   assert (
     lib.xor (tag == null) (rev == null)
-    || throw "fetchFromGitHub requires one of either `rev` or `tag` to be provided (not both)."
+    || throw "${functionName} requires one of either `rev` or `tag` to be provided (not both)."
   );
 
   let
@@ -115,6 +116,7 @@ decorate (
         "repo"
         "tag"
         "rev"
+        "functionName"
         "private"
         "githubBase"
         "varPrefix"
@@ -135,7 +137,7 @@ decorate (
         in
         ''
           if [ -z "''$${varBase}USERNAME" -o -z "''$${varBase}PASSWORD" ]; then
-            echo "Error: Private fetchFromGitHub requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
+            echo "Error: Private ${functionName} requires the nix building process (nix-daemon in multi user mode) to have the ${varBase}USERNAME and ${varBase}PASSWORD env vars set." >&2
             exit 1
           fi
           cat > netrc <<EOF


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Allow overriding function name in fetch source functions for better error message.

Should cause no rebuild.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
