### PR TITLE
postgresqlPackages.pg_background: 1.5 -> 1.6

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_background.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_background.nix
@@ -8,13 +8,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "pg_background";
-  version = "1.5";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "vibhorkum";
     repo = "pg_background";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9fW5wHdo9r5fLwU8zN2EEVSWxa+7q2qMjPpMo6iCavg=";
+    hash = "sha256-RA4ZI3BmtbwIGX9Gc+QSxh9lNj5jLVZY5RtPgbt7cTM=";
   };
 
   buildInputs = postgresql.buildInputs;


### PR DESCRIPTION
Release 1.6 of  https://github.com/vibhorkum/pg_background brings several improvements among which one of the most important is fixing race condition in detach. See release notes: https://github.com/vibhorkum/pg_background/releases/tag/v1.6

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.