### PR TITLE
pymcuprog: init at 3.19.4.61, pyedbglib: init at 2.24.2.18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21411,6 +21411,12 @@
     githubId = 4033651;
     name = "Keagan McClelland";
   };
+  prophetofxenu = {
+    email = "xenu@prophetofxenu.net";
+    github = "prophetofxenu";
+    githubId = 20529712;
+    name = "William Harrell";
+  };
   protoben = {
     email = "protob3n@gmail.com";
     github = "protoben";

--- a/pkgs/by-name/py/pymcuprog/package.nix
+++ b/pkgs/by-name/py/pymcuprog/package.nix
@@ -1,0 +1,1 @@
+{ python3Packages }: with python3Packages; toPythonApplication pymcuprog

--- a/pkgs/development/python-modules/pyedbglib/default.nix
+++ b/pkgs/development/python-modules/pyedbglib/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  cython,
+  hidapi,
+  pyserial,
+
+  # tests
+  pytestCheckHook,
+  mock,
+}:
+
+buildPythonPackage {
+  pname = "pyedbglib";
+  version = "2.24.2.18";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microchip-pic-avr-tools";
+    repo = "pyedbglib";
+    # the repo currently does not tag releases, so using the
+    # commit ID for now
+    rev = "9bbeceba942772ef31b9c059b761460a782313e";
+    hash = "sha256-iZB/+JEBy5n1zfajmJmEqRVQ2hPzJD/U85SvmyFiGhc=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    cython
+    hidapi
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "pyedbglib" ];
+
+  nativeCheckInputs = [
+    mock
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Low-level protocol library for communicating with Microchip CMSIS-DAP based debuggers";
+    homepage = "https://github.com/microchip-pic-avr-tools/pyedbglib";
+    changelog = "https://github.com/microchip-pic-avr-tools/pyedbglib/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ prophetofxenu ];
+  };
+}

--- a/pkgs/development/python-modules/pymcuprog/default.nix
+++ b/pkgs/development/python-modules/pymcuprog/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  appdirs,
+  intelhex,
+  pyedbglib,
+  pyserial,
+  pyyaml,
+
+  # tests
+  mock,
+  parameterized,
+  pytestCheckHook,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage {
+  pname = "pymcuprog";
+  version = "3.19.4.61";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "microchip-pic-avr-tools";
+    repo = "pymcuprog";
+    # the repo currently does not tag releases, so using the
+    # commit ID for now
+    rev = "e2fa9a7f0b9cc413367c51b9ccf19d93cdca6c8";
+    hash = "sha256-RmFGQ6LbuwwM/WHr01nYGZYoWG7Qbasz/TL4r8l1NUk";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    appdirs
+    intelhex
+    pyedbglib
+    pyserial
+    pyyaml
+  ];
+
+  pythonImportsCheck = [ "pymcuprog" ];
+
+  nativeCheckInputs = [
+    mock
+    parameterized
+    pytestCheckHook
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = "HOME";
+
+  meta = {
+    description = "Python utility for programming various Microchip MCU devices using Microchip CMSIS-DAP based debuggers";
+    mainProgram = "pymcuprog";
+    homepage = "https://github.com/microchip-pic-avr-tools/pymcuprog";
+    changelog = "https://github.com/microchip-pic-avr-tools/pymcuprog/blob/main/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ prophetofxenu ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13422,6 +13422,8 @@ self: super: with self; {
 
   pyecowitt = callPackage ../development/python-modules/pyecowitt { };
 
+  pyedbglib = callPackage ../development/python-modules/pyedbglib { };
+
   pyedflib = callPackage ../development/python-modules/pyedflib { };
 
   pyedimax = callPackage ../development/python-modules/pyedimax { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13972,6 +13972,8 @@ self: super: with self; {
 
   pymc = callPackage ../development/python-modules/pymc { };
 
+  pymcuprog = callPackage ../development/python-modules/pymcuprog { };
+
   pymdown-extensions = callPackage ../development/python-modules/pymdown-extensions { };
 
   pymdstat = callPackage ../development/python-modules/pymdstat { };


### PR DESCRIPTION
Adds the Python application pymcuprog and its dependency pyedbglib. These are useful for embedded development with microcontrollers that make use of UPDI, such as the popular ATTiny series, with [Platform IO](https://docs.platformio.org/en/stable/platforms/atmelmegaavr.html#upload-using-pymcuprog-serialupdi). Both packages are maintained by Microchip, who maintains the ATTiny series and AVR architecture.

I've used this locally to successfully upload programs to an ATTiny3216 for a project.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
