### PR TITLE
nixos/nixos-containers: fix bind mounts with spaces in paths

### DIFF
--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -120,6 +120,11 @@ let
 
     declare -a extraFlags
 
+    # Add bind mounts to extraFlags array
+    while IFS= read -r flag; do
+      [[ -n "$flag" ]] && extraFlags+=("$flag")
+    done <<< "''${EXTRA_NSPAWN_BIND_MOUNTS-}"
+
     if [[ "''${PRIVATE_NETWORK-}" = 1 ]]; then
       extraFlags+=("--private-network")
     fi
@@ -388,12 +393,12 @@ let
   mkBindFlag =
     d:
     let
-      flagPrefix = if d.isReadOnly then " --bind-ro=" else " --bind=";
+      flagName = if d.isReadOnly then "--bind-ro=" else "--bind=";
       mountstr = if d.hostPath != null then "${d.hostPath}:${d.mountPoint}" else "${d.mountPoint}";
     in
-    flagPrefix + mountstr;
+    flagName + mountstr;
 
-  mkBindFlags = bs: concatMapStrings mkBindFlag (lib.attrValues bs);
+  mkBindFlags = bs: map mkBindFlag (lib.attrValues bs);
 
   networkOptions = {
     hostBridge = mkOption {
@@ -1043,8 +1048,12 @@ in
                   postStart = postStartScript containerConfig;
                   serviceConfig = serviceDirectives containerConfig;
                   unitConfig.RequiresMountsFor =
+                    let
+                      # Escape spaces for systemd's RequiresMountsFor which is space-separated
+                      escapePath = path: lib.strings.escapeC [ " " ] path;
+                    in
                     lib.optional (!containerConfig.ephemeral) "${stateDirectory}/%i"
-                    ++ map (d: if d.hostPath != null then d.hostPath else d.mountPoint) (
+                    ++ map (d: escapePath (if d.hostPath != null then d.hostPath else d.mountPoint)) (
                       builtins.attrValues cfg.bindMounts
                     );
                   environment.root =
@@ -1118,10 +1127,8 @@ in
                 ${optionalString cfg.autoStart ''
                   AUTO_START=1
                 ''}
-                EXTRA_NSPAWN_FLAGS="${
-                  mkBindFlags cfg.bindMounts
-                  + optionalString (cfg.extraFlags != [ ]) (" " + concatStringsSep " " cfg.extraFlags)
-                }"
+                EXTRA_NSPAWN_BIND_MOUNTS="${concatStringsSep "\n" (mkBindFlags cfg.bindMounts)}"
+                EXTRA_NSPAWN_FLAGS="${optionalString (cfg.extraFlags != [ ]) (concatStringsSep " " cfg.extraFlags)}"
               '';
             }
           ) config.containers;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -389,6 +389,7 @@ in
   console-xkb-and-i18n = runTest ./console-xkb-and-i18n.nix;
   consul = runTest ./consul.nix;
   consul-template = runTest ./consul-template.nix;
+  containers-bind-mounts-special-paths = runTest ./containers-bind-mounts-special-paths.nix;
   containers-bridge = runTest ./containers-bridge.nix;
   containers-custom-pkgs = runTest ./containers-custom-pkgs.nix;
   containers-ephemeral = runTest ./containers-ephemeral.nix;

--- a/nixos/tests/containers-bind-mounts-special-paths.nix
+++ b/nixos/tests/containers-bind-mounts-special-paths.nix
@@ -1,0 +1,102 @@
+{ lib, pkgs, ... }:
+{
+  name = "containers-bind-mounts-special-paths";
+  meta.maintainers = [ ];
+
+  nodes.machine = {
+    containers.test-special-paths = {
+      autoStart = true;
+      bindMounts = {
+        # Test single space
+        "/mnt/single-space" = {
+          hostPath = "/tmp/test-bind-mounts/path with spaces";
+          isReadOnly = true;
+        };
+        # Test multiple consecutive spaces
+        "/mnt/double-space" = {
+          hostPath = "/tmp/test-bind-mounts/path  with  double";
+          isReadOnly = true;
+        };
+        # Test space at beginning
+        "/mnt/leading-space" = {
+          hostPath = "/tmp/test-bind-mounts/ leading-space";
+          isReadOnly = true;
+        };
+        # Test space at end
+        "/mnt/trailing-space" = {
+          hostPath = "/tmp/test-bind-mounts/trailing-space ";
+          isReadOnly = true;
+        };
+        # Test path without spaces (control)
+        "/mnt/no-spaces" = {
+          hostPath = "/tmp/test-bind-mounts/no-spaces";
+          isReadOnly = true;
+        };
+      };
+      config = { };
+    };
+
+    # Create the test directories during system activation
+    system.activationScripts.testBindMountPaths = ''
+      mkdir -p "/tmp/test-bind-mounts/path with spaces"
+      mkdir -p "/tmp/test-bind-mounts/path  with  double"
+      mkdir -p "/tmp/test-bind-mounts/ leading-space"
+      mkdir -p "/tmp/test-bind-mounts/trailing-space "
+      mkdir -p "/tmp/test-bind-mounts/no-spaces"
+
+      echo "single-space" > "/tmp/test-bind-mounts/path with spaces/test.txt"
+      echo "double-space" > "/tmp/test-bind-mounts/path  with  double/test.txt"
+      echo "leading-space" > "/tmp/test-bind-mounts/ leading-space/test.txt"
+      echo "trailing-space" > "/tmp/test-bind-mounts/trailing-space /test.txt"
+      echo "no-spaces" > "/tmp/test-bind-mounts/no-spaces/test.txt"
+    '';
+  };
+
+  testScript = ''
+    machine.wait_for_unit("default.target")
+    machine.wait_for_unit("container@test-special-paths.service")
+
+    with subtest("Container started successfully"):
+        assert "test-special-paths" in machine.succeed("nixos-container list")
+        assert "up" in machine.succeed("nixos-container status test-special-paths")
+
+    with subtest("Verify no systemd warnings about invalid paths"):
+        # Check that systemd didn't complain about paths not being absolute
+        journal = machine.succeed("journalctl -u 'container@test-special-paths.service' --no-pager")
+        assert "path is not absolute" not in journal, f"Found path warning in journal: {journal}"
+
+    with subtest("Verify all bind mounts are accessible"):
+        # Test single space
+        output = machine.succeed("nixos-container run test-special-paths -- cat /mnt/single-space/test.txt")
+        assert "single-space" in output, f"Expected 'single-space', got: {output}"
+
+        # Test double spaces
+        output = machine.succeed("nixos-container run test-special-paths -- cat /mnt/double-space/test.txt")
+        assert "double-space" in output, f"Expected 'double-space', got: {output}"
+
+        # Test leading space
+        output = machine.succeed("nixos-container run test-special-paths -- cat /mnt/leading-space/test.txt")
+        assert "leading-space" in output, f"Expected 'leading-space', got: {output}"
+
+        # Test trailing space
+        output = machine.succeed("nixos-container run test-special-paths -- cat /mnt/trailing-space/test.txt")
+        assert "trailing-space" in output, f"Expected 'trailing-space', got: {output}"
+
+        # Test control (no spaces)
+        output = machine.succeed("nixos-container run test-special-paths -- cat /mnt/no-spaces/test.txt")
+        assert "no-spaces" in output, f"Expected 'no-spaces', got: {output}"
+
+    with subtest("Verify bind mounts are read-only"):
+        # Attempting to write should fail
+        machine.fail("nixos-container run test-special-paths -- touch /mnt/single-space/write-test.txt")
+        machine.fail("nixos-container run test-special-paths -- touch /mnt/double-space/write-test.txt")
+
+    with subtest("Verify mount information is correct"):
+        # Check that mounts show the correct source paths with spaces
+        mounts = machine.succeed("nixos-container run test-special-paths -- findmnt /mnt/single-space")
+        assert "path with spaces" in mounts, f"Expected 'path with spaces' in mount info: {mounts}"
+
+        mounts = machine.succeed("nixos-container run test-special-paths -- findmnt /mnt/double-space")
+        assert "path  with  double" in mounts, f"Expected 'path  with  double' in mount info: {mounts}"
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes bind mounts with spaces in filenames for NixOS containers (https://github.com/NixOS/nixpkgs/issues/482452).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
