### PR TITLE
python3Packages.triton: fix libcublas dlopen, python3Packages.triton.gpuCheck: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -99,6 +99,14 @@ buildPythonPackage (finalAttrs: {
       substituteInPlace cmake/AddTritonUnitTest.cmake \
         --replace-fail "include(\''${PROJECT_SOURCE_DIR}/unittest/googletest.cmake)" ""\
         --replace-fail "include(GoogleTest)" "find_package(GTest REQUIRED)"
+    ''
+
+    # triton will try dlopening libcublas.so at runtime
+    + lib.optionalString cudaSupport ''
+      substituteInPlace third_party/nvidia/include/cublas_instance.h \
+        --replace-fail \
+          '"libcublas.so"' \
+          '"${lib.getLib cudaPackages.libcublas}/lib/libcublas.so"'
     '';
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -318,6 +318,7 @@ buildPythonPackage (finalAttrs: {
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      GaetanLepage
       SomeoneSerge
       derdennisop
     ];

--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -41,7 +41,7 @@
   cudaSupport ? config.cudaSupport,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "triton";
   version = "3.5.1";
   pyproject = true;
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "triton-lang";
     repo = "triton";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-dyNRtS1qtU8C/iAf0Udt/1VgtKGSvng1+r2BtvT9RB4=";
   };
 
@@ -314,6 +314,7 @@ buildPythonPackage rec {
   meta = {
     description = "Language and compiler for writing highly efficient custom Deep-Learning primitives";
     homepage = "https://github.com/triton-lang/triton";
+    changelog = "https://github.com/triton-lang/triton/releases/tag/${finalAttrs.src.tag}";
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
@@ -321,4 +322,4 @@ buildPythonPackage rec {
       derdennisop
     ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.triton: use finalAttrs**
- **python3Packages.triton: add GaetanLepage to maintainers**
- **python3Packages.triton: fix libcublas dlopen**
- **python3Packages.triton.gpuCheck: skip failing tests**
  Still a decent coverage: `== 9520 passed, 9059 skipped, 40 deselected, 924 warnings in 89.25s (0:01:29) ==`

Context: fix https://hydra.nixos-cuda.org/build/165385

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
