### PR TITLE
aasvg: init at 0.5.2

### DIFF
--- a/pkgs/by-name/aa/aasvg/package.nix
+++ b/pkgs/by-name/aa/aasvg/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "aasvg";
+  version = "0.5.2";
+
+  src = fetchFromGitHub {
+    owner = "martinthomson";
+    repo = "aasvg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Le6ZbJY7ZkqblZx4TkHWIiRKn1foi8jB+rldhu95NQ0=";
+  };
+
+  # the project has no dependencies
+  preInstall = "mkdir node_modules/";
+  forceEmptyCache = true;
+  dontNpmBuild = true;
+
+  npmDepsHash = "sha256-FdVXR2Myit3GiA1/VXzHBRSihKAQlh+Zd1gzSMuYi6c=";
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Convert ASCII art diagrams into SVG";
+    homepage = "https://github.com/martinthomson/aasvg";
+    platforms = lib.platforms.all;
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ chillcicada ];
+    mainProgram = "aasvg";
+  };
+})


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
