### PR TITLE
sif: init at 0-unstable-2026-01-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28020,6 +28020,11 @@
     githubId = 13259982;
     name = "Vanessa McHale";
   };
+  vmfunc = {
+    github = "vmfunc";
+    githubId = 59031302;
+    name = "vmfunc";
+  };
   vncsb = {
     email = "viniciusbernardino1@hotmail.com";
     github = "vncsb";

--- a/pkgs/by-name/si/sif/package.nix
+++ b/pkgs/by-name/si/sif/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGoModule {
+  pname = "sif";
+  version = "0-unstable-2026-01-11";
+
+  src = fetchFromGitHub {
+    owner = "vmfunc";
+    repo = "sif";
+    tag = "automated-release-c988e54";
+    hash = "sha256-/9LRmSrji/8SCD9aHx82HwBfBRPVKzOnogw+uvDI+WI=";
+  };
+
+  vendorHash = "sha256-ztKXnOjZS/jMxsRjtF0rIZ3lKv4YjMdZd6oQFRuAtR4=";
+
+  subPackages = [ "cmd/sif" ];
+
+  env.CGO_ENABLED = 0;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # network-dependent tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Modular pentesting toolkit written in Go";
+    homepage = "https://github.com/vmfunc/sif";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ vmfunc ];
+    mainProgram = "sif";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

add [sif](https://github.com/vmfunc/sif), modular pentesting toolkit written in Go.

i am more comfortable doing unstable releases for now until the community decides on a proper release pattern for sif. we have automated releases every week.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
