### PR TITLE
python3Package.py3nvml: fix, refactor, modernize

### DIFF
--- a/pkgs/development/python-modules/py3nvml/default.nix
+++ b/pkgs/development/python-modules/py3nvml/default.nix
@@ -1,32 +1,44 @@
 {
   lib,
+  addDriverRunpath,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
+  setuptools,
   xmltodict,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "py3nvml";
   version = "0.2.7";
-  format = "setuptools";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Ce4dBFmKbmZOJEZfgEzjv+EZpv21Ni3xwWj4qpKfvXM=";
+  src = fetchFromGitHub {
+    owner = "fbcotter";
+    repo = "py3nvml";
+    tag = finalAttrs.version;
+    hash = "sha256-NZHpjUFeByhe290R9QWZHsVEtwScP5I3LXRh9OQIUgQ=";
   };
 
-  propagatedBuildInputs = [ xmltodict ];
+  postPatch = ''
+    substituteInPlace py3nvml/py3nvml.py \
+      --replace-fail "libnvidia-ml.so.1" "${addDriverRunpath.driverLink}/lib/libnvidia-ml-so.1"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ xmltodict ];
 
   pythonImportsCheck = [ "py3nvml" ];
 
   meta = {
+    changelog = "https://github.com/fbcotter/py3nvml/releases/tag/${finalAttrs.src.tag}";
     description = "Python 3 Bindings for the NVIDIA Management Library";
     mainProgram = "py3smi";
-    homepage = "https://pypi.org/project/py3nvml/";
+    homepage = "https://github.com/fbcotter/py3nvml";
     license = with lib.licenses; [
       bsd3
       bsd2
     ];
     maintainers = with lib.maintainers; [ happysalada ];
   };
-}
+})


### PR DESCRIPTION
Modernizes the package and patches the CDLL lookup to look into our
driverLink library path to find libnvidia-ml.so.1.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
