### PR TITLE
package-version-server: 0.0.7 -> 0.0.10

### DIFF
--- a/pkgs/by-name/pa/package-version-server/package.nix
+++ b/pkgs/by-name/pa/package-version-server/package.nix
@@ -9,16 +9,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "package-version-server";
-  version = "0.0.7";
+  version = "0.0.10";
 
   src = fetchFromGitHub {
     owner = "zed-industries";
     repo = "package-version-server";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/YyJ8+tKrNKVrN+F/oHgtExBBRatIIOvWr9mAyTHA3E=";
+    hash = "sha256-1+7oqWiJd7AZUlaDGYRtR1lyenrlhyaaGeWufW9lPUU=";
   };
 
-  cargoHash = "sha256-/t1GPdb/zXe0pKeG/A4FKjKFFZ0zy2nT2PV8nxenKXc=";
+  cargoHash = "sha256-AOE0fs3QK8vTIMOIxMg6SooDSQVtqFdB0tF3S88J7Ew=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -28,7 +28,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     updateScript = nix-update-script { };
   };
 
-  doCheck = lib.versionAtLeast finalAttrs.version "0.0.8";
+  # Needs https://github.com/zed-industries/package-version-server/pull/2 to be merged
+  doCheck = false;
 
   meta = {
     description = "Language server that handles hover information in package.json files";


### PR DESCRIPTION
Diff: https://github.com/zed-industries/package-version-server/compare/v0.0.7...v0.0.10

The tests still can't be run since https://github.com/zed-industries/package-version-server/pull/2 hasn't been merged.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
