### PR TITLE
ci: module maintainer review requests; nixos/modules: init `meta.teams`

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -123,9 +123,7 @@ let
   # - values: lists of `packagePlatformPath`s
   diffAttrs = builtins.fromJSON (builtins.readFile "${combined}/combined-diff.json");
 
-  changedPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.changed;
   rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.rebuilds;
-  removedPackagePlatformAttrs = convertToPackagePlatformAttrs diffAttrs.removed;
 
   changed-paths =
     let
@@ -162,9 +160,10 @@ let
 
   inherit
     (callPackage ./maintainers.nix {
-      changedattrs = lib.attrNames (lib.groupBy (a: a.name) changedPackagePlatformAttrs);
-      changedpathsjson = touchedFilesJson;
-      removedattrs = lib.attrNames (lib.groupBy (a: a.name) removedPackagePlatformAttrs);
+      affectedAttrPaths = map (a: a.packagePath) (
+        convertToPackagePlatformAttrs (diffAttrs.changed ++ diffAttrs.removed)
+      );
+      changedFiles = lib.importJSON touchedFilesJson;
     })
     users
     teams
@@ -181,7 +180,7 @@ runCommand "compare"
     ];
     users = builtins.toJSON users;
     teams = builtins.toJSON teams;
-    packages = builtins.toJSON packages;
+    packages = builtins.toJSON (lib.map (lib.concatStringsSep ".") packages);
     passAsFile = [
       "users"
       "teams"

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -25,6 +25,7 @@
     # One example case is, where an attribute is a throw alias, but then re-introduced in a PR.
     # This would trigger the throw. By disabling aliases, we can fallback gracefully below.
     config.allowAliases = false;
+    overlays = [ ];
   },
   lib,
 }:
@@ -37,59 +38,17 @@ let
   moduleMeta = (pkgs.nixos { }).config.meta;
 
   # Currently just nixos module maintainers, but in the future we can use this for code owners too
-  fileMaintainers = stripNixpkgsRootFromKeys moduleMeta.maintainers;
+  fileUsers = stripNixpkgsRootFromKeys moduleMeta.maintainers;
   fileTeams = stripNixpkgsRootFromKeys moduleMeta.teams;
-
-  # Extract attributes that changed from by-name paths.
-  # This allows pinging reviewers for pure refactors.
-  touchedattrs = lib.pipe changedFiles [
-    (lib.filter (changed: lib.hasPrefix "pkgs/by-name/" changed && changed != "pkgs/by-name/README.md"))
-    (map (lib.splitString "/"))
-    (map (path: lib.elemAt path 3))
-    (map lib.singleton)
-    lib.unique
-  ];
 
   anyMatchingFile = filename: lib.any (lib.hasPrefix filename) changedFiles;
 
   anyMatchingFiles = files: lib.any anyMatchingFile files;
 
-  sharded = name: "${lib.substring 0 2 name}/${name}";
-
-  attrsWithMaintainers = lib.pipe (affectedAttrPaths ++ touchedattrs) [
-    # An attribute can appear in changed/removed *and* touched
-    lib.unique
-    (map (
-      path:
-      let
-        # Some packages might be reported as changed on a different platform, but
-        # not even have an attribute on the platform the maintainers are requested on.
-        # Fallback to `null` for these to filter them out below.
-        package = lib.attrByPath path null pkgs;
-      in
-      {
-        inherit path package;
-        # Adds all files in by-name to each package, no matter whether they are discoverable
-        # via meta attributes below. For example, this allows pinging maintainers for
-        # updates to .json files.
-        # TODO: Support by-name package sets.
-        filenames = lib.optional (lib.length path == 1) "pkgs/by-name/${sharded (lib.head path)}/";
-        # meta.maintainers also contains all individual team members.
-        # We only want to ping individuals if they're added individually as maintainers, not via teams.
-        users = package.meta.nonTeamMaintainers or [ ];
-        teams = package.meta.teams or [ ];
-      }
-    ))
-    # No need to match up packages without maintainers with their files.
-    # This also filters out attributes where `package = null`, which is the
-    # case for libintl, for example.
-    (lib.filter (pkg: pkg.users != [ ] || pkg.teams != [ ]))
-  ];
-
   relevantFilenames =
     drv:
     (lib.unique (
-      map (pos: lib.removePrefix "${toString ../../..}/" pos.file) (
+      map (pos: lib.removePrefix nixpkgsRoot pos.file) (
         lib.filter (x: x != null) [
           (drv.meta.maintainersPosition or null)
           (drv.meta.teamsPosition or null)
@@ -112,11 +71,47 @@ let
       )
     ));
 
-  attrsWithFilenames = map (
-    pkg: pkg // { filenames = pkg.filenames ++ relevantFilenames pkg.package; }
-  ) attrsWithMaintainers;
+  relevantAffectedAttrPaths = lib.filter (
+    attrPath:
+    # Some packages might be reported as changed on a different platform, but
+    # not even have an attribute on the platform the maintainers are requested on.
+    # Fallback to `null` for these to filter them out
+    let
+      package = lib.attrByPath attrPath null pkgs;
+    in
+    package != null && anyMatchingFiles (relevantFilenames package)
+  ) affectedAttrPaths;
 
-  attrsWithModifiedFiles = lib.filter (pkg: anyMatchingFiles pkg.filenames) attrsWithFilenames;
+  # Extract attributes that changed from by-name paths.
+  # This allows pinging reviewers for pure refactors.
+  changedByNameAttrPaths = lib.pipe changedFiles [
+    (lib.filter (changed: lib.hasPrefix "pkgs/by-name/" changed))
+    (map (lib.splitString "/"))
+    # Filters out e.g. pkgs/by-name/README.md
+    (lib.filter (path: lib.length path > 3))
+    (map (path: lib.elemAt path 3))
+    (map lib.singleton)
+  ];
+
+  # An attribute can appear in affected *and* touched
+  attrPathsToGetMaintainersFor = lib.unique (relevantAffectedAttrPaths ++ changedByNameAttrPaths);
+
+  attrPathEntities = lib.concatMap (
+    attrPath:
+    let
+      package = lib.getAttrFromPath attrPath pkgs;
+    in
+    # meta.maintainers also contains all individual team members.
+    # We only want to ping individuals if they're added individually as maintainers, not via teams.
+    userPings { inherit attrPath; } (package.meta.nonTeamMaintainers or [ ])
+    ++ lib.concatMap (teamPings { inherit attrPath; }) (package.meta.teams or [ ])
+  ) attrPathsToGetMaintainersFor;
+
+  changedFileEntities = lib.concatMap (
+    file:
+    userPings { inherit file; } (fileUsers.${file} or [ ])
+    ++ lib.concatMap (teamPings { inherit file; }) (fileTeams.${file} or [ ])
+  ) changedFiles;
 
   userPings =
     context:
@@ -139,19 +134,7 @@ let
     else
       userPings context team.members;
 
-  maintainersToPing =
-    lib.concatMap (
-      pkg:
-      userPings { attrPath = pkg.path; } pkg.users
-      ++ lib.concatMap (teamPings { attrPath = pkg.path; }) pkg.teams
-    ) attrsWithModifiedFiles
-    ++ lib.concatMap (
-      path:
-      userPings { file = path; } (fileMaintainers.${path} or [ ])
-      ++ lib.concatMap (teamPings { file = path; }) (fileTeams.${path} or [ ])
-    ) changedFiles;
-
-  byType = lib.groupBy (ping: ping.type) maintainersToPing;
+  byType = lib.groupBy (ping: ping.type) (attrPathEntities ++ changedFileEntities);
 
   byUser = lib.pipe (byType.user or [ ]) [
     (lib.groupBy (ping: toString ping.userId))
@@ -165,5 +148,5 @@ in
 {
   users = byUser;
   teams = byTeam;
-  packages = lib.catAttrs "path" attrsWithModifiedFiles;
+  packages = attrPathsToGetMaintainersFor;
 }

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -6,6 +6,11 @@
 # - pkgs/by-name/<attr>/* is linked to pkgs.<attr>
 # - The file position of various attributes of pkgs.<attr>
 # - Explicitly specified file positions in derivations
+#
+# Test with
+#   nix-instantiate --eval --strict --json test.nix -A result | jq
+#
+# Empty list as an output means success
 {
   # Files that were changed
   # Type: ListOf (Nixpkgs-root-relative path)

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -13,6 +13,14 @@ let
     config.allowAliases = false;
   };
 
+  nixpkgsRoot = toString ../../.. + "/";
+
+  fileMaintainers =
+    # Currently just nixos module maintainers, but in the future we can use this for code owners too
+    lib.mapAttrs' (
+      file: maintainers: lib.nameValuePair (lib.removePrefix nixpkgsRoot file) maintainers
+    ) (pkgs.nixos { }).config.meta.maintainers;
+
   changedpaths = lib.importJSON changedpathsjson;
 
   # Extract attributes that changed from by-name paths.
@@ -94,39 +102,42 @@ let
   attrsWithModifiedFiles = lib.filter (pkg: anyMatchingFiles pkg.filenames) attrsWithFilenames;
 
   userPings =
-    pkg:
+    context:
     map (maintainer: {
       type = "user";
       userId = maintainer.githubId;
-      packageName = pkg.name;
+      inherit context;
     });
 
   teamPings =
-    pkg: team:
+    context: team:
     if team ? github then
       [
         {
           type = "team";
           teamId = team.githubId;
-          packageName = pkg.name;
+          inherit context;
         }
       ]
     else
-      userPings pkg team.members;
+      userPings context team.members;
 
-  maintainersToPing = lib.concatMap (
-    pkg: userPings pkg pkg.users ++ lib.concatMap (teamPings pkg) pkg.teams
-  ) attrsWithModifiedFiles;
+  maintainersToPing =
+    lib.concatMap (
+      pkg:
+      userPings { attr = pkg.name; } pkg.users ++ lib.concatMap (teamPings { pkg = pkg.name; }) pkg.teams
+    ) attrsWithModifiedFiles
+    ++ lib.concatMap (path: userPings { file = path; } (fileMaintainers.${path} or [ ])) changedpaths;
 
   byType = lib.groupBy (ping: ping.type) maintainersToPing;
 
   byUser = lib.pipe (byType.user or [ ]) [
     (lib.groupBy (ping: toString ping.userId))
-    (lib.mapAttrs (_user: lib.map (pkg: pkg.packageName)))
+    (lib.mapAttrs (_user: lib.map (pkg: pkg.context)))
   ];
   byTeam = lib.pipe (byType.team or [ ]) [
     (lib.groupBy (ping: toString ping.teamId))
-    (lib.mapAttrs (_team: lib.map (pkg: pkg.packageName)))
+    (lib.mapAttrs (_team: lib.map (pkg: pkg.context)))
   ];
 in
 {

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -14,12 +14,15 @@ let
   };
 
   nixpkgsRoot = toString ../../.. + "/";
+  stripNixpkgsRootFromKeys = lib.mapAttrs' (
+    file: value: lib.nameValuePair (lib.removePrefix nixpkgsRoot file) value
+  );
 
-  fileMaintainers =
-    # Currently just nixos module maintainers, but in the future we can use this for code owners too
-    lib.mapAttrs' (
-      file: maintainers: lib.nameValuePair (lib.removePrefix nixpkgsRoot file) maintainers
-    ) (pkgs.nixos { }).config.meta.maintainers;
+  moduleMeta = (pkgs.nixos { }).config.meta;
+
+  # Currently just nixos module maintainers, but in the future we can use this for code owners too
+  fileMaintainers = stripNixpkgsRootFromKeys moduleMeta.maintainers;
+  fileTeams = stripNixpkgsRootFromKeys moduleMeta.teams;
 
   changedpaths = lib.importJSON changedpathsjson;
 
@@ -127,7 +130,11 @@ let
       pkg:
       userPings { attr = pkg.name; } pkg.users ++ lib.concatMap (teamPings { pkg = pkg.name; }) pkg.teams
     ) attrsWithModifiedFiles
-    ++ lib.concatMap (path: userPings { file = path; } (fileMaintainers.${path} or [ ])) changedpaths;
+    ++ lib.concatMap (
+      path:
+      userPings { file = path; } (fileMaintainers.${path} or [ ])
+      ++ lib.concatMap (teamPings { file = path; }) (fileTeams.${path} or [ ])
+    ) changedpaths;
 
   byType = lib.groupBy (ping: ping.type) maintainersToPing;
 

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -1,18 +1,29 @@
+# Figure out which maintainers (users/teams) are relevant for a PR:
+# - All maintainers that can be linked directly to changedFiles
+# - Maintainers of affectedAttrPaths if a file directly related to the attribute is in changedFiles
+#
+# Files and attributes are linked in various ways:
+# - pkgs/by-name/<attr>/* is linked to pkgs.<attr>
+# - The file position of various attributes of pkgs.<attr>
+# - Explicitly specified file positions in derivations
 {
-  lib,
-  changedattrs,
-  changedpathsjson,
-  removedattrs,
-}:
-let
-  pkgs = import ../../.. {
+  # Files that were changed
+  # Type: ListOf (Nixpkgs-root-relative path)
+  changedFiles,
+  # Attributes whose value was affected by the change
+  # Type: ListOf (ListOf String)
+  affectedAttrPaths,
+
+  pkgs ? import ../../.. {
     system = "x86_64-linux";
     # We should never try to ping maintainers through package aliases, this can only lead to errors.
     # One example case is, where an attribute is a throw alias, but then re-introduced in a PR.
     # This would trigger the throw. By disabling aliases, we can fallback gracefully below.
     config.allowAliases = false;
-  };
-
+  },
+  lib,
+}:
+let
   nixpkgsRoot = toString ../../.. + "/";
   stripNixpkgsRootFromKeys = lib.mapAttrs' (
     file: value: lib.nameValuePair (lib.removePrefix nixpkgsRoot file) value
@@ -24,37 +35,35 @@ let
   fileMaintainers = stripNixpkgsRootFromKeys moduleMeta.maintainers;
   fileTeams = stripNixpkgsRootFromKeys moduleMeta.teams;
 
-  changedpaths = lib.importJSON changedpathsjson;
-
   # Extract attributes that changed from by-name paths.
   # This allows pinging reviewers for pure refactors.
-  touchedattrs = lib.pipe changedpaths [
+  touchedattrs = lib.pipe changedFiles [
     (lib.filter (changed: lib.hasPrefix "pkgs/by-name/" changed && changed != "pkgs/by-name/README.md"))
     (map (lib.splitString "/"))
     (map (path: lib.elemAt path 3))
+    (map lib.singleton)
     lib.unique
   ];
 
-  anyMatchingFile = filename: lib.any (lib.hasPrefix filename) changedpaths;
+  anyMatchingFile = filename: lib.any (lib.hasPrefix filename) changedFiles;
 
   anyMatchingFiles = files: lib.any anyMatchingFile files;
 
   sharded = name: "${lib.substring 0 2 name}/${name}";
 
-  attrsWithMaintainers = lib.pipe (changedattrs ++ removedattrs ++ touchedattrs) [
+  attrsWithMaintainers = lib.pipe (affectedAttrPaths ++ touchedattrs) [
     # An attribute can appear in changed/removed *and* touched
     lib.unique
     (map (
-      name:
+      path:
       let
-        path = lib.splitString "." name;
         # Some packages might be reported as changed on a different platform, but
         # not even have an attribute on the platform the maintainers are requested on.
         # Fallback to `null` for these to filter them out below.
         package = lib.attrByPath path null pkgs;
       in
       {
-        inherit name package;
+        inherit path package;
         # Adds all files in by-name to each package, no matter whether they are discoverable
         # via meta attributes below. For example, this allows pinging maintainers for
         # updates to .json files.
@@ -114,7 +123,7 @@ let
 
   teamPings =
     context: team:
-    if team ? github then
+    if team ? githubId then
       [
         {
           type = "team";
@@ -128,13 +137,14 @@ let
   maintainersToPing =
     lib.concatMap (
       pkg:
-      userPings { attr = pkg.name; } pkg.users ++ lib.concatMap (teamPings { pkg = pkg.name; }) pkg.teams
+      userPings { attrPath = pkg.path; } pkg.users
+      ++ lib.concatMap (teamPings { attrPath = pkg.path; }) pkg.teams
     ) attrsWithModifiedFiles
     ++ lib.concatMap (
       path:
       userPings { file = path; } (fileMaintainers.${path} or [ ])
       ++ lib.concatMap (teamPings { file = path; }) (fileTeams.${path} or [ ])
-    ) changedpaths;
+    ) changedFiles;
 
   byType = lib.groupBy (ping: ping.type) maintainersToPing;
 
@@ -150,5 +160,5 @@ in
 {
   users = byUser;
   teams = byTeam;
-  packages = lib.catAttrs "name" attrsWithModifiedFiles;
+  packages = lib.catAttrs "path" attrsWithModifiedFiles;
 }

--- a/ci/eval/compare/test.nix
+++ b/ci/eval/compare/test.nix
@@ -1,0 +1,228 @@
+{
+  pkgs ? import ../../.. {
+    config = { };
+    overlays = [ ];
+  },
+  lib ? pkgs.lib,
+}:
+let
+  fun = import ./maintainers.nix;
+
+  mockPkgs =
+    {
+      packages ? [ ],
+      modules ? [ ],
+      githubTeams ? true,
+    }:
+    lib.updateManyAttrsByPath
+      (lib.imap0 (i: p: {
+        path = p;
+        update = _: {
+          meta.maintainersPosition.file = lib.concatStringsSep "/" p;
+          meta.nonTeamMaintainers = [ { githubId = i; } ];
+          meta.teams =
+            if githubTeams then [ { githubId = i + 100; } ] else [ { members = [ { githubId = i + 100; } ]; } ];
+        };
+      }) packages)
+      {
+        nixos =
+          { }:
+          {
+            config.meta.maintainers = lib.listToAttrs (
+              lib.imap0 (i: m: lib.nameValuePair m [ { githubId = i; } ]) modules
+            );
+            config.meta.teams = lib.listToAttrs (
+              lib.imap0 (
+                i: m:
+                lib.nameValuePair m (
+                  if githubTeams then [ { githubId = i + 100; } ] else [ { members = [ { githubId = i + 100; } ]; } ]
+                )
+              ) modules
+            );
+          };
+      };
+
+  tests = {
+    testEmpty = {
+      expr = fun {
+        pkgs = mockPkgs { };
+        inherit lib;
+        changedFiles = [ ];
+        affectedAttrPaths = [ ];
+      };
+      expected = {
+        packages = [ ];
+        teams = { };
+        users = { };
+      };
+    };
+    testNonExistentAffected = {
+      expr = fun {
+        pkgs = mockPkgs { };
+        inherit lib;
+        changedFiles = [ "a" ];
+        affectedAttrPaths = [ [ "b" ] ];
+      };
+      expected = {
+        packages = [ ];
+        teams = { };
+        users = { };
+      };
+    };
+    testIrrelevantAffected = {
+      expr = fun {
+        pkgs = mockPkgs {
+          packages = [ [ "b" ] ];
+        };
+        inherit lib;
+        changedFiles = [ "a" ];
+        affectedAttrPaths = [ [ "b" ] ];
+      };
+      expected = {
+        packages = [ ];
+        teams = { };
+        users = { };
+      };
+    };
+    testRelevantAffected = {
+      expr = fun {
+        pkgs = mockPkgs {
+          packages = [ [ "b" ] ];
+        };
+        inherit lib;
+        # Also tests that subpaths work
+        changedFiles = [ "b/c" ];
+        affectedAttrPaths = [ [ "b" ] ];
+      };
+      expected = {
+        packages = [ [ "b" ] ];
+        teams."100" = [
+          { attrPath = [ "b" ]; }
+        ];
+        users."0" = [
+          { attrPath = [ "b" ]; }
+        ];
+      };
+    };
+    testRelevantAffectedNonGitHub = {
+      expr = fun {
+        pkgs = mockPkgs {
+          packages = [ [ "b" ] ];
+          githubTeams = false;
+        };
+        inherit lib;
+        changedFiles = [ "b/c" ];
+        affectedAttrPaths = [ [ "b" ] ];
+      };
+      expected = {
+        packages = [ [ "b" ] ];
+        teams = { };
+        users."0" = [
+          { attrPath = [ "b" ]; }
+        ];
+        users."100" = [
+          { attrPath = [ "b" ]; }
+        ];
+      };
+    };
+    testByNameChanged = {
+      expr = fun {
+        pkgs = mockPkgs {
+          packages = [ [ "hello" ] ];
+        };
+        inherit lib;
+        changedFiles = [ "pkgs/by-name/he/hello/sources.json" ];
+        affectedAttrPaths = [ ];
+      };
+      expected = {
+        packages = [ [ "hello" ] ];
+        teams."100" = [
+          { attrPath = [ "hello" ]; }
+        ];
+        users."0" = [
+          { attrPath = [ "hello" ]; }
+        ];
+      };
+    };
+    testByNameReadmeChanged = {
+      expr = fun {
+        pkgs = mockPkgs {
+          packages = [ [ "hello" ] ];
+        };
+        inherit lib;
+        changedFiles = [ "pkgs/by-name/README.md" ];
+        affectedAttrPaths = [ ];
+      };
+      expected = {
+        packages = [ ];
+        teams = { };
+        users = { };
+      };
+    };
+    testNoDuplicates = {
+      expr = fun {
+        pkgs = mockPkgs {
+          packages = [ [ "hello" ] ];
+        };
+        inherit lib;
+        changedFiles = [
+          "hello"
+          "pkgs/by-name/he/hello/sources.json"
+        ];
+        affectedAttrPaths = [ [ "hello" ] ];
+      };
+      expected = {
+        packages = [ [ "hello" ] ];
+        teams."100" = [
+          { attrPath = [ "hello" ]; }
+        ];
+        users."0" = [
+          { attrPath = [ "hello" ]; }
+        ];
+      };
+    };
+    testModuleMaintainers = {
+      expr = fun {
+        pkgs = mockPkgs {
+          modules = [ "a" ];
+        };
+        inherit lib;
+        changedFiles = [ "a" ];
+        affectedAttrPaths = [ ];
+      };
+      expected = {
+        packages = [ ];
+        teams."100" = [
+          { file = "a"; }
+        ];
+        users."0" = [
+          { file = "a"; }
+        ];
+      };
+    };
+    testModuleMaintainersNonGithub = {
+      expr = fun {
+        pkgs = mockPkgs {
+          modules = [ "a" ];
+          githubTeams = false;
+        };
+        inherit lib;
+        changedFiles = [ "a" ];
+        affectedAttrPaths = [ ];
+      };
+      expected = {
+        packages = [ ];
+        teams = { };
+        users."100" = [
+          { file = "a"; }
+        ];
+        users."0" = [
+          { file = "a"; }
+        ];
+      };
+    };
+  };
+in
+{
+  result = lib.runTests tests;
+}

--- a/modules/generic/meta-maintainers.nix
+++ b/modules/generic/meta-maintainers.nix
@@ -17,7 +17,14 @@ in
   options = {
     meta = {
       maintainers = mkOption {
-        type = sourceList;
+        type =
+          let
+            allMaintainers = lib.attrValues lib.maintainers;
+          in
+          lib.types.addCheck sourceList (lib.all (v: lib.elem v allMaintainers))
+          // {
+            description = "list of lib.maintainers";
+          };
         default = [ ];
         example = lib.literalExpression "[ lib.maintainers.alice lib.maintainers.bob ]";
         description = ''

--- a/modules/generic/meta-maintainers.nix
+++ b/modules/generic/meta-maintainers.nix
@@ -4,39 +4,12 @@
 let
   inherit (lib)
     mkOption
-    mkOptionType
     types
     ;
 
-  maintainer = mkOptionType {
-    name = "maintainer";
-    check = email: lib.elem email (lib.attrValues lib.maintainers);
-    merge = loc: defs: {
-      # lib.last: Perhaps this could be merged instead, if "at most once per module"
-      # is a problem (see option description).
-      ${(lib.last defs).file} = (lib.last defs).value;
-    };
-  };
-
-  listOfMaintainers = types.listOf maintainer // {
-    merge =
-      loc: defs:
-      lib.zipAttrs (
-        lib.flatten (
-          lib.imap1 (
-            n: def:
-            lib.imap1 (
-              m: def':
-              maintainer.merge (loc ++ [ "[${toString n}-${toString m}]" ]) [
-                {
-                  inherit (def) file;
-                  value = def';
-                }
-              ]
-            ) def.value
-          ) defs
-        )
-      );
+  # The resulting value of this type shows where all values were defined
+  sourceList = types.listOf types.raw // {
+    merge = loc: defs: lib.listToAttrs (lib.map ({ file, value }: lib.nameValuePair file value) defs);
   };
 in
 {
@@ -44,7 +17,7 @@ in
   options = {
     meta = {
       maintainers = mkOption {
-        type = listOfMaintainers;
+        type = sourceList;
         default = [ ];
         example = lib.literalExpression "[ lib.maintainers.alice lib.maintainers.bob ]";
         description = ''

--- a/modules/generic/meta-maintainers.nix
+++ b/modules/generic/meta-maintainers.nix
@@ -34,6 +34,22 @@ in
           The option value is not a list of maintainers, but an attribute set that maps module file names to lists of maintainers.
         '';
       };
+      teams = mkOption {
+        type =
+          let
+            allTeams = lib.attrValues lib.teams;
+          in
+          lib.types.addCheck sourceList (lib.all (v: lib.elem v allTeams))
+          // {
+            description = "list of lib.teams";
+          };
+        default = [ ];
+        example = lib.literalExpression "[ lib.teams.acme lib.teams.haskell ]";
+        description = ''
+          List of team maintainers of each module.
+          This option should be defined at most once per module.
+        '';
+      };
     };
   };
   meta.maintainers = with lib.maintainers; [

--- a/modules/generic/meta-maintainers/test.nix
+++ b/modules/generic/meta-maintainers/test.nix
@@ -14,9 +14,17 @@ let
   };
 in
 rec {
-  lib = import ../../../lib;
+  # Inject ghost into lib.maintainers so it passes the addCheck validation
+  lib = (import ../../../lib).extend (
+    final: prev: {
+      maintainers = prev.maintainers // {
+        inherit ghost;
+      };
+    }
+  );
 
   example = lib.evalModules {
+    specialArgs.lib = lib;
     modules = [
       ../meta-maintainers.nix
       {

--- a/nixos/modules/config/vte.nix
+++ b/nixos/modules/config/vte.nix
@@ -22,7 +22,7 @@ in
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   options = {

--- a/nixos/modules/config/xdg/autostart.nix
+++ b/nixos/modules/config/xdg/autostart.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members;
+    teams = [ lib.teams.freedesktop ];
   };
 
   options = {

--- a/nixos/modules/config/xdg/icons.nix
+++ b/nixos/modules/config/xdg/icons.nix
@@ -6,7 +6,7 @@
 }:
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members;
+    teams = [ lib.teams.freedesktop ];
   };
 
   options = {

--- a/nixos/modules/config/xdg/menus.nix
+++ b/nixos/modules/config/xdg/menus.nix
@@ -1,7 +1,7 @@
 { config, lib, ... }:
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members;
+    teams = [ lib.teams.freedesktop ];
   };
 
   options = {

--- a/nixos/modules/config/xdg/mime.nix
+++ b/nixos/modules/config/xdg/mime.nix
@@ -13,7 +13,7 @@ in
 
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members ++ [ ];
+    teams = [ lib.teams.freedesktop ];
   };
 
   options = {

--- a/nixos/modules/config/xdg/portal.nix
+++ b/nixos/modules/config/xdg/portal.nix
@@ -32,7 +32,7 @@ in
   ];
 
   meta = {
-    maintainers = teams.freedesktop.members;
+    teams = [ teams.freedesktop ];
   };
 
   options.xdg.portal = {

--- a/nixos/modules/config/xdg/portals/lxqt.nix
+++ b/nixos/modules/config/xdg/portals/lxqt.nix
@@ -10,7 +10,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.lxqt.members;
+    teams = [ lib.teams.lxqt ];
   };
 
   options.xdg.portal.lxqt = {

--- a/nixos/modules/config/xdg/sounds.nix
+++ b/nixos/modules/config/xdg/sounds.nix
@@ -6,7 +6,7 @@
 }:
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members;
+    teams = [ lib.teams.freedesktop ];
   };
 
   options = {

--- a/nixos/modules/programs/dsearch.nix
+++ b/nixos/modules/programs/dsearch.nix
@@ -49,5 +49,5 @@ in
     systemd.user.services.dsearch.wantedBy = mkIf cfg.systemd.enable [ cfg.systemd.target ];
   };
 
-  meta.maintainers = lib.teams.danklinux.members;
+  meta.teams = [ lib.teams.danklinux ];
 }

--- a/nixos/modules/programs/geary.nix
+++ b/nixos/modules/programs/geary.nix
@@ -11,7 +11,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   options = {

--- a/nixos/modules/programs/gnome-disks.nix
+++ b/nixos/modules/programs/gnome-disks.nix
@@ -10,7 +10,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/programs/gnome-terminal.nix
+++ b/nixos/modules/programs/gnome-terminal.nix
@@ -16,7 +16,7 @@ in
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   options = {

--- a/nixos/modules/programs/nm-applet.nix
+++ b/nixos/modules/programs/nm-applet.nix
@@ -10,7 +10,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members;
+    teams = [ lib.teams.freedesktop ];
   };
 
   options.programs.nm-applet = {

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -285,5 +285,5 @@ in
     ];
   };
 
-  meta.maintainers = lib.teams.steam.members;
+  meta.teams = [ lib.teams.steam ];
 }

--- a/nixos/modules/programs/thunar.nix
+++ b/nixos/modules/programs/thunar.nix
@@ -11,7 +11,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.xfce.members;
+    teams = [ lib.teams.xfce ];
   };
 
   options = {

--- a/nixos/modules/programs/wayland/dms-shell.nix
+++ b/nixos/modules/programs/wayland/dms-shell.nix
@@ -226,5 +226,5 @@ in
     hardware.graphics.enable = lib.mkDefault true;
   };
 
-  meta.maintainers = lib.teams.danklinux.members;
+  meta.teams = [ lib.teams.danklinux ];
 }

--- a/nixos/modules/programs/wayland/hyprland.nix
+++ b/nixos/modules/programs/wayland/hyprland.nix
@@ -130,5 +130,5 @@ in
     ] "Nvidia patches are no longer needed")
   ];
 
-  meta.maintainers = lib.teams.hyprland.members;
+  meta.teams = [ lib.teams.hyprland ];
 }

--- a/nixos/modules/programs/wayland/hyprlock.nix
+++ b/nixos/modules/programs/wayland/hyprlock.nix
@@ -26,5 +26,5 @@ in
     security.pam.services.hyprlock = { };
   };
 
-  meta.maintainers = lib.teams.hyprland.members;
+  meta.teams = [ lib.teams.hyprland ];
 }

--- a/nixos/modules/programs/xfconf.nix
+++ b/nixos/modules/programs/xfconf.nix
@@ -11,7 +11,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.xfce.members;
+    teams = [ lib.teams.xfce ];
   };
 
   options = {

--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -1218,7 +1218,7 @@ in
   ];
 
   meta = {
-    maintainers = lib.teams.acme.members;
+    teams = [ lib.teams.acme ];
     doc = ./default.md;
   };
 }

--- a/nixos/modules/security/apparmor.nix
+++ b/nixos/modules/security/apparmor.nix
@@ -272,5 +272,5 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.apparmor.members;
+  meta.teams = [ lib.teams.apparmor ];
 }

--- a/nixos/modules/services/cluster/rancher/default.nix
+++ b/nixos/modules/services/cluster/rancher/default.nix
@@ -962,5 +962,6 @@ in
       (import ./rke2.nix args)
     ];
 
-  meta.maintainers = pkgs.rke2.meta.maintainers ++ lib.teams.k3s.members;
+  meta.teams = [ lib.teams.k3s ];
+  meta.maintainers = pkgs.rke2.meta.maintainers;
 }

--- a/nixos/modules/services/continuous-integration/buildbot/master.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/master.nix
@@ -313,5 +313,5 @@ in
     '')
   ];
 
-  meta.maintainers = lib.teams.buildbot.members;
+  meta.teams = [ lib.teams.buildbot ];
 }

--- a/nixos/modules/services/continuous-integration/buildbot/worker.nix
+++ b/nixos/modules/services/continuous-integration/buildbot/worker.nix
@@ -196,6 +196,6 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.buildbot.members;
+  meta.teams = [ lib.teams.buildbot ];
 
 }

--- a/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
+++ b/nixos/modules/services/continuous-integration/gitlab-runner/runner.nix
@@ -893,5 +893,5 @@ in
     )
   ];
 
-  meta.maintainers = teams.gitlab.members;
+  meta.teams = [ teams.gitlab ];
 }

--- a/nixos/modules/services/databases/clickhouse.nix
+++ b/nixos/modules/services/databases/clickhouse.nix
@@ -13,7 +13,7 @@ let
 in
 {
 
-  meta.maintainers = [ "thevar1able" ];
+  meta.maintainers = with lib.maintainers; [ thevar1able ];
 
   ###### interface
 

--- a/nixos/modules/services/desktop-managers/budgie.nix
+++ b/nixos/modules/services/desktop-managers/budgie.nix
@@ -61,7 +61,7 @@ let
   notExcluded = pkg: utils.disablePackageByName pkg config.environment.budgie.excludePackages;
 in
 {
-  meta.maintainers = lib.teams.budgie.members;
+  meta.teams = [ lib.teams.budgie ];
 
   imports = [
     (lib.mkRenamedOptionModule

--- a/nixos/modules/services/desktop-managers/cosmic.nix
+++ b/nixos/modules/services/desktop-managers/cosmic.nix
@@ -44,7 +44,7 @@ let
     ];
 in
 {
-  meta.maintainers = lib.teams.cosmic.members;
+  meta.teams = [ lib.teams.cosmic ];
 
   options = {
     services.desktopManager.cosmic = {

--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -82,7 +82,7 @@ in
 {
   meta = {
     doc = ./gnome.md;
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   imports = [

--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -292,5 +292,5 @@ in
     })
   ];
 
-  meta.maintainers = lib.teams.lomiri.members;
+  meta.teams = [ lib.teams.lomiri ];
 }

--- a/nixos/modules/services/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/desktop-managers/pantheon.nix
@@ -25,7 +25,7 @@ in
 
   meta = {
     doc = ./pantheon.md;
-    maintainers = teams.pantheon.members;
+    teams = [ teams.pantheon ];
   };
 
   imports = [

--- a/nixos/modules/services/desktops/accountsservice.nix
+++ b/nixos/modules/services/desktops/accountsservice.nix
@@ -7,7 +7,7 @@
 }:
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members;
+    teams = [ lib.teams.freedesktop ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -373,6 +373,6 @@ in
   };
 
   meta = {
-    maintainers = [ ] ++ lib.teams.pantheon.members;
+    teams = [ lib.teams.pantheon ];
   };
 }

--- a/nixos/modules/services/desktops/gnome/at-spi2-core.nix
+++ b/nixos/modules/services/desktops/gnome/at-spi2-core.nix
@@ -10,7 +10,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/evolution-data-server.nix
+++ b/nixos/modules/services/desktops/gnome/evolution-data-server.nix
@@ -10,7 +10,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/gcr-ssh-agent.nix
+++ b/nixos/modules/services/desktops/gnome/gcr-ssh-agent.nix
@@ -13,7 +13,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   options = {

--- a/nixos/modules/services/desktops/gnome/glib-networking.nix
+++ b/nixos/modules/services/desktops/gnome/glib-networking.nix
@@ -10,7 +10,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/gnome-browser-connector.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-browser-connector.nix
@@ -16,7 +16,7 @@ in
 
 {
   meta = {
-    maintainers = teams.gnome.members;
+    teams = [ teams.gnome ];
   };
 
   options = {

--- a/nixos/modules/services/desktops/gnome/gnome-initial-setup.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-initial-setup.nix
@@ -48,7 +48,7 @@ in
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/gnome-keyring.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-keyring.nix
@@ -12,7 +12,7 @@ in
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   options = {

--- a/nixos/modules/services/desktops/gnome/gnome-online-accounts.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-online-accounts.nix
@@ -10,7 +10,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/gnome-remote-desktop.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-remote-desktop.nix
@@ -8,7 +8,7 @@
 
 {
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/gnome-settings-daemon.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-settings-daemon.nix
@@ -16,7 +16,7 @@ in
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/gnome-software.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-software.nix
@@ -7,7 +7,7 @@
 
 {
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   options = {

--- a/nixos/modules/services/desktops/gnome/gnome-user-share.nix
+++ b/nixos/modules/services/desktops/gnome/gnome-user-share.nix
@@ -10,7 +10,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/localsearch.nix
+++ b/nixos/modules/services/desktops/gnome/localsearch.nix
@@ -7,7 +7,7 @@
 
 {
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   imports = [

--- a/nixos/modules/services/desktops/gnome/rygel.nix
+++ b/nixos/modules/services/desktops/gnome/rygel.nix
@@ -14,7 +14,7 @@ in
 
 {
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/sushi.nix
+++ b/nixos/modules/services/desktops/gnome/sushi.nix
@@ -10,7 +10,7 @@
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/gnome/tinysparql.nix
+++ b/nixos/modules/services/desktops/gnome/tinysparql.nix
@@ -10,7 +10,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   imports = [

--- a/nixos/modules/services/desktops/gvfs.nix
+++ b/nixos/modules/services/desktops/gvfs.nix
@@ -16,7 +16,7 @@ in
 {
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -85,7 +85,8 @@ let
   };
 in
 {
-  meta.maintainers = teams.freedesktop.members ++ [ maintainers.k900 ];
+  meta.teams = [ teams.freedesktop ];
+  meta.maintainers = [ maintainers.k900 ];
 
   ###### interface
   options = {

--- a/nixos/modules/services/desktops/tumbler.nix
+++ b/nixos/modules/services/desktops/tumbler.nix
@@ -18,7 +18,7 @@ in
   ];
 
   meta = {
-    maintainers = [ ] ++ lib.teams.pantheon.members;
+    teams = [ lib.teams.pantheon ];
   };
 
   ###### interface

--- a/nixos/modules/services/desktops/zeitgeist.nix
+++ b/nixos/modules/services/desktops/zeitgeist.nix
@@ -8,7 +8,7 @@
 {
 
   meta = {
-    maintainers = [ ] ++ lib.teams.pantheon.members;
+    teams = [ lib.teams.pantheon ];
   };
 
   ###### interface

--- a/nixos/modules/services/display-managers/cosmic-greeter.nix
+++ b/nixos/modules/services/display-managers/cosmic-greeter.nix
@@ -16,7 +16,7 @@ let
 in
 
 {
-  meta.maintainers = lib.teams.cosmic.members;
+  meta.teams = [ lib.teams.cosmic ];
 
   options.services.displayManager.cosmic-greeter = {
     enable = lib.mkEnableOption "COSMIC greeter";

--- a/nixos/modules/services/display-managers/dms-greeter.nix
+++ b/nixos/modules/services/display-managers/dms-greeter.nix
@@ -321,5 +321,5 @@ in
     services.libinput.enable = mkDefault true;
   };
 
-  meta.maintainers = lib.teams.danklinux.members;
+  meta.teams = [ lib.teams.danklinux ];
 }

--- a/nixos/modules/services/display-managers/gdm.nix
+++ b/nixos/modules/services/display-managers/gdm.nix
@@ -105,7 +105,7 @@ in
   ];
 
   meta = {
-    maintainers = lib.teams.gnome.members;
+    teams = [ lib.teams.gnome ];
   };
 
   ###### interface

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -171,7 +171,7 @@ in
 
   meta = {
     buildDocsInSandbox = false;
-    maintainers = lib.teams.home-assistant.members;
+    teams = [ lib.teams.home-assistant ];
   };
 
   options.services.home-assistant = {

--- a/nixos/modules/services/matrix/dendrite.nix
+++ b/nixos/modules/services/matrix/dendrite.nix
@@ -341,5 +341,5 @@ in
       };
     };
   };
-  meta.maintainers = lib.teams.matrix.members;
+  meta.teams = [ lib.teams.matrix ];
 }

--- a/nixos/modules/services/misc/forgejo.nix
+++ b/nixos/modules/services/misc/forgejo.nix
@@ -849,5 +849,5 @@ in
   };
 
   meta.doc = ./forgejo.md;
-  meta.maintainers = lib.teams.forgejo.members;
+  meta.teams = [ lib.teams.forgejo ];
 }

--- a/nixos/modules/services/misc/gitlab.nix
+++ b/nixos/modules/services/misc/gitlab.nix
@@ -1911,5 +1911,5 @@ in
   };
 
   meta.doc = ./gitlab.md;
-  meta.maintainers = teams.gitlab.members;
+  meta.teams = [ teams.gitlab ];
 }

--- a/nixos/modules/services/networking/epmd.nix
+++ b/nixos/modules/services/networking/epmd.nix
@@ -63,5 +63,5 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.beam.members;
+  meta.teams = [ lib.teams.beam ];
 }

--- a/nixos/modules/services/networking/jibri/default.nix
+++ b/nixos/modules/services/networking/jibri/default.nix
@@ -444,5 +444,5 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.jitsi.members;
+  meta.teams = [ lib.teams.jitsi ];
 }

--- a/nixos/modules/services/networking/jicofo.nix
+++ b/nixos/modules/services/networking/jicofo.nix
@@ -166,5 +166,5 @@ in
       lib.mkDefault "${pkgs.jicofo}/etc/jitsi/jicofo/logging.properties-journal";
   };
 
-  meta.maintainers = lib.teams.jitsi.members;
+  meta.teams = [ lib.teams.jitsi ];
 }

--- a/nixos/modules/services/networking/jigasi.nix
+++ b/nixos/modules/services/networking/jigasi.nix
@@ -243,5 +243,5 @@ in
       lib.mkDefault "${stateDir}/logging.properties-journal";
   };
 
-  meta.maintainers = lib.teams.jitsi.members;
+  meta.teams = [ lib.teams.jitsi ];
 }

--- a/nixos/modules/services/networking/jitsi-videobridge.nix
+++ b/nixos/modules/services/networking/jitsi-videobridge.nix
@@ -331,5 +331,5 @@ in
     ];
   };
 
-  meta.maintainers = lib.teams.jitsi.members;
+  meta.teams = [ lib.teams.jitsi ];
 }

--- a/nixos/modules/services/networking/modemmanager.nix
+++ b/nixos/modules/services/networking/modemmanager.nix
@@ -9,7 +9,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.freedesktop.members;
+    teams = [ lib.teams.freedesktop ];
   };
 
   options = with lib; {

--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -142,9 +142,8 @@ in
 {
 
   meta = {
-    maintainers = teams.freedesktop.members ++ [
-      lib.maintainers.frontear
-    ];
+    teams = [ lib.teams.freedesktop ];
+    maintainers = [ lib.maintainers.frontear ];
   };
 
   ###### interface

--- a/nixos/modules/services/security/reaction.nix
+++ b/nixos/modules/services/security/reaction.nix
@@ -299,10 +299,8 @@ in
       environment.systemPackages = [ cfg.package ];
     };
 
-  meta.maintainers =
-    with lib.maintainers;
-    [
-      ppom
-    ]
-    ++ lib.teams.ngi.members;
+  meta.teams = [ lib.teams.ngi ];
+  meta.maintainers = with lib.maintainers; [
+    ppom
+  ];
 }

--- a/nixos/modules/services/wayland/hypridle.nix
+++ b/nixos/modules/services/wayland/hypridle.nix
@@ -28,5 +28,5 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.hyprland.members;
+  meta.teams = [ lib.teams.hyprland ];
 }

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -756,5 +756,5 @@ in
   };
 
   meta.doc = ./jitsi-meet.md;
-  meta.maintainers = lib.teams.jitsi.members;
+  meta.teams = [ lib.teams.jitsi ];
 }

--- a/nixos/modules/services/web-apps/nextcloud.nix
+++ b/nixos/modules/services/web-apps/nextcloud.nix
@@ -1774,5 +1774,5 @@ in
   );
 
   meta.doc = ./nextcloud.md;
-  meta.maintainers = lib.teams.nextcloud.members;
+  meta.teams = [ lib.teams.nextcloud ];
 }

--- a/nixos/modules/services/web-apps/peertube-runner.nix
+++ b/nixos/modules/services/web-apps/peertube-runner.nix
@@ -252,5 +252,5 @@ in
     };
   };
 
-  meta.maintainers = lib.teams.ngi.members;
+  meta.teams = [ lib.teams.ngi ];
 }

--- a/nixos/modules/services/x11/desktop-managers/enlightenment.nix
+++ b/nixos/modules/services/x11/desktop-managers/enlightenment.nix
@@ -25,7 +25,7 @@ in
 
 {
   meta = {
-    maintainers = teams.enlightenment.members;
+    teams = [ teams.enlightenment ];
   };
 
   imports = [

--- a/nixos/modules/services/x11/desktop-managers/lumina.nix
+++ b/nixos/modules/services/x11/desktop-managers/lumina.nix
@@ -16,7 +16,7 @@ in
 
 {
   meta = {
-    maintainers = teams.lumina.members;
+    teams = [ teams.lumina ];
   };
 
   options = {

--- a/nixos/modules/services/x11/desktop-managers/lxqt.nix
+++ b/nixos/modules/services/x11/desktop-managers/lxqt.nix
@@ -15,7 +15,7 @@ in
 
 {
   meta = {
-    maintainers = teams.lxqt.members;
+    teams = [ teams.lxqt ];
   };
 
   options = {

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -15,7 +15,7 @@ let
 in
 {
   meta = {
-    maintainers = teams.xfce.members;
+    teams = [ teams.xfce ];
   };
 
   imports = [

--- a/nixos/modules/services/x11/display-managers/account-service-util.nix
+++ b/nixos/modules/services/x11/display-managers/account-service-util.nix
@@ -40,6 +40,6 @@ python3.pkgs.buildPythonApplication {
   '';
 
   meta = {
-    maintainers = [ ] ++ lib.teams.pantheon.members;
+    teams = [ lib.teams.pantheon ];
   };
 }

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/lomiri.nix
@@ -13,7 +13,7 @@ let
 
 in
 {
-  meta.maintainers = lib.teams.lomiri.members;
+  meta.teams = [ lib.teams.lomiri ];
 
   options = {
     services.xserver.displayManager.lightdm.greeters.lomiri = {

--- a/nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm-greeters/pantheon.nix
@@ -16,7 +16,7 @@ let
 in
 {
   meta = {
-    maintainers = [ ] ++ lib.teams.pantheon.members;
+    teams = [ lib.teams.pantheon ];
   };
 
   options = {

--- a/nixos/modules/services/x11/display-managers/lightdm.nix
+++ b/nixos/modules/services/x11/display-managers/lightdm.nix
@@ -73,7 +73,7 @@ let
 in
 {
   meta = {
-    maintainers = [ ] ++ lib.teams.pantheon.members;
+    teams = [ lib.teams.pantheon ];
   };
 
   # Note: the order in which lightdm greeter modules are imported

--- a/nixos/modules/services/x11/touchegg.nix
+++ b/nixos/modules/services/x11/touchegg.nix
@@ -13,7 +13,7 @@ let
 in
 {
   meta = {
-    maintainers = teams.pantheon.members;
+    teams = [ teams.pantheon ];
   };
 
   ###### interface

--- a/nixos/modules/virtualisation/containers.nix
+++ b/nixos/modules/virtualisation/containers.nix
@@ -13,7 +13,7 @@ let
 in
 {
   meta = {
-    maintainers = [ ] ++ lib.teams.podman.members;
+    teams = [ lib.teams.podman ];
   };
 
   options.virtualisation.containers = {

--- a/nixos/modules/virtualisation/cri-o.nix
+++ b/nixos/modules/virtualisation/cri-o.nix
@@ -21,7 +21,7 @@ let
 in
 {
   meta = {
-    maintainers = teams.podman.members;
+    teams = [ teams.podman ];
   };
 
   options.virtualisation.cri-o = {

--- a/nixos/modules/virtualisation/incus-agent.nix
+++ b/nixos/modules/virtualisation/incus-agent.nix
@@ -10,7 +10,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   options = {

--- a/nixos/modules/virtualisation/incus-virtual-machine.nix
+++ b/nixos/modules/virtualisation/incus-virtual-machine.nix
@@ -10,7 +10,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   imports = [

--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -176,7 +176,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   options = {

--- a/nixos/modules/virtualisation/lxc-container.nix
+++ b/nixos/modules/virtualisation/lxc-container.nix
@@ -7,7 +7,7 @@
 
 {
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   imports = [

--- a/nixos/modules/virtualisation/lxc-image-metadata.nix
+++ b/nixos/modules/virtualisation/lxc-image-metadata.nix
@@ -71,7 +71,7 @@ in
   ];
 
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   options = {

--- a/nixos/modules/virtualisation/lxc-instance-common.nix
+++ b/nixos/modules/virtualisation/lxc-instance-common.nix
@@ -2,7 +2,7 @@
 
 {
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   imports = [

--- a/nixos/modules/virtualisation/lxc.nix
+++ b/nixos/modules/virtualisation/lxc.nix
@@ -13,7 +13,7 @@ in
 
 {
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   options.virtualisation.lxc = {

--- a/nixos/modules/virtualisation/lxcfs.nix
+++ b/nixos/modules/virtualisation/lxcfs.nix
@@ -12,7 +12,7 @@ let
 in
 {
   meta = {
-    maintainers = lib.teams.lxc.members;
+    teams = [ lib.teams.lxc ];
   };
 
   ###### interface

--- a/nixos/modules/virtualisation/podman/default.nix
+++ b/nixos/modules/virtualisation/podman/default.nix
@@ -63,7 +63,7 @@ in
   ];
 
   meta = {
-    maintainers = lib.teams.podman.members;
+    teams = [ lib.teams.podman ];
   };
 
   options.virtualisation.podman = {

--- a/nixos/modules/virtualisation/podman/network-socket-ghostunnel.nix
+++ b/nixos/modules/virtualisation/podman/network-socket-ghostunnel.nix
@@ -35,5 +35,6 @@ in
 
   };
 
-  meta.maintainers = lib.teams.podman.members ++ [ lib.maintainers.roberth ];
+  meta.teams = [ lib.teams.podman ];
+  meta.maintainers = [ lib.maintainers.roberth ];
 }

--- a/nixos/modules/virtualisation/podman/network-socket.nix
+++ b/nixos/modules/virtualisation/podman/network-socket.nix
@@ -95,5 +95,6 @@ in
     networking.firewall.allowedTCPPorts = lib.optional (cfg.enable && cfg.openFirewall) cfg.port;
   };
 
-  meta.maintainers = lib.teams.podman.members ++ [ lib.maintainers.roberth ];
+  meta.teams = [ lib.teams.podman ];
+  meta.maintainers = [ lib.maintainers.roberth ];
 }

--- a/nixos/modules/virtualisation/xen-dom0.nix
+++ b/nixos/modules/virtualisation/xen-dom0.nix
@@ -937,6 +937,6 @@ in
   };
   meta = {
     doc = ./xen.md;
-    maintainers = teams.xen.members;
+    teams = [ teams.xen ];
   };
 }


### PR DESCRIPTION
> [!note]
> This PR was reverted, but then reapplied in https://github.com/NixOS/nixpkgs/pull/499596

Request reviews from module maintainers when the module changes! Also support for `meta.teams` :)

Closes https://github.com/NixOS/nixpkgs/issues/454385
Effectively closes https://github.com/NixOS/nixpkgs/pull/413097
Relates to https://github.com/NixOS/nixpkgs/issues/447514
Relates to https://github.com/NixOS/nixpkgs/pull/394797

Requested by @mweinelt on Matrix ;)

## Things done
- [x] Tested locally with https://github.com/NixOS/nixpkgs/pull/487733
- [x] Confirmed that CI will ensure `meta.*` to be valid: https://github.com/NixOS/nixpkgs/blob/99928de252e875e7be0ed5fbc8de5116e3b2d453/.github/workflows/eval.yml#L465