### PR TITLE
dataexplorer: 3.9.3 -> 4.0.2

### DIFF
--- a/pkgs/by-name/da/dataexplorer/package.nix
+++ b/pkgs/by-name/da/dataexplorer/package.nix
@@ -3,32 +3,33 @@
   stdenv,
   fetchurl,
   ant,
-  # executable fails to start for jdk > 17
-  jdk17,
+  openjdk25,
   swt,
   makeWrapper,
   strip-nondeterminism,
   udevCheckHook,
 }:
 let
-  swt-jdk17 = swt.override { jdk = jdk17; };
+  swt-jdk = swt.override { jdk = openjdk25; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "dataexplorer";
-  version = "3.9.3";
+  version = "4.0.2";
 
   src = fetchurl {
     url = "mirror://savannah/dataexplorer/dataexplorer-${finalAttrs.version}-src.tar.gz";
-    hash = "sha256-NfbhamhRx78MW5H4BpKMDfrV2d082UkaIBFfbemOSOY=";
+    hash = "sha256-HaupE8tCbmlUVMd0ZFt7QwY1AKEx+op21fUeGBpR+UY=";
   };
 
   nativeBuildInputs = [
     ant
-    jdk17
+    openjdk25
     makeWrapper
     strip-nondeterminism
     udevCheckHook
   ];
+
+  dontConfigure = true;
 
   buildPhase = ''
     runHook preBuild
@@ -49,18 +50,18 @@ stdenv.mkDerivation (finalAttrs: {
 
     ant -Dprefix=$out/share/ -f build/build.xml install
     # Use SWT from nixpkgs
-    ln -sf '${swt-jdk17}/jars/swt.jar' "$out/share/DataExplorer/java/ext/swt.jar"
+    ln -sf '${swt-jdk}/jars/swt.jar' "$out/share/DataExplorer/java/ext/swt.jar"
 
     # The sources contain a wrapper script in $out/share/DataExplorer/DataExplorer
     # but it hardcodes bash shebang and does not pin the java path.
     # So we create our own wrapper, using similar cmdline args as upstream.
     mkdir -p $out/bin
-    makeWrapper ${jdk17}/bin/java $out/bin/DataExplorer \
-      --prefix LD_LIBRARY_PATH : '${swt-jdk17}/lib' \
+    makeWrapper ${openjdk25}/bin/java $out/bin/DataExplorer \
+      --prefix LD_LIBRARY_PATH : '${swt-jdk}/lib' \
       --add-flags "-Xms64m -Xmx3092m -jar $out/share/DataExplorer/DataExplorer.jar" \
       --set SWT_GTK3 0
 
-    makeWrapper ${jdk17}/bin/java $out/bin/DevicePropertiesEditor \
+    makeWrapper ${openjdk25}/bin/java $out/bin/DevicePropertiesEditor \
       --add-flags "-Xms32m -Xmx512m -classpath $out/share/DataExplorer/DataExplorer.jar gde.ui.dialog.edit.DevicePropertiesEditor" \
       --set SWT_GTK3 0 \
       --set LIBOVERLAY_SCROLLBAR 0


### PR DESCRIPTION
## Things done

~Note: currently fails to build because of an issue with ant. #364094 seems to fix it.~

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - [x] Tested with a battery charger
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `cea1b086f08ed2d8df14be0d00e0cd907a0cd095`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>dataexplorer</li>
  </ul>
</details>