### PR TITLE
neovim: use evalModule to typecheck plugins config

### DIFF
--- a/pkgs/applications/editors/neovim/module.nix
+++ b/pkgs/applications/editors/neovim/module.nix
@@ -1,0 +1,115 @@
+{ config, lib, ... }:
+let
+  /*
+    transform all plugins into an attrset
+    { optional = bool; plugin = package; }
+  */
+  normalizePlugins =
+    plugins:
+    let
+      defaultPlugin = {
+        plugin = null;
+        config = null;
+        optional = false;
+      };
+    in
+    map (x: defaultPlugin // (if (x ? plugin) then x else { plugin = x; })) plugins;
+
+  pluginWithConfigType =
+    with lib;
+    types.submodule {
+      options = {
+        config = mkOption {
+          type = types.nullOr types.lines;
+          description = "viml configuration associated with this plugin.";
+          default = null;
+          example = "set title";
+        };
+
+        optional = mkEnableOption "optional" // {
+          description = "Don't load automatically on startup (load with :packadd)";
+        };
+
+        plugin = mkOption {
+          type = types.package;
+          example = lib.literalExpression "vimPlugins.vim-fugitive";
+          description = "vim plugin";
+        };
+      };
+    };
+
+in
+{
+  options = {
+    plugins = lib.mkOption {
+      type = with lib.types; listOf (either package pluginWithConfigType);
+      default = [ ];
+      apply = normalizePlugins;
+      example = lib.literalExpression ''
+        with pkgs.vimPlugins; [
+          yankring
+          vim-nix
+          { plugin = vim-startify;
+            config = "let g:startify_change_to_vcs_root = 0";
+          }
+        ]
+      '';
+      description = ''
+        List of vim plugins to install optionally associated with
+        configuration to be placed in init.vim.
+      '';
+    };
+
+    runtimeDeps = lib.mkOption {
+      readOnly = true;
+      type = with lib.types; listOf package;
+      description = ''
+        List of derivations required at runtime
+      '';
+    };
+
+    pluginAdvisedLua = lib.mkOption {
+      readOnly = true;
+      type = lib.types.listOf lib.types.lines;
+      description = ''
+        Recommended configuration set in vim plugins via ".passthru.initLua".
+      '';
+    };
+
+    userPluginViml = lib.mkOption {
+      readOnly = true;
+      type = lib.types.listOf (lib.types.lines);
+      description = ''
+        The viml config set by the user.
+      '';
+    };
+
+  };
+
+  config =
+    let
+      pluginsNormalized = normalizePlugins config.plugins;
+    in
+    {
+      pluginAdvisedLua =
+        let
+          op =
+            acc: normalizedPlugin:
+            acc
+            ++ lib.optional (
+              normalizedPlugin.plugin.passthru ? initLua
+            ) normalizedPlugin.plugin.passthru.initLua;
+        in
+        lib.foldl' op [ ] pluginsNormalized;
+
+      runtimeDeps =
+        let
+          op = acc: normalizedPlugin: acc ++ normalizedPlugin.plugin.runtimeDeps or [ ];
+        in
+        lib.foldl' op [ ] pluginsNormalized;
+
+      userPluginViml = lib.foldl (
+        acc: p: if p.config != null then acc ++ [ p.config ] else acc
+      ) [ ] pluginsNormalized;
+    };
+}

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -79,24 +79,29 @@ let
     plugins:
 
     let
+      neovimConfig =
+        structuredConfigure:
+        let
+          module = import ./module.nix;
+          # Generate init.vim configuration
+          cfg = (
+            lib.evalModules {
+              modules = [
+                module
+                structuredConfigure
+              ];
+            }
+          );
+        in
+        cfg.config;
+
+      checked_cfg = neovimConfig {
+        inherit plugins;
+      };
+
       pluginsNormalized = normalizePlugins plugins;
 
       vimPackage = normalizedPluginsToVimPackage pluginsNormalized;
-
-      userPluginViml = lib.foldl (
-        acc: p: if p.config != null then acc ++ [ p.config ] else acc
-      ) [ ] pluginsNormalized;
-
-      pluginAdvisedLua =
-        let
-          op =
-            acc: normalizedPlugin:
-            acc
-            ++ lib.optional (
-              normalizedPlugin.plugin.passthru ? initLua
-            ) normalizedPlugin.plugin.passthru.initLua;
-        in
-        lib.foldl' op [ ] pluginsNormalized;
 
       getDeps = attrname: map (plugin: plugin.${attrname} or (_: [ ]));
 
@@ -108,22 +113,17 @@ let
       inherit pluginPython3Packages;
 
       # viml config set by the user along with the plugin
-      inherit userPluginViml;
-
-      # recommended configuration set in vim plugins ".passthru.initLua"
-      inherit pluginAdvisedLua;
+      inherit (checked_cfg)
+        userPluginViml
+        runtimeDeps
+        pluginAdvisedLua
+        ;
 
       # A Vim "package", see ':h packages'
       # You most likely want to use vimPackage as follows:
       #     packpathDirs.myNeovimPackages = vimPackage;
       #     finalPackdir = neovimUtils.packDir packpathDirs;
       inherit vimPackage;
-
-      runtimeDeps =
-        let
-          op = acc: normalizedPlugin: acc ++ normalizedPlugin.plugin.runtimeDeps or [ ];
-        in
-        lib.foldl' op [ ] pluginsNormalized;
 
     };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
I've had a full evalModule based neovim config for ~7 years.  
I see home-manager neovim module as (my) ideal interface for neovim in nixpkgs, simple and not too opiniated yet. I would like to expose something similar in nixpkgs and I've realized we were missing several pieces (per-plugin lua config for instance).
Neovim is often complained about so I hope we can typecheck the config with better error messages, better migration paths via the module system see https://github.com/NixOS/nixpkgs/issues/358552.
This is a simple backwards-compatible change. I hope we can build on this to expose the full set of neovim options.

WIP, tests dont pass yet + I have to check with HM

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
