### PR TITLE
universal-android-debloater: add missing dbus dependency

### DIFF
--- a/pkgs/by-name/un/universal-android-debloater/package.nix
+++ b/pkgs/by-name/un/universal-android-debloater/package.nix
@@ -1,6 +1,7 @@
 {
   android-tools,
   clang,
+  dbus,
   expat,
   fetchFromGitHub,
   fontconfig,
@@ -56,6 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapProgram $out/bin/uad-ng --prefix LD_LIBRARY_PATH : ${
       lib.makeLibraryPath (
         [
+          dbus
           fontconfig
           freetype
           libglvnd


### PR DESCRIPTION
Fixes the runtime error "Can't connect to a portal: libdbus-1.so not found" when trying to use a file picker

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
