### PR TITLE
psysh: 0.12.7 -> 0.12.19

### DIFF
--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -1,6 +1,5 @@
 {
   fetchFromGitHub,
-  fetchurl,
   lib,
   php,
   versionCheckHook,
@@ -8,19 +7,14 @@
 
 let
   pname = "psysh";
-  version = "0.12.7";
+  version = "0.12.19";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
     tag = "v${version}";
-    hash = "sha256-dgMUz7lB1XoJ08UvF9XMZGVXYcFK9sNnSb+pcwfeoqQ=";
-  };
-
-  composerLock = fetchurl {
-    name = "composer.lock";
-    url = "https://github.com/bobthecow/psysh/releases/download/v${version}/composer-v${version}.lock";
-    hash = "sha256-JYJksHKyKKhU248hLPaNXFCh3X+5QiT8iNKzeGc1ZPw=";
+    hash = "sha256-Gdye6+fdqqxgHqq79XJgSkywP1IMMAIVexh0kEol0Jw=";
+    forceFetchGit = true;
   };
 in
 php.buildComposerProject2 (finalAttrs: {
@@ -35,17 +29,14 @@ php.buildComposerProject2 (finalAttrs: {
       src
       version
       pname
-      composerLock
       ;
 
-    preBuild = ''
-      composer config platform.php 7.4
-      composer require --no-cache --no-update symfony/polyfill-iconv:1.31 symfony/polyfill-mbstring:1.31
-      composer require --no-cache --no-update --dev roave/security-advisories:dev-latest
-      composer update --no-cache --lock --no-install
+    preConfigure = ''
+      cp build/composer.json .
+      cp build/composer.lock .
     '';
 
-    vendorHash = "sha256-S3rekG0KPHk6cmQecmb5ETQ1V4ey5+pK+PpHNSEcXNw=";
+    vendorHash = "sha256-MbYMFQVUmRAV7qttJBEJxzimeFIA0K8wbrwC9yDirf8=";
   };
 
   doInstallCheck = true;

--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -46,6 +46,7 @@ php.buildComposerProject2 (finalAttrs: {
     changelog = "https://github.com/bobthecow/psysh/releases/tag/v${finalAttrs.version}";
     description = "PsySH is a runtime developer console, interactive debugger and REPL for PHP";
     mainProgram = "psysh";
+    maintainers = [ lib.maintainers.piotrkwiecinski ];
     license = lib.licenses.mit;
     homepage = "https://psysh.org/";
   };


### PR DESCRIPTION
Resolves: https://github.com/NixOS/nixpkgs/issues/488128

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
