### PR TITLE
xtr: init at 0.1.11

### DIFF
--- a/pkgs/by-name/xt/xtr/package.nix
+++ b/pkgs/by-name/xt/xtr/package.nix
@@ -1,0 +1,25 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xtr";
+  version = "0.1.11";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-ouuctuXZp97OWfM8IfJUMG9WdVji6WCGD2L5mXWHs/I=";
+  };
+
+  cargoHash = "sha256-1nqFGYbW8d4I+H2yyD/cyUE0UmYpYgy5pQ/0aDKpP5w=";
+
+  meta = {
+    description = "Extract strings from a rust crate to be translated with gettext";
+    homepage = "https://crates.io/crates/xtr";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ pineapplehunter ];
+    mainProgram = "xtr";
+  };
+})


### PR DESCRIPTION
This commit adds xtr to nixpkgs.
xtr is used for rust packages using gettext during development. This tool was needed when using cargo-i18n.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
