### PR TITLE
aasvg-rs: init at 1.0.0

### DIFF
--- a/pkgs/by-name/aa/aasvg-rs/package.nix
+++ b/pkgs/by-name/aa/aasvg-rs/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "aasvg-rs";
+  version = "1.0.0";
+
+  src = fetchCrate {
+    inherit (finalAttrs) version;
+    pname = "aasvg-cli";
+    hash = "sha256-0qGCXHSCTg2yXLxREOfY7lOA3ZQCNFvST6GTBIsG/f4=";
+  };
+
+  cargoHash = "sha256-zl3IPKKG738cr1Au4Vw9SRstgOp57hM/JhPRNl0VsII=";
+
+  meta = {
+    description = "CLI tool to convert ASCII art diagrams to SVG";
+    homepage = "https://github.com/bearcove/aasvg-rs";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "aasvg";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
