### PR TITLE
pyside6: Add numpy support

### DIFF
--- a/pkgs/development/python-modules/shiboken6/default.nix
+++ b/pkgs/development/python-modules/shiboken6/default.nix
@@ -3,6 +3,7 @@
   fetchgit,
   llvmPackages,
   python,
+  numpy,
   cmake,
   autoPatchelfHook,
   stdenv,
@@ -38,12 +39,16 @@ stdenv'.mkDerivation (finalAttrs: {
     python.pkgs.ninja
     python.pkgs.packaging
     python.pkgs.setuptools
+    numpy
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     python.pkgs.qt6.darwinVersionInputs
   ];
 
-  cmakeFlags = [ "-DBUILD_TESTS=OFF" ];
+  cmakeFlags = [
+    "-DBUILD_TESTS=OFF"
+    "-DNUMPY_INCLUDE_DIR=${numpy.coreIncludeDir}"
+  ];
 
   # We intentionally use single quotes around `${BASH}` since it expands from a CMake
   # variable available in this file.


### PR DESCRIPTION
This allows optional numpy support which is especially important for the higher performance options it offers with qtgraph.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

