### PR TITLE
[staging-next] arrow-cpp: vendor patch for boost 1.89 support

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/boost-189.patch
+++ b/pkgs/by-name/ar/arrow-cpp/boost-189.patch
@@ -1,0 +1,51 @@
+diff --git a/cmake_modules/ThirdpartyToolchain.cmake b/cmake_modules/ThirdpartyToolchain.cmake
+index 7b8cef5fb5..06f188f0b7 100644
+--- a/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cmake_modules/ThirdpartyToolchain.cmake
+@@ -1198,6 +1198,8 @@
+ endif()
+ # CMake 3.25.0 has 1.80 and older versions.
+ set(Boost_ADDITIONAL_VERSIONS
++    "1.89.0"
++    "1.89"
+     "1.88.0"
+     "1.88"
+     "1.87.0"
+@@ -1268,7 +1270,7 @@
+     set(Boost_USE_STATIC_LIBS ON)
+   endif()
+   if(ARROW_BOOST_REQUIRE_LIBRARY)
+-    set(ARROW_BOOST_COMPONENTS filesystem system)
++    set(ARROW_BOOST_COMPONENTS filesystem)
+     if(ARROW_FLIGHT_SQL_ODBC AND MSVC)
+       list(APPEND ARROW_BOOST_COMPONENTS locale)
+     endif()
+@@ -1322,9 +1324,6 @@
+       if(TARGET Boost::filesystem)
+         target_link_libraries(arrow::Boost::process INTERFACE Boost::filesystem)
+       endif()
+-      if(TARGET Boost::system)
+-        target_link_libraries(arrow::Boost::process INTERFACE Boost::system)
+-      endif()
+       if(TARGET Boost::headers)
+         target_link_libraries(arrow::Boost::process INTERFACE Boost::headers)
+       endif()
+diff --git a/src/arrow/filesystem/CMakeLists.txt b/src/arrow/filesystem/CMakeLists.txt
+index 5250ed2a88..9c5e655f6c 100644
+--- a/src/arrow/filesystem/CMakeLists.txt
++++ b/src/arrow/filesystem/CMakeLists.txt
+@@ -132,12 +132,11 @@
+                    DEFINITIONS
+                    ARROW_S3_LIBPATH="$<TARGET_FILE:arrow_s3fs>"
+                    EXTRA_LINK_LIBS
+-                   Boost::filesystem
+-                   Boost::system)
++                   Boost::filesystem)
+     target_compile_definitions(arrow-filesystem-test
+                                PUBLIC ARROW_S3_LIBPATH="$<TARGET_FILE:arrow_s3fs>")
+     target_sources(arrow-filesystem-test PUBLIC s3fs_module_test.cc s3_test_util.cc)
+-    target_link_libraries(arrow-filesystem-test PUBLIC Boost::filesystem Boost::system)
++    target_link_libraries(arrow-filesystem-test PUBLIC Boost::filesystem)
+   endif()
+ endif()
+ 

--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -195,6 +195,14 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'discover_tz_dir();' '"${tzdata}/share/zoneinfo";'
   '';
 
+  patches = [
+    # Remove dependency on Boost.System, which was removed in Boost 1.89.
+    # Upstream PR: https://github.com/apache/arrow/pull/47947
+    # PR doesn't apply cleanly due to changes between 22.0.0 and the time of
+    # PR, so we vendor the portions we need
+    ./boost-189.patch
+  ];
+
   cmakeFlags = [
     (lib.cmakeBool "CMAKE_FIND_PACKAGE_PREFER_CONFIG" true)
     (lib.cmakeBool "ARROW_BUILD_SHARED" enableShared)


### PR DESCRIPTION
Boost 1.89 (https://www.boost.org/releases/1.89.0/) dropped the stub compiled `Boost::system` library, leading to errors when arrow tried to include it. This was fixed upstream (apache/arrow#47947) after the release of 22.0.0, but since the surrounding code changed such that the patch does not cleanly apply, we vendor it here.

Alternatively, we could update to Arrow 23.0.0: https://arrow.apache.org/release/23.0.0.html

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
