### PR TITLE
ocamlPackages.jingoo: 1.4.4 → 1.5.2

### DIFF
--- a/pkgs/development/ocaml-modules/jingoo/default.nix
+++ b/pkgs/development/ocaml-modules/jingoo/default.nix
@@ -2,7 +2,6 @@
   lib,
   buildDunePackage,
   fetchFromGitHub,
-  ocaml,
   menhir,
   ppxlib,
   ppx_deriving,
@@ -12,17 +11,15 @@
   ounit2,
 }:
 
-buildDunePackage rec {
+buildDunePackage (finalAttrs: {
   pname = "jingoo";
-  version = "1.4.4";
-
-  minimalOCamlVersion = "4.05";
+  version = "1.5.2";
 
   src = fetchFromGitHub {
     owner = "tategakibunko";
     repo = "jingoo";
-    rev = "v${version}";
-    sha256 = "sha256-qIw69OE7wYyZYKnIc9QrmF8MzY5Fg5pBFyIpexmaYxA=";
+    tag = finalAttrs.version;
+    hash = "sha256-1357XOYZseItCrIm/qNP46aL8tQyX8CFh77CBycL1ew=";
   };
 
   nativeBuildInputs = [ menhir ];
@@ -34,7 +31,7 @@ buildDunePackage rec {
     uucp
   ];
   checkInputs = [ ounit2 ];
-  doCheck = lib.versionAtLeast ocaml.version "4.08";
+  doCheck = true;
 
   meta = {
     homepage = "https://github.com/tategakibunko/jingoo";
@@ -43,4 +40,4 @@ buildDunePackage rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.ericbmerritt ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
