### PR TITLE
avdl: init 0.1.5+1.12.1

### DIFF
--- a/pkgs/by-name/av/avdl/package.nix
+++ b/pkgs/by-name/av/avdl/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "avdl";
+  version = "0.1.5+1.12.1";
+
+  src = fetchFromGitHub {
+    owner = "jonhoo";
+    repo = "avdl";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-/YGDtezPMMdogk8eGoHgqt8B0t6SNA3TVqroLOOANxs=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-QPC58tt7e8O/KJyE3c5mdLMyEt37hKG9lEDBs47prAQ=";
+
+  meta = {
+    description = "Rust port of avro-tools' IDL tooling";
+    homepage = "https://github.com/jonhoo/avdl";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ck3d ];
+    mainProgram = "avdl";
+  };
+})


### PR DESCRIPTION
Add **AVDL** compiler, Rust port of avro-tools' IDL tooling.

https://github.com/jonhoo/avdl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
