### PR TITLE
openscreen: 1.1.0 -> 1.1.2

### DIFF
--- a/pkgs/by-name/op/openscreen/package.nix
+++ b/pkgs/by-name/op/openscreen/package.nix
@@ -17,16 +17,16 @@ buildNpmPackage (finalAttrs: {
   inherit nodejs;
 
   pname = "openscreen";
-  version = "1.1.0";
+  version = "1.1.2";
 
   src = fetchFromGitHub {
     owner = "siddharthvaddem";
     repo = "openscreen";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eneZ/2oCjIimlqGpwKGdxiPPsDTdaBOHpTUfWOQSD54=";
+    hash = "sha256-NW6GrmWgdLgobYGAoxlSF/ne17A0IzAQBi4LJk2awpw=";
   };
 
-  npmDepsHash = "sha256-TNUbF0YVpAGZFGYf3cgM2oTrSGTo6tTvckqLrvdiE6g=";
+  npmDepsHash = "sha256-IaYSejp4sXEN0KlK7+bmzufGs8D60ZjmFWjO2zMkFrM=";
 
   npmRebuildFlags = [ "--ignore-scripts" ]; # Prevent running `node-gyp build`
 


### PR DESCRIPTION
Update openscreen from 1.1.0 to 1.1.2

<https://github.com/siddharthvaddem/openscreen/releases/tag/v1.1.2>

<https://github.com/siddharthvaddem/openscreen/compare/v1.1.0...v1.1.2>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
