### PR TITLE
psysh: refactor

### DIFF
--- a/pkgs/by-name/ps/psysh/package.nix
+++ b/pkgs/by-name/ps/psysh/package.nix
@@ -4,40 +4,23 @@
   php,
   versionCheckHook,
 }:
-
-let
+php.buildComposerProject2 (finalAttrs: {
   pname = "psysh";
   version = "0.12.19";
 
   src = fetchFromGitHub {
     owner = "bobthecow";
     repo = "psysh";
-    tag = "v${version}";
-    hash = "sha256-Gdye6+fdqqxgHqq79XJgSkywP1IMMAIVexh0kEol0Jw=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j2AcpbptbsdK/GOIuglMBwklTZSAEa8oD7g/H9oibUo=";
     forceFetchGit = true;
-  };
-in
-php.buildComposerProject2 (finalAttrs: {
-  inherit
-    pname
-    version
-    src
-    ;
-
-  composerVendor = php.mkComposerVendor {
-    inherit
-      src
-      version
-      pname
-      ;
-
-    preConfigure = ''
-      cp build/composer.json .
-      cp build/composer.lock .
+    postFetch = ''
+      cp $out/build/composer.json $out/
+      cp $out/build/composer.lock $out/
     '';
-
-    vendorHash = "sha256-MbYMFQVUmRAV7qttJBEJxzimeFIA0K8wbrwC9yDirf8=";
   };
+
+  vendorHash = "sha256-MbYMFQVUmRAV7qttJBEJxzimeFIA0K8wbrwC9yDirf8=";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
remove a need for composerVendor should fix:

```
… while evaluating derivation 'nixpkgs-update-script'
   whose name attribute is located at /home/alex/git/nixpkgs/pkgs/stdenv/generic/make-derivation.nix:536:13

 … while evaluating attribute 'shellHook' of derivation 'nixpkgs-update-script'
   at /home/alex/git/nixpkgs/maintainers/scripts/update.nix:275:3:
    274|   '';
    275|   shellHook = ''
       |   ^
    276|     unset shellHook # do not contaminate nested shells

 (stack trace truncated; use '--show-trace' to show the full, detailed trace)

 error: attribute 'composerLock' missing
 at /home/alex/git/nixpkgs/pkgs/build-support/php/builders/v2/build-composer-project.nix:111:20:
    110|           args.passthru.updateScript
    111|             or (if finalAttrs.composerVendor.composerLock == null then nix-update-script { } else null);
       |                    ^
       112|       };
```

Related to https://github.com/NixOS/nixpkgs/pull/488541

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
