### PR TITLE
pixel2svg: fix build, modernise, move to by-name

### DIFF
--- a/pkgs/by-name/pi/pixel2svg/package.nix
+++ b/pkgs/by-name/pi/pixel2svg/package.nix
@@ -1,13 +1,11 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchurl,
-  pillow,
-  svgwrite,
   versionCheckHook,
 }:
 
-buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "pixel2svg";
   version = "0.3.0";
   pyproject = true;

--- a/pkgs/tools/graphics/pixel2svg/default.nix
+++ b/pkgs/tools/graphics/pixel2svg/default.nix
@@ -1,25 +1,30 @@
 {
   lib,
-  buildPythonPackage,
+  buildPythonApplication,
   fetchurl,
   pillow,
   svgwrite,
+  versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonApplication (finalAttrs: {
   pname = "pixel2svg";
   version = "0.3.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchurl {
-    url = "https://static.florian-berger.de/pixel2svg-${version}.zip";
-    sha256 = "sha256-aqcTTmZKcdRdVd8GGz5cuaQ4gjPapVJNtiiZu22TZgQ=";
+    url = "https://static.florian-berger.de/pixel2svg-${finalAttrs.version}.zip";
+    hash = "sha256-aqcTTmZKcdRdVd8GGz5cuaQ4gjPapVJNtiiZu22TZgQ=";
   };
 
-  propagatedBuildInputs = [
+  build-system = with python3Packages; [ setuptools ];
+
+  dependencies = with python3Packages; [
     pillow
     svgwrite
   ];
+
+  nativeCheckInputs = [ versionCheckHook ];
 
   meta = {
     homepage = "https://florian-berger.de/en/software/pixel2svg/";
@@ -28,4 +33,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ annaaurora ];
     mainProgram = "pixel2svg.py";
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10165,8 +10165,6 @@ with pkgs;
 
   pinboard-notes-backup = haskell.lib.compose.justStaticExecutables haskellPackages.pinboard-notes-backup;
 
-  pixel2svg = python311Packages.callPackage ../tools/graphics/pixel2svg { };
-
   inherit (callPackage ../applications/virtualization/singularity/packages.nix { })
     apptainer
     singularity

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10165,7 +10165,7 @@ with pkgs;
 
   pinboard-notes-backup = haskell.lib.compose.justStaticExecutables haskellPackages.pinboard-notes-backup;
 
-  pixel2svg = python310Packages.callPackage ../tools/graphics/pixel2svg { };
+  pixel2svg = python311Packages.callPackage ../tools/graphics/pixel2svg { };
 
   inherit (callPackage ../applications/virtualization/singularity/packages.nix { })
     apptainer


### PR DESCRIPTION
Alternatively we can just drop this package? It seems unmaintained, last release was back in 2011.
It does however still build, and testing it using the inputs on the homepage seems to produce the correct result.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
