### PR TITLE
surge-downloader: init at 0.12.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8035,6 +8035,12 @@
     github = "eripa";
     githubId = 1429673;
   };
+  ErmitaVulpe = {
+    name = "Emily Wilczek";
+    email = "emily.wilczek@proton.me";
+    github = "ErmitaVulpe";
+    githubId = 34629570;
+  };
   ern775 = {
     email = "eren.demir2479090@gmail.com";
     github = "ern775";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8654,6 +8654,12 @@
     github = "eripa";
     githubId = 1429673;
   };
+  ErmitaVulpe = {
+    name = "Emily Wilczek";
+    email = "emily.wilczek@proton.me";
+    github = "ErmitaVulpe";
+    githubId = 34629570;
+  };
   ern775 = {
     email = "eren.demir2479090@gmail.com";
     github = "ern775";

--- a/pkgs/by-name/su/surge-downloader/package.nix
+++ b/pkgs/by-name/su/surge-downloader/package.nix
@@ -1,0 +1,42 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  writableTmpDirAsHomeHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "surge-downloader";
+  version = "0.6.8";
+
+  src = fetchFromGitHub {
+    owner = "surge-downloader";
+    repo = "surge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-6ISP7S5rcsjFQxXQGnqZ4jWgjNk98/npy7Z0pobIB98=";
+  };
+
+  vendorHash = "sha256-IGVt/HanZHglYSZ8WASrzqvTZZtK/bJpJzXNVqSqUfE=";
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+  ];
+
+  # tests are mostly stress-tests
+  doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI download manager";
+    longDescription = ''
+      Surge is a blazing fast, open-source terminal (TUI) download manager built in Go.
+      Designed for power users who prefer a keyboard-driven workflow. It features a beautiful TUI,
+      as well as a background Headless Server and a CLI tool for automation.
+    '';
+    homepage = "https://github.com/surge-downloader/surge";
+    license = lib.licenses.mit;
+    mainProgram = "surge";
+    maintainers = with lib.maintainers; [ ErmitaVulpe ];
+  };
+})

--- a/pkgs/by-name/su/surge-downloader/package.nix
+++ b/pkgs/by-name/su/surge-downloader/package.nix
@@ -1,0 +1,63 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  stdenv,
+  versionCheckHook,
+}:
+buildGoModule (finalAttrs: {
+  pname = "surge-downloader";
+  version = "0.12.1";
+
+  src = fetchFromGitHub {
+    owner = "SurgeDM";
+    repo = "Surge";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-cUJwt4gRdlQvMnrEvYG7JZe/2oz4cN9k35TEur13Sks=";
+  };
+
+  vendorHash = "sha256-Ei2i7dQ9s42Gg6f2iLABbTG7OQspjHoRnqIhkfcNvFo=";
+
+  subPackages = [ "." ];
+
+  ldflags = [
+    "-s"
+    "-X github.com/SurgeDM/Surge/cmd.Version=${finalAttrs.version}"
+  ];
+
+  postInstall =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        mv $out/bin/Surge $out/bin/surge.tmp
+        mv $out/bin/surge.tmp $out/bin/surge
+      ''
+    else
+      ''
+        mv $out/bin/Surge $out/bin/surge
+        ln -s $out/bin/surge $out/bin/Surge
+      '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "TUI download manager";
+    longDescription = ''
+      Surge is a blazing fast, open-source terminal (TUI) download manager built in Go.
+      Designed for power users who prefer a keyboard-driven workflow. It features a beautiful TUI,
+      as well as a background Headless Server and a CLI tool for automation.
+    '';
+    homepage = "https://github.com/SurgeDM/Surge";
+    changelog = "https://github.com/SurgeDM/Surge/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "surge";
+    maintainers = with lib.maintainers; [ ErmitaVulpe ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Added [surge](https://github.com/surge-downloader/surge), a TUI download manager. Sadly the name `surge` was already taken so I added it as `surge-downloader`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
