### PR TITLE
python3Packages.roma: 1.5.4 -> 1.5.5 + clean

### DIFF
--- a/pkgs/development/python-modules/roma/default.nix
+++ b/pkgs/development/python-modules/roma/default.nix
@@ -8,7 +8,7 @@
   torch,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "roma";
   version = "1.5.5";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "naver";
     repo = "roma";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0R8p8pQxLQqK7MTbk9J5lFtA13XJth76Glemkfj9X/E=";
   };
 
@@ -38,9 +38,10 @@ buildPythonPackage rec {
   ];
 
   meta = {
+    changelog = "https://naver.github.io/roma/#changelog";
     description = "Lightweight library to deal with 3D rotations in PyTorch";
     homepage = "https://github.com/naver/roma";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ nim65s ];
   };
-}
+})

--- a/pkgs/development/python-modules/roma/default.nix
+++ b/pkgs/development/python-modules/roma/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "roma";
-  version = "1.5.4";
+  version = "1.5.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "naver";
     repo = "roma";
     tag = "v${version}";
-    hash = "sha256-byPW58I+6mCE2fR6eVNQfNDCLbZSfoPmPbc/GuRpKGo=";
+    hash = "sha256-0R8p8pQxLQqK7MTbk9J5lFtA13XJth76Glemkfj9X/E=";
   };
 
   build-system = [


### PR DESCRIPTION
ref. #488540

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
