### PR TITLE
alt-ergo-free: 2.4.3 and ocamlPackages.ocplib-simplex: 0.4.1

### DIFF
--- a/pkgs/by-name/al/alt-ergo-free/package.nix
+++ b/pkgs/by-name/al/alt-ergo-free/package.nix
@@ -1,0 +1,40 @@
+{
+  fetchurl,
+  lib,
+  ocamlPackages,
+  stdenv,
+}:
+
+ocamlPackages.buildDunePackage (finalAttrs: {
+  pname = "alt-ergo-free";
+  version = "2.4.3";
+
+  src = fetchurl {
+    url = "https://github.com/OCamlPro/alt-ergo/releases/download/v${finalAttrs.version}-free/alt-ergo-${finalAttrs.version}-free.tar.gz";
+    hash = "sha256-ksVP9HH9pY+T6Es/wgC9pGd805AGw1e1vgfVlNGCXG8=";
+  };
+
+  nativeBuildInputs = [ ocamlPackages.menhir ];
+
+  sourceRoot = ".";
+
+  buildInputs = with ocamlPackages; [
+    cmdliner
+    camlzip
+    stdlib-shims
+    dune-configurator
+    dune-build-info
+    num
+    psmt2-frontend
+    ocplib-simplex_0_4
+    zarith
+    seq
+  ];
+
+  meta = {
+    description = "High-performance theorem prover and SMT solver";
+    homepage = "https://alt-ergo.ocamlpro.com/";
+    license = lib.licenses.cecill-c;
+    maintainers = with lib.maintainers; [ redianthus ];
+  };
+})

--- a/pkgs/development/ocaml-modules/ocplib-simplex/0_4.nix
+++ b/pkgs/development/ocaml-modules/ocplib-simplex/0_4.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  stdenv,
+  autoreconfHook,
+  ocaml,
+  findlib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ocplib-simplex";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "OCamlPro";
+    repo = finalAttrs.pname;
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-bhlTBpJg031x2lUjwuVrhQgOGmDLW/+0naN8wRjv6i4=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    ocaml
+    findlib
+  ];
+
+  preInstall = ''
+    mkdir -p $out/lib/ocaml/${ocaml.version}/site-lib/
+  '';
+
+  postInstall = ''
+    mv $out/lib/${finalAttrs.pname} $out/lib/ocaml/${ocaml.version}/site-lib
+  '';
+
+  meta = {
+    description = "OCaml library implementing a simplex algorithm, in a functional style, for solving systems of linear inequalities";
+    homepage = "https://github.com/OCamlPro/ocplib-simplex";
+    license = lib.licenses.lgpl21Only;
+    maintainers = with lib.maintainers; [ redianthus ];
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1563,6 +1563,8 @@ let
 
         ocplib-simplex = callPackage ../development/ocaml-modules/ocplib-simplex { };
 
+        ocplib-simplex_0_4 = callPackage ../development/ocaml-modules/ocplib-simplex/0_4.nix { };
+
         ocsigen-ppx-rpc = callPackage ../development/ocaml-modules/ocsigen-ppx-rpc { };
 
         ocsigen_server = callPackage ../development/ocaml-modules/ocsigen-server { };


### PR DESCRIPTION
This PR adds two packages:
- `alt-ergo-free` is a free release of the Alt-Ergo SMT solver under the terms of CeCILL-C. 
- As the free release is older than the commercial version, it requires older `ocplib-simplex` too.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
