### PR TITLE
freenet-core: init at 0.1.118

### DIFF
--- a/pkgs/by-name/fr/freenet-core/package.nix
+++ b/pkgs/by-name/fr/freenet-core/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchCrate,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "freenet-core";
+  version = "0.1.118";
+
+  src = fetchCrate {
+    pname = "freenet";
+    version = finalAttrs.version;
+    hash = "sha256-UGNNZ87thBKZ5XEFLpMtdaTv/wcG+IgU8wnMpovQ5yg=";
+  };
+
+  cargoHash = "sha256-VflN0W1HigyEky6IzQEB88jyCWYsjaXi1VqDowRz8b4=";
+
+  # freenet edge-case tests cause build failure otherwise
+  doCheck = false;
+
+  meta = {
+    description = "Freenet Core";
+    homepage = "https://freenet.org/";
+    license = lib.licenses.agpl3Only;
+    platforms = with lib.platforms; linux;
+    maintainers = [ ];
+    changelog = "https://github.com/freenet/freenet-core/releases/tag/v${finalAttrs.version}";
+    mainProgram = "freenet";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added new package `freenet-core` which provides the binary `freenet` (distinct from existing package `freenet`, which is now known as hyphanet). Built and tested the binary `freenet` on x86_64-linux, and was able to connect to Freenet.

Freenet homepage: [https://freenet.org]()
Freenet release v0.1.118: [https://github.com/freenet/freenet-core/releases/tag/v0.1.118]()

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
