### PR TITLE
gptfdisk: split man output

### DIFF
--- a/pkgs/by-name/gp/gptfdisk/package.nix
+++ b/pkgs/by-name/gp/gptfdisk/package.nix
@@ -59,6 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
     done
   '';
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   passthru.tests = lib.optionalAttrs stdenv.hostPlatform.isx86 {
     installer-simpleLabels = nixosTests.installer.simpleLabels;
   };

--- a/pkgs/by-name/gp/gptfdisk/package.nix
+++ b/pkgs/by-name/gp/gptfdisk/package.nix
@@ -7,6 +7,7 @@
   icu,
   ncurses,
   nixosTests,
+  installShellFiles,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -19,6 +20,10 @@ stdenv.mkDerivation (finalAttrs: {
     url = "mirror://sourceforge/gptfdisk/gptfdisk-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-Kr7WG8bSuexJiXPARAuLgEt6ctcUQGm1qSCbKtaTooI=";
   };
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
 
   postPatch = ''
     patchShebangs gdisk_test.sh
@@ -47,12 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   installPhase = ''
-    mkdir -p $out/sbin
-    mkdir -p $out/share/man/man8
     for prog in gdisk sgdisk fixparts cgdisk
     do
-        install -v -m755 $prog $out/sbin
-        install -v -m644 $prog.8 $out/share/man/man8
+        installBin $prog
+        installManPage $prog.8
     done
   '';
 


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test