### PR TITLE
postgresqlPackages.pg_tracing: init at 0.1.3

### DIFF
--- a/pkgs/servers/sql/postgresql/ext/pg_tracing.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_tracing.nix
@@ -1,0 +1,30 @@
+{
+  fetchFromGitHub,
+  lib,
+  postgresql,
+  postgresqlBuildExtension,
+  curl,
+}:
+
+postgresqlBuildExtension (finalAttrs: {
+  pname = "pg_tracing";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "DataDog";
+    repo = "pg_tracing";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5W1lOpY0RrBsYQPUSD8xKCedLktI+GGkn0xGlqJ0N6c=";
+  };
+
+  buildInputs = [ curl ];
+
+  meta = {
+    description = "PostgreSQL extension that generates server-side spans for distributed tracing";
+    homepage = "https://github.com/DataDog/pg_tracing";
+    changelog = "https://github.com/DataDog/pg_tracing/releases/tag/v${finalAttrs.version}";
+    maintainers = with lib.maintainers; [ mkleczek ];
+    platforms = postgresql.meta.platforms;
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
pg_tracing is a PostgreSQL extension that generates server-side spans for distributed tracing. This extension enables end-to-end tracing with visibility into PostgreSQL query execution. See: https://github.com/DataDog/pg_tracing

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
