### PR TITLE
wivrn: 25.12 -> 26.2

### DIFF
--- a/nixos/modules/services/video/wivrn.nix
+++ b/nixos/modules/services/video/wivrn.nix
@@ -66,7 +66,6 @@ let
   serverExec = concatStringsSep " " (
     [
       serverPackageExe
-      "--systemd"
       enabledConfig
     ]
     ++ cfg.extraServerFlags
@@ -126,24 +125,29 @@ in
             Like upstream, the application option is a list including the application and it's flags. In the case of the NixOS module however, the first element of the list must be a package. The module will assert otherwise.
             The application can be set to a single package because it gets passed to lib.toList, though this will not allow for flags to be passed.
 
+            WiVRn has good default configurations and most options can be configured at runtime so it is recommended to leave this empty and try the defaults before attempting manual configuration.
+
             See <https://github.com/WiVRn/WiVRn/blob/master/docs/configuration.md>
           '';
           default = { };
           example = literalExpression ''
             {
-              scale = 0.5;
-              bitrate = 100000000;
-              encoders = [
+              # left eye, hardware; right eye, software; transparency, hardware
+              encoder = [
                 {
-                  encoder = "nvenc";
+                  encoder = "vulkan";
+                  codec = "h265";
+                }
+                {
+                  encoder = "x264";
                   codec = "h264";
-                  width = 1.0;
-                  height = 1.0;
-                  offset_x = 0.0;
-                  offset_y = 0.0;
+                }
+                {
+                  encoder = "vulkan";
+                  codec = "h265";
                 }
               ];
-              application = [ pkgs.wlx-overlay-s ];
+              application = [ pkgs.wayvr ];
             }
           '';
         };
@@ -206,6 +210,7 @@ in
                 RestrictSUIDSGID = true;
               }
           );
+          # Needs Steam in the PATH to allow launching games from the headset
           path = [ cfg.steam.package ];
           wantedBy = mkIf cfg.autoStart [ "default.target" ];
           restartTriggers = [

--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -4,7 +4,6 @@
   stdenv,
   fetchFromGitHub,
   fetchFromGitLab,
-  fetchpatch,
   applyPatches,
   autoAddDriverRunpath,
   avahi,
@@ -34,7 +33,6 @@
   makeDesktopItem,
   nix-update-script,
   nlohmann_json,
-  onnxruntime,
   opencomposite,
   openxr-loader,
   ovrCompatSearchPaths ? "${xrizer}/lib/xrizer:${opencomposite}/lib/opencomposite",
@@ -43,7 +41,6 @@
   python3,
   qt6,
   shaderc,
-  spdlog,
   systemd,
   udev,
   vulkan-headers,
@@ -56,13 +53,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wivrn";
-  version = "25.12";
+  version = "26.2";
 
   src = fetchFromGitHub {
     owner = "wivrn";
     repo = "wivrn";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-gadfW3/PXi9SEztaHbi4U29Vj7ik/ia8BVDTy8P5aJE=";
+    hash = "sha256-wVFC8VDtALHI6e0655Ytc4gNOPnJP65XWNzlhzH2eoc=";
   };
 
   monado = applyPatches {
@@ -70,8 +67,8 @@ stdenv.mkDerivation (finalAttrs: {
       domain = "gitlab.freedesktop.org";
       owner = "monado";
       repo = "monado";
-      rev = "20e0dacbdd2de863923790326beec76e848b056a";
-      hash = "sha256-wiXdMgp3bKW17KqLnSn6HHhz7xbQtjp4c3aU7qp+2BE=";
+      rev = "9dcc3e1de2f7449d9757f5db332c867b4d794fb3";
+      hash = "sha256-ueg/GDnKP4nRVepdNE3sgK8sYckZc0aaC0CQc3tuxik=";
     };
 
     postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package:
- Bumped WiVRn version
- Removed unused dependencies leftover from an older commit

Module:
- Removed systemd flag (removed upstread) (closes https://github.com/NixOS/nixpkgs/issues/482152)
- Updated some comments and example/descriptions (closes https://github.com/NixOS/nixpkgs/pull/480758)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
