### PR TITLE
nixos/nm-file-secret-agent: enable `trim` by default

### DIFF
--- a/nixos/modules/services/networking/nm-file-secret-agent.nix
+++ b/nixos/modules/services/networking/nm-file-secret-agent.nix
@@ -112,7 +112,7 @@ in
               trim = lib.mkOption {
                 description = "whether leading and trailing whitespace should be stripped from the files content before being passed to NetworkManager";
                 type = lib.types.nullOr lib.types.bool;
-                default = null;
+                default = true;
               };
             };
           }


### PR DESCRIPTION
Most users likely use editors that automatically add trailing newlines to files they've edited.
This change spares them the trouble of needing to find out why their password is not accepted.

This might be a breaking change for users whose passwords have leading or trailing white space characters.
Is it worth to add a info about this fact to `nixos/doc/manual/release-notes/rl-2605.section.md`?

@lilioid here the discussed change :slightly_smiling_face: 
(I'm not 100% sure what you've meant with opening this change to a different branch. As long as we don't backport this PR, it will be in 26.05 once released, I think)