### PR TITLE
wine: Inline `supportFlags` in `base.nix`

### DIFF
--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -6,7 +6,7 @@
 # };
 # Make additional configurations on demand:
 # wine.override { wineBuild = "wine32"; wineRelease = "staging"; };
-{
+args@{
   lib,
   stdenv,
   callPackage,
@@ -50,6 +50,18 @@
 let
   sources = callPackage ./sources.nix { };
 
+  supportFlags = lib.filterAttrs (
+    name: _:
+    !builtins.elem name [
+      "lib"
+      "stdenv"
+      "callPackage"
+      "darwin"
+      "wineRelease"
+      "wineBuild"
+    ]
+  ) args;
+
   # Map user-facing release names to sources, pname suffix, and staging flag
   releaseInfo = {
     stable = {
@@ -77,47 +89,7 @@ let
   };
 
   baseWine = lib.getAttr wineBuild (
-    callPackage ./packages.nix (
-      releaseInfo.${wineRelease}
-      // {
-        supportFlags = {
-          inherit
-            alsaSupport
-            cairoSupport
-            cupsSupport
-            cursesSupport
-            dbusSupport
-            embedInstallers
-            fontconfigSupport
-            gettextSupport
-            gphoto2Support
-            gstreamerSupport
-            gtkSupport
-            krb5Support
-            mingwSupport
-            netapiSupport
-            odbcSupport
-            openclSupport
-            openglSupport
-            pcapSupport
-            pulseaudioSupport
-            saneSupport
-            sdlSupport
-            tlsSupport
-            udevSupport
-            usbSupport
-            v4lSupport
-            vaSupport
-            vulkanSupport
-            waylandSupport
-            x11Support
-            ffmpegSupport
-            xineramaSupport
-            ;
-        };
-        inherit moltenvk;
-      }
-    )
+    callPackage ./packages.nix (releaseInfo.${wineRelease} // supportFlags)
   );
 in
 if wineRelease == "yabridge" then

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -10,14 +10,14 @@
   src,
   pnameSuffix ? "",
   useStaging ? false,
-  supportFlags,
   # Staging native build deps
   autoconf,
   hexdump,
   perl,
   python3,
   gitMinimal,
-}:
+  ...
+}@args:
 
 let
   inherit (src)
@@ -27,118 +27,110 @@ let
     gecko64
     mono
     ;
+
+  # Args to pass through to base.nix (support flags, etc.)
+  baseArgs = removeAttrs args [
+    "stdenv_32bit"
+    "lib"
+    "pkgs"
+    "pkgsi686Linux"
+    "pkgsCross"
+    "callPackage"
+    "replaceVars"
+  ];
 in
 {
-  wine32 = pkgsi686Linux.callPackage ./base.nix {
-    pname = "wine";
-    inherit
-      src
-      version
-      supportFlags
-      patches
-      moltenvk
-      pnameSuffix
-      useStaging
+  wine32 = pkgsi686Linux.callPackage ./base.nix (
+    baseArgs
+    // {
+      pname = "wine";
+      inherit version patches;
       # Forcing these `nativeBuildInputs` used in the `staging` to come
       # from ambient `pkgs`, rather than being provided by
       # `pkgsi686Linux.callPackage` for that platform.
-      autoconf
-      hexdump
-      perl
-      python3
-      gitMinimal
-      ;
-    pkgArches = [ pkgsi686Linux ];
-    geckos = [ gecko32 ];
-    mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc ];
-    monos = [ mono ];
-    platforms = [
-      "i686-linux"
-      "x86_64-linux"
-    ];
-  };
-  wine64 = callPackage ./base.nix {
-    pname = "wine64";
-    inherit
-      src
-      version
-      supportFlags
-      patches
-      moltenvk
-      pnameSuffix
-      useStaging
-      ;
-    pkgArches = [ pkgs ];
-    mingwGccs = with pkgsCross; [ mingwW64.buildPackages.gcc ];
-    geckos = [ gecko64 ];
-    monos = [ mono ];
-    configureFlags = [ "--enable-win64" ];
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-    ];
-    mainProgram = "wine";
-  };
-  wineWow = callPackage ./base.nix {
-    pname = "wine-wow";
-    inherit
-      src
-      version
-      supportFlags
-      patches
-      moltenvk
-      pnameSuffix
-      useStaging
-      ;
-    stdenv = stdenv_32bit;
-    pkgArches = [
-      pkgs
-      pkgsi686Linux
-    ];
-    geckos = [
-      gecko32
-      gecko64
-    ];
-    mingwGccs = with pkgsCross; [
-      mingw32.buildPackages.gcc
-      mingwW64.buildPackages.gcc
-    ];
-    monos = [ mono ];
-    buildScript = replaceVars ./builder-wow.sh {
-      # pkgconfig has trouble picking the right architecture
-      pkgconfig64remove = lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
-        pkgs.glib
-        pkgs.gst_all_1.gstreamer
+      inherit
+        autoconf
+        hexdump
+        perl
+        python3
+        gitMinimal
+        ;
+      pkgArches = [ pkgsi686Linux ];
+      geckos = [ gecko32 ];
+      mingwGccs = with pkgsCross; [ mingw32.buildPackages.gcc ];
+      monos = [ mono ];
+      platforms = [
+        "i686-linux"
+        "x86_64-linux"
       ];
-    };
-    platforms = [ "x86_64-linux" ];
-    mainProgram = "wine";
-  };
-  wineWow64 = callPackage ./base.nix {
-    pname = "wine-wow64";
-    inherit
-      src
-      version
-      patches
-      moltenvk
-      pnameSuffix
-      useStaging
-      ;
-    supportFlags = supportFlags // {
-      mingwSupport = true;
-    }; # Required because we request "--enable-archs=x86_64"
-    pkgArches = [ pkgs ];
-    mingwGccs = with pkgsCross; [
-      mingw32.buildPackages.gcc
-      mingwW64.buildPackages.gcc
-    ];
-    geckos = [ gecko64 ];
-    monos = [ mono ];
-    configureFlags = [ "--enable-archs=x86_64,i386" ];
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-    ];
-    mainProgram = "wine";
-  };
+    }
+  );
+  wine64 = callPackage ./base.nix (
+    baseArgs
+    // {
+      pname = "wine64";
+      inherit version patches;
+      pkgArches = [ pkgs ];
+      mingwGccs = with pkgsCross; [ mingwW64.buildPackages.gcc ];
+      geckos = [ gecko64 ];
+      monos = [ mono ];
+      configureFlags = [ "--enable-win64" ];
+      platforms = [
+        "x86_64-linux"
+        "x86_64-darwin"
+      ];
+      mainProgram = "wine";
+    }
+  );
+  wineWow = callPackage ./base.nix (
+    baseArgs
+    // {
+      pname = "wine-wow";
+      inherit version patches;
+      stdenv = stdenv_32bit;
+      pkgArches = [
+        pkgs
+        pkgsi686Linux
+      ];
+      geckos = [
+        gecko32
+        gecko64
+      ];
+      mingwGccs = with pkgsCross; [
+        mingw32.buildPackages.gcc
+        mingwW64.buildPackages.gcc
+      ];
+      monos = [ mono ];
+      buildScript = replaceVars ./builder-wow.sh {
+        # pkgconfig has trouble picking the right architecture
+        pkgconfig64remove = lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
+          pkgs.glib
+          pkgs.gst_all_1.gstreamer
+        ];
+      };
+      platforms = [ "x86_64-linux" ];
+      mainProgram = "wine";
+    }
+  );
+  wineWow64 = callPackage ./base.nix (
+    baseArgs
+    // {
+      pname = "wine-wow64";
+      inherit version patches;
+      mingwSupport = true; # Required because we request "--enable-archs=x86_64"
+      pkgArches = [ pkgs ];
+      mingwGccs = with pkgsCross; [
+        mingw32.buildPackages.gcc
+        mingwW64.buildPackages.gcc
+      ];
+      geckos = [ gecko64 ];
+      monos = [ mono ];
+      configureFlags = [ "--enable-archs=x86_64,i386" ];
+      platforms = [
+        "x86_64-linux"
+        "x86_64-darwin"
+      ];
+      mainProgram = "wine";
+    }
+  );
 }


### PR DESCRIPTION
I would like to get rid of `default.nix` entirely, but doing so involves some back-compat issues. This seems like it might be the last change I can make before those back-compat issues become unavoidable?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
