### PR TITLE
linear-cli: init at 1.9.1

### DIFF
--- a/pkgs/by-name/li/linear-cli/package.nix
+++ b/pkgs/by-name/li/linear-cli/package.nix
@@ -1,0 +1,147 @@
+{
+  lib,
+  stdenv,
+  buildPackages,
+  fetchurl,
+  buildFHSEnv,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+let
+  pname = "linear-cli";
+  version = "1.9.1";
+
+  system = stdenv.hostPlatform.system;
+
+  platformData = {
+    aarch64-darwin = {
+      suffix = "aarch64-apple-darwin";
+      hash = "sha256-ZfT+9DdLT9e1GtQSlu2J3fHFQYnUEzijSHNYpElfaWs=";
+    };
+    x86_64-darwin = {
+      suffix = "x86_64-apple-darwin";
+      hash = "sha256-48oKJytD8iUzKugMaTUM+aJKB9Hg1C+3jF6kaW6wQF0=";
+    };
+    aarch64-linux = {
+      suffix = "aarch64-unknown-linux-gnu";
+      hash = "sha256-FZ1zfQqIoX9IXq28Ti5AN+omqwwJGYsAtVbld3pSgN8=";
+    };
+    x86_64-linux = {
+      suffix = "x86_64-unknown-linux-gnu";
+      hash = "sha256-+LEDaEK9WIDPBfR2krTwnAq7Oq01LxjL9O6V3z7C87s=";
+    };
+  };
+
+  platform = platformData.${system} or (throw "${pname}: no upstream binary available for ${system}");
+
+  src = fetchurl {
+    url = "https://github.com/schpet/linear-cli/releases/download/v${version}/linear-${platform.suffix}.tar.xz";
+    hash = platform.hash;
+  };
+
+  sourceRoot = "linear-${platform.suffix}";
+
+  common = {
+    nativeBuildInputs = [ installShellFiles ];
+    nativeInstallCheckInputs = [ versionCheckHook ];
+    doInstallCheck = true;
+  };
+
+  completionsInstall =
+    let
+      exe =
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          "$out/bin/linear"
+        else
+          lib.getExe buildPackages.linear-cli;
+    in
+    lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd linear \
+        --bash <(${exe} completions bash) \
+        --fish <(${exe} completions fish) \
+        --zsh <(${exe} completions zsh)
+    '';
+
+  meta = {
+    description = "CLI for Linear issue tracker - list, start, and create PRs for issues";
+    homepage = "https://github.com/schpet/linear-cli";
+    changelog = "https://github.com/schpet/linear-cli/blob/main/CHANGELOG.md";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [
+      iamanaws
+    ];
+    mainProgram = "linear";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames platformData;
+  };
+
+  upstream = stdenv.mkDerivation {
+    pname = "${pname}-upstream";
+    inherit
+      version
+      src
+      sourceRoot
+      meta
+      ;
+
+    dontStrip = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm755 linear $out/libexec/linear
+      runHook postInstall
+    '';
+  };
+in
+if stdenv.hostPlatform.isLinux then
+  buildFHSEnv (
+    common
+    // {
+      inherit pname version meta;
+
+      executableName = "linear";
+      runScript = "${upstream}/libexec/linear";
+
+      targetPkgs = pkgs: [
+        pkgs.glibc
+        pkgs.libgcc
+      ];
+
+      extraInstallCommands = completionsInstall;
+
+      passthru = {
+        inherit src;
+        updateScript = ./update.sh;
+      };
+    }
+  )
+else
+  stdenv.mkDerivation (
+    common
+    // {
+      inherit
+        pname
+        version
+        meta
+        src
+        ;
+
+      dontUnpack = true;
+
+      dontStrip = true;
+      dontFixup = true;
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/bin
+        ln -s ${upstream}/libexec/linear $out/bin/linear
+        runHook postInstall
+      '';
+
+      postInstall = completionsInstall;
+
+      passthru.updateScript = ./update.sh;
+    }
+  )

--- a/pkgs/by-name/li/linear-cli/update.sh
+++ b/pkgs/by-name/li/linear-cli/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix nix-update common-updater-scripts
+
+set -eou pipefail
+
+latestVersion=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL https://api.github.com/repos/schpet/linear-cli/releases/latest | jq -r .tag_name | sed 's/^v//')
+currentVersion=$(nix eval --raw -f . linear-cli.version)
+
+if [[ "$currentVersion" == "$latestVersion" ]]; then
+    echo "package is up-to-date: $currentVersion"
+    exit 0
+fi
+
+nix-update linear-cli --version "$latestVersion" || true
+
+for system in aarch64-darwin x86_64-darwin aarch64-linux x86_64-linux; do
+    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 $(nix-prefetch-url $(nix eval --raw -f . linear-cli.src.url --system "$system")))
+    update-source-version linear-cli "$latestVersion" "$hash" --system="$system" --ignore-same-version --ignore-same-hash
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
