### PR TITLE
python3Packages.napari-npe2: 0.7.9 -> 0.8.0

### DIFF
--- a/pkgs/development/python-modules/napari-npe2/default.nix
+++ b/pkgs/development/python-modules/napari-npe2/default.nix
@@ -2,31 +2,48 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonOlder,
+
+  # build-system
   hatchling,
   hatch-vcs,
-  pythonOlder,
-  pyyaml,
-  platformdirs,
+
+  # dependencies
   build,
+  platformdirs,
   psygnal,
   pydantic,
-  tomli-w,
-  tomli,
+  pydantic-extra-types,
+  pyyaml,
   rich,
+  tomli-w,
   typer,
+  # python<3.11 only
+  tomli,
+
+  # tests
+  imagemagick,
+  jsonschema,
+  magicgui,
+  napari-plugin-engine,
+  numpy,
+  pytest-pretty,
+  pytestCheckHook,
+
+  # passthru
   napari, # reverse dependency, for tests
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "napari-npe2";
-  version = "0.7.9";
+  version = "0.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "napari";
     repo = "npe2";
-    tag = "v${version}";
-    hash = "sha256-q+vgzUuSSHFR64OajT/j/tLsNgSm3azQPCvDlrIvceM=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aZOs9wTYcblt9EZftYHKFWI/GvpZcC2KqVTAis15+Iw=";
   };
 
   build-system = [
@@ -35,13 +52,14 @@ buildPythonPackage rec {
   ];
 
   dependencies = [
-    pyyaml
-    platformdirs
     build
+    platformdirs
     psygnal
     pydantic
-    tomli-w
+    pydantic-extra-types
+    pyyaml
     rich
+    tomli-w
     typer
   ]
   ++ lib.optionals (pythonOlder "3.11") [
@@ -50,6 +68,30 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "npe2" ];
 
+  nativeCheckInputs = [
+    imagemagick
+    jsonschema
+    magicgui
+    napari-plugin-engine
+    numpy
+    pytest-pretty
+    pytestCheckHook
+  ];
+
+  disabledTests = [
+    # Require internet connection
+    "test_cli_fetch"
+    "test_fetch_npe1_manifest_dock_widget_as_attribute"
+    "test_fetch_npe1_manifest_with_sample_data"
+    "test_fetch_npe2_manifest"
+    "test_get_manifest_from_wheel"
+    "test_get_pypi_url"
+
+    # No package or entry point found with name 'svg'
+    "test_cli_convert_svg"
+    "test_conversion"
+  ];
+
   passthru.tests = {
     inherit napari;
   };
@@ -57,8 +99,9 @@ buildPythonPackage rec {
   meta = {
     description = "Plugin system for napari (the image visualizer)";
     homepage = "https://github.com/napari/npe2";
+    changelog = "https://github.com/napari/npe2/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ SomeoneSerge ];
     mainProgram = "npe2";
   };
-}
+})

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -53,7 +53,7 @@
   zarr,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "napari";
   version = "0.6.6";
   pyproject = true;
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "napari";
     repo = "napari";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-F0l6GWyZ6n4HNZW7XyUk4ZBPQfrAW4DWixCaRHViDPI=";
   };
 
@@ -202,8 +202,8 @@ buildPythonPackage rec {
   meta = {
     description = "Fast, interactive, multi-dimensional image viewer";
     homepage = "https://github.com/napari/napari";
-    changelog = "https://github.com/napari/napari/releases/tag/${src.tag}";
+    changelog = "https://github.com/napari/napari/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ SomeoneSerge ];
   };
-}
+})

--- a/pkgs/development/python-modules/napari/default.nix
+++ b/pkgs/development/python-modules/napari/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  pythonAtLeast,
   fetchFromGitHub,
 
   # build-system
@@ -57,6 +58,10 @@ buildPythonPackage (finalAttrs: {
   pname = "napari";
   version = "0.6.6";
   pyproject = true;
+
+  # napari uses pydantic v1 which is not compatible with python 3.14
+  # ValueError: '__slots__' in __slots__ conflicts with class variable
+  disabled = pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "napari";


### PR DESCRIPTION
## Things done

- **python3Packages.napari-npe2: 0.7.9 -> 0.8.0**
  Diff: https://github.com/napari/npe2/compare/v0.7.9...v0.8.0
- **python3Packages.napari: use finalAttrs**
- **python3Packages.napari: disable on python 3.14**

cc @SomeoneSerge

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test