### PR TITLE
haskellPackages.Gifcurry: 3.0.0.1 -> 6.0.1.0, unbroken

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -14,7 +14,7 @@
 self: super:
 
 let
-  inherit (pkgs) fetchpatch lib;
+  inherit (pkgs) fetchpatch lib callPackage;
   inherit (lib) throwIfNot versionOlder;
 
   warnAfterVersion =
@@ -3009,6 +3009,8 @@ with haskellLib;
     ''
     + (drv.postPatch or "");
   }) super.pdftotext;
+
+  Gifcurry = callPackage ./gifcurry { };
 
   # QuickCheck <2.15
   # https://github.com/google/proto-lens/issues/403

--- a/pkgs/development/haskell-modules/gifcurry/default.nix
+++ b/pkgs/development/haskell-modules/gifcurry/default.nix
@@ -1,0 +1,119 @@
+{
+  lib,
+  applyPatches,
+  fetchFromGitHub,
+  fetchurl,
+  haskell,
+  haskellPackages,
+  makeBinaryWrapper,
+  wrapGAppsHook3,
+  gsettings-desktop-schemas,
+  gtk3,
+  gdk-pixbuf,
+  gst_all_1,
+  ffmpeg,
+  imagemagick,
+}:
+
+let
+  version = "6.0.1.0";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "lettier";
+      repo = "gifcurry";
+      tag = version;
+      hash = "sha256-3xYGWIXLXxsjTgpEGObYG7z+WGFL2W+vUkGcBaGEEUE=";
+    };
+    patches = [
+      (fetchurl {
+        url = "https://github.com/nicholasmullikin/gifcurry/commit/621326558911f21cdb6fee6c787c17845d2d3a89.patch";
+        hash = "sha256-NkaSEwSKcBKPoWGmsVUIKJS3RPDKpk0X7z7iaHo8RLE=";
+      })
+      ./gifcurry-gtk3-deps.patch
+      ./gifcurry-data-text-qualify.patch
+      ./gifcurry-gui-misc-text-qualify.patch
+      ./gifcurry-gui-main-text-qualify.patch
+      ./gifcurry-use-magick.patch
+    ];
+  };
+
+  gstPluginsGood = gst_all_1.gst-plugins-good.override {
+    gtkSupport = true;
+  };
+
+  base = haskellPackages.callCabal2nix "gifcurry" src { };
+in
+haskell.lib.doJailbreak (
+  base.overrideAttrs (old: {
+    inherit src version;
+
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+      makeBinaryWrapper
+      wrapGAppsHook3
+    ];
+    buildInputs = (old.buildInputs or [ ]) ++ [
+      gtk3
+      gdk-pixbuf
+      gsettings-desktop-schemas
+      gst_all_1.gstreamer
+      gst_all_1.gst-plugins-base
+      gstPluginsGood
+      gst_all_1.gst-plugins-bad
+      gst_all_1.gst-plugins-ugly
+      gst_all_1.gst-libav
+    ];
+
+    gappsWrapperArgs = (old.gappsWrapperArgs or [ ]) ++ [
+      "--prefix"
+      "PATH"
+      ":"
+      "${lib.makeBinPath [
+        ffmpeg
+        imagemagick
+        gst_all_1.gstreamer
+      ]}"
+    ];
+
+    postFixup = (old.postFixup or "") + ''
+      gstPluginPath="${
+        lib.makeSearchPath "lib/gstreamer-1.0" [
+          gst_all_1.gst-plugins-base
+          gstPluginsGood
+          gst_all_1.gst-plugins-bad
+          gst_all_1.gst-plugins-ugly
+          gst_all_1.gst-libav
+        ]
+      }"
+      for exe in $out/bin/gifcurry_gui $out/bin/gifcurry_cli; do
+        if [ -e "$exe" ]; then
+          wrapProgram "$exe" --prefix PATH : "${
+            lib.makeBinPath [
+              ffmpeg
+              imagemagick
+              gst_all_1.gstreamer
+            ]
+          }" \
+          --prefix GST_PLUGIN_PATH : "$gstPluginPath" \
+          --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$gstPluginPath"
+        fi
+      done
+    '';
+
+    postInstall = (old.postInstall or "") + ''
+      install -Dm644 packaging/linux/common/com.lettier.gifcurry.desktop \
+        $out/share/applications/com.lettier.gifcurry.desktop
+      install -Dm644 packaging/linux/common/com.lettier.gifcurry.svg \
+        $out/share/icons/hicolor/scalable/apps/com.lettier.gifcurry.svg
+      install -Dm644 packaging/linux/common/com.lettier.gifcurry.appdata.xml \
+        $out/share/metainfo/com.lettier.gifcurry.appdata.xml
+    '';
+
+    meta = with lib; {
+      description = "Haskell-built video editor for GIF makers (GUI and CLI)";
+      homepage = "https://github.com/lettier/gifcurry";
+      license = licenses.bsd3;
+      mainProgram = "gifcurry_gui";
+      platforms = platforms.linux ++ platforms.darwin;
+    };
+  })
+)

--- a/pkgs/development/haskell-modules/gifcurry/gifcurry-data-text-qualify.patch
+++ b/pkgs/development/haskell-modules/gifcurry/gifcurry-data-text-qualify.patch
@@ -1,0 +1,14 @@
+diff --git a/src/lib/Gifcurry.hs b/src/lib/Gifcurry.hs
+index 0a5adb9..f862007 100644
+--- a/src/lib/Gifcurry.hs
++++ b/src/lib/Gifcurry.hs
+@@ -46,7 +46,8 @@ import Text.Printf
+ import Data.List (sortBy)
+ import Data.Maybe
+ import Data.Char
+-import Data.Text
++import Data.Text (Text, pack, unpack, strip)
++import qualified Data.Text as Data.Text
+ import Data.Either
+ import Data.Yaml
+ import qualified Data.ByteString.Char8 as DBC

--- a/pkgs/development/haskell-modules/gifcurry/gifcurry-gtk3-deps.patch
+++ b/pkgs/development/haskell-modules/gifcurry/gifcurry-gtk3-deps.patch
@@ -1,0 +1,14 @@
+--- a/Gifcurry.cabal
++++ b/Gifcurry.cabal
+@@ -149,9 +149,9 @@
+                       , gi-gio >= 2.0 && < 3.0
+                       , gi-glib >= 2.0 && < 3.0
+                       , gi-pango >= 1.0 && < 2.0
+-                      , gi-gdk >= 3.0 && < 4.0
++                      , gi-gdk3 >= 3.0 && < 4.0
+                       , gi-gdkpixbuf >= 2.0 && < 3.0
+-                      , gi-gtk >= 3.0 && < 4.0
++                      , gi-gtk3 >= 3.0 && < 4.0
+                       , gi-cairo >= 1.0 && < 2.0
+                       , gi-gstbase >= 1.0 && < 2.0
+                       , gi-gst >= 1.0 && < 2.0

--- a/pkgs/development/haskell-modules/gifcurry/gifcurry-gui-main-text-qualify.patch
+++ b/pkgs/development/haskell-modules/gifcurry/gifcurry-gui-main-text-qualify.patch
@@ -1,0 +1,12 @@
+--- a/src/gui/Main.hs
++++ b/src/gui/Main.hs
+@@ -17,7 +17,8 @@
+ import Text.Printf
+ import Data.Maybe
+ import Data.Either
+-import Data.Text
++import Data.Text (Text, pack)
++import qualified Data.Text as Data.Text
+ import Data.List
+ import Data.IORef
+ import Data.Int

--- a/pkgs/development/haskell-modules/gifcurry/gifcurry-gui-misc-text-qualify.patch
+++ b/pkgs/development/haskell-modules/gifcurry/gifcurry-gui-misc-text-qualify.patch
@@ -1,0 +1,12 @@
+--- a/src/gui/GuiMisc.hs
++++ b/src/gui/GuiMisc.hs
+@@ -21,7 +21,8 @@
+ import Data.Word
+ import Data.Maybe
+ import Data.Char
+-import Data.Text
++import Data.Text (Text)
++import qualified Data.Text as Data.Text
+ import Data.Time
+ import Data.List
+ import Data.GI.Base.Overloading

--- a/pkgs/development/haskell-modules/gifcurry/gifcurry-use-magick.patch
+++ b/pkgs/development/haskell-modules/gifcurry/gifcurry-use-magick.patch
@@ -1,0 +1,62 @@
+diff --git a/src/gui/GuiCapabilities.hs b/src/gui/GuiCapabilities.hs
+index 925daf5..49deb6d 100644
+--- a/src/gui/GuiCapabilities.hs
++++ b/src/gui/GuiCapabilities.hs
+@@ -63,7 +63,7 @@ checkCapabilitiesAndNotify
+         setLabelStyle "gifcurry-label-error"
+       (_:_:False:_) -> do
+         setImageToFile "data/error-icon.svg"
+-        setLabelText "ImageMagick convert not found. Cannot create GIFs."
++        setLabelText "ImageMagick magick not found. Cannot create GIFs."
+         setLabelStyle "gifcurry-label-error"
+       (_:_:_:False:_) -> do
+         setImageToFile "data/error-icon.svg"
+@@ -171,7 +171,7 @@ hasFfprobeWithVersion =
+ 
+ hasConvertWithVersion :: IO (Bool, Maybe (Int, Int, Int))
+ hasConvertWithVersion =
+-  hasProcessWithVersionNumber "convert" ["-version"]
++  hasProcessWithVersionNumber "magick" ["-version"]
+ 
+ hasIdentifyWithVersion :: IO (Bool, Maybe (Int, Int, Int))
+ hasIdentifyWithVersion =
+diff --git a/src/lib/Gifcurry.hs b/src/lib/Gifcurry.hs
+index 0a5adb9..f784aa8 100644
+--- a/src/lib/Gifcurry.hs
++++ b/src/lib/Gifcurry.hs
+@@ -1380,7 +1380,7 @@ annotateImage
+             , "sRGB"
+             ]
+         ++  [filePath]
+-  result <- tryProcess "convert" params
++  result <- tryProcess "magick" params
+   if isLeft result
+     then return result
+     else return $ Right $ "Annotated " ++ filePath
+@@ -1491,7 +1491,7 @@ mergeFramesIntoGif
+             , outputFile'
+             ]
+   printInfo $ "Saving your GIF to: " ++ outputFile'
+-  result <- tryProcess "convert" params
++  result <- tryProcess "magick" params
+   if isLeft result
+     then return result
+     else return $ Right outputFile'
+@@ -1513,7 +1513,7 @@ mergeFramesIntoVideo
+     printInfo "Converting the frames to the specified color count."
+     result' <-
+       tryProcess
+-        "convert"
++        "magick"
+         (   [ "-quiet"
+             , tempDir ++ [pathSeparator] ++ "extracted-frames_*." ++ frameFileExtension
+             ]
+@@ -1661,7 +1661,7 @@ getSansFontFamily fontFamilies
+ getFontFamilies
+   ::  IO [Text]
+ getFontFamilies = do
+-  (_, stdout', _) <- readProcessWithExitCode "convert" ["-list", "font"] []
++  (_, stdout', _) <- readProcessWithExitCode "magick" ["-list", "font"] []
+   let fontFamilies =
+         Prelude.map
+           (Data.Text.strip . Data.Text.drop 7 . Data.Text.strip)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
