### PR TITLE
pj: init at 1.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12920,6 +12920,12 @@
     github = "jooooscha";
     githubId = 57965027;
   };
+  josephschmitt = {
+    name = "Joseph Schmitt";
+    email = "dev@joe.sh";
+    github = "josephschmitt";
+    githubId = 136007;
+  };
   josephst = {
     name = "Joseph Stahl";
     email = "hello@josephstahl.com";

--- a/pkgs/by-name/pj/pj/package.nix
+++ b/pkgs/by-name/pj/pj/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "pj";
+  version = "1.11.0";
+
+  src = fetchFromGitHub {
+    owner = "josephschmitt";
+    repo = "pj";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xorBRRiG4mcXf0QtsYnEkNnEjyTemfNrpkK/aEbkOjQ=";
+  };
+
+  vendorHash = "sha256-rya2afSV9Y1hmUZU0wyR9NETBl3TXD/OTHv0zvVl8v8=";
+
+  ldflags = [
+    "-s"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Fast project directory finder that searches filesystems for git repositories";
+    homepage = "https://github.com/josephschmitt/pj";
+    changelog = "https://github.com/josephschmitt/pj/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ josephschmitt ];
+    mainProgram = "pj";
+  };
+})


### PR DESCRIPTION
[pj](https://github.com/josephschmitt/pj) is a fast project directory finder CLI written in Go that searches filesystems for git repositories and project directories. Designed for speed and seamless integration with fuzzy finders like `fzf`.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test