### PR TITLE
sbc: 2.1 -> 2.2

### DIFF
--- a/pkgs/by-name/sb/sbc/package.nix
+++ b/pkgs/by-name/sb/sbc/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "sbc";
-  version = "2.1";
+  version = "2.2";
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/linux/bluetooth/sbc-${finalAttrs.version}.tar.xz";
-    sha256 = "sha256-QmYzyr18eYI2RDUW36gzW0fgBLDvN/8Qfgx+rTKZ/MI=";
+    hash = "sha256-oa2nbvNeWvnC+9BjdU3J43qNmJQXxusezrsImxODrp4=";
   };
 
   outputs = [
@@ -26,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "SubBand Codec Library";
     homepage = "https://www.bluez.org/";
+    changelog = "https://git.kernel.org/pub/scm/bluetooth/sbc.git/tree/ChangeLog?h=${finalAttrs.version}";
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
i tried to cross compile fractal and found out sbc is a (transitive) dependencie of it, but it fails to cross compile to armv7l-hf-multiplatform. updating to 2.2 somehow fixed the build failure of sbc for crosscompilation to armv7l

## Things done
- updated version number
- updated hash

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

also crosscompiled to aarch64-multiplatform and armv7l-hf-multiplatform, both work. 

- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
