### PR TITLE
happy-coder: 0.11.2 -> 0.13.0

### DIFF
--- a/pkgs/by-name/ha/happy-coder/package.nix
+++ b/pkgs/by-name/ha/happy-coder/package.nix
@@ -12,18 +12,18 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "happy-coder";
-  version = "0.11.2";
+  version = "0.13.0";
 
   src = fetchFromGitHub {
     owner = "slopus";
     repo = "happy-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WKzbpxHqE3Dxqy/PDj51tM9+Wl2Pallfrc5UU2MxNn8=";
+    hash = "sha256-q4o8FHBhZsNL+D8rREjPzI1ky5+p3YNSxKc1OlA2pcs=";
   };
 
   yarnOfflineCache = fetchYarnDeps {
     yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-3/qcbCJ+Iwc+9zPCHKsCv05QZHPUp0it+QR3z7m+ssw=";
+    hash = "sha256-DlUUAj5b47KFhUBsftLjxYJJxyCxW9/xfp3WUCCClDY=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
## Summary
- Bump happy-coder from 0.11.2 to 0.13.0
- Update source and yarn dependency hashes

## Notable upstream changes
- Gemini backend support via ACP integration
- Session hook tracking for `--continue`/`--resume` support
- New `--claude-env` flag for custom environment variables

## Test plan
- [x] `nix-build -A happy-coder` succeeds
- [x] `happy --version` outputs `0.13.0`
- [x] `happy --help` works
- [x] `happy-mcp --help` works
- [x] `nixfmt` passes with no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)