### PR TITLE
helm-schema-gen: init at 0.20.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19665,6 +19665,12 @@
     githubId = 31112680;
     name = "oidro";
   };
+  ojsef39 = {
+    name = "Josef";
+    github = "ojsef39";
+    email = "me+github@jhofer.de";
+    githubId = 43563019;
+  };
   ok-nick = {
     email = "nick.libraries@gmail.com";
     github = "ok-nick";

--- a/pkgs/by-name/he/helm-schema-gen/package.nix
+++ b/pkgs/by-name/he/helm-schema-gen/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "helm-schema-gen";
+  version = "0.23.2";
+
+  src = fetchFromGitHub {
+    owner = "dadav";
+    repo = "helm-schema";
+    tag = "${finalAttrs.version}";
+    hash = "sha256-stOu9UOp+QvMifYdXMoet2DWSAEsJYQzgfdVJH1i+L0=";
+  };
+
+  vendorHash = "sha256-I05Pe9dkhj28YxUFVsVw1DKMG4pqyYI1VF1E/Hbv1Es=";
+
+  subPackages = [ "cmd/helm-schema" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  postPatch = ''
+    sed -i '/^hooks:/,+2 d' plugin.yaml
+  '';
+
+  postInstall = ''
+    install -dm755 $out/helm-schema-gen
+    mv $out/bin $out/helm-schema-gen/
+    install -m644 -Dt $out/helm-schema-gen plugin.yaml
+
+    mkdir -p $out/bin
+    ln -s $out/helm-schema-gen/bin/helm-schema $out/bin/helm-schema-gen
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/helm-schema-gen";
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for generating JSON schemas from Helm chart values";
+    longDescription = ''
+      Helm plugin and standalone tool that generates JSON schemas from Helm
+      chart values. Supports custom annotations, dependency handling, and
+      helm-docs compatibility. Enables IDE validation and autocomplete for
+      Helm values files.
+    '';
+    homepage = "https://github.com/dadav/helm-schema";
+    changelog = "https://github.com/dadav/helm-schema/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ojsef39 ];
+    mainProgram = "helm-schema-gen";
+  };
+})

--- a/pkgs/by-name/he/helm-schema-gen/package.nix
+++ b/pkgs/by-name/he/helm-schema-gen/package.nix
@@ -7,16 +7,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "helm-schema-gen";
-  version = "0.23.2";
+  version = "0.23.3";
 
   src = fetchFromGitHub {
     owner = "dadav";
     repo = "helm-schema";
     tag = "${finalAttrs.version}";
-    hash = "sha256-stOu9UOp+QvMifYdXMoet2DWSAEsJYQzgfdVJH1i+L0=";
+    hash = "sha256-1vz+42RfBAmlmecVKRWyIUXaPRbJhYTh/tXQ5Mtyir4=";
   };
 
-  vendorHash = "sha256-I05Pe9dkhj28YxUFVsVw1DKMG4pqyYI1VF1E/Hbv1Es=";
+  vendorHash = "sha256-jbK+XD5CbjMQJUJCcKbNN8LhYuhuy+Z3XcCmgiYw25Y=";
 
   subPackages = [ "cmd/helm-schema" ];
 


### PR DESCRIPTION
Helm plugin and standalone tool that generates JSON schemas from Helm chart values.
Supports custom annotations, dependency handling, and helm-docs compatibility. 
Enables IDE validation and autocomplete for Helm values files.

https://github.com/dadav/helm-schema

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
