### PR TITLE
python3Packages.dateparser: 1.2.2 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/dateparser/default.nix
+++ b/pkgs/development/python-modules/dateparser/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   setuptools,
   python-dateutil,
   pytz,
@@ -11,6 +10,7 @@
   hijridate,
   convertdate,
   fasttext,
+  numpy,
   langdetect,
   parameterized,
   pytestCheckHook,
@@ -22,7 +22,7 @@
 
 buildPythonPackage rec {
   pname = "dateparser";
-  version = "1.2.2";
+  version = "1.3.0";
 
   pyproject = true;
 
@@ -30,25 +30,12 @@ buildPythonPackage rec {
     owner = "scrapinghub";
     repo = "dateparser";
     tag = "v${version}";
-    hash = "sha256-cUbY6c0JFzs1oZJOTnMXz3uCah2f50g8/3uWQXtwiGY=";
+    hash = "sha256-X15zNHlF34+8Lmo6Ia3HyKOdfgsu76KbcJUxzHax0EE=";
   };
 
-  patches = [
-    (fetchpatch {
-      # https://github.com/scrapinghub/dateparser/pull/1294
-      url = "https://github.com/scrapinghub/dateparser/commit/6b23348b9367d43bebc9a40b00dda3363eb2acd5.patch";
-      hash = "sha256-LriRbGdYxF51Nwrm7Dp4kivyMikzmhytNQo0txMGsVI=";
-    })
-    (fetchpatch {
-      url = "https://github.com/scrapinghub/dateparser/commit/cbe29797c463c7939234df2923af310ed10aeb4f.patch";
-      includes = [ "dateparser_scripts/write_complete_data.py" ];
-      hash = "sha256-mDHDZlWU2G/NU2W+dxSRb6rRb/bp2PoTbgz8wXhaNCo=";
-    })
-  ];
+  build-system = [ setuptools ];
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     python-dateutil
     pytz
     regex
@@ -60,7 +47,10 @@ buildPythonPackage rec {
       hijridate
       convertdate
     ];
-    fasttext = [ fasttext ];
+    fasttext = [
+      fasttext
+      numpy
+    ];
     langdetect = [ langdetect ];
   };
 
@@ -85,10 +75,6 @@ buildPythonPackage rec {
     # access network
     "test_custom_language_detect_fast_text_0"
     "test_custom_language_detect_fast_text_1"
-
-    # breaks with latest tzdata: https://github.com/scrapinghub/dateparser/issues/1237
-    # FIXME: look into this more
-    "test_relative_base"
   ];
 
   pythonImportsCheck = [ "dateparser" ];


### PR DESCRIPTION
Diff: https://github.com/scrapinghub/dateparser/compare/v1.2.2...v1.3.0

Changelog: https://github.com/scrapinghub/dateparser/blob/v1.3.0/HISTORY.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
