### PR TITLE
[Backport release-25.11] python3Packages.slip10: 1.0.1 -> 1.1.0

### DIFF
--- a/pkgs/development/python-modules/slip10/default.nix
+++ b/pkgs/development/python-modules/slip10/default.nix
@@ -10,12 +10,12 @@
 
 buildPythonPackage rec {
   pname = "slip10";
-  version = "1.0.1";
-  format = "pyproject";
+  version = "1.1.0";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-ArNQrlV7WReRQosXVR+V16xX6SEfN969yBTJC0oSOlQ=";
+    hash = "sha256-0kjT3ybxI/CEdDOcRfDyZCVPdK6aVlcjSh1euR8MTVQ=";
   };
 
   build-system = [ poetry-core ];
@@ -23,7 +23,6 @@ buildPythonPackage rec {
   propagatedBuildInputs = [
     base58
     cryptography
-    ecdsa
   ];
 
   pythonImportsCheck = [ "slip10" ];

--- a/pkgs/development/python-modules/slip10/default.nix
+++ b/pkgs/development/python-modules/slip10/default.nix
@@ -5,7 +5,6 @@
   poetry-core,
   base58,
   cryptography,
-  ecdsa,
 }:
 
 buildPythonPackage rec {


### PR DESCRIPTION
backport of https://github.com/NixOS/nixpkgs/pull/488248

(cherry picked from commit 830dc0473859e3336cc57d9fb8597f977f0db621)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
