### PR TITLE
lib.maintainers: Require uniqueness of github[Id], email and matrix fields

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6944,13 +6944,6 @@
     githubId = 126339;
     name = "Domen Kozar";
   };
-  DomesticMoth = {
-    name = "Andrew";
-    email = "silkmoth@protonmail.com";
-    github = "asciimoth";
-    githubId = 91414737;
-    keys = [ { fingerprint = "7D6B AE0A A98A FDE9 3396  E721 F87E 15B8 3AA7 3087"; } ];
-  };
   dominikh = {
     email = "dominik@honnef.co";
     github = "dominikh";
@@ -7738,7 +7731,7 @@
     name = "Elnu";
   };
   elpdt852 = {
-    email = "nix@pdtpartners.com";
+    email = "nix+elpdt852@pdtpartners.com";
     github = "elpdt852";
     githubId = 122112154;
     name = "Edgar Lee";
@@ -14703,7 +14696,7 @@
     name = "Luka Blaskovic";
   };
   lbpdt = {
-    email = "nix@pdtpartners.com";
+    email = "nix+lbpdt@pdtpartners.com";
     github = "lbpdt";
     githubId = 45168934;
     name = "Louis Blin";
@@ -18198,7 +18191,7 @@
     keys = [ { fingerprint = "5658 4D09 71AF E45F CC29 6BD7 4CE6 2A90 EFC0 B9B2"; } ];
   };
   mupdt = {
-    email = "nix@pdtpartners.com";
+    email = "nix+mupdt@pdtpartners.com";
     github = "mupdt";
     githubId = 25388474;
     name = "Matej Urbas";
@@ -20380,12 +20373,6 @@
     githubId = 58092422;
     name = "Patrick";
     keys = [ { fingerprint = "5E4C 3D74 80C2 35FE 2F0B  D23F 7DD6 A72E C899 617D"; } ];
-  };
-  patricksjackson = {
-    email = "patrick@jackson.dev";
-    github = "arcuru";
-    githubId = 160646;
-    name = "Patrick Jackson";
   };
   patryk27 = {
     email = "pwychowaniec@pm.me";


### PR DESCRIPTION
I found some non-unique values while working on https://github.com/NixOS/nixpkgs/pull/488014. Let's prevent this from happening again. 

Ping @arcuru, @asciimoth, @elpdt852, @mupdt, @lbpdt 

## Things done
- [x] Ran `nix-build lib/tests/release.nix` after the first commit, which shows the non-unique values:
  ```nix
    error: lib.maintainers has non-unique fields: {
    email = {
      "nix@pdtpartners.com" = [
        "elpdt852"
        "lbpdt"
        "mupdt"
      ];
      "patrick@jackson.dev" = [
        "arcuru"
        "patricksjackson"
      ];
    };
    github = {
      arcuru = [
        "arcuru"
        "patricksjackson"
      ];
      asciimoth = [
        "DomesticMoth"
        "asciimoth"
      ];
    };
    githubId = {
      "160646" = [
        "arcuru"
        "patricksjackson"
      ];
      "91414737" = [
        "DomesticMoth"
        "asciimoth"
      ];
    };
  }
  ```
- [x] Ran `nix-build lib/tests/release.nix` successfully after the second commit

