### PR TITLE
nixos/man-db: add option to generate cache at runtime

### DIFF
--- a/nixos/modules/misc/man-db.nix
+++ b/nixos/modules/misc/man-db.nix
@@ -55,6 +55,8 @@ in
           configuration options used for the package.
         '';
       };
+
+      generateCachesAtRuntime = lib.mkEnableOption "run man-db as a systemd service";
     };
   };
 
@@ -65,41 +67,81 @@ in
     )
   ];
 
-  config = lib.mkIf cfg.enable {
-    environment.systemPackages = [ cfg.package ];
-    environment.etc."man_db.conf".text =
-      let
-        # We unfortunately can’t use the customized `cfg.package` when
-        # cross‐compiling. Instead we detect that situation and work
-        # around it by using the vanilla one, like the OpenSSH module.
-        buildPackage =
-          if pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform then
-            cfg.package
-          else
-            pkgs.buildPackages.man-db;
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        environment.systemPackages = [ cfg.package ];
+        environment.etc."man_db.conf".text =
+          let
+            # We unfortunately can’t use the customized `cfg.package` when
+            # cross‐compiling. Instead we detect that situation and work
+            # around it by using the vanilla one, like the OpenSSH module.
+            buildPackage =
+              if pkgs.stdenv.buildPlatform.canExecute pkgs.stdenv.hostPlatform then
+                cfg.package
+              else
+                pkgs.buildPackages.man-db;
 
-        manualCache =
-          pkgs.runCommand "man-cache"
-            {
-              nativeBuildInputs = [ buildPackage ];
-              preferLocalBuild = true;
-            }
-            ''
-              echo "MANDB_MAP ${cfg.manualPages}/share/man $out" > man.conf
-              mandb -C man.conf -pscq
-            '';
-      in
-      ''
-        # Manual pages paths for NixOS
-        MANPATH_MAP /run/current-system/sw/bin /run/current-system/sw/share/man
-        MANPATH_MAP /run/wrappers/bin          /run/current-system/sw/share/man
+            manualCache =
+              pkgs.runCommand "man-cache"
+                {
+                  nativeBuildInputs = [ buildPackage ];
+                  preferLocalBuild = true;
+                }
+                ''
+                  echo "MANDB_MAP ${cfg.manualPages}/share/man $out" > man.conf
+                  mandb -C man.conf -pscq
+                '';
+          in
+          ''
+            # Manual pages paths for NixOS
+            MANPATH_MAP /run/current-system/sw/bin /run/current-system/sw/share/man
+            MANPATH_MAP /run/wrappers/bin          /run/current-system/sw/share/man
 
-        ${lib.optionalString config.documentation.man.generateCaches ''
-          # Generated manual pages cache for NixOS (immutable)
-          MANDB_MAP /run/current-system/sw/share/man ${manualCache}
-        ''}
-        # Manual pages caches for NixOS
-        MANDB_MAP /run/current-system/sw/share/man /var/cache/man/nixos
-      '';
-  };
+            ${lib.optionalString (!cfg.generateCachesAtRuntime && config.documentation.man.generateCaches) ''
+              # Generated manual pages cache for NixOS (immutable)
+              MANDB_MAP /run/current-system/sw/share/man ${manualCache}
+            ''}
+            ${lib.optionalString cfg.generateCachesAtRuntime ''
+              # Manual pages caches for NixOS
+              MANDB_MAP /run/current-system/sw/share/man /var/cache/man/nixos
+            ''}
+          '';
+      }
+
+      (lib.mkIf cfg.generateCachesAtRuntime {
+        users.users.mandb = {
+          isSystemUser = true;
+          group = "mandb";
+        };
+        users.groups.mandb = { };
+
+        systemd.services.mandb = {
+          path = [
+            pkgs.man
+            pkgs.rsync
+          ];
+          script = ''
+            echo "MANDB_MAP $CACHE_DIRECTORY/nixos-manpages $CACHE_DIRECTORY/nixos" \
+              > "$RUNTIME_DIRECTORY/man.conf"
+
+            mkdir -p "$CACHE_DIRECTORY/nixos"
+            rsync \
+              --checksum --recursive --copy-links --delete --no-times --no-perms --chmod=+w \
+              ${cfg.manualPages}/share/man/ "$CACHE_DIRECTORY/nixos-manpages"
+
+            mandb -C "$RUNTIME_DIRECTORY/man.conf" -q
+          '';
+          serviceConfig = {
+            CacheDirectory = "man";
+            RuntimeDirectory = "mandb";
+            User = "mandb";
+            InaccessiblePaths = [ "/etc" ]; # man-db still reads /etc/man_db.conf even when setting -C
+            ProtectSystem = "strict";
+          };
+          wantedBy = [ "default.target" ];
+        };
+      })
+    ]
+  );
 }


### PR DESCRIPTION
Speeds up generation by maintaining a separate copy of `manualPages` with appropriate timestamps so that mandb picks up changes without having to re-generate the full cache.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
