### PR TITLE
solaar: 1.1.16 -> 1.1.19

### DIFF
--- a/pkgs/by-name/so/solaar/package.nix
+++ b/pkgs/by-name/so/solaar/package.nix
@@ -18,14 +18,14 @@
 # instead of adding this to `services.udev.packages` on NixOS,
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "solaar";
-  version = "1.1.16";
+  version = "1.1.19";
   format = "setuptools";
 
   src = fetchFromGitHub {
     owner = "pwr-Solaar";
     repo = "Solaar";
     tag = finalAttrs.version;
-    hash = "sha256-PhZoDRsckJXk2t2qR8O3ZGGeMUhmliqSpibfQDO7BeA=";
+    hash = "sha256-Z3rWGmFQmfJvsWiPgxQmfXMPHXAAiFneBaoSVIXnAV8=";
   };
 
   outputs = [
@@ -67,7 +67,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   preConfigure = ''
     substituteInPlace lib/solaar/listener.py \
-      --replace-fail /usr/bin/getfacl "${lib.getExe' acl "getfacl"}"
+      --replace-fail '"getfacl"' '"${lib.getExe' acl "getfacl"}"'
   '';
 
   # the -cli symlink is just to maintain compabilility with older versions where


### PR DESCRIPTION
## Summary
- Bump solaar from 1.1.16 to 1.1.19
- Fix `preConfigure` substituteInPlace: upstream changed `getfacl` from absolute path `/usr/bin/getfacl` to bare command `"getfacl"` in a subprocess call list

Closes #486880

## Test plan
- [x] `nix-build -A solaar` succeeds
- [x] All 630 tests pass (30 skipped)
- [x] `solaar --version` outputs `solaar 1.1.19`
- [x] `nixfmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)