### PR TITLE
unpaper: Depend on a barebone version of ffmpeg to reduce closure size

### DIFF
--- a/pkgs/by-name/un/unpaper/package.nix
+++ b/pkgs/by-name/un/unpaper/package.nix
@@ -18,6 +18,81 @@
   # tests
   nixosTests,
 }:
+let
+  ffmpeg-bare =
+    (ffmpeg-headless.override {
+      # explicitly required
+      buildAvcodec = true;
+      buildAvformat = true;
+      buildAvutil = true;
+      withPixelutils = true;
+
+      # don't harm, left at default
+      # withBzlib
+      # withIconv
+      # withLzma
+      # withZlib
+      # all the build options
+
+      # rest, defaulting to withHeadlessDeps, are disabled
+      withAlsa = false;
+      withAmf = false;
+      withAom = false;
+      withAss = false;
+      withBluray = false;
+      withCudaLLVM = false;
+      withCuvid = false;
+      withDav1d = false;
+      withDrm = false;
+      withNvcodec = false;
+      withFontconfig = false;
+      withFreetype = false;
+      withFribidi = false;
+      withGmp = false;
+      withGnutls = false;
+      withHarfbuzz = false;
+      withMp3lame = false;
+      withOpenapv = false;
+      withOpencl = false;
+      withOpenjpeg = false;
+      withOpenmpt = false;
+      withOpus = false;
+      withRist = false;
+      withSoxr = false;
+      withSpeex = false;
+      withSrt = false;
+      withSsh = false;
+      withSvtav1 = false;
+      withTheora = false;
+      withV4l2 = false;
+      withVaapi = false;
+      withVidStab = false;
+      withVorbis = false;
+      withVpx = false;
+      withVulkan = false;
+      withWebp = false;
+      withX264 = false;
+      withX265 = false;
+      withXml2 = false;
+      withXvid = false;
+      withZimg = false;
+      withZvbi = false;
+      withNetwork = false;
+      buildFfmpeg = false;
+      buildFfprobe = false;
+      buildAvdevice = false;
+      buildAvfilter = false;
+      buildSwresample = false;
+      buildSwscale = false;
+      withManPages = false;
+      withHtmlDoc = false;
+      withPodDoc = false;
+      withTxtDoc = false;
+    })
+    # tests do not run anymore in this stripped down version
+    .overrideAttrs
+      { doCheck = false; };
+in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unpaper";
@@ -42,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    ffmpeg-headless
+    ffmpeg-bare
   ];
 
   passthru.tests = {


### PR DESCRIPTION
unpaper depends on ffmpeg for writing and reading image data. Even the `ffmpeg-headless` build pulls in ridiculous amounts of dependencies, especially when unpaper is just a dependency for paperless-ngx you want to install on a server.

For this reason, I changed unpaper to use a barebone version of ffmpeg with next to everything disabled. This brings down closure size from ~290 MiB to ~55 MiB. 

The new closure info:
```
% nix path-info --recursive --closure-size --size --human-readable ./result
/nix/store/pkphs076yz5ajnqczzj0588n6miph269-libunistring-1.4.1        	   2.0 MiB	   2.0 MiB
/nix/store/d0d9wqmw5saaynfvmszsda3dmh5q82z8-libidn2-2.3.8             	 359.6 KiB	   2.3 MiB
/nix/store/kbijm6lc9va8xann3cfyam0vczzmwkxj-xgcc-15.2.0-libgcc        	 193.1 KiB	 193.1 KiB
/nix/store/wb6rhpznjfczwlwx23zmdrrw74bayxw4-glibc-2.42-47             	  29.0 MiB	  31.5 MiB
/nix/store/59k463mhfy0i74i6w7d9jabd2rzand2v-xz-5.8.2                  	 837.8 KiB	  32.3 MiB
/nix/store/bhz2i66mwm3vdyslixazss6a46h48ib5-bzip2-1.0.8               	  86.9 KiB	  31.6 MiB
/nix/store/ri9paa3mri4kqakljak8ldvbcp7lpmif-zlib-1.3.1                	 129.2 KiB	  31.6 MiB
/nix/store/v3ahm7rrydchn62hw1960mm0fpxzs4n7-ffmpeg-headless-8.0.1-data	 245.0 KiB	 245.0 KiB
/nix/store/d05rdawdd8iw588lq6v78i164w1z2n4l-ffmpeg-headless-8.0.1-lib 	  22.9 MiB	  55.7 MiB
/nix/store/w76xnyqkgflnbk6cwd5c3k9x7q7dvqs4-unpaper-7.0.0             	  89.7 KiB	  55.7 MiB
```

But I completely understand, when this change feels "icky" and should not be incorporated. It's a suggestion :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
