### PR TITLE
cargo-audit: 0.22.0 -> 0.22.1

### DIFF
--- a/pkgs/by-name/ca/cargo-audit/package.nix
+++ b/pkgs/by-name/ca/cargo-audit/package.nix
@@ -9,14 +9,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-audit";
-  version = "0.22.0";
+  version = "0.22.1";
 
   src = fetchCrate {
     inherit (finalAttrs) pname version;
-    hash = "sha256-Ha2yVyu9331NaqiW91NEwCTIeW+3XPiqZzmatN5KOws=";
+    hash = "sha256-/K84iYr3mRNH8lbqHHa7Tsh7M3ykQ2hs6T1k/qrSsnA=";
   };
 
-  cargoHash = "sha256-f8nrW1l7UA8sixwqXBD1jCJi9qyKC5tNl/dWwCt41Lk=";
+  cargoHash = "sha256-Hr3CliJeb9ljHylx8mjkGyf4ybX79Fmt6CaFb6FMRts=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Summary
- Bump cargo-audit from 0.22.0 to 0.22.1

## Test plan
- [x] `nix-build -A cargo-audit` succeeds
- [x] `cargo-audit --version` outputs `cargo-audit 0.22.1`
- [x] `nixfmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)