### PR TITLE
d2: fix inability to output images

### DIFF
--- a/pkgs/by-name/d2/d2/package.nix
+++ b/pkgs/by-name/d2/d2/package.nix
@@ -6,6 +6,9 @@
   git,
   testers,
   d2,
+  libgbm,
+  makeWrapper,
+  playwright-driver,
 }:
 
 buildGoModule (finalAttrs: {
@@ -29,13 +32,25 @@ buildGoModule (finalAttrs: {
     "-X oss.terrastruct.com/d2/lib/version.Version=v${finalAttrs.version}"
   ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    installShellFiles
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libgbm
+    playwright-driver.browsers
+  ];
+
+  nativeCheckInputs = [ git ];
 
   postInstall = ''
     installManPage ci/release/template/man/d2.1
-  '';
 
-  nativeCheckInputs = [ git ];
+      # Wrap the d2 executable to set LD_LIBRARY_PATH for Playwright
+      wrapProgram $out/bin/d2 \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath finalAttrs.buildInputs}
+  '';
 
   preCheck = ''
     # See https://github.com/terrastruct/d2/blob/master/docs/CONTRIBUTING.md#running-tests.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

closes https://github.com/NixOS/nixpkgs/issues/459954

<img width="1330" height="112" alt="image" src="https://github.com/user-attachments/assets/52b8fa92-c7b7-4e4e-b21f-cdc81f7c40bb" />

<img width="1907" height="1080" alt="image" src="https://github.com/user-attachments/assets/7e7cdd66-85f8-4c64-8899-0e03e228fae5" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
