### PR TITLE
solanum: 0-unstable-2026-01-27 -> 0-unstable-2026-02-03

### DIFF
--- a/pkgs/by-name/so/solanum/dont-create-logdir.patch
+++ b/pkgs/by-name/so/solanum/dont-create-logdir.patch
@@ -1,13 +1,15 @@
 diff --git a/Makefile.am b/Makefile.am
-index 19e7b396..21093521 100644
+index 99444f6c..1804c50a 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -35,9 +35,6 @@ include/serno.h:
+@@ -34,11 +34,6 @@ include/serno.h:
  		echo '#define DATECODE 0UL' >>include/serno.h; \
  	fi
  
 -install-data-hook:
 -	test -d ${DESTDIR}${logdir} || mkdir -p ${DESTDIR}${logdir}
+-	@# needed for FHS paths:
+-	test -d ${DESTDIR}${pkglocalstatedir} || mkdir -p ${DESTDIR}${pkglocalstatedir}
 -
  install-exec-hook:
  	rm -f ${DESTDIR}${libdir}/*.la

--- a/pkgs/by-name/so/solanum/package.nix
+++ b/pkgs/by-name/so/solanum/package.nix
@@ -18,13 +18,13 @@
 
 stdenv.mkDerivation {
   pname = "solanum";
-  version = "0-unstable-2026-01-27";
+  version = "0-unstable-2026-02-03";
 
   src = fetchFromGitHub {
     owner = "solanum-ircd";
     repo = "solanum";
-    rev = "852bef71f56d206aa224231589849c4c9be81867";
-    hash = "sha256-hPlWOHplf6mOMmSX5DWY8kw6YNskTE6YYVqEmGsrnxs=";
+    rev = "9778247c3dca59370b21c4f34f328c52e8b8c669";
+    hash = "sha256-qeAO4AcrPPUW+5TA20GcLSzTKGC51IrK53K9qtBxnH4=";
   };
 
   patches = [
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   ];
 
   postPatch = ''
-    substituteInPlace include/defaults.h --replace 'ETCPATH "' '"/etc/solanum'
+    substituteInPlace include/defaults.h --replace-fail 'ETCPATH "' '"/etc/solanum'
   '';
 
   preConfigure = ''
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
     "--enable-ipv6"
     "--enable-openssl=${openssl.dev}"
     "--with-program-prefix=solanum-"
-    "--localstatedir=/var/lib"
+    "--localstatedir=/var"
     "--with-rundir=/run"
     "--with-logdir=/var/log"
   ]


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
