### PR TITLE
top-level/packages-info: pre-evaluate output paths

### DIFF
--- a/ci/default.nix
+++ b/ci/default.nix
@@ -200,5 +200,6 @@ rec {
     officialRelease = false;
     inherit pkgs lib-tests;
     nix = pkgs.nixVersions.latest;
+    supportedSystems = [ system ];
   };
 }

--- a/pkgs/top-level/make-tarball.nix
+++ b/pkgs/top-level/make-tarball.nix
@@ -4,6 +4,7 @@
   pkgs ? import nixpkgs.outPath { },
   nix ? pkgs.nix,
   lib-tests ? import ../../lib/tests/release.nix { inherit pkgs; },
+  supportedSystems ? builtins.fromJSON (builtins.readFile ../../ci/supportedSystems.json),
 }:
 
 pkgs.releaseTools.sourceTarball {
@@ -44,7 +45,12 @@ pkgs.releaseTools.sourceTarball {
   checkPhase = ''
     echo "generating packages.json"
 
-    NIX_STATE_DIR=$TMPDIR NIX_PATH= nix-instantiate --eval --raw --expr "import $src/pkgs/top-level/packages-info.nix {}" | sed "s|$src/||g" | jq -c > packages.json
+    echo ' '''${builtins.toJSON supportedSystems}''' ' |
+      NIX_STATE_DIR=$TMPDIR NIX_PATH= nix-instantiate \
+        --eval --raw --arg-from-stdin supportedSystems \
+        --expr "{ supportedSystems }: import $src/pkgs/top-level/packages-info.nix { supportedSystems = builtins.fromJSON supportedSystems; }" |
+      sed "s|$src/||g" |
+      jq -c > packages.json
 
     # Arbitrary number. The index has ~115k packages as of April 2024.
     if [ $(jq -r '.packages | length' < packages.json) -lt 100000 ]; then

--- a/pkgs/top-level/packages-info.nix
+++ b/pkgs/top-level/packages-info.nix
@@ -1,10 +1,29 @@
 {
   trace ? false,
+  supportedSystems,
 }:
 
 let
-  pkgs = import ../.. { config = import ./packages-config.nix; };
+  pkgsSystems =
+    if builtins.all (v: v != builtins.currentSystem) supportedSystems then
+      supportedSystems ++ [ builtins.currentSystem ]
+    else
+      supportedSystems;
+
+  pkgsByArch = builtins.listToAttrs (
+    map (system: {
+      name = system;
+      value = import ../.. {
+        inherit system;
+        config = import ./packages-config.nix;
+      };
+    }) pkgsSystems
+  );
+
+  pkgs = pkgsByArch.${builtins.currentSystem};
+
   inherit (pkgs) lib;
+
   generateInfo =
     path: value:
     let
@@ -23,10 +42,42 @@ let
                   system
                   ;
                 ${if value ? "outputs" then "outputs" else null} = lib.listToAttrs (
-                  lib.map (x: {
-                    name = x;
-                    value = null;
-                  }) value.outputs
+                  lib.map (
+                    x:
+                    let
+                      platforms = lib.intersectLists (value.meta.hydraPlatforms
+                        or (lib.subtractLists (value.meta.badPlatforms or [ ]) (value.meta.platforms or supportedSystems))
+                      ) supportedSystems;
+
+                      outPaths = lib.listToAttrs (
+                        lib.map (
+                          platform:
+                          let
+                            drvForPlatform =
+                              if lib.hasAttrByPath path pkgsByArch.${platform} then
+                                lib.getAttrFromPath path pkgsByArch.${platform}
+                              else
+                                null;
+                            outPath =
+                              if builtins.isAttrs drvForPlatform && drvForPlatform ? ${x}.outPath then
+                                builtins.unsafeDiscardStringContext drvForPlatform.${x}.outPath
+                              else
+                                null;
+                            eval = builtins.tryEval outPath;
+                          in
+                          {
+                            name = platform;
+                            value = if eval.success then eval.value else null;
+                          }
+                        ) platforms
+                      );
+                    in
+                    {
+                      name = x;
+                      value = (builtins.tryEval outPaths).value or null;
+                      # value = null;
+                    }
+                  ) value.outputs
                 );
                 # TODO: Remove the following two fallbacks when all packages have been fixed.
                 # Note: pname and version are *required* by repology, so do not change to

--- a/pkgs/top-level/release-small.nix
+++ b/pkgs/top-level/release-small.nix
@@ -42,7 +42,7 @@ in
 {
 
   tarball = import ./make-tarball.nix {
-    inherit nixpkgs;
+    inherit nixpkgs supportedSystems;
     officialRelease = false;
   };
 

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -101,6 +101,7 @@ let
         pkgs
         nixpkgs
         officialRelease
+        supportedSystems
         ;
     };
 


### PR DESCRIPTION
`packages.json` is used by a variety of downstream services for a variety of purposes. Some of those services such as FloxHub and NixHub use it to enable an experience where a user can easily install packages by version, irrespective of nixpkgs versioning. A common optimization is that these services will pre-evaluate some or all of the packages in their index, to enable direct fetching from `https://cache.nixos.org` rather than having to locally evaluate nixpkgs.

This change modifies `packages-info.nix` so that the stubbed `outputs` section of a package's info, which would previously look like this:

```json
{
  "debug": null,
  "out": null
}
```

Now looks like this:

```json
{
  "debug": {
    "aarch64-linux": "/nix/store/bzb0vriv1a1kaz9zv6lzv62zkcvvm88r-python3-3.13.11-debug",
    "x86_64-linux": "/nix/store/gvhg8py0jr9v83ysqb86rr2s1yidppca-python3-3.13.11-debug"
  },
  "out": {
    "aarch64-linux": "/nix/store/ygzfhw5nxrn7qqfqmz2s9p6cikcjqqkh-python3-3.13.11",
    "x86_64-linux": "/nix/store/slhpx9glq7vl99bwi93bgrhn3syv98s1-python3-3.13.11"
  }
}
```

`packages-info.nix` (and `make-tarball.nix`) now takes in `supportedSystems` which it uses to determine which systems to evaluate.

This increases the time and memory usage of `make-tarball`, however in my testing it remains below 5 minutes, which is almost certainly worth it for the downstream optimization. This might necessitate re-tagging it as `big-parallel` as in #229132.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
