### PR TITLE
vivaldi-ffmpeg-codecs: update from vivaldi 7.8.3925.62 update-ffmpeg

### DIFF
--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
@@ -11,12 +11,12 @@
 let
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_85.snap";
-      hash = "sha256-77lcQFFP0eXuaxN2UdsEjFXJt22L6Mp6Fe3ZYPpKVwM=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_82.snap";
+      hash = "sha256-G9RcOuFjkLDJUNlw2G8GiONpWHYvyTnv3Nr0JSdW0As=";
     };
     aarch64-linux = fetchurl {
-      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_85.snap";
-      hash = "sha256-77lcQFFP0eXuaxN2UdsEjFXJt22L6Mp6Fe3ZYPpKVwM=";
+      url = "https://api.snapcraft.io/api/v1/snaps/download/XXzVIXswXKHqlUATPqGCj2w2l7BxosS8_83.snap";
+      hash = "sha256-6XMdH4dnvYB1FaJLMi/MFnTzkelmOHMedVcIg/Fh7h4=";
     };
   };
 in


### PR DESCRIPTION
Update to codecs snap urls from the latest update-ffmpeg install script. This also fixes `proprietaryCodecs = true;` on arm since it uses the arm version of the codecs rather than x86 on both platforms. Tested on my aarch64-linux machine with packageOverrides from the branch

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
