### PR TITLE
virtualboxExtpack: set pname and version

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/extpack.nix
+++ b/pkgs/applications/virtualization/virtualbox/extpack.nix
@@ -3,12 +3,11 @@
   lib,
   virtualbox,
 }:
-let
-  virtualboxExtPackVersion = "7.2.6";
-in
 fetchurl rec {
-  name = "Oracle_VirtualBox_Extension_Pack-${virtualboxExtPackVersion}.vbox-extpack";
-  url = "https://download.virtualbox.org/virtualbox/${virtualboxExtPackVersion}/${name}";
+  pname = "virtualbox-extpack";
+  version = "7.2.6";
+  name = "Oracle_VirtualBox_Extension_Pack-${version}.vbox-extpack";
+  url = "https://download.virtualbox.org/virtualbox/${version}/${name}";
   sha256 =
     # Manually sha256sum the extensionPack file, must be hex!
     # Thus do not use `nix-prefetch-url` but instead plain old `sha256sum`.

--- a/pkgs/applications/virtualization/virtualbox/update.sh
+++ b/pkgs/applications/virtualization/virtualbox/update.sh
@@ -39,7 +39,7 @@ if [ ! "$oldVersion" = "$latestVersion" ]; then
       -e "s/virtualboxSha256 = \".*\";/virtualboxSha256 = \"$virtualBoxShaSum\";/g" \
       -i "$virtualboxNixFile"
   sed -e 's|value = "'$extpackOldShaSum'"|value = "'$extpackShaSum'"|' \
-      -e "s/virtualboxExtPackVersion = \".*\";/virtualboxExtPackVersion = \"$latestVersion\";/g" \
+      -e "s/version = \".*\";/version = \"$latestVersion\";/g" \
       -i $extpackNixFile
   sed -e "s/sha256 = \".*\";/sha256 = \"$guestAdditionsIsoShaSum\";/g" \
       -i "$guestAdditionsIsoNixFile"


### PR DESCRIPTION
Part of #485742

Not really sure if this is the best and if `pname` is actually needed here. The package name isn't up to date with our standards I think.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
