### PR TITLE
jj-fzf: 0.34.0 -> 0.37.0

### DIFF
--- a/pkgs/by-name/jj/jj-fzf/nix-preflight.patch
+++ b/pkgs/by-name/jj/jj-fzf/nix-preflight.patch
@@ -1,5 +1,5 @@
 diff --git a/preflight.sh b/preflight.sh
-index f1ed02fe60..43b9c365c5 100755
+index 1234567..abcdefg 100755
 --- a/preflight.sh
 +++ b/preflight.sh
 @@ -78,19 +78,6 @@
@@ -7,10 +7,10 @@ index f1ed02fe60..43b9c365c5 100755
      __preflightish_die "Failed to find usable 'awk' executable in \$PATH"
 
 -# == Jujutsu ==
--__preflightish_require "0.34" jj --version --ignore-working-copy
+-__preflightish_require "0.37" jj --version --ignore-working-copy
 -
 -# == fzf ==
--__preflightish_require "0.65.2" fzf --version
+-__preflightish_require "0.67.0" fzf --version
 -
 -# == python3 ==
 -__preflightish_require "3.9" python3 --version

--- a/pkgs/by-name/jj/jj-fzf/package.nix
+++ b/pkgs/by-name/jj/jj-fzf/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jj-fzf";
-  version = "0.34.0";
+  version = "0.37.0";
 
   src = fetchFromGitHub {
     owner = "tim-janik";
     repo = "jj-fzf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-aJyKVMg/yI2CmAx5TxN0w670Rq26ESdLzESgh8Jr4nE=";
+    hash = "sha256-p2QgCDhd4k+v7Poo6OVt7Sd9RI2a5vysZ6Cs5Wn4psY=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
## Summary
- Bump jj-fzf from 0.34.0 to 0.37.0
- Update nix-preflight.patch to match new upstream version strings (jj 0.34 -> 0.37, fzf 0.65.2 -> 0.67.0)

Closes #484791

## Test plan
- [x] `nix-build -A jj-fzf` succeeds
- [x] `jj-fzf --version` outputs `jj-fzf 0.37.0`
- [x] `jj-fzf --help` works
- [x] `nixfmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)