### PR TITLE
nixos/power-management: run powerUpCommands in service instead of stage2-init.sh and deprecate powerUpCommands

### DIFF
--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -62,6 +62,19 @@ in
 
   config = lib.mkIf cfg.enable {
 
+    warnings = lib.optional (cfg.powerUpCommands != "") ''
+      powerManagement.powerUpCommands is deprecated due to it having unclear ordering semantics.
+      It will be removed in NixOS 26.11.
+      It is recommended to create an explicit systemd oneshot service instead,
+      that is pulled in at the right time during the boot process.
+      See https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html
+      for more information on possible targets that can be used for this.
+
+      If you also want to run this service upon waking up from resume, the recommended
+      method to do so is described here:
+      https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#sleep.target
+    '';
+
     systemd.targets.post-resume = {
       description = "Post-Resume Actions";
       requires = [ "post-resume.service" ];
@@ -85,8 +98,8 @@ in
       description = "Post-boot Actions";
       # It's not well defined at what point in the bootup sequence this should run
       # we should eventually just remove this.
-      after = [ "multi-user.target" ];
       wantedBy = [ "multi-user.target" ];
+      restartIfChanged = false;
       serviceConfig = {
         Type = "oneshot";
         RemainAfterExit = true;

--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -81,6 +81,21 @@ in
       serviceConfig.Type = "oneshot";
     };
 
+    systemd.services.post-boot = {
+      description = "Post-boot Actions";
+      # It's not well defined at what point in the bootup sequence this should run
+      # we should eventually just remove this.
+      after = [ "multi-user.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+      script = ''
+        ${cfg.powerUpCommands}
+      '';
+    };
+
     systemd.services.post-resume = {
       description = "Post-Resume Actions";
       # Pulled in by post-resume.service above

--- a/nixos/modules/config/power-management.nix
+++ b/nixos/modules/config/power-management.nix
@@ -83,12 +83,8 @@ in
 
     systemd.services.post-resume = {
       description = "Post-Resume Actions";
-      after = [
-        "suspend.target"
-        "hibernate.target"
-        "hybrid-sleep.target"
-        "suspend-then-hibernate.target"
-      ];
+      # Pulled in by post-resume.service above
+      after = [ "sleep.target" ];
       script = ''
         /run/current-system/systemd/bin/systemctl try-restart --no-block post-resume.target
         ${cfg.resumeCommands}

--- a/nixos/modules/system/activation/nixos-init.nix
+++ b/nixos/modules/system/activation/nixos-init.nix
@@ -58,10 +58,6 @@ in
           assertion = config.boot.postBootCommands == "";
           message = "nixos-init cannot be used with boot.postBootCommands";
         }
-        {
-          assertion = config.powerManagement.powerUpCommands == "";
-          message = "nixos-init cannot be used with powerManagement.powerUpCommands";
-        }
       ];
     })
   ];

--- a/nixos/modules/system/boot/stage-2.nix
+++ b/nixos/modules/system/boot/stage-2.nix
@@ -30,7 +30,6 @@ let
       );
       postBootCommands = pkgs.writeText "local-cmds" ''
         ${config.boot.postBootCommands}
-        ${config.powerManagement.powerUpCommands}
       '';
     };
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- **nixos/power-management: use sleep.target instead of listing all individual sleep targets**
  See https://www.freedesktop.org/software/systemd/man/latest/systemd.special.html#sleep.target

- **nixos/power-management: run postBootCommands in a systemd service instead of stage2-init.sh**
  This reduces our initrd script slightly, and we never made any clear ordering guarantees about when these commands run anyway. It also removes this as a blocker for nixos-init.

- **nixos/power-management: deprecate powerUpCommands**
  Their ordering is ill-defined. Users are better off using an explicit systemd service.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
