### PR TITLE
irrd: 4.5.0b2 -> 4.5.0

### DIFF
--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -34,6 +34,19 @@ let
         };
         doCheck = false;
       });
+
+      # https://github.com/irrdnet/irrd/blob/0fd95020279060f2bc2816c0533c825e40f4c73c/pyproject.toml#L58C1-L59C1
+      limits = prev.limits.overridePythonAttrs (oldAttrs: rec {
+        version = "5.6.0";
+        src = fetchFromGitHub {
+          owner = "alisaifee";
+          repo = "limits";
+          tag = version;
+          hash = "sha256-kghfF2ihEvyMPEGO1m9BquCdeBsYRoPyIljdLL1hToQ=";
+        };
+        doCheck = false;
+      });
+
     };
   };
 in

--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -51,7 +51,7 @@ let
   };
 in
 
-py.pkgs.buildPythonPackage rec {
+py.pkgs.buildPythonPackage (finalAttrs: {
   pname = "irrd";
   version = "4.5.0";
   pyproject = true;
@@ -59,7 +59,7 @@ py.pkgs.buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "irrdnet";
     repo = "irrd";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-6z94Ha2QQ0LE4o3hzsNl4y/nPv849cSP8on3UeegE4c=";
   };
 
@@ -160,10 +160,10 @@ py.pkgs.buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://irrd.readthedocs.io/en/${src.tag}/releases/";
+    changelog = "https://irrd.readthedocs.io/en/${finalAttrs.src.tag}/releases/";
     description = "Internet Routing Registry database server, processing IRR objects in the RPSL format";
     license = lib.licenses.mit;
     homepage = "https://github.com/irrdnet/irrd";
     maintainers = with lib.maintainers; [ yureka-wdz ];
   };
-}
+})

--- a/pkgs/by-name/ir/irrd/package.nix
+++ b/pkgs/by-name/ir/irrd/package.nix
@@ -3,7 +3,6 @@
   python3,
   fetchPypi,
   fetchFromGitHub,
-  fetchpatch,
   git,
   postgresql,
   postgresqlTestHook,
@@ -41,20 +40,15 @@ in
 
 py.pkgs.buildPythonPackage rec {
   pname = "irrd";
-  version = "4.5.0b2";
+  version = "4.5.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "irrdnet";
     repo = "irrd";
-    rev = "v${version}";
-    hash = "sha256-MMacxjF0LLSdInSwXwpHJUTdUQJ6sl4yu83vWR/A4Jc=";
+    tag = "v${version}";
+    hash = "sha256-6z94Ha2QQ0LE4o3hzsNl4y/nPv849cSP8on3UeegE4c=";
   };
-
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail py-radix py-radix-sr
-  '';
 
   pythonRelaxDeps = true;
 
@@ -153,7 +147,7 @@ py.pkgs.buildPythonPackage rec {
   ];
 
   meta = {
-    changelog = "https://irrd.readthedocs.io/en/v${version}/releases/";
+    changelog = "https://irrd.readthedocs.io/en/${src.tag}/releases/";
     description = "Internet Routing Registry database server, processing IRR objects in the RPSL format";
     license = lib.licenses.mit;
     homepage = "https://github.com/irrdnet/irrd";


### PR DESCRIPTION
1. Version bump
2. Pin `limits` at 5.6.0 to match upstream pin. Discovered breakage in #487455
3. Migrate to `finalAttrs`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
