### PR TITLE
build-support/node: prepare for structuredAttrs

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -95,9 +95,9 @@ npmConfigHook() {
     fi
 
     export CACHE_MAP_PATH="$TMP/MEOW"
-    @prefetchNpmDeps@ --map-cache
+    npmDeps="$npmDeps" @prefetchNpmDeps@ --map-cache
 
-    @prefetchNpmDeps@ --fixup-lockfile "$srcLockfile"
+    npmDeps="$npmDeps" @prefetchNpmDeps@ --fixup-lockfile "$srcLockfile"
 
     local cachePath
 

--- a/pkgs/build-support/node/prefetch-npm-deps/default.nix
+++ b/pkgs/build-support/node/prefetch-npm-deps/default.nix
@@ -263,7 +263,7 @@
             exit 1
           fi
 
-          prefetch-npm-deps $srcLockfile $out
+          outputHash="${hash_.outputHash}" prefetch-npm-deps $srcLockfile $out
 
           runHook postBuild
         '';
@@ -274,29 +274,31 @@
         # `{ "registry.example.com": "example-registry-bearer-token", ... }`
         impureEnvVars = lib.fetchers.proxyImpureEnvVars ++ [ "NIX_NPM_TOKENS" ];
 
-        NIX_NPM_REGISTRY_OVERRIDES = npmRegistryOverridesString;
+        env = {
+          NIX_NPM_REGISTRY_OVERRIDES = npmRegistryOverridesString;
 
-        # Fetcher version controls which features are enabled in prefetch-npm-deps
-        # Version 2+ enables packument fetching for workspace support
-        NPM_FETCHER_VERSION = toString fetcherVersion;
+          # Fetcher version controls which features are enabled in prefetch-npm-deps
+          # Version 2+ enables packument fetching for workspace support
+          NPM_FETCHER_VERSION = toString fetcherVersion;
 
-        SSL_CERT_FILE =
-          if
-            (
-              hash_.outputHash == ""
-              || hash_.outputHash == lib.fakeSha256
-              || hash_.outputHash == lib.fakeSha512
-              || hash_.outputHash == lib.fakeHash
-            )
-          then
-            "${cacert}/etc/ssl/certs/ca-bundle.crt"
-          else
-            "/no-cert-file.crt";
+          SSL_CERT_FILE =
+            if
+              (
+                hash_.outputHash == ""
+                || hash_.outputHash == lib.fakeSha256
+                || hash_.outputHash == lib.fakeSha512
+                || hash_.outputHash == lib.fakeHash
+              )
+            then
+              "${cacert}/etc/ssl/certs/ca-bundle.crt"
+            else
+              "/no-cert-file.crt";
+        }
+        // forceGitDeps_
+        // forceEmptyCache_;
 
         outputHashMode = "recursive";
       }
       // hash_
-      // forceGitDeps_
-      // forceEmptyCache_
     );
 }


### PR DESCRIPTION
Move env variables into env, explicitly provide `outputHash` and `npmDeps` to prefetch-npm-deps.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
