### PR TITLE
diskgraph: init at 0-unstable-2025-11-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18785,6 +18785,13 @@
     github = "netthier";
     githubId = 66856670;
   };
+  nettika = {
+    email = "nettika@leaf.ninja";
+    name = "Nettika";
+    github = "nettika-cat";
+    githubId = 131948390;
+    keys = [ { fingerprint = "6AC6 0C6F FA92 94AD AEA7  8C03 C357 EE70 D502 7BCC"; } ];
+  };
   networkexception = {
     name = "networkException";
     email = "nix@nwex.de";

--- a/pkgs/by-name/di/diskgraph/package.nix
+++ b/pkgs/by-name/di/diskgraph/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "diskgraph";
+  version = "0-unstable-2025-11-13";
+
+  src = fetchFromGitHub {
+    owner = "stolk";
+    repo = "diskgraph";
+    rev = "9a515fc620a792d118763ea591c304792e511274";
+    hash = "sha256-iL4u63/dGapOSK7AuV1FChDUcwsBOcx0TYAhcH9E+S0=";
+  };
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = {
+    description = "Terminal-based monitor for disk I/O";
+    homepage = "https://github.com/stolk/diskgraph";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      fliegendewurst
+      nettika
+    ];
+    mainProgram = "diskgraph";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
Added a package for [diskgraph](https://github.com/stolk/diskgraph). This is a terminal IO monitor, not the [GUI tool for Mac/iOS of the same name](https://desairem.com/wordpress/diskgraph)

Adapted from the [package in NUR](https://github.com/FliegendeWurst/nur-packages/blob/master/pkgs/diskgraph/default.nix). I've removed the custom `installPhase` and use `PREFIX` instead so the Makefile can install both the binary and the man page.

This is Linux-only (reads /proc/diskstats). I tested build and functionality on both x86 and ARM.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test