### PR TITLE
satisfactorymodmanager: to finalAttrs, remove env.pnpmDeps hack

### DIFF
--- a/pkgs/by-name/sa/satisfactorymodmanager/package.nix
+++ b/pkgs/by-name/sa/satisfactorymodmanager/package.nix
@@ -19,14 +19,14 @@ let
   wails' = wails.override { nodejs = nodejs_20; };
   pnpm' = pnpm_8.override { nodejs = nodejs_20; };
 in
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "satisfactorymodmanager";
   version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "satisfactorymodding";
     repo = "SatisfactoryModManager";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ndvrgSRblm7pVwnGvxpwtGVMEGp+mqpC4kE87lmt36M=";
   };
 
@@ -56,23 +56,19 @@ buildGoModule rec {
     glib-networking
   ];
 
-  # we use env because buildGoModule doesn't forward all normal attrs
-  # this is pretty hacky
-  env = {
-    pnpmDeps = fetchPnpmDeps {
-      inherit
-        pname
-        version
-        src
-        ;
-      pnpm = pnpm';
-      sourceRoot = "${src.name}/frontend";
-      fetcherVersion = 1;
-      hash = "sha256-OP+3zsNlvqLFwvm2cnBd2bj2Kc3EghQZE3hpotoqqrQ=";
-    };
-
-    pnpmRoot = "frontend";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      ;
+    pnpm = pnpm';
+    sourceRoot = "${finalAttrs.src.name}/frontend";
+    fetcherVersion = 3;
+    hash = "sha256-aicvZ/pmBZNcy/MqH/C12llKnoDm9ahH7egJZh5mIGM=";
   };
+
+  pnpmRoot = "frontend";
 
   # running this caches some additional dependencies for the FOD
   overrideModAttrs = {
@@ -122,4 +118,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ tomasajt ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. to `finalAttrs`
2. Remove the `env.pnpmDeps` hack, no longers needed
3. To pnpm `fetcherVersion = 3`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
