### PR TITLE
deezer-desktop: init at 7.1.100

### DIFF
--- a/pkgs/by-name/de/deezer-desktop/package.nix
+++ b/pkgs/by-name/de/deezer-desktop/package.nix
@@ -1,0 +1,74 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  makeWrapper,
+  electron,
+}:
+
+let
+  version = "7.1.100";
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/aunetx/deezer-linux/releases/download/v${version}/deezer-desktop-${version}-x64.tar.xz";
+      hash = "sha256-KU7dmXXJGLVoDf/iHP3LBcbc/+ldTdYsRD3LyGvbvZc=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://github.com/aunetx/deezer-linux/releases/download/v${version}/deezer-desktop-${version}-arm64.tar.xz";
+      hash = "sha256-sLso74DJaJK/o8cYYHEI/XNXjcl1MgfkegsCEOw+79Y=";
+    };
+  };
+
+  src = srcs.${stdenv.hostPlatform.system} or (throw "${stdenv.hostPlatform.system} not supported");
+
+  # Architecture string for directory names
+  archDir =
+    if stdenv.hostPlatform.isx86_64 then
+      "x64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "arm64"
+    else
+      throw "Unsupported architecture";
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "deezer-desktop";
+  inherit version src;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  sourceRoot = ".";
+
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+    install -d $out/bin $out/share/deezer-desktop/resources $out/share/applications $out/share/icons/hicolor/scalable/apps
+
+    substituteInPlace deezer-desktop-${version}-${archDir}/resources/dev.aunetx.deezer.desktop \
+      --replace-fail "run.sh" "deezer-desktop" \
+      --replace-fail "dev.aunetx.deezer" "deezer-desktop"
+    cp deezer-desktop-${version}-${archDir}/resources/dev.aunetx.deezer.desktop $out/share/applications/deezer-desktop.desktop
+    cp deezer-desktop-${version}-${archDir}/resources/dev.aunetx.deezer.svg $out/share/icons/hicolor/scalable/apps/deezer-desktop.svg
+    cp -r deezer-desktop-${version}-${archDir}/resources/{app.asar,linux} $out/share/deezer-desktop/resources/
+
+    makeWrapper "${lib.getExe electron}" "$out/bin/deezer-desktop" \
+      --inherit-argv0 \
+      --add-flags "$out/share/deezer-desktop/resources/app.asar" \
+      --set-default ELECTRON_FORCE_IS_PACKAGED 1 \
+      --set DZ_RESOURCES_PATH "$out/share/deezer-desktop/resources"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Unofficial Linux port of the music streaming application";
+    homepage = "https://github.com/aunetx/deezer-linux";
+    downloadPage = "https://github.com/aunetx/deezer-linux/releases";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ FelixLusseau ];
+    mainProgram = "deezer-desktop";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is an UNOFFICIAL linux port ([legal notice](https://github.com/aunetx/deezer-linux#legal-disclaimer)) of the official windows-only Deezer app. Being based on the native Windows app, it allows downloading your songs to listen to them offline!  
https://github.com/aunetx/deezer-linux

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
