### PR TITLE
postgresql: minor version updates

### DIFF
--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "14.20";
-  rev = "refs/tags/REL_14_20";
-  hash = "sha256-5wWuS78yn1p+ZjlUy5jCf1mLq78D3iI7mWPBVTd1Ufk=";
+  version = "14.21";
+  # rev = "refs/tags/REL_14_21";
+  rev = "eb788b43371849237c61ba2747fc11e96c08d861";
+  hash = "sha256-9uG32BVzXOL2yAJmFVkIvEZJrmI5ToL7ojtivWmufL8=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql14/disable-test-collate.icu.utf8.patch?id=56999e6d0265ceff5c5239f85fdd33e146f06cb7";

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "15.15";
-  rev = "refs/tags/REL_15_15";
-  hash = "sha256-veGKXAvK+dNofBuSXsmCsPdXDJOC04+QV3HEr0XaE68=";
+  version = "15.16";
+  # rev = "refs/tags/REL_15_16";
+  rev = "78bc85dd4455c302c345c550e0628a1522df108d";
+  hash = "sha256-ju/KkeBOumYHCarhqNA8jq+ceUo4y8g/SzjAMWm80ak=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql15/dont-use-locale-a-on-musl.patch?id=f424e934e6d076c4ae065ce45e734aa283eecb9c";

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "16.11";
-  rev = "refs/tags/REL_16_11";
-  hash = "sha256-hxv+N+OWqiXmFmsB+SSYGKQLBbHtNMnneHFvOtUz8z4=";
+  version = "16.12";
+  # rev = "refs/tags/REL_16_12";
+  rev = "e15d96551f9760e62888b5082ad050329c1c4cdf";
+  hash = "sha256-1jkVElZTtp60Jgl5RyPT+8lalDYtjRDe9MxO3KMYJmU=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql16/dont-use-locale-a-on-musl.patch?id=08a24be262339fd093e641860680944c3590238e";

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "17.7";
-  rev = "refs/tags/REL_17_7";
-  hash = "sha256-W+505LAeiO5ln7wBhxZLv/p3GxiJp8MFfCGVDyvHREg=";
+  version = "17.8";
+  # rev = "refs/tags/REL_17_8";
+  rev = "6af885119b52a2a6229959670ba3ae5e36bf9806";
+  hash = "sha256-4lV1/xRmMsc5rgY3RB6WMigTXHgHjh9bmR6nzL82Rs4=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,8 @@
 import ./generic.nix {
-  version = "18.1";
-  rev = "refs/tags/REL_18_1";
-  hash = "sha256-cZA2hWtr5RwsUrRWkvl/yvUzFPSfdtpyAKGXfrVUr0g=";
+  version = "18.2";
+  # rev = "refs/tags/REL_18_2";
+  rev = "5a461dc4dbf72a1ec281394a76eb36d68cbdd935";
+  hash = "sha256-cvBXxA7/kEwDGxFv/YoZCIh17jzUujrCtfKAmtSxKTw=";
   muslPatches = {
     dont-use-locale-a = {
       url = "https://git.alpinelinux.org/aports/plain/main/postgresql17/dont-use-locale-a-on-musl.patch?id=d69ead2c87230118ae7f72cef7d761e761e1f37e";

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -87,7 +87,7 @@ let
         # Building with JIT in pkgsStatic fails like this:
         #   fatal error: 'stdio.h' file not found
         && !stdenv.hostPlatform.isStatic,
-      llvmPackages_20,
+      llvmPackages,
       nukeReferences,
       overrideCC,
 
@@ -162,14 +162,6 @@ let
       zstdEnabled = atLeast "15";
 
       dlSuffix = if olderThan "16" then ".so" else stdenv.hostPlatform.extensions.sharedLibrary;
-
-      # Pin LLVM 20 until upstream has fully resolved:
-      # https://www.postgresql.org/message-id/flat/d25e6e4a-d1b4-84d3-2f8a-6c45b975f53d%40applied-asynchrony.com
-      # Currently still a problem on aarch64.
-      # TODO: Remove with next minor releases
-      llvmPackages = lib.warnIf (
-        version == "17.8"
-      ) "PostgreSQL: Is the pin for LLVM 20 still needed?" llvmPackages_20;
 
       stdenv' =
         if !stdenv.cc.isClang then


### PR DESCRIPTION
Latest set of minor version updates.

Fixes a bunch of (still unpublished) CVEs:
- CVE-2026-2003
- CVE-2026-2004
- CVE-2026-2005
- CVE-2026-2006
- CVE-2026-2007

Release Notes about the CVEs: https://github.com/postgres/postgres/commit/30d2603f5c340133ca03e098fcaa9c242843d5e1

Diff for the CVEs: https://github.com/postgres/postgres/compare/5944beb7398d76f746c9bb32dbca41bd05419925...30d2603f5c340133ca03e098fcaa9c242843d5e1

Full Release Notes:
- https://github.com/postgres/postgres/blob/REL_18_STABLE/doc/src/sgml/release-18.sgml
- https://github.com/postgres/postgres/blob/REL_17_STABLE/doc/src/sgml/release-17.sgml
- https://github.com/postgres/postgres/blob/REL_16_STABLE/doc/src/sgml/release-16.sgml
- https://github.com/postgres/postgres/blob/REL_15_STABLE/doc/src/sgml/release-15.sgml
- https://github.com/postgres/postgres/blob/REL_14_STABLE/doc/src/sgml/release-14.sgml

`libpq` will be updated in a [separate PR](https://github.com/NixOS/nixpkgs/pull/489023) to staging. None of the CVEs apply to that, AFAICS.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test