### PR TITLE
ci/github-script/lint-commits: fix development branch check

### DIFF
--- a/ci/github-script/lint-commits.js
+++ b/ci/github-script/lint-commits.js
@@ -32,10 +32,12 @@ async function checkCommitMessages({ github, context, core }) {
 
   if (
     baseBranchType.includes('development') &&
-    headBranchType.includes('development')
+    headBranchType.includes('development') &&
+    pr.base.repo.id === pr.head.repo?.id
   ) {
-    // This matches, for example, PRs from staging-next to master, or vice versa.
+    // This matches, for example, PRs from NixOS:staging-next to NixOS:master, or vice versa.
     // Ignore them: we should only care about PRs introducing *new* commits.
+    // We still want to run on PRs from, e.g., Someone:master to NixOS:master, though.
     core.info(
       'This PR is from one development branch to another. Skipping checks.',
     )


### PR DESCRIPTION
#487628 should have had this job fail, but [didn't](https://github.com/NixOS/nixpkgs/actions/runs/21753302803/job/62756645701?pr=487628#step:3:18), because the head branch was named `master`.

## Things done


- [x] Tested locally (dry) with PRs 487628 and 487701.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
