### PR TITLE
gnupg{24,1compat}: split info, man & doc outputs

### DIFF
--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   gnupg,
   coreutils,
@@ -7,26 +8,30 @@
 
 stdenv.mkDerivation {
   pname = "gnupg1compat";
-  version = gnupg.version;
+  inherit (gnupg) version outputs;
 
-  builder = writeScript "gnupg1compat-builder" ''
+  builder = writeScript "gnupg1compat-builder" (''
     PATH=${coreutils}/bin
-    # First symlink all top-level dirs
-    mkdir -p $out
-    ln -s "${gnupg}/"* $out
+  ''
+  # First symlink all top-level dirs, output per output
+  + lib.concatMapStringsSep "\n" (o: ''
+    mkdir -p ''$${o}
+    ln -s "${gnupg.${o}}/"* ''$${o}
+  '') gnupg.outputs
+  + ''
 
     # Replace bin with directory and symlink it contents
-    rm $out/bin
-    mkdir -p $out/bin
-    ln -s "${gnupg}/bin/"* $out/bin
+    rm ''${!outputBin}/bin
+    mkdir -p ''${!outputBin}/bin
+    ln -s "${lib.getBin gnupg}/bin/"* ''${!outputBin}/bin
 
     # Add symlinks for any executables that end in 2 and lack any non-*2 version
-    for f in $out/bin/*2; do
+    for f in ''${!outputBin}/bin/*2; do
       [[ -x $f ]] || continue # ignore failed globs and non-executable files
       [[ -e ''${f%2} ]] && continue # ignore commands that already have non-*2 versions
       ln -s -- "''${f##*/}" "''${f%2}"
     done
-  '';
+  '');
 
   meta = gnupg.meta // {
     description = gnupg.meta.description + " with symbolic links for gpg and gpgv";

--- a/pkgs/tools/security/gnupg/1compat.nix
+++ b/pkgs/tools/security/gnupg/1compat.nix
@@ -10,28 +10,30 @@ stdenv.mkDerivation {
   pname = "gnupg1compat";
   inherit (gnupg) version outputs;
 
-  builder = writeScript "gnupg1compat-builder" (''
-    PATH=${coreutils}/bin
-  ''
-  # First symlink all top-level dirs, output per output
-  + lib.concatMapStringsSep "\n" (o: ''
-    mkdir -p ''$${o}
-    ln -s "${gnupg.${o}}/"* ''$${o}
-  '') gnupg.outputs
-  + ''
+  builder = writeScript "gnupg1compat-builder" (
+    ''
+      PATH=${coreutils}/bin
+    ''
+    # First symlink all top-level dirs, output per output
+    + lib.concatMapStringsSep "\n" (o: ''
+      mkdir -p ''$${o}
+      ln -s "${gnupg.${o}}/"* ''$${o}
+    '') gnupg.outputs
+    + ''
 
-    # Replace bin with directory and symlink it contents
-    rm ''${!outputBin}/bin
-    mkdir -p ''${!outputBin}/bin
-    ln -s "${lib.getBin gnupg}/bin/"* ''${!outputBin}/bin
+      # Replace bin with directory and symlink it contents
+      rm ''${!outputBin}/bin
+      mkdir -p ''${!outputBin}/bin
+      ln -s "${lib.getBin gnupg}/bin/"* ''${!outputBin}/bin
 
-    # Add symlinks for any executables that end in 2 and lack any non-*2 version
-    for f in ''${!outputBin}/bin/*2; do
-      [[ -x $f ]] || continue # ignore failed globs and non-executable files
-      [[ -e ''${f%2} ]] && continue # ignore commands that already have non-*2 versions
-      ln -s -- "''${f##*/}" "''${f%2}"
-    done
-  '');
+      # Add symlinks for any executables that end in 2 and lack any non-*2 version
+      for f in ''${!outputBin}/bin/*2; do
+        [[ -x $f ]] || continue # ignore failed globs and non-executable files
+        [[ -e ''${f%2} ]] && continue # ignore commands that already have non-*2 versions
+        ln -s -- "''${f##*/}" "''${f%2}"
+      done
+    ''
+  );
 
   meta = gnupg.meta // {
     description = gnupg.meta.description + " with symbolic links for gpg and gpgv";

--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -167,6 +167,13 @@ stdenv.mkDerivation rec {
   ++ lib.optional withTpm2Tss "--with-tss=intel"
   ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-ccid-driver";
 
+  outputs = [
+    "out"
+    "info"
+    "man"
+    "doc"
+  ];
+
   postInstall =
     if enableMinimal then
       ''


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test