### PR TITLE
python3Packages.pymobiledevice3: 7.4.0 -> 7.5.1

### DIFF
--- a/pkgs/development/python-modules/pymobiledevice3/default.nix
+++ b/pkgs/development/python-modules/pymobiledevice3/default.nix
@@ -31,6 +31,7 @@
   pytest-asyncio,
   pytestCheckHook,
   python-pcapng,
+  pythonOlder,
   pytun-pmd3,
   pyusb,
   qh3,
@@ -49,14 +50,14 @@
 
 buildPythonPackage rec {
   pname = "pymobiledevice3";
-  version = "7.4.0";
+  version = "7.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "doronz88";
     repo = "pymobiledevice3";
     tag = "v${version}";
-    hash = "sha256-sFpC9qG8RxrR35W0UtLslps5hK2VFhpSka2trzIQyIc=";
+    hash = "sha256-j183S5H6jUnhOn/xMfeZtG9c4OowH/6HPpP2giko4dM=";
   };
 
   build-system = [
@@ -97,7 +98,6 @@ buildPythonPackage rec {
     qh3
     requests
     srptools
-    sslpsk-pmd3
     tqdm
     typer
     typer-injector
@@ -105,7 +105,9 @@ buildPythonPackage rec {
     wsproto
     xonsh
   ]
-  ++ fastapi.optional-dependencies.all;
+  ++ lib.optionals (pythonOlder "3.13") [
+    sslpsk-pmd3
+  ];
 
   pythonImportsCheck = [ "pymobiledevice3" ];
 


### PR DESCRIPTION
Diff: https://github.com/doronz88/pymobiledevice3/compare/v7.4.0...v7.5.1

Changelog: https://github.com/doronz88/pymobiledevice3/releases/tag/v7.5.0
           https://github.com/doronz88/pymobiledevice3/releases/tag/v7.5.1

closes https://github.com/NixOS/nixpkgs/pull/488579
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
