### PR TITLE
openmvs: 2.2.0 -> 2.4.0

### DIFF
--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -8,13 +8,16 @@
   fetchFromGitHub,
   glfw,
   gmp,
+  libjxl,
   libjpeg,
   libpng,
   libtiff,
   mpfr,
+  nanoflann,
   opencv,
   openmp,
   pkg-config,
+  python3Packages,
   stdenv,
   vcg,
   zstd,
@@ -26,19 +29,22 @@ let
   });
 in
 stdenv.mkDerivation rec {
-  version = "2.2.0";
+  version = "2.4.0";
   pname = "openmvs";
 
   src = fetchFromGitHub {
     owner = "cdcseacave";
     repo = "openmvs";
     rev = "v${version}";
-    hash = "sha256-j/tGkR73skZiU+bP4j6aZ5CxkbIcHtqKcaUTgNvj0C8=";
+    hash = "sha256-0tL2tqHYBQMGL9k+NqTUxieWuDP3YB6X9DcXYnlGWWg=";
     fetchSubmodules = true;
   };
 
   # SSE is enabled by default
-  cmakeFlags = lib.optional (!stdenv.hostPlatform.isx86_64) "-DOpenMVS_USE_SSE=OFF";
+  cmakeFlags = [
+    (lib.cmakeFeature "Python3_EXECUTABLE" (lib.getExe python3Packages.python))
+  ]
+  ++ lib.optional (!stdenv.hostPlatform.isx86_64) "-DOpenMVS_USE_SSE=OFF";
 
   buildInputs = [
     boostWithZstd
@@ -47,10 +53,12 @@ stdenv.mkDerivation rec {
     eigen
     glfw
     gmp
+    libjxl
     libjpeg
     libpng
     libtiff
     mpfr
+    nanoflann
     opencv
     openmp
     vcg
@@ -59,6 +67,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
+    python3Packages.python
   ];
 
   postInstall = ''
@@ -68,6 +77,16 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    ${lib.optionalString (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) ''
+      export KMP_AFFINITY=disabled
+      export OMP_PROC_BIND=false
+    ''}
+    ctest --output-on-failure
+    runHook postCheck
+  '';
 
   meta = {
     description = "Open Multi-View Stereo reconstruction library";

--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -46,6 +46,12 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional (!stdenv.hostPlatform.isx86_64) "-DOpenMVS_USE_SSE=OFF";
 
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      'FIND_PACKAGE(Boost REQUIRED COMPONENTS iostreams program_options system serialization OPTIONAL_COMPONENTS ''${Boost_EXTRA_COMPONENTS})' \
+      'FIND_PACKAGE(Boost REQUIRED COMPONENTS iostreams program_options serialization OPTIONAL_COMPONENTS ''${Boost_EXTRA_COMPONENTS})'
+  '';
+
   buildInputs = [
     boostWithZstd
     ceres-solver

--- a/pkgs/applications/science/misc/openmvs/default.nix
+++ b/pkgs/applications/science/misc/openmvs/default.nix
@@ -93,6 +93,9 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/cdcseacave/openMVS";
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ bouk ];
+    maintainers = with lib.maintainers; [
+      bouk
+      miniharinn
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Release: https://github.com/cdcseacave/openMVS/releases/tag/v2.4.0
Diff: https://github.com/cdcseacave/openMVS/compare/v2.2.0...v2.4.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
