### PR TITLE
offpunk: 2.8 -> 3.0

### DIFF
--- a/pkgs/by-name/of/offpunk/package.nix
+++ b/pkgs/by-name/of/offpunk/package.nix
@@ -3,6 +3,7 @@
   python3Packages,
   fetchFromSourcehut,
   file,
+  gettext,
   installShellFiles,
   less,
   offpunk,
@@ -14,19 +15,22 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "offpunk";
-  version = "2.8";
+  version = "3.0";
   pyproject = true;
 
   src = fetchFromSourcehut {
     owner = "~lioploum";
     repo = "offpunk";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-s/pEN7n/g9o8a/hYTC39PgbBLyCUwN5LIggqUSMKRS4=";
+    hash = "sha256-5SoMa93QbwbsryeHGc3pkkDA8v9eonZvuflSuDV2hmI=";
   };
 
   build-system = with python3Packages; [ hatchling ];
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    gettext
+    installShellFiles
+  ];
 
   dependencies = [
     file


### PR DESCRIPTION
Regular version bump.

Upstream Changelog:

```
3.0 - February 9th 2026

Changes since 2.8
Important changes:
- "opnk" is deprecated and replaced by "openk"
- Default image size now 100 instead of 40 (can be restored with "set images_size 40")
- Links to available feeds are now displayed at the bottom of HTML pages
- "root" has been modified to go to the root of the capsule/userspace "root /" for real root
- Images are now displayed in Gemini. This can be disabled with "set gemini_images false"
- "ls" command is deprecated
Features:
- Offpunk is now translatable (by JMCS). Translations in ES, GC (JMCS) and NL (Bert Livens)
- Add "unmerdify" tool to extract content from HTML if "ftr_site_config" is set (by Vincent Jousse)
- new "xkcdpunk" command-line tool to directly access your XKCD comics
- new "websearch" command which default to wiby.me
- new "share" command to send a page by email
- new "reply" command to send an email to the author of the page
- "cookies" command and http cookies are now supported in netcache (by Urja)
- "set default_cmd" now allows to configure what happen on empty lines
- "view switch" changes between readable/full view (by Andrew Fowlie)
- customize prompt with "set prompt_on" and "set prompt_off" (by Andrew Fowlie)
- "help help" now sends an email to the offpunk-users mailing-list
- "links" command now display all links
- new "blocked_link" object in theme. By default, blocked link are in red.
- new "theme preset" to allow switching between multiple hardcoded themes like "yellow","cyan" or "bw"
Others:
- In "lists", only consider files ending with .gmi (bug #46 by woffs)
- support for new links color in gopher (by JMCS)
- fix an off by one bug in "cp url XX"
- Ansicat: Fix incorrectly identifying RSS feeds as XHTML when there was no entry
- Fix sync hanging on gopher interactive prompt (by JMCS)
- Fix crash when trying to parse HTML without BS4 (reported by Hoël Bézier)
- Automatically replace space by %20 in img url in HTML
- Ansicat: HTML Render img with data-src if src doesn’t link to a valid image
- Opnk: fix a crash when trying to cache-clean uncached url (such as images)
- added mime-type "application/pgp-keys" as to be opened by TextRenderer
- "redirect" has been refactored to acts on the netcache level
- ansicat: in HTML, the <a> link to a picture is only displayed if different from the picture itself
- added "wgl" and "wde" shortcuts to wikipedia GL & DE (JMCS)
- "bugreport" allows to send a bug report to the -devel list
- "theme" now accept "none" as a color to remove part of the theme you don’t want
- "info" now explain how the HTML content was cleaned
- history now consider multiple successive views of a page as one visit only
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
