### PR TITLE
pfsense-mcp: init at 1.0.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -472,6 +472,12 @@
     githubId = 908758;
     name = "Abigail Bunyan";
   };
+  abl030 = {
+    email = "abl030@gmail.com";
+    github = "abl030";
+    githubId = 60121280;
+    name = "abl030";
+  };
   aborsu = {
     email = "a.borsu@gmail.com";
     github = "aborsu";

--- a/pkgs/by-name/pf/pfsense-mcp/package.nix
+++ b/pkgs/by-name/pf/pfsense-mcp/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  writeShellApplication,
+}:
+
+let
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      fastmcp
+      httpx
+    ]
+  );
+
+  src = fetchFromGitHub {
+    owner = "abl030";
+    repo = "pfsense-mcp";
+    tag = "v1.0.0";
+    hash = "sha256-5lnfiRUe8/3Xdfd4uz1p2jcOv2RS0zxAEtjg6u+PThA=";
+  };
+in
+writeShellApplication {
+  name = "pfsense-mcp";
+
+  runtimeInputs = [ pythonEnv ];
+
+  text = ''
+    exec fastmcp run ${src}/generated/server.py
+  '';
+
+  meta = {
+    description = "MCP server for the pfSense REST API v2 — 677 tools for AI-driven firewall management";
+    homepage = "https://github.com/abl030/pfsense-mcp";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ abl030 ];
+    mainProgram = "pfsense-mcp";
+  };
+}


### PR DESCRIPTION
## Description

[pfsense-mcp](https://github.com/abl030/pfsense-mcp) is an MCP (Model Context Protocol) server for the pfSense REST API v2. It provides **677 tools** covering firewall rules, NAT, VPN (IPsec, WireGuard, OpenVPN), services (DHCP, DNS, HAProxy, BIND, FreeRADIUS, ACME), routing, certificates, users, and diagnostics.

Auto-generated from the official pfSense OpenAPI spec. Designed for AI agents to manage pfSense firewalls via MCP-compatible clients (Claude Code, Claude Desktop, etc).

- **Homepage**: https://github.com/abl030/pfsense-mcp
- **License**: MIT
- **Upstream release**: https://github.com/abl030/pfsense-mcp/releases/tag/v1.0.0

## Build verification

Built and tested locally with `nix-build -A pfsense-mcp`. Binary runs successfully.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Added myself to `maintainers/maintainer-list.nix`
- [x] Package builds from `pkgs/by-name/pf/pfsense-mcp/package.nix`
- [x] `meta.license` matches upstream (MIT)
- [x] `meta.mainProgram` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)