### PR TITLE
compiler-rt: enable build of libatomic

### DIFF
--- a/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
+++ b/pkgs/development/compilers/llvm/common/compiler-rt/default.nix
@@ -21,6 +21,23 @@
   # are, so long as it provides some builtins.
   doFakeLibgcc ? stdenv.hostPlatform.isFreeBSD,
 
+  # Whether to build the set of __atomic_* routines that would typically
+  # be provided by libatomic in gcc environments.
+  withAtomics ?
+    stdenv.hostPlatform.useLLVM
+    && ((stdenv.cc.libc != null) || !stdenv.hostPlatform.hasSharedLibraries),
+  # If withAtomics is enabled, setting this to true ships those routines
+  # in a separate DSO (aliased as libatomic to match gcc's) rather than
+  # making them part of builtins.a. Unless no dynamic linking is used at
+  # all, this is the correct setup as it ensures the locks are unique in
+  # memory.
+  withAtomicsLib ? stdenv.hostPlatform.hasSharedLibraries,
+  # If withAtomics is enabled, this selects the pthreads-based
+  # implementation of the routines instead of the implementation
+  # using ad-hoc mutexes (which doesn't depend on libc at all).
+  # Use of pthreads helps code play better with sanitizers.
+  withAtomicsPthread ? lib.versionAtLeast release_version "19" && stdenv.cc.libc != null,
+
   # In recent releases, the compiler-rt build seems to produce
   # many `libclang_rt*` libraries, but not a single unified
   # `libcompiler_rt` library, at least under certain configurations. Some
@@ -190,6 +207,11 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optional (stdenv.hostPlatform.isAarch64 && !haveLibc)
       # Fixes https://github.com/NixOS/nixpkgs/issues/393603
       (lib.cmakeBool "COMPILER_RT_DISABLE_AARCH64_FMV" true)
+  ++ lib.optionals withAtomics [
+    (lib.cmakeBool "COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN" (!withAtomicsLib))
+    (lib.cmakeBool "COMPILER_RT_BUILD_STANDALONE_LIBATOMIC" withAtomicsLib)
+    (lib.cmakeBool "COMPILER_RT_LIBATOMIC_USE_PTHREAD" withAtomicsPthread)
+  ]
   ++ devExtraCmakeFlags;
 
   outputs = [
@@ -262,6 +284,11 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString forceLinkCompilerRt ''
       ln -s $out/lib/*/libclang_rt.builtins-*.a $out/lib/libcompiler_rt.a
+    ''
+    + lib.optionalString (withAtomics && withAtomicsLib) ''
+      ln -s $out/lib/*/libclang_rt.atomic-*.so $out/lib/libatomic.so
+      # create a link with the original soname as well, so it's found at runtime
+      ln -s $out/lib/*/libclang_rt.atomic-*.so $out/lib/
     '';
 
   meta = llvm_meta // {


### PR DESCRIPTION
continuation of https://github.com/NixOS/nixpkgs/pull/398520.

Additional changes:
- Simplified the conditional logic around LLVM versions, as most of the old versions are no longer included in nixpkgs.

Credit goes to @mildsunrise.

Fixes: https://github.com/NixOS/nixpkgs/issues/311930

Tested with
```
nix-build -E '
let
  pkgs = import ./. {
    crossSystem = {
      system = builtins.currentSystem;
      useLLVM = true;
    };
  };
in
  pkgs.llvmPackages.compiler-rt
'
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
