### PR TITLE
python3Packages.term-image: add patch to fix build failure

### DIFF
--- a/pkgs/development/python-modules/term-image/0001-getdata.patch
+++ b/pkgs/development/python-modules/term-image/0001-getdata.patch
@@ -1,0 +1,48 @@
+From aa8e862769c36e3ea7fe07d2d2623324d3a9293a Mon Sep 17 00:00:00 2001
+From: cinereal <cinereal@riseup.net>
+Date: Sat, 7 Feb 2026 14:52:39 +0100
+Subject: [PATCH] chore: replace `getdata` -> `get_flattened_data`
+
+addresses Pillow's deprecation of `getdata`.
+
+see: https://github.com/python-pillow/Pillow/pull/9292
+
+Signed-off-by: cinereal <cinereal@riseup.net>
+---
+ src/term_image/image/common.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/term_image/image/common.py b/src/term_image/image/common.py
+index 3c21e82..cf935a4 100644
+--- a/src/term_image/image/common.py
++++ b/src/term_image/image/common.py
+@@ -1489,7 +1489,7 @@ class BaseImage(metaclass=ImageMeta):
+         if alpha is None or img.mode in {"1", "L", "RGB", "HSV", "CMYK"}:
+             convert_resize_img("RGB")
+             if pixel_data:
+-                rgb = list(img.getdata())
++                rgb = list(img.get_flattened_data())
+                 a = [255] * mul(*size)
+         else:
+             convert_resize_img("RGBA")
+@@ -1505,7 +1505,7 @@ class BaseImage(metaclass=ImageMeta):
+                     a = [255] * mul(*size)
+             else:
+                 if pixel_data:
+-                    a = list(img.getdata(3))
++                    a = list(img.get_flattened_data(3))
+                     if round_alpha:
+                         alpha = round(alpha * 255)
+                         a = [0 if val < alpha else 255 for val in a]
+@@ -1520,7 +1520,7 @@ class BaseImage(metaclass=ImageMeta):
+                     img = bg
+ 
+             if pixel_data:
+-                rgb = list((img if img.mode == "RGB" else img.convert("RGB")).getdata())
++                rgb = list((img if img.mode == "RGB" else img.convert("RGB")).get_flattened_data())
+ 
+         return (img, *(pixel_data and (rgb, a) or (None, None)))
+ 
+-- 
+2.51.2
+

--- a/pkgs/development/python-modules/term-image/default.nix
+++ b/pkgs/development/python-modules/term-image/default.nix
@@ -21,6 +21,11 @@ buildPythonPackage rec {
     hash = "sha256-uA04KHKLXW0lx1y5brpCDARLac4/C8VmVinVMkEtTdM=";
   };
 
+  patches = [
+    # fix: https://github.com/AnonymouX47/term-image/pull/195
+    ./0001-getdata.patch
+  ];
+
   build-system = [
     setuptools
   ];


### PR DESCRIPTION
Adds a patch to fix `python3Packages.term-image`'s build failure on `master` from [Pillow's `getdata` deprecation](https://github.com/python-pillow/Pillow/pull/9292).

Note that I had yet to find this build failure [on Hydra](https://hydra.nixos.org/search?query=term-image).

<details>
<summary>build failure</summary>

```bash
$ nix-build -A python3Packages.term-image
warning: Nix search path entry 'flake' does not exist, ignoring
this derivation will be built:
  /nix/store/sgrgz0qylazy146r8ayhfh7nz4p92vh9-python3.13-term-image-0.7.2.drv
building '/nix/store/sgrgz0qylazy146r8ayhfh7nz4p92vh9-python3.13-term-image-0.7.2.drv'...
Sourcing python-remove-tests-dir-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
Sourcing pytest-check-hook
Using pytestCheckPhase
Running phase: unpackPhase
unpacking source archive /nix/store/f6rfbgl0w4ghrv6453j7q98a2hanqirv-term-image
source root is term-image
setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "term-image/tests/widget/urwid/test_screen.py"
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
No `packages` or `py_modules` configuration, performing automatic discovery.
`src-layout` detected -- analysing ./src
discovered packages -- ['term_image', 'term_image.image', 'term_image.render', 'term_image.renderable', 'term_image.widget']
discovered py_modules -- []
/nix/store/mfx6d4xq18jlpbi0cwnfhmk9hr0gb8i3-python3.13-setuptools-80.9.0/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/nix/store/mfx6d4xq18jlpbi0cwnfhmk9hr0gb8i3-python3.13-setuptools-80.9.0/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/nix/store/mfx6d4xq18jlpbi0cwnfhmk9hr0gb8i3-python3.13-setuptools-80.9.0/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running egg_info
creating src/term_image.egg-info
writing src/term_image.egg-info/PKG-INFO
writing dependency_links to src/term_image.egg-info/dependency_links.txt
writing requirements to src/term_image.egg-info/requires.txt
writing top-level names to src/term_image.egg-info/top_level.txt
writing manifest file 'src/term_image.egg-info/SOURCES.txt'
reading manifest file 'src/term_image.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'src/term_image.egg-info/SOURCES.txt'
* Building wheel...
No `packages` or `py_modules` configuration, performing automatic discovery.
`src-layout` detected -- analysing ./src
discovered packages -- ['term_image', 'term_image.image', 'term_image.render', 'term_image.renderable', 'term_image.widget']
discovered py_modules -- []
/nix/store/mfx6d4xq18jlpbi0cwnfhmk9hr0gb8i3-python3.13-setuptools-80.9.0/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  corresp(dist, value, root_dir)
/nix/store/mfx6d4xq18jlpbi0cwnfhmk9hr0gb8i3-python3.13-setuptools-80.9.0/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  dist._finalize_license_expression()
/nix/store/mfx6d4xq18jlpbi0cwnfhmk9hr0gb8i3-python3.13-setuptools-80.9.0/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running bdist_wheel
running build
running build_py
creating build/lib/term_image
copying src/term_image/__init__.py -> build/lib/term_image
copying src/term_image/_ctlseqs.py -> build/lib/term_image
copying src/term_image/color.py -> build/lib/term_image
copying src/term_image/exceptions.py -> build/lib/term_image
copying src/term_image/geometry.py -> build/lib/term_image
copying src/term_image/padding.py -> build/lib/term_image
copying src/term_image/utils.py -> build/lib/term_image
creating build/lib/term_image/image
copying src/term_image/image/__init__.py -> build/lib/term_image/image
copying src/term_image/image/block.py -> build/lib/term_image/image
copying src/term_image/image/common.py -> build/lib/term_image/image
copying src/term_image/image/iterm2.py -> build/lib/term_image/image
copying src/term_image/image/kitty.py -> build/lib/term_image/image
creating build/lib/term_image/render
copying src/term_image/render/__init__.py -> build/lib/term_image/render
copying src/term_image/render/_iterator.py -> build/lib/term_image/render
creating build/lib/term_image/renderable
copying src/term_image/renderable/__init__.py -> build/lib/term_image/renderable
copying src/term_image/renderable/_enum.py -> build/lib/term_image/renderable
copying src/term_image/renderable/_exceptions.py -> build/lib/term_image/renderable
copying src/term_image/renderable/_renderable.py -> build/lib/term_image/renderable
copying src/term_image/renderable/_types.py -> build/lib/term_image/renderable
creating build/lib/term_image/widget
copying src/term_image/widget/__init__.py -> build/lib/term_image/widget
copying src/term_image/widget/_urwid.py -> build/lib/term_image/widget
running egg_info
writing src/term_image.egg-info/PKG-INFO
writing dependency_links to src/term_image.egg-info/dependency_links.txt
writing requirements to src/term_image.egg-info/requires.txt
writing top-level names to src/term_image.egg-info/top_level.txt
reading manifest file 'src/term_image.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
adding license file 'LICENSE'
writing manifest file 'src/term_image.egg-info/SOURCES.txt'
copying src/term_image/py.typed -> build/lib/term_image
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/term_image
copying build/lib/term_image/__init__.py -> build/bdist.linux-x86_64/wheel/./term_image
copying build/lib/term_image/_ctlseqs.py -> build/bdist.linux-x86_64/wheel/./term_image
copying build/lib/term_image/color.py -> build/bdist.linux-x86_64/wheel/./term_image
copying build/lib/term_image/exceptions.py -> build/bdist.linux-x86_64/wheel/./term_image
copying build/lib/term_image/geometry.py -> build/bdist.linux-x86_64/wheel/./term_image
copying build/lib/term_image/padding.py -> build/bdist.linux-x86_64/wheel/./term_image
copying build/lib/term_image/utils.py -> build/bdist.linux-x86_64/wheel/./term_image
creating build/bdist.linux-x86_64/wheel/term_image/image
copying build/lib/term_image/image/__init__.py -> build/bdist.linux-x86_64/wheel/./term_image/image
copying build/lib/term_image/image/block.py -> build/bdist.linux-x86_64/wheel/./term_image/image
copying build/lib/term_image/image/common.py -> build/bdist.linux-x86_64/wheel/./term_image/image
copying build/lib/term_image/image/iterm2.py -> build/bdist.linux-x86_64/wheel/./term_image/image
copying build/lib/term_image/image/kitty.py -> build/bdist.linux-x86_64/wheel/./term_image/image
creating build/bdist.linux-x86_64/wheel/term_image/render
copying build/lib/term_image/render/__init__.py -> build/bdist.linux-x86_64/wheel/./term_image/render
copying build/lib/term_image/render/_iterator.py -> build/bdist.linux-x86_64/wheel/./term_image/render
creating build/bdist.linux-x86_64/wheel/term_image/renderable
copying build/lib/term_image/renderable/__init__.py -> build/bdist.linux-x86_64/wheel/./term_image/renderable
copying build/lib/term_image/renderable/_enum.py -> build/bdist.linux-x86_64/wheel/./term_image/renderable
copying build/lib/term_image/renderable/_exceptions.py -> build/bdist.linux-x86_64/wheel/./term_image/renderable
copying build/lib/term_image/renderable/_renderable.py -> build/bdist.linux-x86_64/wheel/./term_image/renderable
copying build/lib/term_image/renderable/_types.py -> build/bdist.linux-x86_64/wheel/./term_image/renderable
creating build/bdist.linux-x86_64/wheel/term_image/widget
copying build/lib/term_image/widget/__init__.py -> build/bdist.linux-x86_64/wheel/./term_image/widget
copying build/lib/term_image/widget/_urwid.py -> build/bdist.linux-x86_64/wheel/./term_image/widget
copying build/lib/term_image/py.typed -> build/bdist.linux-x86_64/wheel/./term_image
running install_egg_info
Copying src/term_image.egg-info to build/bdist.linux-x86_64/wheel/./term_image-0.8.0.dev0-py3.13.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/term_image-0.8.0.dev0.dist-info/WHEEL
creating '/build/term-image/dist/.tmp-i5ucplwe/term_image-0.8.0.dev0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'term_image/__init__.py'
adding 'term_image/_ctlseqs.py'
adding 'term_image/color.py'
adding 'term_image/exceptions.py'
adding 'term_image/geometry.py'
adding 'term_image/padding.py'
adding 'term_image/py.typed'
adding 'term_image/utils.py'
adding 'term_image/image/__init__.py'
adding 'term_image/image/block.py'
adding 'term_image/image/common.py'
adding 'term_image/image/iterm2.py'
adding 'term_image/image/kitty.py'
adding 'term_image/render/__init__.py'
adding 'term_image/render/_iterator.py'
adding 'term_image/renderable/__init__.py'
adding 'term_image/renderable/_enum.py'
adding 'term_image/renderable/_exceptions.py'
adding 'term_image/renderable/_renderable.py'
adding 'term_image/renderable/_types.py'
adding 'term_image/widget/__init__.py'
adding 'term_image/widget/_urwid.py'
adding 'term_image-0.8.0.dev0.dist-info/licenses/LICENSE'
adding 'term_image-0.8.0.dev0.dist-info/METADATA'
adding 'term_image-0.8.0.dev0.dist-info/WHEEL'
adding 'term_image-0.8.0.dev0.dist-info/top_level.txt'
adding 'term_image-0.8.0.dev0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built term_image-0.8.0.dev0-py3-none-any.whl
Finished creating a wheel...
/build/term-image/dist /build/term-image
Unpacking to: unpacked/term_image-0.8.0.dev0...OK
Repacking wheel as ./term_image-0.8.0.dev0-py3-none-any.whl...OK
/build/term-image
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for term_image-0.8.0.dev0-py3-none-any.whl
Finished executing pythonRuntimeDepsCheck
Running phase: installPhase
Executing pypaInstallPhase
Successfully installed term_image-0.8.0.dev0-py3-none-any.whl
Finished executing pypaInstallPhase
Running phase: pythonOutputDistPhase
Executing pythonOutputDistPhase
Finished executing pythonOutputDistPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2
checking for references to /build/ in /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2...
patching script interpreter paths in /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2
stripping (with command strip and flags -S -p) in  /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib
shrinking RPATHs of ELF executables and libraries in /nix/store/flxyhhrv56dfp6p4a3bnl3wzirs8mga0-python3.13-term-image-0.7.2-dist
checking for references to /build/ in /nix/store/flxyhhrv56dfp6p4a3bnl3wzirs8mga0-python3.13-term-image-0.7.2-dist...
patching script interpreter paths in /nix/store/flxyhhrv56dfp6p4a3bnl3wzirs8mga0-python3.13-term-image-0.7.2-dist
Executing pythonRemoveTestsDir
Finished executing pythonRemoveTestsDir
Running phase: installCheckPhase
no Makefile or custom installCheckPhase, doing nothing
Running phase: pythonCatchConflictsPhase
Running phase: pythonRemoveBinBytecodePhase
Running phase: pythonImportsCheckPhase
Executing pythonImportsCheckPhase
Check whether the following modules can be imported: term_image
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/utils.py:832: TermImageUserWarning: It seems this process is not running within a terminal. Hence, some features will behave differently or be disabled.
See https://term-image.readthedocs.io/en/stable/guide/concepts.html#active-terminal
Any filter for this warning must be set before loading `term_image`, using `UserWarning` with the warning message (since `TermImageUserWarning` won't be available).
  warnings.warn(
Running phase: pytestCheckPhase
Executing pytestCheckPhase
pytest flags: -m pytest --ignore-glob=tests/test_image/test_url.py
============================= test session starts ==============================
platform linux -- Python 3.13.11, pytest-8.4.2, pluggy-1.6.0 -- /nix/store/slhpx9glq7vl99bwi93bgrhn3syv98s1-python3-3.13.11/bin/python3.13
cachedir: .pytest_cache
rootdir: /build/term-image
configfile: pyproject.toml
collected 1138 items / 2 errors

==================================== ERRORS ====================================
________________ ERROR collecting tests/test_image/test_base.py ________________
tests/test_image/test_base.py:721: in <module>
    class TestFormatting:
tests/test_image/test_base.py:724: in TestFormatting
    render = str(image)
             ^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:305: in __str__
    return self._renderer(self._render_image, _ALPHA_THRESHOLD)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:1705: in _renderer
    return renderer(self._get_image(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/block.py:112: in _render_image
    img, rgb, a = self._get_render_data(img, alpha, round_alpha=True, frame=frame)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:1508: in _get_render_data
    a = list(img.getdata(3))
             ^^^^^^^^^^^^^^
/nix/store/k5hjvcdk83wpvpg3zzi8i449k0wzgywm-python3.13-pillow-12.1.0/lib/python3.13/site-packages/PIL/Image.py:1438: in getdata
    deprecate("Image.Image.getdata", 14, "get_flattened_data")
/nix/store/k5hjvcdk83wpvpg3zzi8i449k0wzgywm-python3.13-pillow-12.1.0/lib/python3.13/site-packages/PIL/_deprecate.py:68: in deprecate
    warnings.warn(
E   DeprecationWarning: Image.Image.getdata is deprecated and will be removed in Pillow 14 (2027-10-15). Use get_flattened_data instead.
_______________ ERROR collecting tests/test_image/test_others.py _______________
tests/test_image/test_others.py:7: in <module>
    from .test_base import BytesPath, python_image, python_img
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
/nix/store/7n1h5a6pabzkwb81wbwygicv0lk126ql-python3.13-pytest-8.4.2/lib/python3.13/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
    exec(co, module.__dict__)
tests/test_image/test_base.py:721: in <module>
    class TestFormatting:
tests/test_image/test_base.py:724: in TestFormatting
    render = str(image)
             ^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:305: in __str__
    return self._renderer(self._render_image, _ALPHA_THRESHOLD)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:1705: in _renderer
    return renderer(self._get_image(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/block.py:112: in _render_image
    img, rgb, a = self._get_render_data(img, alpha, round_alpha=True, frame=frame)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:1508: in _get_render_data
    a = list(img.getdata(3))
             ^^^^^^^^^^^^^^
/nix/store/k5hjvcdk83wpvpg3zzi8i449k0wzgywm-python3.13-pillow-12.1.0/lib/python3.13/site-packages/PIL/Image.py:1438: in getdata
    deprecate("Image.Image.getdata", 14, "get_flattened_data")
/nix/store/k5hjvcdk83wpvpg3zzi8i449k0wzgywm-python3.13-pillow-12.1.0/lib/python3.13/site-packages/PIL/_deprecate.py:68: in deprecate
    warnings.warn(
E   DeprecationWarning: Image.Image.getdata is deprecated and will be removed in Pillow 14 (2027-10-15). Use get_flattened_data instead.
=========================== short test summary info ============================
ERROR tests/test_image/test_base.py - DeprecationWarning: Image.Image.getdata is deprecated and will be removed i...
ERROR tests/test_image/test_others.py - DeprecationWarning: Image.Image.getdata is deprecated and will be removed i...
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 2 errors in 2.26s ===============================
Exception ignored in: <_io.FileIO name='tests/images/python.png' mode='rb' closefd=True>
Traceback (most recent call last):
  File "/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py", line 625, in close
ResourceWarning: unclosed file <_io.BufferedReader name='tests/images/python.png'>
error: Cannot build '/nix/store/sgrgz0qylazy146r8ayhfh7nz4p92vh9-python3.13-term-image-0.7.2.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2
         /nix/store/flxyhhrv56dfp6p4a3bnl3wzirs8mga0-python3.13-term-image-0.7.2-dist
       Last 25 log lines:
       >     return self._renderer(self._render_image, _ALPHA_THRESHOLD)
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       > /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:1705: in _renderer
       >     return renderer(self._get_image(), *args, **kwargs)
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       > /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/block.py:112: in _render_image
       >     img, rgb, a = self._get_render_data(img, alpha, round_alpha=True, frame=frame)
       >                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       > /nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py:1508: in _get_render_data
       >     a = list(img.getdata(3))
       >              ^^^^^^^^^^^^^^
       > /nix/store/k5hjvcdk83wpvpg3zzi8i449k0wzgywm-python3.13-pillow-12.1.0/lib/python3.13/site-packages/PIL/Image.py:1438: in getdata
       >     deprecate("Image.Image.getdata", 14, "get_flattened_data")
       > /nix/store/k5hjvcdk83wpvpg3zzi8i449k0wzgywm-python3.13-pillow-12.1.0/lib/python3.13/site-packages/PIL/_deprecate.py:68: in deprecate
       >     warnings.warn(
       > E   DeprecationWarning: Image.Image.getdata is deprecated and will be removed in Pillow 14 (2027-10-15). Use get_flattened_data instead.
       > =========================== short test summary info ============================
       > ERROR tests/test_image/test_base.py - DeprecationWarning: Image.Image.getdata is deprecated and will be removed i...
       > ERROR tests/test_image/test_others.py - DeprecationWarning: Image.Image.getdata is deprecated and will be removed i...
       > !!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!
       > ============================== 2 errors in 2.26s ===============================
       > Exception ignored in: <_io.FileIO name='tests/images/python.png' mode='rb' closefd=True>
       > Traceback (most recent call last):
       >   File "/nix/store/80rfzl6jmvyw9xviz2b9wls654ngr0ax-python3.13-term-image-0.7.2/lib/python3.13/site-packages/term_image/image/common.py", line 625, in close
       > ResourceWarning: unclosed file <_io.BufferedReader name='tests/images/python.png'>
       For full logs, run:
         nix log /nix/store/sgrgz0qylazy146r8ayhfh7nz4p92vh9-python3.13-term-image-0.7.2.drv
```

</details>

I further filed the patch [upstream](https://github.com/AnonymouX47/term-image/pull/195).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
