### PR TITLE
finalmouse-udev-rules: 2025-08-15 -> 2026-01-27

### DIFF
--- a/pkgs/by-name/fi/finalmouse-udev-rules/package.nix
+++ b/pkgs/by-name/fi/finalmouse-udev-rules/package.nix
@@ -6,13 +6,13 @@
 
 stdenv.mkDerivation {
   pname = "finalmouse-udev-rules";
-  version = "0-unstable-2025-08-15";
+  version = "0-unstable-2026-01-27";
 
   src = fetchFromGitHub {
     owner = "teamfinalmouse";
     repo = "xpanel-linux-permissions";
-    rev = "6b200ec39f1fa31edf6648f5ec3d5738c3770530";
-    hash = "sha256-Bo8XBvrUlZe0eVQlNQGb0xuTb+wecipsHwLdZpK0dUQ=";
+    rev = "49ba1bf19e7d1f05306baaf72e4514c1f12f139a";
+    hash = "sha256-+tStBzGrPop0zKNf0qIp2PCrVRy2CcFpIrvgft9YkbE=";
   };
 
   dontUnpack = true;
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    install -Dpm644 $src/99-finalmouse.rules $out/lib/udev/rules.d/70-finalmouse.rules
+    install -Dpm644 $src/70-finalmouse.rules $out/lib/udev/rules.d/70-finalmouse.rules
 
     runHook postInstall
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
