### PR TITLE
arrow-cpp: disable broken test on x86_64-darwin

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -304,6 +304,10 @@ stdenv.mkDerivation (finalAttrs: {
         # Failing with "run-test.sh: line 88: 63682 Abort trap: 6"
         "arrow-flight-internals-test"
         "arrow-flight-sql-test"
+      ]
+      ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+        # https://github.com/apache/arrow/issues/41505
+        "TestAzuriteGeneric.Empty"
       ];
     in
     ''


### PR DESCRIPTION
A single test is failing on x86_64-darwin: `TestAzuriteGeneric.Empty`. This broke on an earlier release of `azurite` (https://github.com/apache/arrow/issues/41505) and the `arrow-cpp` team fixed it by pinning `azurite`. I suspect that our newer `azurite` either re-introduced the bug, or wasn't fully tested by the arrow team.

P.S. `azurite` is an Azure Cloud mock only used in testing, and all the other tests are passing.   

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
