### PR TITLE
libpq: 18.1 -> 18.2

### DIFF
--- a/pkgs/servers/sql/postgresql/libpq.nix
+++ b/pkgs/servers/sql/postgresql/libpq.nix
@@ -40,14 +40,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpq";
-  version = "18.1";
+  version = "18.2";
 
   src = fetchFromGitHub {
     owner = "postgres";
     repo = "postgres";
     # rev, not tag, on purpose: see generic.nix.
-    rev = "refs/tags/REL_18_1";
-    hash = "sha256-cZA2hWtr5RwsUrRWkvl/yvUzFPSfdtpyAKGXfrVUr0g=";
+    rev = "refs/tags/REL_18_2";
+    hash = "sha256-cvBXxA7/kEwDGxFv/YoZCIh17jzUujrCtfKAmtSxKTw=";
   };
 
   __structuredAttrs = true;


### PR DESCRIPTION
Release Notes:
https://github.com/postgres/postgres/blob/REL_18_STABLE/doc/src/sgml/release-18.sgml

Note: Could also wait until the tag appears, because the latest CVEs don't seem to affect libpq, only the server.

`postgresql_xx` updates in #489018.

## Things done

- Built on platform (all against master, not staging):
  - x86_64-linux
    - [x] libpq
    - [x] pkgsStatic.libpq
    - [x] pkgsMusl.libpq
    - [x] pkgsCross.x86_64-freebsd.libpq
    - [x] pkgsCross.aarch64-multiplatform.libpq
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
