### PR TITLE
nvtop: 3.2.0 -> 3.3.1

### DIFF
--- a/pkgs/tools/system/nvtop/build-nvtop.nix
+++ b/pkgs/tools/system/nvtop/build-nvtop.nix
@@ -20,6 +20,9 @@
   ascend ? false,
   v3d ? false,
   tpu ? false,
+  rockchip ? false,
+  metax ? false,
+  enflame ? false,
 }:
 
 let
@@ -39,7 +42,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "nvtop";
-  version = "3.2.0";
+  version = "3.3.1";
 
   # between generation of multiple update PRs for each package flavor and manual updates I choose manual updates
   # nixpkgs-update: no auto update
@@ -47,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Syllo";
     repo = "nvtop";
     rev = finalAttrs.version;
-    hash = "sha256-8iChT55L2NSnHg8tLIry0rgi/4966MffShE0ib+2ywc=";
+    hash = "sha256-+SvEp8pbauSLbDuPZqGMTyL2EZecz1VKCJgC+xjV/vQ=";
   };
 
   cmakeFlags = with lib.strings; [
@@ -63,6 +66,9 @@ stdenv.mkDerivation (finalAttrs: {
     (cmakeBool "ASCEND_SUPPORT" ascend)
     (cmakeBool "V3D_SUPPORT" v3d)
     (cmakeBool "TPU_SUPPORT" tpu) # requires libtpuinfo which is not packaged yet
+    (cmakeBool "ROCKCHIP_SUPPORT" rockchip)
+    (cmakeBool "METAX_SUPPORT" metax)
+    (cmakeBool "ENFLAME_SUPPORT" enflame)
   ];
   nativeBuildInputs = [
     cmake

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -11,6 +11,9 @@ let
     "panfrost"
     "panthor"
     "v3d"
+    "rockchip"
+    "metax"
+    "enflame"
   ];
   # these GPU families are partially supported upstream, they are also tricky to build in nixpkgs
   # volunteers with specific hardware needed to build and test these package variants


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Release: https://github.com/Syllo/nvtop/releases/tag/3.3.1
Diff: https://github.com/Syllo/nvtop/compare/3.2.0...3.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
