### PR TITLE
nix-prefetch-fossil: fixups

### DIFF
--- a/pkgs/build-support/fetchfossil/nix-prefetch-fossil
+++ b/pkgs/build-support/fetchfossil/nix-prefetch-fossil
@@ -124,6 +124,7 @@ cat <<EOF
   "url": "$url",
   "rev": "$actualRev",
   "date": "$actualDatetime",
+  "path": "$finalPath",
   "$hashType": "$hash",
   "hash": "$(nix-hash --to-sri --type $hashType $hash)"
 }

--- a/pkgs/build-support/fetchfossil/nix-prefetch-fossil
+++ b/pkgs/build-support/fetchfossil/nix-prefetch-fossil
@@ -89,10 +89,15 @@ fossil open "$tmpPath/fossil-clone.fossil" "$rev" >&2
 
 # Get the actual commit hash and date
 checkoutLine=$(fossil info | grep ^checkout:)
-# Remove 'checkout:' prefix and squeeze multiple spaces, then extract fields
-actualRev=$(echo "$checkoutLine" | sed 's/^checkout:[[:space:]]*//' | tr -s ' ' | cut -d' ' -f1)
-# Extract date (format: checkout:     HASH YYYY-MM-DD HH:MM:SS UTC)
-actualDate=$(echo "$checkoutLine" | sed 's/^checkout:[[:space:]]*//' | tr -s ' ' | cut -d' ' -f2)
+# Remove 'checkout:' prefix & remove whitespace
+checkoutData=$(echo "$checkoutLine" | sed 's/^checkout:[[:space:]]*//' | tr -s ' ')
+# Extract fields: HASH YYYY-MM-DD HH:MM:SS UTC
+actualRev=$(echo "$checkoutData" | cut -d' ' -f1)
+# Get datetime parts
+rawDate=$(echo "$checkoutData" | cut -d' ' -f2)
+rawTime=$(echo "$checkoutData" | cut -d' ' -f3)
+# Combine into ISO 8601 RFC 3339 format
+actualDatetime="${rawDate}T${rawTime}Z"
 cd - >/dev/null
 
 # Remove the fossil checkout file
@@ -118,7 +123,7 @@ cat <<EOF
 {
   "url": "$url",
   "rev": "$actualRev",
-  "date": "$actualDate",
+  "date": "$actualDatetime",
   "$hashType": "$hash",
   "hash": "$(nix-hash --to-sri --type $hashType $hash)"
 }

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -70,6 +70,8 @@ rec {
     mkPrefetchScript "fossil" ../../../build-support/fetchfossil/nix-prefetch-fossil
       [
         fossil
+        gnugrep
+        gnused
       ];
   nix-prefetch-git = mkPrefetchScript "git" ../../../build-support/fetchgit/nix-prefetch-git [
     findutils

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12710,6 +12710,7 @@ with pkgs;
     nix-prefetch-bzr
     nix-prefetch-cvs
     nix-prefetch-darcs
+    nix-prefetch-fossil
     nix-prefetch-git
     nix-prefetch-hg
     nix-prefetch-pijul


### PR DESCRIPTION
The review in #407091 wasn’t thorough enough, but it’s good that the bulk of the work was done. However, in practice I found a number of issues to resolve (each broken out in commits). This includes:
* missing `path` in output
* `date` should have been a datetime to match others (poor naming in Nixpkgs)
* `nix-prefetch-fossil` was not exposed individually
* not all dependencies were declared pulling GNU tools from the system which might fail on systems say using the OpenBSD toolkit.

```console
$ result/bin/nix-prefetch-fossil --url https://pikchr.org/home --rev trunk | jq --tab
Fetching Fossil repository https://pikchr.org/home at revision trunk...
Round-trips: 2   Artifacts sent: 0  received: 2788
Clone done, wire bytes sent: 521  received: 1943313  remote: 194.195.208.62
Rebuilding repository meta-data...
  100.0% complete...
Extra delta compression... none found
Vacuuming the database... 
project-id: 13ab747683ea9d8d2a5b9529c2d848972764cf72
server-id:  58e5a9cc7f20c474894c2c134181a0ac647680cd
admin-user: nobody (password is "8FqDtRsBGY")
Pull from https://pikchr.org/home
Round-trips: 1   Artifacts sent: 0  received: 0
Pull done, wire bytes sent: 308  received: 2817  remote: 194.195.208.62
.fossil-settings/manifest
Makefile
Makefile.msc
README.md
VERSION
doc/annotate.md
doc/arrowdir.md
doc/behind.md
doc/boxobj.md
doc/build.md
doc/changelog.md
doc/chop.md
doc/circleobj.md
doc/colorexpr.md
doc/compassangle.md
doc/copyright-release.html
doc/cylinderobj.md
doc/diamondobj.md
doc/differences.md
doc/download.md
doc/ellipseobj.md
doc/examples.md
doc/fileobj.md
doc/fit.md
doc/grammar.md
doc/integrate.md
doc/invis.md
doc/linelen.md
doc/locattr.md
doc/macro.md
doc/newpropval.md
doc/numprop.md
doc/ovalobj.md
doc/pathattr.md
doc/place.md
doc/position.md
doc/purpose.md
doc/sqlitesyntax.md
doc/stmt.md
doc/stmtlist.md
doc/teardown01.md
doc/textattr.md
doc/thickthin.md
doc/usepikchr.md
doc/userman.md
examples/_txt2js.bash
examples/headings01.pikchr
examples/objects.pikchr
examples/swimlane.pikchr
fiddle/GNUmakefile
fiddle/README.md
fiddle/emscripten.css
fiddle/fiddle.html
fiddle/fiddle.js
fiddle/pikchr-worker.js
fuzzcases/divzero.pikchr
fuzzcases/monospace.pikchr
fuzzcases/nan.pikchr
grammar/gram01.pikchr
grammar/gram02.pikchr
grammar/gram03.pikchr
grammar/gram04.pikchr
homepage.md
lemon.c
lempar.c
make.bat
mkversion.c
pikchr.h.in
pikchr.y
tests/autochop01.pikchr
tests/autochop02.pikchr
tests/autochop03.pikchr
tests/autochop04.pikchr
tests/autochop05.pikchr
tests/autochop06.pikchr
tests/autochop07.pikchr
tests/autochop08.pikchr
tests/autochop09.pikchr
tests/autochop10.pikchr
tests/colortest1.pikchr
tests/diamond01.pikchr
tests/empty.pikchr
tests/expr.pikchr
tests/expr.txt
tests/fonts01.pikchr
tests/gridlines1.pikchr
tests/narrow.pikchr
tests/test01.pikchr
tests/test02.pikchr
tests/test03.pikchr
tests/test04.pikchr
tests/test05.pikchr
tests/test06.pikchr
tests/test07.pikchr
tests/test08.pikchr
tests/test09.pikchr
tests/test10.pikchr
tests/test12.pikchr
tests/test13.pikchr
tests/test14.pikchr
tests/test15.pikchr
tests/test16.pikchr
tests/test17.pikchr
tests/test18.pikchr
tests/test19.pikchr
tests/test20.pikchr
tests/test21.pikchr
tests/test22.pikchr
tests/test23.pikchr
tests/test23b.pikchr
tests/test23c.pikchr
tests/test24.pikchr
tests/test25.pikchr
tests/test26.pikchr
tests/test27.pikchr
tests/test28.pikchr
tests/test29.pikchr
tests/test30.pikchr
tests/test31.pikchr
tests/test32.pikchr
tests/test33.pikchr
tests/test34.pikchr
tests/test35.pikchr
tests/test36.pikchr
tests/test37.pikchr
tests/test38.pikchr
tests/test38b.pikchr
tests/test40.pikchr
tests/test41.pikchr
tests/test42.pikchr
tests/test43.pikchr
tests/test44.pikchr
tests/test45.pikchr
tests/test46.pikchr
tests/test47.pikchr
tests/test47b.pikchr
tests/test48.pikchr
tests/test49.pikchr
tests/test50.pikchr
tests/test51.pikchr
tests/test52.pikchr
tests/test53.pikchr
tests/test54.pikchr
tests/test55.pikchr
tests/test56.pikchr
tests/test57a.pikchr
tests/test57b.pikchr
tests/test57c.pikchr
tests/test58.pikchr
tests/test59.pikchr
tests/test60.pikchr
tests/test61.pikchr
tests/test62.pikchr
tests/test63.pikchr
tests/test64.pikchr
tests/test65.pikchr
tests/test66.pikchr
tests/test67.pikchr
tests/test68.pikchr
tests/test69.pikchr
tests/test70.pikchr
tests/test71.pikchr
tests/test72.pikchr
tests/test73.pikchr
tests/test74.pikchr
tests/test75.pikchr
tests/test76.pikchr
tests/test77.pikchr
tests/test78.pikchr
tests/test79.pikchr
tests/test80.pikchr
tests/test81.pikchr
project-name: Pikchr
repository:   /tmp/fossil-checkout-tmp-L5jDHey7/fossil-clone.fossil
local-root:   /tmp/fossil-checkout-tmp-L5jDHey7/checkout/
config-db:    /home/toastal/.config/fossil.db
project-code: 13ab747683ea9d8d2a5b9529c2d848972764cf72
checkout:     ec28d04c3ec6fb76c27357fd67306798d49fe58a 2026-01-02 01:26:53 UTC
parent:       b5d31bf93826ab03efe8549f7945c4dc6a201853 2026-01-02 01:26:08 UTC
tags:         trunk
comment:      One of the documentation improvements intended for the previous check-in
              was left unsaved in the editor. Fixed here. (user: drh)
check-ins:    500
hash is 1b5xlqj4pcjf0q37jlpqb02irsp64qxp80fsjqnzlp96i843znig
path is /nix/store/nsija8z0bfm1bylnz17d53mjy3q6cxj8-checkout
{
	"url": "https://pikchr.org/home",
	"rev": "ec28d04c3ec6fb76c27357fd67306798d49fe58a",
	"date": "2026-01-02T01:26:53Z",
	"path": "/nix/store/nsija8z0bfm1bylnz17d53mjy3q6cxj8-checkout",
	"sha256": "1b5xlqj4pcjf0q37jlpqb02irsp64qxp80fsjqnzlp96i843znig",
	"hash": "sha256-L9o/CIomXfotltoBdDsm5uocBVj4UnkGBk6ySySmvaw="
}
```

I did _not_ bother implementing quiet, which could be done later but isn’t critcal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.
