### PR TITLE
ssh-agent-switcher: init at 1.0.1 (plus shtk: init shtk at 1.7)

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12536,6 +12536,12 @@
     githubId = 43830312;
     name = "Joël Miramon";
   };
+  jmmv = {
+    email = "julio@meroh.net";
+    github = "jmmv";
+    githubId = 879272;
+    name = "Julio Merino";
+  };
   jn-sena = {
     email = "jn-sena@proton.me";
     github = "jn-sena";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1511,6 +1511,7 @@
   ./services/security/reaction.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix
+  ./services/security/ssh-agent-switcher.nix
   ./services/security/sshguard.nix
   ./services/security/sslmate-agent.nix
   ./services/security/step-ca.nix

--- a/nixos/modules/services/security/ssh-agent-switcher.nix
+++ b/nixos/modules/services/security/ssh-agent-switcher.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.ssh-agent-switcher;
+in
+{
+  meta.maintainers = [ lib.maintainers.jmmv ];
+
+  options = {
+    services.ssh-agent-switcher = {
+      enable = lib.mkEnableOption "ssh-agent-switcher daemon" // {
+        description = ''
+          Whether to enable ssh-agent-switcher, a daemon that proxies SSH agent
+          connections to forwarded agents. This allows tmux/screen sessions to
+          access SSH agents across reconnections.
+
+          This is a per-user service that automatically starts when you log in
+          via SSH and sets SSH_AUTH_SOCK to point to a stable socket location.
+
+          Note: This only activates for SSH sessions, not graphical or console logins.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs "ssh-agent-switcher" { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    environment.loginShellInit = ''
+      if [ -n "$SSH_CONNECTION" ]; then
+        mkdir -p "''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+        export SSH_AUTH_SOCK="''${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/ssh-agent-switcher.sock"
+        ${lib.getExe cfg.package} --daemon --socket-path="$SSH_AUTH_SOCK" 2>/dev/null || true
+      fi
+    '';
+  };
+}

--- a/pkgs/by-name/sh/shtk/package.nix
+++ b/pkgs/by-name/sh/shtk/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "shtk";
+  version = "1.7";
+
+  src = fetchFromGitHub {
+    owner = "jmmv";
+    repo = "shtk";
+    tag = "shtk-${finalAttrs.version}";
+    hash = "sha256-EnJpysBI00JqLsRzdrHW62gV0wXx/Q+tpLR26jrgukU=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  configureFlags = [
+    "SHTK_SHELL=${stdenv.shell}"
+  ];
+
+  enableParallelBuilding = true;
+
+  doCheck = true;
+
+  postInstall = ''
+    # The "shtk" binary is only used when building packages that need shtk at
+    # runtime, so it's only a developer tool.
+    moveToOutput bin "$dev"
+
+    moveToOutput share/aclocal "$dev"
+    moveToOutput lib/pkgconfig "$dev"
+
+    substituteInPlace "$dev/lib/pkgconfig/shtk.pc" \
+      --replace-fail "$out/bin/shtk" "$dev/bin/shtk"
+
+    # Do not install tests.  This is a weird pattern that not many packages
+    # follow.
+    rm -rf "$out/tests"
+  '';
+
+  meta = {
+    description = "Application toolkit for programmers writing POSIX-compliant shell scripts";
+    longDescription = ''
+      The Shell Toolkit, or shtk for short, is an application toolkit
+      for programmers writing POSIX-compliant shell scripts.
+
+      shtk provides a collection of reusable modules that work on a wide
+      variety of operating systems and shell interpreters. These modules are all
+      ready to be used by calling the provided shtk_import primitive and
+      "compiling" the shell scripts into their final form using the shtk(1)
+      utility.
+
+      shtk is purely written in the shell scripting language so there are no
+      dependencies to be installed, and is known to be compatible with at least
+      bash, dash, pdksh and zsh.
+    '';
+    homepage = "https://github.com/jmmv/shtk";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.jmmv ];
+    platforms = lib.platforms.unix;
+    mainProgram = "shtk";
+  };
+})

--- a/pkgs/by-name/ss/ssh-agent-switcher/package.nix
+++ b/pkgs/by-name/ss/ssh-agent-switcher/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  openssh,
+  shtk,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ssh-agent-switcher";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "jmmv";
+    repo = "ssh-agent-switcher";
+    tag = "ssh-agent-switcher-${version}";
+    hash = "sha256-p9W0H25pWDB+GCrwLwuVruX9p8b8kICpp+6I11ym1aw=";
+  };
+
+  cargoHash = "sha256-WioA/RjXOAHM9QWl/lxnb7gqzcp76rus7Rv+IfCYceg=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    shtk.dev
+  ];
+
+  nativeCheckInputs = [ openssh ];
+
+  checkPhase = ''
+    runHook preCheck
+
+    cargoCheckHook
+
+    shtk build -m shtk_unittest_main -o inttest inttest.sh
+    MODE="${stdenv.hostPlatform.rust.rustcTarget}/release" ./inttest
+
+    runHook postCheck
+  '';
+
+  postInstall = ''
+    installManPage ssh-agent-switcher.1
+
+    install -Dm644 README.md -t $out/share/doc/ssh-agent-switcher/
+    install -Dm644 NEWS.md -t $out/share/doc/ssh-agent-switcher/
+    install -Dm644 COPYING -t $out/share/doc/ssh-agent-switcher/
+  '';
+
+  meta = {
+    description = "SSH agent forwarding and tmux done right";
+    longDescription = ''
+      ssh-agent-switcher is a daemon that proxies SSH agent connections to any
+      valid forwarded agent provided by sshd. This allows long-lived processes
+      such as terminal multiplexers like tmux or screen to access the
+      connection-specific forwarded agents.
+    '';
+    homepage = "https://github.com/jmmv/ssh-agent-switcher";
+    changelog = "https://github.com/jmmv/ssh-agent-switcher/blob/ssh-agent-switcher-${version}/NEWS.md";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.jmmv ];
+    mainProgram = "ssh-agent-switcher";
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
This PR contains three separate commits:

*    One to create a new package for `ssh-agent-switcher`, which is my end goal. This is a tool to fix ssh-agent handling when working with tmux on remote hosts. This package comes with NixOS configuration integration to make it trivial to start the per-user daemon (per the upstream instructions).

*   Another to create a new package for `shtk`. This is a toolkit for shell scripts, and `ssh-agent-switcher` uses it for its integration tests. Not strictly required as a dependency... but it's nice to have available so that we can make sure the tool works.

*   And a final one to add myself as a maintainer. (This commit is duplicate from https://github.com/NixOS/nixpkgs/pull/487500 so... whichever PR merges first will get it in and the other will need a rebase.)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
