### PR TITLE
[25.11] imagemagick: fix cross compile

### DIFF
--- a/pkgs/applications/graphics/ImageMagick/default.nix
+++ b/pkgs/applications/graphics/ImageMagick/default.nix
@@ -173,7 +173,7 @@ stdenv.mkDerivation (finalAttrs: {
     configDestination=($out/share/ImageMagick-*)
     grep -v '/nix/store' $dev/lib/ImageMagick-*/config-Q16HDRI/configure.xml > $configDestination/configure.xml
     for file in "$dev"/bin/*-config; do
-      substituteInPlace "$file" --replace pkg-config \
+      substituteInPlace "$file" --replace-fail "$PKG_CONFIG" \
         "PKG_CONFIG_PATH='$dev/lib/pkgconfig' '$(command -v $PKG_CONFIG)'"
     done
   ''

--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -1,11 +1,9 @@
 {
   buildPecl,
-  fetchpatch,
   lib,
   imagemagick,
   pkg-config,
   pcre2,
-  php,
 }:
 
 buildPecl {
@@ -15,7 +13,11 @@ buildPecl {
   sha256 = "sha256-vaZ0YchU8g1hBXgrdpxST8NziLddRIHZUWRNIWf/7sY=";
 
   configureFlags = [ "--with-imagick=${imagemagick.dev}" ];
+
+  depsBuildBuild = [ pkg-config ];
+
   nativeBuildInputs = [ pkg-config ];
+
   buildInputs = [ pcre2 ];
 
   meta = {

--- a/pkgs/development/php-packages/imagick/default.nix
+++ b/pkgs/development/php-packages/imagick/default.nix
@@ -10,7 +10,7 @@ buildPecl {
   pname = "imagick";
 
   version = "3.8.0";
-  sha256 = "sha256-vaZ0YchU8g1hBXgrdpxST8NziLddRIHZUWRNIWf/7sY=";
+  hash = "sha256-vaZ0YchU8g1hBXgrdpxST8NziLddRIHZUWRNIWf/7sY=";
 
   configureFlags = [ "--with-imagick=${imagemagick.dev}" ];
 


### PR DESCRIPTION
Backport of #474586 to `release-25.11`.

Cherry-picked commits:
- 7a272715 phpPackages.imagick: fix cross compilation
- e7a4c6ce imagemagick: fix cross compile
- 624d0407 phpPackages.imagick: cleanup