### PR TITLE
nixVersions.nix_2_33: 2.33.1 -> 2.33.2

### DIFF
--- a/pkgs/tools/package-management/nix/default.nix
+++ b/pkgs/tools/package-management/nix/default.nix
@@ -206,26 +206,17 @@ lib.makeExtensible (
 
       nixComponents_2_33 =
         (nixDependencies.callPackage ./modular/packages.nix rec {
-          version = "2.33.1";
+          version = "2.33.2";
           inherit (self.nix_2_32.meta) teams;
           otherSplices = generateSplicesForNixComponents "nixComponents_2_33";
           src = fetchFromGitHub {
             owner = "NixOS";
             repo = "nix";
             tag = version;
-            hash = "sha256-TVKn52SoKq8mMyW/x3NPPskGVurFdnGGV0DGvnL0gak=";
+            hash = "sha256-bjkycwYUs2TS5pYcqlJ2yA2W8gc6iq+Is1kNSY+QPHk=";
           };
         }).appendPatches
-          (
-            patches_common
-            ++ [
-              (fetchpatch2 {
-                name = "nix-2.33-15012-missing-include-glibc-2.42.patch";
-                url = "https://github.com/NixOS/nix/commit/c0c13d73233c740b7d278c71b161da7b16217564.patch?full_index=1";
-                hash = "sha256-iRMg36UMs5WmUfNxz4zoZq6mM3dwo2NiR8s1cM/uooU=";
-              })
-            ]
-          );
+          patches_common;
 
       nix_2_33 = addTests "nix_2_33" self.nixComponents_2_33.nix-everything;
 


### PR DESCRIPTION
## Bug fixes

- Fix destruction of DerivationBuilder implementations (NixOS/nix#15072)
- Don't report cancelled goals as failures (NixOS/nix#14972)
- Fix `linux` build on fresh `glibc` and `gcc` (NixOS/nix#15011)

## S3 binary cache improvements

- Add AWS SSO support for S3 authentication (NixOS/nix#14645)
- Respect `AWS_PROFILE` environment variable (NixOS/nix#14645)
- Add STS support for default profile (NixOS/nix#14645)
- Skip `Accept-Encoding` header for S3 SigV4 requests (NixOS/nix#15048)
- Restart source before upload retries (NixOS/nix#15047)
- Route AWS CRT logs through Nix logger (NixOS/nix#15059)

The glibc 2.42 build fix patch is dropped as it is now included upstream.

https://github.com/NixOS/nix/releases/tag/2.33.2

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test