### PR TITLE
vikunja, vikunja-desktop: 1.0.0 -> 1.1.0

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -15,12 +15,12 @@
 
 let
   executableName = "vikunja-desktop";
-  version = "1.0.0";
+  version = "1.1.0";
   src = fetchFromGitHub {
     owner = "go-vikunja";
     repo = "vikunja";
     rev = "v${version}";
-    hash = "sha256-IJ6985gLuI0O08xZq8NYoet02NPFqQQhDLND+nfmdbA=";
+    hash = "sha256-xxfn3UoKreRDRC5GR7pLL8gkBLe6VmBYdps9eFc5c3g=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmInstallFlags
       ;
     fetcherVersion = 1;
-    hash = "sha256-BvQfRsV5hiOTkxK+W3qHvVQwMAGdLB3X+PwYBa6Bwl4=";
+    hash = "sha256-mzrck/JdfN3Qu+xhf/iM4HFamVmQkVSwUwU2KBK5XsA=";
   };
 
   env = {

--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -7,7 +7,7 @@
   pnpmConfigHook,
   nodejs,
   electron,
-  unstableGitUpdater,
+  nix-update-script,
   fetchFromGitHub,
   fetchPnpmDeps,
   vikunja,
@@ -94,9 +94,7 @@ stdenv.mkDerivation (finalAttrs: {
     true
   '';
 
-  passthru.updateScript = unstableGitUpdater {
-    url = "${src.meta.homepage}.git";
-  };
+  passthru.updateScript = nix-update-script { };
 
   # The desktop item properties should be kept in sync with data from upstream:
   desktopItem = makeDesktopItem {

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -14,12 +14,12 @@
 }:
 
 let
-  version = "1.0.0";
+  version = "1.1.0";
   src = fetchFromGitHub {
     owner = "go-vikunja";
     repo = "vikunja";
     rev = "v${version}";
-    hash = "sha256-IJ6985gLuI0O08xZq8NYoet02NPFqQQhDLND+nfmdbA=";
+    hash = "sha256-xxfn3UoKreRDRC5GR7pLL8gkBLe6VmBYdps9eFc5c3g=";
   };
 
   frontend = stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ let
         ;
       pnpm = pnpm_10;
       fetcherVersion = 1;
-      hash = "sha256-OmLFn5aKsXPSbW6AehjkuTJMgOMzDSaYo2XbPvU6WXo=";
+      hash = "sha256-NrysokKNmKAUdiC0o4qEPvsHr7KH7mMrcrEjxwmgb+g=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -138,6 +138,7 @@ buildGoModule {
   passthru = {
     tests.vikunja = nixosTests.vikunja;
     frontend = frontend;
+    updateScript = ./update.sh;
   };
 
   meta = {

--- a/pkgs/by-name/vi/vikunja/update.sh
+++ b/pkgs/by-name/vi/vikunja/update.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix wget jq nurl
+
+# shellcheck shell=bash
+
+set -euo pipefail
+
+if [[ $# -gt 1 || "${1:-}" == -* ]]; then
+    echo "Regenerates packaging data for the vikunja package."
+    echo "Usage: $0 [version]"
+    exit 1
+fi
+
+version="${1:-}"
+
+NIXPKGS_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ -z "$version" ]; then
+    TOKEN_ARGS=()
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        TOKEN_ARGS=(--header "Authorization: token $GITHUB_TOKEN")
+    fi
+    version="$(wget -q -O- ${TOKEN_ARGS[@]+"${TOKEN_ARGS[@]}"} "https://api.github.com/repos/go-vikunja/vikunja/releases?per_page=10" | jq -r '[.[] | select(.prerelease == false)][0].tag_name')"
+fi
+
+# strip leading "v"
+version="${version#v}"
+
+cd "$(dirname "$0")"
+
+# Update version, blank out all hashes so nurl can recompute them
+sed -i -E 's#version = ".*"#version = "'"$version"'"#' package.nix
+sed -i -E '/fetchFromGitHub \{/,/\};/ s#hash = ".*"#hash = ""#' package.nix
+sed -i -E '/fetchPnpmDeps \{/,/\};/ s#hash = ".*"#hash = ""#' package.nix
+sed -i -E 's#vendorHash = ".*"#vendorHash = ""#' package.nix
+
+# Source hash (must be computed first, pnpm and vendor depend on it)
+src_hash=$(nurl -e "(import $NIXPKGS_ROOT/. { }).vikunja.src")
+sed -i -E '/fetchFromGitHub \{/,/\};/ s#hash = ".*"#hash = "'"$src_hash"'"#' package.nix
+
+# pnpm dependencies hash for frontend
+pnpm_hash=$(nurl -e "(import $NIXPKGS_ROOT/. { }).vikunja.frontend.pnpmDeps")
+sed -i -E '/fetchPnpmDeps \{/,/\};/ s#hash = ".*"#hash = "'"$pnpm_hash"'"#' package.nix
+
+# Go modules vendor hash
+vendor_hash=$(nurl -e "(import $NIXPKGS_ROOT/. { }).vikunja.goModules")
+sed -i -E 's#vendorHash = ".*"#vendorHash = "'"$vendor_hash"'"#' package.nix
+
+echo "Update complete!"
+echo "Version: $version"
+echo "Source hash: $src_hash"
+echo "Frontend pnpm hash: $pnpm_hash"
+echo "Go vendor hash: $vendor_hash"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

There was a security vulnerability found in Vikunja that applies to 1.0.0. This 1.1.0 release fixes that. Check the changelog post here: https://vikunja.io/changelog/vikunja-v1.1.0-was-released/

I also took the liberty to add update scripts for both packages to make updating easier. Feel free to cherry-pick only the updates if that's easier.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
