### PR TITLE
gitaly.git: remove leaveDotGit from src FOD and modernize

### DIFF
--- a/pkgs/by-name/gi/gitaly/dont-clone-git-repo.patch
+++ b/pkgs/by-name/gi/gitaly/dont-clone-git-repo.patch
@@ -1,0 +1,19 @@
+diff --git a/Makefile b/Makefile
+index e75c22e80b..f702da6f80 100644
+--- a/Makefile
++++ b/Makefile
+@@ -757,12 +757,8 @@
+ # otherwise try to rebuild all targets depending on it whenever we build
+ # something else. We thus depend on the Makefile instead.
+ ${DEPENDENCY_DIR}/git-%/Makefile: ${DEPENDENCY_DIR}/git-%.version
+-	${Q}${GIT} -c init.defaultBranch=master init ${GIT_QUIET} "${@D}"
+-	${Q}${GIT} -C "${@D}" config remote.origin.url ${GIT_REPO_URL}
+-	${Q}${GIT} -C "${@D}" config remote.origin.tagOpt --no-tags
+-	${Q}${GIT} -C "${@D}" fetch --depth 1 ${GIT_QUIET} origin ${GIT_VERSION}
+-	${Q}${GIT} -C "${@D}" reset --hard
+-	${Q}${GIT} -C "${@D}" checkout ${GIT_QUIET} --detach FETCH_HEAD
++	cp -r ${GIT_REPO_PATH} "${@D}"
++	chmod -R oga+rw "${@D}"
+ ifeq ($(OVERRIDE_GIT_VERSION),)
+ 	${Q}rm -f "${@D}"/version
+ else

--- a/pkgs/by-name/gi/gitaly/git-data.json
+++ b/pkgs/by-name/gi/gitaly/git-data.json
@@ -1,5 +1,5 @@
 {
   "version": "2.52-a37bb2ae",
   "rev": "a37bb2ae6c6659cf7cefd0412759fca5202a823d",
-  "hash": "sha256-7yUjXiaFwPG9o4n+IieYNTJKtzyawQFHooNrikpbiEM="
+  "hash": "sha256-A1FOzmVe2e73pie0WYJPwsKOb5BGNrusGy0wXa9ruvI="
 }

--- a/pkgs/by-name/gi/gitlab/update.py
+++ b/pkgs/by-name/gi/gitlab/update.py
@@ -279,7 +279,7 @@ def update_gitaly():
                 NIXPKGS_PATH,
                 "-H",
                 "-a",
-                "leaveDotGit",
+                "fetchSubmodules",
                 "true",
                 "https://gitlab.com/gitlab-org/git",
                 git_rev


### PR DESCRIPTION
leaveDotGit is currently very unstable for this FOD. Gitaly normally clones the Git repo. This change changes this behaviour to just copy Git.

Follow-up to https://github.com/NixOS/nixpkgs/pull/485732#issuecomment-3863897188
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
