### PR TITLE
lichess-external-engine: init at a6ef15a

### DIFF
--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -43,5 +43,4 @@ python3Packages.buildPythonApplication (finalAttrs: {
     maintainers = with lib.maintainers; [ malix ];
     mainProgram = "lichess-external-engine";
   };
-
 })

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -22,10 +22,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-
-    mkdir -p $out/bin
     install -Dm755 example-provider.py $out/bin/lichess-external-engine
-
     runHook postInstall
   '';
 

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -12,8 +12,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
   src = fetchFromGitHub {
     owner = "lichess-org";
     repo = "external-engine";
-    rev = finalAttrs.version;
-    sha256 = "18dwzrcvzycmgjsij3lyrih0n1824kv87bl3bl7f4zg9rr46ksci";
+    rev = "a6ef15a8e395eb609535857aabf18837ea7696cf";
+    hash = "sha256-kelpSM7pfeIOXYOug/YkAgULYMyeDhm1fJX5v1n+vKE=";
   };
 
   dependencies = with python3Packages; [

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -20,8 +20,6 @@ python3Packages.buildPythonApplication (finalAttrs: {
     requests
   ];
 
-  doBuild = false;
-
   installPhase = ''
     runHook preInstall
 

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -1,11 +1,10 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchFromGitHub,
-  requests,
 }:
 
-buildPythonApplication (finalAttrs: {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "lichess-external-engine";
   version = "a6ef15a8e395eb609535857aabf18837ea7696cf";
   pyproject = false;
@@ -17,7 +16,7 @@ buildPythonApplication (finalAttrs: {
     sha256 = "18dwzrcvzycmgjsij3lyrih0n1824kv87bl3bl7f4zg9rr46ksci";
   };
 
-  dependencies = [
+  dependencies = with python3Packages; [
     requests
   ];
 

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -37,11 +37,12 @@ buildPythonApplication (finalAttrs: {
     $out/bin/lichess-external-engine --help
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Using engines running outside of the browser for analysis on lichess";
     homepage = "https://github.com/lichess-org/external-engine";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ malix ];
     mainProgram = "lichess-external-engine";
   };
+
 })

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -8,7 +8,7 @@
 buildPythonApplication (finalAttrs: {
   pname = "lichess-external-engine";
   version = "a6ef15a8e395eb609535857aabf18837ea7696cf";
-  format = "other";
+  pyproject = false;
 
   src = fetchFromGitHub {
     owner = "lichess-org";

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonApplication,
+  fetchFromGitHub,
+  requests,
+}:
+
+buildPythonApplication (finalAttrs: {
+  pname = "lichess-external-engine";
+  version = "a6ef15a8e395eb609535857aabf18837ea7696cf";
+  format = "other";
+
+  src = fetchFromGitHub {
+    owner = "lichess-org";
+    repo = "external-engine";
+    rev = finalAttrs.version;
+    sha256 = "18dwzrcvzycmgjsij3lyrih0n1824kv87bl3bl7f4zg9rr46ksci";
+  };
+
+  dependencies = [
+    requests
+  ];
+
+  doBuild = false;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -Dm755 example-provider.py $out/bin/lichess-external-engine
+
+    runHook postInstall
+  '';
+
+  # Basic smoke test: --help should succeed.
+  installCheckPhase = ''
+    $out/bin/lichess-external-engine --help
+  '';
+
+  meta = with lib; {
+    description = "Using engines running outside of the browser for analysis on lichess";
+    homepage = "https://github.com/lichess-org/external-engine";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ malix ];
+    mainProgram = "lichess-external-engine";
+  };
+})

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -6,7 +6,7 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "lichess-external-engine";
-  version = "a6ef15a8e395eb609535857aabf18837ea7696cf";
+  version = "1.0.0-unstable-2024-05-10";
   pyproject = false;
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/li/lichess-external-engine/package.nix
+++ b/pkgs/by-name/li/lichess-external-engine/package.nix
@@ -16,6 +16,8 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hash = "sha256-kelpSM7pfeIOXYOug/YkAgULYMyeDhm1fJX5v1n+vKE=";
   };
 
+  __structuredAttrs = true;
+
   dependencies = with python3Packages; [
     requests
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2455,6 +2455,8 @@ with pkgs;
 
   licensee = callPackage ../tools/package-management/licensee { };
 
+  lichess-external-engine = python3Packages.callPackage ../by-name/li/lichess-external-engine/package.nix { };
+
   linux-gpib = callPackage ../applications/science/electronics/linux-gpib/user.nix { };
 
   liquidctl = with python3Packages; toPythonApplication liquidctl;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2455,8 +2455,6 @@ with pkgs;
 
   licensee = callPackage ../tools/package-management/licensee { };
 
-  lichess-external-engine = callPackage ../by-name/li/lichess-external-engine/package.nix { };
-
   linux-gpib = callPackage ../applications/science/electronics/linux-gpib/user.nix { };
 
   liquidctl = with python3Packages; toPythonApplication liquidctl;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2455,7 +2455,7 @@ with pkgs;
 
   licensee = callPackage ../tools/package-management/licensee { };
 
-  lichess-external-engine = python3Packages.callPackage ../by-name/li/lichess-external-engine/package.nix { };
+  lichess-external-engine = callPackage ../by-name/li/lichess-external-engine/package.nix { };
 
   linux-gpib = callPackage ../applications/science/electronics/linux-gpib/user.nix { };
 


### PR DESCRIPTION
https://github.com/lichess-org/external-engine

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (but it's a python wrapper, should work everywhere)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test