### PR TITLE
nixosTests.kmscon: improve term test

### DIFF
--- a/nixos/tests/kmscon.nix
+++ b/nixos/tests/kmscon.nix
@@ -33,12 +33,18 @@
 
     with subtest("ensure we can open a tty"):
       machine.wait_for_text("machine login:")
+
       machine.send_chars("alice\n")
       machine.wait_for_text("Password:")
+
       machine.send_chars("foobar\n")
       machine.wait_for_text("alice@machine")
-      machine.send_chars("echo $TERM\n")
-      machine.wait_for_text("xterm-256color")
+
+      machine.send_chars("echo $TERM | tee /tmp/term.txt\n")
+      machine.wait_until_succeeds("test -s /tmp/term.txt")
+      term = machine.succeed("cat /tmp/term.txt").strip()
+      assert term == "xterm-256color", f"Unexpected TERM value: {term!r}"
+
       machine.screenshot("tty.png")
   '';
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Now, when $TERM is not xterm-256color, it can fail immediately instead of waiting.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
