### PR TITLE
applyPatches: to extendMkDerivation, fix meta.position

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1018,24 +1018,24 @@ rec {
       let
         keepAttrs = names: lib.filterAttrs (name: val: lib.elem name names);
         # enables tools like nix-update to determine what src attributes to replace
-        extraPassthru = lib.optionalAttrs (lib.isAttrs src) (
+        extraPassthru = lib.optionalAttrs (lib.isAttrs finalAttrs.src) (
           keepAttrs [
             "rev"
             "tag"
             "url"
             "outputHash"
             "outputHashAlgo"
-          ] src
+          ] finalAttrs.src
         );
       in
       {
         name =
           args.name or (
-            if builtins.isPath src then
-              baseNameOf src + "-patched"
-            else if builtins.isAttrs src && (src ? name) then
+            if builtins.isPath finalAttrs.src then
+              baseNameOf finalAttrs.src + "-patched"
+            else if builtins.isAttrs finalAttrs.src && (finalAttrs.src ? name) then
               let
-                srcName = builtins.parseDrvName src;
+                srcName = builtins.parseDrvName finalAttrs.src.name;
               in
               "${srcName.name}-patched${lib.optionalString (srcName.version != "") "-${srcName.version}"}"
             else
@@ -1055,10 +1055,13 @@ rec {
 
         installPhase = "cp -R ./ $out";
 
-        passthru = extraPassthru // src.passthru or { };
+        # passthru the git and hash info for nix-update, as well
+        # as all the src's passthru attrs.
+        passthru = extraPassthru // finalAttrs.src.passthru or { };
 
         # Carry (and merge) information from the underlying `src` if present.
-        meta = lib.optionalAttrs (src ? meta) removeAttrs src.meta [ "position" ];
+        # If there is not src.meta, this meta block will be blank regardless.
+        meta = lib.optionalAttrs (finalAttrs.src ? meta) removeAttrs finalAttrs.src.meta [ "position" ];
       };
   };
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1054,14 +1054,12 @@ rec {
         doCheck = false;
 
         installPhase = "cp -R ./ $out";
-      }
-      # Carry (and merge) information from the underlying `src` if present.
-      // (optionalAttrs (src ? meta) {
-        meta = removeAttrs src.meta [ "position" ];
-      })
-      // (optionalAttrs (extraPassthru != { } || src ? passthru) {
+
         passthru = extraPassthru // src.passthru or { };
-      });
+
+        # Carry (and merge) information from the underlying `src` if present.
+        meta = lib.optionalAttrs (src ? meta) removeAttrs src.meta [ "position" ];
+      };
   };
 
   # TODO: move docs to Nixpkgs manual

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1017,9 +1017,6 @@ rec {
               throw "applyPatches: please supply a `name` argument because a default name can only be computed when the `src` is a path or is an attribute set with a `name` attribute."
           )
           + "-patched",
-        patches ? [ ],
-        prePatch ? "",
-        postPatch ? "",
         ...
       }@args:
       assert lib.assertMsg (
@@ -1044,10 +1041,6 @@ rec {
       {
         inherit
           name
-          src
-          patches
-          prePatch
-          postPatch
           ;
         preferLocalBuild = true;
         allowSubstitutes = false;
@@ -1060,15 +1053,7 @@ rec {
       })
       // (optionalAttrs (extraPassthru != { } || src ? passthru) {
         passthru = extraPassthru // src.passthru or { };
-      })
-      # Forward any additional arguments to the derivation
-      // (removeAttrs args [
-        "src"
-        "name"
-        "patches"
-        "prePatch"
-        "postPatch"
-      ]);
+      });
   };
 
   # TODO: move docs to Nixpkgs manual

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1053,7 +1053,7 @@ rec {
       }
       # Carry (and merge) information from the underlying `src` if present.
       // (optionalAttrs (src ? meta) {
-        inherit (src) meta;
+        meta = removeAttrs src.meta [ "position" ];
       })
       // (optionalAttrs (extraPassthru != { } || src ? passthru) {
         passthru = extraPassthru // src.passthru or { };

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1044,7 +1044,11 @@ rec {
           ;
         preferLocalBuild = true;
         allowSubstitutes = false;
-        phases = "unpackPhase patchPhase installPhase";
+
+        dontConfigure = true;
+        dontBuild = true;
+        doCheck = false;
+
         installPhase = "cp -R ./ $out";
       }
       # Carry (and merge) information from the underlying `src` if present.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. To extendMkDerivation
2. Clean up once in extendMkDerivation
3. Add fix so that `meta.position` gets filled properly #488794

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
