### PR TITLE
build-support/php: fix updateScript when composerVendor omits composerLock

### DIFF
--- a/pkgs/build-support/php/builders/v2/build-composer-project.nix
+++ b/pkgs/build-support/php/builders/v2/build-composer-project.nix
@@ -107,8 +107,7 @@ let
       # Projects providing a lockfile from upstream can be automatically updated.
       passthru = passthru // {
         updateScript =
-          args.passthru.updateScript
-            or (if finalAttrs.composerVendor.composerLock == null then nix-update-script { } else null);
+          args.passthru.updateScript or (if composerLock == null then nix-update-script { } else null);
       };
 
       meta = meta // {


### PR DESCRIPTION
Need some help/checks to make sure this is the proper fix here.

#### Solution:
`updateScript` fallback now reads `composerLock` from the function parameter instead of `finalAttrs.composerVendor.composerLock`

#### Problem:
The `updateScript` logic accessed `finalAttrs.composerVendor.composerLock` to decide whether to use `nix-update-script`. This relied on `composerLock` being present as an attribute on the vendor derivation, which only holds when the caller explicitly passes `composerLock` in its input attrset.

When a package provides a custom `composerVendor` and omits `composerLock` (relying on the function default), `extendMkDerivation` never sees it in the caller's input attrs, so it's absent from the derivation. This produces an `attribute 'composerLock' missing` error.

This error class cannot be caught by `builtins.tryEval`, and I believe since `maintainers/scripts/update.nix` evaluates every package's `updateScript` during its tree walk, if there is one broken package it blocks `update.nix`.

I believe I experienced this issue from the pkg psysh (aae6550ebace), which dropped `composerLock` from its custom `composerVendor` without passing `composerLock` and broke running the nix update maintainer script for something else, giving me:
```
 … while evaluating derivation 'nixpkgs-update-script'
   whose name attribute is located at /home/alex/git/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:536:13

 … while evaluating attribute 'shellHook' of derivation 'nixpkgs-update-script'
   at /home/alex/git/nixpkgs/maintainers/scripts/update.nix:275:3:
    274|   '';
    275|   shellHook = ''
       |   ^
    276|     unset shellHook # do not contaminate nested shells

 (stack trace truncated; use '--show-trace' to show the full, detailed trace)

 error: attribute 'composerLock' missing
 at /home/alex/git/nixpkgs/pkgs/build-support/php/builders/v2/build-composer-project.nix:111:20:
    110|           args.passthru.updateScript
    111|             or (if finalAttrs.composerVendor.composerLock == null then nix-update-script { } else null);
       |                    ^
       112|       };
```

I tested with:
`nix-instantiate --eval` showing that `pkgs.psysh.updateScript` doesn't throw anymore
and
`nix-shell maintainers/scripts/update.nix` with a predicate completed without error

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
