### PR TITLE
cudaPackages.cuda_nvcc: do not patch crt/math_functions.h on cuda 13

### DIFF
--- a/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
+++ b/pkgs/development/cuda-modules/packages/cuda_nvcc.nix
@@ -168,7 +168,7 @@ buildRedist (finalAttrs: {
       # The cospi|sinpi|rsqrt function signatures in include/common/math_functions.h do not match
       # glibc 2.42's.
       # Indeed, there they are declared with noexcept(true) which is not the case in cuda_nvcc.
-      + lib.optionalString (lib.versionAtLeast glibc.version "2.42") ''
+      + lib.optionalString (cudaOlder "13.0" && lib.versionAtLeast glibc.version "2.42") ''
         nixLog "Patching math_functions.h signatures to match glibc's ones"
         substituteInPlace "''${!outputInclude:?}/include/crt/math_functions.h" \
           --replace-fail \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Follow up to #484031.
The patch does not apply on cuda>=13.0:
```
substitute(): ERROR: file '/nix/store/30grlfcg220aky6r9a306sqs8jj8ljhh-cuda13.0-cuda_nvcc-13.0.88/include/crt/math_functions.h' does not exist
```

Caught on the NixOS-CUDA hydra instance: https://hydra.nixos-cuda.org/build/165433

cc @NixOS/cuda-maintainers

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
