### PR TITLE
iroh-ssh: init at 0.2.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15628,6 +15628,12 @@
     githubId = 84395723;
     name = "Lukas Wurzinger";
   };
+  luke = {
+    email = "luke@maraud.earth";
+    github = "LukeDSchenk";
+    githubId = 41804945;
+    name = "Luke Schenk";
+  };
   lukebfox = {
     email = "lbentley-fox1@sheffield.ac.uk";
     github = "lukebfox";

--- a/pkgs/by-name/ir/iroh-ssh/package.nix
+++ b/pkgs/by-name/ir/iroh-ssh/package.nix
@@ -40,7 +40,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "SSH to any machine without IP";
     homepage = "https://github.com/rustonbsd/iroh-ssh";
-    maintainers = with lib.maintainers; [ luke ];
+    maintainers = with lib.maintainers; [
+      luke
+      rvdp
+    ];
     license = lib.licenses.mit;
     mainProgram = "iroh-ssh";
   };

--- a/pkgs/by-name/ir/iroh-ssh/package.nix
+++ b/pkgs/by-name/ir/iroh-ssh/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "iroh-ssh";
-  version = "0.2.8";
+  version = "0.2.9";
 
   src = fetchFromGitHub {
     owner = "rustonbsd";
     repo = "iroh-ssh";
     tag = finalAttrs.version;
-    hash = "sha256-jKJ0dathwsFif2N/X4CnMAG74h0h/5hnuWWwbJrbU18=";
+    hash = "sha256-0G2RZbxyxi96FpVPEamfcTrOgPxpFYHmyYg1kQfo7TQ=";
   };
 
-  cargoHash = "sha256-KZu4HA5E9R4sdBW5cdhyA5E2bo2YN2TPSKDlJuzDGnU=";
+  cargoHash = "sha256-2/hc1K6zUyQlWorZh34HP9PCdV4YD1ob9l1DFiW7c1Y=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/ir/iroh-ssh/package.nix
+++ b/pkgs/by-name/ir/iroh-ssh/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  autoAddDriverRunpath,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "iroh-ssh";
+  version = "0.2.8";
+
+  src = fetchFromGitHub {
+    owner = "rustonbsd";
+    repo = "iroh-ssh";
+    tag = finalAttrs.version;
+    hash = "sha256-jKJ0dathwsFif2N/X4CnMAG74h0h/5hnuWWwbJrbU18=";
+  };
+
+  cargoHash = "sha256-KZu4HA5E9R4sdBW5cdhyA5E2bo2YN2TPSKDlJuzDGnU=";
+
+  nativeBuildInputs = [
+    autoAddDriverRunpath
+    installShellFiles
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/iroh-ssh";
+  versionCheckProgramArg = "version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "ssh without ip";
+    homepage = "https://github.com/rustonbsd/iroh-ssh";
+    maintainers = "LukeDSchenk";
+    license = lib.licenses.mit;
+    mainProgram = "iroh-ssh";
+  };
+})
+
+

--- a/pkgs/by-name/ir/iroh-ssh/package.nix
+++ b/pkgs/by-name/ir/iroh-ssh/package.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  stdenv,
   rustPlatform,
   fetchFromGitHub,
-  autoAddDriverRunpath,
   installShellFiles,
   writableTmpDirAsHomeHook,
   versionCheckHook,
@@ -24,7 +22,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-KZu4HA5E9R4sdBW5cdhyA5E2bo2YN2TPSKDlJuzDGnU=";
 
   nativeBuildInputs = [
-    autoAddDriverRunpath
     installShellFiles
   ];
 
@@ -41,12 +38,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   meta = {
-    description = "ssh without ip";
+    description = "SSH to any machine without IP";
     homepage = "https://github.com/rustonbsd/iroh-ssh";
-    maintainers = "LukeDSchenk";
+    maintainers = with lib.maintainers; [ luke ];
     license = lib.licenses.mit;
     mainProgram = "iroh-ssh";
   };
 })
-
-


### PR DESCRIPTION
Adds [iroh-ssh](https://github.com/rustonbsd/iroh-ssh) as a package. `iroh-ssh` allows for SSH connections without IP addresses. It naturally hole punches NATs. It is built on [iroh](https://github.com/n0-computer/iroh).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
