### PR TITLE
`postgresql`: fix overrides being forgotten on `withPackages`

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -563,64 +563,64 @@ let
           (withBlocksize == null && withWalBlocksize == null);
       installCheckTarget = "check-world";
 
-      passthru =
-        let
-          this = self.callPackage generic args;
-        in
-        {
-          inherit dlSuffix;
+      passthru = {
+        inherit dlSuffix;
 
-          psqlSchema = lib.versions.major version;
+        psqlSchema = lib.versions.major version;
 
-          withJIT = if jitSupport then this.withPackages (_: [ this.jit ]) else null;
-          withoutJIT = this;
+        withJIT =
+          if jitSupport then
+            finalAttrs.finalPackage.withPackages (_: [ finalAttrs.finalPackage.jit ])
+          else
+            null;
+        withoutJIT = finalAttrs.finalPackage;
 
-          pkgs =
-            let
-              scope = {
-                inherit
-                  jitSupport
-                  pythonSupport
-                  perlSupport
-                  tclSupport
-                  ;
-                inherit (llvmPackages) llvm;
-                postgresql = this;
-                stdenv = stdenv';
-                postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
-                postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
-              };
-              newSelf = self // scope;
-              newSuper = {
-                callPackage = newScope (scope // this.pkgs);
-              };
-            in
-            import ./ext.nix newSelf newSuper;
-
-          withPackages = postgresqlWithPackages {
-            inherit buildEnv lib makeBinaryWrapper;
-            postgresql = this;
-          };
-
-          pg_config = buildPackages.callPackage ./pg_config.nix {
-            inherit (finalAttrs) finalPackage;
-            outputs = {
-              out = lib.getOutput "out" finalAttrs.finalPackage;
-              man = lib.getOutput "man" finalAttrs.finalPackage;
+        pkgs =
+          let
+            scope = {
+              inherit
+                jitSupport
+                pythonSupport
+                perlSupport
+                tclSupport
+                ;
+              inherit (llvmPackages) llvm;
+              postgresql = finalAttrs.finalPackage;
+              stdenv = stdenv';
+              postgresqlTestExtension = newSuper.callPackage ./postgresqlTestExtension.nix { };
+              postgresqlBuildExtension = newSuper.callPackage ./postgresqlBuildExtension.nix { };
             };
-          };
+            newSelf = self // scope;
+            newSuper = {
+              callPackage = newScope (scope // finalAttrs.finalPackage.pkgs);
+            };
+          in
+          import ./ext.nix newSelf newSuper;
 
-          tests = {
-            postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
-            postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
-            postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
-            postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
-            pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-          }
-          // lib.optionalAttrs jitSupport {
-            postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
+        withPackages = postgresqlWithPackages {
+          inherit buildEnv lib makeBinaryWrapper;
+          postgresql = finalAttrs.finalPackage;
+        };
+
+        pg_config = buildPackages.callPackage ./pg_config.nix {
+          inherit (finalAttrs) finalPackage;
+          outputs = {
+            out = lib.getOutput "out" finalAttrs.finalPackage;
+            man = lib.getOutput "man" finalAttrs.finalPackage;
           };
         };
+
+        tests = {
+          postgresql = nixosTests.postgresql.postgresql.passthru.override finalAttrs.finalPackage;
+          postgresql-replication = nixosTests.postgresql.postgresql-replication.passthru.override finalAttrs.finalPackage;
+          postgresql-tls-client-cert = nixosTests.postgresql.postgresql-tls-client-cert.passthru.override finalAttrs.finalPackage;
+          postgresql-wal-receiver = nixosTests.postgresql.postgresql-wal-receiver.passthru.override finalAttrs.finalPackage;
+          pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+        }
+        // lib.optionalAttrs jitSupport {
+          postgresql-jit = nixosTests.postgresql.postgresql-jit.passthru.override finalAttrs.finalPackage;
+        };
+      };
 
       meta = {
         homepage = "https://www.postgresql.org";


### PR DESCRIPTION
Remove the old `this` let binding, which erases `overrideAttrs`. Instead use `finalAttrs.finalPackage` which correctly stacks the `withPackages` `buildEnv` on top of previous `overrideAttrs` calls.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
