### PR TITLE
markitdown-mcp: init at 0.1.5b1

### DIFF
--- a/pkgs/by-name/ma/markitdown-mcp/package.nix
+++ b/pkgs/by-name/ma/markitdown-mcp/package.nix
@@ -43,7 +43,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp";
     changelog = "https://github.com/microsoft/markitdown/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ malik ];
+    maintainers = python3Packages.markitdown.meta.maintainers;
     mainProgram = "markitdown-mcp";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/ma/markitdown-mcp/package.nix
+++ b/pkgs/by-name/ma/markitdown-mcp/package.nix
@@ -39,7 +39,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   passthru.updateScripts = gitUpdater { };
 
   meta = {
-    description = "An MCP server for the \"markitdown\" library";
+    description = "MCP server for the markitdown library";
     homepage = "https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp";
     changelog = "https://github.com/microsoft/markitdown/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;

--- a/pkgs/by-name/ma/markitdown-mcp/package.nix
+++ b/pkgs/by-name/ma/markitdown-mcp/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "markitdown-mcp";
+  version = "0.1.5b1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "markitdown";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-twZEkUih76QEl2dkh81eCBnfX/+tKAHI9wDyCkjfOsQ=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/packages/markitdown-mcp";
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "mcp"
+  ];
+
+  dependencies = with python3Packages; [
+    markitdown
+    mcp
+  ];
+
+  pythonImportsCheck = [
+    "markitdown_mcp"
+  ];
+
+  passthru.updateScripts = gitUpdater { };
+
+  meta = {
+    description = "An MCP server for the \"markitdown\" library";
+    homepage = "https://github.com/microsoft/markitdown/tree/main/packages/markitdown-mcp";
+    changelog = "https://github.com/microsoft/markitdown/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ malik ];
+    mainProgram = "markitdown-mcp";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/markitdown/default.nix
+++ b/pkgs/development/python-modules/markitdown/default.nix
@@ -107,6 +107,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/microsoft/markitdown";
     changelog = "https://github.com/microsoft/markitdown/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ malik ];
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
