### PR TITLE
python3Packages.tkinter: work around wantobjects resource

### DIFF
--- a/pkgs/development/python-modules/tkinter/default.nix
+++ b/pkgs/development/python-modules/tkinter/default.nix
@@ -5,6 +5,7 @@
   replaceVars,
   setuptools,
   python,
+  pythonAtLeast,
   pythonOlder,
   tcl,
   tclPackages,
@@ -74,6 +75,18 @@ buildPythonPackage {
   preCheck = ''
     cd $NIX_BUILD_TOP/Python-*/Lib
     export HOME=$TMPDIR
+  ''
+  + lib.optionalString (pythonAtLeast "3.13" && pythonOlder "3.15") ''
+    # https://github.com/python/cpython/pull/143570
+    # wantobject resources are only supported via libregrtest
+    substituteInPlace \
+      test/test_tcl.py \
+      test/test_ttk/__init__.py \
+      test/test_tkinter/__init__.py \
+      test/test_tkinter/support.py \
+        --replace-fail \
+          "support.get_resource_value('wantobjects')" \
+          "0"
   '';
 
   checkPhase =


### PR DESCRIPTION
This is only supported when running with `python -m test` through libregrtest.

cc #486806
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (3.13, 3.14, 3.15)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
