### PR TITLE
timewall: move SHELL_COMPLETIONS_DIR into env for structuredAttrs, mo…

### DIFF
--- a/pkgs/by-name/ti/timewall/package.nix
+++ b/pkgs/by-name/ti/timewall/package.nix
@@ -7,15 +7,14 @@
   libheif,
   nix-update-script,
 }:
-
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "timewall";
   version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "bcyran";
     repo = "timewall";
-    rev = version;
+    tag = finalAttrs.version;
     hash = "sha256-+jQ8cQENxTgCyekF65tr4d2a7OwbJvagUX01DiJ8ytg=";
   };
 
@@ -28,17 +27,17 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ libheif ];
 
-  SHELL_COMPLETIONS_DIR = "completions";
+  env.SHELL_COMPLETIONS_DIR = "completions";
 
   preBuild = ''
-    mkdir ${SHELL_COMPLETIONS_DIR}
+    mkdir $SHELL_COMPLETIONS_DIR
   '';
 
   postInstall = ''
     installShellCompletion \
-      --bash ${SHELL_COMPLETIONS_DIR}/timewall.bash \
-      --zsh ${SHELL_COMPLETIONS_DIR}/_timewall \
-      --fish ${SHELL_COMPLETIONS_DIR}/timewall.fish
+      --bash $SHELL_COMPLETIONS_DIR/timewall.bash \
+      --zsh $SHELL_COMPLETIONS_DIR/_timewall \
+      --fish $SHELL_COMPLETIONS_DIR/timewall.fish
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -46,9 +45,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Apple dynamic HEIF wallpapers on GNU/Linux";
     homepage = "https://github.com/bcyran/timewall";
-    changelog = "https://github.com/bcyran/timewall/releases/tag/${version}";
+    changelog = "https://github.com/bcyran/timewall/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     mainProgram = "timewall";
     maintainers = with lib.maintainers; [ bcyran ];
   };
-}
+})


### PR DESCRIPTION
…dernize


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
