### PR TITLE
jetbrains.idea,phpstorm,pycharm,rider,ruby-mine,webstorm: fix buildInputs on darwin

### DIFF
--- a/pkgs/applications/editors/jetbrains/ides/idea.nix
+++ b/pkgs/applications/editors/jetbrains/ides/idea.nix
@@ -55,7 +55,7 @@ mkJetBrainsProduct {
     ''--set M2 "${maven}/maven/bin"''
   ];
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     lldb
     musl
   ];

--- a/pkgs/applications/editors/jetbrains/ides/phpstorm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/phpstorm.nix
@@ -45,7 +45,7 @@ mkJetBrainsProduct {
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     musl
   ];
 

--- a/pkgs/applications/editors/jetbrains/ides/pycharm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/pycharm.nix
@@ -46,7 +46,7 @@ in
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     musl
   ];
 

--- a/pkgs/applications/editors/jetbrains/ides/rider.nix
+++ b/pkgs/applications/editors/jetbrains/ides/rider.nix
@@ -57,20 +57,21 @@ in
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));
 
-  buildInputs = [
-    openssl
-    libxcrypt
-    lttng-ust_2_12
-    musl
-  ]
-  ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libxcb-keysyms
-  ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch) [
-    expat
-    libxml2
-    xz
-  ];
+  # TODO: Some of these dependencies should probably also be added on Darwin - however it seems that JetBrains bundles them all? Unclear.
+  #       Somebody with a Darwin machine should investigate this.
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      openssl
+      libxcrypt
+      lttng-ust_2_12
+      musl
+      libxcb-keysyms
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch) [
+      expat
+      libxml2
+      xz
+    ];
   extraLdPath = lib.optionals (stdenv.hostPlatform.isLinux) [
     # Avalonia dependencies needed for dotMemory
     libice

--- a/pkgs/applications/editors/jetbrains/ides/ruby-mine.nix
+++ b/pkgs/applications/editors/jetbrains/ides/ruby-mine.nix
@@ -45,7 +45,7 @@ mkJetBrainsProduct {
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     musl
   ];
 

--- a/pkgs/applications/editors/jetbrains/ides/webstorm.nix
+++ b/pkgs/applications/editors/jetbrains/ides/webstorm.nix
@@ -45,7 +45,7 @@ mkJetBrainsProduct {
 
   src = fetchurl (urls.${system} or (throw "Unsupported system: ${system}"));
 
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     musl
   ];
 


### PR DESCRIPTION
Caused by a regression through #478575, see https://github.com/NixOS/nixpkgs/pull/478575#issuecomment-3866445161

Should fix #488169 - all packages should be detected as added by CI? Or at least as rebuilds on Darwin?

**I can not test this.**

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
