### PR TITLE
asterisk: 20.18.1 -> 20.18.2, 21.12.0 -> 21.12.1, 22.8.1 -> 22.8.2, 23.2.1 -> 23.2.2 (CVE fixes)

### DIFF
--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -4,19 +4,19 @@
     "version": "18.26.4"
   },
   "asterisk_20": {
-    "sha256": "fffc04d9348676c884224d5f66201c0c88468f382b3f58c41c2e5afd4a72868f",
-    "version": "20.18.1"
+    "sha256": "247e47727856b113ad520f3142225b3b7e526e1ba471fb7d546bc0fa4a734592",
+    "version": "20.18.2"
   },
   "asterisk_21": {
-    "sha256": "ccd04f5f433dd398448858dcac68231c67cf13826f068f4321d06d45dbd999a8",
-    "version": "21.12.0"
+    "sha256": "f7d2535e949dfc531c8480ba2c72c4a007701d787986c01730e391d601320153",
+    "version": "21.12.1"
   },
   "asterisk_22": {
-    "sha256": "9a63ae4df974ab55199b0d1fbde22fec6ce7ede69929b18890ed5c928b4ad63b",
-    "version": "22.8.1"
+    "sha256": "8dd373ce0771a9ed40bb54a72a889ccdd14c0cee458ed68da9ce913a668e4b22",
+    "version": "22.8.2"
   },
   "asterisk_23": {
-    "sha256": "8d3eddea9a9d5f0239c1509a8890787ae0ef23ba07c4b3ac99e96a3ff391b47c",
-    "version": "23.2.1"
+    "sha256": "dfba245e993d500a4a04a7e859e5e60d9623e769b403919254a140ec1d52aa71",
+    "version": "23.2.2"
   }
 }


### PR DESCRIPTION
- [CVE-2026-23738](https://nvd.nist.gov/vuln/detail/CVE-2026-23738) https://github.com/NixOS/nixpkgs/issues/488035
- [CVE-2026-23741](https://nvd.nist.gov/vuln/detail/CVE-2026-23741) https://github.com/NixOS/nixpkgs/issues/488048
- [CVE-2026-23740](https://nvd.nist.gov/vuln/detail/CVE-2026-23740) https://github.com/NixOS/nixpkgs/issues/488042


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
