### PR TITLE
treewide: fix build of various zig packages after breakage in e20232eab

### DIFF
--- a/pkgs/by-name/bl/blackshades/package.nix
+++ b/pkgs/by-name/bl/blackshades/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-W6ltmWCw7jfiTiNlh60YVF7mz//8s+bgu4F9gy5cDgw=";
   };
 
-  postUnpack = ''
+  postConfigure = ''
     ln -s ${
       zig_0_14.fetchDeps {
         inherit (finalAttrs)

--- a/pkgs/by-name/bo/bold/package.nix
+++ b/pkgs/by-name/bo/bold/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/bo/bork/package.nix
+++ b/pkgs/by-name/bo/bork/package.nix
@@ -31,7 +31,7 @@ stdenvNoCC.mkDerivation {
 
   zigBuildFlags = [ "--release=fast" ];
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/fa/fancy-cat/package.nix
+++ b/pkgs/by-name/fa/fancy-cat/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     libz
   ];
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./build.zig.zon.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/fl/flow-control/package.nix
+++ b/pkgs/by-name/fl/flow-control/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-868FK3wr/fjXzrQJ4YVDBvzNuX818lufEx/K0fvJdWo=";
   };
-  postPatch = ''
+  postConfigure = ''
     ln -s ${
       callPackage ./build.zig.zon.nix {
         zig = zig_0_15;

--- a/pkgs/by-name/he/hevi/package.nix
+++ b/pkgs/by-name/he/hevi/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     zig
   ];
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/li/linuxwave/package.nix
+++ b/pkgs/by-name/li/linuxwave/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OuD5U/T3GuCQrzdhx01NXPSXD7pUAvLnNsznttJogz8=";
   };
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/ls/lsr/package.nix
+++ b/pkgs/by-name/ls/lsr/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-VeB0R/6h9FXSzBfx0IgpGlBz16zQScDSiU7ZvTD/Cds=";
   };
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/ly/ly/package.nix
+++ b/pkgs/by-name/ly/ly/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ (lib.optionals x11Support [ libxcb ]);
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${
       callPackage ./deps.nix {
         inherit zig;

--- a/pkgs/by-name/od/odiff/package.nix
+++ b/pkgs/by-name/od/odiff/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-gCF+CInczBJfDyZgxEQor5C/OSxKciCu9gbZanaE/nA=";
   };
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./build.zig.zon.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/ri/river-classic/package.nix
+++ b/pkgs/by-name/ri/river-classic/package.nix
@@ -59,8 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional xwaylandSupport libx11;
 
-  dontConfigure = true;
-
   zigBuildFlags = [
     "--system"
     "${finalAttrs.deps}"

--- a/pkgs/by-name/ri/rivercarro/package.nix
+++ b/pkgs/by-name/ri/rivercarro/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     zig
   ];
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/by-name/su/superhtml/package.nix
+++ b/pkgs/by-name/su/superhtml/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     zig
   ];
 
-  postPatch = ''
+  postConfigure = ''
     ln -s ${callPackage ./deps.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
   '';
 

--- a/pkgs/development/tools/zls/default.nix
+++ b/pkgs/development/tools/zls/default.nix
@@ -40,7 +40,7 @@ lib.mapAttrs (_: extension: stdenv.mkDerivation (lib.extends common extension)) 
 
     nativeBuildInputs = [ zig_0_14 ];
 
-    postPatch = ''
+    postConfigure = ''
       ln -s ${callPackage ./deps_0_14.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
     '';
   };
@@ -58,7 +58,7 @@ lib.mapAttrs (_: extension: stdenv.mkDerivation (lib.extends common extension)) 
 
     nativeBuildInputs = [ zig_0_15 ];
 
-    postPatch = ''
+    postConfigure = ''
       ln -s ${callPackage ./deps_0_15.nix { }} $ZIG_GLOBAL_CACHE_DIR/p
     '';
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Commit e20232eab690 moved ZIG_GLOBAL_CACHE_DIR setup from an
addEnvHooks call into zigConfigurePhase. This broke all zig packages
that referenced $ZIG_GLOBAL_CACHE_DIR in postPatch or postUnpack,
since that variable is no longer set until configurePhase runs.

Move the symlink creation to postConfigure for all affected packages.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
