### PR TITLE
picplanner: init at 0.5.4

### DIFF
--- a/pkgs/by-name/pi/picplanner/package.nix
+++ b/pkgs/by-name/pi/picplanner/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  wrapGAppsHook4,
+  desktop-file-utils,
+  gettext,
+  glib,
+  gtk4,
+  libadwaita,
+  libshumate,
+  geocode-glib_2,
+  libgweather,
+  geoclue2,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "picplanner";
+  version = "0.5.4";
+
+  src = fetchFromGitLab {
+    owner = "Zwarf";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-pDsm/IZQuXLAOOWDyL6lJ/W4uE7bX6YtfW1do4ELpBA=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    desktop-file-utils
+    gettext
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    libshumate
+    geocode-glib_2
+    libgweather
+    geoclue2
+    glib
+  ];
+
+  postPatch = ''
+    # Install script tries to run host tools not allowed in Nix builds
+    sed -i "/meson.add_install_script/d" meson.build
+  '';
+
+  preFixup = ''
+    # Not handled automatically by wrapGAppsHook4
+    glib-compile-schemas "$out/share/gsettings-schemas/$name/glib-2.0/schemas"
+  '';
+
+  strictDeps = true;
+
+  meta = with lib; {
+    description = "Application for photographers to plan the position of the Sun, Moon and Milky Way";
+    homepage = "https://gitlab.com/Zwarf/picplanner";
+    license = licenses.gpl3Plus;
+    maintainers = [ ];
+    platforms = platforms.linux;
+    mainProgram = "picplanner";
+  };
+})


### PR DESCRIPTION

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
