### PR TITLE
home-assistant-custom-components.battery_notes: init at 3.3.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "andrew-codechimp";
+  domain = "battery_notes";
+  version = "3.3.0";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "HA-Battery-Notes";
+    tag = version;
+    hash = "sha256-WOSWiWojT0pUhKvnl7qGvk6IHjENOy1rr0SFpTaQ0yI=";
+  };
+
+  # has no tests
+  doCheck = false;
+
+  meta = {
+    description = "Home Assistant integration to provide battery details of devices";
+    homepage = "https://github.com/andrew-codechimp/HA-Battery-Notes";
+    changelog = "https://github.com/andrew-codechimp/HA-Battery-Notes/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
