### PR TITLE
invidious: 2.20250913.0 -> 2.20260207.0

### DIFF
--- a/pkgs/by-name/in/invidious/package.nix
+++ b/pkgs/by-name/in/invidious/package.nix
@@ -51,6 +51,7 @@ crystal.buildCrystalPackage rec {
       # This always uses the latest commit which invalidates the cache even if
       # the assets were not changed
       assetCommitTemplate = ''{{ "#{`git rev-list HEAD --max-count=1 --abbrev-commit -- assets`.strip}" }}'';
+      tagTemplate = ''{{ "#{`git tag --points-at HEAD`.strip}" }}'';
 
       inherit (versions.invidious) commit date;
     in
@@ -63,7 +64,8 @@ crystal.buildCrystalPackage rec {
           --replace-fail ${lib.escapeShellArg branchTemplate} '"master"' \
           --replace-fail ${lib.escapeShellArg commitTemplate} '"${commit}"' \
           --replace-fail ${lib.escapeShellArg versionTemplate} '"${date}"' \
-          --replace-fail ${lib.escapeShellArg assetCommitTemplate} '"${commit}"'
+          --replace-fail ${lib.escapeShellArg assetCommitTemplate} '"${commit}"' \
+          --replace-fail ${lib.escapeShellArg tagTemplate} '"v${version}"'
 
       # Patch the assets and locales paths to be absolute
       substituteInPlace src/invidious.cr \

--- a/pkgs/by-name/in/invidious/versions.json
+++ b/pkgs/by-name/in/invidious/versions.json
@@ -1,9 +1,9 @@
 {
   "invidious": {
-    "hash": "sha256-tVytYxFcHnGhI5mdZhZk9NBp++8q9PGdYbl8H6j7dAE=",
-    "version": "2.20250913.0",
-    "date": "2025.09.13",
-    "commit": "cf019e3b"
+    "hash": "sha256-tACx4+HqouftDalZlrurS75gYvS02qnmxQoL91YfTjg=",
+    "version": "2.20260207.0",
+    "date": "2026.02.07",
+    "commit": "118d6356"
   },
   "videojs": {
     "hash": "sha256-jED3zsDkPN8i6GhBBJwnsHujbuwlHdsVpVqa1/pzSH4="


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


Resolves https://github.com/NixOS/nixpkgs/issues/488232