### PR TITLE
linux_xanmod, linux_xanmod_latest: 2026-02-11

### DIFF
--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -21,8 +21,8 @@ let
     };
     # ./update-xanmod.sh main
     main = {
-      version = "6.18.8";
-      hash = "sha256-BagAixl3Eo9vX6F/vpQv8OCw5vm8l7JtZBqvE0m5gAs=";
+      version = "6.18.9";
+      hash = "sha256-iBRajsZ4WqamkIHGQGK+jeFALYGxOFMA2djoMWGdPj4=";
     };
   };
 

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -15,8 +15,8 @@ let
   variants = {
     # ./update-xanmod.sh lts
     lts = {
-      version = "6.12.69";
-      hash = "sha256-Znn87KqkcYp+tfuGC+JBSr3jvf6Bk8Jtw7K3JV2Za1U=";
+      version = "6.12.70";
+      hash = "sha256-Azhv4au48TQbhGsngPvY8Uue71K9KQuJyqcYrM655xM=";
       isLTS = true;
     };
     # ./update-xanmod.sh main

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -15,8 +15,8 @@ let
   variants = {
     # ./update-xanmod.sh lts
     lts = {
-      version = "6.12.68";
-      hash = "sha256-HCBSAEyLZeHufBj+TCTzdv6NBvWZGUknAAQ2eWK/Tmw=";
+      version = "6.12.69";
+      hash = "sha256-Znn87KqkcYp+tfuGC+JBSr3jvf6Bk8Jtw7K3JV2Za1U=";
       isLTS = true;
     };
     # ./update-xanmod.sh main

--- a/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/xanmod-kernels.nix
@@ -21,8 +21,8 @@ let
     };
     # ./update-xanmod.sh main
     main = {
-      version = "6.18.9";
-      hash = "sha256-iBRajsZ4WqamkIHGQGK+jeFALYGxOFMA2djoMWGdPj4=";
+      version = "6.18.10";
+      hash = "sha256-bYKYx9ctHuWG+WS/Wtt4p2uW6vy2g5ikLqSPWeNeSn0=";
     };
   };
 


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/pull/490202
Closes https://github.com/NixOS/nixpkgs/pull/489866

## Changes

<details><summary>2026-02-08</summary>
<p>

- **linux_xanmod:** 6.12.68 -> 6.12.69
  - Changelog: https://dl.xanmod.org/changelog/6.12/ChangeLog-6.12.69-xanmod1.gz
  - Diff: https://gitlab.com/xanmod/linux/-/compare/6.12.68-xanmod1..6.12.69-xanmod1?from_project_id=51590166

- **linux_xanmod_latest:** 6.18.8 -> 6.18.9
  - Changelog: https://dl.xanmod.org/changelog/6.18/ChangeLog-6.18.9-xanmod1.gz
  - Diff: https://gitlab.com/xanmod/linux/-/compare/6.18.8-xanmod1..6.18.9-xanmod1?from_project_id=51590166

</p>
</details> 

<details><summary>2026-02-11</summary>
<p>

- **linux_xanmod**: 6.12.69 -> 6.12.70
  - Changelog: https://dl.xanmod.org/changelog/6.12/ChangeLog-6.12.70-xanmod1.gz
  - Diff: https://gitlab.com/xanmod/linux/-/compare/6.12.69-xanmod1..6.12.70-xanmod1?from_project_id=51590166

- **linux_xanmod_latest**: 6.18.9 -> 6.18.10
  - Changelog: https://dl.xanmod.org/changelog/6.18/ChangeLog-6.18.10-xanmod1.gz
  - Diff: https://gitlab.com/xanmod/linux/-/compare/6.18.9-xanmod1..6.18.10-xanmod1?from_project_id=51590166

</p>
</details> 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
