### PR TITLE
cisco-packet-tracer_{8,9}: rename from ciscoPacketTracer{8,9}

### DIFF
--- a/pkgs/by-name/ci/cisco-packet-tracer_8/package.nix
+++ b/pkgs/by-name/ci/cisco-packet-tracer_8/package.nix
@@ -59,7 +59,7 @@ let
   };
 
   unwrapped = stdenvNoCC.mkDerivation {
-    name = "ciscoPacketTracer8-unwrapped";
+    name = "cisco-packet-tracer-unwrapped";
     inherit version;
 
     src =
@@ -135,14 +135,15 @@ let
   };
 
   fhs-env = buildFHSEnv {
-    name = "ciscoPacketTracer8-fhs-env";
+    pname = "cisco-packet-tracer-fhs-env";
+    inherit version;
     runScript = lib.getExe' unwrapped "packettracer8";
     targetPkgs = _: [ libudev0-shim ];
   };
 in
 
 stdenvNoCC.mkDerivation {
-  pname = "ciscoPacketTracer8";
+  pname = "cisco-packet-tracer";
   inherit version;
 
   dontUnpack = true;
@@ -155,7 +156,7 @@ stdenvNoCC.mkDerivation {
     runHook preInstall
 
     mkdir -p $out/bin
-    ln -s ${fhs-env}/bin/${fhs-env.name} $out/bin/packettracer8
+    ln -s ${fhs-env}/bin/${fhs-env.pname} $out/bin/packettracer8
 
     mkdir -p $out/share/icons/hicolor/48x48/apps
     ln -s ${unwrapped}/opt/pt/art/app.png $out/share/icons/hicolor/48x48/apps/cisco-packet-tracer-8.png

--- a/pkgs/by-name/ci/cisco-packet-tracer_9/package.nix
+++ b/pkgs/by-name/ci/cisco-packet-tracer_9/package.nix
@@ -10,10 +10,8 @@
 }:
 
 let
-  pname = "ciscoPacketTracer9";
-
   appimage = stdenvNoCC.mkDerivation {
-    pname = "ciscoPacketTracer9-appimage";
+    pname = "cisco-packet-tracer-appimage";
     inherit version;
 
     src =
@@ -45,7 +43,9 @@ let
 
 in
 appimageTools.wrapType2 rec {
-  inherit pname version;
+  pname = "cisco-packet-tracer";
+  inherit version;
+
   src = appimage;
 
   extraPkgs = _: [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -447,7 +447,9 @@ mapAliases {
   chrome-gnome-shell = throw "'chrome-gnome-shell' has been renamed to/replaced by 'gnome-browser-connector'"; # Converted to throw 2025-10-27
   ci-edit = throw "'ci-edit' has been removed due to lack of maintenance upstream"; # Added 2025-08-26
   cinnamon-common = cinnamon; # Added 2025-08-06
-  ciscoPacketTracer7 = throw "'ciscoPacketTracer7' has been removed in favor of 'ciscoPacketTracer8' and 'ciscoPacketTracer9'";
+  ciscoPacketTracer7 = throw "'ciscoPacketTracer7' has been removed in favor of 'cisco-packet-tracer_8' and 'cisco-packet-tracer_9'";
+  ciscoPacketTracer8 = cisco-packet-tracer_8; # Added 2026-02-08
+  ciscoPacketTracer9 = cisco-packet-tracer_9; # Added 2026-02-08
   citrix_workspace_23_11_0 = throw "'citrix_workspace_23_11_0' has been removed because it has reached EOL."; # Added 2025-11-25
   citrix_workspace_24_02_0 = throw "'citrix_workspace_24_02_0' has been removed because it has reached EOL."; # Added 2025-11-25
   citrix_workspace_24_05_0 = throw "'citrix_workspace_24_05_0' has been removed because it depended on the removed webkitgtk_4_0."; # Added 2025-11-25


### PR DESCRIPTION
The upstream package name seems to be in Title Case, so i converted that to lower-kebap-case to fit package naming conventions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
