### PR TITLE
cubelify: init at 1.25.9

### DIFF
--- a/pkgs/by-name/cu/cubelify/package.nix
+++ b/pkgs/by-name/cu/cubelify/package.nix
@@ -1,0 +1,41 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+  makeWrapper,
+}:
+appimageTools.wrapType2 rec {
+  pname = "cubelify";
+  version = "1.25.9";
+
+  src = fetchurl {
+    url = "https://storage.cubelify.com/overlay/v1/Cubelify%20Overlay-${version}.AppImage";
+    hash = "sha512-2Kkd8nH//UBYL7K01bZWlOUBTfHpp8GjtB0LwYxp/+/yJJfGq+3eTQGJnlt0mHcnIauVy1ep4IKlPSJQqtigKA==";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  extraInstallCommands =
+    let
+      contents = appimageTools.extract { inherit pname version src; };
+    in
+    ''
+      wrapProgram $out/bin/cubelify \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}"
+      install -Dm444 ${contents}/cubelify-overlay.desktop -t $out/share/applications/
+      install -Dm444 ${contents}/cubelify-overlay.png -t $out/share/pixmaps/
+      substituteInPlace $out/share/applications/cubelify-overlay.desktop \
+        --replace-fail 'Exec=AppRun --no-sandbox %U' 'Exec=cubelify' \
+    '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Powerful and feature-rich Hypixel anti-sniping stats overlay";
+    homepage = "https://cubelify.com/";
+    license = with lib.licenses; [ unfree ];
+    mainProgram = "cubelify";
+    maintainers = with lib.maintainers; [ yunfachi ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/cu/cubelify/update.sh
+++ b/pkgs/by-name/cu/cubelify/update.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl yq
+set -eu -o pipefail
+
+target="$(dirname "$(readlink -f "$0")")/package.nix"
+host="https://storage.cubelify.com"
+metadata=$(curl "$host/overlay/v1/latest-linux.yml")
+version=$(echo "$metadata" | yq .version -r | cut -d- -f1)
+hash=$(echo "$metadata" | yq .sha512 -r)
+
+sed -i "s@version = .*;@version = \"$version\";@g" "$target"
+sed -i "s@hash.* = .*;@hash = \"sha512-$hash\";@g" "$target"


### PR DESCRIPTION
Cubelify is, I think, the most popular stats overlay for Hypixel (Minecraft). 

For some reason, the download mechanism is very similar to Lunar Client, so I just adapted the Lunar Client package. Tested it for a few hours - works without any issues.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
