### PR TITLE
vk-bootstrap: 0.7 -> 1.4.335

### DIFF
--- a/pkgs/by-name/vk/vk-bootstrap/0001-disable-fetch-content.patch
+++ b/pkgs/by-name/vk/vk-bootstrap/0001-disable-fetch-content.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7ec2d39..f52313d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -129,7 +128,8 @@ if(VK_BOOTSTRAP_TEST)
+         endif()
+     endif()
+ 
+-    add_subdirectory(ext)
++    find_package(glfw3)
++    find_package(Catch2 3)
+     add_subdirectory(tests)
+     add_subdirectory(example)
+ endif ()

--- a/pkgs/by-name/vk/vk-bootstrap/0002-fix-install-tests.patch
+++ b/pkgs/by-name/vk/vk-bootstrap/0002-fix-install-tests.patch
@@ -1,0 +1,38 @@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 0b4f2e1..4dd1fe0 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -58,14 +58,16 @@ list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+ include(Catch)
+ catch_discover_tests(vk-bootstrap-test)
+ 
+-# Test add_subdirectory support using fetch content vulkan headers
+-add_test(NAME integration.add_subdirectory.fetch_content_vulkan_headers
+-    COMMAND ${CMAKE_CTEST_COMMAND}
+-        --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration
+-                         ${CMAKE_CURRENT_BINARY_DIR}/add_subdirectory/fetch_content_vulkan_headers
+-        --build-generator ${CMAKE_GENERATOR}
+-        --build-options -DADD_SUBDIRECTORY_TESTING=ON -DVULKAN_HEADER_VERSION_GIT_TAG=${VK_BOOTSTRAP_SOURCE_HEADER_VERSION_GIT_TAG}
+-)
++# Commented out for nixpkgs due to external dependencies.
++#
++# # Test add_subdirectory support using fetch content vulkan headers
++# add_test(NAME integration.add_subdirectory.fetch_content_vulkan_headers
++#     COMMAND ${CMAKE_CTEST_COMMAND}
++#         --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration
++#                          ${CMAKE_CURRENT_BINARY_DIR}/add_subdirectory/fetch_content_vulkan_headers
++#         --build-generator ${CMAKE_GENERATOR}
++#         --build-options -DADD_SUBDIRECTORY_TESTING=ON -DVULKAN_HEADER_VERSION_GIT_TAG=${VK_BOOTSTRAP_SOURCE_HEADER_VERSION_GIT_TAG}
++# )
+ 
+  get_target_property(vulkan_headers_include_dir Vulkan::Headers INTERFACE_INCLUDE_DIRECTORIES)
+ 
+@@ -105,7 +107,7 @@ if (VulkanHeaders_FOUND)
+                 --build-and-test ${CMAKE_CURRENT_LIST_DIR}/integration
+                                 ${CMAKE_CURRENT_BINARY_DIR}/find_package/find_package_vulkan_headers
+                 --build-generator ${CMAKE_GENERATOR}
+-                --build-options -DFIND_PACKAGE_TESTING=ON "-DCMAKE_PREFIX_PATH=${vulkan_headers_install_dir};${test_install_dir}"
++                --build-options -DFIND_PACKAGE_TESTING=ON "-DCMAKE_PREFIX_PATH=${vulkan_headers_install_dir};${test_install_dir};${CMAKE_INSTALL_PREFIX}"
+         )
+ 
+         set_tests_properties(integration.find_package.find_package_vulkan_headers PROPERTIES DEPENDS integration.install)

--- a/pkgs/by-name/vk/vk-bootstrap/package.nix
+++ b/pkgs/by-name/vk/vk-bootstrap/package.nix
@@ -5,40 +5,40 @@
   cmake,
   vulkan-headers,
   glfw,
-  catch2,
+  catch2_3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vk-bootstrap";
-  version = "0.7";
-  outputs = [
-    "out"
-    "dev"
-  ];
+  version = "1.4.335";
 
   src = fetchFromGitHub {
     owner = "charles-lunarg";
     repo = "vk-bootstrap";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-X3ANqfplrCF1R494+H5/plcwMH7rbW6zpLA4MZrYaoE=";
+    hash = "sha256-WFROoVAOl4HBNb/a8rx522Zz2LP4m2Zk03jckWxv7w0=";
   };
 
-  postPatch = ''
-    # Upstream uses cmake FetchContent to resolve glfw and catch2
-    # needed for examples and tests
-    sed -i 's=add_subdirectory(ext)==g' CMakeLists.txt
-    sed -i 's=Catch2==g' tests/CMakeLists.txt
-  '';
-
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [
-    vulkan-headers
-    glfw
-    catch2
+  patches = [
+    ./0001-disable-fetch-content.patch
+    ./0002-fix-install-tests.patch
   ];
 
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    vulkan-headers
+  ];
+
+  checkInputs = [
+    glfw
+    catch2_3
+  ];
+
+  doCheck = true;
+
   cmakeFlags = [
-    "-DVK_BOOTSTRAP_VULKAN_HEADER_DIR=${vulkan-headers}/include"
+    "-DVK_BOOTSTRAP_INSTALL=1"
   ];
 
   meta = {


### PR DESCRIPTION
Resolves #438504

Motivation: the package is outdated by 3 years. Also, it lacks cmake targets.

Things done:
1. Bump the version (to match the current version of Vulkan headers in nixpkgs).
2. Update the catch2 dependency to catch2_3, following upstream.
3. Upstream uses FetchContent to fetch catch2 and glfw for testing. Patch CMakeLists.txt so that system packages are used instead.
4. Remove the [out, dev] split. It's pointless because this is a static library.
5. Enable checkPhase. Comment out a test which uses FetchContent. Fix CMAKE_PREFIX_PATH in one of the integration tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] (N/A) [NixOS tests] in [nixos/tests].
  - [ ] (N/A) [Package tests] at `passthru.tests`.
  - [ ] (N/A) Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] (N/A, no package in nixpkgs depends on vk-bootstrap). Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (It's a library, so there are no executables. But I tested the change by building a private project which depends on vk-bootstrap, finding it via cmake).
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
