### PR TITLE
slippi-launcher: init at 2.13.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4866,6 +4866,12 @@
     githubId = 31200881;
     keys = [ { fingerprint = "5D03 A5E6 0754 A3E3 CA57 5037 E838 CED8 1CFF D3F9"; } ];
   };
+  chuu-p = {
+    email = "nixos@chuu.dev";
+    github = "chuu-p";
+    githubId = 180400228;
+    name = "Chuu P";
+  };
   chvp = {
     email = "nixpkgs@cvpetegem.be";
     matrix = "@charlotte:vanpetegem.me";

--- a/pkgs/by-name/sl/slippi-launcher/package.nix
+++ b/pkgs/by-name/sl/slippi-launcher/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  appimageTools,
+  undmg,
+}: let
+  pname = "slippi-launcher";
+  version = "2.13.3";
+
+  src =
+    fetchurl
+    {
+      x86_64-linux = {
+        url = "https://github.com/project-slippi/slippi-launcher/releases/download/v${version}/Slippi-Launcher-${version}-x86_64.AppImage";
+        hash = "sha256-5tFl0ezk/yMkfd59kUKxGZBvt5MqnoCvxRSepy7O8BQ=";
+      };
+    }
+      .${
+      stdenv.system
+    } or (throw "Unsupported system: ${stdenv.system}");
+
+  meta = {
+    homepage = "https://slippi.gg/";
+    description = "The way to play Slippi Online and watch replays.";
+    mainProgram = "slippi-launcher";
+    changelog = "https://github.com/project-slippi/slippi-launcher/releases/tag/v${version}";
+    license = lib.licenses.gpl3Only;
+    platforms = [
+      "x86_64-linux"
+    ];
+    maintainers = with lib.maintainers; [
+      chuu
+    ];
+  };
+in
+  appimageTools.wrapType2 {
+    inherit
+      pname
+      version
+      src
+      meta
+      ;
+
+    extraInstallCommands = let
+      appimageContents = appimageTools.extract {
+        inherit pname version src;
+      };
+    in ''
+      # Install desktop entry
+      install -Dm444 \
+        ${appimageContents}/slippi-launcher.desktop \
+        $out/share/applications/slippi-launcher.desktop
+
+      # Install icon
+      install -Dm444 \
+        ${appimageContents}/slippi-launcher.png \
+        $out/share/pixmaps/slippi-launcher.png
+
+      # Fix Exec line in desktop file to point to wrapped binary
+      substituteInPlace $out/share/applications/slippi-launcher.desktop \
+        --replace-fail 'Exec=AppRun' 'Exec=slippi-launcher'
+
+      # Some Electron desktop files include extra args – be defensive
+      substituteInPlace $out/share/applications/slippi-launcher.desktop \
+        --replace 'Exec=AppRun %U' 'Exec=slippi-launcher %U'
+    '';
+  }

--- a/pkgs/by-name/sl/slippi-launcher/package.nix
+++ b/pkgs/by-name/sl/slippi-launcher/package.nix
@@ -4,21 +4,20 @@
   fetchurl,
   appimageTools,
   undmg,
-}: let
+}:
+let
   pname = "slippi-launcher";
   version = "2.13.3";
 
   src =
     fetchurl
-    {
-      x86_64-linux = {
-        url = "https://github.com/project-slippi/slippi-launcher/releases/download/v${version}/Slippi-Launcher-${version}-x86_64.AppImage";
-        hash = "sha256-5tFl0ezk/yMkfd59kUKxGZBvt5MqnoCvxRSepy7O8BQ=";
-      };
-    }
-      .${
-      stdenv.system
-    } or (throw "Unsupported system: ${stdenv.system}");
+      {
+        x86_64-linux = {
+          url = "https://github.com/project-slippi/slippi-launcher/releases/download/v${version}/Slippi-Launcher-${version}-x86_64.AppImage";
+          hash = "sha256-5tFl0ezk/yMkfd59kUKxGZBvt5MqnoCvxRSepy7O8BQ=";
+        };
+      }
+      .${stdenv.system} or (throw "Unsupported system: ${stdenv.system}");
 
   meta = {
     homepage = "https://slippi.gg/";
@@ -34,19 +33,21 @@
     ];
   };
 in
-  appimageTools.wrapType2 {
-    inherit
-      pname
-      version
-      src
-      meta
-      ;
+appimageTools.wrapType2 {
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
 
-    extraInstallCommands = let
+  extraInstallCommands =
+    let
       appimageContents = appimageTools.extract {
         inherit pname version src;
       };
-    in ''
+    in
+    ''
       # Install desktop entry
       install -Dm444 \
         ${appimageContents}/slippi-launcher.desktop \
@@ -65,4 +66,4 @@ in
       substituteInPlace $out/share/applications/slippi-launcher.desktop \
         --replace 'Exec=AppRun %U' 'Exec=slippi-launcher %U'
     '';
-  }
+}

--- a/pkgs/by-name/sl/slippi-launcher/package.nix
+++ b/pkgs/by-name/sl/slippi-launcher/package.nix
@@ -30,7 +30,7 @@
       "x86_64-linux"
     ];
     maintainers = with lib.maintainers; [
-      chuu
+      chuu-p
     ];
   };
 in


### PR DESCRIPTION
Adds slippi-launcher, the official Project Slippi launcher, packaged from the upstream AppImage.

This makes the launcher easily installable and updatable on NixOS and other nixpkgs-based systems. I will maintain the package going forward.

### Testing
- nix build .#slippi-launcher
- Launcher starts successfully on x86_64-linux

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
