### PR TITLE
ffmpeg: Add a -bare variant

### DIFF
--- a/pkgs/development/libraries/ffmpeg/default.nix
+++ b/pkgs/development/libraries/ffmpeg/default.nix
@@ -54,6 +54,7 @@ rec {
   ffmpeg_8 = mkFFmpeg v8 "small";
   ffmpeg_8-headless = mkFFmpeg v8 "headless";
   ffmpeg_8-full = mkFFmpeg v8 "full";
+  ffmpeg_8-bare = mkFFmpeg v8 "bare";
 
   # Please make sure this is updated to new major versions once they
   # build and work on all the major platforms. If absolutely necessary
@@ -68,4 +69,5 @@ rec {
   ffmpeg = ffmpeg_8;
   ffmpeg-headless = ffmpeg_8-headless;
   ffmpeg-full = ffmpeg_8-full;
+  ffmpeg-bare = ffmpeg_8-bare;
 }

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -22,6 +22,11 @@
 
   ffmpegVariant ? "small", # Decides which dependencies are enabled by default
 
+  # Build nothing by default. Enable all features that are needed.
+  # To be used for purposes that don't require external dependencies, like `unpaper`
+  # that uses ffmpeg for image processing.
+  withBareDeps ? ffmpegVariant == "bare" || withHeadlessDeps,
+
   # Build with headless deps; excludes dependencies that are only necessary for
   # GUI applications. To be used for purposes that don't generally need such
   # components and i.e. only depend on libav
@@ -52,7 +57,7 @@
   withAvisynth ? withFullDeps, # AviSynth script files reading
   withBluray ? withHeadlessDeps, # BluRay reading
   withBs2b ? withFullDeps, # bs2b DSP library
-  withBzlib ? withHeadlessDeps,
+  withBzlib ? withBareDeps,
   withCaca ? withFullDeps, # Textual display (ASCII art)
   withCdio ? withFullDeps && withGPL, # Audio CD grabbing
   withCelt ? withFullDeps, # CELT decoder
@@ -169,7 +174,7 @@
   withXml2 ? withHeadlessDeps, # libxml2 support, for IMF and DASH demuxers
   withXvid ? withHeadlessDeps && withGPL, # Xvid encoder, native encoder exists
   withZimg ? withHeadlessDeps,
-  withZlib ? withHeadlessDeps,
+  withZlib ? withBareDeps,
   withZmq ? withFullDeps, # Message passing
   withZvbi ? withHeadlessDeps, # Teletext support
 
@@ -201,14 +206,14 @@
   buildQtFaststart ? withFullDeps, # Build qt-faststart executable
   withBin ? buildFfmpeg || buildFfplay || buildFfprobe || buildQtFaststart,
   # Library options
-  buildAvcodec ? withHeadlessDeps, # Build avcodec library
+  buildAvcodec ? withBareDeps, # Build avcodec library
   buildAvdevice ? withHeadlessDeps, # Build avdevice library
   buildAvfilter ? withHeadlessDeps, # Build avfilter library
-  buildAvformat ? withHeadlessDeps, # Build avformat library
+  buildAvformat ? withBareDeps, # Build avformat library
   # Deprecated but depended upon by some packages.
   # https://github.com/NixOS/nixpkgs/pull/211834#issuecomment-1417435991)
   buildAvresample ? withHeadlessDeps && lib.versionOlder version "5", # Build avresample library
-  buildAvutil ? withHeadlessDeps, # Build avutil library
+  buildAvutil ? withBareDeps, # Build avutil library
   # Libpostproc is only available on versions lower than 8.0
   # https://code.ffmpeg.org/FFmpeg/FFmpeg/commit/8c920c4c396163e3b9a0b428dd550d3c986236aa
   buildPostproc ? withHeadlessDeps && lib.versionOlder version "8.0", # Build postproc library
@@ -394,6 +399,7 @@ let
 in
 
 assert lib.elem ffmpegVariant [
+  "bare"
   "headless"
   "small"
   "full"
@@ -992,7 +998,8 @@ stdenv.mkDerivation (
     };
 
     # tests linking broken with shaderc after https://github.com/NixOS/nixpkgs/pull/477464/changes/5a47b12dfcd1b909ba35778a866394430054319a
-    doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform && !withShaderc;
+    # tests need at least the headless deps to compile
+    doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform && !withShaderc && withHeadlessDeps;
 
     # Fails with SIGABRT otherwise FIXME: Why?
     checkPhase =

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6405,9 +6405,11 @@ with pkgs;
     ffmpeg_8
     ffmpeg_8-headless
     ffmpeg_8-full
+    ffmpeg_8-bare
     ffmpeg
     ffmpeg-headless
     ffmpeg-full
+    ffmpeg-bare
     ;
 
   fftwSinglePrec = fftw.override { precision = "single"; };


### PR DESCRIPTION
Some packages, like unpaper, need a very basic ffmpeg installation without any external codec dependencies, because they do nothing more than pixel / picture manipulation. Especially in a server context, you don't want all what is pulled in by headless.

Spawned by #488736

I added the bare variant for ffmpeg-8 only, because this is where I can test atm. Adding it for other versions can be done, though.

I enabled bz2 and zlib support for the bare package, because those libs are probably on each system (and zlib is required for some simple formats like png). It may be an idea to add lzma as well. Or, in opposite, to only have zlib.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
