### PR TITLE
diffoscope: add tools, use dexdump from androidenv

### DIFF
--- a/pkgs/by-name/de/dexdump/package.nix
+++ b/pkgs/by-name/de/dexdump/package.nix
@@ -1,0 +1,22 @@
+{
+  androidenv,
+  stdenv,
+}:
+let
+  buildTools = builtins.head androidenv.androidPkgs.build-tools;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dexdump";
+  version = buildTools.version;
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    ln -s ${buildTools}/libexec/android-sdk/build-tools/${finalAttrs.version}/dexdump \
+    $out/bin/dexdump
+  '';
+
+  meta = {
+    inherit (buildTools.meta) license platforms;
+    description = "Dexdump from Android SDK build-tools";
+  };
+})

--- a/pkgs/by-name/de/dexdump/package.nix
+++ b/pkgs/by-name/de/dexdump/package.nix
@@ -1,22 +1,39 @@
 {
-  androidenv,
   stdenv,
+  fetchurl,
+  unzip,
+  patchelf,
+  lib,
 }:
-let
-  buildTools = builtins.head androidenv.androidPkgs.build-tools;
-in
+
 stdenv.mkDerivation (finalAttrs: {
   pname = "dexdump";
-  version = buildTools.version;
+  version = "36.1";
 
-  buildCommand = ''
+  src = fetchurl {
+    url = "https://dl.google.com/android/repository/build-tools_r${finalAttrs.version}_linux.zip";
+    hash = "sha256-p7WInkp5/POwl2vvQNQB9CQPse7YkdnZEWnaERHhHXg=";
+  };
+
+  nativeBuildInputs = [
+    unzip
+    patchelf
+  ];
+
+  installPhase = ''
     mkdir -p $out/bin
-    ln -s ${buildTools}/libexec/android-sdk/build-tools/${finalAttrs.version}/dexdump \
-    $out/bin/dexdump
+    cp dexdump $out/bin/
+
+    # Patch ELF interpreter and RPATH so the binary runs on NixOS
+    patchelf \
+      --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
+      --set-rpath ${stdenv.cc.cc.lib}/lib \
+      $out/bin/dexdump
   '';
 
   meta = {
-    inherit (buildTools.meta) license platforms;
     description = "Dexdump from Android SDK build-tools";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -7,15 +7,18 @@
   apksigcopier,
   apksigner,
   apktool,
+  asar,
   binutils-unwrapped-all-targets,
   bzip2,
   cbfstool,
+  cctools,
   cdrkit,
   colord,
   colordiff,
   coreutils,
   cpio,
   db,
+  dexdump,
   diffutils,
   docutils,
   dtc,
@@ -54,6 +57,7 @@
   oggvideotools,
   openssh,
   openssl,
+  p7zip,
   pdftk,
   perl,
   pgpdump,
@@ -143,11 +147,6 @@ python.pkgs.buildPythonApplication rec {
   # To help figuring out what's missing from the list, run: ./pkgs/tools/misc/diffoscope/list-missing-tools.sh
   #
   # Still missing these tools:
-  # Android-specific tools:
-  # dexdump
-  # Darwin-specific tools:
-  # lipo
-  # otool
   # Other tools:
   # docx2txt <- makes tests broken:
   # > FAILED tests/comparators/test_docx.py::test_diff - IndexError: list index out of range
@@ -163,6 +162,7 @@ python.pkgs.buildPythonApplication rec {
   pythonPath = lib.filter (lib.meta.availableOn stdenv.hostPlatform) (
     [
       acl
+      asar
       binutils-unwrapped-all-targets
       bzip2
       cdrkit
@@ -185,6 +185,7 @@ python.pkgs.buildPythonApplication rec {
       lz4
       lzip
       openssl
+      p7zip
       pgpdump
       sng
       sqlite
@@ -216,6 +217,7 @@ python.pkgs.buildPythonApplication rec {
         apksigner
         cbfstool
         colord
+        dexdump
         enjarify
         ffmpeg
         fpc
@@ -224,7 +226,7 @@ python.pkgs.buildPythonApplication rec {
         giflib
         gnumeric
         gnupg
-        hdf5
+        hdf5.bin
         imagemagick
         jdk8
         libcaca
@@ -263,6 +265,9 @@ python.pkgs.buildPythonApplication rec {
         aapt
         apktool
       ]
+      # Add lipo and otool
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [ cctools ]
+
     )
   );
 
@@ -323,7 +328,7 @@ python.pkgs.buildPythonApplication rec {
 
       # Expect the text in format of "Latest release: 198 (31 Dec 2021)"'.
       newVersion="$(curl -s https://diffoscope.org/ | pcregrep -o1 'Latest release: ([0-9]+)')"
-      update-source-version ${pname} "$newVersion"
+      update-source-version diffoscope "$newVersion"
     '';
   };
 


### PR DESCRIPTION
This pull request updates the `diffoscope` package and its dependencies, primarily to support new tools and improve platform compatibility. The most significant change is upgrading `diffoscope` to version 312, alongside the addition of new dependencies such as `dexdump`, `asar`, `p7zip`, and platform-specific tools for Darwin. Below are the most important changes grouped by theme:

**Package version update:**

* Upgraded `diffoscope` from version 309 to 312, updating the source hash accordingly.

**Dependency additions:**

* Added `dexdump` as a new dependency and included its package definition in `pkgs/by-name/de/dexdump/package.nix`.

* Added `asar` and `p7zip` to the dependency lists to enhance archive handling capabilities.

**Platform compatibility improvements:**

* Added `cctools` (which provides `lipo` and `otool`) as a dependency for Darwin platforms to improve macOS support. 

**Other dependency adjustments:**

* Changed the `hdf5` dependency to `hdf5.bin` to ensure the correct binary package is used.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
