### PR TITLE
invidious: 2.20250913.0 -> 2.20260207.0

### DIFF
--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -48,11 +48,12 @@ crystal.buildCrystalPackage rec {
       branchTemplate = ''{{ "#{`git branch | sed -n '/* /s///p'`.strip}" }}'';
       commitTemplate = ''{{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit`.strip}" }}'';
       versionTemplate = ''{{ "#{`git log -1 --format=%ci | awk '{print $1}' | sed s/-/./g`.strip}" }}'';
+      tagTemplate = ''{{ "#{`git tag --points-at HEAD`.strip}" }}'';
       # This always uses the latest commit which invalidates the cache even if
       # the assets were not changed
       assetCommitTemplate = ''{{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit -- assets`.strip}" }}'';
 
-      inherit (versions.invidious) commit date;
+      inherit (versions.invidious) commit date version;
     in
     ''
       for d in ${videojs}/*; do ln -s "$d" assets/videojs; done
@@ -63,6 +64,7 @@ crystal.buildCrystalPackage rec {
           --replace-fail ${lib.escapeShellArg branchTemplate} '"master"' \
           --replace-fail ${lib.escapeShellArg commitTemplate} '"${commit}"' \
           --replace-fail ${lib.escapeShellArg versionTemplate} '"${date}"' \
+          --replace-fail ${lib.escapeShellArg tagTemplate} '"v${version}"' \
           --replace-fail ${lib.escapeShellArg assetCommitTemplate} '"${commit}"'
 
       # Patch the assets and locales paths to be absolute

--- a/pkgs/by-name/in/invidious/update.sh
+++ b/pkgs/by-name/in/invidious/update.sh
@@ -51,7 +51,7 @@ json_set '.invidious.date' "$date"
 json_set '.invidious.commit' "$commit"
 json_set '.invidious.version' "$new_version"
 
-new_hash=$(nix-prefetch -I 'nixpkgs=../../../..' "$pkg")
+new_hash=$(nix-prefetch -I 'nixpkgs=../../..' "$pkg")
 json_set '.invidious.hash' "$new_hash"
 
 # fetch video.js dependencies

--- a/pkgs/by-name/in/invidious/versions.json
+++ b/pkgs/by-name/in/invidious/versions.json
@@ -1,9 +1,9 @@
 {
   "invidious": {
-    "hash": "sha256-tVytYxFcHnGhI5mdZhZk9NBp++8q9PGdYbl8H6j7dAE=",
-    "version": "2.20250913.0",
-    "date": "2025.09.13",
-    "commit": "cf019e3b"
+    "hash": "sha256-tACx4+HqouftDalZlrurS75gYvS02qnmxQoL91YfTjg=",
+    "version": "2.20260207.0",
+    "date": "2026.02.07",
+    "commit": "118d6356"
   },
   "videojs": {
     "hash": "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4="


### PR DESCRIPTION
https://github.com/iv-org/invidious/releases/tag/v2.20260207.0

Fixes various problems, like restoring the ability to view channels.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
