### PR TITLE
ladspa-header: refactor and rename from ladspaH

### DIFF
--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -19,7 +19,7 @@
   gtkmm3,
   hicolor-icon-theme,
   intltool,
-  ladspaH,
+  ladspa-header,
   libjack2,
   libsndfile,
   lilv,
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     gsettings-desktop-schemas
     gtk3
     gtkmm3
-    ladspaH
+    ladspa-header
     libjack2
     libsndfile
     lilv

--- a/pkgs/applications/audio/ladspa-plugins/default.nix
+++ b/pkgs/applications/audio/ladspa-plugins/default.nix
@@ -5,7 +5,7 @@
   autoreconfHook,
   automake,
   fftw,
-  ladspaH,
+  ladspa-header,
   libxml2,
   pkg-config,
   perlPackages,
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     fftw
-    ladspaH
+    ladspa-header
     libxml2
   ];
 

--- a/pkgs/applications/audio/non/default.nix
+++ b/pkgs/applications/audio/non/default.nix
@@ -9,7 +9,7 @@
   ntk,
   libjack2,
   libsndfile,
-  ladspaH,
+  ladspa-header,
   liblo,
   libsigcxx,
   lrdf,
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
     ntk
     libjack2
     libsndfile
-    ladspaH
+    ladspa-header
     liblo
     libsigcxx
     lrdf

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -21,7 +21,7 @@
   alsa-lib,
   dssiSupport ? false,
   dssi,
-  ladspaH,
+  ladspa-header,
   jackSupport ? true,
   libjack2,
   ossSupport ? true,
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
   ++ lib.optionals alsaSupport [ alsa-lib ]
   ++ lib.optionals dssiSupport [
     dssi
-    ladspaH
+    ladspa-header
   ]
   ++ lib.optionals jackSupport [ libjack2 ]
   ++ lib.optionals portaudioSupport [ portaudio ]

--- a/pkgs/by-name/al/alsaequal/package.nix
+++ b/pkgs/by-name/al/alsaequal/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   alsa-lib,
   caps,
-  ladspaH,
+  ladspa-header,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     alsa-lib
-    ladspaH
+    ladspa-header
   ];
 
   makeFlags = [ "DESTDIR=$(out)" ];

--- a/pkgs/by-name/am/amb-plugins/package.nix
+++ b/pkgs/by-name/am/amb-plugins/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  ladspaH,
+  ladspa-header,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "0x4blm4visjqj0ndqr0cg776v3b7lvplpc8cgi9n51llhavn0jpl";
   };
 
-  buildInputs = [ ladspaH ];
+  buildInputs = [ ladspa-header ];
 
   patchPhase = ''
     sed -i 's@/usr/bin/install@install@g' Makefile

--- a/pkgs/by-name/am/ams/package.nix
+++ b/pkgs/by-name/am/ams/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchgit,
   alsa-lib,
-  ladspaH,
+  ladspa-header,
   libjack2,
   fftw,
   zita-alsa-pcmi,
@@ -30,7 +30,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     alsa-lib
-    ladspaH
+    ladspa-header
     libjack2
     fftw
     zita-alsa-pcmi

--- a/pkgs/by-name/ca/calf/package.nix
+++ b/pkgs/by-name/ca/calf/package.nix
@@ -8,7 +8,7 @@
   glib,
   gtk2,
   libjack2,
-  ladspaH,
+  ladspa-header,
   gnome2,
   lv2,
   pkg-config,
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     glib
     gtk2
     libjack2
-    ladspaH
+    ladspa-header
     gnome2.libglade
     lv2
   ];

--- a/pkgs/by-name/cm/cmt/package.nix
+++ b/pkgs/by-name/cm/cmt/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  ladspaH,
+  ladspa-header,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-qC+GNt4fSto4ahmaAXqc13Wkm0nnFrEejdP3I8k99so=";
   };
 
-  buildInputs = [ ladspaH ];
+  buildInputs = [ ladspa-header ];
 
   preBuild = ''
     cd src

--- a/pkgs/by-name/ds/dsp/package.nix
+++ b/pkgs/by-name/ds/dsp/package.nix
@@ -11,7 +11,7 @@
   alsa-lib,
   libao,
   libmad,
-  ladspaH,
+  ladspa-header,
   libtool,
   libpulseaudio,
 }:
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     libao
     libmad
-    ladspaH
+    ladspa-header
     libtool
     libpulseaudio
   ];

--- a/pkgs/by-name/ds/dssi/package.nix
+++ b/pkgs/by-name/ds/dssi/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  ladspaH,
+  ladspa-header,
   libjack2,
   liblo,
   alsa-lib,
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
   buildInputs = [
-    ladspaH
+    ladspa-header
     libjack2
     liblo
     alsa-lib

--- a/pkgs/by-name/ea/easyeffects/package.nix
+++ b/pkgs/by-name/ea/easyeffects/package.nix
@@ -11,7 +11,7 @@
   gsl,
   intltool,
   kdePackages,
-  ladspaH,
+  ladspa-header,
   libbs2b,
   libebur128,
   libmysofa,
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     kiconthemes
     kirigami
     kirigami-addons
-    ladspaH
+    ladspa-header
     qqc2-desktop-style
     libbs2b
     libebur128

--- a/pkgs/by-name/fa/faust2ladspa/package.nix
+++ b/pkgs/by-name/fa/faust2ladspa/package.nix
@@ -1,7 +1,7 @@
 {
   boost,
   faust,
-  ladspaH,
+  ladspa-header,
 }:
 
 faust.wrapWithBuildEnv {
@@ -10,7 +10,7 @@ faust.wrapWithBuildEnv {
 
   propagatedBuildInputs = [
     boost
-    ladspaH
+    ladspa-header
   ];
 
 }

--- a/pkgs/by-name/fi/fil-plugins/package.nix
+++ b/pkgs/by-name/fi/fil-plugins/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  ladspaH,
+  ladspa-header,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-HAvycSEZZfZwoVp3g7QWcwfbdyZKwWJKBuVmeWTajuk=";
   };
 
-  buildInputs = [ ladspaH ];
+  buildInputs = [ ladspa-header ];
 
   postPatch = ''
     substituteInPlace Makefile \

--- a/pkgs/by-name/la/ladspa-header/package.nix
+++ b/pkgs/by-name/la/ladspa-header/package.nix
@@ -1,15 +1,14 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  ladspa-sdk,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  pname = "ladspa.h";
-  version = "1.17";
-  src = fetchurl {
-    url = "https://www.ladspa.org/download/ladspa_sdk_${finalAttrs.version}.tgz";
-    hash = "sha256-J9JPJ55Lgb0X7L3MOOTEKZG7OIgmwLIABnzg61nT2ls=";
-  };
+  pname = "ladspa-header";
+
+  inherit (ladspa-sdk) version src;
+
+  dontBuild = true;
 
   installPhase = ''
     mkdir -p $out/include
@@ -17,14 +16,12 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   meta = {
+    inherit (ladspa-sdk.meta) homepage license maintainers;
     description = "LADSPA format audio plugins header file";
     longDescription = ''
       The ladspa.h API header file from the LADSPA SDK.
       For the full SDK, use the ladspa-sdk package.
     '';
-    homepage = "http://www.ladspa.org/ladspa_sdk/overview.html";
-    license = lib.licenses.lgpl2;
-    maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/la/ladspa-sdk/package.nix
+++ b/pkgs/by-name/la/ladspa-sdk/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
       The LADSPA SDK, including the ladspa.h API header file,
       ten example LADSPA plugins and
       three example programs (applyplugin, analyseplugin and listplugins).
-      For just ladspa.h, use the ladspaH package.
+      For just ladspa.h, use the ladspa-header package.
     '';
     homepage = "http://www.ladspa.org/ladspa_sdk/overview.html";
     license = lib.licenses.lgpl2;

--- a/pkgs/by-name/ls/lsp-plugins/package.nix
+++ b/pkgs/by-name/ls/lsp-plugins/package.nix
@@ -5,7 +5,7 @@
   fetchurl,
   gst_all_1,
   jack2,
-  ladspaH,
+  ladspa-header,
   libGL,
   libGLU,
   libxrandr,
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     gst_all_1.gst-plugins-base
     gst_all_1.gstreamer
     jack2
-    ladspaH
+    ladspa-header
     libGL
     libGLU
     libxrandr

--- a/pkgs/by-name/mu/muse/package.nix
+++ b/pkgs/by-name/mu/muse/package.nix
@@ -8,7 +8,7 @@
   alsa-lib,
   dssi,
   fluidsynth,
-  ladspaH,
+  ladspa-header,
   libinstpatch,
   libjack2,
   liblo,
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     alsa-lib
     dssi
     fluidsynth
-    ladspaH
+    ladspa-header
     libinstpatch
     libjack2
     liblo

--- a/pkgs/by-name/no/nova-filters/package.nix
+++ b/pkgs/by-name/no/nova-filters/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
   scons,
   boost,
-  ladspaH,
+  ladspa-header,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace SConstruct \
       --replace "'TERM' : os.environ['TERM']," "" \
       --replace "Options" "Variables" \
-      --replace "-fomit-frame-pointer -ffast-math -mfpmath=sse" "-I${boost.dev}/include -I${ladspaH}/include" \
+      --replace "-fomit-frame-pointer -ffast-math -mfpmath=sse" "-I${boost.dev}/include -I${ladspa-header}/include" \
       --replace "env.has_key('cxx')" "True" \
       --replace "env['cxx']" "'${stdenv.cc.targetPrefix}c++'" \
       --replace "-Wl,--strip-all" ""

--- a/pkgs/by-name/pl/plugin-torture/package.nix
+++ b/pkgs/by-name/pl/plugin-torture/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   boost,
-  ladspaH,
+  ladspa-header,
   lilv,
   lv2,
   pkg-config,
@@ -26,7 +26,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     boost
-    ladspaH
+    ladspa-header
     lilv
     lv2
     serd

--- a/pkgs/by-name/pl/pluginval/package.nix
+++ b/pkgs/by-name/pl/pluginval/package.nix
@@ -15,7 +15,7 @@
   libxinerama,
   libxrandr,
   libxtst,
-  ladspaH,
+  ladspa-header,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxinerama
     libxrandr
     libxtst
-    ladspaH
+    ladspa-header
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/qt/qtractor/package.nix
+++ b/pkgs/by-name/qt/qtractor/package.nix
@@ -7,7 +7,7 @@
   fetchurl,
   flac,
   libjack2,
-  ladspaH,
+  ladspa-header,
   ladspaPlugins,
   liblo,
   libmad,
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     dssi
     flac
     libjack2
-    ladspaH
+    ladspa-header
     ladspaPlugins
     liblo
     libmad

--- a/pkgs/by-name/ro/rosegarden/package.nix
+++ b/pkgs/by-name/ro/rosegarden/package.nix
@@ -12,7 +12,7 @@
   fftwSinglePrec,
   flac,
   glib,
-  ladspaH,
+  ladspa-header,
   ladspaPlugins,
   libjack2,
   liblo,
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     fftwSinglePrec
     flac
     glib
-    ladspaH
+    ladspa-header
     ladspaPlugins
     libjack2
     liblo

--- a/pkgs/by-name/ru/rubberband/package.nix
+++ b/pkgs/by-name/ru/rubberband/package.nix
@@ -9,7 +9,7 @@
   lv2,
   jdk_headless,
   vamp-plugin-sdk,
-  ladspaH,
+  ladspa-header,
   meson,
   ninja,
 }:
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsndfile
     fftw
     vamp-plugin-sdk
-    ladspaH
+    ladspa-header
     lv2
   ];
   makeFlags = [ "AR:=$(AR)" ];

--- a/pkgs/by-name/za/zam-plugins/package.nix
+++ b/pkgs/by-name/za/zam-plugins/package.nix
@@ -7,7 +7,7 @@
   libGL,
   liblo,
   libjack2,
-  ladspaH,
+  ladspa-header,
   lv2,
   pkg-config,
   rubberband,
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     liblo
     libjack2
-    ladspaH
+    ladspa-header
     lv2
     rubberband
     libsndfile

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -265,7 +265,7 @@
   harfbuzz,
   intel-media-sdk,
   kvazaar,
-  ladspaH,
+  ladspa-header,
   lame,
   lcevcdec,
   lcms2,
@@ -892,7 +892,7 @@ stdenv.mkDerivation (
       ++ optionals withJack [ libjack2 ]
       ++ optionals withJxl [ libjxl ]
       ++ optionals withKvazaar [ kvazaar ]
-      ++ optionals withLadspa [ ladspaH ]
+      ++ optionals withLadspa [ ladspa-header ]
       ++ optionals withLc3 [ liblc3 ]
       ++ optionals withLcevcdec [ lcevcdec ]
       ++ optionals withLcms2 [ lcms2 ]

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -29,7 +29,7 @@
   liblc3,
   libass,
   lrdf,
-  ladspaH,
+  ladspa-header,
   lcms2,
   libnice,
   webrtcAudioProcessingSupport ? lib.meta.availableOn stdenv.hostPlatform webrtc-audio-processing_1,
@@ -242,7 +242,7 @@ stdenv.mkDerivation (finalAttrs: {
     spandsp
 
     # ladspa plug-in
-    ladspaH
+    ladspa-header
     lrdf # TODO: make build on Darwin
 
     # lv2 plug-in

--- a/pkgs/development/ocaml-modules/ladspa/default.nix
+++ b/pkgs/development/ocaml-modules/ladspa/default.nix
@@ -3,7 +3,7 @@
   buildDunePackage,
   fetchFromGitHub,
   dune-configurator,
-  ladspaH,
+  ladspa-header,
 }:
 
 buildDunePackage (finalAttrs: {
@@ -18,7 +18,7 @@ buildDunePackage (finalAttrs: {
   };
 
   buildInputs = [ dune-configurator ];
-  propagatedBuildInputs = [ ladspaH ];
+  propagatedBuildInputs = [ ladspa-header ];
 
   meta = {
     homepage = "https://github.com/savonet/ocaml-alsa";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -951,6 +951,7 @@ mapAliases {
   kubei = throw "'kubei' has been renamed to/replaced by 'kubeclarity'"; # Converted to throw 2025-10-27
   kubo-migrator-all-fs-repo-migrations = throw "'kubo-migrator-all-fs-repo-migrations' has been renamed to/replaced by 'kubo-fs-repo-migrations'"; # Converted to throw 2025-10-27
   kwm = throw "'kwm' has been removed since upstream is a 404"; # Added 2025-12-21
+  ladspaH = warnAlias "'ladspaH' has been renamed to 'ladspa-header'" ladspa-header; # Added 2026-02-08
   languageMachines.frog = frog; # Added 2025-10-7
   languageMachines.frogdata = frogdata; # Added 2025-10-7
   languageMachines.libfolia = libfolia; # Added 2025-10-7


### PR DESCRIPTION
There isn't really an upstream package name since this header file is normally just part of ladspa-sdk.
ladspa-header seems like a more fitting name for this package. Could also be ladspa-sdk-header, but there are also probably other headers than ladspa.h in ladspa-sdk.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
