### PR TITLE
nixos/immich: enable more systemd sandboxing features for the services

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -238,6 +238,12 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
   As a result, options `services.immich.database.enableVectors` and `services.immich.database.enableVectorchord` have been removed, and VectorChord is now always used.
   If you have not completed the migration yet, ensure you completely remove the extension from your database before upgrading by following the [migration guide](https://github.com/NixOS/nixpkgs/blob/nixos-25.11/nixos/modules/services/web-apps/immich.md#migrating-from-pgvecto-rs-to-vectorchord-pre-2511-installations-module-services-immich-vectorchord-migration).
 
+- `services.immich` is now started with additional systemd sandboxing options. By default, write access to `services.immich.mediaLocation` is allowed. To allow writing to external libraries, use `systemd.services.immich-server.serviceConfig.ReadWritePaths`
+
+  ```nix
+  { systemd.services.immich-server.serviceConfig.ReadWritePaths = [ "/mnt/external-library-rw" ]; }
+  ```
+
 - `services.cgit` before always had the git-http-backend and its "export all" setting enabled, which sidestepped any access control configured in cgit's settings. Now you have to make a decision and either enable or disable `services.cgit.gitHttpBackend.checkExportOkFiles` (or disable the git-http-backend).
 
 - `rocmPackages_6` has been removed. `rocmPackages` has been updated to ROCm 7.x. Out of tree packages may rely on obsolete hipblas APIs or compile time constant warp size and need to be updated.

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -26,6 +26,7 @@ let
     PrivateTmp = true;
     PrivateDevices = cfg.accelerationDevices == [ ];
     DeviceAllow = mkIf (cfg.accelerationDevices != null) cfg.accelerationDevices;
+    LockPersonality = true;
     PrivateMounts = true;
     ProtectClock = true;
     ProtectControlGroups = true;
@@ -34,6 +35,8 @@ let
     ProtectKernelLogs = true;
     ProtectKernelModules = true;
     ProtectKernelTunables = true;
+    ProtectSystem = "strict";
+    RemoveIPC = true;
     RestrictAddressFamilies = [
       "AF_INET"
       "AF_INET6"
@@ -42,6 +45,11 @@ let
     RestrictNamespaces = true;
     RestrictRealtime = true;
     RestrictSUIDSGID = true;
+    SystemCallFilter = [
+      "@system-service"
+      "~@privileged"
+    ];
+    SystemCallArchitectures = "native";
     UMask = "0077";
   };
   inherit (lib)
@@ -417,6 +425,11 @@ in
         # ensure that immich-server has permission to connect to the redis socket.
         SupplementaryGroups = mkIf (cfg.redis.enable && isRedisUnixSocket) [
           config.services.redis.servers.immich.group
+        ];
+        ProtectProc = "invisible";
+        ProcSubset = "pid";
+        ReadWritePaths = [
+          cfg.mediaLocation
         ];
       };
     };


### PR DESCRIPTION
- Immich should only have write access to its media files.
- Immich services can have a more restricted set of system calls.
- immich-server does not require /proc access

See #377827 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
