### PR TITLE
Various: Move to Qt6

### DIFF
--- a/pkgs/by-name/in/inkcut/package.nix
+++ b/pkgs/by-name/in/inkcut/package.nix
@@ -1,10 +1,9 @@
 {
   lib,
-  fetchpatch,
   python3,
   fetchFromGitHub,
-  qt5,
   cups,
+  qt6,
 }:
 
 python3.pkgs.buildPythonApplication rec {
@@ -24,7 +23,9 @@ python3.pkgs.buildPythonApplication rec {
       --replace-fail ", 'lpr', " ", '${cups}/bin/lpr', "
   '';
 
-  nativeBuildInputs = [ qt5.wrapQtAppsHook ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+
+  buildInputs = [ qt6.qtbase ];
 
   build-system = with python3.pkgs; [ setuptools ];
 
@@ -37,7 +38,7 @@ python3.pkgs.buildPythonApplication rec {
     pyserial
     pycups
     qtconsole
-    pyqt5
+    pyqt6
   ];
 
   # QtApplication.instance() does not work during tests?

--- a/pkgs/development/python-modules/enamlx/default.nix
+++ b/pkgs/development/python-modules/enamlx/default.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   enaml,
   pyqtgraph,
-  pyqt5,
   pythonocc-core,
   typing-extensions,
 }:
@@ -25,7 +24,6 @@ buildPythonPackage rec {
     enaml
     # Until https://github.com/inkcut/inkcut/issues/105 perhaps
     pyqtgraph
-    pyqt5
     pythonocc-core
     typing-extensions
   ];

--- a/pkgs/development/python-modules/magicgui/default.nix
+++ b/pkgs/development/python-modules/magicgui/default.nix
@@ -8,6 +8,9 @@
   napari, # a reverse-dependency, for tests
   psygnal,
   pyside2,
+  pyside6,
+  pyqt6,
+  pyqt5,
   pytestCheckHook,
   superqt,
   typing-extensions,
@@ -33,10 +36,16 @@ buildPythonPackage rec {
   dependencies = [
     typing-extensions
     superqt
-    pyside2
     psygnal
     docstring-parser
   ];
+
+  optional-dependencies = {
+    pyside2 = [ pyside2 ];
+    pyside6 = [ pyside6 ];
+    pyqt6 = [ pyqt6 ];
+    pyqt5 = [ pyqt5 ];
+  };
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  mkDerivationWith,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -9,7 +8,7 @@
   setuptools-scm,
 
   # nativeBuildInputs
-  wrapQtAppsHook,
+  qt6,
 
   # dependencies
   app-model,
@@ -54,7 +53,7 @@
   zarr,
 }:
 
-mkDerivationWith buildPythonPackage rec {
+buildPythonPackage rec {
   pname = "napari";
   version = "0.6.6";
   pyproject = true;
@@ -76,7 +75,11 @@ mkDerivationWith buildPythonPackage rec {
     setuptools-scm
   ];
 
-  nativeBuildInputs = [ wrapQtAppsHook ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
+
+  buildInputs = [
+    qt6.qtbase
+  ];
 
   pythonRelaxDeps = [
     "app-model"

--- a/pkgs/development/python-modules/qreactor/default.nix
+++ b/pkgs/development/python-modules/qreactor/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   twisted,
   qtpy,
-  pyqt5,
+  pyqt6,
 }:
 
 buildPythonPackage {
@@ -19,12 +19,14 @@ buildPythonPackage {
     sha256 = "1nb5iwg0nfz86shw28a2kj5pyhd4jvvxhf73fhnfbl8scgnvjv9h";
   };
 
+  strictDeps = true;
+
   propagatedBuildInputs = [
     twisted
     qtpy
   ];
 
-  nativeCheckInputs = [ pyqt5 ];
+  nativeCheckInputs = [ pyqt6 ];
 
   pythonImportsCheck = [ "qreactor" ];
 

--- a/pkgs/development/python-modules/qtawesome/default.nix
+++ b/pkgs/development/python-modules/qtawesome/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pyqt5,
+  pyqt6,
   pytestCheckHook,
   qtpy,
 }:
@@ -20,7 +20,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    pyqt5
+    pyqt6
     qtpy
   ];
 

--- a/pkgs/development/python-modules/qtconsole/default.nix
+++ b/pkgs/development/python-modules/qtconsole/default.nix
@@ -11,7 +11,7 @@
   jupyter-core,
   jupyter-client,
   pygments,
-  pyqt5,
+  pyqt6,
   qtpy,
   traitlets,
 
@@ -38,7 +38,7 @@ buildPythonPackage rec {
     jupyter-core
     jupyter-client
     pygments
-    pyqt5
+    pyqt6
     qtpy
     traitlets
   ];

--- a/pkgs/development/python-modules/spyder/default.nix
+++ b/pkgs/development/python-modules/spyder/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
 
   # nativeBuildInputs
-  pyqtwebengine,
+  pyqt6-webengine,
 
   # build-system
   setuptools,
@@ -36,6 +36,7 @@
   pylint-venv,
   pyls-spyder,
   pyopengl,
+  pyqt6,
   python-lsp-black,
   python-lsp-ruff,
   python-lsp-server,
@@ -55,6 +56,7 @@
   three-merge,
   watchdog,
   yarl,
+  qt6,
 }:
 
 buildPythonPackage rec {
@@ -69,13 +71,18 @@ buildPythonPackage rec {
 
   patches = [ ./dont-clear-pythonpath.patch ];
 
-  nativeBuildInputs = [ pyqtwebengine.wrapQtAppsHook ];
+  nativeBuildInputs = [ qt6.wrapQtAppsHook ];
 
   build-system = [ setuptools ];
 
   pythonRelaxDeps = [
     "ipython"
     "python-lsp-server"
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtwayland
   ];
 
   dependencies = [
@@ -105,7 +112,7 @@ buildPythonPackage rec {
     pylint-venv
     pyls-spyder
     pyopengl
-    pyqtwebengine
+    pyqt6-webengine
     python-lsp-black
     python-lsp-ruff
     python-lsp-server
@@ -125,11 +132,14 @@ buildPythonPackage rec {
     three-merge
     watchdog
     yarl
+    pyqt6
   ]
   ++ python-lsp-server.optional-dependencies.all;
 
   # There is no test for spyder
   doCheck = false;
+
+  env.SPYDER_QT_BINDING = "pyqt6";
 
   postInstall = ''
     # Add Python libs to env so Spyder subprocesses

--- a/pkgs/development/python-modules/superqt/default.nix
+++ b/pkgs/development/python-modules/superqt/default.nix
@@ -34,7 +34,6 @@ buildPythonPackage rec {
 
   dependencies = [
     pygments
-    pyqt5
     qtpy
     typing-extensions
   ];
@@ -44,6 +43,7 @@ buildPythonPackage rec {
     pyside2 = [ pyside2 ];
     pyside6 = [ pyside6 ];
     pyqt6 = [ pyqt6 ];
+    pyqt5 = [ pyqt5 ];
   };
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10667,9 +10667,7 @@ self: super: with self; {
 
   napalm-ros = callPackage ../development/python-modules/napalm/ros.nix { };
 
-  napari = callPackage ../development/python-modules/napari {
-    inherit (pkgs.libsForQt5) mkDerivationWith wrapQtAppsHook;
-  };
+  napari = callPackage ../development/python-modules/napari { };
 
   napari-console = callPackage ../development/python-modules/napari-console { };
 


### PR DESCRIPTION
Main motivation for this is spyder, which depends on qtwebengine.
Part of https://github.com/NixOS/nixpkgs/pull/480196

## Testing methodology:
- `nixpkgs-review` to get rebuild list
- execute programs to make sure they start, both with `QT_QPA_PLATFORM=wayland` and `QT_QPA_PLATFORM=xcb`
- `nix why-depends` to ensure no qt5 leaks into qt6 apps
- Fix whatever was broken

## Programs Tested
- `magicgui`: dependency to `napari`, choses QT backend automatically now
- `napari`: Works on python 3.12 and 3.13
<img width="960" height="525" alt="image" src="https://github.com/user-attachments/assets/70157020-a63a-4ce6-b0ca-4270ed673b92" />

- `python3.14Packages.napari`: broken because of `napari-npe2`, not Qt
- `angr-management`: runs
- `inkcut`: Updated to qt6, runs
<img width="960" height="526" alt="image" src="https://github.com/user-attachments/assets/55e1c63e-6599-4233-8aa7-12a7f75f01f1" />

- `napari-console`: dependency for `napari`
- `qtawesome`: dependency for spyder
- `qtconsole`: dependency for spyder
- `superqt`: dependency for most of these, choses QT backend automatically now
- `enamix`: dependency to `inkcut`
- `rare`: Still runs, but update to Qt6 likely needs an update of the software and i do not have EpicGames to test
- `sasview`: already was qt6, runs
- `typstwriter`: already was qt6, runs
- `spyder`: Does not find kernels unless run with `nix-shell -I nixpkgs=. -p "(python3.withPackages (python-pkgs: [python-pkgs.spyder]))"`, but this issue exists on master already. I do not believe this is a blocker.
<img width="1917" height="1048" alt="image" src="https://github.com/user-attachments/assets/d4947dd1-f6cd-43d8-b8c0-1f2bfe766ffe" />



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
