### PR TITLE
xdg-utils: patch out qtpaths runtime dependency

### DIFF
--- a/pkgs/by-name/xd/xdg-utils/package.nix
+++ b/pkgs/by-name/xd/xdg-utils/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   fetchFromGitLab,
+  fetchpatch,
   runCommand,
   writeText,
   # docs deps
@@ -142,7 +143,6 @@ let
         "ktraderclient" # KDE 3
         "ktradertest" # KDE 3
         "mimetype" # alternative tool for file, pulls in perl, avoid
-        "qtpaths" # Plasma
         "qtxdg-mat" # LXQT
       ];
       fix."/usr/bin/file" = true;
@@ -315,6 +315,11 @@ stdenv.mkDerivation (finalAttrs: {
     ./allow-forcing-portal-use.patch
     #  Enable build of xdg-terminal
     ./enable-xdg-terminal.patch
+    # Get rid of qtpaths runtime dependency (can be dropped in next release)
+    (fetchpatch {
+      url = "https://cgit.freedesktop.org/xdg/xdg-utils/patch/?id=e6a6e4f1fbcb029bac0cb8eecdeb2879694e1ba8";
+      hash = "sha256-toSFzIaw7gCWZH/kvIalWDQYL1xecOsRBAHvpbBlsY8=";
+    })
   ];
 
   # just needed when built from git
@@ -367,7 +372,9 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.freedesktop.org/wiki/Software/xdg-utils/";
     description = "Set of command line tools that assist applications with a variety of desktop integration tasks";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      tmarkus
+    ];
     platforms = lib.platforms.all;
   };
 })


### PR DESCRIPTION
A commit on master removes the qtpaths dependency that can lead to errors running `xdg-mime` on KDE. Fixes #338263.
Also add myself as maintainer.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
