### PR TITLE
[Backport release-25.11] GNOME updates 2026-01-24

### DIFF
--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -73,7 +73,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-shell";
-  version = "49.2";
+  version = "49.3";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-shell/${lib.versions.major finalAttrs.version}/gnome-shell-${finalAttrs.version}.tar.xz";
-    hash = "sha256-0TuFXY35nev37M+BC24FT9sK64fvixMZGKbkyRl6Asc=";
+    hash = "sha256-KPDb1kRS8AVxKfImdTyV0nJt4H8fX0c63cfDxQem0xo=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-text-editor/package.nix
+++ b/pkgs/by-name/gn/gnome-text-editor/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-text-editor";
-  version = "49.0";
+  version = "49.1";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-text-editor/${lib.versions.major finalAttrs.version}/gnome-text-editor-${finalAttrs.version}.tar.xz";
-    hash = "sha256-jkOwz6gVLNPHYw3lZd4taTDoh88ti4RID7+FOivCyKY=";
+    hash = "sha256-8ESPJHu1l5pQxgIixExFEYgK1HTiVJV2Xl7SJG5U27E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gt/gthumb/package.nix
+++ b/pkgs/by-name/gt/gthumb/package.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gthumb";
-  version = "3.12.8.1";
+  version = "3.12.8.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gthumb/${lib.versions.majorMinor finalAttrs.version}/gthumb-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-JzYvwRylxYHzFoIjDJUCDlofzd9M/+vnVVeCjGF021s=";
+    sha256 = "sha256-q8V7EQMWXdaRU1eW99vbp2hiF8fQael07Q89gA/oh5Y=";
   };
 
   strictDeps = true;
@@ -85,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs data/gschemas/make-enums.py \
       gthumb/make-gthumb-h.py \
       po/make-potfiles-in.py \
-      postinstall.py \
       gthumb/make-authors-tab.py
   '';
 

--- a/pkgs/by-name/gt/gthumb/package.nix
+++ b/pkgs/by-name/gt/gthumb/package.nix
@@ -34,11 +34,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gthumb";
-  version = "3.12.8.2";
+  version = "3.12.9";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gthumb/${lib.versions.majorMinor finalAttrs.version}/gthumb-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-q8V7EQMWXdaRU1eW99vbp2hiF8fQael07Q89gA/oh5Y=";
+    sha256 = "sha256-13+ItWneSSV4BzDnhnspB3GNpmBowkLd6bvaEH4YP/o=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/mu/mutter/package.nix
+++ b/pkgs/by-name/mu/mutter/package.nix
@@ -71,7 +71,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mutter";
-  version = "49.2";
+  version = "49.3";
 
   outputs = [
     "out"
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/mutter/${lib.versions.major finalAttrs.version}/mutter-${finalAttrs.version}.tar.xz";
-    hash = "sha256-J2ORoIDlCVaSQKyGECVdd4q2qIoyUPmxd0AlXxNOPAo=";
+    hash = "sha256-nvH2HW/kAcyj/L5tmjsqT5tCY4y/hENzVmamGWSo8MM=";
   };
 
   mesonFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Backport PR 
- https://github.com/NixOS/nixpkgs/pull/483366

## Things done

Cherry-picked the commits.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
