### PR TITLE
acme-dns: 1.1-unstable-2024-12-15 -> 2.0.2

### DIFF
--- a/nixos/modules/services/networking/acme-dns.nix
+++ b/nixos/modules/services/networking/acme-dns.nix
@@ -95,11 +95,11 @@ in
           database = {
             engine = mkOption {
               type = types.enum [
-                "sqlite3"
+                "sqlite"
                 "postgres"
               ];
               description = "Database engine to use.";
-              default = "sqlite3";
+              default = "sqlite";
             };
             connection = mkOption {
               type = types.str;

--- a/pkgs/by-name/ac/acme-dns/package.nix
+++ b/pkgs/by-name/ac/acme-dns/package.nix
@@ -8,25 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "acme-dns";
-  # Unstable version to allow building with toolchains later than EOL Go 1.22,
-  # see https://github.com/joohoi/acme-dns/issues/365
-  version = "1.1-unstable-2024-12-15";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
-    owner = "joohoi";
+    owner = "acme-dns";
     repo = "acme-dns";
-    rev = "b7a0a8a7bcef39f6158dd596fe716594a170d362";
-    hash = "sha256-UApFNcU6a6nzpwbIJv1LLmXVTGLzY0HQBlRATq2s9x8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-tjVI+CaQTN1SB/RkTg0CJ1o9azb2ULwR1uKK5fJZ8fw=";
   };
 
-  # Fetching of goModules fails with 'go: updates to go.mod needed'
-  postPatch = ''
-    substituteInPlace go.mod \
-      --replace-fail 'go 1.22' 'go 1.22.0' \
-      --replace-fail 'toolchain go1.22.0' 'toolchain go1.24.1'
-  '';
-
-  vendorHash = "sha256-pKEOmMF1lvm/CU1n3ykh6YvtRNH/2i+0AvOJzq8eets=";
+  vendorHash = "sha256-n3icQQkdA0nCkvthsFsUTrYg0B3t8hROL4QXgBQRbSg=";
 
   postInstall = ''
     install -D -m0444 -t $out/lib/systemd/system ./acme-dns.service
@@ -37,8 +28,8 @@ buildGoModule (finalAttrs: {
 
   meta = {
     description = "Limited DNS server to handle ACME DNS challenges easily and securely";
-    homepage = "https://github.com/joohoi/acme-dns";
-    changelog = "https://github.com/joohoi/acme-dns/releases/tag/${finalAttrs.src.rev}";
+    homepage = "https://github.com/acme-dns/acme-dns";
+    changelog = "https://github.com/acme-dns/acme-dns/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ emilylange ];
     mainProgram = "acme-dns";


### PR DESCRIPTION
https://github.com/acme-dns/acme-dns/releases/tag/v2.0

https://github.com/acme-dns/acme-dns/releases/tag/v2.0.1

https://github.com/acme-dns/acme-dns/releases/tag/v2.0.2

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
