### PR TITLE
walker: 0.13.26 -> 2.14.1

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -94,6 +94,12 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `services.desktopManager.gnome` no longer installs the Geary e-mail client since it is not part of the GNOME [core applications](https://apps.gnome.org/) list. Geary's position in the default favorite apps section has been replaced by GNOME Text Editor. To keep it installed, add `programs.geary.enable = true;` to your configuration.
 
+- `walker` has been updated to 2.0.0+, which is a complete rewrite in rust.
+
+  It now requires a running `elephant` application launcher backend service, which can be enabled using the new `services.elephpant.enable`.
+
+  The way keybinds and actions are handled have been completely revamped. Please refer to the [default config](https://raw.githubusercontent.com/abenz1267/walker/refs/heads/master/resources/config.toml).
+
 - Support for `reiserfs` in nixpkgs has been removed, following the removal in Linux 6.13.
 
 - `services.tor` no longer bind mounts Unix sockets of onion services into its chroot

--- a/pkgs/by-name/wa/walker/package.nix
+++ b/pkgs/by-name/wa/walker/package.nix
@@ -1,52 +1,71 @@
 {
   lib,
-  buildGoModule,
   fetchFromGitHub,
   pkg-config,
-  vips,
+  protobuf,
+  glib,
   gobject-introspection,
-  wrapGAppsHook4,
+  gst_all_1,
   gtk4,
   gtk4-layer-shell,
+  gdk-pixbuf,
+  graphene,
+  cairo,
+  pango,
+  wrapGAppsHook4,
+  poppler,
   nix-update-script,
-  libqalculate,
+  rustPlatform,
 }:
 
-buildGoModule (finalAttrs: {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "walker";
-  version = "0.13.26";
+  version = "2.14.1";
 
   src = fetchFromGitHub {
     owner = "abenz1267";
     repo = "walker";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-LslpfHXj31Lvq+26ZDzCTaGBbxmp7yXlgKT+uwUEEts=";
+    hash = "sha256-ccwJ1ADGNFd5LDF2JWdfP7+f1Hs2EvJ+2o6sUOdYi7w=";
   };
 
-  vendorHash = "sha256-N7lNxO/l3E1BlSSbSiQjrDPy2sWwk4G4JYlUArmMJxs=";
-  subPackages = [ "cmd/walker.go" ];
-
-  passthru.updateScript = nix-update-script { };
+  cargoHash = "sha256-2amur4gkjtYV+CyArBCbMVy9p+2MLl2afQ/diR/4GDo=";
 
   nativeBuildInputs = [
-    pkg-config
     gobject-introspection
+    pkg-config
+    protobuf
     wrapGAppsHook4
   ];
 
   buildInputs = [
+    glib
     gtk4
-    vips
     gtk4-layer-shell
-    libqalculate
-  ];
+    gdk-pixbuf
+    graphene
+    cairo
+    pango
+    poppler
+  ]
+  ++ (with gst_all_1; [
+    gstreamer
+    gst-plugins-base
+    gst-plugins-good
+    gst-libav
+  ]);
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Wayland-native application runner";
     homepage = "https://github.com/abenz1267/walker";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ donovanglover ];
+    maintainers = with lib.maintainers; [
+      donovanglover
+      saadndm
+    ];
     mainProgram = "walker";
   };
 })


### PR DESCRIPTION
Updates the [walker](https://github.com/abenz1267/walker) package to the latest stable release. The project has been rewritten in rust and now relies on a running [elephant](https://github.com/abenz1267/elephant) service implemented in https://github.com/NixOS/nixpkgs/pull/483810, which can be enabled using `services.elephant.enable`.

Also added myself as a maintainer of this package.

I chose not to create a new module for walker, since it already exists in home-manager (although it is currently outdated).

Closes https://github.com/NixOS/nixpkgs/issues/448779
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @adamcstephens 