### PR TITLE
Fixed nv-fabricmanager Build Phases

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -17,6 +17,11 @@ let
 in
 
 stdenv.mkDerivation rec {
+  phases = [
+    "unpackPhase"
+    "installPhase"
+  ];
+
   pname = "fabricmanager";
   version = fmver;
   src = fetchurl {

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -21,6 +21,7 @@ stdenv.mkDerivation rec {
   phases = [
     "unpackPhase"
     "installPhase"
+    "checkPhase"
     "installCheckPhase"
   ];
 
@@ -58,10 +59,12 @@ stdenv.mkDerivation rec {
       mv $d $out/.
     done
     patchShebangs $out/bin
+  '';
 
-    for b in $out/bin/*;do
-      ${ldd} $b | grep -vqz "not found"
-    done
+  doCheck = true;
+
+  checkPhase = ''
+    ldd $out/bin/* | grep -v "not found"
   '';
 
   meta = {

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -39,6 +39,8 @@ stdenv.mkDerivation rec {
   ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/{bin,share/nvidia-fabricmanager}
     for bin in nv{-fabricmanager,switch-audit};do
       ${patchelf}/bin/patchelf \
@@ -59,6 +61,8 @@ stdenv.mkDerivation rec {
       mv $d $out/.
     done
     patchShebangs $out/bin
+
+    runHook postInstall
   '';
 
   doCheck = true;

--- a/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/fabricmanager.nix
@@ -7,6 +7,7 @@ nvidia_x11: sha256:
   patchelf,
   zlib,
   glibc,
+  versionCheckHook,
 }:
 
 let
@@ -20,6 +21,7 @@ stdenv.mkDerivation rec {
   phases = [
     "unpackPhase"
     "installPhase"
+    "installCheckPhase"
   ];
 
   pname = "fabricmanager";
@@ -30,6 +32,10 @@ stdenv.mkDerivation rec {
       + "${sys}/${pname}-${sys}-${fmver}-archive.tar.xz";
     inherit sha256;
   };
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   installPhase = ''
     mkdir -p $out/{bin,share/nvidia-fabricmanager}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Ran into this issue when trying to move over to NixOS 25.11 from 25.05 while using [hardware.nvidia.datacenter.enable](https://search.nixos.org/options?channel=unstable&query=datacenter).

Seems that something going on in one of  the build phases is causing the following to happen when the `nv-fabricmanager` binary is called: [nv-fabricmanager.log](https://github.com/user-attachments/files/25142867/nv-fabricmanager.log).

The exact same output is logged when running checking the nv-fabricmanager binary with ldd. There is a part of the installPhase that checks the binaries with ldd, but it just checks `grep -vqz "not found"`, which doesn't appear in the above. This means the derivation still gets evaluated successfully, but the built binary is in a broken state.

## Things done

* Revert build phases back to how they were in NixOS 25.05.
* Enabled the `installCheckPhase`. This solves the issue without change as it runs the binary and checks to see if the version gets logged.
* Enabled the checkPhase and pulled the ldd check from the installPhase into the checkPhase. Makes more sense to be in the checkPhase imo.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
