### PR TITLE
lixPackageSets.stable.nurl: init at 0.4.0

### DIFF
--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -25,6 +25,7 @@
   colmena,
   nix-update,
   nix-init,
+  nurl,
 
   storeDir ? "/nix/store",
   stateDir ? "/nix/var",
@@ -142,6 +143,10 @@ let
           };
 
           nix-init = nix-init.override {
+            nix = self.lix;
+          };
+
+          nurl = nurl.override {
             nix = self.lix;
           };
         };

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -144,6 +144,7 @@ let
 
           nix-init = nix-init.override {
             nix = self.lix;
+            inherit (self) nurl;
           };
 
           nurl = nurl.override {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Also overrides nurl for lixPackageSets.*.nix-init, so it doesn't depend on cpp nix

Before:
```console
$ nix path-info result/ -r | rg -- -nix-
/nix/store/1gv9jskvy4g04p5jpwxrdq2cwcnji39i-nix-main-2.31.3
/nix/store/aps7lmjy30p7x06gm3h2h4hvv04l4qh4-nix-fetchers-2.31.3
/nix/store/acsnl92pb1yhsqciazz6bbkbcyjczn96-nix-expr-2.31.3
/nix/store/4vh92xsxdll0n3iqsjjgs3mrch50ws4n-nix-flake-2.31.3
/nix/store/0fpyygvvmwgdyck7gl2rn30mhd6qpfx2-nix-cmd-2.31.3
/nix/store/y7m2phpvda41km4m4hqg1p08acvqi44r-nix-2.31.3
/nix/store/wxm9qds5wayqnfryk3mgqikg0v4gm98l-nix-2.31.3
/nix/store/wbccs44bvl0sg3bjib0pc9yymqxh080i-nix-init-0.3.3
```

After:
```console
$ nix path-info result/ -r | rg -- -nix-
/nix/store/ml9lpg4xn3kdfw3hlwivpsn4lk7swb20-nix-init-0.3.3
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
