### PR TITLE
sratoolkit 3.2.1 -> 3.3.0

### DIFF
--- a/pkgs/by-name/nc/ncbi-vdb/package.nix
+++ b/pkgs/by-name/nc/ncbi-vdb/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ncbi-vdb";
-  version = "3.2.1";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "ncbi";
     repo = "ncbi-vdb";
     tag = finalAttrs.version;
-    hash = "sha256-ccKJF6Ank/hyADnDwN0qoQbb0BniXlz/Fgnc1IXq0P0=";
+    hash = "sha256-bYVwgNYnFg2OPaPWSbXIW+VXprxg/PxwHIRCnDfQRls=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sr/sratoolkit/package.nix
+++ b/pkgs/by-name/sr/sratoolkit/package.nix
@@ -16,13 +16,13 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "sratoolkit";
 
   # NOTE: When updating make sure to update ncbi-vdb as well for versions to match
-  version = "3.2.1";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "ncbi";
     repo = "sra-tools";
     tag = finalAttrs.version;
-    hash = "sha256-OeM4syv9c1rZn2ferrhXyKJu68ywVYwnHoqnviWBZy4=";
+    hash = "sha256-Lv4EWAKJ6F5uvsXgo2Bx3JyY9lYaL1El9Jbi2LidmHo=";
   };
 
   patches = [ ./attribute_unused.patch ];


### PR DESCRIPTION
sratoolkit version 3.2.1 fails to build due to missing headers, version 3.3.0 adds the missing headers.

Changelog: https://github.com/ncbi/sra-tools/blob/a7fff20b1a8c1dcf1586dd1a32460b9d2dfb9392/CHANGES.md

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
