### PR TITLE
cavif: init at 1.6.0

### DIFF
--- a/pkgs/by-name/ca/cavif/package.nix
+++ b/pkgs/by-name/ca/cavif/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchCrate,
+  nasm,
+  nix-update-script,
+  nixos-icons,
+  runCommand,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cavif";
+  version = "1.6.0";
+
+  src = fetchCrate {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-F2b03x+jklgxa3VcRA3y0wuK7AQ2LJtCEvCa6eFeG3w=";
+  };
+
+  cargoHash = "sha256-x/0Kgf8oWjL6m2/8ol32EJpKkWSgBRbdCTay6KYrtzg=";
+
+  nativeBuildInputs = [ nasm ];
+
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = finalAttrs.finalPackage;
+      };
+      encode = runCommand "cavif-encode-test" { nativeBuildInputs = [ finalAttrs.finalPackage ]; } ''
+        cavif ${nixos-icons}/share/icons/hicolor/512x512/apps/nix-snowflake.png -o $out
+      '';
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Encoder/converter CLI for AVIF images";
+    homepage = "https://github.com/kornelski/cavif-rs";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ nettika ];
+    mainProgram = "cavif";
+  };
+})


### PR DESCRIPTION
Add a package for [cavif](https://lib.rs/cavif)

Adapted from [NUR](https://github.com/nix-community/nur-combined/blob/main/repos/AndrewKvalheim/packages/cavif.nix)

The source repo does not commit a Cargo.lock, and GitHub releases seem to be behind crates.io releases. So I stuck with fetchCrate like the NUR package. The downside of this is that the /tests directory is not available for use in passthru.tests, which would have been handy for the image conversion smoketest; instead I'm leveraging nixos-icons.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test