### PR TITLE
talm: init at 0.22.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13917,6 +13917,11 @@
     githubId = 148352;
     name = "Jim Fowler";
   };
+  kitsunoff = {
+    github = "kitsunoff";
+    githubId = 58953114;
+    name = "Maxim Belyy";
+  };
   Kitt3120 = {
     email = "nixpkgs@schweren.dev";
     github = "Kitt3120";

--- a/pkgs/by-name/ta/talm/package.nix
+++ b/pkgs/by-name/ta/talm/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "talm";
+  version = "0.22.1";
+
+  src = fetchFromGitHub {
+    owner = "cozystack";
+    repo = "talm";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-I3rSpFCNMoA5tAp3WVLM6Ae7Vo8m+9px9fg7Fgw0/oA=";
+  };
+
+  vendorHash = "sha256-jDp1WVETDbCtSq+v0BrIiTqoR2cnmI7JXdy5ydnt5wA=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # go.mod requires 1.25.6 but nixpkgs has 1.25.5
+  preBuild = ''
+    substituteInPlace go.mod --replace-fail "go 1.25.6" "go 1.25.5"
+  '';
+
+  ldflags = [
+    "-s"
+    "-X main.Version=v${finalAttrs.version}"
+  ];
+
+  # Skip DNS test that fails in sandbox
+  checkFlags = [ "-skip=^TestRenderWithDNS$" ];
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd talm \
+      --bash <($out/bin/talm completion bash) \
+      --fish <($out/bin/talm completion fish) \
+      --zsh <($out/bin/talm completion zsh)
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Manage Talos Linux the GitOps way";
+    homepage = "https://github.com/cozystack/talm";
+    changelog = "https://github.com/cozystack/talm/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ kitsunoff ];
+    mainProgram = "talm";
+  };
+})


### PR DESCRIPTION
## Description

Add talm, a tool for managing Talos Linux clusters via GitOps approach.

This package includes shell completions for bash, fish, and zsh, which work correctly starting from version 0.22.1 thanks to a fix that skips config loading for completion subcommands.

I'm using talm to manage Talos Linux infrastructure and would like to help maintain this package.

## Package Information

- **Homepage**: https://github.com/cozystack/talm
- **Description**: Manage Talos Linux the GitOps way
- **License**: Apache-2.0
- **Version**: 0.22.1

## Changes

- Initialize talm package at version 0.22.1
- Added shell completions for bash, fish, and zsh
- Added \`passthru.updateScript\` using \`nix-update-script\` for automatic updates
- Added kitsunoff as maintainer

## Changelog

https://github.com/cozystack/talm/releases/tag/v0.22.1

## Things done

- Built on platform:
  - [x] x86_64-darwin
  - [ ] aarch64-linux
  - [ ] x86_64-linux
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at \`passthru.tests\`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran \`nixpkgs-review\` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in \`./result/bin/\`.
  - [x] Verified shell completions are installed correctly in \`./result/share/\`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test