### PR TITLE
python3Packages.lazy-imports: switch to its fork

### DIFF
--- a/pkgs/development/python-modules/lazy-imports/default.nix
+++ b/pkgs/development/python-modules/lazy-imports/default.nix
@@ -1,36 +1,41 @@
 {
-  lib,
   buildPythonPackage,
   fetchFromGitHub,
+  lib,
+
+  # build system
+  setuptools,
+
+  # test dependencies
   pytestCheckHook,
-  packaging,
 }:
 let
   pname = "lazy-imports";
-  version = "0.3.1";
-in
-buildPythonPackage {
-  inherit pname version;
-  format = "setuptools";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
-    owner = "telekom";
+    owner = "bachorp";
     repo = "lazy-imports";
     tag = version;
-    hash = "sha256-i+VPlBoxNqk56U4oiEgS1Ayhi1t2O8PtLZ/bzEurUY8=";
+    hash = "sha256-KtKqR/e0ldpsrz3dyY1ehF4cM5k7jDziiB+8uV0HEwc=";
   };
+in
+buildPythonPackage {
+  inherit pname version src;
+  pyproject = true;
+
+  build-system = [ setuptools ];
 
   pythonImportsCheck = [ "lazy_imports" ];
 
   nativeCheckInputs = [
     pytestCheckHook
-    packaging
   ];
 
   meta = {
-    description = "Python tool to support lazy imports";
-    homepage = "https://github.com/telekom/lazy-imports";
-    changelog = "https://github.com/telekom/lazy-imports/releases/tag/${version}";
+    description = "Utility package to create lazy modules, deferring associated imports until attribute access";
+    homepage = "https://github.com/bachorp/lazy-imports";
+    changelog = "https://github.com/bachorp/lazy-imports/releases/tag/${src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ happysalada ];
   };


### PR DESCRIPTION
The main repository has been archived which points to this 'friendly' fork and its PyPI listing has also changed its source

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
