### PR TITLE
Revert "passt: 2025_09_19.623dbf6 -> 2026_01_20.386b5f5"

### DIFF
--- a/pkgs/by-name/pa/passt/package.nix
+++ b/pkgs/by-name/pa/passt/package.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "passt";
-  version = "2026_01_20.386b5f5";
+  version = "2025_09_19.623dbf6";
 
   src = fetchurl {
     url = "https://passt.top/passt/snapshot/passt-${finalAttrs.version}.tar.gz";
-    hash = "sha256-s3izbMbReYj9jv3J5DJJWvyWeHw+4jGu5VvH5QxO320=";
+    hash = "sha256-3krWW/QKijgZsmHuelMjpcaL8OyRqmPKC/wUvag0ZHI=";
   };
 
   separateDebugInfo = true;


### PR DESCRIPTION
Reverts NixOS/nixpkgs#470714
This should fix `nixosTests.podman`