### PR TITLE
pgadmin4: 9.11 -> 9.12

### DIFF
--- a/pkgs/by-name/pg/pgadmin4/package.nix
+++ b/pkgs/by-name/pg/pgadmin4/package.nix
@@ -20,14 +20,14 @@
 
 let
   pname = "pgadmin";
-  version = "9.11";
-  yarnHash = "sha256-x8EbZPQxCRBfeBXJGHW1tyN3tWzTqlMGvftizspfBRw=";
+  version = "9.12";
+  yarnHash = "sha256-PEqs2gSreCNE06EjiD3M+xQtDb8SqYW15WkarS63Lvs=";
 
   src = fetchFromGitHub {
     owner = "pgadmin-org";
     repo = "pgadmin4";
     rev = "REL-${lib.versions.major version}_${lib.versions.minor version}";
-    hash = "sha256-t+TdudbCq68fXJrcAzyESZTiA4qVkQgwF4efc4IJrl0=";
+    hash = "sha256-DHV6YhkufEoEId4naFzm06BwRTfrQG14HFIn0P13D08=";
   };
 
   # keep the scope, as it is used throughout the derivation and tests


### PR DESCRIPTION
Release notes: https://www.pgadmin.org/docs/pgadmin4/latest/release_notes_9_12.html
Diff: https://github.com/pgadmin-org/pgadmin4/compare/REL-9_11...REL-9_12

Fixes: CVE-2026-1707

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
