### PR TITLE
python3Packages.python-openstackclient: fix subpackages builds

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27968,8 +27968,9 @@
   };
   vinetos = {
     name = "vinetos";
-    email = "vinetosdev@gmail.com";
+    email = "contact+git@vinetos.fr";
     github = "vinetos";
+    matrix = "@vinetos:matrix.org";
     githubId = 10145351;
   };
   vinnymeller = {

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -44,6 +44,10 @@ buildPythonPackage (finalAttrs: {
     hash = "sha256-CEz1v4e4NadSZ+qhotFtLB4y/KdhDZbDOohN8D9FB30=";
   };
 
+  patches = [
+    ./fix-pyproject.patch
+  ];
+
   env.PBR_VERSION = finalAttrs.version;
 
   build-system = [
@@ -79,7 +83,18 @@ buildPythonPackage (finalAttrs: {
     runHook postCheck
   '';
 
-  pythonImportsCheck = [ "openstackclient" ];
+  pythonImportsCheck = [
+    "openstackclient"
+    "openstackclient.api"
+    "openstackclient.common"
+    "openstackclient.compute"
+    "openstackclient.identity"
+    "openstackclient.image"
+    "openstackclient.network"
+    "openstackclient.object"
+    "openstackclient.volume"
+    "openstackclient.tests"
+  ];
 
   optional-dependencies = {
     # See https://github.com/openstack/python-openstackclient/blob/master/doc/source/contributor/plugins.rst

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -79,7 +79,7 @@ buildPythonPackage (finalAttrs: {
   checkPhase = ''
     runHook preCheck
     stestr run -E \
-      "openstackclient.tests.unit.(volume.v3.test_volume.(TestVolumeCreate|TestVolumeShow)|common.test_module.TestModuleList)"
+      "openstackclient.tests.unit.common.test_module.TestModuleList.(test_module_list_no_options|test_module_list_all)"
     runHook postCheck
   '';
 

--- a/pkgs/development/python-modules/python-openstackclient/fix-pyproject.patch
+++ b/pkgs/development/python-modules/python-openstackclient/fix-pyproject.patch
@@ -1,0 +1,18 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 37fb8d0c..21571714 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -730,10 +730,9 @@ volume_transfer_request_show = "openstackclient.volume.v3.volume_transfer_reques
+ volume_summary = "openstackclient.volume.v3.volume:VolumeSummary"
+ volume_revert = "openstackclient.volume.v3.volume:VolumeRevertToSnapshot"
+ 
+-[tool.setuptools]
+-packages = [
+-    "openstackclient"
+-]
++[tool.setuptools.packages.find]
++where = ["."]
++include = ["openstackclient*"]
+ 
+ [tool.mypy]
+ python_version = "3.10"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves #488802

When migrating to `fetchFromGithub`, we broke the build of `python-openstackclient` as a dependencies because of sub-packages misconfiguration upstream.

I have added a patch to build and includes theses sub-packages.

I also disabled `openstackclient.tests.unit.common.test_module.TestModuleList.(test_module_list_no_options|test_module_list_all)` that fails because of Python 3.14 :
```
======
Totals
======
Ran: 2782 tests in 2.8295 sec.
 - Passed: 2780
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 2
Sum of execute time for each test: 33.5325 sec.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
