### PR TITLE
python3Packages.md2pdf: 2.1.0 -> 3.1.0

### DIFF
--- a/pkgs/by-name/md/md2pdf/package.nix
+++ b/pkgs/by-name/md/md2pdf/package.nix
@@ -1,0 +1,9 @@
+{
+  python3Packages,
+}:
+
+python3Packages.toPythonApplication (
+  python3Packages.md2pdf.overridePythonAttrs (oldAttrs: {
+    dependencies = oldAttrs.dependencies ++ oldAttrs.optional-dependencies.cli;
+  })
+)

--- a/pkgs/development/python-modules/md2pdf/default.nix
+++ b/pkgs/development/python-modules/md2pdf/default.nix
@@ -1,6 +1,5 @@
 {
   buildPythonPackage,
-  click,
   fetchFromGitHub,
   hatchling,
   jinja2,
@@ -8,28 +7,30 @@
   markdown,
   pygments,
   pymdown-extensions,
+  pypdf,
   pytest-cov-stub,
   pytestCheckHook,
   python-frontmatter,
+  typer,
+  watchfiles,
   weasyprint,
 }:
 
 buildPythonPackage rec {
   pname = "md2pdf";
-  version = "2.1.0";
+  version = "3.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "jmaupetit";
     repo = "md2pdf";
     tag = "v${version}";
-    hash = "sha256-oVWUoWIS9GmkNPbJg90diT0jEgOULySSNxNdg95T2Vs=";
+    hash = "sha256-ksccl9K0o0mZleyLe1K1ob78W2MKZksTFtu6/dZUWeg=";
   };
 
   build-system = [ hatchling ];
 
   dependencies = [
-    click
     jinja2
     markdown
     pygments
@@ -38,16 +39,36 @@ buildPythonPackage rec {
     weasyprint
   ];
 
+  optional-dependencies = {
+    cli = [
+      typer
+      watchfiles
+    ];
+    latex = [
+      # FIXME package markdown-latex
+    ];
+  };
+
   pythonImportsCheck = [ "md2pdf" ];
 
   nativeCheckInputs = [
+    pypdf
     pytest-cov-stub
     pytestCheckHook
-  ];
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
 
   preCheck = ''
     export PATH="$out/bin:$PATH"
   '';
+
+  disabledTests = [
+    # AssertionError caused by
+    #     glyph rendered for Unicode string unsupported by fonts: "👋" (U+1F44B)
+    "test_generate_pdf_with_jinja_context_input"
+    "test_generate_pdf_with_jinja_frontmatter_and_context_input"
+    "test_generate_pdf_with_jinja_frontmatter_input"
+  ];
 
   meta = {
     changelog = "https://github.com/jmaupetit/md2pdf/blob/${src.tag}/CHANGELOG.md";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2820,8 +2820,6 @@ with pkgs;
 
   md2gemini = with python3.pkgs; toPythonApplication md2gemini;
 
-  md2pdf = with python3Packages; toPythonApplication md2pdf;
-
   mdcat = callPackage ../tools/text/mdcat {
     inherit (python3Packages) ansi2html;
   };


### PR DESCRIPTION
Diff: https://github.com/jmaupetit/md2pdf/compare/v2.1.0...v3.1.0

Changelog: https://github.com/jmaupetit/md2pdf/blob/v3.1.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
