### PR TITLE
spdx-license-list-data: avoid using an env variable

### DIFF
--- a/pkgs/by-name/sp/spdx-license-list-data/package.nix
+++ b/pkgs/by-name/sp/spdx-license-list-data/package.nix
@@ -3,18 +3,7 @@
   lib,
   fetchFromGitHub,
 }:
-
-stdenvNoCC.mkDerivation rec {
-  pname = "spdx-license-list-data";
-  version = "3.27.0";
-
-  src = fetchFromGitHub {
-    owner = "spdx";
-    repo = "license-list-data";
-    rev = "v${version}";
-    hash = "sha256-TRrsxk+gtxI9KqJvFzD0Cfy1h5cZAJ2kT9KUARjlXcY=";
-  };
-
+let
   # List of file formats to package.
   _types = [
     "html"
@@ -27,6 +16,17 @@ stdenvNoCC.mkDerivation rec {
     "template"
     "text"
   ];
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "spdx-license-list-data";
+  version = "3.27.0";
+
+  src = fetchFromGitHub {
+    owner = "spdx";
+    repo = "license-list-data";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TRrsxk+gtxI9KqJvFzD0Cfy1h5cZAJ2kT9KUARjlXcY=";
+  };
 
   outputs = [ "out" ] ++ _types;
 
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
 
     mkdir -pv $out
-    for t in $_types
+    for t in ${lib.concatStringsSep " " _types}
     do
       _outpath=''${!t}
       mkdir -pv $_outpath
@@ -60,4 +60,4 @@ stdenvNoCC.mkDerivation rec {
     ];
     platforms = lib.platforms.all;
   };
-}
+})


### PR DESCRIPTION
This avoids polluting the environment and makes
tracking cleanup for __structuredAttrs easier.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
