### PR TITLE
[25.11] mesa: allow rusticl zink to find libvulkan

### DIFF
--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -379,7 +379,7 @@ stdenv.mkDerivation {
     jdupes --hard-links --link-soft --recurse "$out"
 
     # add RPATH here so Zink can find libvulkan.so
-    patchelf --add-rpath ${vulkan-loader}/lib $out/lib/libgallium*.so
+    patchelf --add-rpath ${vulkan-loader}/lib $out/lib/libgallium*.so $opencl/lib/libRusticlOpenCL.so
   '';
 
   passthru = {


### PR DESCRIPTION
#488702 is a trivial fix so I'd like it to have it backported right away, if possible :)