### PR TITLE
{k3s,rke2}: disable r-ryantm automatic updates

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/default.nix
+++ b/pkgs/applications/networking/cluster/k3s/default.nix
@@ -12,51 +12,15 @@ let
   extraArgs = removeAttrs args [ "callPackage" ];
 in
 {
-  k3s_1_32 = common (
-    (import ./1_32/versions.nix)
-    // {
-      updateScript = [
-        ./update-script.sh
-        "32"
-      ];
-    }
-  ) extraArgs;
+  k3s_1_32 = common (import ./1_32/versions.nix) extraArgs;
 
-  k3s_1_33 = common (
-    (import ./1_33/versions.nix)
-    // {
-      updateScript = [
-        ./update-script.sh
-        "33"
-      ];
-    }
-  ) extraArgs;
+  k3s_1_33 = common (import ./1_33/versions.nix) extraArgs;
 
-  k3s_1_34 =
-    (common (
-      (import ./1_34/versions.nix)
-      // {
-        updateScript = [
-          ./update-script.sh
-          "34"
-        ];
-      }
-    ) extraArgs).overrideAttrs
-      {
-        patches = [ ./go_runc_require.patch ];
-      };
+  k3s_1_34 = (common (import ./1_34/versions.nix) extraArgs).overrideAttrs {
+    patches = [ ./go_runc_require.patch ];
+  };
 
-  k3s_1_35 =
-    (common (
-      (import ./1_35/versions.nix)
-      // {
-        updateScript = [
-          ./update-script.sh
-          "35"
-        ];
-      }
-    ) extraArgs).overrideAttrs
-      {
-        patches = [ ./go_runc_require.patch ];
-      };
+  k3s_1_35 = (common (import ./1_35/versions.nix) extraArgs).overrideAttrs {
+    patches = [ ./go_runc_require.patch ];
+  };
 }

--- a/pkgs/applications/networking/cluster/rke2/README.md
+++ b/pkgs/applications/networking/cluster/rke2/README.md
@@ -108,19 +108,9 @@ respective package block.
 
 ```nix
 {
-  rke2_1_34 =
-    (common (
-      (import ./1_34/versions.nix)
-      // {
-        updateScript = [
-          ./update-script.sh
-          "34"
-        ];
-      }
-    ) extraArgs).overrideAttrs
-      {
-        meta.knownVulnerabilities = [ "rke2_1_34 has reached end-of-life on 2026-10-27" ];
-      };
+  rke2_1_34 = (common (import ./1_34/versions.nix) extraArgs).overrideAttrs {
+    meta.knownVulnerabilities = [ "rke2_1_34 has reached end-of-life on 2026-10-27" ];
+  };
 }
 ```
 

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -4,7 +4,7 @@ lib:
   rke2Commit,
   rke2TarballHash,
   rke2VendorHash,
-  updateScript,
+  updateScript ? null,
   k8sImageTag,
   etcdVersion,
   pauseVersion,

--- a/pkgs/applications/networking/cluster/rke2/default.nix
+++ b/pkgs/applications/networking/cluster/rke2/default.nix
@@ -5,45 +5,13 @@ let
   extraArgs = removeAttrs args [ "callPackage" ];
 in
 rec {
-  rke2_1_32 = common (
-    (import ./1_32/versions.nix)
-    // {
-      updateScript = [
-        ./update-script.sh
-        "32"
-      ];
-    }
-  ) extraArgs;
+  rke2_1_32 = common (import ./1_32/versions.nix) extraArgs;
 
-  rke2_1_33 = common (
-    (import ./1_33/versions.nix)
-    // {
-      updateScript = [
-        ./update-script.sh
-        "33"
-      ];
-    }
-  ) extraArgs;
+  rke2_1_33 = common (import ./1_33/versions.nix) extraArgs;
 
-  rke2_1_34 = common (
-    (import ./1_34/versions.nix)
-    // {
-      updateScript = [
-        ./update-script.sh
-        "34"
-      ];
-    }
-  ) extraArgs;
+  rke2_1_34 = common (import ./1_34/versions.nix) extraArgs;
 
-  rke2_1_35 = common (
-    (import ./1_35/versions.nix)
-    // {
-      updateScript = [
-        ./update-script.sh
-        "35"
-      ];
-    }
-  ) extraArgs;
+  rke2_1_35 = common (import ./1_35/versions.nix) extraArgs;
 
   # Automatically set by update script, changes shouldn't be backported
   rke2_stable = rke2_1_34;


### PR DESCRIPTION
Discussed in #487614 - this should prevent @r-ryantm from creating redundant PRs like #487523 & #487374 when all packages are updated in a single PR, plus make the `default.nix`s a lot more concise as a side effect.

Since K3s/RKE2 both have active maintainers at the moment doing this should be fine. For RKE2 in particular the bot isn't very reliable anyway since it runs all `passthru.tests` before creating a PR, which needs a lot of resources and lately seems to never finish at all (its latest RKE2 PR is [from 2024](https://github.com/NixOS/nixpkgs/pulls?q=in%3Atitle+rke2+author%3Ar-ryantm)).

cc @NixOS/k3s @rorosen @zimbatm @stefan-bordei

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
