### PR TITLE
buf: 1.64.0 -> 1.66.1, adopt

### DIFF
--- a/pkgs/by-name/bu/buf/package.nix
+++ b/pkgs/by-name/bu/buf/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "buf";
-  version = "1.64.0";
+  version = "1.66.1";
 
   src = fetchFromGitHub {
     owner = "bufbuild";
     repo = "buf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vz7HtNe198Wjy4bjpx327VW11Qme5VWZMyeb56nWy0A=";
+    hash = "sha256-bBQSQ/ZLLSEYVmfpgh5OKapSHdBOFjrjAaMT/0js1Ts=";
   };
 
-  vendorHash = "sha256-jBwIDPDRdXO89uyrw2Ul2uE50zCLxS9qBzoYOQXupUQ=";
+  vendorHash = "sha256-JFuH/NXWhw/Myzk2ct5xzKGuMM4ma0og2YT7ZIq3kKg=";
 
   patches = [
     # Skip a test that requires networking to be available to work.
@@ -45,8 +45,8 @@ buildGoModule (finalAttrs: {
   preCheck = ''
     # Some tests take longer depending on builder load.
     substituteInPlace private/bufpkg/bufcheck/lint_test.go \
-      --replace-fail 'context.WithTimeout(context.Background(), 60*time.Second)' \
-                     'context.WithTimeout(context.Background(), 600*time.Second)'
+      --replace-fail 'context.WithTimeout(t.Context(), 60*time.Second)' \
+                     'context.WithTimeout(t.Context(), 600*time.Second)'
     # For WebAssembly runtime tests
     GOOS=wasip1 GOARCH=wasm go build -o $GOPATH/bin/buf-plugin-suffix.wasm \
       ./private/bufpkg/bufcheck/internal/cmd/buf-plugin-suffix

--- a/pkgs/by-name/bu/buf/package.nix
+++ b/pkgs/by-name/bu/buf/package.nix
@@ -88,6 +88,7 @@ buildGoModule (finalAttrs: {
     description = "Create consistent Protobuf APIs that preserve compatibility and comply with design best-practices";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
+      hythera
       jk
       lrewega
     ];


### PR DESCRIPTION
Changelogs: 
- https://github.com/bufbuild/buf/releases/tag/v1.65.0
- https://github.com/bufbuild/buf/releases/tag/v1.66.0
- https://github.com/bufbuild/buf/releases/tag/v1.66.1

Diff: https://github.com/bufbuild/buf/compare/v1.64.0...v1.66.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
