### PR TITLE
ocamlPackages.symex: init at 0.1

### DIFF
--- a/pkgs/development/ocaml-modules/symex/default.nix
+++ b/pkgs/development/ocaml-modules/symex/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildDunePackage,
+  fetchFromGitHub,
+  fmt,
+  prelude,
+  smtml,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "symex";
+  version = "0.1";
+
+  src = fetchFromGitHub {
+    owner = "ocamlpro";
+    repo = "symex";
+    tag = finalAttrs.version;
+    hash = "sha256-jKwFtxVcBD8Y1bfKRB8Z/MSeQLQWKvk00i8HqodkBbM=";
+  };
+
+  propagatedBuildInputs = [
+    fmt
+    prelude
+    smtml
+  ];
+
+  meta = {
+    description = "Primitives to write symbolic execution engines";
+    homepage = "https://github.com/ocamlpro/symex";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ redianthus ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2041,6 +2041,8 @@ let
 
         swhid_core = callPackage ../development/ocaml-modules/swhid_core { };
 
+        symex = callPackage ../development/ocaml-modules/symex { };
+
         synchronizer = callPackage ../development/ocaml-modules/synchronizer { };
 
         syslog = callPackage ../development/ocaml-modules/syslog { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
