### PR TITLE
gitlab-art: init at 0.5.0

### DIFF
--- a/pkgs/by-name/gi/gitlab-art/package.nix
+++ b/pkgs/by-name/gi/gitlab-art/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication rec {
+  pname = "gitlab-art";
+  version = "0.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kosma";
+    repo = "gitlab-art";
+    tag = "v${version}";
+    hash = "sha256-j1MdkZUGMfrzowdhjJKhZqwN07JusaJsGkFu78IFdTY=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    pyaml
+    platformdirs
+    click
+    python-gitlab
+  ];
+
+  meta = {
+    description = "Pull cross-project Gitlab artifact dependencies";
+    homepage = "https://github.com/kosma/gitlab-art";
+    changelog = "https://github.com/kosma/gitlab-art/releases/tag/${src.tag}";
+    license = lib.licenses.wtfpl;
+    maintainers = with lib.maintainers; [ tbaldwin ];
+    mainProgram = "art";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## gitlab-art

From the docs:
> art solves a burning problem of pulling artifacts from different repositories.

This CLI application wraps the gitlab API commands to pull artifacts. It is mostly used in place of git submodules when the dependencies do not to be rebuilt every time CI runs.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
