### PR TITLE
Add packages for Nunito and Nunito Sans fonts

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1441,6 +1441,13 @@
     githubId = 373;
     name = "Alexandre Girard Davila";
   };
+  alyamanmas = {
+    email = "alyaman.maasarani@gmail.com";
+    github = "AlyamanMas";
+    githubId = 33905034;
+    name = "Alyaman Huzaifa Massarani";
+    keys = [ { fingerprint = "570D 147B 9514 08C6 2CD8  D530 515E 428A C916 D39C"; } ];
+  };
   amaanq = {
     email = "contact@amaanq.com";
     github = "amaanq";

--- a/pkgs/by-name/nu/nunito-sans/package.nix
+++ b/pkgs/by-name/nu/nunito-sans/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "nunito-sans";
+  version = "0-unstable-2023-03-31";
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "NunitoSans";
+    rev = "058bd7a2f33d6ad5ef1df985b3db403622016a8c";
+    hash = "sha256-JfEu/QJNs4zvlFiHxevLWFva+I48Cv5C0NZM0o7k7oo=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/variable/*.ttf -t $out/share/fonts/truetype/NunitoSans/variable
+    install -Dm644 fonts/ttf/*.ttf -t $out/share/fonts/truetype/NunitoSans/static
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Nunito is a well balanced sans serif typeface superfamily";
+    longDescription = ''
+      Nunito is a well balanced sans serif typeface superfamily, with 2 versions: The project began with Nunito, created by Vernon Adams as a rounded terminal sans serif for display typography. Jacques Le Bailly extended it to a full set of weights, and an accompanying regular non-rounded terminal version, Nunito Sans.
+
+      In February 2023, Nunito Sans has been upgraded to a variable font with four axes: ascenders high, optical size, width and weight. Cyrillic has been added and the language support expanded.
+    '';
+    homepage = "https://fonts.google.com/specimen/Nunito+Sans";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.alyamanmas ];
+  };
+}

--- a/pkgs/by-name/nu/nunito/package.nix
+++ b/pkgs/by-name/nu/nunito/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "nunito";
+  version = "0-unstable-2025-02-26";
+
+  src = fetchFromGitHub {
+    owner = "googlefonts";
+    repo = "nunito";
+    rev = "8c6a9bb9732545b9ed53f29ec5e1ab0ff53c4e6f";
+    hash = "sha256-m276Gnkwpd+MjHo4mPU1RBcTs34puao7Wi+OOEuTuI0=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm644 fonts/variable/*.ttf -t $out/share/fonts/truetype/Nunito
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Nunito is a well balanced sans serif typeface superfamily";
+    longDescription = ''
+      Nunito is a well balanced sans serif typeface superfamily, with 2 versions: The project began with Nunito, created by Vernon Adams as a rounded terminal sans serif for display typography. Jacques Le Bailly extended it to a full set of weights, and an accompanying regular non-rounded terminal version, Nunito Sans.
+    '';
+    homepage = "https://fonts.google.com/specimen/Nunito";
+    license = lib.licenses.ofl;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.alyamanmas ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added packages for Nunito and Nunito Sans fonts.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
