### PR TITLE
firefox: Don't rely on file extension to identify dynamic libraries

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -423,10 +423,21 @@ let
           # Maybe related to how omni.ja file is mmapped into memory. See:
           # https://github.com/mozilla/gecko-dev/blob/b1662b447f306e6554647914090d4b73ac8e1664/modules/libjar/nsZipArchive.cpp#L204
           #
-          # The *.dylib files are copied, otherwise some basic functionality, e.g. Crypto API, is broken.
-          for file in $(find . -name "omni.ja" -o -name "*.dylib"); do
+          # Mach-O shared libraries must be copied, not symlinked, otherwise some
+          # functionality like the Crypto API and audio decoding is broken.
+          find . -type l -print0 |
+          while IFS= read -r -d "" file; do
+            case "$(basename "$file")" in
+              omni.ja)
+                ;;
+              *)
+                # Copy if the symlink resolves to a Mach-O dylib
+                otool -l "$file" 2>/dev/null | grep -q 'LC_ID_DYLIB' || continue
+                ;;
+            esac
+
             rm "$file"
-            cp "${browser}/${appPath}/$file" "$file"
+            cp "${browser}/${appPath}/''${file#./}" "$file"
           done
 
           # Copy any embedded .app directories; plugin-container fails to start otherwise.


### PR DESCRIPTION
Since a2e886428b4a52bd908a3eccd5c4a6f48993dccf, dynamic libraries are copied rather than symlinked.  The issue is that not all dynamic libraries follow the convention of ending in .dylib.  This patch addresses this by implementing a more robust search for dynamic libraries using `file`.

Resolves #462923.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
