### PR TITLE
[Backport release-25.11] Add wine 11

### DIFF
--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -71,6 +71,11 @@ let
       pnameSuffix = "-staging";
       useStaging = true;
     };
+    staging_11 = {
+      src = sources.unstable_11;
+      pnameSuffix = "-staging";
+      useStaging = true;
+    };
     # "yabridge" enables staging too --- we are not interested in
     # yabridge without the staging patches applied.
     yabridge = {

--- a/pkgs/applications/emulators/wine/default.nix
+++ b/pkgs/applications/emulators/wine/default.nix
@@ -56,6 +56,10 @@ let
       src = sources.stable;
       useStaging = false;
     };
+    stable_11 = {
+      src = sources.stable_11;
+      useStaging = false;
+    };
     unstable = {
       src = sources.unstable;
       useStaging = false;

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -214,6 +214,32 @@ rec {
     '';
   };
 
+  unstable_11 = fetchurl rec {
+    # NOTE: Don't forget to change the hash for staging as well.
+    version = "11.1";
+    url = "https://dl.winehq.org/wine/source/11.x/wine-${version}.tar.xz";
+    hash = "sha256-v0x8j7XYwfZW8wor6pOHDIXxP/gxGrL2Hd75AOsoy48=";
+
+    patches = [
+      # Also look for root certificates at $NIX_SSL_CERT_FILE
+      ./cert-path.patch
+    ];
+
+    # see https://gitlab.winehq.org/wine/wine-staging
+    staging = fetchFromGitLab {
+      inherit version;
+      hash = "sha256-KBiESkLVEEWyUPzv1I7j8U9zjqfYdF+FL6wRCcIE290=";
+      domain = "gitlab.winehq.org";
+      owner = "wine";
+      repo = "wine-staging";
+      rev = "v${version}";
+
+      disabledPatchsets = [ ];
+    };
+
+    inherit (unstable) gecko32 gecko64 mono;
+  };
+
   yabridge = fetchurl rec {
     # NOTE: This is a pinned version with staging patches; don't forget to update them as well
     version = "9.21";

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -131,6 +131,26 @@ rec {
     '';
   };
 
+  stable_11 = fetchurl rec {
+    version = "11.0";
+    url = "https://dl.winehq.org/wine/source/11.0/wine-${version}.tar.xz";
+    hash = "sha256-wHpoV5M8H8YN/1RI1585ySSBwenbWqYo250DWERuBwE=";
+
+    inherit (stable) gecko32 gecko64;
+
+    ## see http://wiki.winehq.org/Mono
+    mono = fetchurl rec {
+      version = "10.0.0";
+      url = "https://dl.winehq.org/wine/wine-mono/${version}/wine-mono-${version}-x86.msi";
+      hash = "sha256-26ynPl0J96OnwVetBCia+cpHw87XAS1GVEpgcEaQK4c=";
+    };
+
+    patches = [
+      # Also look for root certificates at $NIX_SSL_CERT_FILE
+      ./cert-path.patch
+    ];
+  };
+
   unstable = fetchurl rec {
     # NOTE: Don't forget to change the hash for staging as well.
     version = "10.20";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14266,6 +14266,8 @@ with pkgs;
           waylandFull
           yabridge
           fonts
+          stable_11
+          stableFull_11
           ;
       }
     );

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -14268,6 +14268,8 @@ with pkgs;
           fonts
           stable_11
           stableFull_11
+          staging_11
+          stagingFull_11
           ;
       }
     );

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -71,4 +71,7 @@ rec {
       yabridge = base.override { wineRelease = "yabridge"; };
     in
     if wineBuild == "wineWow" then yabridge else lib.dontDistribute yabridge;
+
+  stable_11 = base.override { wineRelease = "stable_11"; };
+  stableFull_11 = full.override { wineRelease = "stable_11"; };
 }

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -74,4 +74,7 @@ rec {
 
   stable_11 = base.override { wineRelease = "stable_11"; };
   stableFull_11 = full.override { wineRelease = "stable_11"; };
+
+  staging_11 = base.override { wineRelease = "staging_11"; };
+  stagingFull_11 = full.override { wineRelease = "staging_11"; };
 }


### PR DESCRIPTION
The is a "backport" if https://github.com/NixOS/nixpkgs/pull/484145, except instead of bumping the version, which might cause problems, it adds a new version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux: Built `wineWow64Packages.stable_11`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
