### PR TITLE
rumdl: optimize checkPhase, 0.1.14 -> 0.1.15 

### DIFF
--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.1.14";
+  version = "0.1.15";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-qaxDVycNszmgqvDwZxHEowkoHGz4FC1g6DZhH+xwBBk=";
+    hash = "sha256-jIkEKFEdNbSwgYTqNvz6XM8E+cIdtsCCYCxvbCu03sc=";
   };
 
-  cargoHash = "sha256-h80IiE5PMuRP/eBrm3wlNSPHAKQASioQt3Fyoh253PI=";
+  cargoHash = "sha256-eP6IaebCj3OYunlPTJZmB4wUy5Mzh7VQNCmWz/n4MR8=";
 
   cargoBuildFlags = [
     "--bin=rumdl"

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -37,6 +37,13 @@ rustPlatform.buildRustPackage (finalAttrs: {
   useNextest = true;
 
   cargoTestFlags = [
+    "--bins"
+
+    # Building all tests takes too long, and filtering by profile does not solve it.
+    # It also causes flaky results on Darwin in Hydra.
+    "--test"
+    "cli_*"
+
     # Prefer the "smoke" profile over "ci" to exclude flaky tests: https://github.com/rvben/rumdl/pull/341
     "--profile"
     "smoke"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Optimize checkPhase

This PR aims to stabilize Hydra results on Darwin. Running nixpkgs-review on GHA did not raise error for these platforms.

```console
> hydra-check rumdl --arch aarch64-darwin
Build Status for rumdl.aarch64-darwin on jobset nixpkgs/unstable
https://hydra.nixos.org/job/nixpkgs/unstable/rumdl.aarch64-darwin
✖ (Failed)     rumdl-0.1.14   2026-02-07  https://hydra.nixos.org/build/321115075
✔              rumdl-0.1.10   2026-02-02  https://hydra.nixos.org/build/320824558
✔              rumdl-0.1.8    2026-02-01  https://hydra.nixos.org/build/320802632
✔              rumdl-0.1.2    2026-01-29  https://hydra.nixos.org/build/320733063
✔              rumdl-0.1.1    2026-01-28  https://hydra.nixos.org/build/320486714

> hydra-check rumdl --arch x86_64-darwin
Build Status for rumdl.x86_64-darwin on jobset nixpkgs/unstable
https://hydra.nixos.org/job/nixpkgs/unstable/rumdl.x86_64-darwin
✖ (Timed out)  rumdl-0.1.14   2026-02-07  https://hydra.nixos.org/build/321115074
✔              rumdl-0.1.10   2026-02-02  https://hydra.nixos.org/build/320824555
✔              rumdl-0.1.8    2026-02-01  https://hydra.nixos.org/build/320802633
✔              rumdl-0.1.2    2026-01-29  https://hydra.nixos.org/build/320733062
✔              rumdl-0.1.1    2026-01-28  https://hydra.nixos.org/build/320486719

> hydra-check rumdl --arch aarch64-darwin --channel=nixpkgs-25.11-darwin
Build Status for rumdl.aarch64-darwin on jobset nixpkgs/nixpkgs-25.11-darwin
https://hydra.nixos.org/job/nixpkgs/nixpkgs-25.11-darwin/rumdl.aarch64-darwin
✖ (Failed)  rumdl-0.1.10   2026-02-02  https://hydra.nixos.org/build/320822752
✖ (Failed)  rumdl-0.1.8    2026-02-01  https://hydra.nixos.org/build/320804586
✖ (Failed)  rumdl-0.1.2    2026-01-30  https://hydra.nixos.org/build/320739948
✔           rumdl-0.1.1    2026-01-28  https://hydra.nixos.org/build/320485736


> hydra-check rumdl --arch x86_64-darwin --channel=nixpkgs-25.11-darwin
Build Status for rumdl.x86_64-darwin on jobset nixpkgs/nixpkgs-25.11-darwin
https://hydra.nixos.org/job/nixpkgs/nixpkgs-25.11-darwin/rumdl.x86_64-darwin
✖ (Failed)  rumdl-0.1.10   2026-02-02  https://hydra.nixos.org/build/320822753
✔           rumdl-0.1.8    2026-02-01  https://hydra.nixos.org/build/320804585
✔           rumdl-0.1.2    2026-01-29  https://hydra.nixos.org/build/320739947
✔           rumdl-0.1.1    2026-01-28  https://hydra.nixos.org/build/320485735
```

When I checked GHA, the total `nix-build` time was reduced to:

* aarch64-darwin: 21m -> 8m
* x86_64-darwin: 47m -> 15m

Follow-up: https://github.com/NixOS/nixpkgs/pull/484473

## Version up

Diff: https://github.com/rvben/rumdl/compare/v0.1.14...v0.1.15

Changelog: https://github.com/rvben/rumdl/blob/v0.1.15/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

cc: @Hasnep