### PR TITLE
python3Packages.exceptiongroup: fix build on staging

### DIFF
--- a/pkgs/development/python-modules/exceptiongroup/default.nix
+++ b/pkgs/development/python-modules/exceptiongroup/default.nix
@@ -6,6 +6,7 @@
   pytestCheckHook,
   pythonAtLeast,
   pythonOlder,
+  isPy313,
   typing-extensions,
 }:
 
@@ -20,6 +21,15 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-3WInufN+Pp6vB/Gik6e8V1a34Dr/oiH3wDMB+2lHRMM=";
   };
+
+  # CPython fixed https://github.com/python/cpython/issues/141732 in
+  # https://github.com/python/cpython/pull/141736, but exceptiongroup 1.3.1,
+  # including its test suite, still matches the old repr behavior.
+  # The CPython fix has only been backported to 3.13 so far, where it was
+  # first included in version 3.13.12, so we only need to patch for 3.13
+  # and 3.15+.
+  # Upstream issue: https://github.com/agronholm/exceptiongroup/issues/154
+  patches = lib.optional (isPy313 || pythonAtLeast "3.15") ./match-repr-fix.patch;
 
   build-system = [ flit-scm ];
 

--- a/pkgs/development/python-modules/exceptiongroup/match-repr-fix.patch
+++ b/pkgs/development/python-modules/exceptiongroup/match-repr-fix.patch
@@ -1,0 +1,48 @@
+From 9be2b65dbd8366da27cd79c09195493217dbf539 Mon Sep 17 00:00:00 2001
+From: Tom Hunze <dev@thunze.de>
+Date: Sat, 7 Feb 2026 11:37:49 +0100
+Subject: [PATCH] Fix `ExceptionGroup` repr changing when original exception
+ sequence is mutated
+
+https://github.com/python/cpython/pull/141736
+---
+ src/exceptiongroup/_exceptions.py | 3 ++-
+ tests/test_exceptions.py          | 3 +--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/exceptiongroup/_exceptions.py b/src/exceptiongroup/_exceptions.py
+index f42c1ad..996d8e1 100644
+--- a/src/exceptiongroup/_exceptions.py
++++ b/src/exceptiongroup/_exceptions.py
+@@ -101,6 +101,7 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
+                         )
+ 
+         instance = super().__new__(cls, __message, __exceptions)
++        instance._exceptions_str = repr(__exceptions)
+         instance._exceptions = tuple(__exceptions)
+         return instance
+ 
+@@ -275,7 +276,7 @@ class BaseExceptionGroup(BaseException, Generic[_BaseExceptionT_co]):
+         return f"{self.message} ({len(self._exceptions)} sub-exception{suffix})"
+ 
+     def __repr__(self) -> str:
+-        return f"{self.__class__.__name__}({self.args[0]!r}, {self.args[1]!r})"
++        return f"{self.__class__.__name__}({self.args[0]!r}, {self._exceptions_str})"
+ 
+ 
+ class ExceptionGroup(BaseExceptionGroup[_ExceptionT_co], Exception):
+diff --git a/tests/test_exceptions.py b/tests/test_exceptions.py
+index e2bc81a..a253236 100644
+--- a/tests/test_exceptions.py
++++ b/tests/test_exceptions.py
+@@ -883,6 +883,5 @@ def test_exceptions_mutate_original_sequence():
+     exceptions.append(KeyError("bar"))
+     assert excgrp.exceptions is exc_tuple
+     assert repr(excgrp) == (
+-        "BaseExceptionGroup('foo', [ValueError(1), KeyboardInterrupt(), "
+-        "KeyError('bar')])"
++        "BaseExceptionGroup('foo', [ValueError(1), KeyboardInterrupt()])"
+     )
+-- 
+2.51.2
+


### PR DESCRIPTION
`python313Packages.exceptiongroup` currently fails to build on staging.

Reason: CPython fixed https://github.com/python/cpython/issues/141732 in https://github.com/python/cpython/pull/141736, but exceptiongroup 1.3.1, including its test suite, still matches the old repr behavior. The CPython fix has only been backported to 3.13 so far, where it was first included in version 3.13.12, so we only need to patch for 3.13 and 3.15+ at the moment.

I verified that exceptiongroup builds on Python 3.12+.

Upstream issue: https://github.com/agronholm/exceptiongroup/issues/154

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
