### PR TITLE
python3Packages.pysfcgal: init at 2.2.0

### DIFF
--- a/pkgs/development/python-modules/pysfcgal/default.nix
+++ b/pkgs/development/python-modules/pysfcgal/default.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  pytestCheckHook,
+
+  cffi,
+  icontract,
+  setuptools,
+  sfcgal,
+  wheel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "pysfcgal";
+  version = "2.2.0";
+  pyproject = true;
+
+  src = fetchFromGitLab {
+    owner = "sfcgal";
+    repo = "pysfcgal";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-/G6yC7u2CYM7D9xO2IOB8+AjWc4ErzTIdvHmwGRxXBc=";
+  };
+
+  buildInputs = [
+    sfcgal
+  ];
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  dependencies = [
+    cffi
+  ];
+
+  pythonImportsCheck = [
+    "pysfcgal"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  checkInputs = [
+    icontract
+  ];
+
+  # remove src module, so tests use the installed module instead
+  preCheck = ''
+    rm -rf pysfcgal
+  '';
+
+  disabledTests = [
+    # this test is failing due to mismatched output
+    "test_wrap_geom_segfault"
+  ];
+
+  meta = {
+    description = "Python wrapper for SFCGAL";
+    homepage = "https://gitlab.com/sfcgal/pysfcgal";
+    changelog = "https://gitlab.com/sfcgal/pysfcgal/-/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.gpl3Plus;
+    teams = with lib.teams; [
+      geospatial
+      ngi
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14683,6 +14683,8 @@ self: super: with self; {
 
   pyseventeentrack = callPackage ../development/python-modules/pyseventeentrack { };
 
+  pysfcgal = callPackage ../development/python-modules/pysfcgal { };
+
   pysftp = callPackage ../development/python-modules/pysftp { };
 
   pyshark = callPackage ../development/python-modules/pyshark { };


### PR DESCRIPTION
From NGIpkgs

- closes https://github.com/ngi-nix/projects/issues/1524
- closes https://github.com/ngi-nix/ngipkgs/pull/2055

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
