### PR TITLE
luaPackages.lux-lua: fix darwin build

### DIFF
--- a/pkgs/development/lua-modules/lux-lua.nix
+++ b/pkgs/development/lua-modules/lux-lua.nix
@@ -13,6 +13,7 @@
   pkg-config,
   rustPlatform,
   toLuaModule,
+  stdenv,
 }:
 let
   luaMajorMinor = lib.take 2 (lib.splitVersion lua.version);
@@ -62,6 +63,8 @@ toLuaModule (
       LIBGIT2_NO_VENDOR = 1;
       LIBSSH2_SYS_USE_PKG_CONFIG = 1;
       LUX_SKIP_IMPURE_TESTS = 1; # Disable impure unit tests
+      # Allow undefined symbols on Darwin - they must be provided by the Lua runtime
+      RUSTFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-C link-arg=-undefined -C link-arg=dynamic_lookup";
     };
 
     buildPhase = ''


### PR DESCRIPTION
Allow undefined symbols for mlua

Follow up https://github.com/NixOS/nixpkgs/pull/488556 

Did not test build yet, just copying from my other implementations for a similar darwin building issue. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
