### PR TITLE
elastic-agent

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23267,6 +23267,12 @@
     githubId = 40308458;
     name = "rwxd";
   };
+  rwyattwalker = {
+    email = "wyatt@wwalker.me";
+    github = "rwyattwalker";
+    githubId = 82427125;
+    name = "Wyatt Walker";
+  };
   rxiao = {
     email = "ben.xiao@me.com";
     github = "benxiao";

--- a/nixos/modules/services/monitoring/elastic-agent.nix
+++ b/nixos/modules/services/monitoring/elastic-agent.nix
@@ -1,0 +1,154 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.elastic-agent;
+  stateDir = "/var/lib/elastic-agent";
+  elasticConfig = pkgs.writeText "elastic-agent.yml" cfg.yml;
+in
+{
+  options = {
+    services.elastic-agent = {
+      enable = lib.mkEnableOption "Elastic Agent";
+      package = lib.mkPackageOption pkgs "elastic-agent" { };
+      ca = lib.mkOption {
+        type = lib.types.path;
+        description = "Path to root certificate for server verification used by Elastic Agent and Fleet Server";
+      };
+      yml = lib.mkOption {
+        type = lib.types.lines;
+        description = "elastic-agent.yml";
+        default = "";
+      };
+      enrollInFleet = {
+        description = "Configuration for enrolling Elastic Agent into Fleet.";
+        enable = lib.mkEnableOption "Enroll Agent in Fleet";
+        enrollmentToken = lib.mkOption {
+          type = lib.types.str;
+          description = "Path to file containing enrollment token to use to enroll Agent into Fleet";
+        };
+        url = lib.mkOption {
+          type = lib.types.str;
+          description = "URL to enroll Agent into Fleet";
+        };
+      };
+      fleetServer = {
+        description = "Config for running Fleet Server";
+        enable = lib.mkEnableOption "Fleet Server";
+        url = lib.mkOption {
+          type = lib.types.str;
+          description = "Fleet Server URL";
+        };
+        es = lib.mkOption {
+          type = lib.types.str;
+          description = "URL or IP Address for Elasticsearch";
+        };
+        serviceToken = lib.mkOption {
+          type = lib.types.str;
+          description = "Path to file containing service token for Fleet Server to use for communication with Elasticsearch";
+        };
+        policy = lib.mkOption {
+          type = lib.types.str;
+          description = "Start and run a Fleet Server on this specific policy";
+        };
+        esCa = lib.mkOption {
+          type = lib.types.path;
+          description = "Path to certificate authority for Fleet Server to use to communicate with Elasticsearch";
+        };
+        cert = lib.mkOption {
+          type = lib.types.path;
+          description = "Path to certificate for Fleet Server to use for exposed HTTPS endpoint";
+        };
+        certKey = lib.mkOption {
+          type = lib.types.str;
+          description = "Path to private key for the certificate used by Fleet Server for exposed HTTPS endpoint";
+        };
+        port = lib.mkOption {
+          type = lib.types.port;
+          description = "Fleet Server HTTP binding port";
+        };
+      };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.xor cfg.fleetServer.enable cfg.enrollInFleet.enable;
+        message = "elastic-agent: either services.elastic-agent.enrollInFleet or services.elastic-agent.fleetServer must be enabled";
+      }
+    ];
+    systemd.tmpfiles.rules = [
+      "d /var/lib/elastic-agent 0750 root root -"
+      "C ${stateDir}/elastic-agent.yml 0640 root root - ${elasticConfig}"
+    ];
+    systemd.services.elastic-agent = {
+      description = "Elastic Agent";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network-online.target"
+        "systemd-tmpfiles-setup.service"
+      ];
+      wants = [
+        "network-online.target"
+        "systemd-tmpfiles-setup.service"
+      ];
+      preStart = ''
+        if [ -f ${stateDir}/fleet.enc ]; then
+          echo "elastic-agent:already enrolled (fleet.enc exists), skipping enrollment."
+          exit 0
+        fi
+
+        ${lib.optionalString cfg.fleetServer.enable ''
+          serviceToken="$(tr -d '\n' < ${cfg.fleetServer.serviceToken})"
+          ${lib.getExe cfg.package} enroll --force \
+            --url=${cfg.fleetServer.url} \
+            --fleet-server-es=${cfg.fleetServer.es} \
+            --fleet-server-es-ca=${cfg.fleetServer.esCa} \
+            --fleet-server-service-token=$serviceToken \
+            --fleet-server-policy=${cfg.fleetServer.policy} \
+            --fleet-server-port=${toString cfg.fleetServer.port} \
+            --fleet-server-cert=${cfg.fleetServer.cert} \
+            --fleet-server-cert-key=${cfg.fleetServer.certKey} \
+            --certificate-authorities=${cfg.ca} \
+            --path.home ${stateDir} \
+            --path.config ${stateDir} \
+            --path.logs ${stateDir}/logs \
+            --path.socket ${stateDir}/elastic-agent.sock
+        ''}
+
+        ${lib.optionalString cfg.enrollInFleet.enable ''
+          enrollmentToken="$(tr -d '\n' < ${cfg.enrollInFleet.enrollmentToken})"
+          ${lib.getExe cfg.package} enroll --delay-enroll \
+            --enrollment-token=$enrollmentToken \
+            --url=${cfg.enrollInFleet.url} \
+            --certificate-authorities=${cfg.ca} \
+            --path.config ${stateDir} \
+            --path.downloads ${stateDir} \
+            --path.home ${stateDir} \
+            --path.logs ${stateDir}/logs
+        ''}
+      '';
+      path = [ pkgs.coreutils ];
+      serviceConfig = {
+        User = "root";
+        Group = "root";
+        StateDirectory = "elastic-agent";
+        WorkingDirectory = stateDir;
+        ExecStart = ''
+          ${lib.getExe cfg.package} run \
+            --path.config ${stateDir} \
+            --path.downloads ${stateDir} \
+            --path.home ${stateDir} \
+            --path.logs ${stateDir}/logs \
+            --path.socket ${stateDir}/elastic-agent.sock
+        '';
+      };
+    };
+  };
+  meta = {
+    maintainers = [ lib.maintainers.rwyattwalker ];
+  };
+}

--- a/pkgs/by-name/el/elastic-agent/package.nix
+++ b/pkgs/by-name/el/elastic-agent/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenv,
+  autoPatchelfHook,
+  lib,
+  fetchzip,
+}:
+let
+  version = "9.2.4";
+in
+stdenv.mkDerivation {
+  pname = "elastic-agent";
+  inherit version;
+  src = fetchzip {
+    url =
+      {
+        x86_64-linux = "https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${version}-linux-x86_64.tar.gz";
+        aarch64-linux = "https://artifacts.elastic.co/downloads/beats/elastic-agent/elastic-agent-${version}-linux-arm64.tar.gz";
+      }
+      .${stdenv.hostPlatform.system}
+        or (throw "elastic-agent: unsupported system ${stdenv.hostPlatform.system}");
+    hash =
+      {
+        x86_64-linux = "sha256-NR+86/mss/Kol1AQX1orNHjI6GouHWg8UkQj4xO65qo=";
+        aarch64-linux = "sha256-cN3yEyD/aKp5kvNF2zr1gfSrQo0ZBWuZq3mJftzfgbo=";
+      }
+      .${stdenv.hostPlatform.system}
+        or (throw "elastic-agent: unsupported system ${stdenv.hostPlatform.system}");
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/elastic-agent $out/bin
+    cp -r $src/* $out/share/elastic-agent/
+    ln -s $out/share/elastic-agent/elastic-agent $out/bin/elastic-agent
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Elastic Agent";
+    homepage = "https://www.elastic.co/elastic-agent";
+    mainProgram = "elastic-agent";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    license = lib.licenses.elastic20;
+    maintainers = [ lib.maintainers.rwyattwalker ];
+  };
+}


### PR DESCRIPTION
This change adds a package and module for running elastic agent. There is necessary because there is currently not a package for elastic agent so running it requires manual customization. The homepage can be found [here](https://www.elastic.co/elastic-agent).

## Things done

- Added elastic agent package
- Added module for configuring fleet server / fleet managed elastic agent
- Added self as maintainer

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
