### PR TITLE
maintainers/haskell: record pnames, not attr names to transitive broken

### DIFF
--- a/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
+++ b/maintainers/scripts/haskell/regenerate-transitive-broken-packages.sh
@@ -20,6 +20,6 @@ cat > $tmpfile << EOF
 dont-distribute-packages:
 EOF
 
-nix-instantiate --eval --option restrict-eval true -I . --strict --json maintainers/scripts/haskell/transitive-broken-packages.nix | jq -r . | LC_ALL=C.UTF-8 sort --ignore-case >> $tmpfile
+nix-instantiate --show-trace --eval --option restrict-eval true -I . --strict --json maintainers/scripts/haskell/transitive-broken-packages.nix | jq -r . | LC_ALL=C.UTF-8 sort --ignore-case >> $tmpfile
 
 mv $tmpfile $config_file

--- a/maintainers/scripts/haskell/transitive-broken-packages.nix
+++ b/maintainers/scripts/haskell/transitive-broken-packages.nix
@@ -1,11 +1,16 @@
 let
   nixpkgs = import ../../..;
   inherit (nixpkgs { }) pkgs lib;
+  isVersioned = attr: builtins.match "[A-Za-z0-9-]+(_[0-9]+)+" attr != null;
   getEvaluating =
     x:
-    builtins.attrNames (
+    lib.mapAttrsToList (_: v: v.pname) (
       lib.filterAttrs (
-        _: v: (builtins.tryEval (v.outPath or null)).success && lib.isDerivation v && !v.meta.broken
+        n: v:
+        !(isVersioned n)
+        && (builtins.tryEval (v.outPath or null)).success
+        && lib.isDerivation v
+        && !v.meta.broken
       ) x
     );
   brokenDeps = lib.subtractLists (getEvaluating pkgs.haskellPackages) (

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -4,6 +4,7 @@
 # depend on a dependency marked as broken.
 dont-distribute-packages:
 
+ - 4Blocks
  - a50
  - abcBridge
  - AbortT-monadstf
@@ -600,7 +601,6 @@ dont-distribute-packages:
  - cprng-aes
  - cprng-aes-effect
  - cql-io-tinylog
- - cql_4_1_0_0
  - cqrs-example
  - cqrs-memory
  - cqrs-postgresql
@@ -765,7 +765,6 @@ dont-distribute-packages:
  - distribution-plot
  - dixi
  - dl-fedora
- - dl-fedora_2_2
  - dmenu-pkill
  - dmenu-pmount
  - dmenu-search
@@ -945,7 +944,6 @@ dont-distribute-packages:
  - fay-uri
  - fay-websockets
  - fbrnch
- - fbrnch_1_8
  - fcd
  - FComp
  - feature-flipper-postgres
@@ -1775,7 +1773,6 @@ dont-distribute-packages:
  - hylotab
  - hyloutils
  - hyperbole
- - hyperbole_0_6_0
  - hyperpublic
  - ide-backend
  - ide-backend-server
@@ -2592,7 +2589,6 @@ dont-distribute-packages:
  - persistent-hssqlppp
  - persistent-iproute
  - persistent-map
- - persistent-postgresql_2_14_3_0
  - persistent-protobuf
  - persona-idp
  - peyotls
@@ -3031,7 +3027,6 @@ dont-distribute-packages:
  - sandwich-contexts-kubernetes
  - sandwich-contexts-minio
  - sandwich-webdriver
- - sandwich-webdriver_0_4_0_2
  - sarsi
  - sasl
  - sat-micro-hs
@@ -3203,7 +3198,6 @@ dont-distribute-packages:
  - SimpleLog
  - SimpleServer
  - simseq
- - singletons-base_3_5_1
  - singletons-presburger
  - siphon
  - siren-json
@@ -3741,7 +3735,6 @@ dont-distribute-packages:
  - WebCont
  - webcrank-wai
  - webdriver-w3c
- - webdriver_0_14_0_0
  - webify
  - webserver
  - websnap
@@ -3906,4 +3899,3 @@ dont-distribute-packages:
  - zoovisitor
  - zuramaru
  - zwirn
- - _4Blocks


### PR DESCRIPTION
The attribute names in haskellPackages no longer match the Hackage package names in all cases (which hackage2nix uses to match its config files against packages), but the pnames do, so let's use those here.

To prevent accidentally disabling a package because a versioned package depends on a broken one, we need to filter out all versioned attributes as well. This doesn't change anything since they already have empty hydraPlatforms.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
