### PR TITLE
requireFile: Move to extendMkDerivation, fix meta.position handling

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -932,9 +932,15 @@ rec {
         message ? null,
         hashMode ? "flat",
       }:
-      assert (message != null) || (url != null);
-      assert (sha256 != null) || (sha1 != null) || (hash != null);
-      assert (name != null) || (url != null);
+      assert lib.assertMsg (
+        (message != null) || (url != null)
+      ) "to help end-users, either `message` or `url` must be set so they can find the required file";
+      assert lib.assertMsg (
+        (sha256 != null) || (sha1 != null) || (hash != null)
+      ) "a hash must be provided to the derivatoin";
+      assert lib.assertMsg (
+        (name != null) || (url != null)
+      ) "the derivation must have a name or a url provided";
       let
         msg =
           if message != null then

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -931,7 +931,7 @@ rec {
         url ? null,
         message ? null,
         hashMode ? "flat",
-      }:
+      }@args:
       assert lib.assertMsg (
         sha1 == null
       ) "sha1 is insecure, and collisions can be bought online. Do not use it.";
@@ -950,19 +950,15 @@ rec {
             message
           else
             ''
-              Unfortunately, we cannot download file ${name_} automatically.
+              Unfortunately, we cannot download file ${finalAttrs.name} automatically.
               Please go to ${url} to download it yourself, and add it to the Nix store
               using either
-                nix-store --add-fixed ${hashAlgo} ${name_}
-              or
-                nix-prefetch-url --type ${hashAlgo} file:///path/to/${name_}
+                nix-prefetch-url ${if url != null then url else "https://website.com/path/to/${finalAttrs.name}"}
+              or if already downloaded
+                nix-prefetch-url file:///path/to/${finalAttrs.name}
             '';
-
-        # If a name is not provided, use the basename of the url
-        name_ = if name == null then baseNameOf (toString url) else name;
       in
       {
-        name = name_;
         outputHashMode = hashMode;
         outputHashAlgo = if hash != null then "" else "sha256";
         outputHash = if hash != null then hash else sha256;
@@ -978,7 +974,18 @@ rec {
           _EOF_
           exit 1
         '';
-      };
+      }
+      // (lib.optionalAttrs (name == null) {
+        # The case of providing `url`, but not `name`. This has
+        # weird interactions with the positoining system
+
+        # When we set `name` explicitly here, we override where the
+        # position is read from. So we must fix it here.
+        pos = lib.unsafeGetAttrPos "url" args;
+
+        # If a name is not provided, use the basename of the url
+        name = builtins.warn "providing a URL without a name is deprecated" baseNameOf (toString url);
+      });
   };
 
   # TODO: move copyPathToStore docs to the Nixpkgs manual

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -907,67 +907,83 @@ rec {
 
   # Docs in doc/build-helpers/fetchers.chapter.md
   # See https://nixos.org/manual/nixpkgs/unstable/#requirefile
-  requireFile =
-    {
-      name ? null,
-      sha256 ? null,
-      sha1 ? null,
-      hash ? null,
-      url ? null,
-      message ? null,
-      hashMode ? "flat",
-    }:
-    assert (message != null) || (url != null);
-    assert (sha256 != null) || (sha1 != null) || (hash != null);
-    assert (name != null) || (url != null);
-    let
-      msg =
-        if message != null then
-          message
-        else
-          ''
-            Unfortunately, we cannot download file ${name_} automatically.
-            Please go to ${url} to download it yourself, and add it to the Nix store
-            using either
-              nix-store --add-fixed ${hashAlgo} ${name_}
-            or
-              nix-prefetch-url --type ${hashAlgo} file:///path/to/${name_}
-          '';
-      hashAlgo =
-        if hash != null then
-          (builtins.head (lib.strings.splitString "-" hash))
-        else if sha256 != null then
-          "sha256"
-        else
-          "sha1";
-      hashAlgo_ = if hash != null then "" else hashAlgo;
-      hash_ =
-        if hash != null then
-          hash
-        else if sha256 != null then
-          sha256
-        else
-          sha1;
-      name_ = if name == null then baseNameOf (toString url) else name;
-    in
-    stdenvNoCC.mkDerivation {
-      name = name_;
-      outputHashMode = hashMode;
-      outputHashAlgo = hashAlgo_;
-      outputHash = hash_;
-      preferLocalBuild = true;
-      builder = writeScript "restrict-message" ''
-        source ${stdenvNoCC}/setup
-        cat <<_EOF_
+  requireFile = lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
 
-        ***
-        ${msg}
-        ***
+    excludeDrvArgNames = [
+      "sha256"
+      "sha1"
+      "hash"
+      "url"
+      "message"
+      "hashMode"
+    ];
 
-        _EOF_
-        exit 1
-      '';
-    };
+    inheritFunctionArgs = false;
+
+    extendDrvArgs =
+      finalAttrs:
+      {
+        name ? null,
+        sha256 ? null,
+        sha1 ? null,
+        hash ? null,
+        url ? null,
+        message ? null,
+        hashMode ? "flat",
+      }:
+      assert (message != null) || (url != null);
+      assert (sha256 != null) || (sha1 != null) || (hash != null);
+      assert (name != null) || (url != null);
+      let
+        msg =
+          if message != null then
+            message
+          else
+            ''
+              Unfortunately, we cannot download file ${name_} automatically.
+              Please go to ${url} to download it yourself, and add it to the Nix store
+              using either
+                nix-store --add-fixed ${hashAlgo} ${name_}
+              or
+                nix-prefetch-url --type ${hashAlgo} file:///path/to/${name_}
+            '';
+        hashAlgo =
+          if hash != null then
+            (builtins.head (lib.strings.splitString "-" hash))
+          else if sha256 != null then
+            "sha256"
+          else
+            "sha1";
+        hashAlgo_ = if hash != null then "" else hashAlgo;
+        hash_ =
+          if hash != null then
+            hash
+          else if sha256 != null then
+            sha256
+          else
+            sha1;
+        name_ = if name == null then baseNameOf (toString url) else name;
+      in
+      {
+        name = name_;
+        outputHashMode = hashMode;
+        outputHashAlgo = hashAlgo_;
+        outputHash = hash_;
+        preferLocalBuild = true;
+        builder = writeScript "restrict-message" ''
+          source ${stdenvNoCC}/setup
+          cat <<_EOF_
+
+          ***
+          ${msg}
+          ***
+
+          _EOF_
+          exit 1
+        '';
+      };
+  };
 
   # TODO: move copyPathToStore docs to the Nixpkgs manual
   /*

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -933,6 +933,9 @@ rec {
         hashMode ? "flat",
       }:
       assert lib.assertMsg (
+        sha1 == null
+      ) "sha1 is insecure, and collisions can be bought online. Do not use it.";
+      assert lib.assertMsg (
         (message != null) || (url != null)
       ) "to help end-users, either `message` or `url` must be set so they can find the required file";
       assert lib.assertMsg (
@@ -954,28 +957,15 @@ rec {
               or
                 nix-prefetch-url --type ${hashAlgo} file:///path/to/${name_}
             '';
-        hashAlgo =
-          if hash != null then
-            (builtins.head (lib.strings.splitString "-" hash))
-          else if sha256 != null then
-            "sha256"
-          else
-            "sha1";
-        hashAlgo_ = if hash != null then "" else hashAlgo;
-        hash_ =
-          if hash != null then
-            hash
-          else if sha256 != null then
-            sha256
-          else
-            sha1;
+
+        # If a name is not provided, use the basename of the url
         name_ = if name == null then baseNameOf (toString url) else name;
       in
       {
         name = name_;
         outputHashMode = hashMode;
-        outputHashAlgo = hashAlgo_;
-        outputHash = hash_;
+        outputHashAlgo = if hash != null then "" else "sha256";
+        outputHash = if hash != null then hash else sha256;
         preferLocalBuild = true;
         builder = writeScript "restrict-message" ''
           source ${stdenvNoCC}/setup


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Main goal is #488794, but I decided to clean it up as much as I can as well. 

1. This will be a zero-rebuild change
3. Fixed-point attr support
4. Assert on sha1 #77238 
5. A little bit of support for coherent overrides with `name`
6. Fix `meta.position` handling
7. Deprecate providing `url` but not `name`

There can definitly be more improvements, but this is good for now I think.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
