### PR TITLE
yarnConfigHook: rewrite git URLs in package.json

### DIFF
--- a/pkgs/build-support/node/fetch-yarn-deps/fixup.js
+++ b/pkgs/build-support/node/fetch-yarn-deps/fixup.js
@@ -2,12 +2,14 @@
 'use strict'
 
 const fs = require('fs')
+const path = require('path')
 const process = require('process')
 const lockfile = require('./yarnpkg-lockfile.js')
 const { urlToName } = require('./common.js')
 
 const fixupYarnLock = async (lockContents, verbose) => {
   const lockData = lockfile.parse(lockContents)
+  const urlRewrites = new Map()
 
   const fixedData = Object.fromEntries(
     Object.entries(lockData.object)
@@ -33,13 +35,58 @@ const fixupYarnLock = async (lockContents, verbose) => {
       if (hash)
         pkg.resolved += `#${hash}`
 
+      // Yarn uses the lockfile entry key to decide which resolver to use.
+      // Keys containing "git+" or ending in ".git" trigger the git resolver,
+      // which tries to run the git binary. Strip these so yarn treats the
+      // dependency as a regular tarball resolved from the offline cache.
+      let fixedDep = dep.replace(/@git\+/, '@').replace(/\.git(#|$)/, '$1')
+      if (fixedDep !== dep) {
+        // Record the version URL rewrite so we can apply it to internal refs and package.json
+        const oldVersion = dep.match(/^@?[^@]+@(.+)$/)[1]
+        const newVersion = fixedDep.match(/^@?[^@]+@(.+)$/)[1]
+        urlRewrites.set(oldVersion, newVersion)
+        return [fixedDep, pkg]
+      }
       return [dep, pkg]
     })
   )
 
+  // Other lockfile entries may reference git dependencies in their
+  // dependencies/optionalDependencies fields. These references must match the
+  // rewritten keys above, otherwise yarn can't find the entry and falls back
+  // to the git resolver.
+  if (urlRewrites.size > 0) {
+    for (const pkg of Object.values(fixedData)) {
+      for (const depField of ['dependencies', 'optionalDependencies']) {
+        if (!pkg[depField]) continue
+        for (const [name, version] of Object.entries(pkg[depField])) {
+          if (urlRewrites.has(version)) pkg[depField][name] = urlRewrites.get(version)
+        }
+      }
+    }
+  }
+
   if (verbose) console.log('Done')
 
-  return fixedData
+  return { fixedData, urlRewrites }
+}
+
+// package.json may also reference git dependencies. Apply the same rewrites
+// so that yarn's lookup keys match the rewritten lockfile entry keys.
+const fixupPackageJson = async (pkgJsonPath, urlRewrites, verbose) => {
+  if (urlRewrites.size === 0 || !fs.existsSync(pkgJsonPath)) return
+
+  const pkgJson = JSON.parse(await fs.promises.readFile(pkgJsonPath, 'utf-8'))
+  for (const field of ['dependencies', 'devDependencies', 'optionalDependencies']) {
+    if (!pkgJson[field]) continue
+    for (const [name, version] of Object.entries(pkgJson[field])) {
+      if (urlRewrites.has(version)) {
+        if (verbose) console.log(`Rewriting package.json ${field}.${name}: ${version} -> ${urlRewrites.get(version)}`)
+        pkgJson[field][name] = urlRewrites.get(version)
+      }
+    }
+  }
+  await fs.promises.writeFile(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n')
 }
 
 const showUsage = async () => {
@@ -74,8 +121,11 @@ const main = async () => {
     showUsage()
   }
 
-  const fixedData = await fixupYarnLock(lockContents, verbose)
+  const { fixedData, urlRewrites } = await fixupYarnLock(lockContents, verbose)
   await fs.promises.writeFile(lockFile || 'yarn.lock', lockfile.stringify(fixedData))
+
+  const pkgJsonPath = path.join(path.dirname(lockFile || 'yarn.lock'), 'package.json')
+  await fixupPackageJson(pkgJsonPath, urlRewrites, verbose)
 }
 
 main()


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

-->

`fixup-yarn-lock` rewrites `yarn.lock` keys to strip `git+` prefixes and `.git` suffixes, preventing yarn from detecting them as git dependencies via `hosted-git-info`. However, `package.json` still contained the original URLs, causing a key mismatch. yarn couldn't find the lockfile entry and fell back to git resolution, failing with "Couldn't find the binary git".

Apply the same URL rewriting to `package.json` dependency fields so they stay in sync with the rewritten lockfile keys.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
