### PR TITLE
av1an-unwrapped: 0.4.4 -> 0.5.2

### DIFF
--- a/pkgs/by-name/av/av1an-unwrapped/package.nix
+++ b/pkgs/by-name/av/av1an-unwrapped/package.nix
@@ -2,8 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
-  ffmpeg_7,
+  ffmpeg,
   libaom,
   nasm,
   nix-update-script,
@@ -15,26 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "av1an-unwrapped";
-  version = "0.4.4";
+  version = "0.5.2";
 
   src = fetchFromGitHub {
-    owner = "master-of-zen";
-    repo = "av1an";
-    tag = finalAttrs.version;
-    hash = "sha256-YF+j349777pE+evvXWTo42DQn1CE0jlfKBEXUFTfcb8=";
+    owner = "rust-av";
+    repo = "Av1an";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JwYnDl9ZSSE+dD+ZAxuN7ywqFN314Ib/9Flh52kL3do=";
   };
 
-  cargoPatches = [
-    # TODO: Remove in next version
-    # Avoids https://github.com/shssoichiro/ffmpeg-the-third/issues/63
-    # https://github.com/master-of-zen/Av1an/pull/912
-    (fetchpatch {
-      url = "https://github.com/master-of-zen/Av1an/commit/e6b29a5a624434eb0dc95b7e8aa31ccf624ccb9d.patch";
-      hash = "sha256-nFE04hlTzApYafSzgl/XOUdchxEjKvxXy+SKr/d6+0Q=";
-    })
-  ];
-
-  cargoHash = "sha256-PcxnWkruFH4d2FqS+y3PmyA70kSe9BKtmTdCnfKnfpU=";
+  cargoHash = "sha256-mxWYXujwp7tYAj9bM/ZhqbyISMjvX+AYG07otcB67pg=";
 
   nativeBuildInputs = [
     nasm
@@ -43,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   buildInputs = [
-    ffmpeg_7
+    ffmpeg
     vapoursynth
   ];
 
@@ -56,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     updateScript = nix-update-script {
       extraArgs = [
         "--version-regex"
-        "'^(\\d*\\.\\d*\\.\\d*)$'"
+        "^v(\\d*\\.\\d*\\.\\d*)$"
       ];
     };
   };
@@ -67,8 +56,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
       Cross-platform command-line AV1 / VP9 / HEVC / H264 encoding framework with per scene quality encoding.
       It can increase your encoding speed and improve cpu utilization by running multiple encoder processes in parallel.
     '';
-    homepage = "https://github.com/master-of-zen/Av1an";
-    changelog = "https://github.com/master-of-zen/Av1an/releases/tag/${finalAttrs.version}";
+    homepage = "https://github.com/rust-av/Av1an";
+    changelog = "https://github.com/rust-av/Av1an/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "av1an";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Continued from #465774. I tried to fix the tests being broken but couldn't find a solution.

I think this PR would also fix #481391, as the current `av1an` version (`0.4.4`), doesn't seem compatible[^1] with the `vapoursynth` version (`73`).


[^1]: https://github.com/rust-av/Av1an/issues/1179#issuecomment-3667107930
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
