### PR TITLE
atac: install shell completions & manual page

### DIFF
--- a/pkgs/by-name/at/atac/package.nix
+++ b/pkgs/by-name/at/atac/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   pkg-config,
   oniguruma,
+  installShellFiles,
+  writableTmpDirAsHomeHook,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "atac";
@@ -18,13 +20,33 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-lJO9riP/3FRrQ/gkKQCghfkNn1ePS+p6FtMcJTIJxZY=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    installShellFiles
+    writableTmpDirAsHomeHook
+    pkg-config
+  ];
 
   buildInputs = [ oniguruma ];
 
   env = {
     RUSTONIG_SYSTEM_LIBONIG = true;
   };
+
+  postInstall = ''
+    $out/bin/atac completions bash
+    $out/bin/atac completions fish
+    $out/bin/atac completions zsh
+    installShellCompletion --cmd atac \
+      --bash atac.bash \
+      --fish atac.fish \
+      --zsh _atac
+
+    mkdir -p $out/share/powershell
+    $out/bin/atac completions powershell $out/share/powershell
+
+    $out/bin/atac man
+    installManPage atac.1
+  '';
 
   meta = {
     description = "Simple API client (postman like) in your terminal";


### PR DESCRIPTION
## Things done

Previously due to an upstream bug it was impossible to generate the completions in the build. Has been fixed in the latest release, so we add the completions for bash, fish, zsh, and powershell, as well as install the man page
 
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
