### PR TITLE
sail: init at 0.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5913,6 +5913,12 @@
     githubId = 10701143;
     name = "David Crompton";
   };
+  davidlghellin = {
+    email = "hola@devel0pez.com";
+    github = "davidlghellin";
+    githubId = 1321512;
+    name = "David López";
+  };
   davidrusu = {
     email = "davidrusu.me@gmail.com";
     github = "davidrusu";

--- a/pkgs/by-name/sa/sail/package.nix
+++ b/pkgs/by-name/sa/sail/package.nix
@@ -1,0 +1,64 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  protobuf,
+  pkg-config,
+  python3,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "sail";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "lakehq";
+    repo = "sail";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JHeFJnPgDuRlUVHg5DrlC/rpeOKu/g9LfS2drpmpVa8=";
+  };
+
+  cargoHash = "sha256-pDB9tXDdPZ9YhAJC2Vax0/SCWiG3APVQQy/PgSSClUw=";
+
+  cargoBuildFlags = [
+    "-p"
+    "sail-cli"
+  ];
+  cargoTestFlags = [
+    "-p"
+    "sail-cli"
+  ];
+
+  nativeBuildInputs = [
+    protobuf
+    pkg-config
+  ];
+
+  buildInputs = [
+    python3
+  ];
+
+  env = {
+    PYO3_PYTHON = lib.getExe python3;
+    PROTOC = lib.getExe protobuf;
+  };
+
+  # Tests require a running server
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Spark-compatible compute engine built on Apache Arrow and DataFusion";
+    homepage = "https://github.com/lakehq/sail";
+    changelog = "https://github.com/lakehq/sail/blob/v${finalAttrs.version}/docs/reference/changelog/index.md";
+    license = lib.licenses.asl20;
+    mainProgram = "sail";
+    maintainers = [ lib.maintainers.davidlghellin ];
+  };
+})


### PR DESCRIPTION
## Summary

Add [Sail](https://github.com/lakehq/sail), a Rust-native Spark-compatible compute engine built on Apache Arrow and Apache DataFusion. It implements the Spark Connect protocol, allowing existing PySpark code to work without modification.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.