### PR TITLE
bartender: 5.3.7 -> 6.4.1

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -78,6 +78,8 @@
 
 - `forgejo` has been updated to major version 14. For more information, see the [release blog post](https://forgejo.org/2026-01-release-v14-0/) and [full release notes](https://codeberg.org/forgejo/forgejo/src/branch/forgejo/release-notes-published/14.0.0.md)
 
+- `bartender` has been updated to major version 6. This removes support for MacOS Sonoma (and adds support for Tahoe). For more information, see [the release notes](https://www.macbartender.com/Bartender6/release_notes/) or [the Bartender 6 support page](https://www.macbartender.com/Bartender6/support/).
+
 - `lima` has been updated from `1.x` to `2.x`. This major update includes several breaking changes, such as `/tmp/lima` no longer being mounted by default.
 
 - `minio_legacy_fs` has been removed. If you used that package, migrate your data to be compatible with the newest minio and use the package `minio`.

--- a/pkgs/by-name/ba/bartender/package.nix
+++ b/pkgs/by-name/ba/bartender/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenvNoCC,
-  fetchurl,
-  _7zz,
+  fetchzip,
   curl,
   cacert,
   xmlstarlet,
@@ -12,14 +11,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "bartender";
-  version = "5.3.7";
+  version = "6.4.1";
 
-  src = fetchurl {
-    name = "Bartender ${lib.versions.major finalAttrs.version}.dmg";
+  src = fetchzip {
     url = "https://www.macbartender.com/B2/updates/${
       builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
-    }/Bartender%20${lib.versions.major finalAttrs.version}.dmg";
-    hash = "sha256-8hOe8MTDGyxEZTv0QndjkD3BEJ6kOHcbeU0uhat/N1s=";
+    }/Bartender%20${lib.versions.major finalAttrs.version}.zip";
+    hash = "sha256-UtLTfRhL7JTYzQXf7kyYyGZXy1TLJ0ODk1nRs2pLfQ4=";
   };
 
   dontPatch = true;
@@ -27,15 +25,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   dontBuild = true;
   dontFixup = true;
 
-  nativeBuildInputs = [ _7zz ];
-
-  sourceRoot = "Bartender ${lib.versions.major finalAttrs.version}.app";
+  appName = "Bartender ${lib.versions.major finalAttrs.version}.app";
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/Applications/${finalAttrs.sourceRoot}"
-    cp -R . "$out/Applications/${finalAttrs.sourceRoot}"
+    mkdir -p "$out/Applications/${finalAttrs.appName}"
+    cp -R . "$out/Applications/${finalAttrs.appName}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
https://www.macbartender.com/Bartender6/release_notes/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
