### PR TITLE
treewide: move env variable(s) into env for structuredAttrs (U-Z)

### DIFF
--- a/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
+++ b/pkgs/applications/networking/mailreaders/notmuch/muchsync.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     xapian
     zlib
   ];
-  XAPIAN_CONFIG = "${xapian}/bin/xapian-config";
+  env.XAPIAN_CONFIG = "${xapian}/bin/xapian-config";
   meta = {
     description = "Synchronize maildirs and notmuch databases";
     mainProgram = "muchsync";

--- a/pkgs/by-name/ad/adoptopenjdk-icedtea-web/package.nix
+++ b/pkgs/by-name/ad/adoptopenjdk-icedtea-web/package.nix
@@ -62,8 +62,10 @@ stdenv.mkDerivation (finalAttrs: {
     touch $XDG_CONFIG_HOME/icedtea-web/deployment.properties
   '';
 
-  HOME = "/build";
-  XDG_CONFIG_HOME = "/build";
+  env = {
+    HOME = "/build";
+    XDG_CONFIG_HOME = "/build";
+  };
 
   configureFlags = [
     "--with-itw-libs=DISTRIBUTION"

--- a/pkgs/by-name/av/avalonia/package.nix
+++ b/pkgs/by-name/av/avalonia/package.nix
@@ -70,11 +70,21 @@ stdenvNoCC.mkDerivation (
         ./0004-disable-windows-desktop.patch
       ];
 
-      # this needs to be match the version being patched above
-      UNICODE_CHARACTER_DATABASE = fetchzip {
-        url = "https://www.unicode.org/Public/15.0.0/ucd/UCD.zip";
-        hash = "sha256-jj6bX46VcnH7vpc9GwM9gArG+hSPbOGL6E4SaVd0s60=";
-        stripRoot = false;
+      env = {
+        # this needs to be match the version being patched above
+        UNICODE_CHARACTER_DATABASE = fetchzip {
+          url = "https://www.unicode.org/Public/15.0.0/ucd/UCD.zip";
+          hash = "sha256-jj6bX46VcnH7vpc9GwM9gArG+hSPbOGL6E4SaVd0s60=";
+          stripRoot = false;
+        };
+        FONTCONFIG_FILE =
+          let
+            fc = makeFontsConf { fontDirectories = [ liberation_ttf ]; };
+          in
+          runCommand "fonts.conf" { } ''
+            substitute ${fc} $out \
+            --replace-fail "/etc/" "${fontconfig.out}/etc/"
+          '';
       };
 
       postPatch = ''
@@ -141,15 +151,6 @@ stdenvNoCC.mkDerivation (
       #  - Project assets file '/build/source/nukebuild/obj/project.assets.json'
       #  - NuGet packages config '/build/source/nukebuild/_build.csproj'
       linkNuGetPackagesAndSources = true;
-
-      FONTCONFIG_FILE =
-        let
-          fc = makeFontsConf { fontDirectories = [ liberation_ttf ]; };
-        in
-        runCommand "fonts.conf" { } ''
-          substitute ${fc} $out \
-            --replace-fail "/etc/" "${fontconfig.out}/etc/"
-        '';
 
       preConfigure = ''
         # closed source (telemetry?) https://github.com/AvaloniaUI/Avalonia/discussions/16878

--- a/pkgs/by-name/de/deadlock-mod-manager/package.nix
+++ b/pkgs/by-name/de/deadlock-mod-manager/package.nix
@@ -86,7 +86,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ./no-updater-artifacts.patch
   ];
 
-  VITE_API_URL = "https://api.deadlockmods.app";
+  env.VITE_API_URL = "https://api.deadlockmods.app";
 
   # Skip tests that require network access
   checkFlags = [

--- a/pkgs/by-name/di/digitalbitbox/package.nix
+++ b/pkgs/by-name/di/digitalbitbox/package.nix
@@ -84,12 +84,14 @@ stdenv.mkDerivation (finalAttrs: {
     libsForQt5.qtmultimedia
   ];
 
-  LUPDATE = "${libsForQt5.qttools.dev}/bin/lupdate";
-  LRELEASE = "${libsForQt5.qttools.dev}/bin/lrelease";
-  MOC = "${libsForQt5.qtbase.dev}/bin/moc";
-  QTDIR = libsForQt5.qtbase.dev;
-  RCC = "${libsForQt5.qtbase.dev}/bin/rcc";
-  UIC = "${libsForQt5.qtbase.dev}/bin/uic";
+  env = {
+    LUPDATE = "${libsForQt5.qttools.dev}/bin/lupdate";
+    LRELEASE = "${libsForQt5.qttools.dev}/bin/lrelease";
+    MOC = "${libsForQt5.qtbase.dev}/bin/moc";
+    QTDIR = libsForQt5.qtbase.dev;
+    RCC = "${libsForQt5.qtbase.dev}/bin/rcc";
+    UIC = "${libsForQt5.qtbase.dev}/bin/uic";
+  };
 
   configureFlags = [
     "--enable-libusb"

--- a/pkgs/by-name/ev/evdev-proto/package.nix
+++ b/pkgs/by-name/ev/evdev-proto/package.nix
@@ -19,28 +19,30 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ freebsd.makeMinimal ];
 
-  ARCH = freebsd.makeMinimal.MACHINE_ARCH;
-  OPSYS = "FreeBSD";
-  _OSRELEASE = "${lib.versions.majorMinor freebsd.makeMinimal.version}-RELEASE";
+  env = {
+    ARCH = freebsd.makeMinimal.MACHINE_ARCH;
+    OPSYS = "FreeBSD";
+    _OSRELEASE = "${lib.versions.majorMinor freebsd.makeMinimal.version}-RELEASE";
 
-  AWK = "awk";
-  CHMOD = "chmod";
-  FIND = "find";
-  MKDIR = "mkdir -p";
-  PKG_BIN = "${buildPackages.pkg}/bin/pkg";
-  RM = "rm -f";
-  SED = "${buildPackages.freebsd.sed}/bin/sed";
-  SETENV = "env";
-  SH = "sh";
-  TOUCH = "touch";
-  XARGS = "xargs";
+    AWK = "awk";
+    CHMOD = "chmod";
+    FIND = "find";
+    MKDIR = "mkdir -p";
+    PKG_BIN = "${buildPackages.pkg}/bin/pkg";
+    RM = "rm -f";
+    SED = "${buildPackages.freebsd.sed}/bin/sed";
+    SETENV = "env";
+    SH = "sh";
+    TOUCH = "touch";
+    XARGS = "xargs";
 
-  ABI_FILE = runCommandCC "abifile" { } "$CC -shared -o $out";
-  CLEAN_FETCH_ENV = true;
-  INSTALL_AS_USER = true;
-  NO_CHECKSUM = true;
-  NO_MTREE = true;
-  SRC_BASE = freebsd.source;
+    ABI_FILE = runCommandCC "abifile" { } "$CC -shared -o $out";
+    CLEAN_FETCH_ENV = true;
+    INSTALL_AS_USER = true;
+    NO_CHECKSUM = true;
+    NO_MTREE = true;
+    SRC_BASE = freebsd.source;
+  };
 
   preUnpack = ''
     export MAKE_JOBS_NUMBER="$NIX_BUILD_CORES"

--- a/pkgs/by-name/gi/git-cinnabar/package.nix
+++ b/pkgs/by-name/gi/git-cinnabar/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IVizzc2dKZ83dz3KBMDDiaFNdnS40cS++k8AywyvakQ=";
   };
 
-  ZSTD_SYS_USE_PKG_CONFIG = true;
+  env.ZSTD_SYS_USE_PKG_CONFIG = true;
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/hi/hiredis/package.nix
+++ b/pkgs/by-name/hi/hiredis/package.nix
@@ -20,8 +20,10 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
   ];
 
-  PREFIX = "\${out}";
-  USE_SSL = 1;
+  env = {
+    PREFIX = "\${out}";
+    USE_SSL = 1;
+  };
 
   meta = {
     homepage = "https://github.com/redis/hiredis";

--- a/pkgs/by-name/ke/keyscope/package.nix
+++ b/pkgs/by-name/ke/keyscope/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     echo "fn main() {}" > build.rs
   '';
 
-  VERGEN_GIT_SEMVER = "v${finalAttrs.version}";
+  env.VERGEN_GIT_SEMVER = "v${finalAttrs.version}";
 
   # Test require network access
   doCheck = false;

--- a/pkgs/by-name/ku/kubectl/package.nix
+++ b/pkgs/by-name/ku/kubectl/package.nix
@@ -9,7 +9,7 @@ kubernetes.overrideAttrs (_: {
     "convert"
   ];
 
-  WHAT = lib.concatStringsSep " " [
+  env.WHAT = toString [
     "cmd/kubectl"
     "cmd/kubectl-convert"
   ];

--- a/pkgs/by-name/ku/kubernetes/package.nix
+++ b/pkgs/by-name/ku/kubernetes/package.nix
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
 
   patches = [ ./fixup-addonmanager-lib-path.patch ];
 
-  WHAT = lib.concatStringsSep " " components;
+  env.WHAT = toString components;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/li/lingua-franca/package.nix
+++ b/pkgs/by-name/li/lingua-franca/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ jdk17_headless ];
 
-  _JAVA_HOME = "${jdk17_headless}/";
+  env._JAVA_HOME = "${jdk17_headless}/";
 
   postPatch = ''
     substituteInPlace bin/lfc \

--- a/pkgs/by-name/mu/mudlet/package.nix
+++ b/pkgs/by-name/mu/mudlet/package.nix
@@ -103,8 +103,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCMAKE_SKIP_BUILD_RPATH=ON"
   ];
 
-  WITH_FONTS = "NO";
-  WITH_UPDATER = "NO";
+  env = {
+    WITH_FONTS = "NO";
+    WITH_UPDATER = "NO";
+  };
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/ng/ngt/package.nix
+++ b/pkgs/by-name/ng/ngt/package.nix
@@ -25,8 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
     openblas
   ];
 
-  NIX_ENFORCE_NO_NATIVE = !enableAVX;
-  __AVX2__ = if enableAVX then 1 else 0;
+  env = {
+    NIX_ENFORCE_NO_NATIVE = !enableAVX;
+    __AVX2__ = if enableAVX then 1 else 0;
+  };
 
   meta = {
     homepage = "https://github.com/yahoojapan/NGT";

--- a/pkgs/by-name/ni/nitrocli/package.nix
+++ b/pkgs/by-name/ni/nitrocli/package.nix
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage {
   doCheck = false;
 
   # link against packaged libnitrokey
-  USE_SYSTEM_LIBNITROKEY = 1;
+  env.USE_SYSTEM_LIBNITROKEY = 1;
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/rq/rq/package.nix
+++ b/pkgs/by-name/rq/rq/package.nix
@@ -30,7 +30,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     rm build.rs
   '';
 
-  VERGEN_SEMVER = finalAttrs.version;
+  env.VERGEN_SEMVER = finalAttrs.version;
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/sa/salt/package.nix
+++ b/pkgs/by-name/sa/salt/package.nix
@@ -65,7 +65,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ++ extraInputs;
 
   # Don't use fixed dependencies on Darwin
-  USE_STATIC_REQUIREMENTS = "0";
+  env.USE_STATIC_REQUIREMENTS = "0";
 
   # The tests fail due to socket path length limits at the very least;
   # possibly there are more issues but I didn't leave the test suite running

--- a/pkgs/by-name/sn/snapraid/package.nix
+++ b/pkgs/by-name/sn/snapraid/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-IoK37ZXlMRLDPjzsLUqcfcu4asdstFJYgHc2wAg9lno=";
   };
 
-  VERSION = finalAttrs.version;
+  env.VERSION = finalAttrs.version;
 
   doCheck = true;
 

--- a/pkgs/by-name/uw/uwsgi/package.nix
+++ b/pkgs/by-name/uw/uwsgi/package.nix
@@ -126,11 +126,23 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optional withPAM "pam" ++ lib.optional withSystemd "systemd_logger"
   );
 
-  # UWSGI_INCLUDES environment variable required for "auto" plugins
-  # to be detected. See uwsgiconfig.py for more details.
-  UWSGI_INCLUDES = lib.concatStringsSep "," (
-    map (p: "${lib.getDev p}/include") finalAttrs.buildInputs
-  );
+  env = {
+    # UWSGI_INCLUDES environment variable required for "auto" plugins
+    # to be detected. See uwsgiconfig.py for more details.
+    UWSGI_INCLUDES = lib.concatStringsSep "," (
+      map (p: "${lib.getDev p}/include") finalAttrs.buildInputs
+    );
+  }
+  // lib.optionalAttrs (lib.any (x: x.name == "php") needed) {
+    # this is a hack to make the php plugin link with session.so (which on nixos is a separate package)
+    # the hack works in coordination with ./additional-php-ldflags.patch
+    UWSGICONFIG_PHP_LDFLAGS = lib.concatStringsSep "," [
+      "-Wl"
+      "-rpath=${php-embed.extensions.session}/lib/php/extensions/"
+      "--library-path=${php-embed.extensions.session}/lib/php/extensions/"
+      "-l:session.so"
+    ];
+  };
 
   passthru = {
     inherit python3;
@@ -153,17 +165,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postConfigure
   '';
-
-  # this is a hack to make the php plugin link with session.so (which on nixos is a separate package)
-  # the hack works in coordination with ./additional-php-ldflags.patch
-  UWSGICONFIG_PHP_LDFLAGS = lib.optionalString (lib.any (x: x.name == "php") needed) (
-    lib.concatStringsSep "," [
-      "-Wl"
-      "-rpath=${php-embed.extensions.session}/lib/php/extensions/"
-      "--library-path=${php-embed.extensions.session}/lib/php/extensions/"
-      "-l:session.so"
-    ]
-  );
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ve/verilator/package.nix
+++ b/pkgs/by-name/ve/verilator/package.nix
@@ -21,10 +21,6 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "verilator";
   version = "5.044";
 
-  # Verilator gets the version from this environment variable
-  # if it can't do git describe while building.
-  VERILATOR_SRC_VERSION = "v${finalAttrs.version}";
-
   src = fetchFromGitHub {
     owner = "verilator";
     repo = "verilator";
@@ -88,6 +84,10 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   env = {
+    # Verilator gets the version from this environment variable
+    # if it can't do git describe while building.
+    VERILATOR_SRC_VERSION = "v${finalAttrs.version}";
+
     SYSTEMC_INCLUDE = "${lib.getDev systemc}/include";
     SYSTEMC_LIBDIR = "${lib.getLib systemc}/lib";
   };

--- a/pkgs/by-name/wa/waylyrics/package.nix
+++ b/pkgs/by-name/wa/waylyrics/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=tests::netease_lyric::get_netease_lyric" # Requires network access
   ];
 
-  WAYLYRICS_THEME_PRESETS_DIR = "${placeholder "out"}/share/waylyrics/themes";
+  env.WAYLYRICS_THEME_PRESETS_DIR = "${placeholder "out"}/share/waylyrics/themes";
 
   postInstall = ''
     # Install themes

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "lix";
 
   version = "${version}${suffix}";
-  VERSION_SUFFIX = suffix;
+  env.VERSION_SUFFIX = suffix;
 
   inherit src patches;
 


### PR DESCRIPTION
Moving by variable name this time, moving backwards: U-Z.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
