### PR TITLE
crystal, buildCrystalPackage: move env variable(s) into env

### DIFF
--- a/pkgs/development/compilers/crystal/build-package.nix
+++ b/pkgs/development/compilers/crystal/build-package.nix
@@ -108,9 +108,11 @@ stdenv.mkDerivation (
         ++ [ "runHook postConfigure" ]
       ));
 
-    CRFLAGS = lib.concatStringsSep " " defaultOptions;
+    env = {
+      CRFLAGS = lib.concatStringsSep " " defaultOptions;
 
-    PREFIX = placeholder "out";
+      PREFIX = placeholder "out";
+    };
 
     inherit enableParallelBuilding;
     strictDeps = true;

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -199,15 +199,17 @@ let
         "progress=1"
       ];
 
-      LLVM_CONFIG = "${llvmPackages.llvm.dev}/bin/llvm-config";
+      env = {
+        LLVM_CONFIG = "${llvmPackages.llvm.dev}/bin/llvm-config";
 
-      FLAGS = [
-        "--single-module" # needed for deterministic builds
-      ];
+        FLAGS = [
+          "--single-module" # needed for deterministic builds
+        ];
 
-      # This makes sure we don't keep depending on the previous version of
-      # crystal used to build this one.
-      CRYSTAL_LIBRARY_PATH = "${placeholder "lib"}/crystal";
+        # This makes sure we don't keep depending on the previous version of
+        # crystal used to build this one.
+        CRYSTAL_LIBRARY_PATH = "${placeholder "lib"}/crystal";
+      };
 
       # We *have* to add `which` to the PATH or crystal is unable to build
       # stuff later if which is not available.


### PR DESCRIPTION
for `structuredAttrs`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
