### PR TITLE
hfsutils: init at 3.2.6

### DIFF
--- a/pkgs/by-name/hf/hfsutils/package.nix
+++ b/pkgs/by-name/hf/hfsutils/package.nix
@@ -1,0 +1,143 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  fetchDebianPatch,
+  testers,
+  autoreconfHook,
+  bash,
+  tcl,
+  tk,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hfsutils";
+  version = "3.2.6";
+
+  src = fetchurl {
+    urls = [
+      "https://fossies.org/linux/misc/old/hfsutils-${finalAttrs.version}.tar.gz"
+      "https://ftp2.osuosl.org/pub/clfs/conglomeration/hfsutils/hfsutils-${finalAttrs.version}.tar.gz"
+      "ftp://ftp.mars.org/hfs/hfsutils-${finalAttrs.version}.tar.gz"
+    ];
+    hash = "sha256-vJ0i1tJSuSDsnN8Y4At2VaYYmz809C5Y1bsVKVcomEA=";
+  };
+
+  patches = [
+    # extern declarations of errno instead of errno.h include breaks linking
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "15";
+      patch = "0002-Fix-FTBFS-with-gcc-3.4.patch";
+      hash = "sha256-3xOuEFHJeuVBmdqT/fec1jOxdBiXoUFG7ixGztJlxic=";
+    })
+
+    # Support files > 2GB
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "15";
+      patch = "0003-Add-support-for-files-larger-than-2GB.patch";
+      hash = "sha256-vXRjfJE3mJZyt739Ji5PnMnb94X50QhF0gpwCxRYqc4=";
+    })
+
+    # Tcl-interfacing code is old, needs deprecated interp->result
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "15";
+      patch = "0004-Add-DUSE_INTERP_RESULT-to-DEFINES-in-Makefile.in.patch";
+      hash = "sha256-m0zDWZsMXcytaOyHUqo8Dbb5A9G2DyjX8TCGXvXVpmc=";
+    })
+
+    # Fix missing string.h include for strcmp
+    (fetchDebianPatch {
+      inherit (finalAttrs) pname version;
+      debianRevision = "16";
+      patch = "0005-Fix-missing-inclusion-of-string.h-in-hpwd.c.patch";
+      hash = "sha256-PIksZZle+FCiexvecy4IOayNZD/X+Qa8DdE8Ej/p79U=";
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile.in \
+      --replace-fail 'exec hfssh' 'exec ${placeholder "out"}/bin/hfssh'
+  ''
+  # Overriding AR breaks cross
+  + ''
+    substituteInPlace libhfs/Makefile.in \
+      --replace-fail 'AR =' '#AR =' \
+      --replace-fail '$(AR) ' '$(AR) rc '
+  '';
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    bash # allow /bin/sh shebang in hfs to get patched during fixupPhase
+    tcl
+    tk
+  ];
+
+  configureFlags = [
+    (lib.strings.withFeatureAs true "tcl" "${tcl}")
+    (lib.strings.withFeatureAs true "tk" "${tk}")
+  ];
+
+  # Tcl code doesn't pass const strings to API
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
+  enableParallelBuilding = true;
+
+  # Makefile.in expects already-existing target dirs
+  preInstall = ''
+    mkdir -p $out/{bin,share/man/man1}
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  installCheckPhase =
+    let
+      diskLabel = "Test Disk";
+    in
+    ''
+      runHook preInstallCheck
+
+      # current volume is tracked in $HOME/.hcwd
+      export HOME=$(mktemp -d)
+
+      # Allow pipeline to fail here
+      set +o pipefail
+      yes | head -c 819200 > disk.hfs
+      set -o pipefail
+
+      $out/bin/hformat -l '${diskLabel}' disk.hfs
+
+      mount_output="$($out/bin/hmount disk.hfs)"
+      if ! echo "$mount_output" | grep "${diskLabel}"; then
+        echo "Label '${diskLabel}' not found" && exit 1
+      fi
+
+      runHook postInstallCheck
+    '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "hvol --version";
+  };
+
+  meta = {
+    description = "Tools for reading and writing Macintosh volumes";
+    longDescription = ''
+      HFS is the “Hierarchical File System”, the native volume format used on modern Macintosh computers.
+      hfsutils is the name of a comprehensive software package being developed to permit manipulation of
+      HFS volumes from UNIX and other systems.
+    '';
+    homepage = "https://www.mars.org/home/rob/proj/hfs/";
+    license = lib.licenses.gpl2Plus;
+    maintainers = [ lib.maintainers.OPNA2608 ];
+    mainProgram = "hfs";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Supersedes #357145

Will need this to make the boot partition for New World ROM Macs (must be a HFS[+] partition on an APM-formatted disk, with a blessed system directory, and a file blessed to be the `tbxi`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] powerpc64-linux (native, cross)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

Closes: #357145