### PR TITLE
[Backport release-25.11] trilium-desktop: 0.99.5 -> 0.101.3

### DIFF
--- a/pkgs/by-name/tr/trilium-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-desktop/package.nix
@@ -42,7 +42,7 @@ let
 
   meta = {
     description = "Hierarchical note taking application with focus on building large personal knowledge bases";
-    homepage = "https://github.com/TriliumNext/Notes";
+    homepage = "https://triliumnotes.org/";
     license = lib.licenses.agpl3Plus;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [

--- a/pkgs/by-name/tr/trilium-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-desktop/package.nix
@@ -15,7 +15,7 @@
 
 let
   pname = "trilium-desktop";
-  version = "0.99.5";
+  version = "0.100.0";
 
   triliumSource = os: arch: hash: {
     url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-v${version}-${os}-${arch}.zip";
@@ -26,10 +26,10 @@ let
   darwinSource = triliumSource "macos";
 
   # exposed like this for update.sh
-  x86_64-linux.hash = "sha256-TCb7cYjgaHghKH2uwXZ2nwu6WskcOCrmBUks2RleL/w=";
-  aarch64-linux.hash = "sha256-rZ3NYSsa//+WH0O1hMmMj37YXpny+nsSk89Gzd4VVzQ=";
-  x86_64-darwin.hash = "sha256-IIpblB9wi55QttVO45fv3itDS6TFc0H+DFYKScI80ks=";
-  aarch64-darwin.hash = "sha256-JXulpxlRmo7+/NuvIdH8Bnrj11g7ZL01N86GQfjf33U=";
+  x86_64-linux.hash = "sha256-zT8XRetevG7eIlIgC5GejGqA8sifom0un3K+Z+hSaEo=";
+  aarch64-linux.hash = "sha256-xsKiVIRzFYzF8lwOZZ7yCmpi7SpPKDnPhL+GuIzoiHE=";
+  x86_64-darwin.hash = "sha256-jxaNLFRmm24Hb5D6ECWWVqZQQfIpsF6u/LYf9Tt5BjI=";
+  aarch64-darwin.hash = "sha256-M2VhemxBtqclExwbDxgEiu7NjNoxMYC6Gub0uY5hSh0=";
 
   sources = {
     x86_64-linux = linuxSource "x64" x86_64-linux.hash;

--- a/pkgs/by-name/tr/trilium-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-desktop/package.nix
@@ -15,7 +15,7 @@
 
 let
   pname = "trilium-desktop";
-  version = "0.101.1";
+  version = "0.101.3";
 
   triliumSource = os: arch: hash: {
     url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-v${version}-${os}-${arch}.zip";
@@ -26,10 +26,10 @@ let
   darwinSource = triliumSource "macos";
 
   # exposed like this for update.sh
-  x86_64-linux.hash = "sha256-6kz3V/pbC+7PnSk2t9LeUckfdCFQOBIhqMaJhKbnkJA=";
-  aarch64-linux.hash = "sha256-Ttw7sNUuWgc1kAOSwCm8tf0eCRSZmQM5gMf0eOZhpJQ=";
-  x86_64-darwin.hash = "sha256-fAQHPx1DZ4IRCbEjUZdCJFjqUtdVMDoxQxGP89Skf00=";
-  aarch64-darwin.hash = "sha256-vAF1AL2tkdikuvmR2HEQfWD/IcVaknLnoNERoElawuI=";
+  x86_64-linux.hash = "sha256-+Q0RfWa9wl0SEb5hiT9q9+careuLgZh7Bgpi8HuUFyA=";
+  aarch64-linux.hash = "sha256-r8CJBBiSzgNpZ5K3FKwKR84xqm90pxgBEj1NVbRfQos=";
+  x86_64-darwin.hash = "sha256-oprNyKQs8sPPrm67SyTxvlgGuRKJ0OcVJ4OGAsOT6rQ=";
+  aarch64-darwin.hash = "sha256-1VXeU+a1tw4fhlZX0r88BkIo/wXBvWEFBzloBjVvouk=";
 
   sources = {
     x86_64-linux = linuxSource "x64" x86_64-linux.hash;

--- a/pkgs/by-name/tr/trilium-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-desktop/package.nix
@@ -5,7 +5,7 @@
   fetchurl,
   makeBinaryWrapper,
   # use specific electron since it has to load a compiled module
-  electron_38,
+  electron_39,
   autoPatchelfHook,
   makeDesktopItem,
   copyDesktopItems,
@@ -15,7 +15,7 @@
 
 let
   pname = "trilium-desktop";
-  version = "0.100.0";
+  version = "0.101.1";
 
   triliumSource = os: arch: hash: {
     url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-v${version}-${os}-${arch}.zip";
@@ -26,10 +26,10 @@ let
   darwinSource = triliumSource "macos";
 
   # exposed like this for update.sh
-  x86_64-linux.hash = "sha256-zT8XRetevG7eIlIgC5GejGqA8sifom0un3K+Z+hSaEo=";
-  aarch64-linux.hash = "sha256-xsKiVIRzFYzF8lwOZZ7yCmpi7SpPKDnPhL+GuIzoiHE=";
-  x86_64-darwin.hash = "sha256-jxaNLFRmm24Hb5D6ECWWVqZQQfIpsF6u/LYf9Tt5BjI=";
-  aarch64-darwin.hash = "sha256-M2VhemxBtqclExwbDxgEiu7NjNoxMYC6Gub0uY5hSh0=";
+  x86_64-linux.hash = "sha256-6kz3V/pbC+7PnSk2t9LeUckfdCFQOBIhqMaJhKbnkJA=";
+  aarch64-linux.hash = "sha256-Ttw7sNUuWgc1kAOSwCm8tf0eCRSZmQM5gMf0eOZhpJQ=";
+  x86_64-darwin.hash = "sha256-fAQHPx1DZ4IRCbEjUZdCJFjqUtdVMDoxQxGP89Skf00=";
+  aarch64-darwin.hash = "sha256-vAF1AL2tkdikuvmR2HEQfWD/IcVaknLnoNERoElawuI=";
 
   sources = {
     x86_64-linux = linuxSource "x64" x86_64-linux.hash;
@@ -111,7 +111,7 @@ let
       asar pack $tmp/ $out/share/trilium/resources/app.asar
       rm -rf $tmp
 
-      makeWrapper ${lib.getExe electron_38} $out/bin/trilium \
+      makeWrapper ${lib.getExe electron_39} $out/bin/trilium \
         "''${gappsWrapperArgs[@]}" \
         --set-default ELECTRON_IS_DEV 0 \
         --add-flags $out/share/trilium/resources/app.asar

--- a/pkgs/by-name/tr/trilium-server/package.nix
+++ b/pkgs/by-name/tr/trilium-server/package.nix
@@ -7,12 +7,12 @@
 }:
 
 let
-  version = "0.99.5";
+  version = "0.100.0";
 
   serverSource_x64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-x64.tar.xz";
-  serverSource_x64.hash = "sha256-SDKLVqcqBpISW+0iSfvhEe+5Zcz9Cw/zuVQljHETZe8=";
+  serverSource_x64.hash = "sha256-5ferbClXNe0jcyCNi1sFz8hUE0sDwnriZAHcDxnOFS0=";
   serverSource_arm64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-arm64.tar.xz";
-  serverSource_arm64.hash = "sha256-vNQBs4qgr35Dx+UYdiksUaE4qMU8UEdeEhIZDVz4Df0=";
+  serverSource_arm64.hash = "sha256-r6mxrvLT2tmNz5nPGDDumsj4tz7dDKc3/yOMAx3gM1c=";
 
   serverSource =
     if stdenv.hostPlatform.isx86_64 then

--- a/pkgs/by-name/tr/trilium-server/package.nix
+++ b/pkgs/by-name/tr/trilium-server/package.nix
@@ -7,12 +7,12 @@
 }:
 
 let
-  version = "0.101.1";
+  version = "0.101.3";
 
   serverSource_x64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-x64.tar.xz";
-  serverSource_x64.hash = "sha256-Auo0ONEoEO69Fp7sHduRfeCOazqNofvWg7Mp8qNtvMM=";
+  serverSource_x64.hash = "sha256-WbEv3B1axs8UI7uj4JRW0hQKEfkKfiLxtQWbNgiYeos=";
   serverSource_arm64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-arm64.tar.xz";
-  serverSource_arm64.hash = "sha256-+RLRCTCfZyeN0t/uehdVxYS3qVAXYBmtUMTcztKMvhE=";
+  serverSource_arm64.hash = "sha256-k1mtBqw6BGqe7/kwoMl8N01BShVRTxMxnTxkYkwGbCc=";
 
   serverSource =
     if stdenv.hostPlatform.isx86_64 then

--- a/pkgs/by-name/tr/trilium-server/package.nix
+++ b/pkgs/by-name/tr/trilium-server/package.nix
@@ -7,12 +7,12 @@
 }:
 
 let
-  version = "0.100.0";
+  version = "0.101.1";
 
   serverSource_x64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-x64.tar.xz";
-  serverSource_x64.hash = "sha256-5ferbClXNe0jcyCNi1sFz8hUE0sDwnriZAHcDxnOFS0=";
+  serverSource_x64.hash = "sha256-Auo0ONEoEO69Fp7sHduRfeCOazqNofvWg7Mp8qNtvMM=";
   serverSource_arm64.url = "https://github.com/TriliumNext/Trilium/releases/download/v${version}/TriliumNotes-Server-v${version}-linux-arm64.tar.xz";
-  serverSource_arm64.hash = "sha256-r6mxrvLT2tmNz5nPGDDumsj4tz7dDKc3/yOMAx3gM1c=";
+  serverSource_arm64.hash = "sha256-+RLRCTCfZyeN0t/uehdVxYS3qVAXYBmtUMTcztKMvhE=";
 
   serverSource =
     if stdenv.hostPlatform.isx86_64 then


### PR DESCRIPTION
Backport to fix #488030 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
