### PR TITLE
thruster: init at 0.1.19

### DIFF
--- a/pkgs/by-name/th/thruster/package.nix
+++ b/pkgs/by-name/th/thruster/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildGo126Module,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildGo126Module (finalAttrs: {
+  pname = "thruster";
+  version = "0.1.19";
+
+  src = fetchFromGitHub {
+    owner = "basecamp";
+    repo = "thruster";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Bavw7w/3AWRqiMVGpsazmVOIGcqkZPAWVBOQRRlnaS0=";
+  };
+
+  vendorHash = "sha256-i5u1quR5V0ceFwRDW0Vym+9/dFUwzp9Wc1JrM0KGgY8=";
+
+  subPackages = [ "cmd/thrust" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Zero-config HTTP/2 proxy for Rails applications";
+    homepage = "https://github.com/basecamp/thruster";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "thrust";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
