### PR TITLE
Intune 1.2511.11

### DIFF
--- a/nixos/modules/services/security/intune.nix
+++ b/nixos/modules/services/security/intune.nix
@@ -30,6 +30,11 @@ in
 
     systemd.tmpfiles.packages = [ pkgs.intune-portal ];
     services.dbus.packages = [ pkgs.microsoft-identity-broker ];
+
+    systemd.services.microsoft-identity-device-broker.wantedBy = [ "multi-user.target" ];
+    systemd.sockets.intune-daemon.wantedBy = [ "sockets.target" ];
+    systemd.user.services.microsoft-identity-broker.wantedBy = [ "default.target" ];
+    systemd.user.services.intune-agent.wantedBy = [ "default.target" ];
   };
 
   meta = {

--- a/pkgs/by-name/in/intune-portal/package.nix
+++ b/pkgs/by-name/in/intune-portal/package.nix
@@ -30,11 +30,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "intune-portal";
-  version = "1.2503.10-noble";
+  version = "1.2511.11-noble";
 
   src = fetchurl {
     url = "https://packages.microsoft.com/ubuntu/24.04/prod/pool/main/i/intune-portal/intune-portal_${version}_amd64.deb";
-    hash = "sha256-NlJ8m7V1yLErOntprHs3EagPtwSzYWd7NBH0jc72+i4=";
+    hash = "sha256-MLVrO1OXkVappLyzydxBneh1hlJ9rORO9FTNcq69p8Q=";
   };
 
   nativeBuildInputs = [ dpkg ];


### PR DESCRIPTION
Bumped intune to 1.2511.11-noble and made sure appropriate services are started. 2503.10 is completely broken for me.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test