### PR TITLE
mochi: 1.18.11 -> 1.20.10; unbreak

### DIFF
--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -1,23 +1,24 @@
 {
-  _7zz,
   appimageTools,
   fetchurl,
-  fetchzip,
   lib,
+  makeWrapper,
+  stdenv,
   stdenvNoCC,
   libxshmfence,
+  undmg,
 }:
 
 let
   pname = "mochi";
-  version = "1.18.11";
+  version = "1.20.10";
 
   linux = appimageTools.wrapType2 rec {
     inherit pname version meta;
 
     src = fetchurl {
-      url = "https://mochi.cards/releases/Mochi-${version}.AppImage";
-      hash = "sha256-NQ591KtWQz8hlXPhV83JEwGm+Au26PIop5KVzsyZKp4=";
+      url = "https://download.mochi.cards/releases/Mochi-${version}.AppImage";
+      hash = "sha256-oC53TXgK6UUgsHbLo0Ri/+2/UajYwpoXxHwqO1xY91U=";
     };
 
     appimageContents = appimageTools.extractType2 { inherit pname version src; };
@@ -32,21 +33,31 @@ let
     '';
   };
 
-  darwin = stdenvNoCC.mkDerivation {
+  darwin = stdenv.mkDerivation {
     inherit pname version meta;
 
-    src = fetchzip {
-      url = "https://mochi.cards/releases/Mochi-${version}.dmg";
-      hash = "sha256-5RM4eqHQoYfO5JiUH9ol+3XxOk4VX4ocE3Yia82sovI=";
-      stripRoot = false;
-      nativeBuildInputs = [ _7zz ];
+    src = fetchurl {
+      url = "https://download.mochi.cards/releases/Mochi-${version}${lib.optionalString stdenv.hostPlatform.isAarch64 "-arm64"}.dmg";
+      hash =
+        if stdenv.hostPlatform.isAarch64 then
+          "sha256-nLz73G6vthiXex7+y6bLVhe/RvK3fE3UHuzHf8lcilE="
+        else
+          "sha256-MuvzijF2eDELcSfOyqffKk5tx2a51vU8cGV2/ShSfTg=";
     };
+
+    sourceRoot = ".";
+
+    nativeBuildInputs = [
+      makeWrapper
+      undmg
+    ];
 
     installPhase = ''
       runHook preInstall
 
-      mkdir -p $out/Applications
-      cp -r *.app $out/Applications
+      mkdir -p $out/{Applications,bin}
+      cp -a Mochi.app $out/Applications
+      makeWrapper $out/Applications/Mochi.app/Contents/MacOS/Mochi $out/bin/${pname}
 
       runHook postInstall
     '';
@@ -57,6 +68,7 @@ let
     homepage = "https://mochi.cards/";
     changelog = "https://mochi.cards/changelog.html";
     license = lib.licenses.unfree;
+    mainProgram = "mochi";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [ poopsicles ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/mo/mochi/package.nix
+++ b/pkgs/by-name/mo/mochi/package.nix
@@ -31,6 +31,8 @@ let
       substituteInPlace $out/share/applications/${pname}.desktop \
         --replace-fail 'Exec=AppRun --no-sandbox' 'Exec=${pname}'
     '';
+
+    passthru.updateScript = ./update.sh;
   };
 
   darwin = stdenv.mkDerivation {

--- a/pkgs/by-name/mo/mochi/update.sh
+++ b/pkgs/by-name/mo/mochi/update.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl nix common-updater-scripts
+
+set -euo pipefail
+
+latestVersion=$(curl -Ls https://mochi.cards/ | grep -oP 'Mochi-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.AppImage)' | head -1)
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; mochi.version" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+# Update version and hash for x86_64-linux (AppImage)
+update-source-version mochi "$latestVersion" --system=x86_64-linux
+
+# Update hashes for darwin systems
+for system in x86_64-darwin aarch64-darwin; do
+    url=$(nix-instantiate --eval --json -E "with import ./. { system = \"$system\"; }; mochi.src.url" | tr -d '"')
+    hash=$(nix-prefetch-url "$url")
+    sriHash=$(nix --extra-experimental-features nix-command hash convert --hash-algo sha256 --to sri "$hash")
+    update-source-version mochi "$latestVersion" "$sriHash" --system="$system" --ignore-same-version
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
