### PR TITLE
nixpkgs-whereis: init at 1.2.3

### DIFF
--- a/pkgs/by-name/ni/nixpkgs-whereis/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-whereis/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  makeWrapper,
+  coreutils,
+  fish,
+  jq,
+  nix,
+  testers,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nixpkgs-whereis";
+  version = "1.2.3";
+
+  src = fetchgit {
+    url = "https://git.envs.net/binarycat/nixpkgs-whereis.git";
+    rev = finalAttrs.version;
+    hash = "sha256-CZokiob077hNf/ipKWQL1bo+8dXoLcpT748xFoQRMbI=";
+  };
+
+  nativeBuildInputs = [
+    fish
+    makeWrapper
+  ];
+
+  makeFlags = [ "PREFIX=$(out)" ];
+
+  postInstall = ''
+    patchShebangs $out/bin/nixpkgs-whereis
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/nixpkgs-whereis \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          fish
+          jq
+          nix
+        ]
+      }
+  '';
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "nixpkgs-whereis --version";
+  };
+
+  meta = {
+    description = "Simple command to check where in nixpkgs an attribute is defined";
+    homepage = "https://git.envs.net/binarycat/nixpkgs-whereis";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ nettika ];
+    mainProgram = "nixpkgs-whereis";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Adds [nixpkgs-whereis](https://git.envs.net/binarycat/nixpkgs-whereis)

Adapted from [NUR package](https://github.com/nix-community/nur-combined/blob/main/repos/binarycat/pkgs/by-name/nixpkgs-whereis/package.nix). Switched to `fetchgit` as the git.envs.net archive endpoint seems to not be working. Made two fixes: added `jq` to the runtime deps and fixed shebang patching for sandboxed environments.

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test