### PR TITLE
localsend: patch CVE-2026-25154

### DIFF
--- a/pkgs/by-name/lo/localsend/package.nix
+++ b/pkgs/by-name/lo/localsend/package.nix
@@ -10,6 +10,7 @@
   libayatana-appindicator,
   undmg,
   makeBinaryWrapper,
+  fetchpatch,
 }:
 
 let
@@ -34,6 +35,18 @@ let
       permission_handler_windows = "sha256-+TP3neqlQRZnW6BxHaXr2EbmdITIx1Yo7AEn5iwAhwM=";
       pasteboard = "sha256-lJA5OWoAHfxORqWMglKzhsL1IFr9YcdAQP/NVOLYB4o=";
     };
+
+    patches = [
+      # Fix for https://github.com/localsend/localsend/security/advisories/GHSA-34v6-52hh-x4r4
+      # See: https://github.com/NixOS/nixpkgs/issues/488755
+      # Can be removed with new release > 1.17.0
+      (fetchpatch {
+        url = "https://github.com/localsend/localsend/commit/8f3cec85aa29b2b13fed9b2f8e499e1ac9b0504c.patch";
+        hash = "sha256-Fswir+TebCDPxHVBg8YM3ROx2uoLG92E3E15wnzHz+U=";
+      })
+    ];
+
+    patchFlags = [ "-p2" ];
 
     postPatch = ''
       substituteInPlace lib/util/native/autostart_helper.dart \


### PR DESCRIPTION
Patching: https://github.com/localsend/localsend/security/advisories/GHSA-34v6-52hh-x4r4
Diff: https://github.com/localsend/localsend/commit/8f3cec85aa29b2b13fed9b2f8e499e1ac9b0504c

Resolves: #488755

~~Added the patch as a file instead of via `fetchpatch`, because the `sourceRoot` is set in our package which required me to edit the filepath for the file to be patched. If there is a cleaner way to do this, e.g. by still using `fetchpatch` somehow, please let me know.~~

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
