### PR TITLE
nixos/llama-cpp: add multi-instance support

### DIFF
--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -9,181 +9,618 @@
 let
   cfg = config.services.llama-cpp;
 
-  modelsPresetFile =
-    if cfg.modelsPreset != null then
-      pkgs.writeText "llama-models.ini" (lib.generators.toINI { } cfg.modelsPreset)
-    else
-      null;
+  mkInstanceConfig =
+    name: inst:
+    let
+      basePackage = inst.package;
+      pkg =
+        if inst.rocmGpuTargets != null then
+          basePackage.override { rocmGpuTargets = inst.rocmGpuTargets; }
+        else
+          basePackage;
+
+      useCuda = pkg.passthru.cudaSupport or false;
+      useRocm = pkg.passthru.rocmSupport or false;
+      useVulkan = pkg.passthru.vulkanSupport or false;
+      needsGpu = useCuda || useRocm || useVulkan;
+
+      deviceRules =
+        lib.optionals useRocm [
+          "char-drm"
+          "char-kfd"
+        ]
+        ++ lib.optionals useCuda [
+          "char-nvidiactl"
+          "char-nvidia-caps"
+          "char-nvidia-frontend"
+          "char-nvidia-uvm"
+        ]
+        ++ lib.optionals useVulkan [ "char-drm" ];
+
+      gpuGroups = [
+        "video"
+        "render"
+      ];
+    in
+    {
+      inherit
+        pkg
+        needsGpu
+        deviceRules
+        gpuGroups
+        ;
+    };
+
+  instanceModule =
+    { name, config, ... }:
+    {
+      options = {
+        enable = lib.mkEnableOption "this llama-cpp instance";
+
+        package = lib.mkPackageOption pkgs "llama-cpp" { };
+
+        rocmGpuTargets = lib.mkOption {
+          type = lib.types.nullOr (lib.types.listOf lib.types.str);
+          default = null;
+          example = [
+            "gfx906"
+            "gfx1102"
+          ];
+          description = ''
+            AMD ROCm GPU architectures to target. When set, overrides the package's
+            default GPU targets for faster, architecture-specific builds.
+
+            Common targets:
+            - `gfx906`: AMD MI50, MI60
+            - `gfx908`: AMD MI100
+            - `gfx90a`: AMD MI210, MI250, MI250X
+            - `gfx942`: AMD MI300A, MI300X, MI325X
+            - `gfx1030`: Radeon PRO W6800, Radeon PRO V620
+            - `gfx1100`: Radeon RX 7900 XTX, Radeon RX 7900 XT
+            - `gfx1101`: Radeon RX 7800 XT, Radeon RX 7700 XT
+            - `gfx1102`: Radeon PRO W7500, Radeon PRO W7600
+            - `gfx1200`: Radeon RX 9060 XT
+            - `gfx1201`: Radeon RX 9070 XT, Radeon RX 9070
+          '';
+        };
+
+        model = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          example = "/models/llama-3.1-8b-instruct-q4_k_m.gguf";
+          description = ''
+            Path to the GGUF model file.
+
+            Popular models include:
+            - Llama 3.1/3.2/3.3 (Meta)
+            - Qwen 2.5/3 (Alibaba)
+            - Mistral/Mixtral (Mistral AI)
+            - Phi-3/4 (Microsoft)
+            - Gemma 2 (Google)
+
+            Browse GGUF models at <https://huggingface.co/models?library=gguf>
+
+            Alternatively, use `hfRepo` and `hfFile` to download models
+            automatically from Hugging Face.
+          '';
+        };
+
+        modelsDir = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          example = "/models/";
+          description = "Models directory.";
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1";
+          example = "0.0.0.0";
+          description = "IP address the server listens on.";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 8080;
+          description = "Listen port for the server.";
+        };
+
+        openFirewall = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Open the firewall port for this instance.";
+        };
+
+        gpuLayers = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          example = 35;
+          description = ''
+            Number of layers to offload to GPU (--gpu-layers).
+
+            When null (default), automatically set to 99 if the package has GPU
+            support enabled (ROCm, CUDA, or Vulkan), or 0 for CPU-only packages.
+            This auto-detection is recommended for most users.
+
+            llama.cpp clamps this value to the model's actual layer count, so 99
+            effectively means "offload all layers to GPU". You can override with
+            a specific value for partial offloading when VRAM is limited.
+          '';
+        };
+
+        contextSize = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          example = 4096;
+          description = "Context size (--ctx-size).";
+        };
+
+        parallel = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          description = "Number of server slots / concurrent requests (--parallel).";
+        };
+
+        threads = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          description = "CPU threads for generation (--threads).";
+        };
+
+        threadsHttp = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          description = "Threads for HTTP request handling (--threads-http).";
+        };
+
+        batchSize = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          description = "Logical batch size for prompt processing (--batch-size).";
+        };
+
+        flashAttention = lib.mkOption {
+          type = lib.types.nullOr (
+            lib.types.enum [
+              "on"
+              "off"
+              "auto"
+            ]
+          );
+          default = null;
+          description = "Flash Attention mode (--flash-attn).";
+        };
+
+        mlock = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Lock model in RAM to prevent swap (--mlock).";
+        };
+
+        numa = lib.mkOption {
+          type = lib.types.nullOr (
+            lib.types.enum [
+              "distribute"
+              "isolate"
+              "numactl"
+            ]
+          );
+          default = null;
+          description = "NUMA optimization strategy (--numa).";
+        };
+
+        splitMode = lib.mkOption {
+          type = lib.types.nullOr (
+            lib.types.enum [
+              "none"
+              "layer"
+              "row"
+            ]
+          );
+          default = null;
+          description = "GPU split strategy (--split-mode).";
+        };
+
+        mainGpu = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          description = "Primary GPU index (--main-gpu).";
+        };
+
+        tensorSplit = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "3,1";
+          description = "GPU memory ratio for tensor splitting (--tensor-split).";
+        };
+
+        alias = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Model name in REST API responses (--alias).";
+        };
+
+        chatTemplate = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = "Override the model's chat template (--chat-template).";
+        };
+
+        timeout = lib.mkOption {
+          type = lib.types.nullOr lib.types.int;
+          default = null;
+          description = "Server read/write timeout in seconds (--timeout).";
+        };
+
+        slots = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Expose slot monitoring endpoint. Set false for --no-slots.";
+        };
+
+        embedding = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Dedicated embedding service mode (--embedding).";
+        };
+
+        enableMetrics = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Enable Prometheus-compatible metrics endpoint (--metrics).";
+        };
+
+        apiKey = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            API key for authentication. Mutually exclusive with apiKeyFile.
+
+            WARNING: This value is stored in the world-readable Nix store.
+            For production use, prefer apiKeyFile with a secrets manager.
+          '';
+        };
+
+        apiKeyFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Path to a file containing the API key. Mutually exclusive with apiKey.";
+        };
+
+        sslKeyFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "PEM-encoded SSL private key for HTTPS (--ssl-key-file).";
+        };
+
+        sslCertFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "PEM-encoded SSL certificate for HTTPS (--ssl-cert-file).";
+        };
+
+        lora = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "LoRA adapter paths. Each entry adds a --lora flag.";
+        };
+
+        logFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Log to file instead of journal (--log-file).";
+        };
+
+        logVerbosity = lib.mkOption {
+          type = lib.types.nullOr (lib.types.ints.between 0 4);
+          default = null;
+          example = 4;
+          description = ''
+            Log verbosity level (--log-verbosity). When null, logging is disabled.
+            Values: 0 = generic, 1 = info, 2 = warnings, 3 = errors, 4 = debug.
+          '';
+        };
+
+        hfRepo = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "Qwen/Qwen2.5-3B-Instruct-GGUF";
+          description = "HuggingFace model repo (--hf-repo).";
+        };
+
+        hfFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "qwen2.5-3b-instruct-q4_k_m.gguf";
+          description = "Specific file from HuggingFace repo (--hf-file).";
+        };
+
+        extraFlags = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [
+            "--rope-scaling"
+            "yarn"
+          ];
+          description = "Extra flags passed to llama-server.";
+        };
+
+        environment = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
+          default = { };
+          example = {
+            ROCR_VISIBLE_DEVICES = "0";
+          };
+          description = "Extra environment variables passed to the service.";
+        };
+      };
+    };
+
+  # Filter to only enabled instances
+  enabledInstances = lib.filterAttrs (_: inst: inst.enable) cfg.instances;
+
 in
 {
-
-  options = {
-
-    services.llama-cpp = {
-      enable = lib.mkEnableOption "LLaMA C++ server";
-
-      package = lib.mkPackageOption pkgs "llama-cpp" { };
-
-      model = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        example = "/models/mistral-instruct-7b/ggml-model-q4_0.gguf";
-        description = "Model path.";
-        default = null;
-      };
-
-      modelsDir = lib.mkOption {
-        type = lib.types.nullOr lib.types.path;
-        example = "/models/";
-        description = "Models directory.";
-        default = null;
-      };
-
-      modelsPreset = lib.mkOption {
-        type = lib.types.nullOr (lib.types.attrsOf lib.types.attrs);
-        default = null;
-        description = ''
-          Models preset configuration as a Nix attribute set.
-          This is converted to an INI file and passed to llama-server via --model-preset.
-          See llama-server documentation for available options.
-        '';
-        example = lib.literalExpression ''
-          {
-            "Qwen3-Coder-Next" = {
-              hf-repo = "unsloth/Qwen3-Coder-Next-GGUF";
-              hf-file = "Qwen3-Coder-Next-UD-Q4_K_XL.gguf";
-              alias = "unsloth/Qwen3-Coder-Next";
-              fit = "on";
-              seed = "3407";
-              temp = "1.0";
-              top-p = "0.95";
-              min-p = "0.01";
-              top-k = "40";
-              jinja = "on";
-            };
-          }
-        '';
-      };
-
-      extraFlags = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        description = "Extra flags passed to llama-cpp-server.";
-        example = [
-          "-c"
-          "4096"
-          "-ngl"
-          "32"
-          "--numa"
-          "numactl"
-        ];
-        default = [ ];
-      };
-
-      host = lib.mkOption {
-        type = lib.types.str;
-        default = "127.0.0.1";
-        example = "0.0.0.0";
-        description = "IP address the LLaMA C++ server listens on.";
-      };
-
-      port = lib.mkOption {
-        type = lib.types.port;
-        default = 8080;
-        description = "Listen port for LLaMA C++ server.";
-      };
-
-      openFirewall = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Open ports in the firewall for LLaMA C++ server.";
-      };
+  options.services.llama-cpp = {
+    instances = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule instanceModule);
+      default = { };
+      description = "Named llama-cpp server instances.";
+      example = lib.literalExpression ''
+        {
+          main = {
+            enable = true;
+            port = 8090;
+            rocmGpuTargets = [ "gfx906" ];
+            hfRepo = "Qwen/Qwen2.5-3B-Instruct-GGUF";
+            environment.ROCR_VISIBLE_DEVICES = "1";
+          };
+        }
+      '';
     };
-
   };
 
-  config = lib.mkIf cfg.enable {
-    systemd.services.llama-cpp = {
-      description = "LLaMA C++ server";
-      after = [ "network.target" ];
-      wantedBy = [ "multi-user.target" ];
+  config = lib.mkIf (enabledInstances != { }) {
+    assertions = lib.flatten (
+      lib.mapAttrsToList (name: inst: [
+        {
+          assertion = !(inst.apiKey != null && inst.apiKeyFile != null);
+          message = "services.llama-cpp.instances.${name}: apiKey and apiKeyFile are mutually exclusive.";
+        }
+        {
+          assertion = !(inst.sslKeyFile != null && inst.sslCertFile == null);
+          message = "services.llama-cpp.instances.${name}: sslKeyFile requires sslCertFile.";
+        }
+        {
+          assertion = !(inst.sslCertFile != null && inst.sslKeyFile == null);
+          message = "services.llama-cpp.instances.${name}: sslCertFile requires sslKeyFile.";
+        }
+      ]) enabledInstances
+    );
 
-      serviceConfig = {
-        Type = "idle";
-        KillSignal = "SIGINT";
-        StateDirectory = "llama-cpp";
-        CacheDirectory = "llama-cpp";
-        WorkingDirectory = "/var/lib/llama-cpp";
-        Environment = [ "LLAMA_CACHE=/var/cache/llama-cpp" ];
-        ExecStart =
-          let
-            args = [
+    systemd.services = lib.mapAttrs' (
+      name: inst:
+      let
+        instCfg = mkInstanceConfig name inst;
+        pkg = instCfg.pkg;
+        needsGpu = instCfg.needsGpu;
+        deviceRules = instCfg.deviceRules;
+        gpuGroups = instCfg.gpuGroups;
+        serviceName = "llama-cpp-${name}";
+
+        # Auto-detect gpuLayers: 99 for GPU packages, 0 for CPU-only
+        effectiveGpuLayers =
+          if inst.gpuLayers != null then
+            inst.gpuLayers
+          else if needsGpu then
+            99
+          else
+            0;
+      in
+      lib.nameValuePair serviceName {
+        description = "LLaMA C++ server (${name})";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+
+        environment = {
+          HOME = "/var/cache/${serviceName}";
+        }
+        // inst.environment;
+
+        serviceConfig = {
+          Type = "idle";
+          KillSignal = "SIGINT";
+          Restart = "on-failure";
+          RestartSec = 300;
+
+          ExecStart = utils.escapeSystemdExecArgs (
+            [ (lib.getExe' pkg "llama-server") ]
+            ++ (
+              if inst.logVerbosity != null then
+                [
+                  "--log-verbosity"
+                  (toString inst.logVerbosity)
+                ]
+              else
+                [ "--log-disable" ]
+            )
+            ++ [
               "--host"
-              cfg.host
+              inst.host
               "--port"
-              (toString cfg.port)
+              (toString inst.port)
             ]
-            ++ lib.optionals (cfg.model != null) [
-              "-m"
-              cfg.model
+            ++ lib.optionals (inst.model != null) [
+              "--model"
+              (toString inst.model)
             ]
-            ++ lib.optionals (cfg.modelsDir != null) [
+            ++ lib.optionals (inst.modelsDir != null) [
               "--models-dir"
-              cfg.modelsDir
+              (toString inst.modelsDir)
             ]
-            ++ lib.optionals (cfg.modelsPreset != null) [
-              "--models-preset"
-              modelsPresetFile
+            ++ [
+              "--gpu-layers"
+              (toString effectiveGpuLayers)
             ]
-            ++ cfg.extraFlags;
-          in
-          "${cfg.package}/bin/llama-server ${utils.escapeSystemdExecArgs args}";
-        Restart = "on-failure";
-        RestartSec = 300;
+            ++ lib.optionals (inst.contextSize != null) [
+              "--ctx-size"
+              (toString inst.contextSize)
+            ]
+            ++ lib.optionals (inst.parallel != null) [
+              "--parallel"
+              (toString inst.parallel)
+            ]
+            ++ lib.optionals (inst.threads != null) [
+              "--threads"
+              (toString inst.threads)
+            ]
+            ++ lib.optionals (inst.threadsHttp != null) [
+              "--threads-http"
+              (toString inst.threadsHttp)
+            ]
+            ++ lib.optionals (inst.batchSize != null) [
+              "--batch-size"
+              (toString inst.batchSize)
+            ]
+            ++ lib.optionals (inst.flashAttention != null) [
+              "--flash-attn"
+              inst.flashAttention
+            ]
+            ++ lib.optionals inst.mlock [ "--mlock" ]
+            ++ lib.optionals (inst.numa != null) [
+              "--numa"
+              inst.numa
+            ]
+            ++ lib.optionals (inst.splitMode != null) [
+              "--split-mode"
+              inst.splitMode
+            ]
+            ++ lib.optionals (inst.mainGpu != null) [
+              "--main-gpu"
+              (toString inst.mainGpu)
+            ]
+            ++ lib.optionals (inst.tensorSplit != null) [
+              "--tensor-split"
+              inst.tensorSplit
+            ]
+            ++ lib.optionals (inst.alias != null) [
+              "--alias"
+              inst.alias
+            ]
+            ++ lib.optionals (inst.chatTemplate != null) [
+              "--chat-template"
+              inst.chatTemplate
+            ]
+            ++ lib.optionals (inst.timeout != null) [
+              "--timeout"
+              (toString inst.timeout)
+            ]
+            ++ lib.optionals (!inst.slots) [ "--no-slots" ]
+            ++ lib.optionals inst.embedding [ "--embedding" ]
+            ++ lib.optionals inst.enableMetrics [ "--metrics" ]
+            ++ lib.optionals (inst.apiKey != null) [
+              "--api-key"
+              inst.apiKey
+            ]
+            ++ lib.optionals (inst.apiKeyFile != null) [
+              "--api-key-file"
+              (toString inst.apiKeyFile)
+            ]
+            ++ lib.optionals (inst.sslKeyFile != null) [
+              "--ssl-key-file"
+              (toString inst.sslKeyFile)
+            ]
+            ++ lib.optionals (inst.sslCertFile != null) [
+              "--ssl-cert-file"
+              (toString inst.sslCertFile)
+            ]
+            ++ lib.concatMap (l: [
+              "--lora"
+              l
+            ]) inst.lora
+            ++ lib.optionals (inst.logFile != null) [
+              "--log-file"
+              (toString inst.logFile)
+            ]
+            ++ lib.optionals (inst.hfRepo != null) [
+              "--hf-repo"
+              inst.hfRepo
+            ]
+            ++ lib.optionals (inst.hfFile != null) [
+              "--hf-file"
+              inst.hfFile
+            ]
+            ++ inst.extraFlags
+          );
 
-        # for GPU acceleration
-        PrivateDevices = false;
+          StateDirectory = serviceName;
+          CacheDirectory = serviceName;
 
-        # hardening
-        DynamicUser = true;
-        CapabilityBoundingSet = "";
-        RestrictAddressFamilies = [
-          "AF_INET"
-          "AF_INET6"
-          "AF_UNIX"
-        ];
-        NoNewPrivileges = true;
-        PrivateMounts = true;
-        PrivateTmp = true;
-        PrivateUsers = true;
-        ProtectClock = true;
-        ProtectControlGroups = true;
-        ProtectHome = true;
-        ProtectKernelLogs = true;
-        ProtectKernelModules = true;
-        ProtectKernelTunables = true;
-        ProtectSystem = "strict";
-        MemoryDenyWriteExecute = true;
-        LockPersonality = true;
-        RemoveIPC = true;
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        SystemCallArchitectures = "native";
-        SystemCallFilter = [
-          "@system-service"
-          "~@privileged"
-        ];
-        SystemCallErrorNumber = "EPERM";
-        ProtectProc = "invisible";
-        ProtectHostname = true;
-        ProcSubset = "pid";
-      };
-    };
+          # GPU requires device access. PrivateDevices=true would hide /dev entirely;
+          # instead use DevicePolicy=closed + DeviceAllow for cgroup-based filtering.
+          PrivateDevices = !needsGpu;
+        }
+        // lib.optionalAttrs needsGpu {
+          DevicePolicy = "closed";
+          DeviceAllow = lib.unique deviceRules;
+          SupplementaryGroups = lib.unique gpuGroups;
+        }
+        // {
+          DynamicUser = true;
+          UMask = "0077";
+          CapabilityBoundingSet = "";
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+          ];
+          NoNewPrivileges = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectSystem = "strict";
+          MemoryDenyWriteExecute = true;
+          LockPersonality = true;
+          RemoveIPC = true;
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
+          SystemCallArchitectures = "native";
+          SystemCallFilter =
+            if needsGpu then
+              [
+                "@system-service @resources"
+                "~@privileged"
+              ]
+            else
+              [
+                "@system-service"
+                "~@privileged"
+              ];
+          SystemCallErrorNumber = "EPERM";
+          ProtectProc = "invisible";
+          ProtectHostname = true;
+          ProcSubset = if needsGpu then "all" else "pid";
+        }
+        // lib.optionalAttrs (inst.model != null) {
+          ReadOnlyPaths = [ (toString inst.model) ];
+        };
+      }
+    ) enabledInstances;
 
-    networking.firewall = lib.mkIf cfg.openFirewall {
-      allowedTCPPorts = [ cfg.port ];
-    };
+    networking.firewall.allowedTCPPorts = lib.mapAttrsToList (_: inst: inst.port) (
+      lib.filterAttrs (_: inst: inst.openFirewall) enabledInstances
+    );
 
   };
 
-  meta.maintainers = with lib.maintainers; [ newam ];
+  meta.maintainers = with lib.maintainers; [
+    newam
+    randomizedcoder
+  ];
 }

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -1,3 +1,25 @@
+# llama-cpp NixOS module — llama.cpp inference server
+#
+# Single instance (backward-compatible):
+#
+#   services.llama-cpp = {
+#     enable = true;
+#     model = "/models/my-model.gguf";
+#     extraFlags = [ "-c" "4096" "--gpu-layers" "99" ];
+#     ...
+#   };
+#
+# Multi-instance (each instance gets its own systemd service):
+#
+#   services.llama-cpp.instances = {
+#     code   = { enable = true; port = 8090; model = "/models/code.gguf";  ... };
+#     chat   = { enable = true; port = 8091; model = "/models/chat.gguf";  ... };
+#   };
+#
+# The single-instance API maps to instances."" internally and creates
+# a service named llama-cpp.service.  Named instances create
+# llama-cpp-<name>.service.
+
 {
   config,
   lib,
@@ -371,15 +393,17 @@ let
       "pipefail"
     ];
     text = ''
-      # Instance data baked in at eval time (name:host:port:metrics:slots)
+      # Instance data baked in at eval time (displayName:serviceName:host:port:metrics:slots)
       INSTANCES=(
         ${lib.concatStringsSep "\n        " (
           lib.mapAttrsToList (
             name: inst:
             let
+              displayName = if name == "" then "default" else name;
+              svcName = "llama-cpp" + lib.optionalString (name != "") "-${name}";
               connectHost = if inst.host == "0.0.0.0" then "127.0.0.1" else inst.host;
             in
-            ''"${name}:${connectHost}:${toString inst.port}:${lib.boolToString inst.enableMetrics}:${lib.boolToString inst.slots}"''
+            ''"${displayName}:${svcName}:${connectHost}:${toString inst.port}:${lib.boolToString inst.enableMetrics}:${lib.boolToString inst.slots}"''
           ) enabledInstances
         )}
       )
@@ -407,7 +431,7 @@ let
       warn() { echo -e "  ''${YELLOW}WARN''${NC} $1"; WARN=$((WARN + 1)); }
 
       check_service() {
-        local svc="llama-cpp-$1.service"
+        local svc="$1.service"
         if systemctl is-active --quiet "$svc"; then
           pass "systemd service $svc is active"
         else
@@ -416,7 +440,8 @@ let
       }
 
       check_health() {
-        local url="http://$2:$3/health"
+        local host="$1" port="$2"
+        local url="http://''${host}:''${port}/health"
         local resp
         if resp=$(curl -sf --max-time 5 --connect-timeout 2 "$url" 2>/dev/null); then
           local status
@@ -432,8 +457,9 @@ let
       }
 
       check_metrics() {
-        if [ "$4" != "true" ]; then return; fi
-        local url="http://$2:$3/metrics"
+        local host="$1" port="$2" enabled="$3"
+        if [ "$enabled" != "true" ]; then return; fi
+        local url="http://''${host}:''${port}/metrics"
         if curl -sf --max-time 5 --connect-timeout 2 "$url" >/dev/null 2>&1; then
           pass "/metrics ($url) reachable"
         else
@@ -442,8 +468,9 @@ let
       }
 
       check_slots() {
-        if [ "$4" != "true" ]; then return; fi
-        local url="http://$2:$3/slots"
+        local host="$1" port="$2" enabled="$3"
+        if [ "$enabled" != "true" ]; then return; fi
+        local url="http://''${host}:''${port}/slots"
         if curl -sf --max-time 5 --connect-timeout 2 "$url" >/dev/null 2>&1; then
           pass "/slots ($url) reachable"
         else
@@ -452,7 +479,7 @@ let
       }
 
       check_security() {
-        local svc="llama-cpp-$1.service"
+        local svc="$1.service"
         local output
         if output=$(systemd-analyze security --no-pager "$svc" 2>/dev/null | tail -1); then
           if [ -n "$output" ]; then
@@ -466,8 +493,9 @@ let
       }
 
       check_inference() {
+        local host="$1" port="$2"
         if [ "$DO_INFERENCE" != "true" ]; then return; fi
-        local url="http://$2:$3/v1/chat/completions"
+        local url="http://''${host}:''${port}/v1/chat/completions"
         local resp
         if resp=$(curl -sf --max-time 30 --connect-timeout 2 \
           -H "Content-Type: application/json" \
@@ -489,14 +517,14 @@ let
       echo -e "Instances: ''${#INSTANCES[@]}\n"
 
       for entry in "''${INSTANCES[@]}"; do
-        IFS=: read -r name host port metrics slots <<< "$entry"
+        IFS=: read -r name svcname host port metrics slots <<< "$entry"
         echo -e "''${BOLD}[$name]''${NC} http://$host:$port"
-        check_service "$name"
-        check_health "$name" "$host" "$port"
-        check_metrics "$name" "$host" "$port" "$metrics"
-        check_slots "$name" "$host" "$port" "$slots"
-        check_security "$name"
-        check_inference "$name" "$host" "$port"
+        check_service "$svcname"
+        check_health "$host" "$port"
+        check_metrics "$host" "$port" "$metrics"
+        check_slots "$host" "$port" "$slots"
+        check_security "$svcname"
+        check_inference "$host" "$port"
         echo
       done
 
@@ -509,6 +537,44 @@ let
 
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "enable" ]
+      [ "services" "llama-cpp" "instances" "" "enable" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "package" ]
+      [ "services" "llama-cpp" "instances" "" "package" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "model" ]
+      [ "services" "llama-cpp" "instances" "" "model" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "modelsDir" ]
+      [ "services" "llama-cpp" "instances" "" "modelsDir" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "extraFlags" ]
+      [ "services" "llama-cpp" "instances" "" "extraFlags" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "host" ]
+      [ "services" "llama-cpp" "instances" "" "host" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "port" ]
+      [ "services" "llama-cpp" "instances" "" "port" ]
+    )
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "openFirewall" ]
+      [ "services" "llama-cpp" "instances" "" "openFirewall" ]
+    )
+    (lib.mkRemovedOptionModule [ "services" "llama-cpp" "modelsPreset" ]
+      "services.llama-cpp.modelsPreset has been removed. Use services.llama-cpp.instances.<name>.extraFlags with --models-preset instead."
+    )
+  ];
+
   options.services.llama-cpp = {
     instances = lib.mkOption {
       type = lib.types.attrsOf (lib.types.submodule instanceModule);
@@ -529,7 +595,21 @@ in
   };
 
   config = lib.mkIf (enabledInstances != { }) {
-    assertions = lib.flatten (
+    warnings =
+      lib.optional (enabledInstances ? "")
+        "services.llama-cpp: Single-instance configuration is supported but consider migrating to services.llama-cpp.instances for multi-instance support. See the llama-cpp NixOS module documentation for details.";
+
+    assertions = [
+      {
+        assertion =
+          let
+            endpoints = lib.mapAttrsToList (_: inst: "${inst.host}:${toString inst.port}") enabledInstances;
+          in
+          lib.length endpoints == lib.length (lib.unique endpoints);
+        message = "services.llama-cpp: multiple instances share the same host:port.";
+      }
+    ]
+    ++ lib.flatten (
       lib.mapAttrsToList (name: inst: [
         {
           assertion = !(inst.apiKey != null && inst.apiKeyFile != null);
@@ -554,7 +634,7 @@ in
         needsGpu = instCfg.needsGpu;
         deviceRules = instCfg.deviceRules;
         gpuGroups = instCfg.gpuGroups;
-        serviceName = "llama-cpp-${name}";
+        serviceName = "llama-cpp" + lib.optionalString (name != "") "-${name}";
 
         # Auto-detect gpuLayers: 99 for GPU packages, 0 for CPU-only
         effectiveGpuLayers =
@@ -581,125 +661,65 @@ in
           Restart = "on-failure";
           RestartSec = 300;
 
-          ExecStart = utils.escapeSystemdExecArgs (
-            [ (lib.getExe' pkg "llama-server") ]
-            ++ (
-              if inst.logVerbosity != null then
-                [
-                  "--log-verbosity"
-                  (toString inst.logVerbosity)
-                ]
-              else
-                [ "--log-disable" ]
-            )
-            ++ [
-              "--host"
-              inst.host
-              "--port"
-              (toString inst.port)
-            ]
-            ++ lib.optionals (inst.model != null) [
-              "--model"
-              (toString inst.model)
-            ]
-            ++ lib.optionals (inst.modelsDir != null) [
-              "--models-dir"
-              (toString inst.modelsDir)
-            ]
-            ++ [
-              "--gpu-layers"
-              (toString effectiveGpuLayers)
-            ]
-            ++ lib.optionals (inst.contextSize != null) [
-              "--ctx-size"
-              (toString inst.contextSize)
-            ]
-            ++ lib.optionals (inst.parallel != null) [
-              "--parallel"
-              (toString inst.parallel)
-            ]
-            ++ lib.optionals (inst.threads != null) [
-              "--threads"
-              (toString inst.threads)
-            ]
-            ++ lib.optionals (inst.threadsHttp != null) [
-              "--threads-http"
-              (toString inst.threadsHttp)
-            ]
-            ++ lib.optionals (inst.batchSize != null) [
-              "--batch-size"
-              (toString inst.batchSize)
-            ]
-            ++ lib.optionals (inst.flashAttention != null) [
-              "--flash-attn"
-              inst.flashAttention
-            ]
-            ++ lib.optionals inst.mlock [ "--mlock" ]
-            ++ lib.optionals (inst.numa != null) [
-              "--numa"
-              inst.numa
-            ]
-            ++ lib.optionals (inst.splitMode != null) [
-              "--split-mode"
-              inst.splitMode
-            ]
-            ++ lib.optionals (inst.mainGpu != null) [
-              "--main-gpu"
-              (toString inst.mainGpu)
-            ]
-            ++ lib.optionals (inst.tensorSplit != null) [
-              "--tensor-split"
-              inst.tensorSplit
-            ]
-            ++ lib.optionals (inst.alias != null) [
-              "--alias"
-              inst.alias
-            ]
-            ++ lib.optionals (inst.chatTemplate != null) [
-              "--chat-template"
-              inst.chatTemplate
-            ]
-            ++ lib.optionals (inst.timeout != null) [
-              "--timeout"
-              (toString inst.timeout)
-            ]
-            ++ lib.optionals (!inst.slots) [ "--no-slots" ]
-            ++ lib.optionals inst.embedding [ "--embedding" ]
-            ++ lib.optionals inst.enableMetrics [ "--metrics" ]
-            ++ lib.optionals (inst.apiKey != null) [
-              "--api-key"
-              inst.apiKey
-            ]
-            ++ lib.optionals (inst.apiKeyFile != null) [
-              "--api-key-file"
-              (toString inst.apiKeyFile)
-            ]
-            ++ lib.optionals (inst.sslKeyFile != null) [
-              "--ssl-key-file"
-              (toString inst.sslKeyFile)
-            ]
-            ++ lib.optionals (inst.sslCertFile != null) [
-              "--ssl-cert-file"
-              (toString inst.sslCertFile)
-            ]
-            ++ lib.concatMap (l: [
-              "--lora"
-              l
-            ]) inst.lora
-            ++ lib.optionals (inst.logFile != null) [
-              "--log-file"
-              (toString inst.logFile)
-            ]
-            ++ lib.optionals (inst.hfRepo != null) [
-              "--hf-repo"
-              inst.hfRepo
-            ]
-            ++ lib.optionals (inst.hfFile != null) [
-              "--hf-file"
-              inst.hfFile
-            ]
-            ++ inst.extraFlags
-          );
+          ExecStart =
+            let
+              # Build CLI flags declaratively; null values are omitted,
+              # false booleans are omitted, true booleans become bare flags,
+              # and lists repeat the flag per element.
+              flagArgs =
+                lib.cli.toCommandLine
+                  (_: {
+                    option = "--${_}";
+                    sep = null;
+                    explicitBool = false;
+                  })
+                  {
+                    host = inst.host;
+                    port = inst.port;
+                    model = inst.model;
+                    models-dir = inst.modelsDir;
+                    gpu-layers = effectiveGpuLayers;
+                    ctx-size = inst.contextSize;
+                    parallel = inst.parallel;
+                    threads = inst.threads;
+                    threads-http = inst.threadsHttp;
+                    batch-size = inst.batchSize;
+                    flash-attn = inst.flashAttention;
+                    mlock = inst.mlock;
+                    numa = inst.numa;
+                    split-mode = inst.splitMode;
+                    main-gpu = inst.mainGpu;
+                    tensor-split = inst.tensorSplit;
+                    alias = inst.alias;
+                    chat-template = inst.chatTemplate;
+                    timeout = inst.timeout;
+                    no-slots = !inst.slots;
+                    embedding = inst.embedding;
+                    metrics = inst.enableMetrics;
+                    api-key = inst.apiKey;
+                    api-key-file = inst.apiKeyFile;
+                    ssl-key-file = inst.sslKeyFile;
+                    ssl-cert-file = inst.sslCertFile;
+                    lora = inst.lora;
+                    log-file = inst.logFile;
+                    hf-repo = inst.hfRepo;
+                    hf-file = inst.hfFile;
+                  };
+            in
+            utils.escapeSystemdExecArgs (
+              [ (lib.getExe' pkg "llama-server") ]
+              ++ (
+                if inst.logVerbosity != null then
+                  [
+                    "--log-verbosity"
+                    (toString inst.logVerbosity)
+                  ]
+                else
+                  [ "--log-disable" ]
+              )
+              ++ flagArgs
+              ++ inst.extraFlags
+            );
 
           StateDirectory = serviceName;
           CacheDirectory = serviceName;

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -359,6 +359,151 @@ let
   # Filter to only enabled instances
   enabledInstances = lib.filterAttrs (_: inst: inst.enable) cfg.instances;
 
+  llama-cpp-verify = pkgs.writeShellApplication {
+    name = "llama-cpp-verify";
+    runtimeInputs = with pkgs; [
+      curl
+      jq
+      systemd
+    ];
+    bashOptions = [
+      "nounset"
+      "pipefail"
+    ];
+    text = ''
+      # Instance data baked in at eval time (name:host:port:metrics:slots)
+      INSTANCES=(
+        ${lib.concatStringsSep "\n        " (lib.mapAttrsToList (name: inst:
+          let
+            connectHost = if inst.host == "0.0.0.0" then "127.0.0.1" else inst.host;
+          in
+          ''"${name}:${connectHost}:${toString inst.port}:${lib.boolToString inst.enableMetrics}:${lib.boolToString inst.slots}"''
+        ) enabledInstances)}
+      )
+
+      RED='\033[0;31m'
+      GREEN='\033[0;32m'
+      YELLOW='\033[0;33m'
+      BOLD='\033[1m'
+      NC='\033[0m'
+
+      PASS=0
+      FAIL=0
+      WARN=0
+      DO_INFERENCE=false
+
+      for arg in "$@"; do
+        case "$arg" in
+          --inference) DO_INFERENCE=true ;;
+          *) echo "Usage: llama-cpp-verify [--inference]"; exit 1 ;;
+        esac
+      done
+
+      pass() { echo -e "  ''${GREEN}PASS''${NC} $1"; PASS=$((PASS + 1)); }
+      fail() { echo -e "  ''${RED}FAIL''${NC} $1"; FAIL=$((FAIL + 1)); }
+      warn() { echo -e "  ''${YELLOW}WARN''${NC} $1"; WARN=$((WARN + 1)); }
+
+      check_service() {
+        local svc="llama-cpp-$1.service"
+        if systemctl is-active --quiet "$svc"; then
+          pass "systemd service $svc is active"
+        else
+          fail "systemd service $svc is not active"
+        fi
+      }
+
+      check_health() {
+        local url="http://$2:$3/health"
+        local resp
+        if resp=$(curl -sf --max-time 5 --connect-timeout 2 "$url" 2>/dev/null); then
+          local status
+          status=$(echo "$resp" | jq -r '.status // empty' 2>/dev/null)
+          if [ "$status" = "ok" ]; then
+            pass "/health ($url) status=ok"
+          else
+            warn "/health ($url) responded but status='$status'"
+          fi
+        else
+          fail "/health ($url) unreachable"
+        fi
+      }
+
+      check_metrics() {
+        if [ "$4" != "true" ]; then return; fi
+        local url="http://$2:$3/metrics"
+        if curl -sf --max-time 5 --connect-timeout 2 "$url" >/dev/null 2>&1; then
+          pass "/metrics ($url) reachable"
+        else
+          fail "/metrics ($url) unreachable"
+        fi
+      }
+
+      check_slots() {
+        if [ "$4" != "true" ]; then return; fi
+        local url="http://$2:$3/slots"
+        if curl -sf --max-time 5 --connect-timeout 2 "$url" >/dev/null 2>&1; then
+          pass "/slots ($url) reachable"
+        else
+          fail "/slots ($url) unreachable"
+        fi
+      }
+
+      check_security() {
+        local svc="llama-cpp-$1.service"
+        local output
+        if output=$(systemd-analyze security --no-pager "$svc" 2>/dev/null | tail -1); then
+          if [ -n "$output" ]; then
+            pass "security: $output"
+          else
+            warn "could not read security score for $svc"
+          fi
+        else
+          warn "systemd-analyze security failed for $svc"
+        fi
+      }
+
+      check_inference() {
+        if [ "$DO_INFERENCE" != "true" ]; then return; fi
+        local url="http://$2:$3/v1/chat/completions"
+        local resp
+        if resp=$(curl -sf --max-time 30 --connect-timeout 2 \
+          -H "Content-Type: application/json" \
+          -d '{"messages":[{"role":"user","content":"Say hello in one word."}],"max_tokens":16}' \
+          "$url" 2>/dev/null); then
+          local content
+          content=$(echo "$resp" | jq -r '.choices[0].message.content // empty' 2>/dev/null)
+          if [ -n "$content" ]; then
+            pass "inference ($url): $(echo "$content" | head -c 60)"
+          else
+            fail "inference ($url): empty response"
+          fi
+        else
+          fail "inference ($url): request failed"
+        fi
+      }
+
+      echo -e "''${BOLD}llama-cpp instance verification''${NC}"
+      echo -e "Instances: ''${#INSTANCES[@]}\n"
+
+      for entry in "''${INSTANCES[@]}"; do
+        IFS=: read -r name host port metrics slots <<< "$entry"
+        echo -e "''${BOLD}[$name]''${NC} http://$host:$port"
+        check_service "$name"
+        check_health "$name" "$host" "$port"
+        check_metrics "$name" "$host" "$port" "$metrics"
+        check_slots "$name" "$host" "$port" "$slots"
+        check_security "$name"
+        check_inference "$name" "$host" "$port"
+        echo
+      done
+
+      echo -e "''${BOLD}Summary:''${NC} ''${GREEN}$PASS passed''${NC}, ''${RED}$FAIL failed''${NC}, ''${YELLOW}$WARN warnings''${NC}"
+      if [ "$FAIL" -gt 0 ]; then
+        exit 1
+      fi
+    '';
+  };
+
 in
 {
   options.services.llama-cpp = {
@@ -616,6 +761,8 @@ in
     networking.firewall.allowedTCPPorts = lib.mapAttrsToList (_: inst: inst.port) (
       lib.filterAttrs (_: inst: inst.openFirewall) enabledInstances
     );
+
+    environment.systemPackages = [ llama-cpp-verify ];
 
   };
 

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -373,12 +373,15 @@ let
     text = ''
       # Instance data baked in at eval time (name:host:port:metrics:slots)
       INSTANCES=(
-        ${lib.concatStringsSep "\n        " (lib.mapAttrsToList (name: inst:
-          let
-            connectHost = if inst.host == "0.0.0.0" then "127.0.0.1" else inst.host;
-          in
-          ''"${name}:${connectHost}:${toString inst.port}:${lib.boolToString inst.enableMetrics}:${lib.boolToString inst.slots}"''
-        ) enabledInstances)}
+        ${lib.concatStringsSep "\n        " (
+          lib.mapAttrsToList (
+            name: inst:
+            let
+              connectHost = if inst.host == "0.0.0.0" then "127.0.0.1" else inst.host;
+            in
+            ''"${name}:${connectHost}:${toString inst.port}:${lib.boolToString inst.enableMetrics}:${lib.boolToString inst.slots}"''
+          ) enabledInstances
+        )}
       )
 
       RED='\033[0;31m'

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -134,6 +134,27 @@ let
           description = "Models directory.";
         };
 
+        modelsPreset = lib.mkOption {
+          type = lib.types.nullOr (lib.types.attrsOf lib.types.attrs);
+          default = null;
+          description = ''
+            Models preset configuration as a Nix attribute set.
+            This is converted to an INI file and passed to llama-server via --models-preset.
+            See llama-server documentation for available options.
+          '';
+          example = lib.literalExpression ''
+            {
+              "Qwen3-Coder-Next" = {
+                hf-repo = "unsloth/Qwen3-Coder-Next-GGUF";
+                hf-file = "Qwen3-Coder-Next-UD-Q4_K_XL.gguf";
+                alias = "unsloth/Qwen3-Coder-Next";
+                fit = "on";
+                jinja = "on";
+              };
+            }
+          '';
+        };
+
         host = lib.mkOption {
           type = lib.types.str;
           default = "127.0.0.1";
@@ -570,8 +591,9 @@ in
       [ "services" "llama-cpp" "openFirewall" ]
       [ "services" "llama-cpp" "instances" "" "openFirewall" ]
     )
-    (lib.mkRemovedOptionModule [ "services" "llama-cpp" "modelsPreset" ]
-      "services.llama-cpp.modelsPreset has been removed. Use services.llama-cpp.instances.<name>.extraFlags with --models-preset instead."
+    (lib.mkRenamedOptionModule
+      [ "services" "llama-cpp" "modelsPreset" ]
+      [ "services" "llama-cpp" "instances" "" "modelsPreset" ]
     )
   ];
 
@@ -705,6 +727,10 @@ in
                     hf-repo = inst.hfRepo;
                     hf-file = inst.hfFile;
                   };
+              modelsPresetArgs = lib.optionals (inst.modelsPreset != null) [
+                "--models-preset"
+                (pkgs.writeText "llama-models-${name}.ini" (lib.generators.toINI { } inst.modelsPreset))
+              ];
             in
             utils.escapeSystemdExecArgs (
               [ (lib.getExe' pkg "llama-server") ]
@@ -718,6 +744,7 @@ in
                   [ "--log-disable" ]
               )
               ++ flagArgs
+              ++ modelsPresetArgs
               ++ inst.extraFlags
             );
 

--- a/nixos/modules/services/misc/llama-cpp.nix
+++ b/nixos/modules/services/misc/llama-cpp.nix
@@ -9,11 +9,23 @@
 #     ...
 #   };
 #
-# Multi-instance (each instance gets its own systemd service):
+# Multiple models on the same GPU architecture — use modelsPreset:
+#
+#   services.llama-cpp = {
+#     enable = true;
+#     modelsPreset = {
+#       "code"  = { hf-repo = "..."; device = "cuda0"; ... };
+#       "chat"  = { hf-repo = "..."; device = "cuda1"; ... };
+#     };
+#   };
+#
+# Multiple GPU architectures (e.g. AMD + NVIDIA in the same machine)
+# — use multi-instance (each gets its own package build and systemd
+# service):
 #
 #   services.llama-cpp.instances = {
-#     code   = { enable = true; port = 8090; model = "/models/code.gguf";  ... };
-#     chat   = { enable = true; port = 8091; model = "/models/chat.gguf";  ... };
+#     rocm = { enable = true; port = 8090; package = pkgs.llama-cpp-rocm; rocmGpuTargets = [ "gfx906" ]; ... };
+#     cuda = { enable = true; port = 8091; package = pkgs.llama-cpp.override { cudaSupport = true; };   ... };
 #   };
 #
 # The single-instance API maps to instances."" internally and creates
@@ -140,7 +152,16 @@ let
           description = ''
             Models preset configuration as a Nix attribute set.
             This is converted to an INI file and passed to llama-server via --models-preset.
-            See llama-server documentation for available options.
+            The server runs in router mode, spawning a child process per model.
+
+            Each key maps to a CLI flag for the child process. Use `device` to
+            assign a model to a specific GPU (e.g. `cuda0`, `cuda1`, `rocm0`).
+            This is the recommended way to serve multiple models on GPUs of the
+            same architecture. For GPUs with different architectures (requiring
+            different package builds), use multi-instance via
+            `services.llama-cpp.instances` instead.
+
+            See llama-server documentation for available preset options.
           '';
           example = lib.literalExpression ''
             {
@@ -148,6 +169,7 @@ let
                 hf-repo = "unsloth/Qwen3-Coder-Next-GGUF";
                 hf-file = "Qwen3-Coder-Next-UD-Q4_K_XL.gguf";
                 alias = "unsloth/Qwen3-Coder-Next";
+                device = "cuda0";
                 fit = "on";
                 jinja = "on";
               };
@@ -601,15 +623,29 @@ in
     instances = lib.mkOption {
       type = lib.types.attrsOf (lib.types.submodule instanceModule);
       default = { };
-      description = "Named llama-cpp server instances.";
+      description = ''
+        Named llama-cpp server instances.  Each instance gets its own
+        systemd service and can use a different package build, which is
+        needed when targeting GPUs with different architectures (e.g.
+        gfx906 + gfx1102) via `rocmGpuTargets`.
+
+        For multiple models on GPUs of the same architecture, prefer
+        `modelsPreset` with the `device` property instead.
+      '';
       example = lib.literalExpression ''
         {
-          main = {
+          rocm = {
             enable = true;
             port = 8090;
+            package = pkgs.llama-cpp-rocm;
             rocmGpuTargets = [ "gfx906" ];
             hfRepo = "Qwen/Qwen2.5-3B-Instruct-GGUF";
-            environment.ROCR_VISIBLE_DEVICES = "1";
+          };
+          cuda = {
+            enable = true;
+            port = 8091;
+            package = pkgs.llama-cpp.override { cudaSupport = true; };
+            hfRepo = "Qwen/Qwen2.5-3B-Instruct-GGUF";
           };
         }
       '';

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -888,6 +888,7 @@ in
   livebook-service = runTest ./livebook-service.nix;
   livekit = runTest ./networking/livekit.nix;
   lk-jwt-service = runTest ./matrix/lk-jwt-service.nix;
+  llama-cpp = runTest ./llama-cpp.nix;
   llama-swap = runTest ./web-servers/llama-swap.nix;
   lldap = runTest ./lldap.nix;
   local-content-share = runTest ./local-content-share.nix;

--- a/nixos/tests/llama-cpp.nix
+++ b/nixos/tests/llama-cpp.nix
@@ -1,0 +1,67 @@
+{ lib, pkgs, ... }:
+{
+  name = "llama-cpp";
+  meta.maintainers = with lib.maintainers; [ newam ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.llama-cpp ];
+
+      services.llama-cpp = {
+        enable = true;
+        # Model path does not need to exist — we're testing module
+        # evaluation and service unit configuration, not inference.
+        model = "/nonexistent.gguf";
+        gpuLayers = 33;
+        contextSize = 2048;
+        parallel = 4;
+        threads = 8;
+        batchSize = 512;
+        flashAttention = "auto";
+        mlock = true;
+        embedding = true;
+        enableMetrics = true;
+        alias = "test-model";
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    machine.succeed("llama-server --help")
+
+    unit = machine.succeed("systemctl cat llama-cpp.service")
+    print(f"Service unit:\n{unit}")
+
+    for directive in [
+        "DynamicUser=true",
+        "NoNewPrivileges=true",
+        "ProtectSystem=strict",
+        "CapabilityBoundingSet=",
+        "StateDirectory=llama-cpp",
+        "CacheDirectory=llama-cpp",
+    ]:
+        assert directive in unit, f"Missing {directive} in service unit"
+
+    assert "PrivateDevices=true" in unit, \
+        "CPU-only build should have PrivateDevices=true"
+
+    assert "DeviceAllow" not in unit, \
+        "CPU-only build should not have DeviceAllow rules"
+
+    for flag in [
+        "--metrics",
+        "--ctx-size",
+        "--gpu-layers",
+        "--parallel",
+        "--threads",
+        "--batch-size",
+        "--flash-attn",
+        "--mlock",
+        "--embedding",
+        "--alias",
+    ]:
+        assert flag in unit, f"Typed option {flag} not reflected in ExecStart"
+  '';
+}

--- a/nixos/tests/llama-cpp.nix
+++ b/nixos/tests/llama-cpp.nix
@@ -3,6 +3,22 @@
   name = "llama-cpp";
   meta.maintainers = with lib.maintainers; [ newam ];
 
+  nodes.legacy =
+    { pkgs, ... }:
+    {
+      environment.systemPackages = [ pkgs.llama-cpp ];
+
+      # Legacy single-instance API (backward-compatible with master branch)
+      services.llama-cpp = {
+        enable = true;
+        model = "/nonexistent.gguf";
+        extraFlags = [
+          "-c"
+          "2048"
+        ];
+      };
+    };
+
   nodes.machine =
     { pkgs, ... }:
     {
@@ -27,6 +43,44 @@
     };
 
   testScript = ''
+    # --- Legacy single-instance API ---
+    legacy.wait_for_unit("multi-user.target")
+
+    legacy.succeed("llama-server --help")
+
+    legacy_unit = legacy.succeed("systemctl cat llama-cpp.service")
+    print(f"Legacy service unit:\n{legacy_unit}")
+
+    # Service must be named llama-cpp (no suffix, not llama-cpp-)
+    legacy.succeed("systemctl cat llama-cpp.service")
+
+    for directive in [
+        "DynamicUser=true",
+        "NoNewPrivileges=true",
+        "ProtectSystem=strict",
+        "CapabilityBoundingSet=",
+        "StateDirectory=llama-cpp",
+        "CacheDirectory=llama-cpp",
+    ]:
+        assert directive in legacy_unit, f"Missing {directive} in legacy service unit"
+
+    # StateDirectory must not have a trailing dash
+    assert "StateDirectory=llama-cpp-" not in legacy_unit, \
+        "Legacy service should not have trailing dash in StateDirectory"
+
+    assert "PrivateDevices=true" in legacy_unit, \
+        "CPU-only build should have PrivateDevices=true"
+
+    # extraFlags should be reflected in ExecStart
+    assert "-c" in legacy_unit, "extraFlags -c not in ExecStart"
+
+    # Verify llama-cpp-verify is installed
+    legacy.succeed("command -v llama-cpp-verify")
+    legacy_verify = legacy.succeed("cat $(command -v llama-cpp-verify)")
+    assert "default:" in legacy_verify or "llama-cpp:" in legacy_verify, \
+        "verify script should contain legacy instance data"
+
+    # --- Multi-instance API ---
     machine.wait_for_unit("multi-user.target")
 
     machine.succeed("llama-server --help")

--- a/nixos/tests/llama-cpp.nix
+++ b/nixos/tests/llama-cpp.nix
@@ -8,7 +8,7 @@
     {
       environment.systemPackages = [ pkgs.llama-cpp ];
 
-      services.llama-cpp = {
+      services.llama-cpp.instances.test = {
         enable = true;
         # Model path does not need to exist — we're testing module
         # evaluation and service unit configuration, not inference.
@@ -31,7 +31,7 @@
 
     machine.succeed("llama-server --help")
 
-    unit = machine.succeed("systemctl cat llama-cpp.service")
+    unit = machine.succeed("systemctl cat llama-cpp-test.service")
     print(f"Service unit:\n{unit}")
 
     for directive in [
@@ -39,8 +39,8 @@
         "NoNewPrivileges=true",
         "ProtectSystem=strict",
         "CapabilityBoundingSet=",
-        "StateDirectory=llama-cpp",
-        "CacheDirectory=llama-cpp",
+        "StateDirectory=llama-cpp-test",
+        "CacheDirectory=llama-cpp-test",
     ]:
         assert directive in unit, f"Missing {directive} in service unit"
 
@@ -63,5 +63,11 @@
         "--alias",
     ]:
         assert flag in unit, f"Typed option {flag} not reflected in ExecStart"
+
+    # Verify llama-cpp-verify is installed and config-aware
+    machine.succeed("command -v llama-cpp-verify")
+    verify_script = machine.succeed("cat $(command -v llama-cpp-verify)")
+    assert "test:" in verify_script, \
+        "verify script should contain instance name 'test'"
   '';
 }

--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -195,6 +195,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   doCheck = false;
 
   passthru = {
+    inherit rocmSupport cudaSupport vulkanSupport;
     tests = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
       metal = llama-cpp.override { metalSupport = true; };
     };

--- a/pkgs/by-name/ll/llama-cpp/package.nix
+++ b/pkgs/by-name/ll/llama-cpp/package.nix
@@ -78,7 +78,7 @@ let
 in
 effectiveStdenv.mkDerivation (finalAttrs: {
   pname = "llama-cpp";
-  version = "8548";
+  version = "8779";
 
   outputs = [
     "out"
@@ -89,7 +89,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     owner = "ggml-org";
     repo = "llama.cpp";
     tag = "b${finalAttrs.version}";
-    hash = "sha256-DBsTZBkngCnPbSZzs9zqWgIN1+tn8xTJ8EkNYg3xaLE=";
+    hash = "sha256-7WfDXHxluitoFn2YX5d5xiXGEKOLMmSB8h7i41lSMVU=";
     leaveDotGit = true;
     postFetch = ''
       git -C "$out" rev-parse --short HEAD > $out/COMMIT
@@ -100,7 +100,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
   patches = [ ];
 
   postPatch = ''
-    rm tools/server/public/index.html.gz
+    rm -f tools/server/public/index.html.gz
   '';
 
   nativeBuildInputs = [
@@ -125,7 +125,7 @@ effectiveStdenv.mkDerivation (finalAttrs: {
     ++ [ openssl ];
 
   npmRoot = "tools/server/webui";
-  npmDepsHash = "sha256-DxgUDVr+kwtW55C4b89Pl+j3u2ILmACcQOvOBjKWAKQ=";
+  npmDepsHash = "sha256-RAFtsbBGBjteCt5yXhrmHL39rIDJMCFBETgzId2eRRk=";
   npmDeps = fetchNpmDeps {
     name = "${finalAttrs.pname}-${finalAttrs.version}-npm-deps";
     inherit (finalAttrs) src patches;


### PR DESCRIPTION
# nixos/llama-cpp: add multi-instance support

## Summary

Refactor the llama-cpp NixOS module to support multiple named instances, each with independent configuration. This allows running multiple llama-cpp servers simultaneously with different models, ports, and GPU configurations. e.g. GPUs with different amount of VRAM, running different models.

Also bumped llama-cpp package from b7898 to b7951 and add NixOS VM tests (cpu based only obviously).

### Key changes

- Replace single-service model with `services.llama-cpp.instances.<name>`
- Add per-instance `rocmGpuTargets` option for AMD GPU architecture targeting
- Add automatic `gpuLayers` detection based on package GPU support (99 for GPU packages, 0 for CPU-only)
- Add `hfRepo` and `hfFile` options for Hugging Face model downloads
- Add GPU-backend-aware DeviceAllow rules (ROCm, CUDA, Vulkan)
- Add typed options: `flashAttention`, `contextSize`, `parallel`, `slots`, etc.
- Add `environment` option for per-instance environment variables
- Add NixOS VM tests for module evaluation and service configuration

### Motivation

This pull request has taken me a few days to put together and test.  The original intention was to get my MI50 working, but then I found it was hard to run with both graphics cards (other card is a baby). 

Therefore, I've added support for multi instances.  e.g. Run one bigger model on a bigger 32GB card, and a little model on the baby 8GB card.

This will be a "breaking change", so I would understand if people aren't so keen.  The change to config should be small, but if you guys would prefer to make a different service with "-multi" or similar, I'd be happy to do that.  Happy to discuss the best way forward.

Testing this took a long time, because the compiling takes so long, and I tighten the systemd security, which also took time to get correct.  This is about as well tested as I can do with the hardware I have.  Would be nice to test on machines with fancy/expensive GPUs (that I don't have ).  I have tested on AMD and Nvidia, but all these cards are pretty old.

Another thing I notice is that our nixpkgs nix is pretty out of sync with the llama.cpp repo itself.  I will try to create a pull request for llama.cpp to see if we can more closely align them. ( But it's cool to see the Meta team using nix! woot woot ;) )

Anyway - I'm very excited to be able to run models locally, and so hopefully this pull request helps!

### Security hardening

All settings verified working with GPU workloads:

- DynamicUser, PrivateUsers, PrivateTmp, ProtectSystem=strict
- DevicePolicy=closed with GPU-specific DeviceAllow rules
- MemoryDenyWriteExecute, SystemCallFilter, RestrictNamespaces
- UMask=0077, ProtectHome, ProtectKernelTunables
- Security score: **1.4 OK** (systemd-analyze security)

This was tested for the cards listed below, and took quite some time to get correct.

### Example configuration

```nix
services.llama-cpp.instances = {
  # Large model on MI50 (32GB VRAM)
  mi50 = {
    enable = true;
    rocmGpuTargets = [ "gfx906" ];
    port = 8090;
    contextSize = 32768;
    flashAttention = "on";
    enableMetrics = true;
    hfRepo = "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF";
    environment.ROCR_VISIBLE_DEVICES = "1";
  };

  # Small model on W7500 (8GB VRAM)
  w7500 = {
    enable = true;
    rocmGpuTargets = [ "gfx1102" ];
    port = 8091;
    contextSize = 8192;
    flashAttention = "on";
    enableMetrics = true;
    hfRepo = "Qwen/Qwen2.5-3B-Instruct-GGUF";
    hfFile = "qwen2.5-3b-instruct-q4_k_m.gguf";
    environment.ROCR_VISIBLE_DEVICES = "0";
  };
};
```

---

## Testing performed (x86_64-linux)

### Hardware tested

| Machine | GPU | Architecture | VRAM | Backend |
|---------|-----|--------------|------|---------|
| l | AMD MI50 | gfx906 | 32GB | ROCm |
| l | AMD Radeon Pro W7500 | gfx1102 | 8GB | ROCm |
| l2 | NVIDIA RTX 3070 | sm_86 | 8GB | CUDA |

### Test results

| Test | Configuration | Result | Notes |
|------|---------------|--------|-------|
| **Single-instance (ROCm)** | MI50 + W7500, both cards | ✅ PASS | Single instance using both AMD GPUs |
| **Single-instance (CUDA)** | RTX 3070 | ✅ PASS | Single instance, full GPU offload |
| Single GPU (ROCm) | MI50 only, Qwen3-30B | ✅ PASS | Full GPU offload, ~88 tok/s |
| Single GPU (ROCm) | W7500 only, Qwen2.5-3B | ✅ PASS | Full GPU offload, ~62 tok/s |
| Single GPU (CUDA) | RTX 3070, Qwen2.5-3B | ✅ PASS | Full GPU offload, ~150 tok/s |
| Multi-instance (ROCm) | MI50 + W7500 separate instances | ✅ PASS | Separate ports, GPU isolation |
| Mixed architectures | gfx906 + gfx1102 | ✅ PASS | Via ROCR_VISIBLE_DEVICES |
| Security hardening | All settings | ✅ PASS | Score: 1.4 OK |
| Auto gpuLayers | GPU/CPU detection | ✅ PASS | 99 for GPU, 0 for CPU |
| Model caching | CacheDirectory | ✅ PASS | Persists across restarts |

### Systemd security verification

All hardening settings tested and verified compatible with both ROCm and CUDA:

| Setting | Value | GPU Impact | Result |
|---------|-------|------------|--------|
| DynamicUser | true | None | ✅ PASS |
| PrivateDevices | false (GPU) / true (CPU) | Required false for GPU | ✅ PASS |
| DevicePolicy | closed | None | ✅ PASS |
| DeviceAllow | char-drm, char-kfd (ROCm) / char-nvidia* (CUDA) | Required for GPU | ✅ PASS |
| SupplementaryGroups | video, render | Required for GPU access | ✅ PASS |
| MemoryDenyWriteExecute | true | None | ✅ PASS |
| PrivateUsers | true | None | ✅ PASS |
| ProtectSystem | strict | None | ✅ PASS |
| SystemCallFilter | @system-service @resources ~@privileged | @resources needed for GPU | ✅ PASS |
| ProcSubset | all (GPU) / pid (CPU) | Required all for GPU | ✅ PASS |

### Performance results

**AMD W7500 (gfx1102) - Qwen2.5-3B-Instruct:**
```
Prompt processing: 308.8 tokens/sec
Generation: 62.5 tokens/sec
```

**AMD MI50 (gfx906) - Qwen3-Coder-30B:**
```
Prompt processing: ~50 tokens/sec
Generation: ~88 tokens/sec
```

**NVIDIA RTX 3070 - Qwen2.5-3B-Instruct:**
```
Prompt processing: 743 tokens/sec
Generation: 150 tokens/sec
```

---

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

## Breaking changes

This is a **breaking change** for existing users. The single-instance configuration:

```nix
# Old (no longer works)
services.llama-cpp = {
  enable = true;
  model = "/path/to/model.gguf";
};
```

Must be migrated to:

```nix
# New
services.llama-cpp.instances.default = {
  enable = true;
  model = "/path/to/model.gguf";
};
```

Or use the new Hugging Face download feature:

```nix
services.llama-cpp.instances.default = {
  enable = true;
  hfRepo = "Qwen/Qwen2.5-3B-Instruct-GGUF";
  hfFile = "qwen2.5-3b-instruct-q4_k_m.gguf";
};
```
