### PR TITLE
python3Packages.cbor2: 5.7.0 -> 5.8.0

### DIFF
--- a/pkgs/development/python-modules/cbor2/default.nix
+++ b/pkgs/development/python-modules/cbor2/default.nix
@@ -10,7 +10,6 @@
   setuptools,
   withCExtensions ? true,
 }:
-
 buildPythonPackage rec {
   pname = "cbor2";
   version = "5.8.0";
@@ -49,6 +48,5 @@ buildPythonPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "cbor2";
-
   };
 }


### PR DESCRIPTION
## Summary

Update cbor2 from 5.7.0 to 5.8.0.

### Changes in 5.8.0

- Added readahead buffering to C decoder for improved performance (20-140% improvement)
- Fixed Python decoder not preserving share index when decoding array items containing
nested shareable tags
- Reset shared reference state at the start of each top-level encode/decode operation

[Changelog](https://github.com/agronholm/cbor2/releases/tag/5.8.0)

## Things done

- Built on platform:
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- Tested, as applicable:
- [ ] [NixOS tests] in [nixos/tests].
- [ ] [Package tests] at `passthru.tests`.
- [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
- [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
- [ ] Module addition: when adding a new NixOS module.
- [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

### Additional testing

- Verified encode/decode functionality in Python
- Built reverse dependencies: `aiocoap`, `remarshal`, `cattrs`, `autobahn` (all passed)
