### PR TITLE
kmscon: 9.3.0 -> 9.3.1, test `$TERM`

### DIFF
--- a/nixos/tests/kmscon.nix
+++ b/nixos/tests/kmscon.nix
@@ -29,8 +29,7 @@
   enableOCR = true;
 
   testScript = ''
-    machine.succeed(":")
-    # ^ this create a screen
+    machine.wait_for_unit("multi-user.target")
 
     with subtest("ensure we can open a tty"):
       machine.wait_for_text("machine login:")
@@ -38,6 +37,8 @@
       machine.wait_for_text("Password:")
       machine.send_chars("foobar\n")
       machine.wait_for_text("alice@machine")
+      machine.send_chars("echo $TERM\n")
+      machine.wait_for_text("xterm-256color")
       machine.screenshot("tty.png")
   '';
 }

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -73,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "KMS/DRM based System Console";
     mainProgram = "kmscon";
     homepage = "https://www.freedesktop.org/wiki/Software/kmscon/";
+    changelog = "https://github.com/kmscon/kmscon/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ccicnce113424 ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kmscon";
-  version = "9.3.0";
+  version = "9.3.1";
 
   src = fetchFromGitHub {
     owner = "kmscon";
     repo = "kmscon";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-vdM/3n3Y2FM+PLDgVuU10kkNLCSzTrFI35CaY5NxWks=";
+    hash = "sha256-pH+dBcUKXrVh9/y6mNWmYBx6HVbuSZX/F2sCG/Yj5UQ=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -12,6 +12,7 @@
   pango,
   pkg-config,
   docbook_xsl,
+  docbook_xml_dtd_42,
   libxslt,
   libgbm,
   ninja,
@@ -60,9 +61,22 @@ stdenv.mkDerivation (finalAttrs: {
     libxslt # xsltproc
   ];
 
+  outputs = [
+    "out"
+    "man"
+  ];
+
   patches = [
     ./sandbox.patch # Generate system units where they should be (nix store) instead of /etc/systemd/system
   ];
+
+  postPatch = ''
+    for i in ./docs/man/*.in; do
+      substituteInPlace "''${i}" \
+        --replace-fail "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd" \
+                       "${docbook_xml_dtd_42}/xml/dtd/docbook/docbookx.dtd"
+    done
+  '';
 
   passthru = {
     tests.kmscon = nixosTests.kmscon;

--- a/pkgs/by-name/li/libtsm/package.nix
+++ b/pkgs/by-name/li/libtsm/package.nix
@@ -35,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Terminal-emulator State Machine";
     homepage = "https://www.freedesktop.org/wiki/Software/kmscon/libtsm/";
+    changelog = "https://github.com/kmscon/libtsm/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ccicnce113424 ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Changelog: https://github.com/kmscon/kmscon/releases/tag/v9.3.1
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
