### PR TITLE
noto-fonts: avoid using an env variable

### DIFF
--- a/pkgs/by-name/no/noto-fonts/package.nix
+++ b/pkgs/by-name/no/noto-fonts/package.nix
@@ -17,15 +17,17 @@
     weights, and freely available to all.
   '',
 }:
-
-stdenvNoCC.mkDerivation rec {
+let
+  _variants = map (variant: builtins.replaceStrings [ " " ] [ "" ] variant) variants;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noto-fonts${suffix}";
   version = "2026.02.01";
 
   src = fetchFromGitHub {
     owner = "notofonts";
     repo = "notofonts.github.io";
-    rev = "noto-monthly-release-${version}";
+    tag = "noto-monthly-release-${finalAttrs.version}";
     hash = "sha256-vhu3jojG6QlgY5gP4bCbpJznsQ1gExAfcRT42FcZUp4=";
   };
 
@@ -33,8 +35,6 @@ stdenvNoCC.mkDerivation rec {
     "out"
     "megamerge" # Experimental fonts created by merging regular notofonts
   ];
-
-  _variants = map (variant: builtins.replaceStrings [ " " ] [ "" ] variant) variants;
 
   installPhase = ''
     # We check availability in order of variable -> otf -> ttf
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation rec {
       ''
     else
       ''
-        for variant in $_variants; do
+        for variant in ${lib.concatStringsSep " " _variants}; do
           if [[ -d fonts/"$variant"/unhinted/variable-ttf ]]; then
             install -m444 -Dt $out_font fonts/"$variant"/unhinted/variable-ttf/*.ttf
           elif [[ -d fonts/"$variant"/unhinted/otf ]]; then
@@ -91,4 +91,4 @@ stdenvNoCC.mkDerivation rec {
       jopejoe1
     ];
   };
-}
+})


### PR DESCRIPTION
This avoids polluting the environment and makes
tracking cleanup for __structuredAttrs easier.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
