### PR TITLE
himalaya: 1.1.0 -> 1.2.0

### DIFF
--- a/pkgs/by-name/hi/himalaya/package.nix
+++ b/pkgs/by-name/hi/himalaya/package.nix
@@ -1,40 +1,55 @@
 {
-  lib,
-  rustPlatform,
-  fetchFromGitHub,
-  stdenv,
-  buildPackages,
-  pkg-config,
   apple-sdk,
-  installShellFiles,
-  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-  installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
-  notmuch,
-  gpgme,
-  buildNoDefaultFeatures ? false,
   buildFeatures ? [ ],
-  withNoDefaultFeatures ? buildNoDefaultFeatures,
-  withFeatures ? buildFeatures,
-}@args:
+  buildNoDefaultFeatures ? false,
+  buildPackages,
+  dbus,
+  fetchFromGitHub,
+  gpgme,
+  installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellFiles,
+  lib,
+  notmuch,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
 
 let
-  version = "1.1.0";
-  hash = "sha256-gdrhzyhxRHZkALB3SG/aWOdA5iMYkel3Cjk5VBy3E4M=";
-  cargoHash = "sha256-ulqMjpW3UI509vs3jVHXAEQUhxU/f/hN8XiIo8UBRq8=";
+  version = "1.2.0";
+  hash = "sha256-BBzfDeNu7s010ARCYuydCyR7QWrbeI3/B4CxA6d4olw=";
+  cargoHash = "sha256-IkvRiU9NuD6n7aCF8J235u2LjjmLftnF1n874IWVcN0=";
 
-  noDefaultFeatures =
-    lib.warnIf (args ? buildNoDefaultFeatures)
-      "buildNoDefaultFeatures is deprecated in favour of withNoDefaultFeatures and will be removed in the next release"
-      withNoDefaultFeatures;
+  inherit (stdenv.hostPlatform)
+    isLinux
+    isWindows
+    isAarch64
+    ;
 
-  features =
-    lib.warnIf (args ? buildFeatures)
-      "buildFeatures is deprecated in favour of withFeatures and will be removed in the next release"
-      withFeatures;
+  emulator = stdenv.hostPlatform.emulator buildPackages;
+  exe = stdenv.hostPlatform.extensions.executable;
+
+  hasPgpGpgFeature = builtins.elem "pgp-gpg" buildFeatures;
+  hasKeyringFeature = builtins.elem "keyring" buildFeatures;
+  hasNotmuchFeature = builtins.elem "notmuch" buildFeatures;
+
+  dbus' = dbus.overrideAttrs (old: {
+    env = (old.env or { }) // {
+      NIX_CFLAGS_COMPILE =
+        (old.env.NIX_CFLAGS_COMPILE or "")
+        # required for D-Bus on Linux AArch64
+        + lib.optionalString (isLinux && isAarch64) " -mno-outline-atomics";
+    };
+  });
+
 in
-
 rustPlatform.buildRustPackage {
-  inherit version cargoHash;
+  inherit
+    version
+    cargoHash
+    buildNoDefaultFeatures
+    ;
 
   pname = "himalaya";
 
@@ -45,36 +60,44 @@ rustPlatform.buildRustPackage {
     rev = "v${version}";
   };
 
-  buildNoDefaultFeatures = noDefaultFeatures;
-  buildFeatures = features;
+  env = {
+    # OpenSSL should not be provided by vendors, not even on Windows
+    OPENSSL_NO_VENDOR = "1";
+  };
 
-  nativeBuildInputs = [
-    pkg-config
-  ]
-  ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
+  nativeBuildInputs =
+    [ ]
+    ++ lib.optional (hasPgpGpgFeature || hasKeyringFeature || hasNotmuchFeature) pkg-config
+    ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
 
   buildInputs =
     [ ]
-    ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk
-    ++ lib.optional (builtins.elem "notmuch" withFeatures) notmuch
-    ++ lib.optional (builtins.elem "pgp-gpg" withFeatures) gpgme;
+    ++ lib.optional hasPgpGpgFeature gpgme
+    ++ lib.optional (hasKeyringFeature && !isWindows) dbus'
+    ++ lib.optional hasNotmuchFeature notmuch;
+
+  buildFeatures =
+    buildFeatures
+    # D-Bus is provided by vendors on Windows
+    ++ lib.optional (hasKeyringFeature && isWindows) "vendored";
 
   # most of the tests are lib side
   doCheck = false;
 
   postInstall =
-    let
-      emulator = stdenv.hostPlatform.emulator buildPackages;
-    in
+    lib.optionalString (lib.hasInfix "wine" emulator) ''
+      export WINEPREFIX="''${WINEPREFIX:-$(mktemp -d)}"
+      mkdir -p $WINEPREFIX
     ''
+    + ''
       mkdir -p $out/share/{applications,completions,man}
       cp assets/himalaya.desktop "$out"/share/applications/
-      ${emulator} "$out"/bin/himalaya man "$out"/share/man
-      ${emulator} "$out"/bin/himalaya completion bash > "$out"/share/completions/himalaya.bash
-      ${emulator} "$out"/bin/himalaya completion elvish > "$out"/share/completions/himalaya.elvish
-      ${emulator} "$out"/bin/himalaya completion fish > "$out"/share/completions/himalaya.fish
-      ${emulator} "$out"/bin/himalaya completion powershell > "$out"/share/completions/himalaya.powershell
-      ${emulator} "$out"/bin/himalaya completion zsh > "$out"/share/completions/himalaya.zsh
+      ${emulator} "$out"/bin/himalaya${exe} man "$out"/share/man
+      ${emulator} "$out"/bin/himalaya${exe} completion bash > "$out"/share/completions/himalaya.bash
+      ${emulator} "$out"/bin/himalaya${exe} completion elvish > "$out"/share/completions/himalaya.elvish
+      ${emulator} "$out"/bin/himalaya${exe} completion fish > "$out"/share/completions/himalaya.fish
+      ${emulator} "$out"/bin/himalaya${exe} completion powershell > "$out"/share/completions/himalaya.powershell
+      ${emulator} "$out"/bin/himalaya${exe} completion zsh > "$out"/share/completions/himalaya.zsh
     ''
     + lib.optionalString installManPages ''
       installManPage "$out"/share/man/*


### PR DESCRIPTION
https://github.com/pimalaya/himalaya/releases/tag/v1.2.0

I also improved the derivation to fit better Pimalaya standards, see #489528 #489918 #490853.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
