### PR TITLE
vicinae: 0.19.3 -> 0.19.6

### DIFF
--- a/pkgs/by-name/vi/vicinae/package.nix
+++ b/pkgs/by-name/vi/vicinae/package.nix
@@ -16,28 +16,28 @@
   pkg-config,
   protobuf,
   qt6,
-  gcc15Stdenv,
+  stdenv,
   wayland,
   libxml2,
 }:
-gcc15Stdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vicinae";
-  version = "0.19.3";
+  version = "0.19.6";
 
   src = fetchFromGitHub {
     owner = "vicinaehq";
     repo = "vicinae";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-x/WIhul+slaDhW8PvcHpa/FElraGCWfFvgT7Xgw1Hbo=";
+    hash = "sha256-ZS3WnNMOuH/h7aKno2aDGvfs96nItfVJB/HHDwJfODQ=";
   };
 
   apiDeps = fetchNpmDeps {
-    src = "${finalAttrs.src}/typescript/api";
+    src = "${finalAttrs.src}/src/typescript/api";
     hash = "sha256-UsTpMR23UQBRseRo33nbT6z/UCjZByryWfn2AQSgm6U=";
   };
 
   extensionManagerDeps = fetchNpmDeps {
-    src = "${finalAttrs.src}/typescript/extension-manager";
+    src = "${finalAttrs.src}/src/typescript/extension-manager";
     hash = "sha256-wl8FDFB6Vl1zD0/s2EbU6l1KX4rwUW6dOZof4ebMMO8=";
   };
 
@@ -84,8 +84,8 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
   postPatch = ''
     local postPatchHooks=()
     source ${npmHooks.npmConfigHook}/nix-support/setup-hook
-    npmRoot=typescript/api npmDeps=${finalAttrs.apiDeps} npmConfigHook
-    npmRoot=typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
+    npmRoot=src/typescript/api npmDeps=${finalAttrs.apiDeps} npmConfigHook
+    npmRoot=src/typescript/extension-manager npmDeps=${finalAttrs.extensionManagerDeps} npmConfigHook
   '';
 
   qtWrapperArgs = [

--- a/pkgs/by-name/vi/vicinae/update.sh
+++ b/pkgs/by-name/vi/vicinae/update.sh
@@ -12,8 +12,8 @@ if [[ "$UPDATE_NIX_OLD_VERSION" == "$version" ]]; then
 fi
 
 pushd "$(mktemp -d)"
-curl -s "https://raw.githubusercontent.com/vicinaehq/vicinae/v${version}/typescript/api/package-lock.json" -o api-package-lock.json
-curl -s "https://raw.githubusercontent.com/vicinaehq/vicinae/v${version}/typescript/extension-manager/package-lock.json" -o extension-manager-package-lock.json
+curl -s "https://raw.githubusercontent.com/vicinaehq/vicinae/v${version}/src/typescript/api/package-lock.json" -o api-package-lock.json
+curl -s "https://raw.githubusercontent.com/vicinaehq/vicinae/v${version}/src/typescript/extension-manager/package-lock.json" -o extension-manager-package-lock.json
 newApiDepsHash=$(prefetch-npm-deps api-package-lock.json)
 newExtensionManagerDepsHash=$(prefetch-npm-deps extension-manager-package-lock.json)
 popd


### PR DESCRIPTION
Release notes: https://github.com/vicinaehq/vicinae/releases/tag/v0.19.6

Version 0.19.4 was the initial release of these same changes, but v0.19.5 reverted it due to a packaging issue. v0.19.6 is the re-release.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
