### PR TITLE
haskellPackages.iserv-proxy: fix on GHC 9.6

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -38,7 +38,6 @@ in
   haskeline = null;
   hpc = null;
   integer-gmp = null;
-  libiserv = null;
   mtl = null;
   parsec = null;
   pretty = null;
@@ -59,6 +58,10 @@ in
   unix = null;
   xhtml = null;
   Win32 = null;
+
+  libiserv = doJailbreak (markUnbroken (doDistribute super.libiserv)); # ghci ==9.6.6
+
+  iserv-proxy = addBuildDepend self.libiserv super.iserv-proxy;
 
   # Becomes a core package in GHC >= 9.8
   semaphore-compat = doDistribute self.semaphore-compat_1_0_0;

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -2239,8 +2239,9 @@ builtins.intersectAttrs super {
           enableExternalInterpreter = false;
         };
       in
-      lib.mapAttrs (_: noExternalInterpreter) { inherit (super) iserv-proxy network; }
+      lib.mapAttrs (_: noExternalInterpreter) { inherit (super) libiserv iserv-proxy network; }
     )
+    libiserv
     iserv-proxy
     network
     ;

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -26,8 +26,9 @@ let
     needsExternalInterpreterSetup = !stdenv.hostPlatform.isGhcjs; # JS backend already handles this
 
     canProxyTH =
-      # iserv-proxy currently does not build on GHC 9.6
-      lib.versionAtLeast ghc.version "9.8" && stdenv.hostPlatform.emulatorAvailable buildPackages;
+      # Using iserv-proxy with 9.4 yields
+      #   no location info>: error: Dynamic loading not supported
+      lib.versionAtLeast ghc.version "9.6" && stdenv.hostPlatform.emulatorAvailable buildPackages;
 
     iservWrapper =
       let

--- a/pkgs/development/tools/haskell/iserv-proxy/default.nix
+++ b/pkgs/development/tools/haskell/iserv-proxy/default.nix
@@ -15,14 +15,14 @@
 }:
 mkDerivation {
   pname = "iserv-proxy";
-  version = "9.3-unstable-2025-10-30";
+  version = "9.3-unstable-2026-02-04";
 
   # https://github.com/stable-haskell/iserv-proxy/pull/1
   src = fetchFromGitHub {
     owner = "stable-haskell";
     repo = "iserv-proxy";
-    rev = "bbee090fc67bb5cc6ad4508fa5def560b7672591";
-    hash = "sha256-2aCGboNCF602huvmbyTcfhe6s+D4/n/NlOefd0c0SC0=";
+    rev = "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6";
+    hash = "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg";
   };
 
   isLibrary = true;

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -543,6 +543,7 @@ let
       ] released;
       hpack = released;
       hsdns = released;
+      iserv-proxy = released;
       jailbreak-cabal = released;
       language-nix = released;
       nix-paths = released;


### PR DESCRIPTION
```
$ nix-build -A pkgsStatic.haskell.packages.ghc96.th-orphans
/nix/store/xiz44a1r3vbzv684hvh6fp1flq9x82ag-th-orphans-static-x86_64-unknown-linux-musl-0.13.17

$ nix-build -A pkgsCross.aarch64-multiplatform.haskell.packages.ghc96.th-orphans
/nix/store/grjigzm3spm18xlwzahrmgagwlamw6dp-th-orphans-aarch64-unknown-linux-gnu-0.13.17
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
