### PR TITLE
[Backport release-25.11] jetbrains.pycharm*: 2025.3.1 -> 2025.3.2; mark community-bin unsecure

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -80,10 +80,10 @@
     },
     "pycharm": {
       "url-template": "https://download.jetbrains.com/python/pycharm-{version}.tar.gz",
-      "version": "2025.3.1",
-      "sha256": "933fd42d7cc2a76ad4ba23f9112294e4df013fa4c3362435a1e3368051c07391",
-      "url": "https://download.jetbrains.com/python/pycharm-2025.3.1.tar.gz",
-      "build_number": "253.29346.142"
+      "version": "2025.3.2",
+      "sha256": "60b5cef9886e9587e439247a7e364aba9a663dafae2eabcffc4e0dc409bba3c4",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.3.2.tar.gz",
+      "build_number": "253.30387.127"
     },
     "rider": {
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.tar.gz",
@@ -202,10 +202,10 @@
     },
     "pycharm": {
       "url-template": "https://download.jetbrains.com/python/pycharm-{version}-aarch64.tar.gz",
-      "version": "2025.3.1",
-      "sha256": "2b6f5a430132773ea7caf3046f7763ea7a031dbfab6e1be72bdc86f3cc7a758b",
-      "url": "https://download.jetbrains.com/python/pycharm-2025.3.1-aarch64.tar.gz",
-      "build_number": "253.29346.142"
+      "version": "2025.3.2",
+      "sha256": "92985c4fa6bb255ef616a713abb8aebc0728952816745bce6e7fe8d2364febd8",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.3.2-aarch64.tar.gz",
+      "build_number": "253.30387.127"
     },
     "rider": {
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.tar.gz",
@@ -324,10 +324,10 @@
     },
     "pycharm": {
       "url-template": "https://download.jetbrains.com/python/pycharm-{version}.dmg",
-      "version": "2025.3.1",
-      "sha256": "586c9eed67da609fc1e565a8bfc36eb155b23e5483d5dc6e9dcf8b5540f47fa5",
-      "url": "https://download.jetbrains.com/python/pycharm-2025.3.1.dmg",
-      "build_number": "253.29346.142"
+      "version": "2025.3.2",
+      "sha256": "2f1ca9d60d0a61aa5eb1527e2e4445b25cc81aba7628f32b5cff67171fc24d82",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.3.2.dmg",
+      "build_number": "253.30387.127"
     },
     "rider": {
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}.dmg",
@@ -446,10 +446,10 @@
     },
     "pycharm": {
       "url-template": "https://download.jetbrains.com/python/pycharm-{version}-aarch64.dmg",
-      "version": "2025.3.1",
-      "sha256": "ec8e97856f00da902020c72b0f079cc10983de6bb4438292ea5faa1e5b0cb935",
-      "url": "https://download.jetbrains.com/python/pycharm-2025.3.1-aarch64.dmg",
-      "build_number": "253.29346.142"
+      "version": "2025.3.2",
+      "sha256": "9561fa33994e8d4630cf1d80a84bf9dd5ec9fb93c417df8a31929fa9b8af51e6",
+      "url": "https://download.jetbrains.com/python/pycharm-2025.3.2-aarch64.dmg",
+      "build_number": "253.30387.127"
     },
     "rider": {
       "url-template": "https://download.jetbrains.com/rider/JetBrains.Rider-{version}-aarch64.dmg",

--- a/pkgs/applications/editors/jetbrains/default.nix
+++ b/pkgs/applications/editors/jetbrains/default.nix
@@ -416,9 +416,17 @@ in
   pycharm-community-bin =
     lib.warnOnInstantiate
       "pycharm-community-bin: PyCharm Community has been discontinued by Jetbrains. This binary build is no longer updated. Switch to 'jetbrains.pycharm-oss' for open source builds (from source) or 'jetbrains.pycharm' for commercial builds (binary, unfree). See: https://blog.jetbrains.com/pycharm/2025/04/pycharm-2025"
-      (buildPycharm {
-        pname = "pycharm-community";
-      });
+      (
+        (buildPycharm {
+          pname = "pycharm-community";
+        }).overrideAttrs
+          (
+            finalAttrs: previousAttrs: {
+              # https://github.com/NixOS/nixpkgs/issues/488993
+              meta.knownVulnerabilities = [ "CVE-2026-25847" ];
+            }
+          )
+      );
 
   pycharm-community-src = lib.warnOnInstantiate "jetbrains.idea-community-src: PyCharm Community has been discontinued by Jetbrains. This is now an alias for 'jetbrains.pycharm-oss', the Open Source build of PyCharm. See: https://blog.jetbrains.com/pycharm/2025/04/pycharm-2025" _pycharm-oss;
 

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -17,17 +17,17 @@
       "builds": {
         "252.28238.29": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
         "252.28238.7": "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip"
+        "253.28294.337": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip"
       },
       "name": "ideavim"
     },
@@ -42,7 +42,7 @@
       ],
       "builds": {
         "252.28238.7": "https://plugins.jetbrains.com/files/1347/918482/scala-intellij-bin-2025.2.51.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/1347/918481/scala-intellij-bin-2025.3.26.zip"
+        "253.29346.138": "https://plugins.jetbrains.com/files/1347/943891/scala-intellij-bin-2025.3.28.zip"
       },
       "name": "scala"
     },
@@ -69,11 +69,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/2162/820000/StringManipulation-9.16.0.zip"
       },
       "name": "stringmanipulation"
     },
@@ -100,11 +100,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip"
       },
       "name": "handlebars-mustache"
     },
@@ -131,11 +131,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/6954/939222/Kotlin-253.30387.90-IJ.zip"
       },
       "name": "kotlin"
     },
@@ -162,11 +162,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip"
       },
       "name": "ini"
     },
@@ -193,11 +193,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip"
       },
       "name": "acejump"
     },
@@ -224,11 +224,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7125/819837/GrepConsole-13.3.0-IJ2023.3.zip"
       },
       "name": "grep-console"
     },
@@ -255,11 +255,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7177/899679/fileWatcher-253.28294.218.zip"
       },
       "name": "file-watchers"
     },
@@ -296,11 +296,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7212/932646/cucumber-java-253.30387.20.zip"
       },
       "name": "cucumber-for-java"
     },
@@ -309,7 +309,7 @@
         "phpstorm"
       ],
       "builds": {
-        "253.29346.151": "https://plugins.jetbrains.com/files/7219/911329/Symfony_Plugin-2025.1.282.zip"
+        "253.29346.151": "https://plugins.jetbrains.com/files/7219/941667/Symfony_Plugin-2026.1.286.zip"
       },
       "name": "symfony-plugin"
     },
@@ -337,13 +337,13 @@
         "252.28238.29": "https://plugins.jetbrains.com/files/7322/896612/python-ce-252.28238.7.zip",
         "252.28238.7": "https://plugins.jetbrains.com/files/7322/896612/python-ce-252.28238.7.zip",
         "253.28294.337": "https://plugins.jetbrains.com/files/7322/908768/python-ce-253.28294.334.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip"
+        "253.29346.138": "https://plugins.jetbrains.com/files/7322/928110/python-ce-253.29346.240.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/7322/928110/python-ce-253.29346.240.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/7322/928110/python-ce-253.29346.240.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/7322/928110/python-ce-253.29346.240.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/7322/928110/python-ce-253.29346.240.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/7322/928110/python-ce-253.29346.240.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7322/939236/python-ce-253.30387.90.zip"
       },
       "name": "python-community-edition"
     },
@@ -364,17 +364,17 @@
       "builds": {
         "252.28238.29": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
         "252.28238.7": "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip"
+        "253.28294.337": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip"
       },
       "name": "asciidoc"
     },
@@ -401,11 +401,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "253.29346.140": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "253.29346.141": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "253.29346.143": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "253.29346.144": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
         "253.29346.151": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
+        "253.29346.170": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar"
       },
       "name": "wakatime"
     },
@@ -426,17 +426,17 @@
       "builds": {
         "252.28238.29": "https://plugins.jetbrains.com/files/7499/883982/gittoolbox-600.1.13_243-signed.zip",
         "252.28238.7": "https://plugins.jetbrains.com/files/7499/883982/gittoolbox-600.1.13_243-signed.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip"
+        "253.28294.337": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip"
       },
       "name": "gittoolbox"
     },
@@ -463,11 +463,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/7724/934041/clouds-docker-impl-253.30387.30.zip"
       },
       "name": "docker"
     },
@@ -494,11 +494,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip"
       },
       "name": "graphql"
     },
@@ -523,11 +523,11 @@
         "253.29346.138": null,
         "253.29346.140": null,
         "253.29346.141": null,
-        "253.29346.142": null,
         "253.29346.143": null,
         "253.29346.144": null,
         "253.29346.151": null,
-        "253.29346.170": null
+        "253.29346.170": null,
+        "253.30387.127": null
       },
       "name": "-deprecated-rust"
     },
@@ -552,11 +552,11 @@
         "253.29346.138": null,
         "253.29346.140": null,
         "253.29346.141": null,
-        "253.29346.142": null,
         "253.29346.143": null,
         "253.29346.144": null,
         "253.29346.151": null,
-        "253.29346.170": null
+        "253.29346.170": null,
+        "253.30387.127": null
       },
       "name": "-deprecated-rust-beta"
     },
@@ -583,11 +583,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/8195/908791/toml-253.28294.334.zip"
       },
       "name": "toml"
     },
@@ -624,11 +624,11 @@
         "253.29346.139": null,
         "253.29346.140": null,
         "253.29346.141": null,
-        "253.29346.142": null,
         "253.29346.143": null,
         "253.29346.144": null,
         "253.29346.151": null,
-        "253.29346.170": null
+        "253.29346.170": null,
+        "253.30387.127": null
       },
       "name": "ide-features-trainer"
     },
@@ -655,11 +655,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip"
       },
       "name": "nixidea"
     },
@@ -686,11 +686,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip"
       },
       "name": "gherkin"
     },
@@ -709,19 +709,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/9525/909501/dotenv-253.28294.351.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/9525/909501/dotenv-253.28294.351.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip"
+        "252.28238.29": null,
+        "252.28238.7": null,
+        "253.28294.337": null,
+        "253.28294.432": null,
+        "253.29346.138": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/9525/952937/dotenv-253.30387.193.zip"
       },
       "name": "-env-files"
     },
@@ -757,11 +757,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
         "253.29346.140": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
         "253.29346.141": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
-        "253.29346.142": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
         "253.29346.143": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
         "253.29346.144": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
         "253.29346.151": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
-        "253.29346.170": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar"
+        "253.29346.170": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar",
+        "253.30387.127": "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar"
       },
       "name": "ansi-highlighter-premium"
     },
@@ -788,11 +788,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip"
       },
       "name": "key-promoter-x"
     },
@@ -819,11 +819,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/9836/840770/intellij-randomness-3.4.2.zip"
       },
       "name": "randomness"
     },
@@ -842,19 +842,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip"
       },
       "name": "csv-editor"
     },
@@ -881,11 +881,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip"
       },
       "name": "rainbow-brackets"
     },
@@ -912,11 +912,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip"
       },
       "name": "dot-language"
     },
@@ -937,17 +937,17 @@
       "builds": {
         "252.28238.29": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
         "252.28238.7": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip"
+        "253.28294.337": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip"
       },
       "name": "hocon"
     },
@@ -972,11 +972,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip"
       },
       "name": "go-template"
     },
@@ -995,19 +995,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip"
       },
       "name": "extra-icons"
     },
@@ -1026,19 +1026,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/11349/909846/aws-toolkit-jetbrains-standalone-3.100.252.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/11349/909846/aws-toolkit-jetbrains-standalone-3.100.252.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/11349/934124/aws-toolkit-jetbrains-standalone-3.102.252.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/11349/934124/aws-toolkit-jetbrains-standalone-3.102.252.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip"
       },
       "name": "aws-toolkit"
     },
@@ -1074,11 +1074,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip"
       },
       "name": "vscode-keymap"
     },
@@ -1105,11 +1105,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/12559/899597/keymap-eclipse-253.28294.218.zip"
       },
       "name": "eclipse-keymap"
     },
@@ -1136,11 +1136,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/12896/173977/RainbowCSV.zip"
       },
       "name": "rainbow-csv"
     },
@@ -1167,11 +1167,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip"
       },
       "name": "visual-studio-keymap"
     },
@@ -1198,11 +1198,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip"
       },
       "name": "indent-rainbow"
     },
@@ -1229,11 +1229,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip"
       },
       "name": "protocol-buffers"
     },
@@ -1260,11 +1260,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "253.29346.140": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "253.29346.141": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "253.29346.142": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "253.29346.143": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "253.29346.144": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "253.29346.151": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "253.29346.170": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
+        "253.29346.170": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "253.30387.127": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
     },
@@ -1291,11 +1291,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "253.29346.140": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "253.29346.141": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "253.29346.142": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "253.29346.143": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "253.29346.144": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
         "253.29346.151": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
-        "253.29346.170": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
+        "253.29346.170": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar",
+        "253.30387.127": "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar"
       },
       "name": "mario-progress-bar"
     },
@@ -1322,11 +1322,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "253.29346.140": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "253.29346.141": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "253.29346.142": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "253.29346.143": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "253.29346.144": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
         "253.29346.151": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
-        "253.29346.170": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar"
+        "253.29346.170": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar",
+        "253.30387.127": "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar"
       },
       "name": "which-key"
     },
@@ -1345,19 +1345,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip"
       },
       "name": "extra-toolwindow-colorful-icons"
     },
@@ -1376,19 +1376,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip"
       },
       "name": "github-copilot--your-ai-pair-programmer"
     },
@@ -1415,11 +1415,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
     },
@@ -1438,19 +1438,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip"
       },
       "name": "catppuccin-theme"
     },
@@ -1477,11 +1477,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip"
       },
       "name": "codeglance-pro"
     },
@@ -1500,19 +1500,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "252.28238.7": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.28294.337": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.28294.432": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.138": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.139": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.140": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.141": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.142": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.143": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.144": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.151": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar",
-        "253.29346.170": "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar"
+        "252.28238.29": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "252.28238.7": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.28294.337": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.28294.432": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.138": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.139": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.140": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.141": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.143": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.144": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.151": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.29346.170": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar",
+        "253.30387.127": "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar"
       },
       "name": "gerry-themes"
     },
@@ -1539,11 +1539,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip"
       },
       "name": "better-direnv"
     },
@@ -1570,11 +1570,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip"
       },
       "name": "mermaid"
     },
@@ -1601,11 +1601,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip"
       },
       "name": "ferris"
     },
@@ -1632,11 +1632,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/21667/913438/code-complexity-plugin-1.6.4.zip"
       },
       "name": "code-complexity"
     },
@@ -1663,11 +1663,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip"
       },
       "name": "developer-tools"
     },
@@ -1698,8 +1698,8 @@
         "rust-rover"
       ],
       "builds": {
-        "253.29346.139": "https://plugins.jetbrains.com/files/22407/916786/intellij-rust-253.29346.139.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/22407/916786/intellij-rust-253.29346.139.zip"
+        "253.29346.139": "https://plugins.jetbrains.com/files/22407/932616/intellij-rust-253.29346.361.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/22407/932616/intellij-rust-253.29346.361.zip"
       },
       "name": "rust"
     },
@@ -1718,19 +1718,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip"
       },
       "name": "continue"
     },
@@ -1757,11 +1757,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip"
       },
       "name": "gitlab"
     },
@@ -1780,19 +1780,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip"
       },
       "name": "catppuccin-icons"
     },
@@ -1819,11 +1819,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip"
       },
       "name": "mermaid-chart"
     },
@@ -1850,11 +1850,11 @@
         "253.29346.139": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
         "253.29346.140": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
         "253.29346.141": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
         "253.29346.143": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
         "253.29346.144": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
         "253.29346.151": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip"
+        "253.29346.170": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip"
       },
       "name": "oxocarbon"
     },
@@ -1873,19 +1873,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip"
       },
       "name": "extra-ide-tweaks"
     },
@@ -1904,19 +1904,19 @@
         "webstorm"
       ],
       "builds": {
-        "252.28238.29": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "252.28238.7": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.28294.337": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.28294.432": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.138": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.139": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.140": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.141": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.142": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.143": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.144": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.151": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip",
-        "253.29346.170": "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip"
+        "252.28238.29": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "252.28238.7": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.28294.337": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.28294.432": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.138": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.139": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.140": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.141": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.143": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.144": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.151": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.29346.170": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip",
+        "253.30387.127": "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip"
       },
       "name": "extra-tools-pack"
     },
@@ -1964,25 +1964,26 @@
         "253.29346.139": null,
         "253.29346.140": null,
         "253.29346.141": null,
-        "253.29346.142": null,
         "253.29346.143": null,
         "253.29346.144": null,
         "253.29346.151": null,
-        "253.29346.170": null
+        "253.29346.170": null,
+        "253.30387.127": null
       },
       "name": "markdtask"
     }
   },
   "files": {
-    "https://plugins.jetbrains.com/files/10037/851933/intellij-csv-validator-4.1.0.zip": "sha256-jk5JisClylJCL6PdQIUC5pyKb9ccEYJl7T7AyAkAkEE=",
+    "https://plugins.jetbrains.com/files/10037/940650/intellij-csv-validator-4.2.0.zip": "sha256-g6MZdBpGOsJrwBVh/pUw39zS1746ItKA9H78wKDdQf0=",
     "https://plugins.jetbrains.com/files/10080/887330/intellij-rainbow-brackets-2025.3.6.zip": "sha256-MOW8OwMdeBKr9jsc2lWnuiRRkmbg7rSUsKbZMftKzHU=",
     "https://plugins.jetbrains.com/files/10312/581013/dotplugin-1.5.4.zip": "sha256-25vtwXuBNiYL9E0pKG4dqJDkwX1FckAErdqRPKXybQA=",
     "https://plugins.jetbrains.com/files/10481/671222/intellij-hocon-2025.1.0.zip": "sha256-GO0bXJsHx9O1A6M9NUCv9m4JwKHs5plwSssgx+InNqE=",
+    "https://plugins.jetbrains.com/files/10481/927382/intellij-hocon-2026.1.1.zip": "sha256-UepvdlZMZcL16JHnyvAZXS+5Xr/a6xZgSz4vDmJLKA0=",
     "https://plugins.jetbrains.com/files/10581/796391/go-template-252.23892.201.zip": "sha256-XKv4jEKOk2O++VdHycGoLgICsusULbWRlQ0J5p+KgAE=",
     "https://plugins.jetbrains.com/files/10581/899596/go-template-253.28294.218.zip": "sha256-L5Minmw5GvCvf2axo6+jLoQj8i8pOlW+wEz79MvrQ9g=",
-    "https://plugins.jetbrains.com/files/11058/897579/Extra_Icons-2025.1.18.zip": "sha256-/PC7wIs/zmiBGnqOtvWchFH2+QvmPNizOzNQU22vEZg=",
-    "https://plugins.jetbrains.com/files/11349/909846/aws-toolkit-jetbrains-standalone-3.100.252.zip": "sha256-OZW4FJHlwzHKcdMP2CAP0zT1F6jOYhUfivJ5gyNgrgE=",
-    "https://plugins.jetbrains.com/files/11349/909880/aws-toolkit-jetbrains-standalone-3.100.253.zip": "sha256-LqzMbEDcsFijUS+DJn1ry35ze9vfFpW+JPmynG/UreM=",
+    "https://plugins.jetbrains.com/files/11058/937839/Extra_Icons-2026.1.2.zip": "sha256-WTCjgK4L5PXgoaLqBbKe/hJ8tvgJxbPDdPRd5qENoMk=",
+    "https://plugins.jetbrains.com/files/11349/934124/aws-toolkit-jetbrains-standalone-3.102.252.zip": "sha256-lOwW3xCZ4uIm8smEb4ALcHF6saFXLFH7LcLHAziY03Q=",
+    "https://plugins.jetbrains.com/files/11349/934128/aws-toolkit-jetbrains-standalone-3.102.253.zip": "sha256-Eumob1qcXErt0nRUMW3JbJjQOLfhjBDU7hmNmninh0A=",
     "https://plugins.jetbrains.com/files/12024/899101/ReSharperPlugin.CognitiveComplexity-2025.3.0.zip": "sha256-KNhVP1oRU8qj96EK8UxafLtPWcnRdJwQXmsgmQ82Pbc=",
     "https://plugins.jetbrains.com/files/12062/796429/keymap-vscode-252.23892.201.zip": "sha256-V3Vk6UYLUSiSmypD+g0DCX1sPw3/wZqvLxFhbkTqY34=",
     "https://plugins.jetbrains.com/files/12062/899661/keymap-vscode-253.28294.218.zip": "sha256-rJI9k6Cqj89aWmTrZ6Eozf8Qv2cMdYuC3/yXBdRPwHY=",
@@ -1992,21 +1993,21 @@
     "https://plugins.jetbrains.com/files/13017/796396/keymap-visualStudio-252.23892.201.zip": "sha256-5qDjLRMNwn+1QVN8cKUYlakQ8aBRiTyGuA7se3l9BI0=",
     "https://plugins.jetbrains.com/files/13017/899665/keymap-visualStudio-253.28294.218.zip": "sha256-PFlgX7R2/mN62tQZWPaGORRHwdpGyiRAhw95ybReZCc=",
     "https://plugins.jetbrains.com/files/13308/370912/Indent_Rainbow-2.2.0-signed.zip": "sha256-eKwDE+PMtYhrGbDDZPS5cimssH+1xV4GF6RXXg/3urU=",
-    "https://plugins.jetbrains.com/files/1347/918481/scala-intellij-bin-2025.3.26.zip": "sha256-wU1DNK5m1UH/L6iAUBnm1Mfv1D/Luz4SUmnvjdf/pso=",
     "https://plugins.jetbrains.com/files/1347/918482/scala-intellij-bin-2025.2.51.zip": "sha256-VDP5+x7UcdD6Jw8rablIEpD8RWGB7LfKeDXtgTauSPA=",
+    "https://plugins.jetbrains.com/files/1347/943891/scala-intellij-bin-2025.3.28.zip": "sha256-2s2xmbSaL1OzObeXMipdc3HEaJRgoQk6leLUrs6mUOc=",
     "https://plugins.jetbrains.com/files/14004/796340/protoeditor-252.23892.201.zip": "sha256-WK9ukN6g2tCmeljFXwv3F+xFI/VZKlIeFs8DXqPcIKA=",
     "https://plugins.jetbrains.com/files/14004/899609/protoeditor-253.28294.218.zip": "sha256-XFngadW3SnrxxO4BYogZZfsMjjEu4MBLSmF5Wm9ETrk=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/14708/475401/MarioProgressBar-1.9.jar": "sha256-mB09zvUg1hLXl9lgW1NEU+DyVel1utZv6s+mFykckYY=",
     "https://plugins.jetbrains.com/files/15976/851109/IDEA_Which-Key-0.11.2.jar": "sha256-Qujmu2j8nrgkbsRc+ei/musrNAI1UPC3vhwIjv53zxY=",
     "https://plugins.jetbrains.com/files/164/835262/IdeaVIM-2.27.2.zip": "sha256-upipz12aBnfW5I+IpO7FFmrSyQNTqNWxYn4Bghu4LV4=",
-    "https://plugins.jetbrains.com/files/164/909533/IdeaVIM-2.28.0.zip": "sha256-gbldn7jiZTo/U6/jzXUuLjOE/CZfhLV1WPGmydeFM+4=",
-    "https://plugins.jetbrains.com/files/16604/897519/Extra_ToolWindow_Colorful_Icons_Subscription-2025.1.16.zip": "sha256-UvUbaEH7qa7mCvSbj69np3WMu0J+tjiHSrv1hn81lPo=",
-    "https://plugins.jetbrains.com/files/17718/911423/github-copilot-intellij-1.5.62-243.zip": "sha256-wko62wGlm1yAnNQ3wDJV2QTf/R5TJHmrqNHFDyY/cIY=",
+    "https://plugins.jetbrains.com/files/164/948739/IdeaVIM-2.29.0.zip": "sha256-8aSvrmyLOnHt2s/9KIeiVSRhOhVIXkZ8/1aBbvmKcWQ=",
+    "https://plugins.jetbrains.com/files/16604/937837/Extra_ToolWindow_Colorful_Icons_Subscription-2026.1.2.zip": "sha256-EndOcECQl1W3G7JnTCD0UcKt5OxbFsSCbzZ1+dLoJow=",
+    "https://plugins.jetbrains.com/files/17718/949506/github-copilot-intellij-1.5.64-243.zip": "sha256-ZVFOggoRj1Qy0yF6DKg+2FvqIueJa84YvFPoGxBgg4c=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
-    "https://plugins.jetbrains.com/files/18682/864736/Catppuccin_Theme-3.5.2.zip": "sha256-F37RoWSV96ofEw7ckvhSS4nHaXUJOBuWecEhzaH2Zk4=",
+    "https://plugins.jetbrains.com/files/18682/950662/Catppuccin_Theme-3.5.3.zip": "sha256-is29oJbJo8q0cZUQ4L8Q6pUNcIaYDogglOeOqRCQyDg=",
     "https://plugins.jetbrains.com/files/18824/916605/CodeGlancePro-2.0.2-signed.zip": "sha256-ht7dEijHexQYEGNuoVjEAMZCDGXt8xlN5zjKnttdJyA=",
-    "https://plugins.jetbrains.com/files/18922/913174/GerryThemes.jar": "sha256-ZsIniBwGy/8QRDgGa1NlFiI4DYyC53gnz/FRThsZkfE=",
+    "https://plugins.jetbrains.com/files/18922/953827/GerryThemes.jar": "sha256-3bXs8JkMVevtzDCUysxOKw5Io3IblKpU0BAZs3N/bCw=",
     "https://plugins.jetbrains.com/files/19275/355572/better_direnv-1.2.2-signed.zip": "sha256-hoFfIid7lClHDiT+ZH3H+tFSvWYb1tSRZH1iif+kWrM=",
     "https://plugins.jetbrains.com/files/20146/811306/Mermaid-0.0.26_IJ.252.zip": "sha256-QTh77pyi4lh7V0DGPFx9kERjFCop219d76wTDwD0SYY=",
     "https://plugins.jetbrains.com/files/21551/323564/ferris-2021.1.zip": "sha256-N66Bh0AwHmg5N9PNguRAGtpJ/dLMWMp3rxjTgz9poFo=",
@@ -2016,21 +2017,22 @@
     "https://plugins.jetbrains.com/files/21904/744652/intellij-developer-tools-plugin-7.1.0-signed.zip": "sha256-lOPUSxlbgagD0SuXTw+fEdwTxxfUHP1Kl6L+u/oa4fs=",
     "https://plugins.jetbrains.com/files/21962/899641/clouds-docker-gateway-253.28294.218.zip": "sha256-qrcvzWEQ9GgnePriIFwdcEDJcCQhz2bjJz1OjomGfkc=",
     "https://plugins.jetbrains.com/files/21962/915488/clouds-docker-gateway-253.29346.125.zip": "sha256-+eNO/llnAOUng1SmMOOi2gd6BvX277tmYwl9rsivOQo=",
-    "https://plugins.jetbrains.com/files/22407/916786/intellij-rust-253.29346.139.zip": "sha256-If2aX+tJmUycqVu909AMOrTrUJD80O7kAN5dMlr3TIg=",
-    "https://plugins.jetbrains.com/files/22707/896158/continue-intellij-extension-1.0.55.zip": "sha256-4nfUc4ftZB5aQO3gHB+D6HYIyDetqOs9S/W4cdai9ZU=",
+    "https://plugins.jetbrains.com/files/22407/932616/intellij-rust-253.29346.361.zip": "sha256-YxW8Rpy/wLRz6oPG/d4GI0xgPYYlo2R+EG+PBWVa+5A=",
+    "https://plugins.jetbrains.com/files/22707/941688/continue-intellij-extension-1.0.59.zip": "sha256-rv0DiHRZxxnzCR4krJs04yPW/SRVNFPQX3XSwdQ9E/g=",
     "https://plugins.jetbrains.com/files/22857/903121/vcs-gitlab-IU-252.28238.33-IU.zip": "sha256-OFwBVKhRgxBlNpvDJU/L5rGzuDClFKEkrhpH7g6mY+4=",
     "https://plugins.jetbrains.com/files/22857/907468/vcs-gitlab-253.28294.325.zip": "sha256-E1WbqzQGk3hnasxS+m85r7eHI+QUzRoAZb1OWhMrRbI=",
     "https://plugins.jetbrains.com/files/22857/911693/vcs-gitlab-253.29346.50.zip": "sha256-sE+KZViUfMH2s32RrOD2jvFvTxK/pZlx0gMSIT6I2dk=",
-    "https://plugins.jetbrains.com/files/23029/876768/Catppuccin_Icons-1.13.0.zip": "sha256-fE0M8jYTYVIC0bbBDY9fWB+mgGcVIFkeee0VTAMXt2E=",
+    "https://plugins.jetbrains.com/files/23029/950679/Catppuccin_Icons-1.13.1.zip": "sha256-x/4vJKI+Y8LKWhYC7lx73zIAWwppT5Qma+GU/Pb9iYg=",
     "https://plugins.jetbrains.com/files/23043/635877/MermaidChart-1.1.8.zip": "sha256-ssaSY1I6FopLBgVKHUyjBrqzxHLSuI/swtDfQWJ7gxU=",
     "https://plugins.jetbrains.com/files/23806/904375/Oxocarbon-1.4.8.zip": "sha256-9Wg9In1YeoeIg//jJy1GXEeziFPusKPLMZlIHbFioL0=",
-    "https://plugins.jetbrains.com/files/23927/897514/Extra_IDE_Tweaks_Subscription-2025.1.15.zip": "sha256-xH4x7QdOfEJEDDTfioz8oKCRJ1KFk0X2jRhlEiFV5+Y=",
-    "https://plugins.jetbrains.com/files/24559/897580/Extra_Tools_Pack-2025.1.20.zip": "sha256-/7NpzC+WSlbWNvenqp761LFJVMAcxMw3esVct0s2Y+8=",
+    "https://plugins.jetbrains.com/files/23927/940548/Extra_IDE_Tweaks_Subscription-2026.1.3.zip": "sha256-qbZmQAXsdmzy+ip+CReQDFGUf0RczfssF7sHeZwEEik=",
+    "https://plugins.jetbrains.com/files/24559/940550/Extra_Tools_Pack-2026.1.3.zip": "sha256-Ak+6D/P4Q7QaCozcouOGwR/d4vZXZM2HmJP+yKzUDNU=",
     "https://plugins.jetbrains.com/files/6884/796395/handlebars-252.23892.201.zip": "sha256-iWKLgk+eWhUmv/lH9+B2HI97d++EYvLwGgtRsJf4aSE=",
     "https://plugins.jetbrains.com/files/6884/899695/handlebars-253.28294.218.zip": "sha256-cBlLj/EjQlntN/tlY+yw+Yp0rxNrQSm8D9+N/gE6+II=",
     "https://plugins.jetbrains.com/files/6954/896608/Kotlin-252.28238.7-IJ.zip": "sha256-ou7v0fFwJiRMCNyQkxcRC3M7bDR0EsXQVXB7vwebtIM=",
     "https://plugins.jetbrains.com/files/6954/907470/Kotlin-253.28294.325-IJ.zip": "sha256-WY8wyDU1Vl9hJbD3+ZNIohh6/iHAI2T2Hxuo/zsWACA=",
     "https://plugins.jetbrains.com/files/6954/911712/Kotlin-253.29346.50-IJ.zip": "sha256-Lq58RIC1Qrt+6OOTDcXRPVjdpNSR2+kuqHLVBgVRG1M=",
+    "https://plugins.jetbrains.com/files/6954/939222/Kotlin-253.30387.90-IJ.zip": "sha256-sPNGOc6m2uA2uY7jSNxoaqqOFEnrSKTJ4r8MHlK1zXM=",
     "https://plugins.jetbrains.com/files/6981/897159/ini-252.28238.10.zip": "sha256-29ARoz8vHdMjjbv+yxvbzY2/LLbJ6GWwwMjaNT2P2cI=",
     "https://plugins.jetbrains.com/files/6981/905873/ini-253.28294.259.zip": "sha256-x8lC/XCddoW3W3etNACfAakEopCkku1Nj5u0G92XQ2Q=",
     "https://plugins.jetbrains.com/files/7086/738977/AceJump.zip": "sha256-BW47ZEUINVnhV0RZ1np7Dkf3lfyrtKoZ9ej/SVct2Xs=",
@@ -2040,19 +2042,22 @@
     "https://plugins.jetbrains.com/files/7179/922461/MavenHelper-5.0.0-IJ2025.1.zip": "sha256-YNk/opJGeKqxk4/f9MPFzrCrXnOXASi5zUEROi68LZk=",
     "https://plugins.jetbrains.com/files/7212/896606/cucumber-java-252.28238.7.zip": "sha256-yudu3+5U30RpvSW3k/1hlosM+p9tpat/DTMz7ZP78/c=",
     "https://plugins.jetbrains.com/files/7212/902600/cucumber-java-253.28294.251.zip": "sha256-2OA+5HIBQaWDrINu+GpEzZIUQmGO/ShMxQkdjLNWlBI=",
-    "https://plugins.jetbrains.com/files/7219/911329/Symfony_Plugin-2025.1.282.zip": "sha256-kw/cDYuDQJGh3Mop/tXnWl7TuOl8gO4h2rMB8GWJ9Lk=",
+    "https://plugins.jetbrains.com/files/7212/932646/cucumber-java-253.30387.20.zip": "sha256-KeyBSwDj41M9ed9TOx5OO++NwSXjRYv+sP0ox0HWv8E=",
+    "https://plugins.jetbrains.com/files/7219/941667/Symfony_Plugin-2026.1.286.zip": "sha256-pO4GGc3MYRsyGscbLs9Z3eh9DLLlgTpA6dCTP8T247w=",
     "https://plugins.jetbrains.com/files/7320/909205/PHP_Annotations-12.0.2.zip": "sha256-ntG2JdHcGLijDdYCKUsfQgEvvq7ft0qrB3+3C73Lw8U=",
     "https://plugins.jetbrains.com/files/7322/896612/python-ce-252.28238.7.zip": "sha256-yiKr/0dJWFn4nZoaKEUUsGzFif63DX3j8mpAvujDbGQ=",
     "https://plugins.jetbrains.com/files/7322/908768/python-ce-253.28294.334.zip": "sha256-cJhsssxkD4KEZD+HofJ9Um2PPCRFym19/JfRGa1rTCI=",
-    "https://plugins.jetbrains.com/files/7322/915705/python-ce-253.29346.138.zip": "sha256-3GnoA5rpdvqYf9bxn07Q6nicVXFYaDK4CTdm8YUXgP8=",
+    "https://plugins.jetbrains.com/files/7322/928110/python-ce-253.29346.240.zip": "sha256-M0oLD1HFT5ep7jVIxZOSG5IEvAbq76vyXD0vJs+t3cA=",
+    "https://plugins.jetbrains.com/files/7322/939236/python-ce-253.30387.90.zip": "sha256-WITOSCKOt5ZALqXkK4cjwmylYNVe9Wx4i281GdYmM1I=",
     "https://plugins.jetbrains.com/files/7391/880448/asciidoctor-intellij-plugin-0.44.10.zip": "sha256-k2nL2OupoiqQHkLAauo/bLJ2hQ5HVAXrGEQMkVel0eE=",
-    "https://plugins.jetbrains.com/files/7391/922666/asciidoctor-intellij-plugin-0.45.2.zip": "sha256-vYfiMVZCkE4f5R0HbicY9NKWlY9pGcjc+9qvf2Eyjzo=",
+    "https://plugins.jetbrains.com/files/7391/924106/asciidoctor-intellij-plugin-0.45.3.zip": "sha256-CKdJiXc5EN5lyJIeuj1TQE6kgqKGER9QW8PTf9QZh6Q=",
     "https://plugins.jetbrains.com/files/7425/760442/WakaTime.jar": "sha256-DobKZKokueqq0z75d2Fo3BD8mWX9+LpGdT9C7Eu2fHc=",
     "https://plugins.jetbrains.com/files/7499/883982/gittoolbox-600.1.13_243-signed.zip": "sha256-GJfaRzhKVqXK1boiqUi6TDfPIJ8YymG/vqbY3jau5sI=",
-    "https://plugins.jetbrains.com/files/7499/910684/gittoolbox-600.2.1_253-signed.zip": "sha256-49nmyhcCTR55JNF6xr6Xc9xZf+M9xlegrlXeLchUU0M=",
+    "https://plugins.jetbrains.com/files/7499/942219/gittoolbox-600.2.2_253-signed.zip": "sha256-myGeT+v5U7iLBw9PjH4hQ4omge9e7OTJNPjZm/SRePc=",
     "https://plugins.jetbrains.com/files/7724/903124/clouds-docker-impl-252.28238.33.zip": "sha256-fhilgn6yBEgcUzTnXarAMTZ8n4WIKbtNZKVl/UP6rd4=",
     "https://plugins.jetbrains.com/files/7724/905864/clouds-docker-impl-253.28294.259.zip": "sha256-if3/c8ouuohfFsl2h1pMaF8K2M32XqXsvfmMaiLw5gM=",
     "https://plugins.jetbrains.com/files/7724/915492/clouds-docker-impl-253.29346.125.zip": "sha256-bUIneHULrwHnb4dqiEAuBchZhXrHfygTMkd8JXrlWwA=",
+    "https://plugins.jetbrains.com/files/7724/934041/clouds-docker-impl-253.30387.30.zip": "sha256-PVxwByxWk5o4E4pXFrf59UhJFW8vKjSWBpQMYJCzJsA=",
     "https://plugins.jetbrains.com/files/8097/827445/graphql-252.25557.23.zip": "sha256-wN3+7++f6i0MvEmOTiWZgAW1QzM5HiD7jSAMS8jWC5s=",
     "https://plugins.jetbrains.com/files/8097/899668/graphql-253.28294.218.zip": "sha256-DJmS4fPsP2bMtfcl8caAHW5btU8r+loLuVzkLXXyACs=",
     "https://plugins.jetbrains.com/files/8195/896664/toml-252.28238.9.zip": "sha256-/27gkG8jrj1lIaOkNMopb8G/RB1ecvgU4WJJ1iZbXjU=",
@@ -2064,9 +2069,8 @@
     "https://plugins.jetbrains.com/files/8607/786671/NixIDEA-0.4.0.18.zip": "sha256-JShheBoOBiWM9HubMUJvBn4H3DnWykvqPyrmetaCZiM=",
     "https://plugins.jetbrains.com/files/9164/827451/gherkin-252.25557.23.zip": "sha256-y66kYTYD+R9Sert2JHWGwFFIgc5UJTssZrjgvzOjljk=",
     "https://plugins.jetbrains.com/files/9164/899634/gherkin-253.28294.218.zip": "sha256-oaiOnF8IO/RrFG3d08kg3lsXp9V1M8c6eAir+XIcIS4=",
-    "https://plugins.jetbrains.com/files/9525/796325/dotenv-252.23892.201.zip": "sha256-N0DNEtF3FDcRirfjfSCCVUbDIA4SB35F/9XY1tPXXmg=",
-    "https://plugins.jetbrains.com/files/9525/909501/dotenv-253.28294.351.zip": "sha256-Qa3UEr5kIklJF1ByqJmelmfHI31i/4aEzJKWnLz4uAA=",
-    "https://plugins.jetbrains.com/files/9525/918427/dotenv-253.29346.157.zip": "sha256-KqCZc2jzxfS6/z193jJipGd2TaTlqk2hmm+CBAYISKk=",
+    "https://plugins.jetbrains.com/files/9525/932605/dotenv-253.29346.379.zip": "sha256-PGIeXCZChYRvj6YXY75J4N9HlRm2JYYuCNrz5yjHJ64=",
+    "https://plugins.jetbrains.com/files/9525/952937/dotenv-253.30387.193.zip": "sha256-47XUN1BH1Oe4Kks37jzs8Rwxd3RuIehRzeFBGajB9e0=",
     "https://plugins.jetbrains.com/files/9568/902520/go-plugin-253.28294.251.zip": "sha256-d0MAjfOm+B9u/LRldc55QXnIpWrqqjlJaWhNP8rwmSY=",
     "https://plugins.jetbrains.com/files/9707/896146/ANSI_Highlighter_Premium-25.3.0.jar": "sha256-X9aLM7fhdnsDV0A5v5sEHlKQxaCb6YnjvVDe64Lz60o=",
     "https://plugins.jetbrains.com/files/9792/633158/Key_Promoter_X-2024.2.2.zip": "sha256-Mzmmq0RzMKZeKfBSo7FHvzeEtPGIrwqEDLAONQEsR1M=",

--- a/pkgs/applications/editors/jetbrains/source/pycharm_maven_artefacts.json
+++ b/pkgs/applications/editors/jetbrains/source/pycharm_maven_artefacts.json
@@ -1,903 +1,573 @@
 [
     {
-        "url": "commons-io/commons-io/2.18.0/commons-io-2.18.0.jar",
-        "hash": "f3ca0f8d63c40e23a56d54101c60d5edee136b42d84bfb85bc7963093109cf8b",
-        "path": "commons-io/commons-io/2.18.0/commons-io-2.18.0.jar"
+        "url": "ai/grazie/api/api-gateway-api-jvm/0.8.74/api-gateway-api-jvm-0.8.74.jar",
+        "hash": "9a9575297ed98677e19883b1b2d2169161d8330559c1d2971f73ce75ffae8f05",
+        "path": "ai/grazie/api/api-gateway-api-jvm/0.8.74/api-gateway-api-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar",
-        "hash": "61cd5eee5367d10e0cca664afdc4bbde2ff7aab9c175c5b520aac8b5315d874d",
-        "path": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar"
+        "url": "ai/grazie/api/api-gateway-client-jvm/0.8.74/api-gateway-client-jvm-0.8.74.jar",
+        "hash": "6eed4b225d44e13090f8c59716ac9207be07cadb6b0733da613365f839495540",
+        "path": "ai/grazie/api/api-gateway-client-jvm/0.8.74/api-gateway-client-jvm-0.8.74.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar",
-        "hash": "095e5d11868ae359bd640c922c2d1ed7a20ba519496599ee697e81c468761339",
-        "path": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar"
+        "url": "ai/grazie/auth/auth-model-jvm/0.8.74/auth-model-jvm-0.8.74.jar",
+        "hash": "e739417d466e9ec195d34eaaa1d81df93c4229051dcf9045a961114d0a102cd1",
+        "path": "ai/grazie/auth/auth-model-jvm/0.8.74/auth-model-jvm-0.8.74.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar",
-        "hash": "e88a667c25b8ebb7c81f76dd96cb34ea804754752b5533a842b99d0daea2be99",
-        "path": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar"
+        "url": "ai/grazie/auth/gec-agg-model-public-jvm/0.8.74/gec-agg-model-public-jvm-0.8.74.jar",
+        "hash": "760adbd5039f1c119f309d14b62b20ccd436f65192548fd00b17faedc62708bf",
+        "path": "ai/grazie/auth/gec-agg-model-public-jvm/0.8.74/gec-agg-model-public-jvm-0.8.74.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar",
-        "hash": "6086acf1d65bca24de344b493e3fc241f0db2b25fa0606057eee39e3a2264737",
-        "path": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar"
+        "url": "ai/grazie/auth/product/auth-product-model-jvm/0.8.74/auth-product-model-jvm-0.8.74.jar",
+        "hash": "353f0f34ac89b4138da9d2548e2c036b7ede13cb3eeb2d861db65fdbcb909550",
+        "path": "ai/grazie/auth/product/auth-product-model-jvm/0.8.74/auth-product-model-jvm-0.8.74.jar"
     },
     {
-        "url": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar",
-        "hash": "dd9a13ba6b0803040b6fea56b6db66bc9c4f31dacf678dac642aaaff8d88a543",
-        "path": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar"
+        "url": "ai/grazie/client/client-attribute-jvm/0.8.74/client-attribute-jvm-0.8.74.jar",
+        "hash": "9fbfe9aadb29ecaa362915ae65fab0b14ad502ec1b9be952386939f24a73073c",
+        "path": "ai/grazie/client/client-attribute-jvm/0.8.74/client-attribute-jvm-0.8.74.jar"
     },
     {
-        "url": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar",
-        "hash": "c74a6c72221dfb76eb92f2bb40108ea561a7da2f315dc3b1e64afa8f077f210c",
-        "path": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar"
+        "url": "ai/grazie/client/client-common-jvm/0.8.74/client-common-jvm-0.8.74.jar",
+        "hash": "977c6aa3684410a21179b8a531576f53003e2d90d3cf72429685420e3aba3f3e",
+        "path": "ai/grazie/client/client-common-jvm/0.8.74/client-common-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/studio-test-platform/2025.1.2-287/studio-test-platform-2025.1.2-287.jar",
-        "hash": "146d8ebb454cccee149a81cc47026b6a576953aeb811f2ef6979bb44a5e4b50f",
-        "path": "org/jetbrains/intellij/deps/studio-test-platform/2025.1.2-287/studio-test-platform-2025.1.2-287.jar"
+        "url": "ai/grazie/client/client-ktor-jvm/0.8.74/client-ktor-jvm-0.8.74.jar",
+        "hash": "71ee5cf5122c33ef949228389350efa77de54ec29af603e33a4c0f4289bac393",
+        "path": "ai/grazie/client/client-ktor-jvm/0.8.74/client-ktor-jvm-0.8.74.jar"
     },
     {
-        "url": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar",
-        "hash": "8b94840d71ad0caa36b3309425b2d23084bc8788ce84d71f2d805b0fc84d1f5a",
-        "path": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar"
+        "url": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar",
+        "hash": "54b321650a50f78ceee6bd06653ee3cea0b19db5fe95e3c3a109e6af4a20126c",
+        "path": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar"
     },
     {
-        "url": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar",
-        "hash": "88ed8e730f7386297485176c4387146c6914a38c0e58fc296e8a01cdc3b621e1",
-        "path": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar"
+        "url": "ai/grazie/indexing/indexing-server-api-jvm/0.8.74/indexing-server-api-jvm-0.8.74.jar",
+        "hash": "0d7c04d58f97c28976f2d17e01418cf5fa147d0b037e4165e9cd1c5f47b02979",
+        "path": "ai/grazie/indexing/indexing-server-api-jvm/0.8.74/indexing-server-api-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jline/jline-terminal-jna/3.27.0/jline-terminal-jna-3.27.0.jar",
-        "hash": "e7322e6d8dc1bd69f507b91865af741af4a95c649ccab36e79e8be89696bb432",
-        "path": "org/jline/jline-terminal-jna/3.27.0/jline-terminal-jna-3.27.0.jar"
+        "url": "ai/grazie/llm/llm-agg-api-model-jvm/0.8.74/llm-agg-api-model-jvm-0.8.74.jar",
+        "hash": "a7c8db405963faeaad887598ecedddc5a5fd2a7372eb3e07db2d79964f8e5bf9",
+        "path": "ai/grazie/llm/llm-agg-api-model-jvm/0.8.74/llm-agg-api-model-jvm-0.8.74.jar"
     },
     {
-        "url": "net/java/dev/jna/jna/5.15.0/jna-5.15.0.jar",
-        "hash": "a564158d28ab5127fc6a958028ed54279fe0999662c46425b6a3b09a2a52094d",
-        "path": "net/java/dev/jna/jna/5.15.0/jna-5.15.0.jar"
+        "url": "ai/grazie/model/model-auth-jvm/0.8.74/model-auth-jvm-0.8.74.jar",
+        "hash": "1c009c97c5fc005f2337871a0558c716cb0f4e07d0bc37b025c2d537deffef9e",
+        "path": "ai/grazie/model/model-auth-jvm/0.8.74/model-auth-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
-        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
-        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
+        "url": "ai/grazie/model/model-bdg-jvm/0.8.74/model-bdg-jvm-0.8.74.jar",
+        "hash": "85c23a42fef7bf9db650a1595b0a56d99acddde7dd5ff1f1e027731ad5373944",
+        "path": "ai/grazie/model/model-bdg-jvm/0.8.74/model-bdg-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
-        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
-        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
+        "url": "ai/grazie/model/model-chat-jvm/0.8.74/model-chat-jvm-0.8.74.jar",
+        "hash": "723c27f8880afb15a6bd8629d0ee1fd3847872670f4d215f05ddc15e10616474",
+        "path": "ai/grazie/model/model-chat-jvm/0.8.74/model-chat-jvm-0.8.74.jar"
     },
     {
-        "url": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar",
-        "hash": "3acf3de882ec2c714dfc173cc382c38a5aee70c3f2bdda732583916845226d0c",
-        "path": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar"
+        "url": "ai/grazie/model/model-cloud-jvm/0.8.74/model-cloud-jvm-0.8.74.jar",
+        "hash": "93aa91ddea2263dfe7da7f376afab7282e32d0caefc9f27318f3d9ca87dd3d84",
+        "path": "ai/grazie/model/model-cloud-jvm/0.8.74/model-cloud-jvm-0.8.74.jar"
     },
     {
-        "url": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar",
-        "hash": "9977d913ef1fccf2e2663b5906d955fdf8215d0ec48265d669b01e05179e2043",
-        "path": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar"
+        "url": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar",
+        "hash": "d9c0813e00ff06888f30008098a3938a348863ee65c0b7f9a6aa524bb10982bf",
+        "path": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar"
     },
     {
-        "url": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar",
-        "hash": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
-        "path": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+        "url": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar",
+        "hash": "d9c0813e00ff06888f30008098a3938a348863ee65c0b7f9a6aa524bb10982bf",
+        "path": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar"
     },
     {
-        "url": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar",
-        "hash": "a2a4d02b86b2e849e514d18dbdf4b29e2e9d091e3c6f4d9d028db9cdc55dd28b",
-        "path": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar"
+        "url": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar",
+        "hash": "d9c0813e00ff06888f30008098a3938a348863ee65c0b7f9a6aa524bb10982bf",
+        "path": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar"
     },
     {
-        "url": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar",
-        "hash": "8b1c3e582e2f6f662261f3f45a6d723f3dd8d8b2b0b86a3f7d8e6c966eca0568",
-        "path": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar"
+        "url": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar",
+        "hash": "d9c0813e00ff06888f30008098a3938a348863ee65c0b7f9a6aa524bb10982bf",
+        "path": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar"
     },
     {
-        "url": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar",
-        "hash": "4c7517e848a71b36d069d12bb3bf46a70fd4cda3105d822b0ed2e19c00b69291",
-        "path": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar"
+        "url": "ai/grazie/model/model-def-jvm/0.8.74/model-def-jvm-0.8.74.jar",
+        "hash": "d79871ceab86ee827ee1f1f069ffccb5da3fba05b7cd9829b4deca5936126fef",
+        "path": "ai/grazie/model/model-def-jvm/0.8.74/model-def-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar",
-        "hash": "02e0f9bf95e4b9f81e34593691a5c0ff14604db39fb8446fe9a4efa66553f3ac",
-        "path": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar"
+        "url": "ai/grazie/model/model-def-jvm/0.8.74/model-def-jvm-0.8.74.jar",
+        "hash": "d79871ceab86ee827ee1f1f069ffccb5da3fba05b7cd9829b4deca5936126fef",
+        "path": "ai/grazie/model/model-def-jvm/0.8.74/model-def-jvm-0.8.74.jar"
     },
     {
-        "url": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar",
-        "hash": "e36445438d72d83cc48015dcb3f14d9a97eaa42c4663a9826db2bb50e4c7713b",
-        "path": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar"
+        "url": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar",
+        "hash": "fd646112e2bb2bb16527397946016a17e269a27095d0c7343a8f154b83db9d0a",
+        "path": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar"
     },
     {
-        "url": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar",
-        "hash": "8328289ba6b73445e982a1cadf8e651ea65354e288c825a43e7c77f16da8a056",
-        "path": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar"
+        "url": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar",
+        "hash": "fd646112e2bb2bb16527397946016a17e269a27095d0c7343a8f154b83db9d0a",
+        "path": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar"
     },
     {
-        "url": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar",
-        "hash": "b7df6cbcc30b7a3219f06483a9a9d320a431beda8a1ace5b16d879f84112373f",
-        "path": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar"
+        "url": "ai/grazie/model/model-feedback-jvm/0.8.74/model-feedback-jvm-0.8.74.jar",
+        "hash": "8dc12eeacf0a1eb33623fc30c0d4c4eda6e89dd06cdf35afa5ce412204dfa6d8",
+        "path": "ai/grazie/model/model-feedback-jvm/0.8.74/model-feedback-jvm-0.8.74.jar"
     },
     {
-        "url": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar",
-        "hash": "c5fb188895ffdfd529473c5e7ba1c58da2f514a44134b15ad0d51efe3f28bb38",
-        "path": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar"
+        "url": "ai/grazie/model/model-gateway-jvm/0.8.74/model-gateway-jvm-0.8.74.jar",
+        "hash": "5a9bf64cb860e143c5cf7c0e7eec5630de583807ec9a9c41bdaa80caceede255",
+        "path": "ai/grazie/model/model-gateway-jvm/0.8.74/model-gateway-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-45/kotlin-build-common-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "c5d0331fb960fbb5e392118d1322e905f37be1b0b0abd6121d06caade7cc9b16",
-        "path": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-45/kotlin-build-common-tests-for-ide-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/model/model-gec-jvm/0.8.74/model-gec-jvm-0.8.74.jar",
+        "hash": "99cac5b6a3d8cd6e32333bb88c1aead22c7360a1471ea4a546425b822546f57f",
+        "path": "ai/grazie/model/model-gec-jvm/0.8.74/model-gec-jvm-0.8.74.jar"
     },
     {
-        "url": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar",
-        "hash": "11cc5e7b75b23feb65e41e28e5c225b4a77dbf7210d6cedd4bdb3f04c1f6ea24",
-        "path": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar"
+        "url": "ai/grazie/model/model-gec-jvm/0.8.74/model-gec-jvm-0.8.74.jar",
+        "hash": "99cac5b6a3d8cd6e32333bb88c1aead22c7360a1471ea4a546425b822546f57f",
+        "path": "ai/grazie/model/model-gec-jvm/0.8.74/model-gec-jvm-0.8.74.jar"
     },
     {
-        "url": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar",
-        "hash": "85f2a329245e4a6a1e4552ac62db4c1f23b6f02bf3c96e4df8240668187c848a",
-        "path": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar"
+        "url": "ai/grazie/model/model-indexing-jvm/0.8.74/model-indexing-jvm-0.8.74.jar",
+        "hash": "664721a747bad766340aed882e265f01be3575a4d4800b003df35cbd9c698f6c",
+        "path": "ai/grazie/model/model-indexing-jvm/0.8.74/model-indexing-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar",
-        "hash": "4ac10d8fb7e6326e09179fd83e664610a3362dc1d661fb32e5b2a19bcb9fc867",
-        "path": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar"
+        "url": "ai/grazie/model/model-jet-jvm/0.8.74/model-jet-jvm-0.8.74.jar",
+        "hash": "60e534c0ccb4ef8fd7869829ec7bf63682b5db4464d9712fcf57278a8981f861",
+        "path": "ai/grazie/model/model-jet-jvm/0.8.74/model-jet-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-45/analysis-api-fe10-for-ide-2.3.20-ij253-45.jar",
-        "hash": "cbf24708e46c2e064a37887d5b53d1234ba2b3c1d285ecc9ba82cb6152076297",
-        "path": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-45/analysis-api-fe10-for-ide-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/model/model-license-jvm/0.8.74/model-license-jvm-0.8.74.jar",
+        "hash": "24b83bb28bb549d1dc44776bae33bf78e77f73f27de999ddfde8c1ff90c9ac62",
+        "path": "ai/grazie/model/model-license-jvm/0.8.74/model-license-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-45/symbol-light-classes-for-ide-2.3.20-ij253-45.jar",
-        "hash": "298e61756dab332adc36712f14803e47f65f114f736c41cace04eaef2cce380e",
-        "path": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-45/symbol-light-classes-for-ide-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/model/model-llm-jvm/0.8.74/model-llm-jvm-0.8.74.jar",
+        "hash": "0d6a157b67003c8ec2bc94977b938bb78344bb8fdb3d14e54e80e8e48011845b",
+        "path": "ai/grazie/model/model-llm-jvm/0.8.74/model-llm-jvm-0.8.74.jar"
     },
     {
-        "url": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar",
-        "hash": "74deb86cbab6871a3e4d0f97ba8eacbdae7aacd7537f142bcb083590465a6219",
-        "path": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar"
+        "url": "ai/grazie/model/model-ner-jvm/0.8.74/model-ner-jvm-0.8.74.jar",
+        "hash": "f2c12ec41507a192df5740a91ef004b6587e7a3d542741d010ff099ff523246f",
+        "path": "ai/grazie/model/model-ner-jvm/0.8.74/model-ner-jvm-0.8.74.jar"
     },
     {
-        "url": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar",
-        "hash": "d01d6ce85f9824d8ddb22ea7f1bccd581b831ffad504f48a4f18abf9bc6f2eac",
-        "path": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar"
+        "url": "ai/grazie/model/model-ner-jvm/0.8.74/model-ner-jvm-0.8.74.jar",
+        "hash": "f2c12ec41507a192df5740a91ef004b6587e7a3d542741d010ff099ff523246f",
+        "path": "ai/grazie/model/model-ner-jvm/0.8.74/model-ner-jvm-0.8.74.jar"
     },
     {
-        "url": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar",
-        "hash": "9f78e9988e84c98569edcf9a6225d5b7354939529642e54c2c58da3ef3913106",
-        "path": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar"
+        "url": "ai/grazie/model/model-nlc-jvm/0.8.74/model-nlc-jvm-0.8.74.jar",
+        "hash": "84f506f92fa7f48e222215ce53ad898aa2f37f5df154a0679c3750976bac001b",
+        "path": "ai/grazie/model/model-nlc-jvm/0.8.74/model-nlc-jvm-0.8.74.jar"
     },
     {
-        "url": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar",
-        "hash": "a919a8fec03dfb0c084cb43dafcebe2dd9351431c7a08c2fc8147037de1d06b7",
-        "path": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar"
+        "url": "ai/grazie/model/model-nlp-jvm/0.8.74/model-nlp-jvm-0.8.74.jar",
+        "hash": "223ac217288d7e4b74831fe64c749e32ff1d21cb92eccd88305dbebe6225c892",
+        "path": "ai/grazie/model/model-nlp-jvm/0.8.74/model-nlp-jvm-0.8.74.jar"
     },
     {
-        "url": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar",
-        "hash": "060fffe7452e74f6e18bb9dfe1221e92c4ec0de29a84b022fb562ec6cd954691",
-        "path": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar"
+        "url": "ai/grazie/model/model-nmt-jvm/0.8.74/model-nmt-jvm-0.8.74.jar",
+        "hash": "ee74b094dcd48b6d7208a16ecc9e187092e476525f95c61b9ab4810e99afa269",
+        "path": "ai/grazie/model/model-nmt-jvm/0.8.74/model-nmt-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar",
-        "hash": "fa31a084adbecaaf98166e734fba1bf964e04e22671d70230ed9598cecd22124",
-        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar"
+        "url": "ai/grazie/model/model-qa-jvm/0.8.74/model-qa-jvm-0.8.74.jar",
+        "hash": "a6b0363ec58de48f81d1bf9676c2a6680f68468e9eb2ad80c254a450b6f14067",
+        "path": "ai/grazie/model/model-qa-jvm/0.8.74/model-qa-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
-        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
-        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-quota-jvm/0.8.74/model-quota-jvm-0.8.74.jar",
+        "hash": "9c09d3e2744c71e6130126cc25cbe0cdf6331db8c5f7dd8f169c7bf9ce96ca46",
+        "path": "ai/grazie/model/model-quota-jvm/0.8.74/model-quota-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
-        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
-        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-sum-jvm/0.8.74/model-sum-jvm-0.8.74.jar",
+        "hash": "dfaa447742d8ab05cd0ce37da42bcf4a456020a26f53c8baa00ee95c8eae10a9",
+        "path": "ai/grazie/model/model-sum-jvm/0.8.74/model-sum-jvm-0.8.74.jar"
     },
     {
-        "url": "com/typesafe/config/1.4.3/config-1.4.3.jar",
-        "hash": "8ada4c185ce72416712d63e0b5afdc5f009c0cdf405e5f26efecdf156aa5dfb6",
-        "path": "com/typesafe/config/1.4.3/config-1.4.3.jar"
+        "url": "ai/grazie/model/model-syn-jvm/0.8.74/model-syn-jvm-0.8.74.jar",
+        "hash": "26a2de7cd201bff5a8b0956382b59a532c1a49b3dad0ff4238721fdf42250bef",
+        "path": "ai/grazie/model/model-syn-jvm/0.8.74/model-syn-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-task-jvm/0.8.74/model-task-jvm-0.8.74.jar",
+        "hash": "4c430e83cfc99b60e509fa7a98a430625fba1c011f0d4ad105251a3c3079203d",
+        "path": "ai/grazie/model/model-task-jvm/0.8.74/model-task-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar",
+        "hash": "fa7db0b8e4cad3a8951c91d6d09c2c6baf8ae9008b0b59d76158cf2282797caa",
+        "path": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar",
+        "hash": "fa7db0b8e4cad3a8951c91d6d09c2c6baf8ae9008b0b59d76158cf2282797caa",
+        "path": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar",
+        "hash": "fa7db0b8e4cad3a8951c91d6d09c2c6baf8ae9008b0b59d76158cf2282797caa",
+        "path": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-tone-formality-jvm/0.8.74/model-tone-formality-jvm-0.8.74.jar",
+        "hash": "5596f5406cc20b0f0eb1a95733a39924eff44d443bc9b9d49687268d636f59d0",
+        "path": "ai/grazie/model/model-tone-formality-jvm/0.8.74/model-tone-formality-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-tree-jvm/0.8.74/model-tree-jvm-0.8.74.jar",
+        "hash": "ed6ca179c61ad44fd3a0b0401f6f25bfef680e3a3e704e83249ce5c26dc1a505",
+        "path": "ai/grazie/model/model-tree-jvm/0.8.74/model-tree-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/model-tree-jvm/0.8.74/model-tree-jvm-0.8.74.jar",
+        "hash": "ed6ca179c61ad44fd3a0b0401f6f25bfef680e3a3e704e83249ce5c26dc1a505",
+        "path": "ai/grazie/model/model-tree-jvm/0.8.74/model-tree-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
-        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
-        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+        "url": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar",
+        "hash": "e3c8ebc2e1d06fd9efece9fed214d80e16416b6630567d891e200dcad2f07144",
+        "path": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar"
     },
     {
-        "url": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar",
-        "hash": "ceda311f476c3b18e1d2b240c94e2dcb9c8d44e70f8afa9facab88bac4ddc03a",
-        "path": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar"
+        "url": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar",
+        "hash": "e3c8ebc2e1d06fd9efece9fed214d80e16416b6630567d891e200dcad2f07144",
+        "path": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar"
     },
     {
-        "url": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar",
-        "hash": "ead60e9cac0e42b57092b9e2d087ff43536e9477d4486ba393037a8cc156cda7",
-        "path": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar"
+        "url": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar",
+        "hash": "e3c8ebc2e1d06fd9efece9fed214d80e16416b6630567d891e200dcad2f07144",
+        "path": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar"
     },
     {
-        "url": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar",
-        "hash": "e465ab42d9c79cdec7147c8210f8e65d5f816704d47b959ac9f2cfc3f68dedb5",
-        "path": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar"
+        "url": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar",
+        "hash": "e3c8ebc2e1d06fd9efece9fed214d80e16416b6630567d891e200dcad2f07144",
+        "path": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar"
     },
     {
-        "url": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar",
-        "hash": "0a7e032bf5bcdd5b2bf8bf2e5cf02c5646f2aa6fee66933b8150dbe84e651e8a",
-        "path": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar"
+        "url": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar",
+        "hash": "fae2d16393c9b42f5808021204f0989a27c825a72128eef943e9ebe1702d5ea1",
+        "path": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar"
     },
     {
-        "url": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar",
-        "hash": "89b1360f407381bf61fde411019d8cbd009ebb10cff715f3669017a031027560",
-        "path": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar"
+        "url": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar",
+        "hash": "fae2d16393c9b42f5808021204f0989a27c825a72128eef943e9ebe1702d5ea1",
+        "path": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar"
     },
     {
-        "url": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar",
-        "hash": "1d68dfc6ba67ec96ecb5a373dbd9fb557ce2210ffc2d74d6b528e4f1f73e7003",
-        "path": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar"
+        "url": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar",
+        "hash": "fae2d16393c9b42f5808021204f0989a27c825a72128eef943e9ebe1702d5ea1",
+        "path": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar"
     },
     {
-        "url": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar",
-        "hash": "d401243d5c6eae928a37121b6e819158c8c32ea0584793e7285bb489ab2a3d17",
-        "path": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar"
+        "url": "ai/grazie/nlp/nlp-detect-jvm/0.8.74/nlp-detect-jvm-0.8.74.jar",
+        "hash": "887f672cc8b16ad9ca2a660bcd46d32cfa5fa6a726eca23c61ff5eceaab4af35",
+        "path": "ai/grazie/nlp/nlp-detect-jvm/0.8.74/nlp-detect-jvm-0.8.74.jar"
     },
     {
-        "url": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar",
-        "hash": "c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6",
-        "path": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"
+        "url": "ai/grazie/nlp/nlp-detect-jvm/0.8.74/nlp-detect-jvm-0.8.74.jar",
+        "hash": "887f672cc8b16ad9ca2a660bcd46d32cfa5fa6a726eca23c61ff5eceaab4af35",
+        "path": "ai/grazie/nlp/nlp-detect-jvm/0.8.74/nlp-detect-jvm-0.8.74.jar"
     },
     {
-        "url": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar",
-        "hash": "6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f",
-        "path": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"
+        "url": "ai/grazie/nlp/nlp-langs-jvm/0.8.74/nlp-langs-jvm-0.8.74.jar",
+        "hash": "8619419456eb300942b819ce1046d7f6aa170efe892321a2d9e25ef7df612331",
+        "path": "ai/grazie/nlp/nlp-langs-jvm/0.8.74/nlp-langs-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar",
-        "hash": "3841d6ad1fdd4bf90143ac6012146d291409b431e837f143c023135bd24b79a6",
-        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar"
+        "url": "ai/grazie/nlp/nlp-langs-jvm/0.8.74/nlp-langs-jvm-0.8.74.jar",
+        "hash": "8619419456eb300942b819ce1046d7f6aa170efe892321a2d9e25ef7df612331",
+        "path": "ai/grazie/nlp/nlp-langs-jvm/0.8.74/nlp-langs-jvm-0.8.74.jar"
     },
     {
-        "url": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar",
-        "hash": "c0c5891b390759a0cf503c7864e6eb4d8447cc8df20806a4254bfdf3d2f43a91",
-        "path": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar"
+        "url": "ai/grazie/nlp/nlp-patterns-jvm/0.8.74/nlp-patterns-jvm-0.8.74.jar",
+        "hash": "97b03ed0b5c87cb486c64b1ed6574e05be2f3331d4ac394c85f35c24cb7a0f44",
+        "path": "ai/grazie/nlp/nlp-patterns-jvm/0.8.74/nlp-patterns-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar",
-        "hash": "102764921129e1e44a74f408b7a0b8dac6d1892c6042e0e48f8bdbbbf78c6d2e",
-        "path": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar"
+        "url": "ai/grazie/nlp/nlp-patterns-jvm/0.8.74/nlp-patterns-jvm-0.8.74.jar",
+        "hash": "97b03ed0b5c87cb486c64b1ed6574e05be2f3331d4ac394c85f35c24cb7a0f44",
+        "path": "ai/grazie/nlp/nlp-patterns-jvm/0.8.74/nlp-patterns-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-45/compose-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "84612c6b067f7018325c00975bb49a35e1947d8de1c03009e999b746219105f4",
-        "path": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-45/compose-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/nlp/nlp-phonetics-jvm/0.8.74/nlp-phonetics-jvm-0.8.74.jar",
+        "hash": "ea4cd2ec177029c88ab81e3b120d2c9aacc01997dc2ecc9ada5e22de9f10d723",
+        "path": "ai/grazie/nlp/nlp-phonetics-jvm/0.8.74/nlp-phonetics-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-45/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "9d2369a7e71ff367dbed384ee50976c25743b09e4be68a58f9412ad165d8e0d7",
-        "path": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-45/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/nlp/nlp-phonetics-jvm/0.8.74/nlp-phonetics-jvm-0.8.74.jar",
+        "hash": "ea4cd2ec177029c88ab81e3b120d2c9aacc01997dc2ecc9ada5e22de9f10d723",
+        "path": "ai/grazie/nlp/nlp-phonetics-jvm/0.8.74/nlp-phonetics-jvm-0.8.74.jar"
     },
     {
-        "url": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar",
-        "hash": "88d690d2d373cd66170770c317977196ce9e465f2388930f4bc9665e887385f6",
-        "path": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar"
+        "url": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar",
+        "hash": "0fbf476e73762b15509264e31e282bfb1a63342a8e0c6921d88c24c4eaf3c2a3",
+        "path": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar"
     },
     {
-        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
-        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
-        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+        "url": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar",
+        "hash": "0fbf476e73762b15509264e31e282bfb1a63342a8e0c6921d88c24c4eaf3c2a3",
+        "path": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar"
     },
     {
-        "url": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar",
-        "hash": "86e8faf87f3151a3d545850852a0f2cc55ea8a2434eee9e08f83881c52d55992",
-        "path": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar"
+        "url": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar",
+        "hash": "0fbf476e73762b15509264e31e282bfb1a63342a8e0c6921d88c24c4eaf3c2a3",
+        "path": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar"
     },
     {
-        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
-        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
-        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+        "url": "ai/grazie/nlp/nlp-tokenizer-jvm/0.8.74/nlp-tokenizer-jvm-0.8.74.jar",
+        "hash": "b45bd05287973a6e30611933a5aa285d2115ea2f16545108f9285922dd71ca90",
+        "path": "ai/grazie/nlp/nlp-tokenizer-jvm/0.8.74/nlp-tokenizer-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
-        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
-        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+        "url": "ai/grazie/nlp/nlp-tokenizer-jvm/0.8.74/nlp-tokenizer-jvm-0.8.74.jar",
+        "hash": "b45bd05287973a6e30611933a5aa285d2115ea2f16545108f9285922dd71ca90",
+        "path": "ai/grazie/nlp/nlp-tokenizer-jvm/0.8.74/nlp-tokenizer-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-45/kotlin-scripting-compiler-impl-2.3.20-ij253-45.jar",
-        "hash": "c2b19162264b2aa78371cd834f8703e1c49c032ec9862cdb9b744a4a2a8e7ded",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-45/kotlin-scripting-compiler-impl-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar",
+        "hash": "9bc5a572406da07a704d5e71e662dd183dfe9385e7c06cab1a49debc5a355638",
+        "path": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar"
     },
     {
-        "url": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar",
-        "hash": "027404a92fe618b72465792a257951495c503a7d5751e2791e0f51c87f67f5bc",
-        "path": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar"
+        "url": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar",
+        "hash": "9bc5a572406da07a704d5e71e662dd183dfe9385e7c06cab1a49debc5a355638",
+        "path": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar"
     },
     {
-        "url": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar",
-        "hash": "ad009e985dd84e4f524f4ed1751866da5bef816b691851bfbcefa48a01180a07",
-        "path": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar"
+        "url": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar",
+        "hash": "9bc5a572406da07a704d5e71e662dd183dfe9385e7c06cab1a49debc5a355638",
+        "path": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar"
     },
     {
-        "url": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar",
-        "hash": "293d80f54b536b74095dcd7ea3cf0a29bbfc3402519281332495f4420d370d16",
-        "path": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar"
+        "url": "ai/grazie/spell/hunspell-de/0.2.327/hunspell-de-0.2.327.jar",
+        "hash": "41ace2052e81a529fdaca24d9ac47a1323d7ac91a4e764481ef4b84477483b42",
+        "path": "ai/grazie/spell/hunspell-de/0.2.327/hunspell-de-0.2.327.jar"
     },
     {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+        "url": "ai/grazie/spell/hunspell-en/0.2.327/hunspell-en-0.2.327.jar",
+        "hash": "474f2837876c3d31ceccd1fad2e28336553ab21472910cd2654aaa3373a3d031",
+        "path": "ai/grazie/spell/hunspell-en/0.2.327/hunspell-en-0.2.327.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar",
-        "hash": "f31793446f372ee33659fc7a4ce93a079fa520ae89ddf6f6280ea50425c408d4",
-        "path": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar"
+        "url": "ai/grazie/spell/hunspell-ru/0.2.327/hunspell-ru-0.2.327.jar",
+        "hash": "8c2b71691fbbc75cd6868aa6e7948f637470ba8b559cf6c98cacfe6b024f3513",
+        "path": "ai/grazie/spell/hunspell-ru/0.2.327/hunspell-ru-0.2.327.jar"
     },
     {
-        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
-        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
-        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
+        "url": "ai/grazie/spell/hunspell-uk/0.2.327/hunspell-uk-0.2.327.jar",
+        "hash": "155565ea33fdac34ffc3117bf645493a245a655eb2030b40f5f532348e72a81a",
+        "path": "ai/grazie/spell/hunspell-uk/0.2.327/hunspell-uk-0.2.327.jar"
     },
     {
-        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
-        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
-        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+        "url": "ai/grazie/tasks-library/tasks-library-api-jvm/0.4.14/tasks-library-api-jvm-0.4.14.jar",
+        "hash": "70210d0eb24dd099e3e2923d55a8f4d5e5cef54f277f0bf1f17568633bec446e",
+        "path": "ai/grazie/tasks-library/tasks-library-api-jvm/0.4.14/tasks-library-api-jvm-0.4.14.jar"
     },
     {
-        "url": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar",
-        "hash": "b4b57bc3d56c5a1ccc674f55a16086c37700eb151fa749b45887e391ec0f26f9",
-        "path": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar"
+        "url": "ai/grazie/tasks-library/tasks-library-model-jvm/0.4.14/tasks-library-model-jvm-0.4.14.jar",
+        "hash": "8722c78b12167e0c05e8797a66ede6984ff3d98882b9b729c008f6494702c706",
+        "path": "ai/grazie/tasks-library/tasks-library-model-jvm/0.4.14/tasks-library-model-jvm-0.4.14.jar"
     },
     {
-        "url": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar",
-        "hash": "c4828e28d7c0a930af9387510b3bada7daa5c04d7c25a75c7b8b081f1c257ddd",
-        "path": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar"
+        "url": "ai/grazie/tasks/provider/llm/completion/tasks-provider-llm-completion-model-jvm/0.8.74/tasks-provider-llm-completion-model-jvm-0.8.74.jar",
+        "hash": "a10c97eefd99d19b6cd706fb8366a0c6274dbeb53cd4e495f77cbe569cf4fc0a",
+        "path": "ai/grazie/tasks/provider/llm/completion/tasks-provider-llm-completion-model-jvm/0.8.74/tasks-provider-llm-completion-model-jvm-0.8.74.jar"
     },
     {
-        "url": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar",
-        "hash": "ea77d0b2eb0b3e1f7fa04f2fbe671f5af3ae836cc40320411e195bdc9421f17b",
-        "path": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar"
+        "url": "ai/grazie/tasks/provider/model/tasks-provider-jet-completion-model-jvm/0.8.74/tasks-provider-jet-completion-model-jvm-0.8.74.jar",
+        "hash": "750ff8436538b639e78e7456090c94f3f8a7ec605044f7941a083ef33b2750f4",
+        "path": "ai/grazie/tasks/provider/model/tasks-provider-jet-completion-model-jvm/0.8.74/tasks-provider-jet-completion-model-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-45/noarg-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "261a90d908355e185f0a291aa71b3ce1f4e3c67aa31411244ef8c124958b0c77",
-        "path": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-45/noarg-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/tasks/provider/model/tasks-provider-proxy-model-jvm/0.8.74/tasks-provider-proxy-model-jvm-0.8.74.jar",
+        "hash": "992dcc9497a2d7ed70105a1ef425cf40d5ed21ac84c91219bd1abd31ccd3bbf9",
+        "path": "ai/grazie/tasks/provider/model/tasks-provider-proxy-model-jvm/0.8.74/tasks-provider-proxy-model-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-serialization-kotlinx-json-jvm/3.1.3/ktor-serialization-kotlinx-json-jvm-3.1.3.jar",
-        "hash": "9b810f01caa6e3f27e02d71caba8595e2b4b04071dba16e0e426e20115bed354",
-        "path": "io/ktor/ktor-serialization-kotlinx-json-jvm/3.1.3/ktor-serialization-kotlinx-json-jvm-3.1.3.jar"
+        "url": "ai/grazie/tasks/provider/tasks-provider-task-schema/0.8.74/tasks-provider-task-schema-0.8.74.jar",
+        "hash": "5e1efbeea5cccffddae7709e3a9d0d2583c7d45ab6986a3878b0e3d310be4238",
+        "path": "ai/grazie/tasks/provider/tasks-provider-task-schema/0.8.74/tasks-provider-task-schema-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-serialization-kotlinx-jvm/3.1.3/ktor-serialization-kotlinx-jvm-3.1.3.jar",
-        "hash": "b4dc2f9d4d1dda8d481a054d7f833ba195f064f5115fde3ab0dfdb8b42f61fda",
-        "path": "io/ktor/ktor-serialization-kotlinx-jvm/3.1.3/ktor-serialization-kotlinx-jvm-3.1.3.jar"
+        "url": "ai/grazie/user/cfg/user-cfg-model-jvm/0.8.74/user-cfg-model-jvm-0.8.74.jar",
+        "hash": "02f994598d0e9d59c3125faeb189d29b0e9e6743c524ed90587b096c6e57fe46",
+        "path": "ai/grazie/user/cfg/user-cfg-model-jvm/0.8.74/user-cfg-model-jvm-0.8.74.jar"
     },
     {
-        "url": "junit/junit/4.13.2/junit-4.13.2.jar",
-        "hash": "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
-        "path": "junit/junit/4.13.2/junit-4.13.2.jar"
+        "url": "ai/grazie/user/strg/user-strg-model-jvm/0.8.74/user-strg-model-jvm-0.8.74.jar",
+        "hash": "d8ccf3778f53df601f8d6b4a9343eb12908b6a7bc46844d30965a4c47c211f13",
+        "path": "ai/grazie/user/strg/user-strg-model-jvm/0.8.74/user-strg-model-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar",
-        "hash": "9d0f4c74e96787499fcc2462c32afeb7f4db97db30042e2578f205f61e5898fb",
-        "path": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar"
+        "url": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar",
+        "hash": "e1cc87b2a052ce4e4124abc6cd6d9c14dbc9e3319f854eb5829d44af860cb7f6",
+        "path": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar",
-        "hash": "0318b967115de0c7c8fbd93bc6e3d279c82de2954f90794146962921de45972d",
-        "path": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar"
+        "url": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar",
+        "hash": "e1cc87b2a052ce4e4124abc6cd6d9c14dbc9e3319f854eb5829d44af860cb7f6",
+        "path": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar",
-        "hash": "22022fe954980d8e183b252889719fc6ca71a13e91b8e869d92532da308e3da1",
-        "path": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar"
+        "url": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar",
+        "hash": "e1cc87b2a052ce4e4124abc6cd6d9c14dbc9e3319f854eb5829d44af860cb7f6",
+        "path": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar",
-        "hash": "4c86546693efaeb889e02d043521cda15da5f10853b0471095b7db80dc0540e7",
-        "path": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar"
+        "url": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar",
+        "hash": "e1cc87b2a052ce4e4124abc6cd6d9c14dbc9e3319f854eb5829d44af860cb7f6",
+        "path": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar"
     },
     {
-        "url": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar",
-        "hash": "0fe8dcdf54b13b5ec56fdb5f63c057364264bb2f51b7f7bc3c271d5b1ba68dcb",
-        "path": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar"
+        "url": "ai/grazie/utils/utils-jwt-jvm/0.8.74/utils-jwt-jvm-0.8.74.jar",
+        "hash": "23c6617feff191e38ebc1be8b17c23e703373c5d68dc894875a228816d5fa6cf",
+        "path": "ai/grazie/utils/utils-jwt-jvm/0.8.74/utils-jwt-jvm-0.8.74.jar"
     },
     {
-        "url": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar",
-        "hash": "26b0fc745ea051b57462be22a150c7600dbac6716b24cc60a5ecc0e8085c41a0",
-        "path": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar"
+        "url": "ai/grazie/utils/utils-ktor-jvm/0.8.74/utils-ktor-jvm-0.8.74.jar",
+        "hash": "719d32f0110a60613b8c55deda0aa6145223aa3fb740457b810a774525ec1a53",
+        "path": "ai/grazie/utils/utils-ktor-jvm/0.8.74/utils-ktor-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar",
-        "hash": "5ed74de192bd48546a6bc6e1c9f8f508663d8506ad9ef257aebbd6e829fdea36",
-        "path": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar"
+        "url": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar",
+        "hash": "ce5f571e5eae530cc4835d99977181a545bc07c85755b5b73a1bfb1a669f40d1",
+        "path": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar"
     },
     {
-        "url": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "71e74b74676099dd9ebbb97780401f9b53f205a69d0d515a5e03c5a42fe20c18",
-        "path": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar"
+        "url": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar",
+        "hash": "ce5f571e5eae530cc4835d99977181a545bc07c85755b5b73a1bfb1a669f40d1",
+        "path": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-45/kotlin-jps-plugin-classpath-2.3.20-ij253-45.jar",
-        "hash": "290744db458f813618c460312a1f35bb2ed082485385d558de368c893509d11c",
-        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-45/kotlin-jps-plugin-classpath-2.3.20-ij253-45.jar"
+        "url": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar",
+        "hash": "ce5f571e5eae530cc4835d99977181a545bc07c85755b5b73a1bfb1a669f40d1",
+        "path": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar"
     },
     {
-        "url": "com/jetbrains/fus/reporting/configuration/171/configuration-171.jar",
-        "hash": "f138ed43c55cb90192518293a5b46a135221c898b2b05d6c0648645b3d0fac64",
-        "path": "com/jetbrains/fus/reporting/configuration/171/configuration-171.jar"
+        "url": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar",
+        "hash": "ce5f571e5eae530cc4835d99977181a545bc07c85755b5b73a1bfb1a669f40d1",
+        "path": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar"
     },
     {
-        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
-        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
-        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+        "url": "androidx/annotation/annotation-jvm/1.9.1/annotation-jvm-1.9.1.jar",
+        "hash": "1e343917ebf27ba96fe4dc52b1cad7fd32b738fbc6355bb6cd5b3b305d7212d0",
+        "path": "androidx/annotation/annotation-jvm/1.9.1/annotation-jvm-1.9.1.jar"
     },
     {
-        "url": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar",
-        "hash": "61ff422fe859c2439d94727eb6dcd7ccadb5ba0d9cce4e181db1946209ef9bf6",
-        "path": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar"
+        "url": "androidx/annotation/annotation/1.1.0/annotation-1.1.0.jar",
+        "hash": "d38d63edb30f1467818d50aaf05f8a692dea8b31392a049bfa991b159ad5b692",
+        "path": "androidx/annotation/annotation/1.1.0/annotation-1.1.0.jar"
     },
     {
-        "url": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar",
-        "hash": "5a810154295fc20a0268cae4cbbc6e5a35a8b32480d8727dc8301910524e4b79",
-        "path": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar"
+        "url": "androidx/arch/core/core-common/2.2.0/core-common-2.2.0.jar",
+        "hash": "65308a06b1c00ee186cb9e19321383f043b993813f1522c47f4a3e3303bdba41",
+        "path": "androidx/arch/core/core-common/2.2.0/core-common-2.2.0.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar",
-        "hash": "5c8bd5dd7ae1ea2eeb2778fdbeaa19a562184975f6cab8a0bb6779e4190731ae",
-        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar"
+        "url": "androidx/collection/collection-jvm/1.5.0/collection-jvm-1.5.0.jar",
+        "hash": "70b35924e4babcdffa37d0e575ee039c56a2d97123342624c48b603233704341",
+        "path": "androidx/collection/collection-jvm/1.5.0/collection-jvm-1.5.0.jar"
     },
     {
-        "url": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar",
-        "hash": "7cfbb7a9c1198053c699c663479fd4836acc22c2650003c8dee20e7fbc55a65a",
-        "path": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar"
+        "url": "androidx/compose/runtime/runtime-annotation-jvm/1.10.0-rc01/runtime-annotation-jvm-1.10.0-rc01.jar",
+        "hash": "f89dda8bcd73876d0fc16568844b2bd79443ee7ca62810874d25c7dcaa394bd6",
+        "path": "androidx/compose/runtime/runtime-annotation-jvm/1.10.0-rc01/runtime-annotation-jvm-1.10.0-rc01.jar"
     },
     {
-        "url": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar",
-        "hash": "0efe45aca820a2f722f29a49e5ffe5cd14f06c51ad60842247fcb15f8048e28a",
-        "path": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar"
+        "url": "androidx/compose/runtime/runtime-desktop/1.10.0-rc01/runtime-desktop-1.10.0-rc01.jar",
+        "hash": "b195860542f612de0512b54a75353e0f6d58815f0c9530a03bc5b0e734474829",
+        "path": "androidx/compose/runtime/runtime-desktop/1.10.0-rc01/runtime-desktop-1.10.0-rc01.jar"
     },
     {
-        "url": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar",
-        "hash": "83789c1710426adb1637f773ec79e46ad0acf845e77e7964d7f2030cc2fd25c9",
-        "path": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar"
+        "url": "androidx/compose/runtime/runtime-retain-desktop/1.10.0-rc01/runtime-retain-desktop-1.10.0-rc01.jar",
+        "hash": "463ee9c1e93d1b913458bfecc96d128a3574a802f41c8c9781d7320c3b55ed8b",
+        "path": "androidx/compose/runtime/runtime-retain-desktop/1.10.0-rc01/runtime-retain-desktop-1.10.0-rc01.jar"
     },
     {
-        "url": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar",
-        "hash": "ac0192fd110a0363732b17ea94fd1ce8cfd85790c8e1551e14f866908b5d80e1",
-        "path": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar"
+        "url": "androidx/compose/runtime/runtime-saveable-desktop/1.10.0-rc01/runtime-saveable-desktop-1.10.0-rc01.jar",
+        "hash": "ef24e24cc8c9c3b9871007fbdf589ed9aaaecf95979a66b7484806f9f0e24d91",
+        "path": "androidx/compose/runtime/runtime-saveable-desktop/1.10.0-rc01/runtime-saveable-desktop-1.10.0-rc01.jar"
     },
     {
-        "url": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar",
-        "hash": "0b20f45e3a0fd8f0d12cdc5316b06776e902b1365db00118876f9175c60f302c",
-        "path": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar"
+        "url": "androidx/lifecycle/lifecycle-common-jvm/2.9.4/lifecycle-common-jvm-2.9.4.jar",
+        "hash": "37d89b2101f074ac6c260917dabb185607645ee200aa3018c7c5bde70edcf184",
+        "path": "androidx/lifecycle/lifecycle-common-jvm/2.9.4/lifecycle-common-jvm-2.9.4.jar"
     },
     {
-        "url": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar",
-        "hash": "d642f145f6123739e779d4156145cc5fe7c2173bb58d437b813961a31c337ff9",
-        "path": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar"
+        "url": "androidx/lifecycle/lifecycle-runtime-compose-desktop/2.9.4/lifecycle-runtime-compose-desktop-2.9.4.jar",
+        "hash": "d25c083df93da718a1876a3293bd15f7dc7a811e998735943bce590683a57835",
+        "path": "androidx/lifecycle/lifecycle-runtime-compose-desktop/2.9.4/lifecycle-runtime-compose-desktop-2.9.4.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-45/analysis-api-k2-for-ide-2.3.20-ij253-45.jar",
-        "hash": "7fdbe230eae422cec677a358823315996f53853d4b4469e45e1531fb4f4e5245",
-        "path": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-45/analysis-api-k2-for-ide-2.3.20-ij253-45.jar"
+        "url": "androidx/lifecycle/lifecycle-runtime-desktop/2.9.4/lifecycle-runtime-desktop-2.9.4.jar",
+        "hash": "2fb49f76d1021792fb359e0a9246c1509f2f5b555f0a46591d24d58deb68bd5c",
+        "path": "androidx/lifecycle/lifecycle-runtime-desktop/2.9.4/lifecycle-runtime-desktop-2.9.4.jar"
     },
     {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar",
-        "hash": "cfd4332afd70ebb3041e244317dc790d8cb7bf6ddd05591cc1188b8052979946",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar"
+        "url": "androidx/lifecycle/lifecycle-viewmodel-desktop/2.9.4/lifecycle-viewmodel-desktop-2.9.4.jar",
+        "hash": "98f816be6869407c87d46058756f97780fa6c6cf61acdba97216f413731af15d",
+        "path": "androidx/lifecycle/lifecycle-viewmodel-desktop/2.9.4/lifecycle-viewmodel-desktop-2.9.4.jar"
     },
     {
-        "url": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar",
-        "hash": "6396a4e67269f3f35851c17613257964f46fd4e937cb3ffe73ddcd963c2a83a7",
-        "path": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar"
+        "url": "androidx/lifecycle/lifecycle-viewmodel-savedstate-desktop/2.9.4/lifecycle-viewmodel-savedstate-desktop-2.9.4.jar",
+        "hash": "3e0b44e2514eafdd6938d5457d9f46e4785077c45d3b4364b5c23c4dcb93efd3",
+        "path": "androidx/lifecycle/lifecycle-viewmodel-savedstate-desktop/2.9.4/lifecycle-viewmodel-savedstate-desktop-2.9.4.jar"
     },
     {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar",
-        "hash": "a700168761f778704d456e4b0cc9183a42a832ac4b970886663c6c855bf5461c",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar"
+        "url": "androidx/navigationevent/navigationevent-desktop/1.0.0/navigationevent-desktop-1.0.0.jar",
+        "hash": "8283896d87f6d3e21dd5b12785e6c7ca3b7f15cbc4d0391b20ad23e54b520515",
+        "path": "androidx/navigationevent/navigationevent-desktop/1.0.0/navigationevent-desktop-1.0.0.jar"
     },
     {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar",
-        "hash": "6d9ebbb6db1567ebc7e3561a555b2e80cded56002f16be4c152bb911f6952cee",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar"
+        "url": "androidx/savedstate/savedstate-compose-desktop/1.3.2/savedstate-compose-desktop-1.3.2.jar",
+        "hash": "4a94787a6e5bcfe143390a4f2737d4425d2ea867f2b34a847de6cda3c6ccc58a",
+        "path": "androidx/savedstate/savedstate-compose-desktop/1.3.2/savedstate-compose-desktop-1.3.2.jar"
     },
     {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar",
-        "hash": "f2cbc864db43bc57d13a79444b2f8d784a01345bbe259c9721be00935f8ba748",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar"
+        "url": "androidx/savedstate/savedstate-desktop/1.3.2/savedstate-desktop-1.3.2.jar",
+        "hash": "c5c89062ba8402b8f8657efd54db1ff192f91ca95fae59c3b418fbc477c3e3ea",
+        "path": "androidx/savedstate/savedstate-desktop/1.3.2/savedstate-desktop-1.3.2.jar"
     },
     {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar",
-        "hash": "a1158e70bb79d591c7d7fcc2ab0bcf6682500f7de4961fda4a9cc1b015cad65e",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar"
+        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
     },
     {
-        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar",
-        "hash": "6a8cb27bdd255a718ca100d52cfdac20cce70ab3a92c248efaee50f63eefd11e",
-        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar"
+        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
     },
     {
-        "url": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar",
-        "hash": "47dcde8986019314ef78ae7280a94973a21d2ed95075a40a000b42da956429e1",
-        "path": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
+        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
     },
     {
-        "url": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar",
-        "hash": "dc0eaf2bbf0036a70b60798c785d6e03a9daf06b68b8edb0f1ba9eb3421baeb3",
-        "path": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar"
+        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
+        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
     },
     {
-        "url": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar",
-        "hash": "df26cc58f235f477db07f753ba5a3ab243ebe5789d9f89ecf68dd62ea9a66c28",
-        "path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
+        "url": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar",
+        "hash": "41984dffaf069b84b814fa787f740bf7ebdc90bf89f69d05bc4660c69874b49e",
+        "path": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar"
     },
     {
-        "url": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
-        "hash": "1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308",
-        "path": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar"
-    },
-    {
-        "url": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar",
-        "hash": "5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1",
-        "path": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar"
-    },
-    {
-        "url": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "eaaae0ef5b03c8cf3d3978699c517f3e2199f50191568efaff4d525be963f544",
-        "path": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar",
-        "hash": "fd65c1a0cd1c60272b6ed0f45025d7afae8de20b5c11e2a131a7ccb4b0f1f1b2",
-        "path": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar",
-        "hash": "ac2ddae3a844c1e2378604616dbe7cc17c64caaf9115d8c9c3b29db8b2982411",
-        "path": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-sdk/1.48.0/opentelemetry-sdk-1.48.0.jar",
-        "hash": "668e78642d50709dd147406a197cfdd256b1d5931023a23f4a25ed88154c8089",
-        "path": "io/opentelemetry/opentelemetry-sdk/1.48.0/opentelemetry-sdk-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-api/1.48.0/opentelemetry-api-1.48.0.jar",
-        "hash": "8d3781bda58892f7d14216908fc0d1faf6f4e6b806e6e73e23489e41c0ecf012",
-        "path": "io/opentelemetry/opentelemetry-api/1.48.0/opentelemetry-api-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-context/1.48.0/opentelemetry-context-1.48.0.jar",
-        "hash": "1fcccff0f8171fe2001a17b99da229c12d0c4edcca617e453460344e92249d42",
-        "path": "io/opentelemetry/opentelemetry-context/1.48.0/opentelemetry-context-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-sdk-common/1.48.0/opentelemetry-sdk-common-1.48.0.jar",
-        "hash": "d8cfbfe6403965f68fc5efca0c9cb85c2cafd5facda9238cd83468692bc00109",
-        "path": "io/opentelemetry/opentelemetry-sdk-common/1.48.0/opentelemetry-sdk-common-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-sdk-trace/1.48.0/opentelemetry-sdk-trace-1.48.0.jar",
-        "hash": "d575e493f6c2e89d3100b3e73d3a2ae720bb8f3ee2fa0f70a7d0da81d048c87a",
-        "path": "io/opentelemetry/opentelemetry-sdk-trace/1.48.0/opentelemetry-sdk-trace-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-sdk-metrics/1.48.0/opentelemetry-sdk-metrics-1.48.0.jar",
-        "hash": "70622ff3bbeee435fba5c49d9ff6b056511a0f9982080aa5959ccfccb8650fd9",
-        "path": "io/opentelemetry/opentelemetry-sdk-metrics/1.48.0/opentelemetry-sdk-metrics-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-sdk-logs/1.48.0/opentelemetry-sdk-logs-1.48.0.jar",
-        "hash": "3cb8107e3d142fb990ce7f7198cd051a3364fc9d254daa22d248215246857567",
-        "path": "io/opentelemetry/opentelemetry-sdk-logs/1.48.0/opentelemetry-sdk-logs-1.48.0.jar"
-    },
-    {
-        "url": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar",
-        "hash": "03b276130c0c1417c9bd07cfd8d2eea1fa465fc930dd132ac11fc383cf11deec",
-        "path": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar"
-    },
-    {
-        "url": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar",
-        "hash": "f0e3ffcbba6744ab4918a55aa32ff4f408fcd21e45ab8bd5f7883a1793b2a253",
-        "path": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar"
-    },
-    {
-        "url": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar",
-        "hash": "ddc386ff14bd25d5c934167196eaf45b18de4f28e1c55a4db37ae594cbfd37e4",
-        "path": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar",
-        "hash": "1f799c9e7691a4dcddb1cb3e28e8517d5e6b27c2ac75093f39714afdc9216950",
-        "path": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar",
-        "hash": "df967eebc2c87eaa3f55338607104ffc8fa62fb2e813d67f95ed4f7f9c6f8cee",
-        "path": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar",
-        "hash": "63aca730b99bb849f4efb87e61765a050b4a46c7d3f2969054e49439cb0132f8",
-        "path": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar"
-    },
-    {
-        "url": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar",
-        "hash": "2b6e6550b40467ede7b3034a1a9eb9148fbf920cfdae5bf0b1d2bb3d4e780625",
-        "path": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar",
-        "hash": "d94e6ba5de99225d3d3fc8759d4480721402c7121d130d73d99d838e913500dd",
-        "path": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
-        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
-        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar",
-        "hash": "2dd9c390e2de0acbdd2fce1aabadd378fa75a9cf73ee723dd8cecbe5c8480457",
-        "path": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar",
-        "hash": "a133e049f0a4e249651582428e166de4dfac9546adf436b6172119255ede510f",
-        "path": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar",
-        "hash": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
-        "path": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm/9.6/asm-9.6.jar",
-        "hash": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
-        "path": "org/ow2/asm/asm/9.6/asm-9.6.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar",
-        "hash": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
-        "path": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar",
-        "hash": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
-        "path": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar",
-        "hash": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
-        "path": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar",
-        "hash": "970636134d61c183b19f8f58fa631e30d2f2abca344b37848a393cac7863dd70",
-        "path": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar",
-        "hash": "2b309a9300092e0b696f7c471fd51d9969001df784c8ab9f07997437d757ad6d",
-        "path": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar",
-        "hash": "b3d9ec0298e84ed09e0448c52a643bfdad7f3d8096f1303592a3046e711551af",
-        "path": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-45/assignment-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "a1c99ebaca3f02a43d27c295ff6481a860c8e1e9f3b5a67dca2d6a01d5d977e5",
-        "path": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-45/assignment-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-45/kotlin-scripting-common-2.3.20-ij253-45.jar",
-        "hash": "a06d90da5af5a992f93223d26976b81141edf5764dc798431352dbcd6606bce6",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-45/kotlin-scripting-common-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/mozilla/rhino-runtime/1.7.15/rhino-runtime-1.7.15.jar",
-        "hash": "4f38c96499c614145b87442700e196df39b0af808b1b1204eaccaa15bef17c2b",
-        "path": "org/mozilla/rhino-runtime/1.7.15/rhino-runtime-1.7.15.jar"
-    },
-    {
-        "url": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar",
-        "hash": "be5805392060c71474bf6c9a67a099471274d30b83eef84bfc4e0889a4f1dcc0",
-        "path": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar"
-    },
-    {
-        "url": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar",
-        "hash": "98b5c1291d9e473ce6df9823781a8a2170f1dfb4c30d985c56ff5242df2ff8f5",
-        "path": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar",
-        "hash": "3575dcb8a98faf943d3c1595c47a16047c4fce8a83ebbb26262f1a2f67546357",
-        "path": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar",
-        "hash": "83f17205a6470c3cd4214306d3ed011651c173297f705acef544c01795f253cd",
-        "path": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar"
-    },
-    {
-        "url": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar",
-        "hash": "d1bb81abfd9e03418306b4e6a3390c8db52c58372e749c2980ac29f0c08278f1",
-        "path": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar"
-    },
-    {
-        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
-        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
-        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar",
-        "hash": "1c25ca641ebaae44ff3ad21ca1b2ef68d0dd84bfeb07c4805ba7840899b77408",
-        "path": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar"
-    },
-    {
-        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
-        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
-        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-45/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "076c66a0899ca0dfaeb18efdf73ca70c0dfbe935a70e7f790e009885b61e56ee",
-        "path": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-45/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/snakeyaml/snakeyaml-engine/2.9/snakeyaml-engine-2.9.jar",
-        "hash": "2f7a957461b6d70c0005e2c35b78a1c97bef6c446704c0ee9393ce98e4958ba8",
-        "path": "org/snakeyaml/snakeyaml-engine/2.9/snakeyaml-engine-2.9.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.45.0/opentelemetry-sdk-extension-autoconfigure-spi-1.45.0.jar",
-        "hash": "d55d8e2e877d5b0424375c79a891c82e78d00eb1b1273295763e1b55b0374123",
-        "path": "io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.45.0/opentelemetry-sdk-extension-autoconfigure-spi-1.45.0.jar"
-    },
-    {
-        "url": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar",
-        "hash": "956a4c7faad66e3471861adaa278d9486f3a050ac25fb6a99ca90809d379adfe",
-        "path": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar"
-    },
-    {
-        "url": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar",
-        "hash": "7e638082b4a14e3a96ca90f3f5db70ac65591e0b6c6670629e849d22ec34455f",
-        "path": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar",
-        "hash": "00aa7be5c214bff31d62b489fbb5f0c389545e9f455324b2b92681956d37c94f",
-        "path": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar"
-    },
-    {
-        "url": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar",
-        "hash": "a7b369a2e697215fed314a58b736f10ae8bdedf218096916a6bdb7bc886fe470",
-        "path": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar"
-    },
-    {
-        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
-        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
-        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
-    },
-    {
-        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
-        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
-        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
-    },
-    {
-        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
-        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
-        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
-    },
-    {
-        "url": "org/jetbrains/jediterm/jediterm-core/3.57/jediterm-core-3.57.jar",
-        "hash": "e3d7c60adfdebe47732889d1ff21bc936ddf9990609ac54501c7cf749b0fe640",
-        "path": "org/jetbrains/jediterm/jediterm-core/3.57/jediterm-core-3.57.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar",
-        "hash": "2074392bf202ae0cea075828e8739a17642eb3093db5f40e46b955937fbd8cdf",
-        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar"
-    },
-    {
-        "url": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar",
-        "hash": "11a9ee6f88bb31f1450108d1cf6441377dec84aca075eb6bb2343be157575bea",
-        "path": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar"
-    },
-    {
-        "url": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar",
-        "hash": "432b9e545848c4141b80717b26e367f83bf33f19250a228ce75da6e967da2bc7",
-        "path": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar"
-    },
-    {
-        "url": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar",
-        "hash": "12314fc6881d66a413fd66370787adba16e504fbf7e138690b0f3952e3fbd321",
-        "path": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar",
-        "hash": "585fbc8bb26dffa4a3174d74352dd3e29cba990a9c1b06c1a547906aff2869ec",
-        "path": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar"
-    },
-    {
-        "url": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar",
-        "hash": "385282b005818cfaccdbe8bd2429811e7e641782f2b88932a6b8ff51d668f616",
-        "path": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar"
-    },
-    {
-        "url": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar",
-        "hash": "c5f95c97171311066a13eb750a6bb999fa7eeb43c1394705034926336c0b7b0f",
-        "path": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-45/analysis-api-for-ide-2.3.20-ij253-45.jar",
-        "hash": "47db94b0240122449cb95aa00dd8b9d0722948b81f8390b9d27d38797c0fc784",
-        "path": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-45/analysis-api-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/js-plain-objects-compiler-plugin-for-ide/2.3.20-ij253-45/js-plain-objects-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "fde628289a120756ea6155cbe76b905e7e800c968404aa20d76382ec0b26cf07",
-        "path": "org/jetbrains/kotlin/js-plain-objects-compiler-plugin-for-ide/2.3.20-ij253-45/js-plain-objects-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar",
-        "hash": "9d70afe194568ca0328b7f762e64eb8094a5e5a76ea3a30b7182f0e7d5f0dd35",
-        "path": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar",
-        "hash": "b21806c4075aa42d4534ba7257097aea091ab99c40466b0f850872cfc07e7507",
-        "path": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-jps-common-for-ide/2.3.20-ij253-45/kotlin-jps-common-for-ide-2.3.20-ij253-45.jar",
-        "hash": "4c42b6d0419bbdcb988df9ee3bd1d4f10fd90a3b1985966f66a9400d9c7a4ab0",
-        "path": "org/jetbrains/kotlin/kotlin-jps-common-for-ide/2.3.20-ij253-45/kotlin-jps-common-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar",
-        "hash": "2037be378980d3ba9333e97955f3b2cde392aa124d04ca73ce2eee6657199297",
-        "path": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar"
+        "url": "cglib/cglib-nodep/3.3.0/cglib-nodep-3.3.0.jar",
+        "hash": "3366d2c88fb576e486d830f521184e8f1839f8c15dcd2151a3f6e1f62b0b37a0",
+        "path": "cglib/cglib-nodep/3.3.0/cglib-nodep-3.3.0.jar"
     },
     {
         "url": "com/amazon/ion/ion-java/1.11.10/ion-java-1.11.10.jar",
@@ -905,164 +575,139 @@
         "path": "com/amazon/ion/ion-java/1.11.10/ion-java-1.11.10.jar"
     },
     {
-        "url": "org/apache/maven/maven-resolver-provider/3.9.9/maven-resolver-provider-3.9.9.jar",
-        "hash": "5dea05049c94f952f48ce2bfe0111afdf986acc591fcc11d23fe3b8dcb70291e",
-        "path": "org/apache/maven/maven-resolver-provider/3.9.9/maven-resolver-provider-3.9.9.jar"
+        "url": "com/amazonaws/aws-java-sdk-core/1.12.431/aws-java-sdk-core-1.12.431.jar",
+        "hash": "e17a93342d623ecd58449b6142db53c5ec9d1fb7a6a40d6266e56ed796e06fdf",
+        "path": "com/amazonaws/aws-java-sdk-core/1.12.431/aws-java-sdk-core-1.12.431.jar"
     },
     {
-        "url": "org/apache/maven/maven-model/3.9.9/maven-model-3.9.9.jar",
-        "hash": "8f59b0a16fe9c933be749a60ae0705a0cb337bb5abaf38801b40b740ff775727",
-        "path": "org/apache/maven/maven-model/3.9.9/maven-model-3.9.9.jar"
+        "url": "com/amazonaws/aws-java-sdk-kms/1.12.431/aws-java-sdk-kms-1.12.431.jar",
+        "hash": "ffc62a11ad6a454d150a28c66c98e0300186faa53ec34d1c58c7dc5e2f7a3011",
+        "path": "com/amazonaws/aws-java-sdk-kms/1.12.431/aws-java-sdk-kms-1.12.431.jar"
     },
     {
-        "url": "org/apache/maven/maven-model-builder/3.9.9/maven-model-builder-3.9.9.jar",
-        "hash": "a4377182ac2e5adfe16be3b3c81981a5ecddab014184de72ae1e522f04a77602",
-        "path": "org/apache/maven/maven-model-builder/3.9.9/maven-model-builder-3.9.9.jar"
+        "url": "com/amazonaws/aws-java-sdk-s3/1.12.431/aws-java-sdk-s3-1.12.431.jar",
+        "hash": "45b24b098dcaec230fde72b4e0568dab464cf7d8afd8b83fb9ac628778c67df9",
+        "path": "com/amazonaws/aws-java-sdk-s3/1.12.431/aws-java-sdk-s3-1.12.431.jar"
     },
     {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar",
-        "hash": "3fb4fb6143fdf964024c3cb738551524b9ea84e5c211cd660c559ad0703e5230",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar"
+        "url": "com/amazonaws/jmespath-java/1.12.431/jmespath-java-1.12.431.jar",
+        "hash": "238630e244b369b57238bb35e9a23382be65771b04a0f36d85df07b61b4ae2b9",
+        "path": "com/amazonaws/jmespath-java/1.12.431/jmespath-java-1.12.431.jar"
     },
     {
-        "url": "org/apache/maven/maven-artifact/3.9.9/maven-artifact-3.9.9.jar",
-        "hash": "30f015d1c1a393e19c18cd4f43532089c36d4ca328608ce3dda78b74d3d31515",
-        "path": "org/apache/maven/maven-artifact/3.9.9/maven-artifact-3.9.9.jar"
+        "url": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar",
+        "hash": "a000df0643439bfc1a41cc35098491dcb5733766e629ecbed2d68adb473f8420",
+        "path": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar"
     },
     {
-        "url": "org/apache/maven/maven-builder-support/3.9.9/maven-builder-support-3.9.9.jar",
-        "hash": "2ca4a967bdd12a9e85d40e012374f86e63d4a1030c199da4832e3d0a1c6770d8",
-        "path": "org/apache/maven/maven-builder-support/3.9.9/maven-builder-support-3.9.9.jar"
+        "url": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar",
+        "hash": "6d8d14b91285cc7c1b73460f413bb3f80672dc34dc506ed578fba1f6dde8661e",
+        "path": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar"
     },
     {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar",
-        "hash": "15335c4dcf082f599fb8eddcfb58d6a7e9a9c97de2883c257089a479b9b24522",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar"
+        "url": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar",
+        "hash": "e826a88e448a0c1d42abc30c9d047131badbac6fc3922b8e93ac3ea27bb0eb2c",
+        "path": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar"
     },
     {
-        "url": "org/apache/maven/maven-repository-metadata/3.9.9/maven-repository-metadata-3.9.9.jar",
-        "hash": "137c297e6a52d489b76663c82324d54e40f5d498a8fc015c0203fd91df8623b0",
-        "path": "org/apache/maven/maven-repository-metadata/3.9.9/maven-repository-metadata-3.9.9.jar"
+        "url": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar",
+        "hash": "ffd6f3fbba2453440e4c04add42b9f903d84151b5b71f7e6bbb181d8096397a4",
+        "path": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar"
     },
     {
-        "url": "org/apache/maven/resolver/maven-resolver-api/1.9.22/maven-resolver-api-1.9.22.jar",
-        "hash": "63f5f665e44a09ef55463b3b91fda0b78ff07dd24b1060d56e79c10b6e32cbfb",
-        "path": "org/apache/maven/resolver/maven-resolver-api/1.9.22/maven-resolver-api-1.9.22.jar"
+        "url": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar",
+        "hash": "11cc5e7b75b23feb65e41e28e5c225b4a77dbf7210d6cedd4bdb3f04c1f6ea24",
+        "path": "com/android/tools/smali/smali-dexlib2/3.0.3/smali-dexlib2-3.0.3.jar"
     },
     {
-        "url": "org/apache/maven/resolver/maven-resolver-spi/1.9.22/maven-resolver-spi-1.9.22.jar",
-        "hash": "99ad721e4631d9bd0c4f9e29c869672577c66f2a674a5723ce38eff13c75cbfd",
-        "path": "org/apache/maven/resolver/maven-resolver-spi/1.9.22/maven-resolver-spi-1.9.22.jar"
+        "url": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar",
+        "hash": "8078a04709f42072a240a6fe7666b71755324745c505b39f86ededfd9c2b90c4",
+        "path": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar"
     },
     {
-        "url": "org/apache/maven/resolver/maven-resolver-util/1.9.22/maven-resolver-util-1.9.22.jar",
-        "hash": "4aaea1584c39294ca926fc474723d9684473609ef4490c4eb169d6ea7daca6b5",
-        "path": "org/apache/maven/resolver/maven-resolver-util/1.9.22/maven-resolver-util-1.9.22.jar"
+        "url": "com/apollographql/apollo/apollo-annotations-jvm/4.0.0/apollo-annotations-jvm-4.0.0.jar",
+        "hash": "ade351bed9f7b5c0c321429187229be7814ade496004dab10c389c4cd1930db9",
+        "path": "com/apollographql/apollo/apollo-annotations-jvm/4.0.0/apollo-annotations-jvm-4.0.0.jar"
     },
     {
-        "url": "org/apache/maven/resolver/maven-resolver-impl/1.9.22/maven-resolver-impl-1.9.22.jar",
-        "hash": "e4dafb8acc13d736377c02d2170d869438dd74b98b860745909d238726babcbb",
-        "path": "org/apache/maven/resolver/maven-resolver-impl/1.9.22/maven-resolver-impl-1.9.22.jar"
+        "url": "com/apollographql/apollo/apollo-ast-jvm/4.0.0/apollo-ast-jvm-4.0.0.jar",
+        "hash": "1e83e448c104d946a6146c32409275a6ed4259999d469514be4f878a420f0b4f",
+        "path": "com/apollographql/apollo/apollo-ast-jvm/4.0.0/apollo-ast-jvm-4.0.0.jar"
     },
     {
-        "url": "org/apache/maven/resolver/maven-resolver-named-locks/1.9.22/maven-resolver-named-locks-1.9.22.jar",
-        "hash": "0685f29ec3b548d9b6917c527f13c667685a3394b955aaa5b25d0559818b7fc5",
-        "path": "org/apache/maven/resolver/maven-resolver-named-locks/1.9.22/maven-resolver-named-locks-1.9.22.jar"
+        "url": "com/auth0/java-jwt/4.3.0/java-jwt-4.3.0.jar",
+        "hash": "25a2353a1789870d960c0a9d8878a62eb1873116a2299d74f278451697676a67",
+        "path": "com/auth0/java-jwt/4.3.0/java-jwt-4.3.0.jar"
     },
     {
-        "url": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar",
-        "hash": "c542657efd81b268535fb77e1866c8234c5a22de416ecbd8aea0e06e2c1588de",
-        "path": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar"
+        "url": "com/beust/jcommander/1.82/jcommander-1.82.jar",
+        "hash": "deeac157c8de6822878d85d0c7bc8467a19cc8484d37788f7804f039dde280b1",
+        "path": "com/beust/jcommander/1.82/jcommander-1.82.jar"
     },
     {
-        "url": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar",
-        "hash": "9c86cf3a130237b059f5ef89661a4fbe715f5e8bce9626a6aded95a1c3775a47",
-        "path": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar"
+        "url": "com/carrotsearch/hppc/0.8.2/hppc-0.8.2.jar",
+        "hash": "97e45d4e0106d98dd3e76d9610e0bd3895409bd1ab1ed189855b05af0571025e",
+        "path": "com/carrotsearch/hppc/0.8.2/hppc-0.8.2.jar"
     },
     {
-        "url": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar",
-        "hash": "10fa70357cbfd55f52d64cf4bb4011e01ced0e0e5dea0bac77f73908cef676ff",
-        "path": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar"
+        "url": "com/carrotsearch/hppc/0.9.1/hppc-0.9.1.jar",
+        "hash": "d58706a2be60c972452550cdba79870bf481447c50eb718308e33a6ba45c65ec",
+        "path": "com/carrotsearch/hppc/0.9.1/hppc-0.9.1.jar"
     },
     {
-        "url": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar",
-        "hash": "b94f2d169acd04e8a41f1082e8f522529be1f5a10515473de9fb8d259afbfc77",
-        "path": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar"
+        "url": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar",
+        "hash": "7e346b94d47fb4e4495ebd6161fd5c6d01659687e93c460bbfd320ba47bea852",
+        "path": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar"
     },
     {
-        "url": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar",
-        "hash": "f39581a55f89fb0586373e237e1e4a9d5e2fe3b94167c7a6762552651e5a6038",
-        "path": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar"
+        "url": "com/dynatrace/hash4j/hash4j/0.26.0/hash4j-0.26.0.jar",
+        "hash": "47c319c7015d31df78c17962c4008861f8630f383d12275cf7abd09f6a804c43",
+        "path": "com/dynatrace/hash4j/hash4j/0.26.0/hash4j-0.26.0.jar"
     },
     {
-        "url": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar",
-        "hash": "3f1912b14a2fdd7ad2ef0bda9eeb1ae544c463857081d7dd69f9aa2b7137de6e",
-        "path": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar"
+        "url": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar",
+        "hash": "2ceef6a5a0527ad89ab6d1fd71bba4fef355cded510970c650d1443412b18dc5",
+        "path": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar"
     },
     {
-        "url": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar",
-        "hash": "dfc1db2a05dafeba40987a76591004cc72d4a27062d874961fadc5059900f65d",
-        "path": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar"
+        "url": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar",
+        "hash": "28829eebb36863b058108fa1b9b8b5cfb94c1871346e4a4f73e69e1fe0a5f0f6",
+        "path": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar"
     },
     {
-        "url": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar",
-        "hash": "a44d21dff0254e4f4f9ceb7870e8b27a403d7f1d6325ab03ae6c045302957761",
-        "path": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar"
+        "url": "com/fasterxml/jackson/core/jackson-annotations/2.18.0/jackson-annotations-2.18.0.jar",
+        "hash": "a09367d2eeb526873abf737ff754c5085f82073a382ee72c3bbe15412217671f",
+        "path": "com/fasterxml/jackson/core/jackson-annotations/2.18.0/jackson-annotations-2.18.0.jar"
     },
     {
-        "url": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar",
-        "hash": "81ad7bfe7e59de4cd047eacf24f979ec47db40eac6afc76e6f10288b456b14b1",
-        "path": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar"
+        "url": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar",
+        "hash": "ead60e9cac0e42b57092b9e2d087ff43536e9477d4486ba393037a8cc156cda7",
+        "path": "com/fasterxml/jackson/core/jackson-annotations/2.19.0/jackson-annotations-2.19.0.jar"
     },
     {
-        "url": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar",
-        "hash": "22d1d4316c4ec13a68b559e98c8256d69071593731da96136640f864fa14fad8",
-        "path": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar"
+        "url": "com/fasterxml/jackson/core/jackson-core/2.18.0/jackson-core-2.18.0.jar",
+        "hash": "215bbd7c8fd65be504cb92ff3aa1c4b790fc7b14cca72f4546aac4143c101bb5",
+        "path": "com/fasterxml/jackson/core/jackson-core/2.18.0/jackson-core-2.18.0.jar"
     },
     {
-        "url": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar",
-        "hash": "03852ab5b4419c1b0b3689930cdc1ac4f0c437a0c8094a900370dcb170cfbb46",
-        "path": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar"
+        "url": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar",
+        "hash": "da8e859bac94874528116a25f20c68560e4287acbf27628711b8a4f96b028430",
+        "path": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar"
     },
     {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar",
-        "hash": "8769e5647557e3700919c32d508f5c5dad53c5d8234cd10846354fbcff14aa24",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar"
+        "url": "com/fasterxml/jackson/core/jackson-databind/2.18.0/jackson-databind-2.18.0.jar",
+        "hash": "2bf1927b7f3224683ed0157a1ec3b0ede75179da3e597d78c572d56ed00f9f3c",
+        "path": "com/fasterxml/jackson/core/jackson-databind/2.18.0/jackson-databind-2.18.0.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-45/analysis-api-impl-base-for-ide-2.3.20-ij253-45.jar",
-        "hash": "1ae230b0e5847a47838b871060b7271c9b2329febb85e1470d1490ffe2e28fd4",
-        "path": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-45/analysis-api-impl-base-for-ide-2.3.20-ij253-45.jar"
+        "url": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar",
+        "hash": "ceda311f476c3b18e1d2b240c94e2dcb9c8d44e70f8afa9facab88bac4ddc03a",
+        "path": "com/fasterxml/jackson/core/jackson-databind/2.19.0/jackson-databind-2.19.0.jar"
     },
     {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar",
-        "hash": "ba1cb46e5494286940b016da372ae94a60d2dbc411b6dac5db1e40128725d501",
-        "path": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar"
-    },
-    {
-        "url": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar",
-        "hash": "e9b7e2b1262fd02fe63b08f636903ff36f453f08ae52190c78e3cbf19d777e42",
-        "path": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar"
-    },
-    {
-        "url": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar",
-        "hash": "fbbf174a4e78aa5be1f1b7db73edc5c0a6a2e59e1562263e2c3a2e510fa1ba45",
-        "path": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
-        "hash": "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720",
-        "path": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar",
-        "hash": "511cea72a464809d7e376968910fa704f9fa5afa8f2a94b53672a061b45475bb",
-        "path": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar"
+        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.19.0/jackson-dataformat-cbor-2.19.0.jar",
+        "hash": "ce27bf04655ac4a9f703ebf340782cf6836fc36c569a2daf25077c32532c88be",
+        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.19.0/jackson-dataformat-cbor-2.19.0.jar"
     },
     {
         "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.19.0/jackson-dataformat-toml-2.19.0.jar",
@@ -1070,59 +715,44 @@
         "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-toml/2.19.0/jackson-dataformat-toml-2.19.0.jar"
     },
     {
-        "url": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar",
-        "hash": "d875ff234a4b72e0eedfe170dd804797a4b87ba4c76207c9659d6f46b527877b",
-        "path": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar"
+        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.0/jackson-dataformat-xml-2.15.0.jar",
+        "hash": "e3137c89b08d0c3d9f7dfeae11d5b941b310f5f7bfdea90063f29c0b3b1f6807",
+        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.0/jackson-dataformat-xml-2.15.0.jar"
     },
     {
-        "url": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar",
-        "hash": "8a80959465bb09848cd41a89301490c55b9d940dc6ec30d8abac0f63b39fd5d0",
-        "path": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar"
+        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar",
+        "hash": "46e54dcbd39d4d12cda18ec9276e7b888e08fc765ea0c77e71662306f0d4abc4",
+        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar"
     },
     {
-        "url": "org/objenesis/objenesis/3.3/objenesis-3.3.jar",
-        "hash": "02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb",
-        "path": "org/objenesis/objenesis/3.3/objenesis-3.3.jar"
+        "url": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar",
+        "hash": "585fbc8bb26dffa4a3174d74352dd3e29cba990a9c1b06c1a547906aff2869ec",
+        "path": "com/fasterxml/jackson/datatype/jackson-datatype-joda/2.19.0/jackson-datatype-joda-2.19.0.jar"
     },
     {
-        "url": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar",
-        "hash": "94855942d4992f112946d3de1c334e709237b8126d8130bf07807c018a4a2120",
-        "path": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar"
+        "url": "com/fasterxml/jackson/jr/jackson-jr-objects/2.19.0/jackson-jr-objects-2.19.0.jar",
+        "hash": "1fbd56f47b0a35031585fa0444b81f1f284ebe4a8752a86f42d0c092c4d693e7",
+        "path": "com/fasterxml/jackson/jr/jackson-jr-objects/2.19.0/jackson-jr-objects-2.19.0.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-45/kotlin-compiler-fe10-for-ide-2.3.20-ij253-45.jar",
-        "hash": "d1f296fae451d3e16f70a6812fe88024132422189a6cb8a74e4f62b1fa5f18fd",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-45/kotlin-compiler-fe10-for-ide-2.3.20-ij253-45.jar"
+        "url": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar",
+        "hash": "df967eebc2c87eaa3f55338607104ffc8fa62fb2e813d67f95ed4f7f9c6f8cee",
+        "path": "com/fasterxml/jackson/module/jackson-module-kotlin/2.19.0/jackson-module-kotlin-2.19.0.jar"
     },
     {
-        "url": "com/typesafe/config/1.4.4/config-1.4.4.jar",
-        "hash": "ab16decc45cc678b0cf17fb9668f380a73bfdf11b75af1fa1ddec5da82805aea",
-        "path": "com/typesafe/config/1.4.4/config-1.4.4.jar"
+        "url": "com/fasterxml/woodstox/woodstox-core/7.1.1/woodstox-core-7.1.1.jar",
+        "hash": "02b9d022e9d47704ff8a7a859a0dbfd3b2882a8311eb7ff1e180f760ccda2712",
+        "path": "com/fasterxml/woodstox/woodstox-core/7.1.1/woodstox-core-7.1.1.jar"
     },
     {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+        "url": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar",
+        "hash": "b58b4d93fc1870b99b2adb3e16e9c483c8e73766b2944bc3cff805c0be47d19e",
+        "path": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar"
     },
     {
-        "url": "org/junit-pioneer/junit-pioneer/2.3.0/junit-pioneer-2.3.0.jar",
-        "hash": "8b09db32c8cf5b2112a00262411ccd4ef6ca3bae695a0015ecad4def23dea9fd",
-        "path": "org/junit-pioneer/junit-pioneer/2.3.0/junit-pioneer-2.3.0.jar"
-    },
-    {
-        "url": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar",
-        "hash": "066b702d850ebcde36f2a8181b46a2f0f1416129d1dc63c3a1e1531006e74739",
-        "path": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar"
-    },
-    {
-        "url": "org/testcontainers/testcontainers/1.20.3/testcontainers-1.20.3.jar",
-        "hash": "e1d89a13d93337e1b14000d6c7c3e8e047fe244db63231134e52fbc1c0ffc5f7",
-        "path": "org/testcontainers/testcontainers/1.20.3/testcontainers-1.20.3.jar"
-    },
-    {
-        "url": "org/rnorth/duct-tape/duct-tape/1.0.8/duct-tape-1.0.8.jar",
-        "hash": "31cef12ddec979d1f86d7cf708c41a17da523d05c685fd6642e9d0b2addb7240",
-        "path": "org/rnorth/duct-tape/duct-tape/1.0.8/duct-tape-1.0.8.jar"
+        "url": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar",
+        "hash": "c74a6c72221dfb76eb92f2bb40108ea561a7da2f315dc3b1e64afa8f077f210c",
+        "path": "com/github/ben-manes/caffeine/caffeine/3.2.2/caffeine-3.2.2.jar"
     },
     {
         "url": "com/github/docker-java/docker-java-api/3.4.0/docker-java-api-3.4.0.jar",
@@ -1140,2029 +770,9 @@
         "path": "com/github/docker-java/docker-java-transport/3.4.0/docker-java-transport-3.4.0.jar"
     },
     {
-        "url": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar",
-        "hash": "8088a80b47f5a7e73fa107f466dfa6a86776ca496fc2e7724aba65202d467913",
-        "path": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar",
-        "hash": "9a05bf77e128371f5b3e25ffc89f7af467a9f68dd365fdfced469ebcf533abc9",
-        "path": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar",
-        "hash": "3b34fd8172d70d0d7c59155e487bd8e77d43bdbfdcfe1d78c2b4eea55e9acb92",
-        "path": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar",
-        "hash": "e7dacfcfa3bc692c0a7a413cefd5f51ae420415a14d39091bdf88aebfdba70b6",
-        "path": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar",
-        "hash": "4b53bf7160e8cdf2ae6bf1a27018bb4fbfdb1841fbdad988c5ff71c7920f4a84",
-        "path": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar"
-    },
-    {
-        "url": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar",
-        "hash": "ef779af5d29a9dde8cc70ce0341f5c6f7735e23edff9685ceaa9d35359b7bb7f",
-        "path": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar"
-    },
-    {
-        "url": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar",
-        "hash": "05492a77e70f6a35f1ce19b60841ba39f2fcbe03b1b26eee7aea0c8745cc5e7e",
-        "path": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar"
-    },
-    {
-        "url": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar",
-        "hash": "99c2478a9b803b7d385d1624d5c1ab6f9a64cac5a2dc00f44a350744a1d858ac",
-        "path": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-45/parcelize-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "c4e51a757d46f19bdc2264c7be0cba0cc52eb52c9047c0be9b1df91eb8195f4e",
-        "path": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-45/parcelize-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
-        "hash": "88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06",
-        "path": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-45/low-level-api-fir-for-ide-2.3.20-ij253-45.jar",
-        "hash": "635cd736b002e250cbb2165f5cb05b2a9750f403ec8eaf6e1be9fad67f3ec1aa",
-        "path": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-45/low-level-api-fir-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar",
-        "hash": "8836ccffd3585fadda9901244b20d42901d2f3cd581058d8434e2ffabcf3a3e7",
-        "path": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar",
-        "hash": "ca0857dcde7cffff8eea3cce2940a285f219f673829f7f9a3381f767d224f411",
-        "path": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar"
-    },
-    {
-        "url": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar",
-        "hash": "efd986ec851c3a5cd57907e72f27d1af9c1e5b1874b07a8b778588646d71d9fc",
-        "path": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar"
-    },
-    {
-        "url": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar",
-        "hash": "12622deeea2618b59b284051a9484f1def8ccbebc847c350358f12d325ba9dd5",
-        "path": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar"
-    },
-    {
-        "url": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar",
-        "hash": "d46f96bf59ccd5800261eec5869a6877ee0a37ea781312e6735be55539f50354",
-        "path": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-45/kotlin-compiler-fir-for-ide-2.3.20-ij253-45.jar",
-        "hash": "51241b1d60e87ef52b69ad58dc530230dd832def0cec16ca3a57e705f7ecd9bc",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-45/kotlin-compiler-fir-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/testng/testng/7.8.0/testng-7.8.0.jar",
-        "hash": "dbbc43e2c64623661c3537f9d74061eb6c8fc3e5b4376f31fadb16de2b200f88",
-        "path": "org/testng/testng/7.8.0/testng-7.8.0.jar"
-    },
-    {
-        "url": "com/beust/jcommander/1.82/jcommander-1.82.jar",
-        "hash": "deeac157c8de6822878d85d0c7bc8467a19cc8484d37788f7804f039dde280b1",
-        "path": "com/beust/jcommander/1.82/jcommander-1.82.jar"
-    },
-    {
-        "url": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar",
-        "hash": "da2381fbee4799631ba44d1f4d6487b886b22450c7fc85842c5fdfa03429b817",
-        "path": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar"
-    },
-    {
-        "url": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar",
-        "hash": "b7e3d46c87bad2eb409b0e704916bcd81206168e357312dfddd0e253679cd9e0",
-        "path": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar"
-    },
-    {
-        "url": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar",
-        "hash": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
-        "path": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar",
-        "hash": "604c4130ca7a0e979a449cf550087a5c2c586485e8af01dcf24b03b7b287306d",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar",
-        "hash": "6ededc9be4d878aea80c7dd609f91bfc47fcd3d36cc91fd0f3f328fbd6656c8f",
-        "path": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar",
-        "hash": "ea38a66b0ff46ed82dded9e81d2dce70e5fbe03bd6cc52b4fc8869381dea7b7d",
-        "path": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar"
-    },
-    {
-        "url": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar",
-        "hash": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a",
-        "path": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
-        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
-        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
-        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
-        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
-        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
-        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar",
-        "hash": "4449fa59e5f4f9a18e18b5ed10db95dba3f65a825cfc32d053097d8bffccfbf1",
-        "path": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/connection-client/171/connection-client-171.jar",
-        "hash": "ca8ebd17e33f333647b905d43fc8cce2ad16abd22bfa99b75cb8a499894648b8",
-        "path": "com/jetbrains/fus/reporting/connection-client/171/connection-client-171.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar",
-        "hash": "3565b6d4d789bf70683c45566944287fc1d8dc75c23d98bd87d01059cc76f2b3",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar"
-    },
-    {
-        "url": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar",
-        "hash": "f8f56f19d2b29da511809c3345d2f0bf283bfb94a0a0d83f5b630e1424625723",
-        "path": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar"
-    },
-    {
-        "url": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar",
-        "hash": "e7f064bf1eab83fa785cf587f657f09649e3b0af6f27caa5382416953b5a35f8",
-        "path": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar"
-    },
-    {
-        "url": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar",
-        "hash": "74d953cec00048b892112f9602fc7b1113ea55337dc1ede32e449efcb2b231c7",
-        "path": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar",
-        "hash": "cc65afe17daf2f9380d3c64460f5b10ec279f98b9461fbf0ccf62b3cb3ee6c37",
-        "path": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar",
-        "hash": "fd0e111cae80bd6285677759b72cb67e7da68ee779a90e51bee12a7011c28436",
-        "path": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar",
-        "hash": "8209083a4a7c4e476d9842b078308fa96a96f07a6bd99f05f3586ee13289ab26",
-        "path": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar"
-    },
-    {
-        "url": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar",
-        "hash": "4b5705f8cabd07e82c81dbce36f1554aa9d1740f03e369fd049a71f375dac2f0",
-        "path": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar",
-        "hash": "da8e859bac94874528116a25f20c68560e4287acbf27628711b8a4f96b028430",
-        "path": "com/fasterxml/jackson/core/jackson-core/2.19.0/jackson-core-2.19.0.jar"
-    },
-    {
-        "url": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar",
-        "hash": "d74a3334fb35195009b338a951f918203d6bbca3d1d359033dc33edd1cadc9ef",
-        "path": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar",
-        "hash": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-        "path": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar"
-    },
-    {
-        "url": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar",
-        "hash": "54b321650a50f78ceee6bd06653ee3cea0b19db5fe95e3c3a109e6af4a20126c",
-        "path": "ai/grazie/grazie-rule-engine/0.3.11/grazie-rule-engine-0.3.11.jar"
-    },
-    {
-        "url": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar",
-        "hash": "80a2f8918240a07d3a6fc7cdcc543d278013f6943c080835e43a22fc90462a9f",
-        "path": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar"
-    },
-    {
-        "url": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar",
-        "hash": "02da615dd0adac62f2d87db878f587529e8d2cb82b3a65ed8b5466a518324180",
-        "path": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar"
-    },
-    {
-        "url": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar",
-        "hash": "ac0f343d6fc0dca4c93f8b6a6266b3bf4cb4d61913b8a4cd2b3abf50025268cf",
-        "path": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar"
-    },
-    {
-        "url": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar",
-        "hash": "e2167e99bdb018576cce9cc0aad154ad995fe67a4b0c36c63344f743865f96e7",
-        "path": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar"
-    },
-    {
-        "url": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar",
-        "hash": "d1c2cc901dd702eb77a2258c0d1446e4a302d28da0d4b49cd11ff3d5929281fa",
-        "path": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar"
-    },
-    {
-        "url": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar",
-        "hash": "e35cfa4a16204bf59fa167bb6d45be0717d6b7cfba1c30f156d8f21cde2f4065",
-        "path": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar"
-    },
-    {
-        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
-        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
-        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
-    },
-    {
-        "url": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar",
-        "hash": "d96425f4bab28798162e59fffbe7e16ea6c2aab303ee8dfb0a2ec38a5a4e2f36",
-        "path": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar"
-    },
-    {
-        "url": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar",
-        "hash": "0df80935d9bc3b3841bc621c6fef6615c93aaf80393ccaa196db11bf97784f18",
-        "path": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar"
-    },
-    {
-        "url": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar"
-    },
-    {
-        "url": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar",
-        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
-        "path": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar"
-    },
-    {
-        "url": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar",
-        "hash": "2bbfa931b2864c4f5e1fd22046d001df8d9a8592a20255baab0d396ed71c854c",
-        "path": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/model/171/model-171.jar",
-        "hash": "8aa0be7e7c1a46ef0827d98c026d328a6f9be27aed79b36692a7f38bacd41a6a",
-        "path": "com/jetbrains/fus/reporting/model/171/model-171.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-45/analysis-api-k2-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "7359f01e280d5d55781135956975278b3e4c1472e9628cce72bb0071705ce63b",
-        "path": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-45/analysis-api-k2-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar",
-        "hash": "94a06c3fdd4aa638df59c8c783a379ca43a5b933187760e219e09e84f1633d76",
-        "path": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
-        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
-        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar",
-        "hash": "34d626ffa4a27ec49e47de7d760f1df30223ecb8944b6472941f5c73ec68dfbd",
-        "path": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar"
-    },
-    {
-        "url": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar",
-        "hash": "6d8d14b91285cc7c1b73460f413bb3f80672dc34dc506ed578fba1f6dde8661e",
-        "path": "com/android/tools/build/aapt2-proto/8.1.0-10154469/aapt2-proto-8.1.0-10154469.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-45/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "7566ed7641a9eb3852d51a58f15f0815827c903b493ed0b7386a9ee4f83769ba",
-        "path": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-45/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar",
-        "hash": "41984dffaf069b84b814fa787f740bf7ebdc90bf89f69d05bc4660c69874b49e",
-        "path": "app/cash/turbine/turbine-jvm/1.0.0/turbine-jvm-1.0.0.jar"
-    },
-    {
-        "url": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar",
-        "hash": "ffd6f3fbba2453440e4c04add42b9f903d84151b5b71f7e6bbb181d8096397a4",
-        "path": "com/android/tools/smali/smali-baksmali/3.0.3/smali-baksmali-3.0.3.jar"
-    },
-    {
-        "url": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar",
-        "hash": "8078a04709f42072a240a6fe7666b71755324745c505b39f86ededfd9c2b90c4",
-        "path": "com/android/tools/smali/smali-util/3.0.3/smali-util-3.0.3.jar"
-    },
-    {
-        "url": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar",
-        "hash": "81981241b8df2eeee48efac05798e7beaa2b8d6bd5d610b3f5a4fea07b0eff6e",
-        "path": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar",
-        "hash": "a3c111c85eabb8149c485c275768d57cd96a05b595ca1946781c0d4c5fb1654a",
-        "path": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar"
-    },
-    {
-        "url": "com/google/truth/truth/0.42/truth-0.42.jar",
-        "hash": "dd652bdf0c4427c59848ac0340fd6b6d20c2cbfaa3c569a8366604dbcda5214c",
-        "path": "com/google/truth/truth/0.42/truth-0.42.jar"
-    },
-    {
-        "url": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar",
-        "hash": "61ba4dc49adca95243beaa0569adc2a23aedb5292ae78aa01186fa782ebdc5c2",
-        "path": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar",
-        "hash": "2285ebfe8e0fd38e186b7033f6f6c542324c9bab23260b914b1b73eaf4492c5d",
-        "path": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar"
-    },
-    {
-        "url": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar",
-        "hash": "f05496e255734759f0d4b5632da7b24f81313147c78c69e90ad045d096191344",
-        "path": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar"
-    },
-    {
-        "url": "org/tukaani/xz/1.10/xz-1.10.jar",
-        "hash": "95c63c1a55b22dd6453890a419cc1a640f790bbf7d8ae82db1e30aefefb08888",
-        "path": "org/tukaani/xz/1.10/xz-1.10.jar"
-    },
-    {
-        "url": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar",
-        "hash": "7e346b94d47fb4e4495ebd6161fd5c6d01659687e93c460bbfd320ba47bea852",
-        "path": "com/charleskorn/kaml/kaml-jvm/0.80.1/kaml-jvm-0.80.1.jar"
-    },
-    {
-        "url": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar",
-        "hash": "733e1347e3ec909e8a7ee199e48a64d0180569461b3bc08c8a6bb1335f5ce1bd",
-        "path": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar"
-    },
-    {
-        "url": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar",
-        "hash": "8d0fd2aeb48d19dc49c563ebc00f274947e45f716c107535c12ead63decd688d",
-        "path": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar"
-    },
-    {
-        "url": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar",
-        "hash": "70feef9dd75ad064def05a3ce8975aeba515ee7d1be146d12199c8828a64174c",
-        "path": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar",
-        "hash": "677e12f96a6c48b1b4c4234417cda17bbcb3c25f5c7178ec752ef2a831c65313",
-        "path": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar",
-        "hash": "3ad94d6402b94932f4341c908827016787cdc6ee3201ee64970822a610c55d34",
-        "path": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar"
-    },
-    {
-        "url": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar",
-        "hash": "4b9fb2e5a13b37cf8bd62eebada8d3485c3dc17df752783b68d89d657bcc01fd",
-        "path": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar"
-    },
-    {
-        "url": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar",
-        "hash": "e22941d77d0d01dfc6ee5612ad421860baae8a3a0dea2eeb67658061f34527b4",
-        "path": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar"
-    },
-    {
-        "url": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar",
-        "hash": "e51ee1761684a946b9d5a0caaec2b92cf4598860cf231dbaf495f268fda35d10",
-        "path": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar"
-    },
-    {
-        "url": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar",
-        "hash": "b58b4d93fc1870b99b2adb3e16e9c483c8e73766b2944bc3cff805c0be47d19e",
-        "path": "com/github/ajalt/clikt/clikt-jvm/3.5.4/clikt-jvm-3.5.4.jar"
-    },
-    {
-        "url": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar",
-        "hash": "9403c2537ac0dd425e556dfc3434e5d9f9a9547312472f4c27b7ab2673e9e862",
-        "path": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar"
-    },
-    {
-        "url": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar",
-        "hash": "f264dd9f79a1fde10ce5ecc53221eff24be4c9331c830b7d52f2f08a7b633de2",
-        "path": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar"
-    },
-    {
-        "url": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar",
-        "hash": "c78613ac0db94650c03a37b2a35b3238b2d018fcac9f10e5fe268c3887cf5e0b",
-        "path": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar",
-        "hash": "7d01bf0334ffa3ab55f3828bb50188bf9969774a23791a3df1905e53bfeea8f5",
-        "path": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar",
-        "hash": "0b93f01cff5bc2a64af829ca01c826e8e861a03b96a871fa2a240fa25681df78",
-        "path": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar",
-        "hash": "a7e19945a6baa86ab285383a0bda632eae7703a889da1d20ea4eaad4c996cc21",
-        "path": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar",
-        "hash": "5b4e125a341566b24d5030479da475b20ea1f6145bf7b3c3d69fe537088bb4c1",
-        "path": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar",
-        "hash": "f3272149099883cf98ad8a2a82a08111a78d17e604aebc094c80592a730fcac5",
-        "path": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar",
-        "hash": "0f5f7220d34d32751cc624bc9c47afdde7392f0d9551569c90a568309015d796",
-        "path": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar"
-    },
-    {
-        "url": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar",
-        "hash": "c07aac2ea55aa42c34fc6b53fbee661e0de077f45483133b6ca297c70a67a44a",
-        "path": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar"
-    },
-    {
-        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
-        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
-        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
-    },
-    {
-        "url": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar",
-        "hash": "c2a88cf8be1eb0870732a7b2e669972efc7f33a145998f568096137f16b20d79",
-        "path": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar"
-    },
-    {
-        "url": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar",
-        "hash": "ba88e5bde7c0d878c3e1f2ec2fcabaf51d201eaf93b3bb9cfecfc1f11b2304d4",
-        "path": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar"
-    },
-    {
-        "url": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar",
-        "hash": "973018b87af911ecf6e6d861dd0d6a477e4d8ae6a883ec5d073d3df1330b87f0",
-        "path": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar"
-    },
-    {
-        "url": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar",
-        "hash": "27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd",
-        "path": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar"
-    },
-    {
-        "url": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar",
-        "hash": "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a",
-        "path": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-45/kotlin-scripting-jvm-2.3.20-ij253-45.jar",
-        "hash": "42d81993e1dd93ba47dc648cf6f8af88aa20ab276077086adcffcc51cd65e08d",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-45/kotlin-scripting-jvm-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "ce4dc5b9232e9467373ef2e79cab9e3404db898ab45020ce14ef893944745331",
-        "path": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-45/kotlin-compiler-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "4b182e6689c0b5ff330195dc89d249df941a11a7027ce08e6e84163fa89d37d2",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-45/kotlin-compiler-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar",
-        "hash": "3b0f0422993e571f3460d8436a0e56538bd474147084a6cbb244a6d5cb1a01a5",
-        "path": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar",
-        "hash": "2ae0d57bb9fceb8ee2aeda6536acc6f3e1de355984b4c9da720566b85f1525e8",
-        "path": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
-        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
-        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-45/analysis-api-platform-interface-for-ide-2.3.20-ij253-45.jar",
-        "hash": "33db5c2be1f298109a32c67efc9ff9f2351812cd18b1d3e3b6142b8c1f6562a0",
-        "path": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-45/analysis-api-platform-interface-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
-        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
-        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
-        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
-        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
-        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
-        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
-        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
-        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar",
-        "hash": "63efc00da99774fb0253330ef9b5788b261022ba73f36bf76889ce7edf3d2b31",
-        "path": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/serialization-kotlin/171/serialization-kotlin-171.jar",
-        "hash": "83380929b70dc8e25db327be8680438f3d80087962a88f4dcf061c919ba2fc32",
-        "path": "com/jetbrains/fus/reporting/serialization-kotlin/171/serialization-kotlin-171.jar"
-    },
-    {
-        "url": "oro/oro/2.0.8/oro-2.0.8.jar",
-        "hash": "e00ccdad5df7eb43fdee44232ef64602bf63807c2d133a7be83ba09fd49af26e",
-        "path": "oro/oro/2.0.8/oro-2.0.8.jar"
-    },
-    {
-        "url": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar",
-        "hash": "cffb55f1e7268e160647e88da142c09c6175ff72970c64f7cb411d78eb661663",
-        "path": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar"
-    },
-    {
-        "url": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar",
-        "hash": "bae13d4e4716a0955d316b5fcb75582504325e5b11ac946b13b64b4fce19bc6e",
-        "path": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar"
-    },
-    {
-        "url": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar",
-        "hash": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
-        "path": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
-    },
-    {
-        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar",
-        "hash": "c720e6e5bcbe6b2f48ded75a47bccdb763eede79d14330102e0d352e3d89ed92",
-        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar"
-    },
-    {
-        "url": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar",
-        "hash": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
-        "path": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar"
-    },
-    {
-        "url": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar",
-        "hash": "d8d6911e225b55501692651272ce961ba5be1f76662ceb7f0aa79ecce8f63f25",
-        "path": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar",
-        "hash": "d767014ad0c9a27d27d26fd38e7afa030aee0d141338f108781ff02ecf2fdab5",
-        "path": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar"
-    },
-    {
-        "url": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar",
-        "hash": "0c8d23755cd08d23c3ea194773a08b2c322d2b70cc8c86ac02b424d8a50c9118",
-        "path": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar"
-    },
-    {
-        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
-        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
-        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar",
-        "hash": "7ea54221f5f91deff2e860fe986eefe208b59fa04300e54c505c5c0c08d55e9a",
-        "path": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar"
-    },
-    {
-        "url": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar",
-        "hash": "3238c68a2f86cec53cc184ad26df8352db87bb22a419bd17fb4acdfbb0bc40f0",
-        "path": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar"
-    },
-    {
-        "url": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar",
-        "hash": "993302b16cd7056f21e779cc577d175a810bb4900ef73cd8fbf2b50f928ba9ce",
-        "path": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar",
-        "hash": "d99052e257681e496590c5c724e1324eb511e4205f5fd413b5f503d8e932b698",
-        "path": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar",
-        "hash": "de175ebed73336e126ecba42c8b93a6566f65b169c6b4a4deb8099fe28e944de",
-        "path": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar"
-    },
-    {
-        "url": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar",
-        "hash": "eae29213e4f16515639c28957200f011b3967fffcada1962cf0255d24919c22f",
-        "path": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
-    },
-    {
-        "url": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar",
-        "hash": "b3640b9f416a4411fd33c59abbeea8fd57d024c23e1819bf9673220a97499fe3",
-        "path": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar"
-    },
-    {
-        "url": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar",
-        "hash": "79626019fed282b70eef91f645a9febd5f6b9f7be46484b6b328313a481f05f0",
-        "path": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar"
-    },
-    {
-        "url": "com/jetbrains/fus/reporting/ap-validation/171/ap-validation-171.jar",
-        "hash": "3c8c66663148ac5d2a953cb048a1939b96be543d4612c23e030a7c6fd20390cd",
-        "path": "com/jetbrains/fus/reporting/ap-validation/171/ap-validation-171.jar"
-    },
-    {
-        "url": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar",
-        "hash": "8103c08a017068f9ba79aa260471780b38e3a68bce8995ec1d5279b523ac87ca",
-        "path": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar"
-    },
-    {
-        "url": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar",
-        "hash": "5280d3e4bae23c4f1cc59bab77dab9f7a9626aeceeaa0bb07a9868bcedae2da9",
-        "path": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar"
-    },
-    {
-        "url": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar",
-        "hash": "28829eebb36863b058108fa1b9b8b5cfb94c1871346e4a4f73e69e1fe0a5f0f6",
-        "path": "com/fasterxml/aalto-xml/1.3.3/aalto-xml-1.3.3.jar"
-    },
-    {
-        "url": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
-        "hash": "a61c48d553efad78bc01fffc4ac528bebbae64cbaec170b2a5e39cf61eb51abe",
-        "path": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar"
-    },
-    {
-        "url": "com/jetbrains/mlapi/mlapi-catboost/0.2.1/mlapi-catboost-0.2.1.jar",
-        "hash": "de75176f3c95433d8da2b95dcdd233b6d9e3cca39f6e2baedb01d4932f911c85",
-        "path": "com/jetbrains/mlapi/mlapi-catboost/0.2.1/mlapi-catboost-0.2.1.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar",
-        "hash": "e7c2a48e8515ba1f49fa637d57b4e2f590b3f5bd97407ac699c3aa5efb1204a9",
-        "path": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar"
-    },
-    {
-        "url": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar",
-        "hash": "8d715c487c8908a8b3b1d982f013f5ec39fb9033eb4272fdb251d648b5ede48c",
-        "path": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar",
-        "hash": "3a8c6365716dbb698c0d49a05456c1e1ad05c406613c550f9dd50037872efc41",
-        "path": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar"
-    },
-    {
-        "url": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar",
-        "hash": "ba005f304cef92a3dede24a38ad5ac9b8afccf0d8f75839d6c1338634cf7f6e4",
-        "path": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
-        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
-        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
-    },
-    {
-        "url": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar",
-        "hash": "1b273d92160b9fa69c3e65389a5c4decd2f38a697e458e6f75080ae09e886404",
-        "path": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-45/kotlin-scripting-dependencies-2.3.20-ij253-45.jar",
-        "hash": "beeae35aaf0e3043b8202e081bbdeb55672a89dc8bbcc482dfa5cc21d26dc1de",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-45/kotlin-scripting-dependencies-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar",
-        "hash": "bd30f6cf55c4f9f0891f8b6ea6601c1502b643543d2535c8b477ea0481809e99",
-        "path": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar",
-        "hash": "5f097b00c6714bb71ecfb5dec62b59bb4c2f789763fafd1ece96c4ef0e6c280f",
-        "path": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar",
-        "hash": "6f81842e9c13e997cac66b44614522f3639419e2388ae2d000c4bc0a6b92d93f",
-        "path": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar"
-    },
-    {
-        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
-        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
-        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-    },
-    {
-        "url": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar",
-        "hash": "241daa21665dd0ca55576a4bc4d8e9ace8891ae3c698cc77f13bb4bdac372e94",
-        "path": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar"
-    },
-    {
-        "url": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
-        "hash": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
-        "path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
-    },
-    {
-        "url": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar",
-        "hash": "f3d7f57f67fd622f4d468dfdd692b3a5e3909246c28017ac3263405f0fe617ed",
-        "path": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar"
-    },
-    {
-        "url": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar",
-        "hash": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
-        "path": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-45/allopen-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "f7374912dbbcfc18686114a78804a7f4ba91aa54b6f3bf4be10a54bb643f8a61",
-        "path": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-45/allopen-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar",
-        "hash": "86b9d2a2378cff951f3bd0750d56ff4cef64f78dbb33e9f7abd9c7e6e14d99de",
-        "path": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar",
-        "hash": "6f4932086ba785deeb74170140508156b21772cd2961a37e7b551eb5d2649a29",
-        "path": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar",
-        "hash": "84f1d58dbf19cd7d42a5301bd256d589af1f520b4c90b8836cee7747f8726992",
-        "path": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar"
-    },
-    {
-        "url": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar",
-        "hash": "d65226949713c4c61a784f41c51167e7b0316f93764398ebba9e4336b3d954c2",
-        "path": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar"
-    },
-    {
-        "url": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar",
-        "hash": "5c0ca9e321c02845c47dc6edcef9f22e49015cef7753c54012f5398425163c08",
-        "path": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar"
-    },
-    {
-        "url": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar",
-        "hash": "0b27938f3d28ccd6884945d7e4f75f4e26a677bbf3cd39bbcb694f130f782aa9",
-        "path": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar"
-    },
-    {
-        "url": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar",
-        "hash": "de8ce5309713e72bb57d5ff2dabdb4c173ae4872bd1439b9c3d3f93430b407d9",
-        "path": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar",
-        "hash": "648eaffe833416e2accea4bf82b980f0e91ae51ef065f5bc74fa3481c373e9fd",
-        "path": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar",
-        "hash": "ab5ec8ea48815197c46a7df9f418a62791fe91cda5023b941ce4de872d810cc1",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar"
-    },
-    {
-        "url": "one/util/streamex/0.8.4/streamex-0.8.4.jar",
-        "hash": "c8bcde95bb6c659bd611a5bc464380f38118a10a0443f3fc15304d91e5c9dd81",
-        "path": "one/util/streamex/0.8.4/streamex-0.8.4.jar"
-    },
-    {
-        "url": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar",
-        "hash": "00cfcc187ff46ce8d702a0f2cb98d6a4f2a67f8f41242b5901e46efdcb7c84b7",
-        "path": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar"
-    },
-    {
-        "url": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar",
-        "hash": "bd7f7b5d07bc0b047f10915b32ca4bb1de9e57d8049098882e4453c88c076a5d",
-        "path": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar",
-        "hash": "7251646a8ea8d56a2415311de6040159479ac0e35de36dab70b667ed899ac931",
-        "path": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar"
-    },
-    {
-        "url": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar",
-        "hash": "6ba90d0d081c03c5c03d2d41497f75a183da7fb23cc2691f7b782dea77f73d21",
-        "path": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar"
-    },
-    {
-        "url": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar",
-        "hash": "7d703a1d484ac1135b78b24a4880f5653161cda83454c0f484fa09e29311d3bd",
-        "path": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar",
-        "hash": "0b0beaeb6880a31149641d2d848b863712885469670c12099586d7f798522564",
-        "path": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar",
-        "hash": "390c5f77b84283a64b644f88251b397e0b0debb80bdcc50f899881aecff43a5a",
-        "path": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar",
-        "hash": "6842753b11a1544198f4a14b0f8820728327939b859c23c50b5fd4179c693900",
-        "path": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar"
-    },
-    {
-        "url": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar",
-        "hash": "cadef0207077074b11a12be442f89ab6cf93fbc2f848702d9371a9611414d558",
-        "path": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar",
-        "hash": "21a748abc565fd6d97d90f2547d0fd1da36810171050b2a337cbc02799cfe482",
-        "path": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
-        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
-        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar",
-        "hash": "e640732fbcd3c6271925a504f125e38384688f4dfbbf92c8622dfcee0d09edb9",
-        "path": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar",
-        "hash": "14b7880cb7c85eed101e2710432fc3ffb83275532a6a894dc4c4095d49ad59f1",
-        "path": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm/9.8/asm-9.8.jar",
-        "hash": "876eab6a83daecad5ca67eb9fcabb063c97b5aeb8cf1fca7a989ecde17522051",
-        "path": "org/ow2/asm/asm/9.8/asm-9.8.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar",
-        "hash": "8938eb97e36320daa3e6fb2a60fd2a05b232ff4a557173c5019f045b8832d9f4",
-        "path": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar",
-        "hash": "7f9fd8e37ec4dfdef7bfc3bc6a687fa5a322976fc588432fa46d2feb1fefc966",
-        "path": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar",
-        "hash": "4c172eb930db7d7cfef36cf3ba7d5094ce08dea6fde2b4be7746680a2ebd7c05",
-        "path": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar",
-        "hash": "b38c604871f3690109a3c00982d9145634125de3365a817ba16eb90d88e242c9",
-        "path": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar",
-        "hash": "31a5fe3a7ba42e3457b83930f0ff8d679fb5b76eaadf2b51f5740c92a394bf52",
-        "path": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar",
-        "hash": "249f396412b0c0ce67f25c8197da757b241b8be3ec4199386c00704a2457459b",
-        "path": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar"
-    },
-    {
-        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
-        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
-        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
-    },
-    {
-        "url": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar",
-        "hash": "e826a88e448a0c1d42abc30c9d047131badbac6fc3922b8e93ac3ea27bb0eb2c",
-        "path": "com/android/tools/layoutlib/layoutlib/15.2.3/layoutlib-15.2.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-45/kotlin-compiler-ir-for-ide-2.3.20-ij253-45.jar",
-        "hash": "230f801ec0de74e6363bf7553c71dbf085d1aaaadcf553afd1248ab51fbcfef1",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-45/kotlin-compiler-ir-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/xerial/sqlite-jdbc/3.50.3.0/sqlite-jdbc-3.50.3.0.jar",
-        "hash": "a3f53a2aa15ae9425a9e793bbe9c8e5288febeb4b65ef5c1a4e80d4c2045cf08",
-        "path": "org/xerial/sqlite-jdbc/3.50.3.0/sqlite-jdbc-3.50.3.0.jar"
-    },
-    {
-        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
-        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
-        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar",
-        "hash": "0628a26040706fea7a222a91c8ca339aef9ea8ceda6d24527a817dc7e0ad5c92",
-        "path": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar"
-    },
-    {
-        "url": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar",
-        "hash": "491c4ae84a1bad34c85624682a80def4f3a3a0fb9d517121d05c2dfeb94966f8",
-        "path": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar",
-        "hash": "9b3211ad7f1508f6453d16922aad6c7dce5b2f9a88b7e272171f63875ee78efd",
-        "path": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar"
-    },
-    {
-        "url": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar",
-        "hash": "bc7af4f3c4ba1a23c20a6e1945f3e17fd3f5719f6f17d62961b3167d939a18e2",
-        "path": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
-        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
-        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar",
-        "hash": "9c4a9713b2722b3b124210e89c3702c3e18c19156a3a06fa6bcef43a850299ca",
-        "path": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar"
-    },
-    {
-        "url": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar",
-        "hash": "2a4e84a51defe9108579b3c0a86bb41e54f04e9042e83adf4348a974dcf1dee6",
-        "path": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar",
-        "hash": "0070e80f9fed930c7209b15a5590f178acfc56028f2b6dd447c2c7cae1fc058d",
-        "path": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar"
-    },
-    {
-        "url": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
-        "hash": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
-        "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-45/kotlin-script-runtime-2.3.20-ij253-45.jar",
-        "hash": "c35fd880ce45b252c0daee0bc644ea91a326a69c9dceda54151f4b2e13f3bdc3",
-        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-45/kotlin-script-runtime-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/google/zxing/core/3.5.1/core-3.5.1.jar",
-        "hash": "1ba7c0fbb6c267e2fb74e1497d855adae633ccc98edc8c75163aa64bc08e3059",
-        "path": "com/google/zxing/core/3.5.1/core-3.5.1.jar"
-    },
-    {
-        "url": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar",
-        "hash": "c1c197ed03acaf46773176a001836219b6299fe267dc4751c2c28ae98edfa0f3",
-        "path": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar",
-        "hash": "7db707d839949384760b0f3e58eff49bfedea05f822e4f3361c4b540aa5dcc16",
-        "path": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-45/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-45.jar",
-        "hash": "c6deada2fac53b8ea6523dbda77597b128006674616f140f04df23264c6d1aa3",
-        "path": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-45/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
-        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
-        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-45/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "98457d26126f1095049a8769d78168ff7d0907f0b472ee28967073709b4b4607",
-        "path": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-45/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar",
-        "hash": "8524eac90f7e8e0f1366883f2c6c820c93bfa61df3d76857c8d3e803cf67315d",
-        "path": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-45/kotlin-gradle-statistics-for-ide-2.3.20-ij253-45.jar",
-        "hash": "94ffb26541561992a8eb23937f28437782830f896b90a6eed6f97e479fffdfa0",
-        "path": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-45/kotlin-gradle-statistics-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-45/kotlin-compiler-cli-for-ide-2.3.20-ij253-45.jar",
-        "hash": "fd9db5d6b301967133bc977935d22295e247ed2ccefc2583942ef7376fd598c1",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-45/kotlin-compiler-cli-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar",
-        "hash": "8d1af87632d95148f122a9fa0ae2903c19ee6fab7d01e017f76e0d2c9a022c20",
-        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar"
-    },
-    {
-        "url": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar",
-        "hash": "7e37284e33b5b304ee6174dcaa92db949b257cc4c8991ca865e7daf5113d8279",
-        "path": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
-        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
-        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar",
-        "hash": "fbd174f72ea82364baa112069f2d7b361758f6b68bd81d2ac51b02c66a48e924",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-45/kotlin-compiler-common-for-ide-2.3.20-ij253-45.jar",
-        "hash": "4af9a30fde5d143da69428bfef59e292c794927613bf0a5b111aaaa0ead01ba2",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-45/kotlin-compiler-common-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar",
-        "hash": "78e527dfea8d79c16ea9ca875bd943d443b63bf9d0df1f253c233dc54366df35",
-        "path": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar"
-    },
-    {
-        "url": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar",
-        "hash": "3941b48f2e9281aab7234395c549cbb399b3dc80fed2e13999a80db47f94b041",
-        "path": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar"
-    },
-    {
-        "url": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar",
-        "hash": "2bcbbf2f3227aa97527730eb92ca8724263e6d555b888fbb14aae52bc712d434",
-        "path": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar"
-    },
-    {
-        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
-        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
-        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar",
-        "hash": "71568c9f8396677219f650268fbf6493ded484edcdbdf2dae6129ca5be81e8db",
-        "path": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-45/lombok-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "8bc0ca5c9bb47b4ae74ab75306e8c0481d2748b3165dc850165d72d199540653",
-        "path": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-45/lombok-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar",
-        "hash": "124bddea3fa0683d3e174552fba5fcf0f24a2f57f1ccf6957010d010d246db8b",
-        "path": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar"
-    },
-    {
-        "url": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar",
-        "hash": "ace77c533236213a1aa9f68b8de10e564da809605371ef2f8c73cd8f4c71293a",
-        "path": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar"
-    },
-    {
-        "url": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar",
-        "hash": "0a5ebc0506ab1e4a08af1ca150f797304ff53b953c5b1f6fcf1f81551d964aad",
-        "path": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar"
-    },
-    {
-        "url": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar",
-        "hash": "050fe139de47d8937e6b0080e8dff3d0f42df6782f147c10bb298c0e9cd94b2f",
-        "path": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar"
-    },
-    {
-        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-    },
-    {
-        "url": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar",
-        "hash": "c53b16b999d3b2f1aa273bf5c560273d23e1fa21ce493ba7cbf5243118386b88",
-        "path": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar"
-    },
-    {
-        "url": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar",
-        "hash": "dda6a96d529f473c952ba7e8205509de29725ad40eff80af7d371df95ccb14c1",
-        "path": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-45/scripting-compiler-plugin-for-ide-2.3.20-ij253-45.jar",
-        "hash": "75048ae78a873e992533ba3c376a65701cff28fbcafd79d587efc999a638e0bd",
-        "path": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-45/scripting-compiler-plugin-for-ide-2.3.20-ij253-45.jar"
-    },
-    {
-        "url": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar",
-        "hash": "2ceef6a5a0527ad89ab6d1fd71bba4fef355cded510970c650d1443412b18dc5",
-        "path": "com/esotericsoftware/kryo5/5.6.0/kryo5-5.6.0.jar"
-    },
-    {
-        "url": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar",
-        "hash": "3c8a183f81e176d9c452c9bb94007574bc8188446b4fc98b527aa79074cd0dda",
-        "path": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar",
-        "hash": "38135d3f995fc505d604aed2e82ac5ba858b2a6a3e476899c3b8be47fd222b68",
-        "path": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar"
-    },
-    {
-        "url": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar",
-        "hash": "a000df0643439bfc1a41cc35098491dcb5733766e629ecbed2d68adb473f8420",
-        "path": "com/android/tools/analytics-library/testing/31.5.0-alpha08/testing-31.5.0-alpha08.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar",
-        "hash": "acbf67631c42197791363ce8e8f155f62aeef51ade809e0847a89eba44785c7d",
-        "path": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar",
-        "hash": "0054c51c672512a918440703e35ea946a8e7a210872f2196dbd6b9f2959198b0",
-        "path": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar",
-        "hash": "46e54dcbd39d4d12cda18ec9276e7b888e08fc765ea0c77e71662306f0d4abc4",
-        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.19.0/jackson-dataformat-yaml-2.19.0.jar"
-    },
-    {
-        "url": "xalan/xalan/2.7.3/xalan-2.7.3.jar",
-        "hash": "febd48bb133a96c447282213951a6b74ea7fb45c0d896121296c014316bda6b0",
-        "path": "xalan/xalan/2.7.3/xalan-2.7.3.jar"
-    },
-    {
-        "url": "xalan/serializer/2.7.3/serializer-2.7.3.jar",
-        "hash": "5f6804bacdfdb3ccc52d2538536fab8986696d61559b081054a420c653806667",
-        "path": "xalan/serializer/2.7.3/serializer-2.7.3.jar"
-    },
-    {
-        "url": "org/apache/xmlbeans/xmlbeans/5.1.1/xmlbeans-5.1.1.jar",
-        "hash": "5f484a78bed71cbffe3709678b6bdd3463781a7c61c6d9872330aecbf150762a",
-        "path": "org/apache/xmlbeans/xmlbeans/5.1.1/xmlbeans-5.1.1.jar"
-    },
-    {
-        "url": "org/apache/logging/log4j/log4j-to-slf4j/2.20.0/log4j-to-slf4j-2.20.0.jar",
-        "hash": "88e731d7f455da59dfa08769527f87d6c496053a712637df7b999f6977933a2c",
-        "path": "org/apache/logging/log4j/log4j-to-slf4j/2.20.0/log4j-to-slf4j-2.20.0.jar"
-    },
-    {
-        "url": "org/apache/logging/log4j/log4j-api/2.20.0/log4j-api-2.20.0.jar",
-        "hash": "2f43eea679ea66f14ca0f13fec2a8600ac124f5a5231dcb4df8393eddcb97550",
-        "path": "org/apache/logging/log4j/log4j-api/2.20.0/log4j-api-2.20.0.jar"
-    },
-    {
-        "url": "com/apollographql/apollo/apollo-ast-jvm/4.0.0/apollo-ast-jvm-4.0.0.jar",
-        "hash": "1e83e448c104d946a6146c32409275a6ed4259999d469514be4f878a420f0b4f",
-        "path": "com/apollographql/apollo/apollo-ast-jvm/4.0.0/apollo-ast-jvm-4.0.0.jar"
-    },
-    {
-        "url": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar",
-        "hash": "ddc386ff14bd25d5c934167196eaf45b18de4f28e1c55a4db37ae594cbfd37e4",
-        "path": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar"
-    },
-    {
-        "url": "com/apollographql/apollo/apollo-annotations-jvm/4.0.0/apollo-annotations-jvm-4.0.0.jar",
-        "hash": "ade351bed9f7b5c0c321429187229be7814ade496004dab10c389c4cd1930db9",
-        "path": "com/apollographql/apollo/apollo-annotations-jvm/4.0.0/apollo-annotations-jvm-4.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/performance-kotlin/0.0.9/performance-kotlin-0.0.9.jar",
-        "hash": "fabf4f175e25ea01a72fb18e6ba1479ebbbd555245021a83174089dc4fac1f5f",
-        "path": "org/jetbrains/intellij/deps/completion/performance-kotlin/0.0.9/performance-kotlin-0.0.9.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/binary-compatibility-validator/0.17.0/binary-compatibility-validator-0.17.0.jar",
-        "hash": "0c8d35914a9094ab7071001c5b789e20d5f80d284c70a915a1ecb8fcecf92031",
-        "path": "org/jetbrains/kotlinx/binary-compatibility-validator/0.17.0/binary-compatibility-validator-0.17.0.jar"
-    },
-    {
-        "url": "org/jetbrains/terminal/completion-spec/0.4.0/completion-spec-0.4.0.jar",
-        "hash": "ddc6f43ff83efb9ac3d61db3f8ec7b74326b780323bf2b49383a75b6c5756397",
-        "path": "org/jetbrains/terminal/completion-spec/0.4.0/completion-spec-0.4.0.jar"
-    },
-    {
-        "url": "org/jetbrains/terminal/completion-db-with-extensions/0.5.0/completion-db-with-extensions-0.5.0.jar",
-        "hash": "c92b8e860be7195d184ff7e29aac2b8d6fe09003921271a3174a5a443eb6a887",
-        "path": "org/jetbrains/terminal/completion-db-with-extensions/0.5.0/completion-db-with-extensions-0.5.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.2/completion-ranking-sh-0.0.2.jar",
-        "hash": "5fd26c04cdbab4538e6ececc33e373094d151de42d5032fb6027de01bc4692b1",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.2/completion-ranking-sh-0.0.2.jar"
-    },
-    {
-        "url": "commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar",
-        "hash": "97d264e2f98821c4cd39eacfd597b4dc7c19d4232cf1f335fc2eab389b2d92fd",
-        "path": "commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar",
-        "hash": "f6f453ba3dc824d16ae0911e403dcde8e18e0ea7406c91e2832e8b6248a1f404",
-        "path": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar",
-        "hash": "f6f453ba3dc824d16ae0911e403dcde8e18e0ea7406c91e2832e8b6248a1f404",
-        "path": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar"
-    },
-    {
-        "url": "info/debatty/java-string-similarity/2.0.0/java-string-similarity-2.0.0.jar",
-        "hash": "87675985e637d231b5783d1fea0bd947e71267bf557adc93ce3daec8a519bd22",
-        "path": "info/debatty/java-string-similarity/2.0.0/java-string-similarity-2.0.0.jar"
-    },
-    {
-        "url": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache.agent/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache.agent-6.6.1.202309021850-r.jar",
-        "hash": "4ddd0cf1a7ece350b33f0a6b865e8fb777c30a2282a0fbd1754020a4e06af481",
-        "path": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache.agent/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache.agent-6.6.1.202309021850-r.jar"
-    },
-    {
-        "url": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache-6.6.1.202309021850-r.jar",
-        "hash": "cc379265edb2b74850156c16fefd7990281bf47e33fe7665e838f8b5fdb94755",
-        "path": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache-6.6.1.202309021850-r.jar"
-    },
-    {
-        "url": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar",
-        "hash": "9bc5a572406da07a704d5e71e662dd183dfe9385e7c06cab1a49debc5a355638",
-        "path": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.0/find-action-model-252.0.0.jar",
-        "hash": "0e2660aabf41c984a38cf8b19f5cfd8ef714d29ed614b47e27547a9319fa4104",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.0/find-action-model-252.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.1/find-action-model-252.0.1.jar",
-        "hash": "f8544a3f781d84ff4983cd72cd5822d581aab0855857db31a3a358b6f1035492",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.1/find-action-model-252.0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.0/find-file-model-252.0.0.jar",
-        "hash": "79a649df8091ebf33aecb28d91eabd8f0b9fb3f6f6aa834665855aacf0dc2044",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.0/find-file-model-252.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.1/find-file-model-252.0.1.jar",
-        "hash": "a90e92a95dc07a7dfdea9e7fd274c7d64678bb89effc4b756b52acb7137782fa",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.1/find-file-model-252.0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.0/find-classes-model-252.0.0.jar",
-        "hash": "925e272431706c9044c296f007249f360b57acdf0f762eeb29fa451f4a955adc",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.0/find-classes-model-252.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.1/find-classes-model-252.0.1.jar",
-        "hash": "808170665e62250dcf80bb5d2adc56105a5d9c0a550bfba8e901f1563479858f",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.1/find-classes-model-252.0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-all-model/252.0.1/find-all-model-252.0.1.jar",
-        "hash": "9670b6befe4aa52df008d6612095d1db587880b42d36550794a3db43ff55c377",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-all-model/252.0.1/find-all-model-252.0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-ec-model/252.0.1/find-ec-model-252.0.1.jar",
-        "hash": "7c49ae42530a312fd8bcb0e63be01b8bae3f2daded8524ba599cd023b376edb2",
-        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-ec-model/252.0.1/find-ec-model-252.0.1.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar",
-        "hash": "fd646112e2bb2bb16527397946016a17e269a27095d0c7343a8f154b83db9d0a",
-        "path": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar",
-        "hash": "fa7db0b8e4cad3a8951c91d6d09c2c6baf8ae9008b0b59d76158cf2282797caa",
-        "path": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar",
-        "hash": "d9c0813e00ff06888f30008098a3938a348863ee65c0b7f9a6aa524bb10982bf",
-        "path": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar",
-        "hash": "e1cc87b2a052ce4e4124abc6cd6d9c14dbc9e3319f854eb5829d44af860cb7f6",
-        "path": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar",
-        "hash": "ce5f571e5eae530cc4835d99977181a545bc07c85755b5b73a1bfb1a669f40d1",
-        "path": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar",
-        "hash": "e3c8ebc2e1d06fd9efece9fed214d80e16416b6630567d891e200dcad2f07144",
-        "path": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar"
-    },
-    {
-        "url": "isorelax/isorelax/20030108/isorelax-20030108.jar",
-        "hash": "3427152431cf7f967f92e69e5cac16147c5d8fb4b4e5a8a72f5291788efcff8c",
-        "path": "isorelax/isorelax/20030108/isorelax-20030108.jar"
-    },
-    {
-        "url": "thaiopensource/jing/20030619/jing-20030619.jar",
-        "hash": "600acd9ebd37dd46e3a006bc6e748d68dfeb31cbf4881a84d06e6dc5cc5eed26",
-        "path": "thaiopensource/jing/20030619/jing-20030619.jar"
-    },
-    {
-        "url": "com/jetbrains/ml/models/python-imports-ranking-model/coral-panda-republished-6/python-imports-ranking-model-coral-panda-republished-6.jar",
-        "hash": "2dbd0ae71bac24a83db76238f0a0cf2bd6b0fd1963b6827371ae8813a0434827",
-        "path": "com/jetbrains/ml/models/python-imports-ranking-model/coral-panda-republished-6/python-imports-ranking-model-coral-panda-republished-6.jar"
-    },
-    {
-        "url": "completion/ml/python/features/ml-completion-prev-exprs-models/1.11/ml-completion-prev-exprs-models-1.11.jar",
-        "hash": "8924b199c8cc52530de2b250670806d8b046fa5ae9d32a9f27a9b224e934a1ad",
-        "path": "completion/ml/python/features/ml-completion-prev-exprs-models/1.11/ml-completion-prev-exprs-models-1.11.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-python-with-full-line/0.2.1/completion-ranking-python-with-full-line-0.2.1.jar",
-        "hash": "141df5d2e70b27911bb5b601e1574623dc43b31bc6b4160f164ddd6f2ca27e6f",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-python-with-full-line/0.2.1/completion-ranking-python-with-full-line-0.2.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20221201/trove4j-1.0.20221201.jar",
-        "hash": "3d1ce86790d123de204215c4b2b8896afaed63abfdece24393e2183df5394c32",
-        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20221201/trove4j-1.0.20221201.jar"
-    },
-    {
-        "url": "commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar",
-        "hash": "eeeae917917144a68a741d4c0dff66aa5c5c5fd85593ff217bced3fc8ca783b8",
-        "path": "commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar"
-    },
-    {
-        "url": "com/intellij/remoterobot/remote-fixtures/0.11.19/remote-fixtures-0.11.19.jar",
-        "hash": "8a8edd8e68b426121e218b3434e5b41d27dc67c83dd97b4b8e457e1ba3e9f0be",
-        "path": "com/intellij/remoterobot/remote-fixtures/0.11.19/remote-fixtures-0.11.19.jar"
-    },
-    {
-        "url": "com/intellij/remoterobot/robot-server-core/0.11.19/robot-server-core-0.11.19.jar",
-        "hash": "e906358a9403c2fe2704a64431639d1eabc4dcae24dd434b65290c257a99322f",
-        "path": "com/intellij/remoterobot/robot-server-core/0.11.19/robot-server-core-0.11.19.jar"
-    },
-    {
-        "url": "com/intellij/remoterobot/remote-robot/0.11.19/remote-robot-0.11.19.jar",
-        "hash": "609b1df54d4c052032024070a17a23dc7b55c63698fc27f8c40f3806bb5a01b6",
-        "path": "com/intellij/remoterobot/remote-robot/0.11.19/remote-robot-0.11.19.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/2.0.7/slf4j-api-2.0.7.jar",
-        "hash": "5d6298b93a1905c32cda6478808ac14c2d4a47e91535e53c41f7feeb85d946f4",
-        "path": "org/slf4j/slf4j-api/2.0.7/slf4j-api-2.0.7.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.jar",
-        "hash": "99672410459045090d062a0194ed87008e2371f06946b6bfa7287c697f924bea",
-        "path": "org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.jar"
-    },
-    {
-        "url": "com/squareup/retrofit2/retrofit/2.9.0/retrofit-2.9.0.jar",
-        "hash": "e6ea1929c46852f5bec66ab3357da383476cef4e8d1deefdbf195b79cc4d6581",
-        "path": "com/squareup/retrofit2/retrofit/2.9.0/retrofit-2.9.0.jar"
-    },
-    {
-        "url": "com/squareup/okhttp3/okhttp/3.14.9/okhttp-3.14.9.jar",
-        "hash": "2570fab55515cbf881d7a4ceef49fc515490bc027057e666776a2832465aeca0",
-        "path": "com/squareup/okhttp3/okhttp/3.14.9/okhttp-3.14.9.jar"
-    },
-    {
-        "url": "com/squareup/okio/okio/1.17.2/okio-1.17.2.jar",
-        "hash": "f80ce42d2ffac47ad4c47e1d6f980d604d247ceb1a886705cf4581ab0c9fe2b8",
-        "path": "com/squareup/okio/okio/1.17.2/okio-1.17.2.jar"
-    },
-    {
-        "url": "com/squareup/retrofit2/converter-gson/2.9.0/converter-gson-2.9.0.jar",
-        "hash": "32aa206b9a29c9df5eda93a092cfb3b0b9133e232c062baa882f0319f0e79f0e",
-        "path": "com/squareup/retrofit2/converter-gson/2.9.0/converter-gson-2.9.0.jar"
-    },
-    {
-        "url": "org/mozilla/rhino/1.7.14/rhino-1.7.14.jar",
-        "hash": "c9290b0d801bf0dbbbc44338e0f769b7650a0c5d04e6bb1aeb85775c0211b003",
-        "path": "org/mozilla/rhino/1.7.14/rhino-1.7.14.jar"
-    },
-    {
-        "url": "org/assertj/assertj-swing-junit/3.17.1/assertj-swing-junit-3.17.1.jar",
-        "hash": "e56fea51b7969240460d027a17f1c704b43e4eeca49a8c57206d573da3e30871",
-        "path": "org/assertj/assertj-swing-junit/3.17.1/assertj-swing-junit-3.17.1.jar"
-    },
-    {
-        "url": "junit/junit/4.12/junit-4.12.jar",
-        "hash": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
-        "path": "junit/junit/4.12/junit-4.12.jar"
-    },
-    {
-        "url": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
-        "hash": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
-        "path": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
-    },
-    {
-        "url": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar",
-        "hash": "e36445438d72d83cc48015dcb3f14d9a97eaa42c4663a9826db2bb50e4c7713b",
-        "path": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar"
-    },
-    {
-        "url": "org/assertj/assertj-core/3.17.2/assertj-core-3.17.2.jar",
-        "hash": "d9a978d559d0b52a87f419b3d8f5bb137b97c661f7be2134e0498b454e4b980e",
-        "path": "org/assertj/assertj-core/3.17.2/assertj-core-3.17.2.jar"
-    },
-    {
-        "url": "org/easytesting/fest-util/1.2.5/fest-util-1.2.5.jar",
-        "hash": "7b52f4d3ad41b7ed71f5b6b11833113b7e08326c8ef70d2dedf0b430c7ba5341",
-        "path": "org/easytesting/fest-util/1.2.5/fest-util-1.2.5.jar"
-    },
-    {
-        "url": "org/easytesting/fest-reflect/1.4.1/fest-reflect-1.4.1.jar",
-        "hash": "c1ca19fcf0cd3555baf7c2af147c04ad22b4393ab75e5db0284e5170fb554c16",
-        "path": "org/easytesting/fest-reflect/1.4.1/fest-reflect-1.4.1.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy-dep/1.14.5/byte-buddy-dep-1.14.5.jar",
-        "hash": "bd597c940f6c8d2e0100e576b0cca1a813e3133912882fc2d962c0fa39183cc8",
-        "path": "net/bytebuddy/byte-buddy-dep/1.14.5/byte-buddy-dep-1.14.5.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm/9.5/asm-9.5.jar",
-        "hash": "b62e84b5980729751b0458c534cf1366f727542bb8d158621335682a460f0353",
-        "path": "org/ow2/asm/asm/9.5/asm-9.5.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar",
-        "hash": "72eee9fbafb9de8d9463f20dd584a48ceeb7e5152ad4c987bfbe17dd4811c9ae",
-        "path": "org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar"
-    },
-    {
-        "url": "com/squareup/okhttp3/mockwebserver/5.0.0-alpha.11/mockwebserver-5.0.0-alpha.11.jar",
-        "hash": "4a30234a911a73ae71f5aec5f98bee243c172665e841f8d532ef77e0b5e81010",
-        "path": "com/squareup/okhttp3/mockwebserver/5.0.0-alpha.11/mockwebserver-5.0.0-alpha.11.jar"
-    },
-    {
-        "url": "com/squareup/okhttp3/mockwebserver3/5.0.0-alpha.11/mockwebserver3-5.0.0-alpha.11.jar",
-        "hash": "9c9e3ef454b514d4a1342faf99c7d4cb41eaae4cb7aefcc93cb7b202bdf4fdfd",
-        "path": "com/squareup/okhttp3/mockwebserver3/5.0.0-alpha.11/mockwebserver3-5.0.0-alpha.11.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.19.0/jackson-dataformat-cbor-2.19.0.jar",
-        "hash": "ce27bf04655ac4a9f703ebf340782cf6836fc36c569a2daf25077c32532c88be",
-        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.19.0/jackson-dataformat-cbor-2.19.0.jar"
-    },
-    {
-        "url": "net/jqwik/jqwik/1.9.2/jqwik-1.9.2.jar",
-        "hash": "92c164d7c9d77b3883f3dd43cec9301603847c30c2e247782dc67fb86a4d8e36",
-        "path": "net/jqwik/jqwik/1.9.2/jqwik-1.9.2.jar"
-    },
-    {
-        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
-        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
-        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
-    },
-    {
-        "url": "net/jqwik/jqwik-api/1.9.2/jqwik-api-1.9.2.jar",
-        "hash": "60244aefd583d349cb26e81f5cc3ef9f66d309d49b6534ab7c9b63be38954054",
-        "path": "net/jqwik/jqwik-api/1.9.2/jqwik-api-1.9.2.jar"
-    },
-    {
-        "url": "net/jqwik/jqwik-web/1.9.2/jqwik-web-1.9.2.jar",
-        "hash": "4f5006f8dd93a13ca59ef92d5476b9aca1c479c0b6d0beb7c3e64970f6b7e632",
-        "path": "net/jqwik/jqwik-web/1.9.2/jqwik-web-1.9.2.jar"
-    },
-    {
-        "url": "net/jqwik/jqwik-time/1.9.2/jqwik-time-1.9.2.jar",
-        "hash": "3d5f67f87a7b305601a8aef6ec400df3ad400123af4e8459acf663126b08e05d",
-        "path": "net/jqwik/jqwik-time/1.9.2/jqwik-time-1.9.2.jar"
-    },
-    {
-        "url": "net/jqwik/jqwik-engine/1.9.2/jqwik-engine-1.9.2.jar",
-        "hash": "623d105e90cd94b688baaa527bd0c4e284001c07c1f53e3b9a2db179ea57a70a",
-        "path": "net/jqwik/jqwik-engine/1.9.2/jqwik-engine-1.9.2.jar"
-    },
-    {
-        "url": "com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar",
-        "hash": "c260c3230b2340af97d54bf01f7f67ebc57c901922736c881bb11cb981302be2",
-        "path": "com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/components/components-resources/1.10.0-alpha01/components-resources-1.10.0-alpha01.jar",
-        "hash": "75ed361cabb9ed491c00dadd0784d329ea6433c39d8240df062778c31b509bdb",
-        "path": "org/jetbrains/compose/components/components-resources/1.10.0-alpha01/components-resources-1.10.0-alpha01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/components/components-resources-desktop/1.10.0-alpha01/components-resources-desktop-1.10.0-alpha01.jar",
-        "hash": "efdd4db41e57baa5cd50d679be5a141ddf8ab9ed75f99fdaf9db7277343e3d96",
-        "path": "org/jetbrains/compose/components/components-resources-desktop/1.10.0-alpha01/components-resources-desktop-1.10.0-alpha01.jar"
-    },
-    {
-        "url": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
-        "hash": "488f51ed95f0fac48d1d87cb0e3bac08c012dcbf6ef3c1688685d708cdbccd56",
-        "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar"
-    },
-    {
-        "url": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar",
-        "hash": "39c6588948ab31b98ab1fea4a6abab37243f387cb48cb50ae599410effb70038",
-        "path": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar"
-    },
-    {
-        "url": "org/commonmark/commonmark-ext-gfm-tables/0.24.0/commonmark-ext-gfm-tables-0.24.0.jar",
-        "hash": "b54dc332f931e6d07c2766144c087b08f3693677e368151a67020b4e95bb4b99",
-        "path": "org/commonmark/commonmark-ext-gfm-tables/0.24.0/commonmark-ext-gfm-tables-0.24.0.jar"
-    },
-    {
-        "url": "org/commonmark/commonmark-ext-gfm-strikethrough/0.24.0/commonmark-ext-gfm-strikethrough-0.24.0.jar",
-        "hash": "7385cb637f04dc4cbda4ddca9c2fcd2af7ac536a50e4c8d2c77f4748bb14bf41",
-        "path": "org/commonmark/commonmark-ext-gfm-strikethrough/0.24.0/commonmark-ext-gfm-strikethrough-0.24.0.jar"
-    },
-    {
-        "url": "org/commonmark/commonmark-ext-autolink/0.24.0/commonmark-ext-autolink-0.24.0.jar",
-        "hash": "013ba4f3ba4850a1de35935d1501587c518f764331d279805da33473e79f5f33",
-        "path": "org/commonmark/commonmark-ext-autolink/0.24.0/commonmark-ext-autolink-0.24.0.jar"
-    },
-    {
-        "url": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar",
-        "hash": "39c6588948ab31b98ab1fea4a6abab37243f387cb48cb50ae599410effb70038",
-        "path": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar"
-    },
-    {
-        "url": "org/commonmark/commonmark/0.24.0/commonmark-0.24.0.jar",
-        "hash": "679338e0b7fc15c02d275d598654b01a149893bc28a87992e90123c8d06af25b",
-        "path": "org/commonmark/commonmark/0.24.0/commonmark-0.24.0.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
-        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
-        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar",
-        "hash": "9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar",
-        "hash": "9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3",
-        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar",
-        "hash": "3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203",
-        "path": "org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar",
-        "hash": "b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03",
-        "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar",
-        "hash": "c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d",
-        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar",
-        "hash": "c24c8bb27bb320c4a93871501a7e5e0c61607638907b197aef675513d4c820be",
-        "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
-        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
-        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
-        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
-        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
-    },
-    {
-        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
-        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
-        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8.jar",
-        "hash": "5383c41e5f22c8def6f890bd66820fe9ff438835600525fdf6eba96742499351",
-        "path": "io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
-        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
-        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar",
-        "hash": "9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar",
-        "hash": "9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3",
-        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar",
-        "hash": "b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03",
-        "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar",
-        "hash": "c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d",
-        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
-        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
-        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
-    },
-    {
-        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
-        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
-        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8.jar",
-        "hash": "c27c0673cad7cc1f2e932c89a060b7ae85749a03d69f221b4c1281f64136c702",
-        "path": "io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8.jar"
-    },
-    {
-        "url": "org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar",
-        "hash": "afff77c186cd317275803872fa5133aa801fd6ac40bd91c78a6cf8009b4b17cc",
-        "path": "org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar"
-    },
-    {
-        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
-        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
-        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.jar",
-        "hash": "b56a5ec000a479df4973b18bba24c98fe0db8faa14c8907d3ef451d8c71fd8ae",
-        "path": "org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.jar"
-    },
-    {
-        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
-        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
-        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar",
-        "hash": "5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5",
-        "path": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar"
-    },
-    {
-        "url": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar",
-        "hash": "672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835",
-        "path": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21.jar",
-        "hash": "36fef581638be9c674295c176f10bc9f13025e5e1160030200991ded62ed6c29",
-        "path": "org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21.jar",
-        "hash": "2413c230fdd8cd47ebbeba273e4df94cf3b44cb3ec95d2cb35472c93768c9f1c",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21.jar",
-        "hash": "6ed0fa5beb25466883989b5641f36809479260b7014535502fd387ce6c7ba833",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21.jar",
-        "hash": "f87deb2b14d068f99cba18217d80af85481c029c731ad8704458e9add9ca20f8",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21.jar",
-        "hash": "88427f0f7a4c47845fa2221d29f6e0e0d7cbe73c3edf8bca30b4d8b3a336a77c",
-        "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
-        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
-        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar",
-        "hash": "1981dea8e4e2e8541af2d83e4f8d3581ce647cfe63175b9eb9ac2a07849d74c9",
-        "path": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
-        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
-        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar",
-        "hash": "9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81",
-        "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar",
-        "hash": "9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3",
-        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar",
-        "hash": "b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03",
-        "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar",
-        "hash": "c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d",
-        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar",
-        "hash": "c24c8bb27bb320c4a93871501a7e5e0c61607638907b197aef675513d4c820be",
-        "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar"
-    },
-    {
-        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
-        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
-        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar",
-        "hash": "5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5",
-        "path": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar"
-    },
-    {
-        "url": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar",
-        "hash": "672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835",
-        "path": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar",
-        "hash": "7e93e9a23b478f70128893b06748673f912100b7ef03040d7d0331e26d30d092",
-        "path": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar",
-        "hash": "f31cc53f105a7e48c093683bbd5437561d1233920513774b470805641bedbc09",
-        "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar"
-    },
-    {
-        "url": "org/jetbrains/annotations/13.0/annotations-13.0.jar",
-        "hash": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
-        "path": "org/jetbrains/annotations/13.0/annotations-13.0.jar"
-    },
-    {
-        "url": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar",
-        "hash": "4053f878c171692aab8782f53a3974f43e55e2b6ed12c3682b36a46968c5ded1",
-        "path": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.jar",
-        "hash": "3ad2fcad0c09ddc0922debab4444d612144b7b465b75a8bb7587e20ddfafd799",
-        "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar",
-        "hash": "718e8f71f5872986e4f5cd4887a41e26aa0aeff42e99cf4a42582291b8738cc4",
-        "path": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
-        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
-        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8.jar",
-        "hash": "8068a15e07718e3bdbf501ede5f666812fb5f9fb1450db060449534c05e6722a",
-        "path": "io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1.jar",
-        "hash": "98bda1c78a5028a134ceb25b63f5c130c89349730d35fd47ef7490b6bf0b63b3",
-        "path": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8.jar",
-        "hash": "cc5b90b1476cef99e112162dbcd1db32b040284a768f3c975a49ec0b63980ca3",
-        "path": "io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8.jar",
-        "hash": "41e85ca3587abce9a03f8dcb2a67e05fcf59b7518fa016c9350ea73c79f9c54a",
-        "path": "io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8.jar",
-        "hash": "d71abaa98890cae8a618839b1309c013dff39c6bd7d0de0b704e6193e027ef09",
-        "path": "io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8.jar",
-        "hash": "c9f9221fc57ed1fbd1374de5c4da6c069160f892a71f83b551d3a32c8cbad13d",
-        "path": "io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8.jar"
-    },
-    {
-        "url": "io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar",
-        "hash": "b3ac96dd97acba8318dbe26f6a432d6c6db91c46c780805e8928b8103e5763dc",
-        "path": "io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar",
-        "hash": "af604c46737121d4225fdb60ef0e17766a3c94b7c1c9ef76b4e3a5c7733d557e",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20.jar",
-        "hash": "e0e91962bc0007338bf5b1739f62927ac32d14ba3d827fa608ab4e5351729d5d",
-        "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar",
-        "hash": "eba7f1c854296e4ce1418fb01360f8f10c5683e7c45aa3472018417a067636f3",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20.jar",
-        "hash": "1da0d306c995945e1f807240ef64b5cd2dd5ac58612afb1a8596143d10b7ded5",
-        "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20.jar",
-        "hash": "524da3c1a2ad56fd52c4ae2272ef3de421de8d2047ab1c51fc306d351243f2f5",
-        "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
-        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
-        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
-    },
-    {
-        "url": "com/pngencoder/pngencoder/0.14.0/pngencoder-0.14.0.jar",
-        "hash": "79bf02e8f49833dc3433ae1554999dd375075e5ab13447fc1e558857b51baecc",
-        "path": "com/pngencoder/pngencoder/0.14.0/pngencoder-0.14.0.jar"
-    },
-    {
-        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
-        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
-        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
-    },
-    {
-        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
-        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
-        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
+        "url": "com/github/hypfvieh/dbus-java-core/4.2.1/dbus-java-core-4.2.1.jar",
+        "hash": "3a7b9fd543a1be94de99009c36ac1803f08d6d12357706c8f5040855315469d1",
+        "path": "com/github/hypfvieh/dbus-java-core/4.2.1/dbus-java-core-4.2.1.jar"
     },
     {
         "url": "com/github/hypfvieh/dbus-java-transport-native-unixsocket/4.2.1/dbus-java-transport-native-unixsocket-4.2.1.jar",
@@ -3170,19 +780,344 @@
         "path": "com/github/hypfvieh/dbus-java-transport-native-unixsocket/4.2.1/dbus-java-transport-native-unixsocket-4.2.1.jar"
     },
     {
-        "url": "com/github/hypfvieh/dbus-java-core/4.2.1/dbus-java-core-4.2.1.jar",
-        "hash": "3a7b9fd543a1be94de99009c36ac1803f08d6d12357706c8f5040855315469d1",
-        "path": "com/github/hypfvieh/dbus-java-core/4.2.1/dbus-java-core-4.2.1.jar"
+        "url": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar",
+        "hash": "7e638082b4a14e3a96ca90f3f5db70ac65591e0b6c6670629e849d22ec34455f",
+        "path": "com/github/lamba92/kotlinx-document-store-core-jvm/0.0.4/kotlinx-document-store-core-jvm-0.0.4.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar",
-        "hash": "52f66c83318dcacb879f2a07fe448eccd1313b077809190810c83aa4b875611c",
-        "path": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar"
+        "url": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar",
+        "hash": "956a4c7faad66e3471861adaa278d9486f3a050ac25fb6a99ca90809d379adfe",
+        "path": "com/github/lamba92/kotlinx-document-store-mvstore/0.0.4/kotlinx-document-store-mvstore-0.0.4.jar"
     },
     {
-        "url": "org/jetbrains/compose/compiler/compiler-hosted/1.5.14/compiler-hosted-1.5.14.jar",
-        "hash": "1133b3191ec68f97cf326bf95cbe00cab5d2f39493812e8e36f0e42dad059f64",
-        "path": "org/jetbrains/compose/compiler/compiler-hosted/1.5.14/compiler-hosted-1.5.14.jar"
+        "url": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar",
+        "hash": "e7f064bf1eab83fa785cf587f657f09649e3b0af6f27caa5382416953b5a35f8",
+        "path": "com/github/luben/zstd-jni/1.5.7-4/zstd-jni-1.5.7-4.jar"
+    },
+    {
+        "url": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar",
+        "hash": "8b94840d71ad0caa36b3309425b2d23084bc8788ce84d71f2d805b0fc84d1f5a",
+        "path": "com/github/marschall/memoryfilesystem/2.8.2/memoryfilesystem-2.8.2.jar"
+    },
+    {
+        "url": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar",
+        "hash": "9403c2537ac0dd425e556dfc3434e5d9f9a9547312472f4c27b7ab2673e9e862",
+        "path": "com/github/oshi/oshi-core/6.8.2/oshi-core-6.8.2.jar"
+    },
+    {
+        "url": "com/github/seregamorph/hamcrest-more-matchers/0.1/hamcrest-more-matchers-0.1.jar",
+        "hash": "0b39c30f73a84dc50181a10e0d66e9543d6ef1b561c207b7fba6944e64dc22b3",
+        "path": "com/github/seregamorph/hamcrest-more-matchers/0.1/hamcrest-more-matchers-0.1.jar"
+    },
+    {
+        "url": "com/github/spullara/cli-parser/cli-parser/1.1.6/cli-parser-1.1.6.jar",
+        "hash": "436143bc3b925a1af4d0b8c9c7c53ac5c937f0f7aa32e4d97a24ce0a301ede27",
+        "path": "com/github/spullara/cli-parser/cli-parser/1.1.6/cli-parser-1.1.6.jar"
+    },
+    {
+        "url": "com/github/weisj/jsvg/1.3.0-jb.8/jsvg-1.3.0-jb.8.jar",
+        "hash": "da76eba4122036f4372008564b0db192c8649a57c7a896ae565a1adfcc31f0b0",
+        "path": "com/github/weisj/jsvg/1.3.0-jb.8/jsvg-1.3.0-jb.8.jar"
+    },
+    {
+        "url": "com/gitlab/dumonts/hunspell/2.1.2/hunspell-2.1.2.jar",
+        "hash": "973329ae3a43d35dacd618b93a5773a0a9210c8bf2b58a6b2d2a1e1c9f0389e9",
+        "path": "com/gitlab/dumonts/hunspell/2.1.2/hunspell-2.1.2.jar"
+    },
+    {
+        "url": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar",
+        "hash": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "path": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
+    },
+    {
+        "url": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar",
+        "hash": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "path": "com/google/android/annotations/4.1.1.4/annotations-4.1.1.4.jar"
+    },
+    {
+        "url": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar",
+        "hash": "0b27938f3d28ccd6884945d7e4f75f4e26a677bbf3cd39bbcb694f130f782aa9",
+        "path": "com/google/api/grpc/proto-google-common-protos/2.51.0/proto-google-common-protos-2.51.0.jar"
+    },
+    {
+        "url": "com/google/api/grpc/proto-google-common-protos/2.59.2/proto-google-common-protos-2.59.2.jar",
+        "hash": "9407f50aef5d1cb12675c170fa64ee216023eefca49f8f5eac45124f23a6cb29",
+        "path": "com/google/api/grpc/proto-google-common-protos/2.59.2/proto-google-common-protos-2.59.2.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
+        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
+    },
+    {
+        "url": "com/google/code/gson/gson/2.11.0/gson-2.11.0.jar",
+        "hash": "57928d6e5a6edeb2abd3770a8f95ba44dce45f3b23b7a9dc2b309c581552a78b",
+        "path": "com/google/code/gson/gson/2.11.0/gson-2.11.0.jar"
+    },
+    {
+        "url": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar",
+        "hash": "94855942d4992f112946d3de1c334e709237b8126d8130bf07807c018a4a2120",
+        "path": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar"
+    },
+    {
+        "url": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar",
+        "hash": "94855942d4992f112946d3de1c334e709237b8126d8130bf07807c018a4a2120",
+        "path": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar"
+    },
+    {
+        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
+        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
+        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
+    },
+    {
+        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
+        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
+        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
+    },
+    {
+        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
+        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
+        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
+    },
+    {
+        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
+        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
+        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
+    },
+    {
+        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
+        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
+        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
+    },
+    {
+        "url": "com/google/errorprone/error_prone_annotations/2.28.0/error_prone_annotations-2.28.0.jar",
+        "hash": "f3fc8a3a0a4020706a373b00e7f57c2512dd26d1f83d28c7d38768f8682b231e",
+        "path": "com/google/errorprone/error_prone_annotations/2.28.0/error_prone_annotations-2.28.0.jar"
+    },
+    {
+        "url": "com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar",
+        "hash": "8a8f81cf9b359e3f6dfa691a1e776985c061ef2f223c9b2c80753e1b458e8064",
+        "path": "com/google/guava/failureaccess/1.0.2/failureaccess-1.0.2.jar"
+    },
+    {
+        "url": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar",
+        "hash": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "path": "com/google/guava/failureaccess/1.0.3/failureaccess-1.0.3.jar"
+    },
+    {
+        "url": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar",
+        "hash": "79626019fed282b70eef91f645a9febd5f6b9f7be46484b6b328313a481f05f0",
+        "path": "com/google/guava/guava-testlib/33.0.0-jre/guava-testlib-33.0.0-jre.jar"
+    },
+    {
+        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
+        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
+        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
+    },
+    {
+        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
+        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
+        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
+    },
+    {
+        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
+        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
+        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
+    },
+    {
+        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
+        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
+        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
+    },
+    {
+        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
+        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
+        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
+    },
+    {
+        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
+        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
+        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
+    },
+    {
+        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
+        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
+        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
+    },
+    {
+        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
+        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
+        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
+    },
+    {
+        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
+        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
+        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
+    },
+    {
+        "url": "com/google/guava/guava/33.3.1-jre/guava-33.3.1-jre.jar",
+        "hash": "4bf0e2c5af8e4525c96e8fde17a4f7307f97f8478f11c4c8e35a0e3298ae4e90",
+        "path": "com/google/guava/guava/33.3.1-jre/guava-33.3.1-jre.jar"
+    },
+    {
+        "url": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar",
+        "hash": "f3d7f57f67fd622f4d468dfdd692b3a5e3909246c28017ac3263405f0fe617ed",
+        "path": "com/google/guava/guava/33.4.8-jre/guava-33.4.8-jre.jar"
+    },
+    {
+        "url": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
+        "hash": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
+        "path": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.0/guice-4.0-no_aop.jar",
+        "hash": "19393891be59b6feaf7e308bd8a3843b4e552c10cdb687ebffd7695634a250a8",
+        "path": "com/google/inject/guice/4.0/guice-4.0-no_aop.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.0/guice-4.0.jar",
+        "hash": "b378ffc35e7f7125b3c5f3a461d4591ae1685e3c781392f0c854ed7b7581d6d2",
+        "path": "com/google/inject/guice/4.0/guice-4.0.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.0/guice-4.0.jar",
+        "hash": "b378ffc35e7f7125b3c5f3a461d4591ae1685e3c781392f0c854ed7b7581d6d2",
+        "path": "com/google/inject/guice/4.0/guice-4.0.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar",
+        "hash": "158fd8f52d2a4b4ce4293ac2b833bb2427f5ddfe30df4ae0fd4675a1038a3b79",
+        "path": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar",
+        "hash": "158fd8f52d2a4b4ce4293ac2b833bb2427f5ddfe30df4ae0fd4675a1038a3b79",
+        "path": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.2.1/guice-4.2.1.jar",
+        "hash": "cb4a9a054a20f5b9fcdd9734e97804779714fa5d62b30a0f5b5e99084f9954b0",
+        "path": "com/google/inject/guice/4.2.1/guice-4.2.1.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.2.1/guice-4.2.1.jar",
+        "hash": "cb4a9a054a20f5b9fcdd9734e97804779714fa5d62b30a0f5b5e99084f9954b0",
+        "path": "com/google/inject/guice/4.2.1/guice-4.2.1.jar"
+    },
+    {
+        "url": "com/google/inject/guice/4.2.2/guice-4.2.2-no_aop.jar",
+        "hash": "0f4f5fb28609a4d2b38b7f7128be7cf9b541f25283d71b4e56066d99683aafff",
+        "path": "com/google/inject/guice/4.2.2/guice-4.2.2-no_aop.jar"
+    },
+    {
+        "url": "com/google/inject/guice/6.0.0/guice-6.0.0.jar",
+        "hash": "b4d4f7ec5e8fc17b4f98dee9d3f6cf6ae3ae13e2e5ed4b2f7bbf09bc4bb675d5",
+        "path": "com/google/inject/guice/6.0.0/guice-6.0.0.jar"
+    },
+    {
+        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
+        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
+    },
+    {
+        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
+        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
+    },
+    {
+        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
+        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
+    },
+    {
+        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
+        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
+    },
+    {
+        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
+        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
+        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
+    },
+    {
+        "url": "com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar",
+        "hash": "88241573467ddca44ffd4d74aa04c2bbfd11bf7c17e0c342c94c9de7a70a7c64",
+        "path": "com/google/j2objc/j2objc-annotations/3.0.0/j2objc-annotations-3.0.0.jar"
+    },
+    {
+        "url": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar",
+        "hash": "c4828e28d7c0a930af9387510b3bada7daa5c04d7c25a75c7b8b081f1c257ddd",
+        "path": "com/google/jimfs/jimfs/1.1/jimfs-1.1.jar"
+    },
+    {
+        "url": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar",
+        "hash": "bd30f6cf55c4f9f0891f8b6ea6601c1502b643543d2535c8b477ea0481809e99",
+        "path": "com/google/protobuf/protobuf-java-util/3.24.4-jb.2/protobuf-java-util-3.24.4-jb.2.jar"
+    },
+    {
+        "url": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar",
+        "hash": "6ba90d0d081c03c5c03d2d41497f75a183da7fb23cc2691f7b782dea77f73d21",
+        "path": "com/google/protobuf/protobuf-java/3.24.4-jb.2/protobuf-java-3.24.4-jb.2.jar"
+    },
+    {
+        "url": "com/google/protobuf/protobuf-java/3.25.8/protobuf-java-3.25.8.jar",
+        "hash": "72bdb32eb38cafb7dcd288262c29a34d57cba2e19101af9685155ba8c0a56008",
+        "path": "com/google/protobuf/protobuf-java/3.25.8/protobuf-java-3.25.8.jar"
+    },
+    {
+        "url": "com/google/truth/truth/0.42/truth-0.42.jar",
+        "hash": "dd652bdf0c4427c59848ac0340fd6b6d20c2cbfaa3c569a8366604dbcda5214c",
+        "path": "com/google/truth/truth/0.42/truth-0.42.jar"
+    },
+    {
+        "url": "com/google/zxing/core/3.5.1/core-3.5.1.jar",
+        "hash": "1ba7c0fbb6c267e2fb74e1497d855adae633ccc98edc8c75163aa64bc08e3059",
+        "path": "com/google/zxing/core/3.5.1/core-3.5.1.jar"
+    },
+    {
+        "url": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar",
+        "hash": "61ba4dc49adca95243beaa0569adc2a23aedb5292ae78aa01186fa782ebdc5c2",
+        "path": "com/googlecode/java-diff-utils/diffutils/1.3.0/diffutils-1.3.0.jar"
+    },
+    {
+        "url": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar",
+        "hash": "d65226949713c4c61a784f41c51167e7b0316f93764398ebba9e4336b3d954c2",
+        "path": "com/googlecode/javaewah/JavaEWAH/1.2.3/JavaEWAH-1.2.3.jar"
+    },
+    {
+        "url": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar",
+        "hash": "88ed8e730f7386297485176c4387146c6914a38c0e58fc296e8a01cdc3b621e1",
+        "path": "com/googlecode/plist/dd-plist/1.28/dd-plist-1.28.jar"
     },
     {
         "url": "com/guardsquare/proguard-base/7.6.1/proguard-base-7.6.1.jar",
@@ -3195,3534 +1130,14 @@
         "path": "com/guardsquare/proguard-core/9.1.7/proguard-core-9.1.7.jar"
     },
     {
-        "url": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.0.0/kotlin-metadata-jvm-2.0.0.jar",
-        "hash": "ad8f1c7dbc5ac46f5cbd2d2e5de39c56c9db65dd7de716a84e01ce208758aee6",
-        "path": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.0.0/kotlin-metadata-jvm-2.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/annotations/26.0.1/annotations-26.0.1.jar",
-        "hash": "2037be378980d3ba9333e97955f3b2cde392aa124d04ca73ce2eee6657199297",
-        "path": "org/jetbrains/annotations/26.0.1/annotations-26.0.1.jar"
-    },
-    {
-        "url": "org/apache/logging/log4j/log4j-api/2.24.2/log4j-api-2.24.2.jar",
-        "hash": "0ca3ecbd4c315bdd5f2ef6af127712df718c78334cce5bf6fb7b4aa17fdab126",
-        "path": "org/apache/logging/log4j/log4j-api/2.24.2/log4j-api-2.24.2.jar"
-    },
-    {
-        "url": "org/apache/logging/log4j/log4j-core/2.24.2/log4j-core-2.24.2.jar",
-        "hash": "7a7b90db866c86a1093b3fde758ca28398ebb2a533da0d79a30cc0a78506b9df",
-        "path": "org/apache/logging/log4j/log4j-core/2.24.2/log4j-core-2.24.2.jar"
-    },
-    {
-        "url": "org/json/json/20231013/json-20231013.jar",
-        "hash": "0f18192df289114e17aa1a0d0a7f8372cc9f5c7e4f7e39adcf8906fe714fa7d3",
-        "path": "org/json/json/20231013/json-20231013.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.0/kotlin-jps-plugin-classpath-2.2.0.jar",
-        "hash": "61002bb21cc3c512bd7c9d532f3932e33e019e58d554bc4d3c208ebec5c11284",
-        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.0/kotlin-jps-plugin-classpath-2.2.0.jar"
-    },
-    {
-        "url": "com/jetbrains/format-ripper/format-ripper/1.2.0/format-ripper-1.2.0.jar",
-        "hash": "7b47cc1b48092566eaf82c8cd6210151661423b755dc578613000cac90464eef",
-        "path": "com/jetbrains/format-ripper/format-ripper/1.2.0/format-ripper-1.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/apple-notary-api-kotlin-client/2.0.1/apple-notary-api-kotlin-client-2.0.1.jar",
-        "hash": "46aa057f38b1cb2ac89d7e4b6357570b82bfd8e2b4d062ab40b09db3290d1c26",
-        "path": "org/jetbrains/apple-notary-api-kotlin-client/2.0.1/apple-notary-api-kotlin-client-2.0.1.jar"
-    },
-    {
-        "url": "com/amazonaws/aws-java-sdk-s3/1.12.431/aws-java-sdk-s3-1.12.431.jar",
-        "hash": "45b24b098dcaec230fde72b4e0568dab464cf7d8afd8b83fb9ac628778c67df9",
-        "path": "com/amazonaws/aws-java-sdk-s3/1.12.431/aws-java-sdk-s3-1.12.431.jar"
-    },
-    {
-        "url": "com/amazonaws/aws-java-sdk-kms/1.12.431/aws-java-sdk-kms-1.12.431.jar",
-        "hash": "ffc62a11ad6a454d150a28c66c98e0300186faa53ec34d1c58c7dc5e2f7a3011",
-        "path": "com/amazonaws/aws-java-sdk-kms/1.12.431/aws-java-sdk-kms-1.12.431.jar"
-    },
-    {
-        "url": "com/amazonaws/aws-java-sdk-core/1.12.431/aws-java-sdk-core-1.12.431.jar",
-        "hash": "e17a93342d623ecd58449b6142db53c5ec9d1fb7a6a40d6266e56ed796e06fdf",
-        "path": "com/amazonaws/aws-java-sdk-core/1.12.431/aws-java-sdk-core-1.12.431.jar"
-    },
-    {
-        "url": "com/amazonaws/jmespath-java/1.12.431/jmespath-java-1.12.431.jar",
-        "hash": "238630e244b369b57238bb35e9a23382be65771b04a0f36d85df07b61b4ae2b9",
-        "path": "com/amazonaws/jmespath-java/1.12.431/jmespath-java-1.12.431.jar"
-    },
-    {
-        "url": "com/auth0/java-jwt/4.3.0/java-jwt-4.3.0.jar",
-        "hash": "25a2353a1789870d960c0a9d8878a62eb1873116a2299d74f278451697676a67",
-        "path": "com/auth0/java-jwt/4.3.0/java-jwt-4.3.0.jar"
-    },
-    {
-        "url": "org/spdx/tools-java/1.1.8/tools-java-1.1.8.jar",
-        "hash": "deaca39f9ae12879f061c946d72641240e731dc9df0059d9b69472f43accb4a5",
-        "path": "org/spdx/tools-java/1.1.8/tools-java-1.1.8.jar"
-    },
-    {
-        "url": "org/spdx/java-spdx-library/1.1.10/java-spdx-library-1.1.10.jar",
-        "hash": "ef116816a4d221933d34d9f113fd47f6780bca2b0c826545081d742f4e7178fb",
-        "path": "org/spdx/java-spdx-library/1.1.10/java-spdx-library-1.1.10.jar"
-    },
-    {
-        "url": "org/spdx/spdx-jackson-store/1.1.9/spdx-jackson-store-1.1.9.jar",
-        "hash": "f2fee72e08fd510479ac93e7e33694bdbc465b32a56896bf1ab8a8dfba366f18",
-        "path": "org/spdx/spdx-jackson-store/1.1.9/spdx-jackson-store-1.1.9.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.0/jackson-dataformat-xml-2.15.0.jar",
-        "hash": "e3137c89b08d0c3d9f7dfeae11d5b941b310f5f7bfdea90063f29c0b3b1f6807",
-        "path": "com/fasterxml/jackson/dataformat/jackson-dataformat-xml/2.15.0/jackson-dataformat-xml-2.15.0.jar"
-    },
-    {
-        "url": "io/netty/netty-all/4.2.0.RC2/netty-all-4.2.0.RC2.jar",
-        "hash": "4a12af2ac8345bfc7e0987ad8748787de033a9e27357cace7f45c7d40be522e0",
-        "path": "io/netty/netty-all/4.2.0.RC2/netty-all-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar",
-        "hash": "74d953cec00048b892112f9602fc7b1113ea55337dc1ede32e449efcb2b231c7",
-        "path": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar",
-        "hash": "f39581a55f89fb0586373e237e1e4a9d5e2fe3b94167c7a6762552651e5a6038",
-        "path": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar",
-        "hash": "b94f2d169acd04e8a41f1082e8f522529be1f5a10515473de9fb8d259afbfc77",
-        "path": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar",
-        "hash": "a44d21dff0254e4f4f9ceb7870e8b27a403d7f1d6325ab03ae6c045302957761",
-        "path": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar",
-        "hash": "c542657efd81b268535fb77e1866c8234c5a22de416ecbd8aea0e06e2c1588de",
-        "path": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar",
-        "hash": "cc65afe17daf2f9380d3c64460f5b10ec279f98b9461fbf0ccf62b3cb3ee6c37",
-        "path": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar",
-        "hash": "3f1912b14a2fdd7ad2ef0bda9eeb1ae544c463857081d7dd69f9aa2b7137de6e",
-        "path": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar",
-        "hash": "dfc1db2a05dafeba40987a76591004cc72d4a27062d874961fadc5059900f65d",
-        "path": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-handler-ssl-ocsp/4.2.0.RC2/netty-handler-ssl-ocsp-4.2.0.RC2.jar",
-        "hash": "c1d3051facf0297a3d7e15078a2c94f3650b6beddd398f21c591d098fd549922",
-        "path": "io/netty/netty-handler-ssl-ocsp/4.2.0.RC2/netty-handler-ssl-ocsp-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar",
-        "hash": "10fa70357cbfd55f52d64cf4bb4011e01ced0e0e5dea0bac77f73908cef676ff",
-        "path": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar",
-        "hash": "9c86cf3a130237b059f5ef89661a4fbe715f5e8bce9626a6aded95a1c3775a47",
-        "path": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-pkitesting/4.2.0.RC2/netty-pkitesting-4.2.0.RC2.jar",
-        "hash": "6d3fbdf60229ee2baafaa850bf46115923109c73d6d1b0fefdcce5a12ddd43e8",
-        "path": "io/netty/netty-pkitesting/4.2.0.RC2/netty-pkitesting-4.2.0.RC2.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcpkix-jdk18on/1.79/bcpkix-jdk18on-1.79.jar",
-        "hash": "3639a24ddf9ba4b7eba0659b44770e91eba816421888e571f285aadefe532cd6",
-        "path": "org/bouncycastle/bcpkix-jdk18on/1.79/bcpkix-jdk18on-1.79.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcutil-jdk18on/1.79/bcutil-jdk18on-1.79.jar",
-        "hash": "c70b88ada58938cbc2f005d40329054078bcfa1149e6ffc03e9242eb6ab21836",
-        "path": "org/bouncycastle/bcutil-jdk18on/1.79/bcutil-jdk18on-1.79.jar"
-    },
-    {
-        "url": "org/bouncycastle/bcprov-jdk18on/1.79/bcprov-jdk18on-1.79.jar",
-        "hash": "0d81ecc3124536b539bce9aa3fe9621b7f84c9cee371b635a5b31c78b79ab1da",
-        "path": "org/bouncycastle/bcprov-jdk18on/1.79/bcprov-jdk18on-1.79.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-classes-epoll/4.2.0.RC2/netty-transport-classes-epoll-4.2.0.RC2.jar",
-        "hash": "b28e39a15989b29683ccbc360d27cdb71fa992c16e50f2b331278a68267d110a",
-        "path": "io/netty/netty-transport-classes-epoll/4.2.0.RC2/netty-transport-classes-epoll-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-classes-kqueue/4.2.0.RC2/netty-transport-classes-kqueue-4.2.0.RC2.jar",
-        "hash": "15c46096b22d0fc833c09ce85d002cc8e171c9f1741030663899a6315997d5bd",
-        "path": "io/netty/netty-transport-classes-kqueue/4.2.0.RC2/netty-transport-classes-kqueue-4.2.0.RC2.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-x86_64.jar",
-        "hash": "d57f64acefa1cebc8b18f1add825f4d965bb495a340eee69b9d626d54e161a24",
-        "path": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-x86_64.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-aarch_64.jar",
-        "hash": "9ff603349365d28397dc239097cab0ceca3b27cacd13fb5f1afda8d4d7388194",
-        "path": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-aarch_64.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-riscv64.jar",
-        "hash": "c9fb752bd54bf2dae1e4330d2446202fdfb28e6a7f933248886de13d4b2f6959",
-        "path": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-riscv64.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-x86_64.jar",
-        "hash": "2c80194e02e8f2424be3eb18be4514ece9fcaec79cb11a7d2f0dbe92fe86e283",
-        "path": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-x86_64.jar"
-    },
-    {
-        "url": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-aarch_64.jar",
-        "hash": "d942f12645bf694c5083e40d7ec2f1d03b897ceccb0d0acd9d1178bf4f72092d",
-        "path": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-aarch_64.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.766/intellij-coverage-reporter-1.0.766.jar",
-        "hash": "25393a60c2f7552955e7f5719a73b044cec83e05a62a3b0b1c75ad3e6953275b",
-        "path": "org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.766/intellij-coverage-reporter-1.0.766.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar",
-        "hash": "8627281c15b1b5347ca618d0dbc2090aa92a096a867c1d030198a51efcc33bfe",
-        "path": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar"
-    },
-    {
-        "url": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
-        "hash": "04d65ec1bde6cea20e3495d5e78ef96ab774d9936434861d3254bd88e7e94f92",
-        "path": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar",
-        "hash": "52f66c83318dcacb879f2a07fe448eccd1313b077809190810c83aa4b875611c",
-        "path": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
-        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
-        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
-        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
-        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
-    },
-    {
-        "url": "com/typesafe/config/1.4.3/config-1.4.3.jar",
-        "hash": "8ada4c185ce72416712d63e0b5afdc5f009c0cdf405e5f26efecdf156aa5dfb6",
-        "path": "com/typesafe/config/1.4.3/config-1.4.3.jar"
-    },
-    {
-        "url": "io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar",
-        "hash": "164e026e01338638e3433e4f6efbda52ed9a64a94ced649c3d0bbe02a7c61282",
-        "path": "io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-embedder/4.0.0-rc-4/maven-embedder-4.0.0-rc-4.jar",
-        "hash": "e7ade06969b92d91941ff57d2d31eae2cf392cd7bcfa848d052859e523a581a2",
-        "path": "org/apache/maven/maven-embedder/4.0.0-rc-4/maven-embedder-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-annotations/4.0.0-rc-4/maven-api-annotations-4.0.0-rc-4.jar",
-        "hash": "2937b37475450e47e1d9175733d6a1af8aa816889c2165e1a1bfc80461c66908",
-        "path": "org/apache/maven/maven-api-annotations/4.0.0-rc-4/maven-api-annotations-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-core/4.0.0-rc-4/maven-api-core-4.0.0-rc-4.jar",
-        "hash": "ba5a77673592e9092247b08cf38b1069c03d31b9ac79bda81d08fb175f32964d",
-        "path": "org/apache/maven/maven-api-core/4.0.0-rc-4/maven-api-core-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-di/4.0.0-rc-4/maven-api-di-4.0.0-rc-4.jar",
-        "hash": "43a19d3d5f852fbd39f0da6b92e678c68648ae78c2e4b815a9de07be944c7c39",
-        "path": "org/apache/maven/maven-api-di/4.0.0-rc-4/maven-api-di-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-settings/4.0.0-rc-4/maven-api-settings-4.0.0-rc-4.jar",
-        "hash": "30d7850abf5bb66902a55c98041edccc50c85dfdbeac3abfd0f5febd2009f638",
-        "path": "org/apache/maven/maven-api-settings/4.0.0-rc-4/maven-api-settings-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-toolchain/4.0.0-rc-4/maven-api-toolchain-4.0.0-rc-4.jar",
-        "hash": "6e9132f8f32764692236e491eafa6c5ff14f0ed4ccf339fc20e3103f01f01076",
-        "path": "org/apache/maven/maven-api-toolchain/4.0.0-rc-4/maven-api-toolchain-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-plugin/4.0.0-rc-4/maven-api-plugin-4.0.0-rc-4.jar",
-        "hash": "f72e30329c609814745fc29a2ea3803f03a0312985b152e896af3b692b6eb08a",
-        "path": "org/apache/maven/maven-api-plugin/4.0.0-rc-4/maven-api-plugin-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-cli/4.0.0-rc-4/maven-api-cli-4.0.0-rc-4.jar",
-        "hash": "f019911b55edef8d2fd0770601cabd45b439b7833dc3e7cfc2922c9118993dea",
-        "path": "org/apache/maven/maven-api-cli/4.0.0-rc-4/maven-api-cli-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-model/4.0.0-rc-4/maven-api-model-4.0.0-rc-4.jar",
-        "hash": "74b6c10ba09f457a8130534e34dc3824aeacbc4767943a533b5ab88efb2f1359",
-        "path": "org/apache/maven/maven-api-model/4.0.0-rc-4/maven-api-model-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-xml/4.0.0-rc-4/maven-api-xml-4.0.0-rc-4.jar",
-        "hash": "a4c1edd5846995fde7bf068b9303bf0949d3cee60cf8a4b0ac385d8d3b3c2eed",
-        "path": "org/apache/maven/maven-api-xml/4.0.0-rc-4/maven-api-xml-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/4.0.0-rc-4/maven-core-4.0.0-rc-4.jar",
-        "hash": "ede5d3c2f31ca66769810b245bbdd524627b14c93cbc3d04e934aa9c033373f9",
-        "path": "org/apache/maven/maven-core/4.0.0-rc-4/maven-core-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-metadata/4.0.0-rc-4/maven-api-metadata-4.0.0-rc-4.jar",
-        "hash": "96eb305694b66dd7717f35b284122f4762c802a70da2d89e4ead82be5ea51ad0",
-        "path": "org/apache/maven/maven-api-metadata/4.0.0-rc-4/maven-api-metadata-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-api-spi/4.0.0-rc-4/maven-api-spi-4.0.0-rc-4.jar",
-        "hash": "46b495fa82b53622aed8e2c1ac9b8b180c21abca6b620a536386917ccf7c0950",
-        "path": "org/apache/maven/maven-api-spi/4.0.0-rc-4/maven-api-spi-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-impl/4.0.0-rc-4/maven-impl-4.0.0-rc-4.jar",
-        "hash": "a78370c3e52ef07a5fa1853bc0c6f4a54b0423d19b96b81880ed0bf047e8fdf5",
-        "path": "org/apache/maven/maven-impl/4.0.0-rc-4/maven-impl-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-connector-basic/2.0.9/maven-resolver-connector-basic-2.0.9.jar",
-        "hash": "544fcbcf39a7084881942bb3bc1f50d3af35eeabfa387f0fbe36965a3f70bd6f",
-        "path": "org/apache/maven/resolver/maven-resolver-connector-basic/2.0.9/maven-resolver-connector-basic-2.0.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/4.0.0-rc-4/maven-repository-metadata-4.0.0-rc-4.jar",
-        "hash": "9cfdc674b846ecb95c26231998952af372e27cb151f75c9e628a4590fa66d8cc",
-        "path": "org/apache/maven/maven-repository-metadata/4.0.0-rc-4/maven-repository-metadata-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-cli/4.0.0-rc-4/maven-cli-4.0.0-rc-4.jar",
-        "hash": "1628cf47fda9fde0e0d012a5020bedace2cecae7f4a216315e7e6001b2a1bf94",
-        "path": "org/apache/maven/maven-cli/4.0.0-rc-4/maven-cli-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-transport-file/2.0.9/maven-resolver-transport-file-2.0.9.jar",
-        "hash": "4128a85241aa9809d4f63508c668ec5ab5d1d8e810393f2cebe6e3411e6699ee",
-        "path": "org/apache/maven/resolver/maven-resolver-transport-file/2.0.9/maven-resolver-transport-file-2.0.9.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-transport-jdk/2.0.9/maven-resolver-transport-jdk-2.0.9.jar",
-        "hash": "6bcfea0808e2693b67a66f23f0e9a9b7b28302465913fa12f27d787f7d34af81",
-        "path": "org/apache/maven/resolver/maven-resolver-transport-jdk/2.0.9/maven-resolver-transport-jdk-2.0.9.jar"
-    },
-    {
-        "url": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar",
-        "hash": "0b20f45e3a0fd8f0d12cdc5316b06776e902b1365db00118876f9175c60f302c",
-        "path": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-di/4.0.0-rc-4/maven-di-4.0.0-rc-4.jar",
-        "hash": "42b3b68b71a796d55381452f676c99176d1b4e4d5d2d28b6ba14dd2027c97bf3",
-        "path": "org/apache/maven/maven-di/4.0.0-rc-4/maven-di-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-jline/4.0.0-rc-4/maven-jline-4.0.0-rc-4.jar",
-        "hash": "5d431c9308cf60f4fbed6cb9a3e1c2b6b7b22318e0d9d5f4f53c8dcb40a77fcd",
-        "path": "org/apache/maven/maven-jline/4.0.0-rc-4/maven-jline-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/jline/jline-reader/3.30.4/jline-reader-3.30.4.jar",
-        "hash": "6989455b7a250698451f08cc59d3797f0fb581eb451e0fae4305a43473b8a668",
-        "path": "org/jline/jline-reader/3.30.4/jline-reader-3.30.4.jar"
-    },
-    {
-        "url": "org/jline/jline-style/3.30.4/jline-style-3.30.4.jar",
-        "hash": "fe24ab7f37be8a807bb2ad32468f985efa9fa21910249788f75f91af146d948c",
-        "path": "org/jline/jline-style/3.30.4/jline-style-3.30.4.jar"
-    },
-    {
-        "url": "org/jline/jline-builtins/3.30.4/jline-builtins-3.30.4.jar",
-        "hash": "17d62755cdab34f26975615a97ef07d395c2d384639ae6c89e9fde97fd5a093f",
-        "path": "org/jline/jline-builtins/3.30.4/jline-builtins-3.30.4.jar"
-    },
-    {
-        "url": "org/jline/jline-console/3.30.4/jline-console-3.30.4.jar",
-        "hash": "8bf80257f33db9f0f411562feb5c804327c8622f23d9570b3cf2f1c25b5da1d5",
-        "path": "org/jline/jline-console/3.30.4/jline-console-3.30.4.jar"
-    },
-    {
-        "url": "org/jline/jline-console-ui/3.30.4/jline-console-ui-3.30.4.jar",
-        "hash": "cc5e3d2f5305021d4c1757bc82b4beab16d6ad99a8a6b970f94bc410f5069161",
-        "path": "org/jline/jline-console-ui/3.30.4/jline-console-ui-3.30.4.jar"
-    },
-    {
-        "url": "org/jline/jline-terminal/3.30.4/jline-terminal-3.30.4.jar",
-        "hash": "1131990dddfd04b27df96ecdb71cfe098a0af2f6285af7359c38174887dc3527",
-        "path": "org/jline/jline-terminal/3.30.4/jline-terminal-3.30.4.jar"
-    },
-    {
-        "url": "org/jline/jline-native/3.30.4/jline-native-3.30.4.jar",
-        "hash": "12075e489a0a70c14885b864a73a70f1da479bc1325522374e0cf53032f66fe9",
-        "path": "org/jline/jline-native/3.30.4/jline-native-3.30.4.jar"
-    },
-    {
-        "url": "org/jline/jline-terminal-jni/3.30.4/jline-terminal-jni-3.30.4.jar",
-        "hash": "23c4a1631d005c22a509536ae14e1aa3c07fb6a958ac083f1221b9e9db7b2932",
-        "path": "org/jline/jline-terminal-jni/3.30.4/jline-terminal-jni-3.30.4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-logging/4.0.0-rc-4/maven-logging-4.0.0-rc-4.jar",
-        "hash": "7284d8c4b0e2cb1e6becaf9877d590e6375278936a1dfcb78dc2f3f0e67d81b0",
-        "path": "org/apache/maven/maven-logging/4.0.0-rc-4/maven-logging-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-xml/4.0.0-rc-4/maven-xml-4.0.0-rc-4.jar",
-        "hash": "0dc3833441ffdbd9f4e0b3f95a52f3ee1189c22f3125cc8a72ed68036abb36ea",
-        "path": "org/apache/maven/maven-xml/4.0.0-rc-4/maven-xml-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "com/fasterxml/woodstox/woodstox-core/7.1.1/woodstox-core-7.1.1.jar",
-        "hash": "02b9d022e9d47704ff8a7a859a0dbfd3b2882a8311eb7ff1e180f760ccda2712",
-        "path": "com/fasterxml/woodstox/woodstox-core/7.1.1/woodstox-core-7.1.1.jar"
-    },
-    {
-        "url": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
-        "hash": "a61c48d553efad78bc01fffc4ac528bebbae64cbaec170b2a5e39cf61eb51abe",
-        "path": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/4.0.0-rc-4/maven-artifact-4.0.0-rc-4.jar",
-        "hash": "257548f12bdbc89e0b0c7e0aaf76765f26ef2b114fcb650a2eea19bd46593419",
-        "path": "org/apache/maven/maven-artifact/4.0.0-rc-4/maven-artifact-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/4.0.0-rc-4/maven-builder-support-4.0.0-rc-4.jar",
-        "hash": "13faeb8b8bbfe402c376e326b89c9d27c927d94ac79424cbfb1141cc71656b5d",
-        "path": "org/apache/maven/maven-builder-support/4.0.0-rc-4/maven-builder-support-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/4.0.0-rc-4/maven-model-4.0.0-rc-4.jar",
-        "hash": "6406a14c084bd991cf25e145a2a4223c27367685442f9c86fae372bbafa93a72",
-        "path": "org/apache/maven/maven-model/4.0.0-rc-4/maven-model-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-support/4.0.0-rc-4/maven-support-4.0.0-rc-4.jar",
-        "hash": "3ce9be1890a4bcc8098c5f371f5b2106896e8d74b34266f6bc638c7cfb68e0e4",
-        "path": "org/apache/maven/maven-support/4.0.0-rc-4/maven-support-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/4.0.0-rc-4/maven-model-builder-4.0.0-rc-4.jar",
-        "hash": "71ed7f3e049ef331f8cd10dc83fc53ee9e37c8b20da37e2f12987e85e4683671",
-        "path": "org/apache/maven/maven-model-builder/4.0.0-rc-4/maven-model-builder-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.28/plexus-interpolation-1.28.jar",
-        "hash": "ab2a8715570438a2e4164d85ad3e8d489eabc38ea5093c2eb8ab7f58403535b5",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.28/plexus-interpolation-1.28.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/4.0.0-rc-4/maven-plugin-api-4.0.0-rc-4.jar",
-        "hash": "b417dfdf78ae03e9f956f1c2826c253dc57169158478c0500e2d845fa094d86d",
-        "path": "org/apache/maven/maven-plugin-api/4.0.0-rc-4/maven-plugin-api-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M4/org.eclipse.sisu.plexus-0.9.0.M4.jar",
-        "hash": "b90579bc652eac7331436e0a25533fce14130b9c6e015f2dd3a3d4bb07e942b7",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M4/org.eclipse.sisu.plexus-0.9.0.M4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/4.0.0-rc-4/maven-settings-4.0.0-rc-4.jar",
-        "hash": "f321dbde8f05187da1e1433f1f9f1a63e4ba93a25cfceed1969e7b23538817bb",
-        "path": "org/apache/maven/maven-settings/4.0.0-rc-4/maven-settings-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/4.0.0-rc-4/maven-settings-builder-4.0.0-rc-4.jar",
-        "hash": "2d514a00ba75d149eee91c6be3db55721a0d7c1d6d8aca786df79e49aa60e355",
-        "path": "org/apache/maven/maven-settings-builder/4.0.0-rc-4/maven-settings-builder-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-toolchain-builder/4.0.0-rc-4/maven-toolchain-builder-4.0.0-rc-4.jar",
-        "hash": "5be595d6457b69f9077bd94146b6ba74b46608fc7ceb32b5e977fd5dceadb476",
-        "path": "org/apache/maven/maven-toolchain-builder/4.0.0-rc-4/maven-toolchain-builder-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-toolchain-model/4.0.0-rc-4/maven-toolchain-model-4.0.0-rc-4.jar",
-        "hash": "800d06d1829ab661f39d940edd927da94c98e46d7c90899224ab521fad0bf55e",
-        "path": "org/apache/maven/maven-toolchain-model/4.0.0-rc-4/maven-toolchain-model-4.0.0-rc-4.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-api/2.0.9/maven-resolver-api-2.0.9.jar",
-        "hash": "a0d83f087c27c57409690a0b2bf499908e17cae6d7e175e294476c9c7f4d9da7",
-        "path": "org/apache/maven/resolver/maven-resolver-api/2.0.9/maven-resolver-api-2.0.9.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-spi/2.0.9/maven-resolver-spi-2.0.9.jar",
-        "hash": "cd4082fcd9036145a9d5c8d6942ed72ed4ed3655e2651fcbdf3dd7924eb86c4a",
-        "path": "org/apache/maven/resolver/maven-resolver-spi/2.0.9/maven-resolver-spi-2.0.9.jar"
-    },
-    {
-        "url": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar",
-        "hash": "94855942d4992f112946d3de1c334e709237b8126d8130bf07807c018a4a2120",
-        "path": "com/google/code/gson/gson/2.13.1/gson-2.13.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-util/2.0.9/maven-resolver-util-2.0.9.jar",
-        "hash": "cb5b9ce3436e8db86705c8f3f38ba4ce2ce0cb753e34fb8a337da647cce95742",
-        "path": "org/apache/maven/resolver/maven-resolver-util/2.0.9/maven-resolver-util-2.0.9.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-impl/2.0.9/maven-resolver-impl-2.0.9.jar",
-        "hash": "dec26e3df2ce3f8d9d830c6fa88418c369dcac5b1aee43bfbf022ad2435e8109",
-        "path": "org/apache/maven/resolver/maven-resolver-impl/2.0.9/maven-resolver-impl-2.0.9.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-named-locks/2.0.9/maven-resolver-named-locks-2.0.9.jar",
-        "hash": "3fb465f80c5a6328e88348edc30f44b43a239290b8023b70ddbe9d79897dae1b",
-        "path": "org/apache/maven/resolver/maven-resolver-named-locks/2.0.9/maven-resolver-named-locks-2.0.9.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.jar",
-        "hash": "8957274e75fe2c278b1428dd16a0daeee1dd38152cb6eff816177ac28fccb697",
-        "path": "org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-xml/4.1.0/plexus-xml-4.1.0.jar",
-        "hash": "86e6a7f07484e8b1f7af66d97d3ba3cb3d692a5461b4b1d0a2b7670cf5748e89",
-        "path": "org/codehaus/plexus/plexus-xml/4.1.0/plexus-xml-4.1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.9.0/plexus-classworlds-2.9.0.jar",
-        "hash": "1ad3292cd563381e3fd632f3fded1988f9e9b2be7a9f3db63ff4c4cedba13fa5",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.9.0/plexus-classworlds-2.9.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-sec-dispatcher/4.1.0/plexus-sec-dispatcher-4.1.0.jar",
-        "hash": "efc10a957d070940701a591685dab92c33f0ba3ffea9518b8d691b23897734fe",
-        "path": "org/codehaus/plexus/plexus-sec-dispatcher/4.1.0/plexus-sec-dispatcher-4.1.0.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar",
-        "hash": "7b751d952061954d5abfed7181c1f645d336091b679891591d63329c622eb832",
-        "path": "org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar"
-    },
-    {
-        "url": "commons-cli/commons-cli/1.9.0/commons-cli-1.9.0.jar",
-        "hash": "d3d530d0f28fd0fbbffe2b0b338f70e8cb96f1605579e2e3abd4db29cac24e69",
-        "path": "commons-cli/commons-cli/1.9.0/commons-cli-1.9.0.jar"
-    },
-    {
-        "url": "org/jline/jansi-core/3.30.4/jansi-core-3.30.4.jar",
-        "hash": "c7ff9f2ae789def538cb68c32d25f5df5839cb25c8fe0550306c4611b4ec9adf",
-        "path": "org/jline/jansi-core/3.30.4/jansi-core-3.30.4.jar"
-    },
-    {
-        "url": "com/google/inject/guice/6.0.0/guice-6.0.0.jar",
-        "hash": "b4d4f7ec5e8fc17b4f98dee9d3f6cf6ae3ae13e2e5ed4b2f7bbf09bc4bb675d5",
-        "path": "com/google/inject/guice/6.0.0/guice-6.0.0.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar",
-        "hash": "15335c4dcf082f599fb8eddcfb58d6a7e9a9c97de2883c257089a479b9b24522",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar",
-        "hash": "8f1a5d4daff952dabeb3acaa0aa642903702a1aa8b442fcd7a07a8cf9e3db48b",
-        "path": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
-        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
-        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
-        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
-        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
-        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
-        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
-        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
-        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
-        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
-        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
-        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
-        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
-        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
-        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
-        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
-        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
-        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
-        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
-        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
-        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
-        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
-        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-    },
-    {
-        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
-        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
-        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
-        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
-        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
-        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
-        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
-        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
-        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
-        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
-        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
-        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
-        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
-        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
-        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
-        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
-        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
-        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
-        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
-        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
-        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
-    },
-    {
-        "url": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar",
-        "hash": "21beff005c5b5754911b85f3a60480341b29a2faf1cf3b56260e6b646081a54f",
-        "path": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.2.1/guice-4.2.1.jar",
-        "hash": "cb4a9a054a20f5b9fcdd9734e97804779714fa5d62b30a0f5b5e99084f9954b0",
-        "path": "com/google/inject/guice/4.2.1/guice-4.2.1.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
-        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
-        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
-    },
-    {
-        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-    },
-    {
-        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
-        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
-        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
-    },
-    {
-        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
-        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
-        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
-    },
-    {
-        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
-        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
-        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
-    },
-    {
-        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
-        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
-        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
-        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
-        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
-        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
-        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
-        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
-        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
-        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
-        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
-        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
-        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
-        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
-        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
-        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
-        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
-        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
-        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
-        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
-        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
-        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
-        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
-        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
-        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
-        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
-        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
-        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
-        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
-        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
-        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
-        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
-        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
-        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
-        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
-        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-    },
-    {
-        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
-        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
-        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
-        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
-        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar",
-        "hash": "158fd8f52d2a4b4ce4293ac2b833bb2427f5ddfe30df4ae0fd4675a1038a3b79",
-        "path": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar"
-    },
-    {
-        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
-        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
-    },
-    {
-        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
-        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
-        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
-    },
-    {
-        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-    },
-    {
-        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
-        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
-        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
-    },
-    {
-        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
-        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
-        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
-    },
-    {
-        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
-        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
-        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
-    },
-    {
-        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
-        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
-        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
-        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
-        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
-        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
-        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
-        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-embedder/3.6.0/maven-embedder-3.6.0.jar",
-        "hash": "e41b031c1e5bc23dc94b67f678644d549b15461361789d592c54cc3939829945",
-        "path": "org/apache/maven/maven-embedder/3.6.0/maven-embedder-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
-        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
-        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
-        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
-        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
-        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
-        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
-        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
-        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
-        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
-        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
-        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
-        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
-        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
-        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
-        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
-        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
-        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
-        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
-        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
-        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
-        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
-        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
-        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
-        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
-        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
-        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
-        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
-        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
-        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
-        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
-        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-    },
-    {
-        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
-        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
-        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar",
-        "hash": "158fd8f52d2a4b4ce4293ac2b833bb2427f5ddfe30df4ae0fd4675a1038a3b79",
-        "path": "com/google/inject/guice/4.2.1/guice-4.2.1-no_aop.jar"
-    },
-    {
-        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
-        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
-    },
-    {
-        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
-        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
-        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
-    },
-    {
-        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-    },
-    {
-        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
-        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
-        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
-    },
-    {
-        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
-        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
-        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
-    },
-    {
-        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
-        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
-        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
-    },
-    {
-        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
-        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
-        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
-        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
-        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
-        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
-        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
-        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar",
-        "hash": "114859861ff10f987b880d6f34e3215274af3cc92b3a73831c84d596e37c6511",
-        "path": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
-        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
-        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
-    },
-    {
-        "url": "commons-cli/commons-cli/1.4/commons-cli-1.4.jar",
-        "hash": "fd3c7c9545a9cdb2051d1f9155c4f76b1e4ac5a57304404a6eedb578ffba7328",
-        "path": "commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
-        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
-        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar",
-        "hash": "dbb8c53ccc0b16a9dd8370d6e7de63102468caedac1e5fa2eb418319a6875293",
-        "path": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar",
-        "hash": "2653f603b4aa7b521d8ad850c88a34dafd64aa79d7650399daa719de71cd1329",
-        "path": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
-        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
-        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
-        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
-        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
-        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
-        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
-        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
-        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
-    },
-    {
-        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
-        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
-        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
-        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
-        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
-        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
-        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
-        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
-        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
-        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
-        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
-        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
-        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
-        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
-        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
-        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
-        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
-        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
-        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
-        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
-        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
-        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
-        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
-        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
-        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
-        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
-        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
-        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
-        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
-        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
-        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
-        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
-    },
-    {
-        "url": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar",
-        "hash": "930b2e409513be03864d7a66e22dfdf5c086725e22ba3cf57ad45ed8af02996d",
-        "path": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar",
-        "hash": "dbb8c53ccc0b16a9dd8370d6e7de63102468caedac1e5fa2eb418319a6875293",
-        "path": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
-        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
-        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
-        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
-        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
-        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
-        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
-        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
-        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
-        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
-        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
-        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
-        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
-        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
-        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
-        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
-        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
-        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
-        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
-    },
-    {
-        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
-        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
-        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
-        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
-        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
-        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
-        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
-        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
-        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
-        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
-        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
-        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
-        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
-        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
-        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
-        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
-        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
-        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
-        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
-        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
-        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
-        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-embedder/3.3.9/maven-embedder-3.3.9.jar",
-        "hash": "6e1736c08f9798ed74efcdcdc435c640aca08af9b8c268dd7ea8ee8a3fef30a6",
-        "path": "org/apache/maven/maven-embedder/3.3.9/maven-embedder-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
-        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
-        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
-        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
-        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
-        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
-        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
-        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
-        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
-        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
-        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
-        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
-        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
-        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
-        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
-        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
-        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
-        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
-        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
-        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
-        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
-        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
-        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.0/guice-4.0-no_aop.jar",
-        "hash": "19393891be59b6feaf7e308bd8a3843b4e552c10cdb687ebffd7695634a250a8",
-        "path": "com/google/inject/guice/4.0/guice-4.0-no_aop.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
-        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
-        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
-        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
-        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
-        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
-        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
-        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
-        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
-    },
-    {
-        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
-        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
-        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar",
-        "hash": "2653f603b4aa7b521d8ad850c88a34dafd64aa79d7650399daa719de71cd1329",
-        "path": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar",
-        "hash": "930b2e409513be03864d7a66e22dfdf5c086725e22ba3cf57ad45ed8af02996d",
-        "path": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
-        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
-        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
-        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
-        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
-        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
-        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar",
-        "hash": "114859861ff10f987b880d6f34e3215274af3cc92b3a73831c84d596e37c6511",
-        "path": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar",
-        "hash": "fe30825245d2336c859dc38d60c0fc5f3668dbf29cd586828d2b5667ec355b91",
-        "path": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar"
-    },
-    {
-        "url": "commons-cli/commons-cli/1.2/commons-cli-1.2.jar",
-        "hash": "e7cd8951956d349b568b7ccfd4f5b2529a8c113e67c32b028f52ffda371259d9",
-        "path": "commons-cli/commons-cli/1.2/commons-cli-1.2.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
-        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
-        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.0/guice-4.0.jar",
-        "hash": "b378ffc35e7f7125b3c5f3a461d4591ae1685e3c781392f0c854ed7b7581d6d2",
-        "path": "com/google/inject/guice/4.0/guice-4.0.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar",
-        "hash": "112e06e6acc1405ad3ba518442e835d1d42758ef31f0bbbdb32aa1e15a17d10f",
-        "path": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.jar",
-        "hash": "b7554a41499282e3b2226a22aff3ebe984f7e159798c461d917c1b829b130cd1",
-        "path": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar",
-        "hash": "3a00a78157a82fff778334764255642585127443e0b3da56bcdb6f8a0f910220",
-        "path": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar",
-        "hash": "112e06e6acc1405ad3ba518442e835d1d42758ef31f0bbbdb32aa1e15a17d10f",
-        "path": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar",
-        "hash": "162ff0cc80445307de05f5e0ce9c014e8cd22cfbd2ed610ae39806e4592c5255",
-        "path": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar",
-        "hash": "cf9bb9e523696557c20bd4c7f41b6adda6074c4da85a7070af2facbab28afaca",
-        "path": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar"
-    },
-    {
-        "url": "org/sonatype/nexus/nexus-indexer-artifact/1.0.1/nexus-indexer-artifact-1.0.1.jar",
-        "hash": "171035740322f96bd8c155cfb6050962dd61d7976a494c0aac6d46b3c83174c4",
-        "path": "org/sonatype/nexus/nexus-indexer-artifact/1.0.1/nexus-indexer-artifact-1.0.1.jar"
-    },
-    {
-        "url": "org/sonatype/nexus/nexus-indexer/3.0.4/nexus-indexer-3.0.4.jar",
-        "hash": "9d43a28d0758914fdcea28a436601ac26d06a3b55d283bb6be0321ccd3631a58",
-        "path": "org/sonatype/nexus/nexus-indexer/3.0.4/nexus-indexer-3.0.4.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar",
-        "hash": "dbb8c53ccc0b16a9dd8370d6e7de63102468caedac1e5fa2eb418319a6875293",
-        "path": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar",
-        "hash": "3a00a78157a82fff778334764255642585127443e0b3da56bcdb6f8a0f910220",
-        "path": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar",
-        "hash": "112e06e6acc1405ad3ba518442e835d1d42758ef31f0bbbdb32aa1e15a17d10f",
-        "path": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar",
-        "hash": "162ff0cc80445307de05f5e0ce9c014e8cd22cfbd2ed610ae39806e4592c5255",
-        "path": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar",
-        "hash": "cf9bb9e523696557c20bd4c7f41b6adda6074c4da85a7070af2facbab28afaca",
-        "path": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar",
-        "hash": "8f1a5d4daff952dabeb3acaa0aa642903702a1aa8b442fcd7a07a8cf9e3db48b",
-        "path": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
-        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
-        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
-        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
-        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
-        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
-        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
-        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
-        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
-        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
-        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
-        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
-        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
-        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
-        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
-        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
-        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
-        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
-        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
-        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
-        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
-        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
-        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
-        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
-    },
-    {
-        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
-        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
-        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
-        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
-        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
-        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
-        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
-        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
-        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
-        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
-        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
-        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
-        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
-        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
-        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
-        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
-        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
-        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
-        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
-        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
-        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
-    },
-    {
-        "url": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar",
-        "hash": "21beff005c5b5754911b85f3a60480341b29a2faf1cf3b56260e6b646081a54f",
-        "path": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.2.1/guice-4.2.1.jar",
-        "hash": "cb4a9a054a20f5b9fcdd9734e97804779714fa5d62b30a0f5b5e99084f9954b0",
-        "path": "com/google/inject/guice/4.2.1/guice-4.2.1.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
-        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
-        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
-    },
-    {
-        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-    },
-    {
-        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
-        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
-        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
-    },
-    {
-        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
-        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
-        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
-    },
-    {
-        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
-        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
-        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
-    },
-    {
-        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
-        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
-        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-core/2.4.1/lucene-core-2.4.1.jar",
-        "hash": "b85d6c2a6b4c29e90fa7c5d94b21fe796f9c6857870268b56904765126bae718",
-        "path": "org/apache/lucene/lucene-core/2.4.1/lucene-core-2.4.1.jar"
-    },
-    {
-        "url": "org/apache/maven/indexer/indexer-core/6.2.2/indexer-core-6.2.2.jar",
-        "hash": "7f69b1b75cc171ec37a9377cf590077c10b6153337236a7a766df70eb9ec7786",
-        "path": "org/apache/maven/indexer/indexer-core/6.2.2/indexer-core-6.2.2.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar",
-        "hash": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-        "path": "org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-core/8.11.1/lucene-core-8.11.1.jar",
-        "hash": "78a61d0b843c1cf1fe5be380a4d3a4c1602d3fbba4ca1185da8797c9bb115483",
-        "path": "org/apache/lucene/lucene-core/8.11.1/lucene-core-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-queryparser/8.11.1/lucene-queryparser-8.11.1.jar",
-        "hash": "23abf022a19e609fe3ca421ab6b6868a3250974d31c5b92f9879d97c127a77b8",
-        "path": "org/apache/lucene/lucene-queryparser/8.11.1/lucene-queryparser-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-queries/8.11.1/lucene-queries-8.11.1.jar",
-        "hash": "11fb2e90da5b4e6a6c26120bb80a2937a20a585d32236ed7c277048ba65f07ca",
-        "path": "org/apache/lucene/lucene-queries/8.11.1/lucene-queries-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-sandbox/8.11.1/lucene-sandbox-8.11.1.jar",
-        "hash": "28bee2711947cf3a9957f3f77132ce37457894c1fb468b0a20e9a95788b11c87",
-        "path": "org/apache/lucene/lucene-sandbox/8.11.1/lucene-sandbox-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-analyzers-common/8.11.1/lucene-analyzers-common-8.11.1.jar",
-        "hash": "1cdcc5a2d9cf4ffaf12fbf24bc2a18f2469cd295b60470ae8b97d1aa85dbad6f",
-        "path": "org/apache/lucene/lucene-analyzers-common/8.11.1/lucene-analyzers-common-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-backward-codecs/8.11.1/lucene-backward-codecs-8.11.1.jar",
-        "hash": "38e72688eef81efffb9c5ea68918f4d1adb2eb0de64ce6a8222abee036eb63cf",
-        "path": "org/apache/lucene/lucene-backward-codecs/8.11.1/lucene-backward-codecs-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-highlighter/8.11.1/lucene-highlighter-8.11.1.jar",
-        "hash": "c8e92e01b7443b2fd1698ac7b260b632197175143e13f0364b6f7258b9447307",
-        "path": "org/apache/lucene/lucene-highlighter/8.11.1/lucene-highlighter-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/lucene/lucene-memory/8.11.1/lucene-memory-8.11.1.jar",
-        "hash": "b948478fe2e8e7f94fa7f533a14a526720701fe98627214c93d924faa4be78de",
-        "path": "org/apache/lucene/lucene-memory/8.11.1/lucene-memory-8.11.1.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-api/1.8.0/maven-resolver-api-1.8.0.jar",
-        "hash": "5c9df7e7f6122172d5d27ce3efb2bc58fc7f423c2fb7468bf75315d742ebb181",
-        "path": "org/apache/maven/resolver/maven-resolver-api/1.8.0/maven-resolver-api-1.8.0.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-util/1.8.0/maven-resolver-util-1.8.0.jar",
-        "hash": "3468ec7ca9ee97878e61f26905546cdd709de778b8884777516a1af2d4a32e4e",
-        "path": "org/apache/maven/resolver/maven-resolver-util/1.8.0/maven-resolver-util-1.8.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.8.5/maven-model-3.8.5.jar",
-        "hash": "7c9eeb30ac1941ea9bdf76c08c162ed98c005913e5bff66de3f1027a304546dc",
-        "path": "org/apache/maven/maven-model/3.8.5/maven-model-3.8.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.8.3/maven-core-3.8.3.jar",
-        "hash": "4b518631aa5bda90a90ef122fba5288438bbf160fcd628246638092fe3050e10",
-        "path": "org/apache/maven/maven-core/3.8.3/maven-core-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.8.3/maven-model-3.8.3.jar",
-        "hash": "a5ce7648e89403e3b45a951648ee10d934b869001048ef05327be412860b50c5",
-        "path": "org/apache/maven/maven-model/3.8.3/maven-model-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.8.3/maven-settings-3.8.3.jar",
-        "hash": "5a80a24569a0eb383b4da05ea1d306b37753ae111e833bef3a2585c78555e0e0",
-        "path": "org/apache/maven/maven-settings/3.8.3/maven-settings-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.8.3/maven-settings-builder-3.8.3.jar",
-        "hash": "6c93c6336365e59841f4b879d08e027ba8f853f83889e2b374ced4de9c667749",
-        "path": "org/apache/maven/maven-settings-builder/3.8.3/maven-settings-builder-3.8.3.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.jar",
-        "hash": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb",
-        "path": "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.jar",
-        "hash": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a",
-        "path": "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.8.3/maven-builder-support-3.8.3.jar",
-        "hash": "b2e17c30158bcabad967c29ccc4f2c4e10065b03eedefdb1d8f901ddd3d12ca5",
-        "path": "org/apache/maven/maven-builder-support/3.8.3/maven-builder-support-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.8.3/maven-repository-metadata-3.8.3.jar",
-        "hash": "bb01f1d30929db0d8ab4bbce0e3ed3a924fa1c22dd0dc26b0ff7e39a067c2f8d",
-        "path": "org/apache/maven/maven-repository-metadata/3.8.3/maven-repository-metadata-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.8.3/maven-artifact-3.8.3.jar",
-        "hash": "be0e20f86b22835a49a355de8912260dff0a7cd47c4605506cd286ed25a34508",
-        "path": "org/apache/maven/maven-artifact/3.8.3/maven-artifact-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.8.3/maven-plugin-api-3.8.3.jar",
-        "hash": "be2e329e86e7547d66d18fb206a2f8e06363774647aaf7da776cc19f589a0d4d",
-        "path": "org/apache/maven/maven-plugin-api/3.8.3/maven-plugin-api-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.8.3/maven-model-builder-3.8.3.jar",
-        "hash": "bb2baf84e3d6c584681220947160e6d53c2bca34208c0295bdc74ab4233d396c",
-        "path": "org/apache/maven/maven-model-builder/3.8.3/maven-model-builder-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-resolver-provider/3.8.3/maven-resolver-provider-3.8.3.jar",
-        "hash": "9f7a733bc6a8c91265c669e8a268e7800578cd43e1435088e07d73a9b067d1be",
-        "path": "org/apache/maven/maven-resolver-provider/3.8.3/maven-resolver-provider-3.8.3.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.jar",
-        "hash": "17aaebe6e3e59df8cb5b4ec210196f7084637312b9bc4ff14cb77ad1ae3c381b",
-        "path": "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.jar",
-        "hash": "d0b28ed944058ba4f9be4b54c25d6d5269cc4f3f3c49aa450d4dc2f7e0d552f6",
-        "path": "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.jar",
-        "hash": "17441a39045ac19bc4a8068fb7284facebf6337754bf2bf8f26a76b5f98ed108",
-        "path": "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.jar",
-        "hash": "cdcad9355b625743f40e4cead9a96353404e010c39c808d23b044be331afa251",
-        "path": "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.jar"
-    },
-    {
-        "url": "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar",
-        "hash": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda",
-        "path": "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar"
-    },
-    {
-        "url": "commons-io/commons-io/2.6/commons-io-2.6.jar",
-        "hash": "f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513",
-        "path": "commons-io/commons-io/2.6/commons-io-2.6.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.jar",
-        "hash": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.jar"
-    },
-    {
-        "url": "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar",
-        "hash": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-        "path": "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.jar",
-        "hash": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.2.2/guice-4.2.2-no_aop.jar",
-        "hash": "0f4f5fb28609a4d2b38b7f7128be7cf9b541f25283d71b4e56066d99683aafff",
-        "path": "com/google/inject/guice/4.2.2/guice-4.2.2-no_aop.jar"
-    },
-    {
-        "url": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar",
-        "hash": "0addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-        "path": "aopalliance/aopalliance/1.0/aopalliance-1.0.jar"
-    },
-    {
-        "url": "com/google/guava/guava/25.1-android/guava-25.1-android.jar",
-        "hash": "f7b8f8fed176b9cf6831b98cb07320d7fbe91d99b29999f752c3821dfe45bdc8",
-        "path": "com/google/guava/guava/25.1-android/guava-25.1-android.jar"
-    },
-    {
-        "url": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar",
-        "hash": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-        "path": "com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar"
-    },
-    {
-        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
-        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
-        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
-    },
-    {
-        "url": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar",
-        "hash": "03d0329547c13da9e17c634d1049ea2ead093925e290567e1a364fd6b1fc7ff8",
-        "path": "com/google/errorprone/error_prone_annotations/2.1.3/error_prone_annotations-2.1.3.jar"
-    },
-    {
-        "url": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar",
-        "hash": "2994a7eb78f2710bd3d3bfb639b2c94e219cedac0d4d084d516e78c16dddecf6",
-        "path": "com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.jar"
-    },
-    {
-        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
-        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
-        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar",
-        "hash": "76d174792540e2775af94d03d10fb2d3c776e2cd0ac0ebf427d3e570072bb9ce",
-        "path": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar",
-        "hash": "52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar",
-        "hash": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar",
-        "hash": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac",
-        "path": "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
-        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
-        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
-    },
-    {
-        "url": "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.jar",
-        "hash": "3624f8474c1af46d75f98bc097d7864a323c81b3808aa43689a6e1c601c027be",
-        "path": "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.jar"
-    },
-    {
-        "url": "org/apache/maven/wagon/wagon-provider-api/3.5.2/wagon-provider-api-3.5.2.jar",
-        "hash": "c7daff38f15c754f609854a01365ced5ad182b5e12d88a6f6ad534c030147cca",
-        "path": "org/apache/maven/wagon/wagon-provider-api/3.5.2/wagon-provider-api-3.5.2.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-common/3.2.1/archetype-common-3.2.1.jar",
-        "hash": "7816a7d7c9a5c64b77a7fd1ebe203a1ce92b924638dd2216f81ea5bcebea6abc",
-        "path": "org/apache/maven/archetype/archetype-common/3.2.1/archetype-common-3.2.1.jar"
-    },
-    {
-        "url": "org/apache/maven/archetype/archetype-catalog/3.2.1/archetype-catalog-3.2.1.jar",
-        "hash": "2aa061856e5e124facf7bf16831069015f98406969a7ba534e1ee557950d6680",
-        "path": "org/apache/maven/archetype/archetype-catalog/3.2.1/archetype-catalog-3.2.1.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
-        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
-        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
-        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
-        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
-        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
-        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
-        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
-        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
-        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
-        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
-        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
-        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
-        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
-        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
-        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
-        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
-        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
-        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
-    },
-    {
-        "url": "com/google/guava/guava/18.0/guava-18.0.jar",
-        "hash": "d664fbfc03d2e5ce9cab2a44fb01f1d0bf9dfebeccc1a473b1f9ea31f79f6f99",
-        "path": "com/google/guava/guava/18.0/guava-18.0.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
-        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
-        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
-        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
-        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
-        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
-        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
-        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
-        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
-        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
-        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
-        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
-    },
-    {
-        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
-        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
-        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
-    },
-    {
-        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
-        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
-        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
-    },
-    {
-        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
-        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
-        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
-        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
-        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
-        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
-        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
-        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
-        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
-        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
-        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
-    },
-    {
-        "url": "com/google/inject/guice/4.0/guice-4.0.jar",
-        "hash": "b378ffc35e7f7125b3c5f3a461d4591ae1685e3c781392f0c854ed7b7581d6d2",
-        "path": "com/google/inject/guice/4.0/guice-4.0.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-core/3.0.5/maven-core-3.0.5.jar",
-        "hash": "ac8e617f951ecde3c4f6bca4922fdd7861500fe7d58289f26ad5adac443075bc",
-        "path": "org/apache/maven/maven-core/3.0.5/maven-core-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model/3.0.5/maven-model-3.0.5.jar",
-        "hash": "876a76b663db6c7326ad234afe430c473d3261a06b3284f31d5eb4889d1c3084",
-        "path": "org/apache/maven/maven-model/3.0.5/maven-model-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings/3.0.5/maven-settings-3.0.5.jar",
-        "hash": "d8f9f237afc21d8202eedffa29cbf6e9d46c78b3c22b217d16267216988221b9",
-        "path": "org/apache/maven/maven-settings/3.0.5/maven-settings-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-settings-builder/3.0.5/maven-settings-builder-3.0.5.jar",
-        "hash": "ac0e62e26b7f690e265ba75667531973b8a2da12b3b0ff102a612f05b42b6faf",
-        "path": "org/apache/maven/maven-settings-builder/3.0.5/maven-settings-builder-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-repository-metadata/3.0.5/maven-repository-metadata-3.0.5.jar",
-        "hash": "c867b4e075a4548bf27422542f96b159f94c4e7ffaaf6427b10433afd6a3a38c",
-        "path": "org/apache/maven/maven-repository-metadata/3.0.5/maven-repository-metadata-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar",
-        "hash": "c6d5e244dd2329971f91b8df666ffe9e0b00a7dd014d6ee073b6f6cb82877f5c",
-        "path": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-plugin-api/3.0.5/maven-plugin-api-3.0.5.jar",
-        "hash": "469505f75b8526a338cfd7e0ec841655ae52ddbcc1b36482e97d72f52ce7d890",
-        "path": "org/apache/maven/maven-plugin-api/3.0.5/maven-plugin-api-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-model-builder/3.0.5/maven-model-builder-3.0.5.jar",
-        "hash": "45a2c6ff76e12678eaf576bd7a68d028c5a5ba85fdc216a381ea86e9187e1b51",
-        "path": "org/apache/maven/maven-model-builder/3.0.5/maven-model-builder-3.0.5.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-aether-provider/3.0.5/maven-aether-provider-3.0.5.jar",
-        "hash": "c74327cd5d7b137c8be3591c766271ac8ace1a617518f0410b8a95579f9839b0",
-        "path": "org/apache/maven/maven-aether-provider/3.0.5/maven-aether-provider-3.0.5.jar"
-    },
-    {
-        "url": "org/sonatype/aether/aether-spi/1.13.1/aether-spi-1.13.1.jar",
-        "hash": "d5de4e299be5a79feb1dbe8ff3814034c6e44314b4c00b92ffa8d97576ded5b3",
-        "path": "org/sonatype/aether/aether-spi/1.13.1/aether-spi-1.13.1.jar"
-    },
-    {
-        "url": "org/sonatype/aether/aether-impl/1.13.1/aether-impl-1.13.1.jar",
-        "hash": "865511994805827e88f327944a089142bb7f3d88cde271ba3dceb732cb137a93",
-        "path": "org/sonatype/aether/aether-impl/1.13.1/aether-impl-1.13.1.jar"
-    },
-    {
-        "url": "org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.jar",
-        "hash": "ae8dc80232771f8913febfa410c5719e9ba8ded81fb99788e214fd676dbbe13f",
-        "path": "org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.jar"
-    },
-    {
-        "url": "org/sonatype/aether/aether-util/1.13.1/aether-util-1.13.1.jar",
-        "hash": "687799a0ce988bee9e8eb9ae0ba870300adc0114248ad4a4327bdb625d27e010",
-        "path": "org/sonatype/aether/aether-util/1.13.1/aether-util-1.13.1.jar"
-    },
-    {
-        "url": "org/sonatype/sisu/sisu-inject-plexus/2.3.0/sisu-inject-plexus-2.3.0.jar",
-        "hash": "bf9083fb846993689409b2bdbc735048e53bac6cc32707cde7ef84817b6e9365",
-        "path": "org/sonatype/sisu/sisu-inject-plexus/2.3.0/sisu-inject-plexus-2.3.0.jar"
-    },
-    {
-        "url": "org/sonatype/sisu/sisu-inject-bean/2.3.0/sisu-inject-bean-2.3.0.jar",
-        "hash": "75819b29737c2bee1bfbda1011d455c7036738e0ef32ffbf85ba1d8fa157ceb2",
-        "path": "org/sonatype/sisu/sisu-inject-bean/2.3.0/sisu-inject-bean-2.3.0.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar",
-        "hash": "7fc63378d3e84663619b9bedace9f9fe78b276c2be3c62ca2245449294c84176",
-        "path": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar",
-        "hash": "8b909f4ca9788647942f883d4e559bcc642123f7c6bcd3846983a2e465469c33",
-        "path": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.jar",
-        "hash": "259d528a29722cab6349d7e7d432e3fd4877c087ffcb04985a6612e97023bba8",
-        "path": "org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
-        "hash": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
-        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
-        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
-    },
-    {
-        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
-        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
-        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
-    },
-    {
-        "url": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0.jar",
-        "hash": "a263933f43e9c273161e0b99f553c33a80a0416ec0bd5dca17d54cf38ae5956f",
-        "path": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0.jar"
-    },
-    {
-        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
-        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
-    },
-    {
-        "url": "org/sonatype/sisu/sisu-guava/0.9.9/sisu-guava-0.9.9.jar",
-        "hash": "9897e80ff6c08fc45b5b5ebd81d9e943a1087bdf0ad50cda457d616abbdaacd9",
-        "path": "org/sonatype/sisu/sisu-guava/0.9.9/sisu-guava-0.9.9.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
-        "hash": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
-        "path": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
-    },
-    {
-        "url": "org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.jar",
-        "hash": "e220097cffad96c2963ab12652ff8833ec6f40143d509f0a2ea59d22209b6ecd",
-        "path": "org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.jar"
-    },
-    {
-        "url": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar",
-        "hash": "c6d5e244dd2329971f91b8df666ffe9e0b00a7dd014d6ee073b6f6cb82877f5c",
-        "path": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar",
-        "hash": "8b909f4ca9788647942f883d4e559bcc642123f7c6bcd3846983a2e465469c33",
-        "path": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar"
-    },
-    {
-        "url": "org/codehaus/plexus/plexus-archiver/4.8.0/plexus-archiver-4.8.0.jar",
-        "hash": "24513c9bc6d52716f5a22f7ef03e26c310f62ebcde309de9833deac6a4ac32e3",
-        "path": "org/codehaus/plexus/plexus-archiver/4.8.0/plexus-archiver-4.8.0.jar"
-    },
-    {
-        "url": "org/jetbrains/idea/maven/maven-indexer-api-rt/2023.2/maven-indexer-api-rt-2023.2.jar",
-        "hash": "b9e8bb167267aa21219d9319d568d3e48198dde3756368e6102879d638248931",
-        "path": "org/jetbrains/idea/maven/maven-indexer-api-rt/2023.2/maven-indexer-api-rt-2023.2.jar"
-    },
-    {
-        "url": "com/thoughtworks/xstream/xstream/1.4.21/xstream-1.4.21.jar",
-        "hash": "f56586f3de59ae2a49430acbc9f27942b8c5cebec9245c869fae7136733333ec",
-        "path": "com/thoughtworks/xstream/xstream/1.4.21/xstream-1.4.21.jar"
-    },
-    {
-        "url": "io/github/x-stream/mxparser/1.2.2/mxparser-1.2.2.jar",
-        "hash": "aeeee23a3303d811bca8790ea7f25b534314861c03cff36dafdcc2180969eb97",
-        "path": "io/github/x-stream/mxparser/1.2.2/mxparser-1.2.2.jar"
-    },
-    {
-        "url": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar",
-        "hash": "34e08ee62116071cbb69c0ed70d15a7a5b208d62798c59f2120bb8929324cb63",
-        "path": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar"
-    },
-    {
-        "url": "org/apache/ws/xmlrpc/xmlrpc/2.0.1/xmlrpc-2.0.1.jar",
-        "hash": "36efda6efee96e83602c9ba246db19bf4c5e733324390d2fa8213417d6b681e7",
-        "path": "org/apache/ws/xmlrpc/xmlrpc/2.0.1/xmlrpc-2.0.1.jar"
-    },
-    {
-        "url": "xerces/xercesImpl/2.12.2/xercesImpl-2.12.2.jar",
-        "hash": "6fc991829af1708d15aea50c66f0beadcd2cfeb6968e0b2f55c1b0909883fe16",
-        "path": "xerces/xercesImpl/2.12.2/xercesImpl-2.12.2.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/winp/winp/1.30.1/winp-1.30.1.jar",
-        "hash": "9e2d7a23a1d3921861939509108606ad1cf6b10c64d65ac91958a62043cfa253",
-        "path": "org/jetbrains/intellij/deps/winp/winp/1.30.1/winp-1.30.1.jar"
-    },
-    {
-        "url": "org/apache/velocity/velocity-engine-core/2.3/velocity-engine-core-2.3.jar",
-        "hash": "b086cee8fd8183e240b4afcf54fe38ec33dd8eb0da414636e5bf7aa4d9856629",
-        "path": "org/apache/velocity/velocity-engine-core/2.3/velocity-engine-core-2.3.jar"
-    },
-    {
-        "url": "uk/org/webcompere/system-stubs-jupiter/2.1.8/system-stubs-jupiter-2.1.8.jar",
-        "hash": "9a24867a51f5d22db67d9052a06bc5dd2e9a3e273bc2ee9814620f2d9f25d0a8",
-        "path": "uk/org/webcompere/system-stubs-jupiter/2.1.8/system-stubs-jupiter-2.1.8.jar"
-    },
-    {
-        "url": "uk/org/webcompere/system-stubs-core/2.1.8/system-stubs-core-2.1.8.jar",
-        "hash": "9c27322cfc7043c75384ad444007b0880ca18fe7231d69bfa69616bc773cafe1",
-        "path": "uk/org/webcompere/system-stubs-core/2.1.8/system-stubs-core-2.1.8.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy/1.17.4/byte-buddy-1.17.4.jar",
-        "hash": "74768731219a5b2e0cc9d2b1c9e2092e0622242e41b1925a6ba7346e160731bc",
-        "path": "net/bytebuddy/byte-buddy/1.17.4/byte-buddy-1.17.4.jar"
-    },
-    {
-        "url": "net/bytebuddy/byte-buddy-agent/1.17.4/byte-buddy-agent-1.17.4.jar",
-        "hash": "e1dae7efc5562c29ad3b625b90e6864208de69bad5632c3f93a547f17622ac51",
-        "path": "net/bytebuddy/byte-buddy-agent/1.17.4/byte-buddy-agent-1.17.4.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/sshj/0.38.0-idea2/sshj-0.38.0-idea2.jar",
-        "hash": "bd0bf08b2b4aca35a87ec2bee62920fb0478d5b21c97f6ece04739bf5b4aeefc",
-        "path": "org/jetbrains/intellij/deps/sshj/0.38.0-idea2/sshj-0.38.0-idea2.jar"
-    },
-    {
-        "url": "com/hierynomus/asn-one/0.6.0/asn-one-0.6.0.jar",
-        "hash": "e4f70fd92849b52240048b8ebace0c9a17d3bb7b9c882b3c7778cec3458495f5",
-        "path": "com/hierynomus/asn-one/0.6.0/asn-one-0.6.0.jar"
-    },
-    {
-        "url": "net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar",
-        "hash": "4dda1120db856640dbec04140ed23242215a075fe127bdefa0dcfa29fb31267d",
-        "path": "net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/skiko/skiko-awt/0.9.30/skiko-awt-0.9.30.jar",
-        "hash": "928b8566c9bd03e51d69d72ed1106ef7eae2c9ad23d64e49966c5dc212dca411",
-        "path": "org/jetbrains/skiko/skiko-awt/0.9.30/skiko-awt-0.9.30.jar"
-    },
-    {
-        "url": "org/jetbrains/skiko/skiko-awt-runtime-all/0.9.30/skiko-awt-runtime-all-0.9.30.jar",
-        "hash": "1f8643e58e3bfd16625b1db6a3fd237410a32a37d54b74c51914069eea0a60a6",
-        "path": "org/jetbrains/skiko/skiko-awt-runtime-all/0.9.30/skiko-awt-runtime-all-0.9.30.jar"
-    },
-    {
-        "url": "org/jetbrains/pty4j/pty4j/0.13.11/pty4j-0.13.11.jar",
-        "hash": "0329ee5520f3b0177a0b2bdefac3c4c69cc9d3915e4f210a8bf39be7ab3887c8",
-        "path": "org/jetbrains/pty4j/pty4j/0.13.11/pty4j-0.13.11.jar"
-    },
-    {
         "url": "com/h2database/h2-mvstore/2.3.232/h2-mvstore-2.3.232.jar",
         "hash": "2c8225cd73b2394382b9d0016d9278a00291562224a594eef00c00a6ac50bc04",
         "path": "com/h2database/h2-mvstore/2.3.232/h2-mvstore-2.3.232.jar"
     },
     {
-        "url": "com/miglayout/miglayout-swing/11.4.2/miglayout-swing-11.4.2.jar",
-        "hash": "036b8532021092afcc7159d3756086a5fbe19f6014ac8474817d55d1289af756",
-        "path": "com/miglayout/miglayout-swing/11.4.2/miglayout-swing-11.4.2.jar"
-    },
-    {
-        "url": "com/miglayout/miglayout-core/11.4.2/miglayout-core-11.4.2.jar",
-        "hash": "1c23f628d8f2a7a1b72c8f634c6775d1a8fd0100fcf05bf50d7a2ac8dafb0e62",
-        "path": "com/miglayout/miglayout-core/11.4.2/miglayout-core-11.4.2.jar"
-    },
-    {
-        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
-        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
-        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar",
-        "hash": "3565b6d4d789bf70683c45566944287fc1d8dc75c23d98bd87d01059cc76f2b3",
-        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar"
-    },
-    {
-        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
-        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
-        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
-        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
-        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-encoding-jvm/3.1.3/ktor-client-encoding-jvm-3.1.3.jar",
-        "hash": "925decea3921e2b89a0cc0000feba3613c4b2d7c96945749d25fde3b8b69627f",
-        "path": "io/ktor/ktor-client-encoding-jvm/3.1.3/ktor-client-encoding-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-content-negotiation-jvm/3.1.3/ktor-client-content-negotiation-jvm-3.1.3.jar",
-        "hash": "9cbf59168645f54a9a9c21c1a0f15cd628234b20bbff3ec1bd64680f10aa779d",
-        "path": "io/ktor/ktor-client-content-negotiation-jvm/3.1.3/ktor-client-content-negotiation-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-auth-jvm/3.1.3/ktor-client-auth-jvm-3.1.3.jar",
-        "hash": "202a46d169ce1472fef818c9c3d3cc30343fd308d45b6557ae8e0b4e48f07bc8",
-        "path": "io/ktor/ktor-client-auth-jvm/3.1.3/ktor-client-auth-jvm-3.1.3.jar"
-    },
-    {
-        "url": "io/ktor/ktor-client-logging-jvm/3.1.3/ktor-client-logging-jvm-3.1.3.jar",
-        "hash": "ecabf013b137f1a69c39cffeae1ba9e365659357b21688f1876ee6cf50fd00b9",
-        "path": "io/ktor/ktor-client-logging-jvm/3.1.3/ktor-client-logging-jvm-3.1.3.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.jar",
-        "hash": "f854126f39acbd963fd54e0cd226000a151a76f7225ee28185d52f44e262befb",
-        "path": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.jar"
-    },
-    {
-        "url": "com/github/weisj/jsvg/1.3.0-jb.8/jsvg-1.3.0-jb.8.jar",
-        "hash": "da76eba4122036f4372008564b0db192c8649a57c7a896ae565a1adfcc31f0b0",
-        "path": "com/github/weisj/jsvg/1.3.0-jb.8/jsvg-1.3.0-jb.8.jar"
-    },
-    {
-        "url": "org/codehaus/jettison/jettison/1.5.4/jettison-1.5.4.jar",
-        "hash": "fc3a68a7c17688ee50817340fef265d8d3f6c192c92bbee00d17f18a6d3dfeda",
-        "path": "org/codehaus/jettison/jettison/1.5.4/jettison-1.5.4.jar"
-    },
-    {
-        "url": "org/jetbrains/jediterm/jediterm-ui/3.57/jediterm-ui-3.57.jar",
-        "hash": "05a51058880face1793bcdee9b31578d0ca160fcf603e773d3a12c41d35fd43f",
-        "path": "org/jetbrains/jediterm/jediterm-ui/3.57/jediterm-ui-3.57.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/jcef/jcef/137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13/jcef-137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13.jar",
-        "hash": "7ff53ee6af9a9b3dcf9ce5366b9e803398d61460840a4232fa7bf3b9ef1388e5",
-        "path": "org/jetbrains/intellij/deps/jcef/jcef/137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13/jcef-137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13.jar"
-    },
-    {
-        "url": "com/fasterxml/jackson/jr/jackson-jr-objects/2.19.0/jackson-jr-objects-2.19.0.jar",
-        "hash": "1fbd56f47b0a35031585fa0444b81f1f284ebe4a8752a86f42d0c092c4d693e7",
-        "path": "com/fasterxml/jackson/jr/jackson-jr-objects/2.19.0/jackson-jr-objects-2.19.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/ini4j/0.5.5-2/ini4j-0.5.5-2.jar",
-        "hash": "6d342a8599aed6e2871c638c87e2533647d6a32aec1e0feaa871133ae21517a4",
-        "path": "org/jetbrains/intellij/deps/ini4j/0.5.5-2/ini4j-0.5.5-2.jar"
-    },
-    {
-        "url": "com/dynatrace/hash4j/hash4j/0.26.0/hash4j-0.26.0.jar",
-        "hash": "47c319c7015d31df78c17962c4008861f8630f383d12275cf7abd09f6a804c43",
-        "path": "com/dynatrace/hash4j/hash4j/0.26.0/hash4j-0.26.0.jar"
-    },
-    {
-        "url": "com/github/seregamorph/hamcrest-more-matchers/0.1/hamcrest-more-matchers-0.1.jar",
-        "hash": "0b39c30f73a84dc50181a10e0d66e9543d6ef1b561c207b7fba6944e64dc22b3",
-        "path": "com/github/seregamorph/hamcrest-more-matchers/0.1/hamcrest-more-matchers-0.1.jar"
-    },
-    {
-        "url": "org/jetbrains/dokka/dokka-cli/2.0.0/dokka-cli-2.0.0.jar",
-        "hash": "5f70f358160b48ef9763b2ced4e96037f1bfc8d0122de692550ca320ab4b9f20",
-        "path": "org/jetbrains/dokka/dokka-cli/2.0.0/dokka-cli-2.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/dokka/javadoc-plugin/2.0.0/javadoc-plugin-2.0.0.jar",
-        "hash": "41055e59e3f0a6e04b77557641b9a2db0311e99f81c5bc7b1fcc3409bb23d99b",
-        "path": "org/jetbrains/dokka/javadoc-plugin/2.0.0/javadoc-plugin-2.0.0.jar"
-    },
-    {
-        "url": "org/jetbrains/dokka/dokka-base/2.0.0/dokka-base-2.0.0.jar",
-        "hash": "0411d1c38a1d100cbd346c6340c3c4b5f154a48a9c119ed11893d6fae94c91aa",
-        "path": "org/jetbrains/dokka/dokka-base/2.0.0/dokka-base-2.0.0.jar"
-    },
-    {
-        "url": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
-        "hash": "04d65ec1bde6cea20e3495d5e78ef96ab774d9936434861d3254bd88e7e94f92",
-        "path": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar"
-    },
-    {
-        "url": "org/jetbrains/dokka/kotlin-as-java-plugin/2.0.0/kotlin-as-java-plugin-2.0.0.jar",
-        "hash": "3d8931b3c03f84edbf72f67348265205d819d327bb110043ab11d840d59bde41",
-        "path": "org/jetbrains/dokka/kotlin-as-java-plugin/2.0.0/kotlin-as-java-plugin-2.0.0.jar"
-    },
-    {
-        "url": "com/soywiz/korlibs/korte/korte-jvm/4.0.10/korte-jvm-4.0.10.jar",
-        "hash": "b9b983817a80dbb5f9b599b508616115c1e8e1e3f1fccc301695f4530792690f",
-        "path": "com/soywiz/korlibs/korte/korte-jvm/4.0.10/korte-jvm-4.0.10.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1/kotlinx-html-jvm-0.9.1.jar",
-        "hash": "b68f39cd9ad7b46de0a0e77e7f5908d4e7661f3d0c85d2d9171543fcd5b156fb",
-        "path": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1/kotlinx-html-jvm-0.9.1.jar"
-    },
-    {
-        "url": "org/jetbrains/dokka/analysis-kotlin-descriptors/2.0.0/analysis-kotlin-descriptors-2.0.0.jar",
-        "hash": "829788c40891a2a3c4b9435cb9ec80d645560d926e9fbbd08ccc29e8e4f1eb7c",
-        "path": "org/jetbrains/dokka/analysis-kotlin-descriptors/2.0.0/analysis-kotlin-descriptors-2.0.0.jar"
-    },
-    {
-        "url": "io/nlopez/compose/rules/detekt/0.4.27/detekt-0.4.27.jar",
-        "hash": "3ebb866359b8ec9ba06e45eb27b1b88ee84dab7b052c3ddef57a0e5d12433fb5",
-        "path": "io/nlopez/compose/rules/detekt/0.4.27/detekt-0.4.27.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar",
-        "hash": "1981dea8e4e2e8541af2d83e4f8d3581ce647cfe63175b9eb9ac2a07849d74c9",
-        "path": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
-        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
-        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
-    },
-    {
-        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
-        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
-        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar",
-        "hash": "5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5",
-        "path": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar"
-    },
-    {
-        "url": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar",
-        "hash": "672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835",
-        "path": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar",
-        "hash": "7e93e9a23b478f70128893b06748673f912100b7ef03040d7d0331e26d30d092",
-        "path": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar"
-    },
-    {
-        "url": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar",
-        "hash": "4053f878c171692aab8782f53a3974f43e55e2b6ed12c3682b36a46968c5ded1",
-        "path": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar",
-        "hash": "718e8f71f5872986e4f5cd4887a41e26aa0aeff42e99cf4a42582291b8738cc4",
-        "path": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
-        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
-        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
-    },
-    {
-        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
-        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
-        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
-    },
-    {
-        "url": "io/nlopez/compose/rules/common-detekt/0.4.27/common-detekt-0.4.27.jar",
-        "hash": "fa0b6f2a76b7c3768d5f3b6095b3deb756840a9251f8f750e344c5213382f2fd",
-        "path": "io/nlopez/compose/rules/common-detekt/0.4.27/common-detekt-0.4.27.jar"
-    },
-    {
-        "url": "androidx/compose/runtime/runtime-desktop/1.10.0-beta01/runtime-desktop-1.10.0-beta01.jar",
-        "hash": "d35610a718146c6623f1dc99bb03d33080da1d139325c7d18c81649061085353",
-        "path": "androidx/compose/runtime/runtime-desktop/1.10.0-beta01/runtime-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "androidx/collection/collection-jvm/1.5.0/collection-jvm-1.5.0.jar",
-        "hash": "70b35924e4babcdffa37d0e575ee039c56a2d97123342624c48b603233704341",
-        "path": "androidx/collection/collection-jvm/1.5.0/collection-jvm-1.5.0.jar"
-    },
-    {
-        "url": "androidx/annotation/annotation-jvm/1.9.1/annotation-jvm-1.9.1.jar",
-        "hash": "1e343917ebf27ba96fe4dc52b1cad7fd32b738fbc6355bb6cd5b3b305d7212d0",
-        "path": "androidx/annotation/annotation-jvm/1.9.1/annotation-jvm-1.9.1.jar"
-    },
-    {
-        "url": "androidx/compose/runtime/runtime-annotation-jvm/1.10.0-beta01/runtime-annotation-jvm-1.10.0-beta01.jar",
-        "hash": "f89dda8bcd73876d0fc16568844b2bd79443ee7ca62810874d25c7dcaa394bd6",
-        "path": "androidx/compose/runtime/runtime-annotation-jvm/1.10.0-beta01/runtime-annotation-jvm-1.10.0-beta01.jar"
-    },
-    {
-        "url": "androidx/compose/runtime/runtime-saveable-desktop/1.10.0-beta01/runtime-saveable-desktop-1.10.0-beta01.jar",
-        "hash": "12f491f7f5b36304d852e373231f06a3057ea52e369f380044ebc23097dfc2c5",
-        "path": "androidx/compose/runtime/runtime-saveable-desktop/1.10.0-beta01/runtime-saveable-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "androidx/savedstate/savedstate-compose-desktop/1.3.2/savedstate-compose-desktop-1.3.2.jar",
-        "hash": "4a94787a6e5bcfe143390a4f2737d4425d2ea867f2b34a847de6cda3c6ccc58a",
-        "path": "androidx/savedstate/savedstate-compose-desktop/1.3.2/savedstate-compose-desktop-1.3.2.jar"
-    },
-    {
-        "url": "androidx/savedstate/savedstate-desktop/1.3.2/savedstate-desktop-1.3.2.jar",
-        "hash": "c5c89062ba8402b8f8657efd54db1ff192f91ca95fae59c3b418fbc477c3e3ea",
-        "path": "androidx/savedstate/savedstate-desktop/1.3.2/savedstate-desktop-1.3.2.jar"
-    },
-    {
-        "url": "androidx/lifecycle/lifecycle-runtime-compose-desktop/2.9.4/lifecycle-runtime-compose-desktop-2.9.4.jar",
-        "hash": "d25c083df93da718a1876a3293bd15f7dc7a811e998735943bce590683a57835",
-        "path": "androidx/lifecycle/lifecycle-runtime-compose-desktop/2.9.4/lifecycle-runtime-compose-desktop-2.9.4.jar"
-    },
-    {
-        "url": "androidx/lifecycle/lifecycle-runtime-desktop/2.9.4/lifecycle-runtime-desktop-2.9.4.jar",
-        "hash": "2fb49f76d1021792fb359e0a9246c1509f2f5b555f0a46591d24d58deb68bd5c",
-        "path": "androidx/lifecycle/lifecycle-runtime-desktop/2.9.4/lifecycle-runtime-desktop-2.9.4.jar"
-    },
-    {
-        "url": "androidx/lifecycle/lifecycle-common-jvm/2.9.4/lifecycle-common-jvm-2.9.4.jar",
-        "hash": "37d89b2101f074ac6c260917dabb185607645ee200aa3018c7c5bde70edcf184",
-        "path": "androidx/lifecycle/lifecycle-common-jvm/2.9.4/lifecycle-common-jvm-2.9.4.jar"
-    },
-    {
-        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
-        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
-        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
-    },
-    {
-        "url": "androidx/arch/core/core-common/2.2.0/core-common-2.2.0.jar",
-        "hash": "65308a06b1c00ee186cb9e19321383f043b993813f1522c47f4a3e3303bdba41",
-        "path": "androidx/arch/core/core-common/2.2.0/core-common-2.2.0.jar"
-    },
-    {
-        "url": "androidx/annotation/annotation/1.1.0/annotation-1.1.0.jar",
-        "hash": "d38d63edb30f1467818d50aaf05f8a692dea8b31392a049bfa991b159ad5b692",
-        "path": "androidx/annotation/annotation/1.1.0/annotation-1.1.0.jar"
-    },
-    {
-        "url": "androidx/compose/runtime/runtime-retain-desktop/1.10.0-beta01/runtime-retain-desktop-1.10.0-beta01.jar",
-        "hash": "e673e7bd810699399fe967675e8f24f3502ef8c9a967ee695b79d4649ef31908",
-        "path": "androidx/compose/runtime/runtime-retain-desktop/1.10.0-beta01/runtime-retain-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-test-junit4-desktop/1.10.0-beta01/ui-test-junit4-desktop-1.10.0-beta01.jar",
-        "hash": "de2f63543b8f646b85c789e3bf53121e4e6d89d3c7c0afc0358954cc27316a71",
-        "path": "org/jetbrains/compose/ui/ui-test-junit4-desktop/1.10.0-beta01/ui-test-junit4-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-test-desktop/1.10.0-beta01/ui-test-desktop-1.10.0-beta01.jar",
-        "hash": "65e46ce4ce2291ed0cead9d184ef96d8e10e31770e23901f71deadde6be72b2e",
-        "path": "org/jetbrains/compose/ui/ui-test-desktop/1.10.0-beta01/ui-test-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/foundation/foundation-desktop/1.10.0-beta01/foundation-desktop-1.10.0-beta01.jar",
-        "hash": "ef70b786c9444735bd634c1e2d224d1511a39bd134afb123e8f408679244b563",
-        "path": "org/jetbrains/compose/foundation/foundation-desktop/1.10.0-beta01/foundation-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/animation/animation-desktop/1.10.0-beta01/animation-desktop-1.10.0-beta01.jar",
-        "hash": "4aab9a942a0bf3cef4b1c01451dbc13c2e30a9289c87c4fe416663d808e920fb",
-        "path": "org/jetbrains/compose/animation/animation-desktop/1.10.0-beta01/animation-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/animation/animation-core-desktop/1.10.0-beta01/animation-core-desktop-1.10.0-beta01.jar",
-        "hash": "530c042dcb2861382ed4d4a039f026c718b1d7c1b3cbbda58b12d26ba86683e3",
-        "path": "org/jetbrains/compose/animation/animation-core-desktop/1.10.0-beta01/animation-core-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-geometry-desktop/1.10.0-beta01/ui-geometry-desktop-1.10.0-beta01.jar",
-        "hash": "cdbfdabccac8abef2d9bc0420ec0c4be7a880f6d26b2d1cc4e2317c0d252ee27",
-        "path": "org/jetbrains/compose/ui/ui-geometry-desktop/1.10.0-beta01/ui-geometry-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/foundation/foundation-layout-desktop/1.10.0-beta01/foundation-layout-desktop-1.10.0-beta01.jar",
-        "hash": "6d38e4de37bcc3adeadf595d559e9cb73a215c763f8127fe780c820faf6a789b",
-        "path": "org/jetbrains/compose/foundation/foundation-layout-desktop/1.10.0-beta01/foundation-layout-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-desktop/1.10.0-beta01/ui-desktop-1.10.0-beta01.jar",
-        "hash": "e4c01eefc1ec2d5a6f0e643f50865b56022b564cdcb0bbc122a64b692cb65d89",
-        "path": "org/jetbrains/compose/ui/ui-desktop/1.10.0-beta01/ui-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "androidx/lifecycle/lifecycle-viewmodel-desktop/2.9.4/lifecycle-viewmodel-desktop-2.9.4.jar",
-        "hash": "98f816be6869407c87d46058756f97780fa6c6cf61acdba97216f413731af15d",
-        "path": "androidx/lifecycle/lifecycle-viewmodel-desktop/2.9.4/lifecycle-viewmodel-desktop-2.9.4.jar"
-    },
-    {
-        "url": "androidx/lifecycle/lifecycle-viewmodel-savedstate-desktop/2.9.4/lifecycle-viewmodel-savedstate-desktop-2.9.4.jar",
-        "hash": "3e0b44e2514eafdd6938d5457d9f46e4785077c45d3b4364b5c23c4dcb93efd3",
-        "path": "androidx/lifecycle/lifecycle-viewmodel-savedstate-desktop/2.9.4/lifecycle-viewmodel-savedstate-desktop-2.9.4.jar"
-    },
-    {
-        "url": "androidx/navigationevent/navigationevent-desktop/1.0.0-beta01/navigationevent-desktop-1.0.0-beta01.jar",
-        "hash": "8283896d87f6d3e21dd5b12785e6c7ca3b7f15cbc4d0391b20ad23e54b520515",
-        "path": "androidx/navigationevent/navigationevent-desktop/1.0.0-beta01/navigationevent-desktop-1.0.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-backhandler-desktop/1.10.0-beta01/ui-backhandler-desktop-1.10.0-beta01.jar",
-        "hash": "08a4ac21eca159e16e959ae27f9431b33ecf8f0fc88bcc7499edd21d340de7a5",
-        "path": "org/jetbrains/compose/ui/ui-backhandler-desktop/1.10.0-beta01/ui-backhandler-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-graphics-desktop/1.10.0-beta01/ui-graphics-desktop-1.10.0-beta01.jar",
-        "hash": "80f61d974f2ddac95084738f0f18e8c0f6c1923b4bf8cc6a9245b1376c8c992f",
-        "path": "org/jetbrains/compose/ui/ui-graphics-desktop/1.10.0-beta01/ui-graphics-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-unit-desktop/1.10.0-beta01/ui-unit-desktop-1.10.0-beta01.jar",
-        "hash": "f0f3439928b3d9132f07cb2d7a86091696372ebc8354d16b48830b6ce15e8161",
-        "path": "org/jetbrains/compose/ui/ui-unit-desktop/1.10.0-beta01/ui-unit-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-text-desktop/1.10.0-beta01/ui-text-desktop-1.10.0-beta01.jar",
-        "hash": "2d230e78f7160cc2dbcf5c2bd2824ee43832b26e40d01ddfe862c0236c37c8f0",
-        "path": "org/jetbrains/compose/ui/ui-text-desktop/1.10.0-beta01/ui-text-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/compose/ui/ui-util-desktop/1.10.0-beta01/ui-util-desktop-1.10.0-beta01.jar",
-        "hash": "7bfc93a8cad2974cdfd5a2c817e3083e0e3c48ef99e4dbba51eb98a14c92ed2d",
-        "path": "org/jetbrains/compose/ui/ui-util-desktop/1.10.0-beta01/ui-util-desktop-1.10.0-beta01.jar"
-    },
-    {
-        "url": "org/jetbrains/kotlinx/atomicfu-jvm/0.23.2/atomicfu-jvm-0.23.2.jar",
-        "hash": "101ff43ff563fca167af5ade98c3b69bf569010eab745013b84d8955034d3b3c",
-        "path": "org/jetbrains/kotlinx/atomicfu-jvm/0.23.2/atomicfu-jvm-0.23.2.jar"
-    },
-    {
-        "url": "org/apache/commons/commons-text/1.14.0/commons-text-1.14.0.jar",
-        "hash": "121fce2282910c8f0c3ba793a5436b31beb710423cbe2d574a3fb7a73c508e92",
-        "path": "org/apache/commons/commons-text/1.14.0/commons-text-1.14.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-network-ktor3-jvm/3.2.0/coil-network-ktor3-jvm-3.2.0.jar",
-        "hash": "377ea37e058df261bcc274ea0c947eccc67fec5a0499bdf646b99c2f34f74a6a",
-        "path": "io/coil-kt/coil3/coil-network-ktor3-jvm/3.2.0/coil-network-ktor3-jvm-3.2.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
-        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
-        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
-    },
-    {
-        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
-        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
-        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-network-core-jvm/3.2.0/coil-network-core-jvm-3.2.0.jar",
-        "hash": "54cff2971fbcb1743b6d4cb6fb5bb863b4f6fae37002ec57a2fdf837b0c3242e",
-        "path": "io/coil-kt/coil3/coil-network-core-jvm/3.2.0/coil-network-core-jvm-3.2.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-svg-jvm/3.2.0/coil-svg-jvm-3.2.0.jar",
-        "hash": "e412715d1e447a43331f2ceb406435f28aafd7476a987de3d8222e6d39a8c84b",
-        "path": "io/coil-kt/coil3/coil-svg-jvm/3.2.0/coil-svg-jvm-3.2.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
-        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
-        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
-    },
-    {
-        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
-        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
-        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-test-jvm/3.2.0/coil-test-jvm-3.2.0.jar",
-        "hash": "bea462cdc351c04dc4895f028b847d65a7dbae72a9b3999ea1089cd56ded43ad",
-        "path": "io/coil-kt/coil3/coil-test-jvm/3.2.0/coil-test-jvm-3.2.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
-        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
-        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
-    },
-    {
-        "url": "org/jetbrains/skiko/skiko-awt/0.9.4/skiko-awt-0.9.4.jar",
-        "hash": "8e26ab1ae75f65786f6b973a66e89a2836d199a5561c4c2edbc1f3f67ad2197f",
-        "path": "org/jetbrains/skiko/skiko-awt/0.9.4/skiko-awt-0.9.4.jar"
-    },
-    {
-        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
-        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
-        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-compose-jvm/3.2.0/coil-compose-jvm-3.2.0.jar",
-        "hash": "b135eafcff7545cba7e39c0c8d4e724c0f42e91050b10df5d635a6c7dfd3fb42",
-        "path": "io/coil-kt/coil3/coil-compose-jvm/3.2.0/coil-compose-jvm-3.2.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-jvm/3.2.0/coil-jvm-3.2.0.jar",
-        "hash": "7d0182c987052d6502135a6a6cc7cc68288ef48f990d75ad4c4ae03e25be786e",
-        "path": "io/coil-kt/coil3/coil-jvm/3.2.0/coil-jvm-3.2.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
-        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
-        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
-    },
-    {
-        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
-        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
-        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
-    },
-    {
-        "url": "io/coil-kt/coil3/coil-compose-core-jvm/3.2.0/coil-compose-core-jvm-3.2.0.jar",
-        "hash": "a74b96cb179fe8f872d4e9f03468e0477d32787e9b6430a9d137aafb76012a60",
-        "path": "io/coil-kt/coil3/coil-compose-core-jvm/3.2.0/coil-compose-core-jvm-3.2.0.jar"
-    },
-    {
-        "url": "com/github/spullara/cli-parser/cli-parser/1.1.6/cli-parser-1.1.6.jar",
-        "hash": "436143bc3b925a1af4d0b8c9c7c53ac5c937f0f7aa32e4d97a24ce0a301ede27",
-        "path": "com/github/spullara/cli-parser/cli-parser/1.1.6/cli-parser-1.1.6.jar"
-    },
-    {
-        "url": "io/github/classgraph/classgraph/4.8.181/classgraph-4.8.181.jar",
-        "hash": "62a6436d69710ef5fab6ec243781ce4c5b299047ed1841b5f92746ae852ce545",
-        "path": "io/github/classgraph/classgraph/4.8.181/classgraph-4.8.181.jar"
-    },
-    {
-        "url": "cglib/cglib-nodep/3.3.0/cglib-nodep-3.3.0.jar",
-        "hash": "3366d2c88fb576e486d830f521184e8f1839f8c15dcd2151a3f6e1f62b0b37a0",
-        "path": "cglib/cglib-nodep/3.3.0/cglib-nodep-3.3.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/blockmap/1.0.7/blockmap-1.0.7.jar",
-        "hash": "7e3f98d3370551fea909ceb952e4797108a3a5ef67a1d7b5fb03a036eab24df9",
-        "path": "org/jetbrains/intellij/blockmap/1.0.7/blockmap-1.0.7.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/asm-all/9.6.1/asm-all-9.6.1.jar",
-        "hash": "a72e84efb1406a7ab326e0b28c4376e9e1ebfc08c09f23edff5e6e7249588df7",
-        "path": "org/jetbrains/intellij/deps/asm-all/9.6.1/asm-all-9.6.1.jar"
-    },
-    {
-        "url": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar",
-        "hash": "9bc5a572406da07a704d5e71e662dd183dfe9385e7c06cab1a49debc5a355638",
-        "path": "ai/grazie/spell/gec-spell-engine-local/0.8.74/gec-spell-engine-local-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar",
-        "hash": "e1cc87b2a052ce4e4124abc6cd6d9c14dbc9e3319f854eb5829d44af860cb7f6",
-        "path": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-gec-jvm/0.8.74/model-gec-jvm-0.8.74.jar",
-        "hash": "99cac5b6a3d8cd6e32333bb88c1aead22c7360a1471ea4a546425b822546f57f",
-        "path": "ai/grazie/model/model-gec-jvm/0.8.74/model-gec-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar",
-        "hash": "fa7db0b8e4cad3a8951c91d6d09c2c6baf8ae9008b0b59d76158cf2282797caa",
-        "path": "ai/grazie/model/model-text-jvm/0.8.74/model-text-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar",
-        "hash": "d9c0813e00ff06888f30008098a3938a348863ee65c0b7f9a6aa524bb10982bf",
-        "path": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-langs-jvm/0.8.74/nlp-langs-jvm-0.8.74.jar",
-        "hash": "8619419456eb300942b819ce1046d7f6aa170efe892321a2d9e25ef7df612331",
-        "path": "ai/grazie/nlp/nlp-langs-jvm/0.8.74/nlp-langs-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar",
-        "hash": "fae2d16393c9b42f5808021204f0989a27c825a72128eef943e9ebe1702d5ea1",
-        "path": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-patterns-jvm/0.8.74/nlp-patterns-jvm-0.8.74.jar",
-        "hash": "97b03ed0b5c87cb486c64b1ed6574e05be2f3331d4ac394c85f35c24cb7a0f44",
-        "path": "ai/grazie/nlp/nlp-patterns-jvm/0.8.74/nlp-patterns-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar",
-        "hash": "0fbf476e73762b15509264e31e282bfb1a63342a8e0c6921d88c24c4eaf3c2a3",
-        "path": "ai/grazie/nlp/nlp-similarity-jvm/0.8.74/nlp-similarity-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-phonetics-jvm/0.8.74/nlp-phonetics-jvm-0.8.74.jar",
-        "hash": "ea4cd2ec177029c88ab81e3b120d2c9aacc01997dc2ecc9ada5e22de9f10d723",
-        "path": "ai/grazie/nlp/nlp-phonetics-jvm/0.8.74/nlp-phonetics-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-tokenizer-jvm/0.8.74/nlp-tokenizer-jvm-0.8.74.jar",
-        "hash": "b45bd05287973a6e30611933a5aa285d2115ea2f16545108f9285922dd71ca90",
-        "path": "ai/grazie/nlp/nlp-tokenizer-jvm/0.8.74/nlp-tokenizer-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar",
-        "hash": "ce5f571e5eae530cc4835d99977181a545bc07c85755b5b73a1bfb1a669f40d1",
-        "path": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/spell/hunspell-en/0.2.318/hunspell-en-0.2.318.jar",
-        "hash": "2156335fe8fdc263beae3912178385c7ef7ea6472fafd429177479d260b20f80",
-        "path": "ai/grazie/spell/hunspell-en/0.2.318/hunspell-en-0.2.318.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-detect-jvm/0.8.74/nlp-detect-jvm-0.8.74.jar",
-        "hash": "887f672cc8b16ad9ca2a660bcd46d32cfa5fa6a726eca23c61ff5eceaab4af35",
-        "path": "ai/grazie/nlp/nlp-detect-jvm/0.8.74/nlp-detect-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar",
-        "hash": "e3c8ebc2e1d06fd9efece9fed214d80e16416b6630567d891e200dcad2f07144",
-        "path": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.0/completion-ranking-kotlin-0.4.0.jar",
-        "hash": "1849979a0cd2a997e1071ac79741b1a77781357e254138f30eabffebccddfec8",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.0/completion-ranking-kotlin-0.4.0.jar"
-    },
-    {
-        "url": "org/ehcache/sizeof/0.4.0/sizeof-0.4.0.jar",
-        "hash": "0429cb1f5cda94180007874ea926a88149fca2028e92b4556d35f0cfce310c53",
-        "path": "org/ehcache/sizeof/0.4.0/sizeof-0.4.0.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/scenebuilderkit/11.0.5/scenebuilderkit-11.0.5.jar",
-        "hash": "36cd8f5bc933bcf726fadfc5276f0efcc7873d3a532e4e164674d2e8919f4781",
-        "path": "org/jetbrains/intellij/deps/scenebuilderkit/11.0.5/scenebuilderkit-11.0.5.jar"
-    },
-    {
-        "url": "org/apache/ant/ant/1.7.1/ant-1.7.1.jar",
-        "hash": "ebe592c9af9fdb6c55f0e6c6fabc76f6e0eec8efdec535398e86c3a883687ebf",
-        "path": "org/apache/ant/ant/1.7.1/ant-1.7.1.jar"
-    },
-    {
-        "url": "org/apache/ant/ant-launcher/1.7.1/ant-launcher-1.7.1.jar",
-        "hash": "25eb5926c975ac6f4126feeb9d004f53f9ebf07dc117f5db9958a6bfb3110783",
-        "path": "org/apache/ant/ant-launcher/1.7.1/ant-launcher-1.7.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.3/completion-ranking-java-0.9.3.jar",
-        "hash": "e3dcfee71eb13467139a1385152bd28554c79c677738cb617a91a772ea6e9f87",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.3/completion-ranking-java-0.9.3.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/debugger-memory-agent/1.0.51/debugger-memory-agent-1.0.51.jar",
-        "hash": "1408ae6528102c098971bde601f99c791cd1c57cc2485516f75f4ccbb45202ef",
-        "path": "org/jetbrains/intellij/deps/debugger-memory-agent/1.0.51/debugger-memory-agent-1.0.51.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/sa-jdwp/1.24/sa-jdwp-1.24.jar",
-        "hash": "2334e030f1ebdaddbd84aa8cd3af514a3b80d674b343532187b6d6bdff24329d",
-        "path": "org/jetbrains/intellij/deps/sa-jdwp/1.24/sa-jdwp-1.24.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/debugger-agent/1.79/debugger-agent-1.79.jar",
-        "hash": "ba7a0aa7bbb813acab3b0edf36c0a15449f41896993c97e0d133fa4ea0a3e6d9",
-        "path": "org/jetbrains/intellij/deps/debugger-agent/1.79/debugger-agent-1.79.jar"
-    },
-    {
-        "url": "org/jacoco/org.jacoco.ant/0.8.14/org.jacoco.ant-0.8.14.jar",
-        "hash": "9fff68954d5de3aad2bf838eaf886ed67d2c22a2d6c6f095548bade8c45caeae",
-        "path": "org/jacoco/org.jacoco.ant/0.8.14/org.jacoco.ant-0.8.14.jar"
-    },
-    {
-        "url": "org/jacoco/org.jacoco.core/0.8.14/org.jacoco.core-0.8.14.jar",
-        "hash": "28abbf0eea5a08e4f24097f2fbac663ca17c341c25c3a04d90d6cd325943c995",
-        "path": "org/jacoco/org.jacoco.core/0.8.14/org.jacoco.core-0.8.14.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm/9.9/asm-9.9.jar",
-        "hash": "03d99a74ad1ee5c71334ef67437f4ef4fe3488caa7c96d8645abc73c8e2017d4",
-        "path": "org/ow2/asm/asm/9.9/asm-9.9.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-commons/9.9/asm-commons-9.9.jar",
-        "hash": "db2f6f26150bbe7c126606b4a1151836bcc22a1e05a423b3585698bece995ff8",
-        "path": "org/ow2/asm/asm-commons/9.9/asm-commons-9.9.jar"
-    },
-    {
-        "url": "org/ow2/asm/asm-tree/9.9/asm-tree-9.9.jar",
-        "hash": "42178f3775c9c63f9e5e1446747d29b4eca4d91bd6e75e5c43cfa372a47d38c6",
-        "path": "org/ow2/asm/asm-tree/9.9/asm-tree-9.9.jar"
-    },
-    {
-        "url": "org/jacoco/org.jacoco.report/0.8.14/org.jacoco.report-0.8.14.jar",
-        "hash": "a3e2026060ab8b8d5c650706406234bb4c033dfd5376afeb8b1666e8ed27c453",
-        "path": "org/jacoco/org.jacoco.report/0.8.14/org.jacoco.report-0.8.14.jar"
-    },
-    {
-        "url": "org/jacoco/org.jacoco.agent/0.8.14/org.jacoco.agent-0.8.14.jar",
-        "hash": "20be9853385bdfc65a5929643412d09243d14514304b89ba23a265158cc8792b",
-        "path": "org/jacoco/org.jacoco.agent/0.8.14/org.jacoco.agent-0.8.14.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar",
-        "hash": "8627281c15b1b5347ca618d0dbc2090aa92a096a867c1d030198a51efcc33bfe",
-        "path": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar"
-    },
-    {
-        "url": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
-        "hash": "04d65ec1bde6cea20e3495d5e78ef96ab774d9936434861d3254bd88e7e94f92",
-        "path": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-transport-file/1.9.22/maven-resolver-transport-file-1.9.22.jar",
-        "hash": "4f2a857d8b832494bae9ef6d7db7bb8409378b28aabd3615f03faebe42a4ad1d",
-        "path": "org/apache/maven/resolver/maven-resolver-transport-file/1.9.22/maven-resolver-transport-file-1.9.22.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-transport-http/1.9.22/maven-resolver-transport-http-1.9.22.jar",
-        "hash": "1cf2a88c984e0eae8b3f13e1eec904eedead2f076d1f3c1d5cb5103a21538bd1",
-        "path": "org/apache/maven/resolver/maven-resolver-transport-http/1.9.22/maven-resolver-transport-http-1.9.22.jar"
-    },
-    {
-        "url": "org/apache/maven/resolver/maven-resolver-connector-basic/1.9.22/maven-resolver-connector-basic-1.9.22.jar",
-        "hash": "4ab68bdec97eec318b2a3bd27e7c954e316f890df92d544b68afd0bf666c9588",
-        "path": "org/apache/maven/resolver/maven-resolver-connector-basic/1.9.22/maven-resolver-connector-basic-1.9.22.jar"
-    },
-    {
-        "url": "com/jetbrains/intellij/documentation/tips-intellij-idea-community/241.62/tips-intellij-idea-community-241.62.jar",
-        "hash": "e46de060e29f3d060de5a9dab21711ff4d376e4b2a7e96d332415df60b7d77c8",
-        "path": "com/jetbrains/intellij/documentation/tips-intellij-idea-community/241.62/tips-intellij-idea-community-241.62.jar"
-    },
-    {
-        "url": "org/spockframework/spock-core/2.1-groovy-3.0/spock-core-2.1-groovy-3.0.jar",
-        "hash": "fa8ff7446df04c51b3ccbc2a1bbc71f9c280878afe2d53be44d59d00b1b9828c",
-        "path": "org/spockframework/spock-core/2.1-groovy-3.0/spock-core-2.1-groovy-3.0.jar"
-    },
-    {
-        "url": "org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar",
-        "hash": "702868ed7e86b9b4672ede0f1e185e905baca9afab57746a7c650be3c7bca047",
-        "path": "org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar"
-    },
-    {
-        "url": "ai/grazie/spell/hunspell-de/0.2.318/hunspell-de-0.2.318.jar",
-        "hash": "4532f6939496a445fcb414851775da773c0ec267578843eac780f4471de091a4",
-        "path": "ai/grazie/spell/hunspell-de/0.2.318/hunspell-de-0.2.318.jar"
-    },
-    {
-        "url": "ai/grazie/spell/hunspell-ru/0.2.318/hunspell-ru-0.2.318.jar",
-        "hash": "8774adc464d22899bb61621f9d8ed4900ba131163e3ff64b8b835f56736d8c14",
-        "path": "ai/grazie/spell/hunspell-ru/0.2.318/hunspell-ru-0.2.318.jar"
-    },
-    {
-        "url": "ai/grazie/spell/hunspell-uk/0.2.318/hunspell-uk-0.2.318.jar",
-        "hash": "a1366fa763f5da5c436c6a94623acdd53370ee59ecc16652dda0a544f468a2bc",
-        "path": "ai/grazie/spell/hunspell-uk/0.2.318/hunspell-uk-0.2.318.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.19/languagetool-core-6.7.19.jar",
-        "hash": "adafb32cef456d63fbc71cd0e193211a58fb712517ad7fea7f3098e34a184842",
-        "path": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.19/languagetool-core-6.7.19.jar"
-    },
-    {
-        "url": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar",
-        "hash": "33021c9cca70c6292d53ff7dac5d1832d422e986aba52ec998532a5f47f921f8",
-        "path": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-ru/6.7.19/language-ru-6.7.19.jar",
-        "hash": "24e353865ce2862de1cb2468b73f28bb4d7fb996ab480c9a9513999ba2a3252e",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-ru/6.7.19/language-ru-6.7.19.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-zh/6.7.19/language-zh-6.7.19.jar",
-        "hash": "9aceb89c3f8b7f1b98eaef06b1b79e64ee5308f0edb2315785aad4f3c4045169",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-zh/6.7.19/language-zh-6.7.19.jar"
-    },
-    {
-        "url": "com/hankcs/hanlp/portable-1.8.2/hanlp-portable-1.8.2.jar",
-        "hash": "f4e8e42211f62dc952a669329f43b78c72927690407b1ccea37448c76f843379",
-        "path": "com/hankcs/hanlp/portable-1.8.2/hanlp-portable-1.8.2.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-de/6.7.19/language-de-6.7.19.jar",
-        "hash": "3b8fdde02fa7c870daaa0d33d040d00a6dd9a8971e5bf01b3946ff2a9a7b5887",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-de/6.7.19/language-de-6.7.19.jar"
-    },
-    {
-        "url": "de/danielnaber/german-pos-dict/1.2.4/german-pos-dict-1.2.4.jar",
-        "hash": "56f0b00adb704cbc1e86776b45f6890efe90685ab370a34b5b299593cdcaae22",
-        "path": "de/danielnaber/german-pos-dict/1.2.4/german-pos-dict-1.2.4.jar"
-    },
-    {
-        "url": "de/danielnaber/jwordsplitter/4.7/jwordsplitter-4.7.jar",
-        "hash": "0435e604abe8b4a0b27f568db9349fbe0546df286bbe62f667c9fd9663df71b2",
-        "path": "de/danielnaber/jwordsplitter/4.7/jwordsplitter-4.7.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-it/6.7.19/language-it-6.7.19.jar",
-        "hash": "66610c22526cae842fbcfc2d64b15b27e1e88f6bd715b8b72d951d60d205e53c",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-it/6.7.19/language-it-6.7.19.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-uk/6.7.19/language-uk-6.7.19.jar",
-        "hash": "a02e7a2aced8f3f43244c9b06bdd2ac620ffc76a173dd33c19f79e12a9056660",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-uk/6.7.19/language-uk-6.7.19.jar"
-    },
-    {
-        "url": "ua/net/nlp/morfologik-ukrainian-lt/6.7.1/morfologik-ukrainian-lt-6.7.1.jar",
-        "hash": "453886930ba7ba0d80d1158577e3e10d814e2c739ee17e297f062542d92dfd04",
-        "path": "ua/net/nlp/morfologik-ukrainian-lt/6.7.1/morfologik-ukrainian-lt-6.7.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-be/6.7.19/language-be-6.7.19.jar",
-        "hash": "e1112c8cbb7bc83523e2fc057e58b0b48dcdba5cb58e9771639ed2cd735ae4e4",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-be/6.7.19/language-be-6.7.19.jar"
-    },
-    {
-        "url": "io/github/belarus/linguistics.grammardb.spell.languagetool/1.0.2/linguistics.grammardb.spell.languagetool-1.0.2.jar",
-        "hash": "1d1a55e905faa9740d648144cf05c4a460f0f26416d2ee01157bad0877be31c2",
-        "path": "io/github/belarus/linguistics.grammardb.spell.languagetool/1.0.2/linguistics.grammardb.spell.languagetool-1.0.2.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-pt/6.7.19/language-pt-6.7.19.jar",
-        "hash": "15082b699292f1b28756337e3fe46295c556d1e1147bf98d155cca4a08382599",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-pt/6.7.19/language-pt-6.7.19.jar"
-    },
-    {
-        "url": "org/languagetool/portuguese-pos-dict/1.2.0/portuguese-pos-dict-1.2.0.jar",
-        "hash": "fe8da88bb31b6372855741fbd81ee1c7477b4f8a0624d3dafd20ee23e184650e",
-        "path": "org/languagetool/portuguese-pos-dict/1.2.0/portuguese-pos-dict-1.2.0.jar"
-    },
-    {
-        "url": "ai/grazie/api/api-gateway-client-jvm/0.8.74/api-gateway-client-jvm-0.8.74.jar",
-        "hash": "6eed4b225d44e13090f8c59716ac9207be07cadb6b0733da613365f839495540",
-        "path": "ai/grazie/api/api-gateway-client-jvm/0.8.74/api-gateway-client-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/api/api-gateway-api-jvm/0.8.74/api-gateway-api-jvm-0.8.74.jar",
-        "hash": "9a9575297ed98677e19883b1b2d2169161d8330559c1d2971f73ce75ffae8f05",
-        "path": "ai/grazie/api/api-gateway-api-jvm/0.8.74/api-gateway-api-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/auth/gec-agg-model-public-jvm/0.8.74/gec-agg-model-public-jvm-0.8.74.jar",
-        "hash": "760adbd5039f1c119f309d14b62b20ccd436f65192548fd00b17faedc62708bf",
-        "path": "ai/grazie/auth/gec-agg-model-public-jvm/0.8.74/gec-agg-model-public-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/llm/llm-agg-api-model-jvm/0.8.74/llm-agg-api-model-jvm-0.8.74.jar",
-        "hash": "a7c8db405963faeaad887598ecedddc5a5fd2a7372eb3e07db2d79964f8e5bf9",
-        "path": "ai/grazie/llm/llm-agg-api-model-jvm/0.8.74/llm-agg-api-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-feedback-jvm/0.8.74/model-feedback-jvm-0.8.74.jar",
-        "hash": "8dc12eeacf0a1eb33623fc30c0d4c4eda6e89dd06cdf35afa5ce412204dfa6d8",
-        "path": "ai/grazie/model/model-feedback-jvm/0.8.74/model-feedback-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-indexing-jvm/0.8.74/model-indexing-jvm-0.8.74.jar",
-        "hash": "664721a747bad766340aed882e265f01be3575a4d4800b003df35cbd9c698f6c",
-        "path": "ai/grazie/model/model-indexing-jvm/0.8.74/model-indexing-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-sum-jvm/0.8.74/model-sum-jvm-0.8.74.jar",
-        "hash": "dfaa447742d8ab05cd0ce37da42bcf4a456020a26f53c8baa00ee95c8eae10a9",
-        "path": "ai/grazie/model/model-sum-jvm/0.8.74/model-sum-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-llm-jvm/0.8.74/model-llm-jvm-0.8.74.jar",
-        "hash": "0d6a157b67003c8ec2bc94977b938bb78344bb8fdb3d14e54e80e8e48011845b",
-        "path": "ai/grazie/model/model-llm-jvm/0.8.74/model-llm-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-bdg-jvm/0.8.74/model-bdg-jvm-0.8.74.jar",
-        "hash": "85c23a42fef7bf9db650a1595b0a56d99acddde7dd5ff1f1e027731ad5373944",
-        "path": "ai/grazie/model/model-bdg-jvm/0.8.74/model-bdg-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-nlp-jvm/0.8.74/model-nlp-jvm-0.8.74.jar",
-        "hash": "223ac217288d7e4b74831fe64c749e32ff1d21cb92eccd88305dbebe6225c892",
-        "path": "ai/grazie/model/model-nlp-jvm/0.8.74/model-nlp-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-quota-jvm/0.8.74/model-quota-jvm-0.8.74.jar",
-        "hash": "9c09d3e2744c71e6130126cc25cbe0cdf6331db8c5f7dd8f169c7bf9ce96ca46",
-        "path": "ai/grazie/model/model-quota-jvm/0.8.74/model-quota-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-license-jvm/0.8.74/model-license-jvm-0.8.74.jar",
-        "hash": "24b83bb28bb549d1dc44776bae33bf78e77f73f27de999ddfde8c1ff90c9ac62",
-        "path": "ai/grazie/model/model-license-jvm/0.8.74/model-license-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-tone-formality-jvm/0.8.74/model-tone-formality-jvm-0.8.74.jar",
-        "hash": "5596f5406cc20b0f0eb1a95733a39924eff44d443bc9b9d49687268d636f59d0",
-        "path": "ai/grazie/model/model-tone-formality-jvm/0.8.74/model-tone-formality-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-gateway-jvm/0.8.74/model-gateway-jvm-0.8.74.jar",
-        "hash": "5a9bf64cb860e143c5cf7c0e7eec5630de583807ec9a9c41bdaa80caceede255",
-        "path": "ai/grazie/model/model-gateway-jvm/0.8.74/model-gateway-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/auth/auth-model-jvm/0.8.74/auth-model-jvm-0.8.74.jar",
-        "hash": "e739417d466e9ec195d34eaaa1d81df93c4229051dcf9045a961114d0a102cd1",
-        "path": "ai/grazie/auth/auth-model-jvm/0.8.74/auth-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/auth/product/auth-product-model-jvm/0.8.74/auth-product-model-jvm-0.8.74.jar",
-        "hash": "353f0f34ac89b4138da9d2548e2c036b7ede13cb3eeb2d861db65fdbcb909550",
-        "path": "ai/grazie/auth/product/auth-product-model-jvm/0.8.74/auth-product-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/user/cfg/user-cfg-model-jvm/0.8.74/user-cfg-model-jvm-0.8.74.jar",
-        "hash": "02f994598d0e9d59c3125faeb189d29b0e9e6743c524ed90587b096c6e57fe46",
-        "path": "ai/grazie/user/cfg/user-cfg-model-jvm/0.8.74/user-cfg-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-jwt-jvm/0.8.74/utils-jwt-jvm-0.8.74.jar",
-        "hash": "23c6617feff191e38ebc1be8b17c23e703373c5d68dc894875a228816d5fa6cf",
-        "path": "ai/grazie/utils/utils-jwt-jvm/0.8.74/utils-jwt-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/user/strg/user-strg-model-jvm/0.8.74/user-strg-model-jvm-0.8.74.jar",
-        "hash": "d8ccf3778f53df601f8d6b4a9343eb12908b6a7bc46844d30965a4c47c211f13",
-        "path": "ai/grazie/user/strg/user-strg-model-jvm/0.8.74/user-strg-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/indexing/indexing-server-api-jvm/0.8.74/indexing-server-api-jvm-0.8.74.jar",
-        "hash": "0d7c04d58f97c28976f2d17e01418cf5fa147d0b037e4165e9cd1c5f47b02979",
-        "path": "ai/grazie/indexing/indexing-server-api-jvm/0.8.74/indexing-server-api-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar",
-        "hash": "e3c8ebc2e1d06fd9efece9fed214d80e16416b6630567d891e200dcad2f07144",
-        "path": "ai/grazie/model/swagger-annotations-jvm/0.8.74/swagger-annotations-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/client/client-common-jvm/0.8.74/client-common-jvm-0.8.74.jar",
-        "hash": "977c6aa3684410a21179b8a531576f53003e2d90d3cf72429685420e3aba3f3e",
-        "path": "ai/grazie/client/client-common-jvm/0.8.74/client-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar",
-        "hash": "d9c0813e00ff06888f30008098a3938a348863ee65c0b7f9a6aa524bb10982bf",
-        "path": "ai/grazie/model/model-common-jvm/0.8.74/model-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-auth-jvm/0.8.74/model-auth-jvm-0.8.74.jar",
-        "hash": "1c009c97c5fc005f2337871a0558c716cb0f4e07d0bc37b025c2d537deffef9e",
-        "path": "ai/grazie/model/model-auth-jvm/0.8.74/model-auth-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/client/client-attribute-jvm/0.8.74/client-attribute-jvm-0.8.74.jar",
-        "hash": "9fbfe9aadb29ecaa362915ae65fab0b14ad502ec1b9be952386939f24a73073c",
-        "path": "ai/grazie/client/client-attribute-jvm/0.8.74/client-attribute-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-cloud-jvm/0.8.74/model-cloud-jvm-0.8.74.jar",
-        "hash": "93aa91ddea2263dfe7da7f376afab7282e32d0caefc9f27318f3d9ca87dd3d84",
-        "path": "ai/grazie/model/model-cloud-jvm/0.8.74/model-cloud-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-nmt-jvm/0.8.74/model-nmt-jvm-0.8.74.jar",
-        "hash": "ee74b094dcd48b6d7208a16ecc9e187092e476525f95c61b9ab4810e99afa269",
-        "path": "ai/grazie/model/model-nmt-jvm/0.8.74/model-nmt-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-nlc-jvm/0.8.74/model-nlc-jvm-0.8.74.jar",
-        "hash": "84f506f92fa7f48e222215ce53ad898aa2f37f5df154a0679c3750976bac001b",
-        "path": "ai/grazie/model/model-nlc-jvm/0.8.74/model-nlc-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar",
-        "hash": "fae2d16393c9b42f5808021204f0989a27c825a72128eef943e9ebe1702d5ea1",
-        "path": "ai/grazie/nlp/nlp-common-jvm/0.8.74/nlp-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-def-jvm/0.8.74/model-def-jvm-0.8.74.jar",
-        "hash": "d79871ceab86ee827ee1f1f069ffccb5da3fba05b7cd9829b4deca5936126fef",
-        "path": "ai/grazie/model/model-def-jvm/0.8.74/model-def-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-syn-jvm/0.8.74/model-syn-jvm-0.8.74.jar",
-        "hash": "26a2de7cd201bff5a8b0956382b59a532c1a49b3dad0ff4238721fdf42250bef",
-        "path": "ai/grazie/model/model-syn-jvm/0.8.74/model-syn-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-qa-jvm/0.8.74/model-qa-jvm-0.8.74.jar",
-        "hash": "a6b0363ec58de48f81d1bf9676c2a6680f68468e9eb2ad80c254a450b6f14067",
-        "path": "ai/grazie/model/model-qa-jvm/0.8.74/model-qa-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar",
-        "hash": "fd646112e2bb2bb16527397946016a17e269a27095d0c7343a8f154b83db9d0a",
-        "path": "ai/grazie/model/model-emb-jvm/0.8.74/model-emb-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-task-jvm/0.8.74/model-task-jvm-0.8.74.jar",
-        "hash": "4c430e83cfc99b60e509fa7a98a430625fba1c011f0d4ad105251a3c3079203d",
-        "path": "ai/grazie/model/model-task-jvm/0.8.74/model-task-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-jet-jvm/0.8.74/model-jet-jvm-0.8.74.jar",
-        "hash": "60e534c0ccb4ef8fd7869829ec7bf63682b5db4464d9712fcf57278a8981f861",
-        "path": "ai/grazie/model/model-jet-jvm/0.8.74/model-jet-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-chat-jvm/0.8.74/model-chat-jvm-0.8.74.jar",
-        "hash": "723c27f8880afb15a6bd8629d0ee1fd3847872670f4d215f05ddc15e10616474",
-        "path": "ai/grazie/model/model-chat-jvm/0.8.74/model-chat-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/tasks/provider/model/tasks-provider-jet-completion-model-jvm/0.8.74/tasks-provider-jet-completion-model-jvm-0.8.74.jar",
-        "hash": "750ff8436538b639e78e7456090c94f3f8a7ec605044f7941a083ef33b2750f4",
-        "path": "ai/grazie/tasks/provider/model/tasks-provider-jet-completion-model-jvm/0.8.74/tasks-provider-jet-completion-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/tasks/provider/tasks-provider-task-schema/0.8.74/tasks-provider-task-schema-0.8.74.jar",
-        "hash": "5e1efbeea5cccffddae7709e3a9d0d2583c7d45ab6986a3878b0e3d310be4238",
-        "path": "ai/grazie/tasks/provider/tasks-provider-task-schema/0.8.74/tasks-provider-task-schema-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/tasks/provider/llm/completion/tasks-provider-llm-completion-model-jvm/0.8.74/tasks-provider-llm-completion-model-jvm-0.8.74.jar",
-        "hash": "a10c97eefd99d19b6cd706fb8366a0c6274dbeb53cd4e495f77cbe569cf4fc0a",
-        "path": "ai/grazie/tasks/provider/llm/completion/tasks-provider-llm-completion-model-jvm/0.8.74/tasks-provider-llm-completion-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/tasks/provider/model/tasks-provider-proxy-model-jvm/0.8.74/tasks-provider-proxy-model-jvm-0.8.74.jar",
-        "hash": "992dcc9497a2d7ed70105a1ef425cf40d5ed21ac84c91219bd1abd31ccd3bbf9",
-        "path": "ai/grazie/tasks/provider/model/tasks-provider-proxy-model-jvm/0.8.74/tasks-provider-proxy-model-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar",
-        "hash": "e1cc87b2a052ce4e4124abc6cd6d9c14dbc9e3319f854eb5829d44af860cb7f6",
-        "path": "ai/grazie/utils/utils-common-jvm/0.8.74/utils-common-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar",
-        "hash": "ce5f571e5eae530cc4835d99977181a545bc07c85755b5b73a1bfb1a669f40d1",
-        "path": "ai/grazie/utils/utils-multiplatform-jvm/0.8.74/utils-multiplatform-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/client/client-ktor-jvm/0.8.74/client-ktor-jvm-0.8.74.jar",
-        "hash": "71ee5cf5122c33ef949228389350efa77de54ec29af603e33a4c0f4289bac393",
-        "path": "ai/grazie/client/client-ktor-jvm/0.8.74/client-ktor-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/utils/utils-ktor-jvm/0.8.74/utils-ktor-jvm-0.8.74.jar",
-        "hash": "719d32f0110a60613b8c55deda0aa6145223aa3fb740457b810a774525ec1a53",
-        "path": "ai/grazie/utils/utils-ktor-jvm/0.8.74/utils-ktor-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/tasks-library/tasks-library-api-jvm/0.4.14/tasks-library-api-jvm-0.4.14.jar",
-        "hash": "70210d0eb24dd099e3e2923d55a8f4d5e5cef54f277f0bf1f17568633bec446e",
-        "path": "ai/grazie/tasks-library/tasks-library-api-jvm/0.4.14/tasks-library-api-jvm-0.4.14.jar"
-    },
-    {
-        "url": "ai/grazie/tasks-library/tasks-library-model-jvm/0.4.14/tasks-library-model-jvm-0.4.14.jar",
-        "hash": "8722c78b12167e0c05e8797a66ede6984ff3d98882b9b729c008f6494702c706",
-        "path": "ai/grazie/tasks-library/tasks-library-model-jvm/0.4.14/tasks-library-model-jvm-0.4.14.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.19/languagetool-core-6.7.19.jar",
-        "hash": "adafb32cef456d63fbc71cd0e193211a58fb712517ad7fea7f3098e34a184842",
-        "path": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.19/languagetool-core-6.7.19.jar"
-    },
-    {
-        "url": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar",
-        "hash": "33021c9cca70c6292d53ff7dac5d1832d422e986aba52ec998532a5f47f921f8",
-        "path": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/languagetool/language-en/6.7.19/language-en-6.7.19.jar",
-        "hash": "4faf190812aff01543fe930c7476db7d21b4a5ac892421c849aa85e090d5dd2b",
-        "path": "org/jetbrains/intellij/deps/languagetool/language-en/6.7.19/language-en-6.7.19.jar"
-    },
-    {
-        "url": "org/languagetool/english-pos-dict/0.6/english-pos-dict-0.6.jar",
-        "hash": "2a3e96b49854e5275f8eb7a1bb5b3b85b82f687fed272f3043882ccc0b1634b1",
-        "path": "org/languagetool/english-pos-dict/0.6/english-pos-dict-0.6.jar"
-    },
-    {
-        "url": "net/loomchild/segment/2.0.3/segment-2.0.3.jar",
-        "hash": "a134be9884ddfa18304c8e437e64aa598d83ccfa439310029e61ea3fdae8b2ce",
-        "path": "net/loomchild/segment/2.0.3/segment-2.0.3.jar"
-    },
-    {
-        "url": "org/carrot2/morfologik-stemming/2.1.9/morfologik-stemming-2.1.9.jar",
-        "hash": "6170895b2315b697f4da5630caf57c6c441f1cb419d89d1cb5326b0673293e8a",
-        "path": "org/carrot2/morfologik-stemming/2.1.9/morfologik-stemming-2.1.9.jar"
-    },
-    {
-        "url": "org/carrot2/morfologik-speller/2.1.9/morfologik-speller-2.1.9.jar",
-        "hash": "8d2566a216f401380878f25196f84bd351b807b11f18bc71acd1417e04a1ec29",
-        "path": "org/carrot2/morfologik-speller/2.1.9/morfologik-speller-2.1.9.jar"
-    },
-    {
-        "url": "com/carrotsearch/hppc/0.9.1/hppc-0.9.1.jar",
-        "hash": "d58706a2be60c972452550cdba79870bf481447c50eb718308e33a6ba45c65ec",
-        "path": "com/carrotsearch/hppc/0.9.1/hppc-0.9.1.jar"
-    },
-    {
-        "url": "org/carrot2/morfologik-fsa-builders/2.1.9/morfologik-fsa-builders-2.1.9.jar",
-        "hash": "f418c519b49470c2ec7024086bf210ba370ff158732368005d3b8cef964d3fff",
-        "path": "org/carrot2/morfologik-fsa-builders/2.1.9/morfologik-fsa-builders-2.1.9.jar"
-    },
-    {
-        "url": "org/carrot2/morfologik-fsa/2.1.9/morfologik-fsa-2.1.9.jar",
-        "hash": "1bfefce937df14cc94d32a98ce59c33f4d5b6c0eddbb436b6bfe27ff2120a23d",
-        "path": "org/carrot2/morfologik-fsa/2.1.9/morfologik-fsa-2.1.9.jar"
-    },
-    {
-        "url": "tech/uom/lib/uom-lib-common/1.1/uom-lib-common-1.1.jar",
-        "hash": "4add5fbcb7f548b79230ed7e01cb9fd4f9e2524bd1598dbcbfd8150563fe27f7",
-        "path": "tech/uom/lib/uom-lib-common/1.1/uom-lib-common-1.1.jar"
-    },
-    {
-        "url": "tech/units/indriya/1.3/indriya-1.3.jar",
-        "hash": "7cbaa6f42e2c8412ef13cd0fb7f81936d64a1c3ea7c4f69cf75bb4e9410cb76b",
-        "path": "tech/units/indriya/1.3/indriya-1.3.jar"
-    },
-    {
-        "url": "javax/measure/unit-api/1.0/unit-api-1.0.jar",
-        "hash": "35da65fdbd3f9c1fe79cfc8399db975fd97660d8a219febfda9fd1a5fc058f10",
-        "path": "javax/measure/unit-api/1.0/unit-api-1.0.jar"
+        "url": "com/hankcs/aho-corasick-double-array-trie/1.2.2/aho-corasick-double-array-trie-1.2.2.jar",
+        "hash": "cbc79badb1e3d18dd18fdb77850da17d4566371c955e5ae85654b770c6e17858",
+        "path": "com/hankcs/aho-corasick-double-array-trie/1.2.2/aho-corasick-double-array-trie-1.2.2.jar"
     },
     {
         "url": "com/hankcs/aho-corasick-double-array-trie/1.2.3/aho-corasick-double-array-trie-1.2.3.jar",
@@ -6730,49 +1145,364 @@
         "path": "com/hankcs/aho-corasick-double-array-trie/1.2.3/aho-corasick-double-array-trie-1.2.3.jar"
     },
     {
+        "url": "com/hankcs/hanlp/portable-1.8.2/hanlp-portable-1.8.2.jar",
+        "hash": "f4e8e42211f62dc952a669329f43b78c72927690407b1ccea37448c76f843379",
+        "path": "com/hankcs/hanlp/portable-1.8.2/hanlp-portable-1.8.2.jar"
+    },
+    {
+        "url": "com/hierynomus/asn-one/0.6.0/asn-one-0.6.0.jar",
+        "hash": "e4f70fd92849b52240048b8ebace0c9a17d3bb7b9c882b3c7778cec3458495f5",
+        "path": "com/hierynomus/asn-one/0.6.0/asn-one-0.6.0.jar"
+    },
+    {
+        "url": "com/ibm/db2/jcc/11.5.7.0/jcc-11.5.7.0.jar",
+        "hash": "1dbc8dc93441890f242be66983f1d1363fe6a80f8d1f0b7ca0e1063f42054bb0",
+        "path": "com/ibm/db2/jcc/11.5.7.0/jcc-11.5.7.0.jar"
+    },
+    {
+        "url": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar",
+        "hash": "b3640b9f416a4411fd33c59abbeea8fd57d024c23e1819bf9673220a97499fe3",
+        "path": "com/ibm/icu/icu4j/77.1/icu4j-77.1.jar"
+    },
+    {
+        "url": "com/intellij/annotations/12.0/annotations-12.0.jar",
+        "hash": "f8ab13b14be080fe2f617f90e55599760e4a1b4deeea5c595df63d0d6375ed6d",
+        "path": "com/intellij/annotations/12.0/annotations-12.0.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar",
+        "hash": "e9b7e2b1262fd02fe63b08f636903ff36f453f08ae52190c78e3cbf19d777e42",
+        "path": "com/intellij/platform/kotlinx-coroutines-core-jvm/1.10.1-intellij-5/kotlinx-coroutines-core-jvm-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar",
+        "hash": "f8f56f19d2b29da511809c3345d2f0bf283bfb94a0a0d83f5b630e1424625723",
+        "path": "com/intellij/platform/kotlinx-coroutines-debug/1.10.1-intellij-5/kotlinx-coroutines-debug-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar",
+        "hash": "61ff422fe859c2439d94727eb6dcd7ccadb5ba0d9cce4e181db1946209ef9bf6",
+        "path": "com/intellij/platform/kotlinx-coroutines-guava/1.10.1-intellij-5/kotlinx-coroutines-guava-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar",
+        "hash": "1d68dfc6ba67ec96ecb5a373dbd9fb557ce2210ffc2d74d6b528e4f1f73e7003",
+        "path": "com/intellij/platform/kotlinx-coroutines-slf4j/1.10.1-intellij-5/kotlinx-coroutines-slf4j-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar",
+        "hash": "98b5c1291d9e473ce6df9823781a8a2170f1dfb4c30d985c56ff5242df2ff8f5",
+        "path": "com/intellij/platform/kotlinx-coroutines-test-jvm/1.10.1-intellij-5/kotlinx-coroutines-test-jvm-1.10.1-intellij-5.jar"
+    },
+    {
+        "url": "com/intellij/remoterobot/remote-fixtures/0.11.19/remote-fixtures-0.11.19.jar",
+        "hash": "8a8edd8e68b426121e218b3434e5b41d27dc67c83dd97b4b8e457e1ba3e9f0be",
+        "path": "com/intellij/remoterobot/remote-fixtures/0.11.19/remote-fixtures-0.11.19.jar"
+    },
+    {
+        "url": "com/intellij/remoterobot/remote-robot/0.11.19/remote-robot-0.11.19.jar",
+        "hash": "609b1df54d4c052032024070a17a23dc7b55c63698fc27f8c40f3806bb5a01b6",
+        "path": "com/intellij/remoterobot/remote-robot/0.11.19/remote-robot-0.11.19.jar"
+    },
+    {
+        "url": "com/intellij/remoterobot/robot-server-core/0.11.19/robot-server-core-0.11.19.jar",
+        "hash": "e906358a9403c2fe2704a64431639d1eabc4dcae24dd434b65290c257a99322f",
+        "path": "com/intellij/remoterobot/robot-server-core/0.11.19/robot-server-core-0.11.19.jar"
+    },
+    {
+        "url": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar",
+        "hash": "11a9ee6f88bb31f1450108d1cf6441377dec84aca075eb6bb2343be157575bea",
+        "path": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar"
+    },
+    {
+        "url": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar",
+        "hash": "89b1360f407381bf61fde411019d8cbd009ebb10cff715f3669017a031027560",
+        "path": "com/jcraft/jzlib/1.1.3/jzlib-1.1.3.jar"
+    },
+    {
+        "url": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar",
+        "hash": "e51ee1761684a946b9d5a0caaec2b92cf4598860cf231dbaf495f268fda35d10",
+        "path": "com/jetbrains/cloudconfig/cloudconfig/2023.9/cloudconfig-2023.9.jar"
+    },
+    {
+        "url": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "71e74b74676099dd9ebbb97780401f9b53f205a69d0d515a5e03c5a42fe20c18",
+        "path": "com/jetbrains/fleet/rpc-compiler-plugin/2.2.20-0.1/rpc-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "com/jetbrains/format-ripper/format-ripper/1.2.0/format-ripper-1.2.0.jar",
+        "hash": "7b47cc1b48092566eaf82c8cd6210151661423b755dc578613000cac90464eef",
+        "path": "com/jetbrains/format-ripper/format-ripper/1.2.0/format-ripper-1.2.0.jar"
+    },
+    {
+        "url": "com/jetbrains/fus/reporting/ap-validation-all/1.0.205/ap-validation-all-1.0.205.jar",
+        "hash": "9921601d14966cf0f9231fd2b92ba9a5b65b02c92a3a9ebc2049c8b2710a2eea",
+        "path": "com/jetbrains/fus/reporting/ap-validation-all/1.0.205/ap-validation-all-1.0.205.jar"
+    },
+    {
+        "url": "com/jetbrains/fus/reporting/api/1.0.205/api-1.0.205.jar",
+        "hash": "bd122fb2110ec009cf3143aef5e2d473611b5e015c0d2701686eb94200e538ca",
+        "path": "com/jetbrains/fus/reporting/api/1.0.205/api-1.0.205.jar"
+    },
+    {
+        "url": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar",
+        "hash": "2bbfa931b2864c4f5e1fd22046d001df8d9a8592a20255baab0d396ed71c854c",
+        "path": "com/jetbrains/infra/download-pgp-verifier/1.1.4/download-pgp-verifier-1.1.4.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar",
+        "hash": "677e12f96a6c48b1b4c4234417cda17bbcb3c25f5c7178ec752ef2a831c65313",
+        "path": "com/jetbrains/intellij/devkit/devkit-runtime-module-repository-jps/252.21158/devkit-runtime-module-repository-jps-252.21158.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/documentation/tips-intellij-idea-community/241.62/tips-intellij-idea-community-241.62.jar",
+        "hash": "e46de060e29f3d060de5a9dab21711ff4d376e4b2a7e96d332415df60b7d77c8",
+        "path": "com/jetbrains/intellij/documentation/tips-intellij-idea-community/241.62/tips-intellij-idea-community-241.62.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar",
+        "hash": "7f9fd8e37ec4dfdef7bfc3bc6a687fa5a322976fc588432fa46d2feb1fefc966",
+        "path": "com/jetbrains/intellij/documentation/tips-pycharm-community/241.74/tips-pycharm-community-241.74.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar",
+        "hash": "3ad94d6402b94932f4341c908827016787cdc6ee3201ee64970822a610c55d34",
+        "path": "com/jetbrains/intellij/platform/runtime-repository/252.21158/runtime-repository-252.21158.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/platform/util-zip-squashed/252.16432/util-zip-squashed-252.16432.jar",
+        "hash": "7df07e447c1de46592dfe4b20345b61ff57c5f3b796b8e946086559b260f7690",
+        "path": "com/jetbrains/intellij/platform/util-zip-squashed/252.16432/util-zip-squashed-252.16432.jar"
+    },
+    {
+        "url": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar",
+        "hash": "78e527dfea8d79c16ea9ca875bd943d443b63bf9d0df1f253c233dc54366df35",
+        "path": "com/jetbrains/intellij/platform/workspace-model-codegen/0.0.9/workspace-model-codegen-0.0.9.jar"
+    },
+    {
+        "url": "com/jetbrains/ml/models/python-imports-ranking-model/coral-panda-republished-6/python-imports-ranking-model-coral-panda-republished-6.jar",
+        "hash": "2dbd0ae71bac24a83db76238f0a0cf2bd6b0fd1963b6827371ae8813a0434827",
+        "path": "com/jetbrains/ml/models/python-imports-ranking-model/coral-panda-republished-6/python-imports-ranking-model-coral-panda-republished-6.jar"
+    },
+    {
+        "url": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar",
+        "hash": "94a06c3fdd4aa638df59c8c783a379ca43a5b933187760e219e09e84f1633d76",
+        "path": "com/jetbrains/mlapi/catboost-shadow-need-slf4j/1.2.5/catboost-shadow-need-slf4j-1.2.5.jar"
+    },
+    {
+        "url": "com/jetbrains/mlapi/mlapi-catboost/0.2.1/mlapi-catboost-0.2.1.jar",
+        "hash": "de75176f3c95433d8da2b95dcdd233b6d9e3cca39f6e2baedb01d4932f911c85",
+        "path": "com/jetbrains/mlapi/mlapi-catboost/0.2.1/mlapi-catboost-0.2.1.jar"
+    },
+    {
+        "url": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar",
+        "hash": "02da615dd0adac62f2d87db878f587529e8d2cb82b3a65ed8b5466a518324180",
+        "path": "com/jetbrains/mlapi/mlapi-core/0.2.1/mlapi-core-0.2.1.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar",
+        "hash": "05492a77e70f6a35f1ce19b60841ba39f2fcbe03b1b26eee7aea0c8745cc5e7e",
+        "path": "com/jetbrains/rd/rd-core/2025.3.1/rd-core-2025.3.1.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar",
+        "hash": "85f2a329245e4a6a1e4552ac62db4c1f23b6f02bf3c96e4df8240668187c848a",
+        "path": "com/jetbrains/rd/rd-framework/2025.3.1/rd-framework-2025.3.1.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar",
+        "hash": "03b276130c0c1417c9bd07cfd8d2eea1fa465fc930dd132ac11fc383cf11deec",
+        "path": "com/jetbrains/rd/rd-gen/2025.3.1/rd-gen-2025.3.1.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar",
+        "hash": "8103c08a017068f9ba79aa260471780b38e3a68bce8995ec1d5279b523ac87ca",
+        "path": "com/jetbrains/rd/rd-swing/2025.3.1/rd-swing-2025.3.1.jar"
+    },
+    {
+        "url": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar",
+        "hash": "e465ab42d9c79cdec7147c8210f8e65d5f816704d47b959ac9f2cfc3f68dedb5",
+        "path": "com/jetbrains/rd/rd-text/2025.3.1/rd-text-2025.3.1.jar"
+    },
+    {
+        "url": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar",
+        "hash": "26b0fc745ea051b57462be22a150c7600dbac6716b24cc60a5ecc0e8085c41a0",
+        "path": "com/jgoodies/forms/1.1-preview/forms-1.1-preview.jar"
+    },
+    {
+        "url": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar",
+        "hash": "efd986ec851c3a5cd57907e72f27d1af9c1e5b1874b07a8b778588646d71d9fc",
+        "path": "com/jgoodies/jgoodies-common/1.4.0/jgoodies-common-1.4.0.jar"
+    },
+    {
+        "url": "com/miglayout/miglayout-core/11.4.2/miglayout-core-11.4.2.jar",
+        "hash": "1c23f628d8f2a7a1b72c8f634c6775d1a8fd0100fcf05bf50d7a2ac8dafb0e62",
+        "path": "com/miglayout/miglayout-core/11.4.2/miglayout-core-11.4.2.jar"
+    },
+    {
+        "url": "com/miglayout/miglayout-swing/11.4.2/miglayout-swing-11.4.2.jar",
+        "hash": "036b8532021092afcc7159d3756086a5fbe19f6014ac8474817d55d1289af756",
+        "path": "com/miglayout/miglayout-swing/11.4.2/miglayout-swing-11.4.2.jar"
+    },
+    {
+        "url": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar",
+        "hash": "81ad7bfe7e59de4cd047eacf24f979ec47db40eac6afc76e6f10288b456b14b1",
+        "path": "com/networknt/json-schema-validator/1.3.1/json-schema-validator-1.3.1.jar"
+    },
+    {
+        "url": "com/optimaize/languagedetector/language-detector/0.6/language-detector-0.6.jar",
+        "hash": "f53ecc3d71da9ebc82edd10fb35638d32e8b9d849273dd717a021eca02f2278d",
+        "path": "com/optimaize/languagedetector/language-detector/0.6/language-detector-0.6.jar"
+    },
+    {
+        "url": "com/pngencoder/pngencoder/0.14.0/pngencoder-0.14.0.jar",
+        "hash": "79bf02e8f49833dc3433ae1554999dd375075e5ab13447fc1e558857b51baecc",
+        "path": "com/pngencoder/pngencoder/0.14.0/pngencoder-0.14.0.jar"
+    },
+    {
+        "url": "com/soywiz/korlibs/korte/korte-jvm/4.0.10/korte-jvm-4.0.10.jar",
+        "hash": "b9b983817a80dbb5f9b599b508616115c1e8e1e3f1fccc301695f4530792690f",
+        "path": "com/soywiz/korlibs/korte/korte-jvm/4.0.10/korte-jvm-4.0.10.jar"
+    },
+    {
+        "url": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar",
+        "hash": "0fe8dcdf54b13b5ec56fdb5f63c057364264bb2f51b7f7bc3c271d5b1ba68dcb",
+        "path": "com/soywiz/korlibs/krypto/krypto-jvm/4.0.10/krypto-jvm-4.0.10.jar"
+    },
+    {
+        "url": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar",
+        "hash": "4c7517e848a71b36d069d12bb3bf46a70fd4cda3105d822b0ed2e19c00b69291",
+        "path": "com/squareup/javapoet/1.13.0/javapoet-1.13.0.jar"
+    },
+    {
+        "url": "com/squareup/okhttp3/mockwebserver/5.0.0-alpha.11/mockwebserver-5.0.0-alpha.11.jar",
+        "hash": "4a30234a911a73ae71f5aec5f98bee243c172665e841f8d532ef77e0b5e81010",
+        "path": "com/squareup/okhttp3/mockwebserver/5.0.0-alpha.11/mockwebserver-5.0.0-alpha.11.jar"
+    },
+    {
+        "url": "com/squareup/okhttp3/mockwebserver3/5.0.0-alpha.11/mockwebserver3-5.0.0-alpha.11.jar",
+        "hash": "9c9e3ef454b514d4a1342faf99c7d4cb41eaae4cb7aefcc93cb7b202bdf4fdfd",
+        "path": "com/squareup/okhttp3/mockwebserver3/5.0.0-alpha.11/mockwebserver3-5.0.0-alpha.11.jar"
+    },
+    {
+        "url": "com/squareup/okhttp3/okhttp/3.14.9/okhttp-3.14.9.jar",
+        "hash": "2570fab55515cbf881d7a4ceef49fc515490bc027057e666776a2832465aeca0",
+        "path": "com/squareup/okhttp3/okhttp/3.14.9/okhttp-3.14.9.jar"
+    },
+    {
+        "url": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar",
+        "hash": "f0e3ffcbba6744ab4918a55aa32ff4f408fcd21e45ab8bd5f7883a1793b2a253",
+        "path": "com/squareup/okhttp3/okhttp/5.0.0-alpha.14/okhttp-5.0.0-alpha.14.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
+        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
+        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
+        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
+        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
+        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
+        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar",
+        "hash": "2d22541a192f901a45c95274567d6957ac1ed613d49e41db4e5e5d86139cf022",
+        "path": "com/squareup/okio/okio-jvm/3.11.0/okio-jvm-3.11.0.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar",
+        "hash": "ddc386ff14bd25d5c934167196eaf45b18de4f28e1c55a4db37ae594cbfd37e4",
+        "path": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar",
+        "hash": "ddc386ff14bd25d5c934167196eaf45b18de4f28e1c55a4db37ae594cbfd37e4",
+        "path": "com/squareup/okio/okio-jvm/3.9.0/okio-jvm-3.9.0.jar"
+    },
+    {
+        "url": "com/squareup/okio/okio/1.17.2/okio-1.17.2.jar",
+        "hash": "f80ce42d2ffac47ad4c47e1d6f980d604d247ceb1a886705cf4581ab0c9fe2b8",
+        "path": "com/squareup/okio/okio/1.17.2/okio-1.17.2.jar"
+    },
+    {
+        "url": "com/squareup/retrofit2/converter-gson/2.9.0/converter-gson-2.9.0.jar",
+        "hash": "32aa206b9a29c9df5eda93a092cfb3b0b9133e232c062baa882f0319f0e79f0e",
+        "path": "com/squareup/retrofit2/converter-gson/2.9.0/converter-gson-2.9.0.jar"
+    },
+    {
+        "url": "com/squareup/retrofit2/retrofit/2.9.0/retrofit-2.9.0.jar",
+        "hash": "e6ea1929c46852f5bec66ab3357da383476cef4e8d1deefdbf195b79cc4d6581",
+        "path": "com/squareup/retrofit2/retrofit/2.9.0/retrofit-2.9.0.jar"
+    },
+    {
+        "url": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar",
+        "hash": "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a",
+        "path": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar"
+    },
+    {
+        "url": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar",
+        "hash": "02156773e4ae9d048d14a56ad35d644bee9f1052a791d072df3ded3c656e6e1a",
+        "path": "com/sun/activation/jakarta.activation/1.2.2/jakarta.activation-1.2.2.jar"
+    },
+    {
+        "url": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar",
+        "hash": "993302b16cd7056f21e779cc577d175a810bb4900ef73cd8fbf2b50f928ba9ce",
+        "path": "com/sun/activation/javax.activation/1.2.0/javax.activation-1.2.0.jar"
+    },
+    {
+        "url": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar",
+        "hash": "27d85fc134c9271d5c79d3300fc4669668f017e72409727c428f54f2417f04cd",
+        "path": "com/sun/istack/istack-commons-runtime/3.0.12/istack-commons-runtime-3.0.12.jar"
+    },
+    {
+        "url": "com/sun/istack/istack-commons-runtime/4.1.2/istack-commons-runtime-4.1.2.jar",
+        "hash": "7fd6792361f4dd00f8c56af4a20cecc0066deea4a8f3dec38348af23fc2296ee",
+        "path": "com/sun/istack/istack-commons-runtime/4.1.2/istack-commons-runtime-4.1.2.jar"
+    },
+    {
+        "url": "com/sun/xml/bind/jaxb-core/2.3.0.1/jaxb-core-2.3.0.1.jar",
+        "hash": "d2ecba63615f317a11fb55c6468f6a9480f6411c10951d9881bafd9a9a8d0467",
+        "path": "com/sun/xml/bind/jaxb-core/2.3.0.1/jaxb-core-2.3.0.1.jar"
+    },
+    {
+        "url": "com/sun/xml/bind/jaxb-impl/2.3.3/jaxb-impl-2.3.3.jar",
+        "hash": "e5178d0c7948247f75a13c689bf36f4d5d4910a121f712aa3b20ae94377069d8",
+        "path": "com/sun/xml/bind/jaxb-impl/2.3.3/jaxb-impl-2.3.3.jar"
+    },
+    {
+        "url": "com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar",
+        "hash": "c260c3230b2340af97d54bf01f7f67ebc57c901922736c881bb11cb981302be2",
+        "path": "com/thoughtworks/qdox/qdox/2.2.0/qdox-2.2.0.jar"
+    },
+    {
+        "url": "com/thoughtworks/xstream/xstream/1.4.21/xstream-1.4.21.jar",
+        "hash": "f56586f3de59ae2a49430acbc9f27942b8c5cebec9245c869fae7136733333ec",
+        "path": "com/thoughtworks/xstream/xstream/1.4.21/xstream-1.4.21.jar"
+    },
+    {
+        "url": "com/typesafe/config/1.4.3/config-1.4.3.jar",
+        "hash": "8ada4c185ce72416712d63e0b5afdc5f009c0cdf405e5f26efecdf156aa5dfb6",
+        "path": "com/typesafe/config/1.4.3/config-1.4.3.jar"
+    },
+    {
+        "url": "com/typesafe/config/1.4.3/config-1.4.3.jar",
+        "hash": "8ada4c185ce72416712d63e0b5afdc5f009c0cdf405e5f26efecdf156aa5dfb6",
+        "path": "com/typesafe/config/1.4.3/config-1.4.3.jar"
+    },
+    {
+        "url": "com/typesafe/config/1.4.4/config-1.4.4.jar",
+        "hash": "ab16decc45cc678b0cf17fb9668f380a73bfdf11b75af1fa1ddec5da82805aea",
+        "path": "com/typesafe/config/1.4.4/config-1.4.4.jar"
+    },
+    {
         "url": "com/vdurmont/emoji-java/5.1.1/emoji-java-5.1.1.jar",
         "hash": "537fae02b7b09de5e47de8f21df20c81af3cd373f369f61e20e00d54827539fb",
         "path": "com/vdurmont/emoji-java/5.1.1/emoji-java-5.1.1.jar"
-    },
-    {
-        "url": "org/json/json/20240205/json-20240205.jar",
-        "hash": "e89df61466f0807f8a86db0e8805a837e59462c8ca47c67786e432133c490aca",
-        "path": "org/json/json/20240205/json-20240205.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-tree-jvm/0.8.74/model-tree-jvm-0.8.74.jar",
-        "hash": "ed6ca179c61ad44fd3a0b0401f6f25bfef680e3a3e704e83249ce5c26dc1a505",
-        "path": "ai/grazie/model/model-tree-jvm/0.8.74/model-tree-jvm-0.8.74.jar"
-    },
-    {
-        "url": "ai/grazie/model/model-ner-jvm/0.8.74/model-ner-jvm-0.8.74.jar",
-        "hash": "f2c12ec41507a192df5740a91ef004b6587e7a3d542741d010ff099ff523246f",
-        "path": "ai/grazie/model/model-ner-jvm/0.8.74/model-ner-jvm-0.8.74.jar"
-    },
-    {
-        "url": "io/github/classgraph/classgraph/4.8.87/classgraph-4.8.87.jar",
-        "hash": "91d2a2b6048c5cfe19f3982ee84eb5c19cab1d741a45ae1b4360c068331f89e6",
-        "path": "io/github/classgraph/classgraph/4.8.87/classgraph-4.8.87.jar"
-    },
-    {
-        "url": "org/jeasy/easy-random-core/4.2.0/easy-random-core-4.2.0.jar",
-        "hash": "e37f9fd2680da69e6e4e0fef6472b53240a935a18804e957ef60ef20f36281de",
-        "path": "org/jeasy/easy-random-core/4.2.0/easy-random-core-4.2.0.jar"
-    },
-    {
-        "url": "org/objenesis/objenesis/3.1/objenesis-3.1.jar",
-        "hash": "cdb3d038c188de6f46ffd5cd930be2d5e5dba59c53b26437995d534e3db2fb80",
-        "path": "org/objenesis/objenesis/3.1/objenesis-3.1.jar"
-    },
-    {
-        "url": "org/apache/ant/ant/1.10.15/ant-1.10.15.jar",
-        "hash": "763acda4a69588c9ea8817a952851ff0c2fc4bffa1d081c2565dc407f29d5794",
-        "path": "org/apache/ant/ant/1.10.15/ant-1.10.15.jar"
-    },
-    {
-        "url": "org/jetbrains/intellij/deps/filePrediction/model/file-prediction-model/0.3.0/file-prediction-model-0.3.0.jar",
-        "hash": "e506fd77462afcdb16f0ccfe7c96c1549443580a3be240c5dcff1ae2bfac0555",
-        "path": "org/jetbrains/intellij/deps/filePrediction/model/file-prediction-model/0.3.0/file-prediction-model-0.3.0.jar"
     },
     {
         "url": "com/willowtreeapps/assertk/assertk-jvm/0.23/assertk-jvm-0.23.jar",
@@ -6785,119 +1515,259 @@
         "path": "com/willowtreeapps/opentest4k/opentest4k-jvm/1.2.1/opentest4k-jvm-1.2.1.jar"
     },
     {
-        "url": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar",
-        "hash": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
-        "path": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+        "url": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar",
+        "hash": "1b273d92160b9fa69c3e65389a5c4decd2f38a697e458e6f75080ae09e886404",
+        "path": "commons-cli/commons-cli/1.10.0/commons-cli-1.10.0.jar"
     },
     {
-        "url": "io/grpc/grpc-inprocess/1.65.1/grpc-inprocess-1.65.1.jar",
-        "hash": "6e3b197f5668e26fec19a831d2dd1f6d53b6eb9d4d3978b8ffd4ff68f1aae020",
-        "path": "io/grpc/grpc-inprocess/1.65.1/grpc-inprocess-1.65.1.jar"
+        "url": "commons-cli/commons-cli/1.2/commons-cli-1.2.jar",
+        "hash": "e7cd8951956d349b568b7ccfd4f5b2529a8c113e67c32b028f52ffda371259d9",
+        "path": "commons-cli/commons-cli/1.2/commons-cli-1.2.jar"
     },
     {
-        "url": "io/cucumber/cucumber-java/5.0.0-RC1/cucumber-java-5.0.0-RC1.jar",
-        "hash": "789e598804155bcca83a01071382af90d0e9e1f6c686c881800b07fc0c1ea3c4",
-        "path": "io/cucumber/cucumber-java/5.0.0-RC1/cucumber-java-5.0.0-RC1.jar"
+        "url": "commons-cli/commons-cli/1.4/commons-cli-1.4.jar",
+        "hash": "fd3c7c9545a9cdb2051d1f9155c4f76b1e4ac5a57304404a6eedb578ffba7328",
+        "path": "commons-cli/commons-cli/1.4/commons-cli-1.4.jar"
     },
     {
-        "url": "io/cucumber/cucumber-core/5.0.0-RC1/cucumber-core-5.0.0-RC1.jar",
-        "hash": "ada4315573c505d9dbb03cb0624f4a4e9fe9af92f4d278c4d7eb0422cdf299ff",
-        "path": "io/cucumber/cucumber-core/5.0.0-RC1/cucumber-core-5.0.0-RC1.jar"
+        "url": "commons-cli/commons-cli/1.9.0/commons-cli-1.9.0.jar",
+        "hash": "d3d530d0f28fd0fbbffe2b0b338f70e8cb96f1605579e2e3abd4db29cac24e69",
+        "path": "commons-cli/commons-cli/1.9.0/commons-cli-1.9.0.jar"
     },
     {
-        "url": "io/cucumber/gherkin/5.2.0/gherkin-5.2.0.jar",
-        "hash": "ab8af6e8e1f5bea8cf04aeb6e87a96121d554132615c35d1d0d0bb8aac6ebe05",
-        "path": "io/cucumber/gherkin/5.2.0/gherkin-5.2.0.jar"
+        "url": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar",
+        "hash": "ba005f304cef92a3dede24a38ad5ac9b8afccf0d8f75839d6c1338634cf7f6e4",
+        "path": "commons-codec/commons-codec/1.18.0/commons-codec-1.18.0.jar"
     },
     {
-        "url": "io/cucumber/gherkin-jvm-deps/1.0.6/gherkin-jvm-deps-1.0.6.jar",
-        "hash": "6ac4b12c6b694ac9ee4eecc8949cf7976d1bd892871cf816298de404bde44bb2",
-        "path": "io/cucumber/gherkin-jvm-deps/1.0.6/gherkin-jvm-deps-1.0.6.jar"
+        "url": "commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar",
+        "hash": "eeeae917917144a68a741d4c0dff66aa5c5c5fd85593ff217bced3fc8ca783b8",
+        "path": "commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar"
     },
     {
-        "url": "io/cucumber/tag-expressions/2.0.2/tag-expressions-2.0.2.jar",
-        "hash": "2c0fd9f293b2ca0ce22531b8769dc2aef37eb704f1212030513a90f6eb975476",
-        "path": "io/cucumber/tag-expressions/2.0.2/tag-expressions-2.0.2.jar"
+        "url": "commons-digester/commons-digester/2.1/commons-digester-2.1.jar",
+        "hash": "e0b2b980a84fc6533c5ce291f1917b32c507f62bcad64198fff44368c2196a3d",
+        "path": "commons-digester/commons-digester/2.1/commons-digester-2.1.jar"
     },
     {
-        "url": "io/cucumber/cucumber-expressions/8.0.0/cucumber-expressions-8.0.0.jar",
-        "hash": "81ad14ebf1a885ab4a201f0e48695eb60d8c55265c8323d49b98a0e34093e30b",
-        "path": "io/cucumber/cucumber-expressions/8.0.0/cucumber-expressions-8.0.0.jar"
+        "url": "commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar",
+        "hash": "97d264e2f98821c4cd39eacfd597b4dc7c19d4232cf1f335fc2eab389b2d92fd",
+        "path": "commons-discovery/commons-discovery/0.4/commons-discovery-0.4.jar"
     },
     {
-        "url": "org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar",
-        "hash": "e09109e54a289d88506b9bfec987ddd199f4217c9464132668351b9a4f00bee9",
-        "path": "org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar"
+        "url": "commons-io/commons-io/2.18.0/commons-io-2.18.0.jar",
+        "hash": "f3ca0f8d63c40e23a56d54101c60d5edee136b42d84bfb85bc7963093109cf8b",
+        "path": "commons-io/commons-io/2.18.0/commons-io-2.18.0.jar"
     },
     {
-        "url": "org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar",
-        "hash": "ba93b2e3a562322ba432f0a1b53addcc55cb188253319a020ed77f824e692050",
-        "path": "org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar"
+        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
+        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
+        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
     },
     {
-        "url": "org/hamcrest/hamcrest-library/2.1/hamcrest-library-2.1.jar",
-        "hash": "b7e2b6895b3b679f0e47b6380fda391b225e9b78505db9d8bdde8d3cc8d52a21",
-        "path": "org/hamcrest/hamcrest-library/2.1/hamcrest-library-2.1.jar"
+        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
+        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
+        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
     },
     {
-        "url": "io/cucumber/datatable/3.0.0/datatable-3.0.0.jar",
-        "hash": "c021f59d4d914edc42cb4c40dc440dca05f36902e0eb36c0307ed2d192ae0860",
-        "path": "io/cucumber/datatable/3.0.0/datatable-3.0.0.jar"
+        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
+        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
+        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
     },
     {
-        "url": "io/cucumber/datatable-dependencies/3.0.0/datatable-dependencies-3.0.0.jar",
-        "hash": "0348ab1b354dbaa327ee3bead884cf6d7b4cb23c086d803012dbb7cc319277b0",
-        "path": "io/cucumber/datatable-dependencies/3.0.0/datatable-dependencies-3.0.0.jar"
+        "url": "commons-io/commons-io/2.5/commons-io-2.5.jar",
+        "hash": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
+        "path": "commons-io/commons-io/2.5/commons-io-2.5.jar"
     },
     {
-        "url": "io/cucumber/cucumber-plugin/5.0.0-RC1/cucumber-plugin-5.0.0-RC1.jar",
-        "hash": "4d4cc28f9c73f5137db7b0ecd371d33696f5eac18db6c1ef65b65dd16275b3f3",
-        "path": "io/cucumber/cucumber-plugin/5.0.0-RC1/cucumber-plugin-5.0.0-RC1.jar"
+        "url": "commons-io/commons-io/2.6/commons-io-2.6.jar",
+        "hash": "f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513",
+        "path": "commons-io/commons-io/2.6/commons-io-2.6.jar"
     },
     {
-        "url": "io/cucumber/docstring/5.0.0-RC1/docstring-5.0.0-RC1.jar",
-        "hash": "90049802a975fde907069eea511687871b53824027ba54d2b7d7f447502e5d59",
-        "path": "io/cucumber/docstring/5.0.0-RC1/docstring-5.0.0-RC1.jar"
+        "url": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
+        "hash": "daddea1ea0be0f56978ab3006b8ac92834afeefbd9b7e4e6316fca57df0fa636",
+        "path": "commons-logging/commons-logging/1.2/commons-logging-1.2.jar"
     },
     {
-        "url": "org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar",
-        "hash": "a9aae9ff8ae3e17a2a18f79175e82b16267c246fbbd3ca9dfbbb290b08dcfdd4",
-        "path": "org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
+        "url": "commons-logging/commons-logging/1.3.4/commons-logging-1.3.4.jar",
+        "hash": "bc2dfe32f1ef06509e6a065144c1adf7b420eabf11a87f30bd127f8faa332016",
+        "path": "commons-logging/commons-logging/1.3.4/commons-logging-1.3.4.jar"
     },
     {
-        "url": "io/cucumber/cucumber-core/4.0.1/cucumber-core-4.0.1.jar",
-        "hash": "25c52c0401f0786f66be90e384e765dbe0358b73fddd8874f7029da5f1b3c259",
-        "path": "io/cucumber/cucumber-core/4.0.1/cucumber-core-4.0.1.jar"
+        "url": "commons-validator/commons-validator/1.9.0/commons-validator-1.9.0.jar",
+        "hash": "c3c14748e2d78db58df88808740711bd643b32c45ffa7b8a739f00fb467cd7d7",
+        "path": "commons-validator/commons-validator/1.9.0/commons-validator-1.9.0.jar"
     },
     {
-        "url": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar",
-        "hash": "c2413a16c107a137f7a9d73f24af17211ef9580eef5fc2fab589610166781099",
-        "path": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar"
+        "url": "completion/ml/python/features/ml-completion-prev-exprs-models/1.11/ml-completion-prev-exprs-models-1.11.jar",
+        "hash": "8924b199c8cc52530de2b250670806d8b046fa5ae9d32a9f27a9b224e934a1ad",
+        "path": "completion/ml/python/features/ml-completion-prev-exprs-models/1.11/ml-completion-prev-exprs-models-1.11.jar"
     },
     {
-        "url": "io/cucumber/gherkin/5.1.0/gherkin-5.1.0.jar",
-        "hash": "67f1cedeb8e85e6af84f89a8fe70bafaf6216dfad7a46b76fe10c5ee814e51e3",
-        "path": "io/cucumber/gherkin/5.1.0/gherkin-5.1.0.jar"
+        "url": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar",
+        "hash": "d642f145f6123739e779d4156145cc5fe7c2173bb58d437b813961a31c337ff9",
+        "path": "de/cketti/unicode/kotlin-codepoints-jvm/0.9.0/kotlin-codepoints-jvm-0.9.0.jar"
     },
     {
-        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
-        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
-        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
+        "url": "de/danielnaber/german-pos-dict/1.2.4/german-pos-dict-1.2.4.jar",
+        "hash": "56f0b00adb704cbc1e86776b45f6890efe90685ab370a34b5b299593cdcaae22",
+        "path": "de/danielnaber/german-pos-dict/1.2.4/german-pos-dict-1.2.4.jar"
     },
     {
-        "url": "io/cucumber/cucumber-expressions/6.1.0/cucumber-expressions-6.1.0.jar",
-        "hash": "660ba952417b95cfb22dda2e8be6fba46f521188e4f8a47ae9614f675bdb9bb8",
-        "path": "io/cucumber/cucumber-expressions/6.1.0/cucumber-expressions-6.1.0.jar"
+        "url": "de/danielnaber/german-pos-dict/1.2.4/german-pos-dict-1.2.4.jar",
+        "hash": "56f0b00adb704cbc1e86776b45f6890efe90685ab370a34b5b299593cdcaae22",
+        "path": "de/danielnaber/german-pos-dict/1.2.4/german-pos-dict-1.2.4.jar"
     },
     {
-        "url": "io/cucumber/datatable/1.1.3/datatable-1.1.3.jar",
-        "hash": "487db14bc5471639a5b05e66f3b5f60ca3f73f9d984088ba88c64078709f38aa",
-        "path": "io/cucumber/datatable/1.1.3/datatable-1.1.3.jar"
+        "url": "de/danielnaber/jwordsplitter/4.7/jwordsplitter-4.7.jar",
+        "hash": "0435e604abe8b4a0b27f568db9349fbe0546df286bbe62f667c9fd9663df71b2",
+        "path": "de/danielnaber/jwordsplitter/4.7/jwordsplitter-4.7.jar"
     },
     {
-        "url": "io/cucumber/datatable-dependencies/1.1.3/datatable-dependencies-1.1.3.jar",
-        "hash": "33b9c48799b681328ec865756a0eb9c8ade946052ef1409a4d882e438956692c",
-        "path": "io/cucumber/datatable-dependencies/1.1.3/datatable-dependencies-1.1.3.jar"
+        "url": "de/danielnaber/jwordsplitter/4.7/jwordsplitter-4.7.jar",
+        "hash": "0435e604abe8b4a0b27f568db9349fbe0546df286bbe62f667c9fd9663df71b2",
+        "path": "de/danielnaber/jwordsplitter/4.7/jwordsplitter-4.7.jar"
+    },
+    {
+        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
+        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
+        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
+    },
+    {
+        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
+        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
+        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
+    },
+    {
+        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
+        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
+        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
+    },
+    {
+        "url": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar",
+        "hash": "940e6d50445bc6b0ae26ad414ec7b953a3e4e802dc7756cc14d56958bc97cc31",
+        "path": "dev/drewhamilton/poko/poko-annotations-jvm/0.17.1/poko-annotations-jvm-0.17.1.jar"
+    },
+    {
+        "url": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar",
+        "hash": "3941b48f2e9281aab7234395c549cbb399b3dc80fed2e13999a80db47f94b041",
+        "path": "dk/brics/automaton/1.12-4/automaton-1.12-4.jar"
+    },
+    {
+        "url": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar",
+        "hash": "33021c9cca70c6292d53ff7dac5d1832d422e986aba52ec998532a5f47f921f8",
+        "path": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar"
+    },
+    {
+        "url": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar",
+        "hash": "33021c9cca70c6292d53ff7dac5d1832d422e986aba52ec998532a5f47f921f8",
+        "path": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar"
+    },
+    {
+        "url": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar",
+        "hash": "33021c9cca70c6292d53ff7dac5d1832d422e986aba52ec998532a5f47f921f8",
+        "path": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar"
+    },
+    {
+        "url": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar",
+        "hash": "33021c9cca70c6292d53ff7dac5d1832d422e986aba52ec998532a5f47f921f8",
+        "path": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar"
+    },
+    {
+        "url": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar",
+        "hash": "33021c9cca70c6292d53ff7dac5d1832d422e986aba52ec998532a5f47f921f8",
+        "path": "edu/washington/cs/knowitall/openregex/1.1.1/openregex-1.1.1.jar"
+    },
+    {
+        "url": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar",
+        "hash": "e2167e99bdb018576cce9cc0aad154ad995fe67a4b0c36c63344f743865f96e7",
+        "path": "info/cukes/cucumber-html/0.2.6/cucumber-html-0.2.6.jar"
+    },
+    {
+        "url": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar",
+        "hash": "2a4e84a51defe9108579b3c0a86bb41e54f04e9042e83adf4348a974dcf1dee6",
+        "path": "info/cukes/cucumber-jvm-deps/1.0.5/cucumber-jvm-deps-1.0.5.jar"
+    },
+    {
+        "url": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar",
+        "hash": "0a5ebc0506ab1e4a08af1ca150f797304ff53b953c5b1f6fcf1f81551d964aad",
+        "path": "info/cukes/gherkin/2.12.2/gherkin-2.12.2.jar"
+    },
+    {
+        "url": "info/debatty/java-string-similarity/2.0.0/java-string-similarity-2.0.0.jar",
+        "hash": "87675985e637d231b5783d1fea0bd947e71267bf557adc93ce3daec8a519bd22",
+        "path": "info/debatty/java-string-similarity/2.0.0/java-string-similarity-2.0.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-compose-core-jvm/3.2.0/coil-compose-core-jvm-3.2.0.jar",
+        "hash": "a74b96cb179fe8f872d4e9f03468e0477d32787e9b6430a9d137aafb76012a60",
+        "path": "io/coil-kt/coil3/coil-compose-core-jvm/3.2.0/coil-compose-core-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-compose-jvm/3.2.0/coil-compose-jvm-3.2.0.jar",
+        "hash": "b135eafcff7545cba7e39c0c8d4e724c0f42e91050b10df5d635a6c7dfd3fb42",
+        "path": "io/coil-kt/coil3/coil-compose-jvm/3.2.0/coil-compose-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
+        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
+        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
+        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
+        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
+        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
+        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar",
+        "hash": "2c64e5a3be4c59a2bf1ead26891cd9c455c37a2802d258ea50a960e7dd1e121a",
+        "path": "io/coil-kt/coil3/coil-core-jvm/3.2.0/coil-core-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-jvm/3.2.0/coil-jvm-3.2.0.jar",
+        "hash": "7d0182c987052d6502135a6a6cc7cc68288ef48f990d75ad4c4ae03e25be786e",
+        "path": "io/coil-kt/coil3/coil-jvm/3.2.0/coil-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-network-core-jvm/3.2.0/coil-network-core-jvm-3.2.0.jar",
+        "hash": "54cff2971fbcb1743b6d4cb6fb5bb863b4f6fae37002ec57a2fdf837b0c3242e",
+        "path": "io/coil-kt/coil3/coil-network-core-jvm/3.2.0/coil-network-core-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-network-ktor3-jvm/3.2.0/coil-network-ktor3-jvm-3.2.0.jar",
+        "hash": "377ea37e058df261bcc274ea0c947eccc67fec5a0499bdf646b99c2f34f74a6a",
+        "path": "io/coil-kt/coil3/coil-network-ktor3-jvm/3.2.0/coil-network-ktor3-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-svg-jvm/3.2.0/coil-svg-jvm-3.2.0.jar",
+        "hash": "e412715d1e447a43331f2ceb406435f28aafd7476a987de3d8222e6d39a8c84b",
+        "path": "io/coil-kt/coil3/coil-svg-jvm/3.2.0/coil-svg-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/coil-kt/coil3/coil-test-jvm/3.2.0/coil-test-jvm-3.2.0.jar",
+        "hash": "bea462cdc351c04dc4895f028b847d65a7dbae72a9b3999ea1089cd56ded43ad",
+        "path": "io/coil-kt/coil3/coil-test-jvm/3.2.0/coil-test-jvm-3.2.0.jar"
+    },
+    {
+        "url": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar",
+        "hash": "00cfcc187ff46ce8d702a0f2cb98d6a4f2a67f8f41242b5901e46efdcb7c84b7",
+        "path": "io/consensys/tuweni/tuweni-toml/2.7.1/tuweni-toml-2.7.1.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar",
+        "hash": "ace77c533236213a1aa9f68b8de10e564da809605371ef2f8c73cd8f4c71293a",
+        "path": "io/cucumber/cucumber-core/1.2.6/cucumber-core-1.2.6.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar",
+        "hash": "ac0f343d6fc0dca4c93f8b6a6266b3bf4cb4d61913b8a4cd2b3abf50025268cf",
+        "path": "io/cucumber/cucumber-core/2.4.0/cucumber-core-2.4.0.jar"
     },
     {
         "url": "io/cucumber/cucumber-core/3.0.2/cucumber-core-3.0.2.jar",
@@ -6905,19 +1775,14 @@
         "path": "io/cucumber/cucumber-core/3.0.2/cucumber-core-3.0.2.jar"
     },
     {
-        "url": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar",
-        "hash": "c2413a16c107a137f7a9d73f24af17211ef9580eef5fc2fab589610166781099",
-        "path": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar"
+        "url": "io/cucumber/cucumber-core/4.0.1/cucumber-core-4.0.1.jar",
+        "hash": "25c52c0401f0786f66be90e384e765dbe0358b73fddd8874f7029da5f1b3c259",
+        "path": "io/cucumber/cucumber-core/4.0.1/cucumber-core-4.0.1.jar"
     },
     {
-        "url": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar",
-        "hash": "e35cfa4a16204bf59fa167bb6d45be0717d6b7cfba1c30f156d8f21cde2f4065",
-        "path": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar"
-    },
-    {
-        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
-        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
-        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
+        "url": "io/cucumber/cucumber-core/5.0.0-RC1/cucumber-core-5.0.0-RC1.jar",
+        "hash": "ada4315573c505d9dbb03cb0624f4a4e9fe9af92f4d278c4d7eb0422cdf299ff",
+        "path": "io/cucumber/cucumber-core/5.0.0-RC1/cucumber-core-5.0.0-RC1.jar"
     },
     {
         "url": "io/cucumber/cucumber-expressions/5.0.19/cucumber-expressions-5.0.19.jar",
@@ -6925,9 +1790,39 @@
         "path": "io/cucumber/cucumber-expressions/5.0.19/cucumber-expressions-5.0.19.jar"
     },
     {
-        "url": "io/cucumber/datatable/1.0.3/datatable-1.0.3.jar",
-        "hash": "0d7fa64225d159ee9d29554ea6fa2bd0891319e5c06a3b0b58db2decf72fd6f2",
-        "path": "io/cucumber/datatable/1.0.3/datatable-1.0.3.jar"
+        "url": "io/cucumber/cucumber-expressions/6.1.0/cucumber-expressions-6.1.0.jar",
+        "hash": "660ba952417b95cfb22dda2e8be6fba46f521188e4f8a47ae9614f675bdb9bb8",
+        "path": "io/cucumber/cucumber-expressions/6.1.0/cucumber-expressions-6.1.0.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-expressions/8.0.0/cucumber-expressions-8.0.0.jar",
+        "hash": "81ad14ebf1a885ab4a201f0e48695eb60d8c55265c8323d49b98a0e34093e30b",
+        "path": "io/cucumber/cucumber-expressions/8.0.0/cucumber-expressions-8.0.0.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar",
+        "hash": "c2413a16c107a137f7a9d73f24af17211ef9580eef5fc2fab589610166781099",
+        "path": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar",
+        "hash": "c2413a16c107a137f7a9d73f24af17211ef9580eef5fc2fab589610166781099",
+        "path": "io/cucumber/cucumber-html/0.2.7/cucumber-html-0.2.7.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-java/5.0.0-RC1/cucumber-java-5.0.0-RC1.jar",
+        "hash": "789e598804155bcca83a01071382af90d0e9e1f6c686c881800b07fc0c1ea3c4",
+        "path": "io/cucumber/cucumber-java/5.0.0-RC1/cucumber-java-5.0.0-RC1.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar",
+        "hash": "d1c2cc901dd702eb77a2258c0d1446e4a302d28da0d4b49cd11ff3d5929281fa",
+        "path": "io/cucumber/cucumber-jvm-deps/1.0.6/cucumber-jvm-deps-1.0.6.jar"
+    },
+    {
+        "url": "io/cucumber/cucumber-plugin/5.0.0-RC1/cucumber-plugin-5.0.0-RC1.jar",
+        "hash": "4d4cc28f9c73f5137db7b0ecd371d33696f5eac18db6c1ef65b65dd16275b3f3",
+        "path": "io/cucumber/cucumber-plugin/5.0.0-RC1/cucumber-plugin-5.0.0-RC1.jar"
     },
     {
         "url": "io/cucumber/datatable-dependencies/1.0.3/datatable-dependencies-1.0.3.jar",
@@ -6935,249 +1830,3599 @@
         "path": "io/cucumber/datatable-dependencies/1.0.3/datatable-dependencies-1.0.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.8.2/completion-ranking-java-0.8.2.jar",
-        "hash": "c1686a3bfa4f29059b39ec51c6d6774fe11933d11aebd95bdb0d94e3ad9d3905",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.8.2/completion-ranking-java-0.8.2.jar"
+        "url": "io/cucumber/datatable-dependencies/1.1.3/datatable-dependencies-1.1.3.jar",
+        "hash": "33b9c48799b681328ec865756a0eb9c8ade946052ef1409a4d882e438956692c",
+        "path": "io/cucumber/datatable-dependencies/1.1.3/datatable-dependencies-1.1.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.2/completion-ranking-java-0.9.2.jar",
-        "hash": "2492dead3c2800e114634681b25b6e718df17005107ed4f1d30403e3aedffeb9",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.2/completion-ranking-java-0.9.2.jar"
+        "url": "io/cucumber/datatable-dependencies/3.0.0/datatable-dependencies-3.0.0.jar",
+        "hash": "0348ab1b354dbaa327ee3bead884cf6d7b4cb23c086d803012dbb7cc319277b0",
+        "path": "io/cucumber/datatable-dependencies/3.0.0/datatable-dependencies-3.0.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.1/completion-ranking-kotlin-0.4.1.jar",
-        "hash": "0be44fc263b4f59517a6dc0c4102d5743dc309ac049ac894f2bea7cd83e570d2",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.1/completion-ranking-kotlin-0.4.1.jar"
+        "url": "io/cucumber/datatable/1.0.3/datatable-1.0.3.jar",
+        "hash": "0d7fa64225d159ee9d29554ea6fa2bd0891319e5c06a3b0b58db2decf72fd6f2",
+        "path": "io/cucumber/datatable/1.0.3/datatable-1.0.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-scala/0.4.1/completion-ranking-scala-0.4.1.jar",
-        "hash": "2bbdd2aeaa31dc35180490ba20ee3096097e8ca4bcecdd1b80a1c162487d3c15",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-scala/0.4.1/completion-ranking-scala-0.4.1.jar"
+        "url": "io/cucumber/datatable/1.1.3/datatable-1.1.3.jar",
+        "hash": "487db14bc5471639a5b05e66f3b5f60ca3f73f9d984088ba88c64078709f38aa",
+        "path": "io/cucumber/datatable/1.1.3/datatable-1.1.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-rust/0.4.0/completion-ranking-rust-0.4.0.jar",
-        "hash": "1a220f42926fc3ac2bfce50c521aced95821ef8e8e7478a00e884acbbdc98248",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-rust/0.4.0/completion-ranking-rust-0.4.0.jar"
+        "url": "io/cucumber/datatable/3.0.0/datatable-3.0.0.jar",
+        "hash": "c021f59d4d914edc42cb4c40dc440dca05f36902e0eb36c0307ed2d192ae0860",
+        "path": "io/cucumber/datatable/3.0.0/datatable-3.0.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-python/0.2.4/completion-ranking-python-0.2.4.jar",
-        "hash": "6e6dda035d972c2ff061c5d90decea9fcaf693b0946fc8c35ef27ef452de7008",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-python/0.2.4/completion-ranking-python-0.2.4.jar"
+        "url": "io/cucumber/docstring/5.0.0-RC1/docstring-5.0.0-RC1.jar",
+        "hash": "90049802a975fde907069eea511687871b53824027ba54d2b7d7f447502e5d59",
+        "path": "io/cucumber/docstring/5.0.0-RC1/docstring-5.0.0-RC1.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-php/0.2.4/completion-ranking-php-0.2.4.jar",
-        "hash": "b73ea2290e95b8f8350a3bcf1c1ab260aed8a249049501f4b175c8dda0f04a78",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-php/0.2.4/completion-ranking-php-0.2.4.jar"
+        "url": "io/cucumber/gherkin-jvm-deps/1.0.6/gherkin-jvm-deps-1.0.6.jar",
+        "hash": "6ac4b12c6b694ac9ee4eecc8949cf7976d1bd892871cf816298de404bde44bb2",
+        "path": "io/cucumber/gherkin-jvm-deps/1.0.6/gherkin-jvm-deps-1.0.6.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-ruby/0.2.4/completion-ranking-ruby-0.2.4.jar",
-        "hash": "10392061789cf7c0101931dbfe851355b3fd33c9249947586d855a9180c439a7",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-ruby/0.2.4/completion-ranking-ruby-0.2.4.jar"
+        "url": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar",
+        "hash": "e35cfa4a16204bf59fa167bb6d45be0717d6b7cfba1c30f156d8f21cde2f4065",
+        "path": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-go/0.2.4/completion-ranking-go-0.2.4.jar",
-        "hash": "a5b09d91c7633fa4dede7c640f189dce258c69aa65874f4eaca0a799a5fc35f9",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-go/0.2.4/completion-ranking-go-0.2.4.jar"
+        "url": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar",
+        "hash": "e35cfa4a16204bf59fa167bb6d45be0717d6b7cfba1c30f156d8f21cde2f4065",
+        "path": "io/cucumber/gherkin/5.0.0/gherkin-5.0.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-js/0.3.0/completion-ranking-js-0.3.0.jar",
-        "hash": "e73816d0b63fa701e916b89f44559f6b8f104501f8b4f2feb300ac513e7a3850",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-js/0.3.0/completion-ranking-js-0.3.0.jar"
+        "url": "io/cucumber/gherkin/5.1.0/gherkin-5.1.0.jar",
+        "hash": "67f1cedeb8e85e6af84f89a8fe70bafaf6216dfad7a46b76fe10c5ee814e51e3",
+        "path": "io/cucumber/gherkin/5.1.0/gherkin-5.1.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-typescript/0.4.0/completion-ranking-typescript-0.4.0.jar",
-        "hash": "1ad40bce28263d3e4ff3e140949211d8812b05a6a0f121e92cb23980832838fc",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-typescript/0.4.0/completion-ranking-typescript-0.4.0.jar"
+        "url": "io/cucumber/gherkin/5.2.0/gherkin-5.2.0.jar",
+        "hash": "ab8af6e8e1f5bea8cf04aeb6e87a96121d554132615c35d1d0d0bb8aac6ebe05",
+        "path": "io/cucumber/gherkin/5.2.0/gherkin-5.2.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-dart/0.0.2/completion-ranking-dart-0.0.2.jar",
-        "hash": "024322c6d09f72f9bddeb94d52e803d235a9afc284bc3efe7dfbc9de58d4fa6f",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-dart/0.0.2/completion-ranking-dart-0.0.2.jar"
+        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
+        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
+        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-swift/0.1.3/completion-ranking-swift-0.1.3.jar",
-        "hash": "c1d511070b2900ced87e03443091640ff7758f5064ff14d3503d6c8f50d28c1b",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-swift/0.1.3/completion-ranking-swift-0.1.3.jar"
+        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
+        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
+        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-cpp/0.1.5/completion-ranking-cpp-0.1.5.jar",
-        "hash": "2c09237e1e0e76d571b77c4f43371d8cd828903ffa442f0e3593894bce3021c3",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-cpp/0.1.5/completion-ranking-cpp-0.1.5.jar"
+        "url": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar",
+        "hash": "e5a0a71fb846752900c0e5a99aa13e5a1bbc3ec97e7faf26803648fa45215584",
+        "path": "io/cucumber/tag-expressions/1.1.1/tag-expressions-1.1.1.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-html/0.0.1/completion-ranking-html-0.0.1.jar",
-        "hash": "c0cd887da7112e3f079e2a5ae28856869f7f1a6919473a4c95d85db5cf85c4aa",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-html/0.0.1/completion-ranking-html-0.0.1.jar"
+        "url": "io/cucumber/tag-expressions/2.0.2/tag-expressions-2.0.2.jar",
+        "hash": "2c0fd9f293b2ca0ce22531b8769dc2aef37eb704f1212030513a90f6eb975476",
+        "path": "io/cucumber/tag-expressions/2.0.2/tag-expressions-2.0.2.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-css/0.2.1/completion-ranking-css-0.2.1.jar",
-        "hash": "82245f691b5db3a47a6bc0ad260b0b04ba5c929c28293edb8bbbc70d1aeb7d7a",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-css/0.2.1/completion-ranking-css-0.2.1.jar"
+        "url": "io/github/belarus/linguistics.grammardb.spell.languagetool/1.0.2/linguistics.grammardb.spell.languagetool-1.0.2.jar",
+        "hash": "1d1a55e905faa9740d648144cf05c4a460f0f26416d2ee01157bad0877be31c2",
+        "path": "io/github/belarus/linguistics.grammardb.spell.languagetool/1.0.2/linguistics.grammardb.spell.languagetool-1.0.2.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.1/completion-ranking-sh-0.0.1.jar",
-        "hash": "2ab8007555b8fdedb7efce607cc77c03da85fcf4ea2e8376b9a352bed5f04f4a",
-        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.1/completion-ranking-sh-0.0.1.jar"
+        "url": "io/github/classgraph/classgraph/4.8.181/classgraph-4.8.181.jar",
+        "hash": "62a6436d69710ef5fab6ec243781ce4c5b299047ed1841b5f92746ae852ce545",
+        "path": "io/github/classgraph/classgraph/4.8.181/classgraph-4.8.181.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar",
-        "hash": "38c437218569f861fd43f15aa810b3eb9af4bdb02a7003f54c4d454590378079",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar"
+        "url": "io/github/classgraph/classgraph/4.8.87/classgraph-4.8.87.jar",
+        "hash": "91d2a2b6048c5cfe19f3982ee84eb5c19cab1d741a45ae1b4360c068331f89e6",
+        "path": "io/github/classgraph/classgraph/4.8.87/classgraph-4.8.87.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar",
-        "hash": "1f85780cda084ba11fe0611558397d02486154777226eedee640d2867ce4231d",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar"
+        "url": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar",
+        "hash": "672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835",
+        "path": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar",
-        "hash": "3b26dc266a24da542c012a08e445b8a212703d152d0f0e4663dd7d253bebe819",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar",
+        "hash": "672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835",
+        "path": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar",
-        "hash": "9613ae5ae4f418e2cd0a4235bcd2911cb9b56ae9e42cc7e672fbc5031bd35d57",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar"
+        "url": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar",
+        "hash": "672cbebb5d45a72b35dd81fd6127e187451bb6fb7fba35315bbdf2f57cfce835",
+        "path": "io/github/davidburstrom/contester/contester-breakpoint/0.2.0/contester-breakpoint-0.2.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar",
-        "hash": "949cf2be2d54ccd9e4f13f9df456190c85738bebb054f50c74e896e31c43d922",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar",
+        "hash": "b3ac96dd97acba8318dbe26f6a432d6c6db91c46c780805e8928b8103e5763dc",
+        "path": "io/github/detekt/sarif4k/sarif4k-jvm/0.6.0/sarif4k-jvm-0.6.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar",
-        "hash": "c2dba4e82e5ad865412f72b8f02ff5462088666100f9734b46a4023bac3e2a5c",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar",
+        "hash": "9990a2039778f6b4cc94790141c2868864eacee0620c6c459451121a901cd5b5",
+        "path": "io/github/java-diff-utils/java-diff-utils/4.12/java-diff-utils-4.12.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar",
-        "hash": "433fd379cf807f5507318b77d83ad46c30a77b34beab868d5f925b939d73aef7",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar"
+        "url": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar",
+        "hash": "241daa21665dd0ca55576a4bc4d8e9ace8891ae3c698cc77f13bb4bdac372e94",
+        "path": "io/github/oshai/kotlin-logging-jvm/7.0.3/kotlin-logging-jvm-7.0.3.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar",
-        "hash": "d35f7a03198f8f71d20e0838c8feb1576680ec1e16693246f200afcfe69e7f2d",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar"
+        "url": "io/github/resilience4j/resilience4j-circuitbreaker/1.7.1/resilience4j-circuitbreaker-1.7.1.jar",
+        "hash": "05ae08b684e6245b8d88bcb823dfd0a2994052098226bd1e614fb9828e5d13df",
+        "path": "io/github/resilience4j/resilience4j-circuitbreaker/1.7.1/resilience4j-circuitbreaker-1.7.1.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar",
-        "hash": "974868dc67392dcf2c2443e0b75fe0840d114da7cd5a9b7ea3024b1cfa4ceef1",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar"
+        "url": "io/github/resilience4j/resilience4j-core/1.7.1/resilience4j-core-1.7.1.jar",
+        "hash": "3153a2c96c3e3b31122a7fa8ca8ea1ab0f305bf82d096c291b7416443fff6491",
+        "path": "io/github/resilience4j/resilience4j-core/1.7.1/resilience4j-core-1.7.1.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar",
-        "hash": "3fa369db5c0cdeb9fe3382512b874a3ccddd5f2799a31b564c438102f1aa7b86",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar"
+        "url": "io/github/resilience4j/resilience4j-micrometer/1.7.1/resilience4j-micrometer-1.7.1.jar",
+        "hash": "71d9be0d10026f2223f2afba5b10d5d1a7b569c6433bbc1fd189ca8817d66d60",
+        "path": "io/github/resilience4j/resilience4j-micrometer/1.7.1/resilience4j-micrometer-1.7.1.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar",
-        "hash": "38c437218569f861fd43f15aa810b3eb9af4bdb02a7003f54c4d454590378079",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar"
+        "url": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar",
+        "hash": "c1c197ed03acaf46773176a001836219b6299fe267dc4751c2c28ae98edfa0f3",
+        "path": "io/github/smiley4/schema-kenerator-core/2.2.0/schema-kenerator-core-2.2.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar",
-        "hash": "1f85780cda084ba11fe0611558397d02486154777226eedee640d2867ce4231d",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar"
+        "url": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar",
+        "hash": "81981241b8df2eeee48efac05798e7beaa2b8d6bd5d610b3f5a4fea07b0eff6e",
+        "path": "io/github/smiley4/schema-kenerator-jsonschema/2.2.0/schema-kenerator-jsonschema-2.2.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar",
-        "hash": "3b26dc266a24da542c012a08e445b8a212703d152d0f0e4663dd7d253bebe819",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar",
+        "hash": "9c4a9713b2722b3b124210e89c3702c3e18c19156a3a06fa6bcef43a850299ca",
+        "path": "io/github/smiley4/schema-kenerator-serialization/2.2.0/schema-kenerator-serialization-2.2.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar",
-        "hash": "9613ae5ae4f418e2cd0a4235bcd2911cb9b56ae9e42cc7e672fbc5031bd35d57",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar"
+        "url": "io/github/x-stream/mxparser/1.2.2/mxparser-1.2.2.jar",
+        "hash": "aeeee23a3303d811bca8790ea7f25b534314861c03cff36dafdcc2180969eb97",
+        "path": "io/github/x-stream/mxparser/1.2.2/mxparser-1.2.2.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar",
-        "hash": "949cf2be2d54ccd9e4f13f9df456190c85738bebb054f50c74e896e31c43d922",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar",
+        "hash": "fbbf174a4e78aa5be1f1b7db73edc5c0a6a2e59e1562263e2c3a2e510fa1ba45",
+        "path": "io/github/z4kn4fein/semver-jvm/2.0.0/semver-jvm-2.0.0.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar",
-        "hash": "c2dba4e82e5ad865412f72b8f02ff5462088666100f9734b46a4023bac3e2a5c",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
+        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
+        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar",
-        "hash": "433fd379cf807f5507318b77d83ad46c30a77b34beab868d5f925b939d73aef7",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
+        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
+        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar",
-        "hash": "d35f7a03198f8f71d20e0838c8feb1576680ec1e16693246f200afcfe69e7f2d",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
+        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
+        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar",
-        "hash": "974868dc67392dcf2c2443e0b75fe0840d114da7cd5a9b7ea3024b1cfa4ceef1",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar",
+        "hash": "dd5b84d420904d5c564aab115d36e6290a9d7daf6955923099015618f2b5c83f",
+        "path": "io/gitlab/arturbosch/detekt/detekt-api/1.23.8/detekt-api-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar",
-        "hash": "3fa369db5c0cdeb9fe3382512b874a3ccddd5f2799a31b564c438102f1aa7b86",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar",
+        "hash": "1981dea8e4e2e8541af2d83e4f8d3581ce647cfe63175b9eb9ac2a07849d74c9",
+        "path": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar",
-        "hash": "1f85780cda084ba11fe0611558397d02486154777226eedee640d2867ce4231d",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar",
+        "hash": "1981dea8e4e2e8541af2d83e4f8d3581ce647cfe63175b9eb9ac2a07849d74c9",
+        "path": "io/gitlab/arturbosch/detekt/detekt-core/1.23.8/detekt-core-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar",
-        "hash": "3b26dc266a24da542c012a08e445b8a212703d152d0f0e4663dd7d253bebe819",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar",
+        "hash": "718e8f71f5872986e4f5cd4887a41e26aa0aeff42e99cf4a42582291b8738cc4",
+        "path": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar",
-        "hash": "9613ae5ae4f418e2cd0a4235bcd2911cb9b56ae9e42cc7e672fbc5031bd35d57",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar",
+        "hash": "718e8f71f5872986e4f5cd4887a41e26aa0aeff42e99cf4a42582291b8738cc4",
+        "path": "io/gitlab/arturbosch/detekt/detekt-metrics/1.23.8/detekt-metrics-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar",
-        "hash": "949cf2be2d54ccd9e4f13f9df456190c85738bebb054f50c74e896e31c43d922",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar",
+        "hash": "5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5",
+        "path": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar",
-        "hash": "c2dba4e82e5ad865412f72b8f02ff5462088666100f9734b46a4023bac3e2a5c",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar",
+        "hash": "5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5",
+        "path": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar",
-        "hash": "433fd379cf807f5507318b77d83ad46c30a77b34beab868d5f925b939d73aef7",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar",
+        "hash": "5cdf45a0172d934d6e7401cd43838e7b954f7adb117eed8358fcae0b177e90e5",
+        "path": "io/gitlab/arturbosch/detekt/detekt-parser/1.23.8/detekt-parser-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar",
-        "hash": "d35f7a03198f8f71d20e0838c8feb1576680ec1e16693246f200afcfe69e7f2d",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
+        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
+        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar",
-        "hash": "974868dc67392dcf2c2443e0b75fe0840d114da7cd5a9b7ea3024b1cfa4ceef1",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
+        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
+        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar",
-        "hash": "3fa369db5c0cdeb9fe3382512b874a3ccddd5f2799a31b564c438102f1aa7b86",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
+        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
+        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar",
-        "hash": "38c437218569f861fd43f15aa810b3eb9af4bdb02a7003f54c4d454590378079",
-        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar",
+        "hash": "9505fa9d4f9a771d256a5d415b5d51ffd7a24e5019f6a60e5a69a12633dcf7ba",
+        "path": "io/gitlab/arturbosch/detekt/detekt-psi-utils/1.23.8/detekt-psi-utils-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/base/libserver-flag-test-proto/232.1.23.0/libserver-flag-test-proto-232.1.23.0.jar",
-        "hash": "e7faa7021cfd9042231fbb5e6bbea2616f7c6947905e5db95c196e9a602f88a0",
-        "path": "org/jetbrains/intellij/deps/android/tools/base/libserver-flag-test-proto/232.1.23.0/libserver-flag-test-proto-232.1.23.0.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8.jar",
+        "hash": "8068a15e07718e3bdbf501ede5f666812fb5f9fb1450db060449534c05e6722a",
+        "path": "io/gitlab/arturbosch/detekt/detekt-report-html/1.23.8/detekt-report-html-1.23.8.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/base/traceprocessor_protos/232.1.23.0/traceprocessor_protos-232.1.23.0.jar",
-        "hash": "d34f8d993c5ad098050d512e3abfd2e6361b73e41b029f58af20dfc89e4ad62c",
-        "path": "org/jetbrains/intellij/deps/android/tools/base/traceprocessor_protos/232.1.23.0/traceprocessor_protos-232.1.23.0.jar"
+        "url": "io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8.jar",
+        "hash": "cc5b90b1476cef99e112162dbcd1db32b040284a768f3c975a49ec0b63980ca3",
+        "path": "io/gitlab/arturbosch/detekt/detekt-report-md/1.23.8/detekt-report-md-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8.jar",
+        "hash": "c9f9221fc57ed1fbd1374de5c4da6c069160f892a71f83b551d3a32c8cbad13d",
+        "path": "io/gitlab/arturbosch/detekt/detekt-report-sarif/1.23.8/detekt-report-sarif-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8.jar",
+        "hash": "41e85ca3587abce9a03f8dcb2a67e05fcf59b7518fa016c9350ea73c79f9c54a",
+        "path": "io/gitlab/arturbosch/detekt/detekt-report-txt/1.23.8/detekt-report-txt-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8.jar",
+        "hash": "d71abaa98890cae8a618839b1309c013dff39c6bd7d0de0b704e6193e027ef09",
+        "path": "io/gitlab/arturbosch/detekt/detekt-report-xml/1.23.8/detekt-report-xml-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8.jar",
+        "hash": "c27c0673cad7cc1f2e932c89a060b7ae85749a03d69f221b4c1281f64136c702",
+        "path": "io/gitlab/arturbosch/detekt/detekt-test-utils/1.23.8/detekt-test-utils-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8.jar",
+        "hash": "5383c41e5f22c8def6f890bd66820fe9ff438835600525fdf6eba96742499351",
+        "path": "io/gitlab/arturbosch/detekt/detekt-test/1.23.8/detekt-test-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar",
+        "hash": "7e93e9a23b478f70128893b06748673f912100b7ef03040d7d0331e26d30d092",
+        "path": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar",
+        "hash": "7e93e9a23b478f70128893b06748673f912100b7ef03040d7d0331e26d30d092",
+        "path": "io/gitlab/arturbosch/detekt/detekt-tooling/1.23.8/detekt-tooling-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
+        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
+        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
+        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
+        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
+        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
+        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
+    },
+    {
+        "url": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar",
+        "hash": "f75fd7e924b9267d9ec661859ca913102de4a8f5895b09685ce10797dc26d056",
+        "path": "io/gitlab/arturbosch/detekt/detekt-utils/1.23.8/detekt-utils-1.23.8.jar"
+    },
+    {
+        "url": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar",
+        "hash": "bae13d4e4716a0955d316b5fcb75582504325e5b11ac946b13b64b4fce19bc6e",
+        "path": "io/grpc/grpc-api/1.73.0/grpc-api-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-api/1.75.0/grpc-api-1.75.0.jar",
+        "hash": "7f309616691fa655d02512762049ed18bf4ab2b52ced424cab2f527d0bb8e3fc",
+        "path": "io/grpc/grpc-api/1.75.0/grpc-api-1.75.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar",
+        "hash": "d8d6911e225b55501692651272ce961ba5be1f76662ceb7f0aa79ecce8f63f25",
+        "path": "io/grpc/grpc-context/1.73.0/grpc-context-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-context/1.75.0/grpc-context-1.75.0.jar",
+        "hash": "7e1de7847ea621a9ec7cb988a8baa947748d0eaef94bfe457d04d9b57105079f",
+        "path": "io/grpc/grpc-context/1.75.0/grpc-context-1.75.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar",
+        "hash": "cffb55f1e7268e160647e88da142c09c6175ff72970c64f7cb411d78eb661663",
+        "path": "io/grpc/grpc-core/1.73.0/grpc-core-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-core/1.75.0/grpc-core-1.75.0.jar",
+        "hash": "f10cdbe558378494e4ffc6b1bb328b8a137f3201d46c8b24f0154eb9e51191a1",
+        "path": "io/grpc/grpc-core/1.75.0/grpc-core-1.75.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-inprocess/1.65.1/grpc-inprocess-1.65.1.jar",
+        "hash": "6e3b197f5668e26fec19a831d2dd1f6d53b6eb9d4d3978b8ffd4ff68f1aae020",
+        "path": "io/grpc/grpc-inprocess/1.65.1/grpc-inprocess-1.65.1.jar"
+    },
+    {
+        "url": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar",
+        "hash": "4b5705f8cabd07e82c81dbce36f1554aa9d1740f03e369fd049a71f375dac2f0",
+        "path": "io/grpc/grpc-kotlin-stub/1.4.3/grpc-kotlin-stub-1.4.3.jar"
+    },
+    {
+        "url": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar",
+        "hash": "8328289ba6b73445e982a1cadf8e651ea65354e288c825a43e7c77f16da8a056",
+        "path": "io/grpc/grpc-netty-shaded/1.73.0/grpc-netty-shaded-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-netty-shaded/1.75.0/grpc-netty-shaded-1.75.0.jar",
+        "hash": "d33d47a9720a392512c4e4ceaa17a458a0e3ed6188d17e98d6c4faf0679374d7",
+        "path": "io/grpc/grpc-netty-shaded/1.75.0/grpc-netty-shaded-1.75.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar",
+        "hash": "de8ce5309713e72bb57d5ff2dabdb4c173ae4872bd1439b9c3d3f93430b407d9",
+        "path": "io/grpc/grpc-protobuf-lite/1.73.0/grpc-protobuf-lite-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-protobuf-lite/1.75.0/grpc-protobuf-lite-1.75.0.jar",
+        "hash": "60fafc627aa04bcab328dcc9206f0e7aa71d95f1b612774a18272dfe7dc24cf1",
+        "path": "io/grpc/grpc-protobuf-lite/1.75.0/grpc-protobuf-lite-1.75.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar",
+        "hash": "5c0ca9e321c02845c47dc6edcef9f22e49015cef7753c54012f5398425163c08",
+        "path": "io/grpc/grpc-protobuf/1.73.0/grpc-protobuf-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-protobuf/1.75.0/grpc-protobuf-1.75.0.jar",
+        "hash": "f52b53c349b0776815e437636dff3d3844e9b10cbb25be419a786bf3d6f20269",
+        "path": "io/grpc/grpc-protobuf/1.75.0/grpc-protobuf-1.75.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar",
+        "hash": "050fe139de47d8937e6b0080e8dff3d0f42df6782f147c10bb298c0e9cd94b2f",
+        "path": "io/grpc/grpc-stub/1.73.0/grpc-stub-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-stub/1.75.0/grpc-stub-1.75.0.jar",
+        "hash": "dc98fe18654206948666e6657e13fe301ad0754751f28c6c10961e1e6c457997",
+        "path": "io/grpc/grpc-stub/1.75.0/grpc-stub-1.75.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar",
+        "hash": "b7df6cbcc30b7a3219f06483a9a9d320a431beda8a1ace5b16d879f84112373f",
+        "path": "io/grpc/grpc-util/1.73.0/grpc-util-1.73.0.jar"
+    },
+    {
+        "url": "io/grpc/grpc-util/1.75.0/grpc-util-1.75.0.jar",
+        "hash": "92b5a1195dad4cbd7c405b01cbd9fd2dbbd548d13d4cfabf9d2d6a37bad4cb81",
+        "path": "io/grpc/grpc-util/1.75.0/grpc-util-1.75.0.jar"
+    },
+    {
+        "url": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar",
+        "hash": "8b1c3e582e2f6f662261f3f45a6d723f3dd8d8b2b0b86a3f7d8e6c966eca0568",
+        "path": "io/kotest/kotest-assertions-api-jvm/5.5.4/kotest-assertions-api-jvm-5.5.4.jar"
+    },
+    {
+        "url": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar",
+        "hash": "3acf3de882ec2c714dfc173cc382c38a5aee70c3f2bdda732583916845226d0c",
+        "path": "io/kotest/kotest-assertions-core-jvm/5.5.4/kotest-assertions-core-jvm-5.5.4.jar"
+    },
+    {
+        "url": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar",
+        "hash": "9977d913ef1fccf2e2663b5906d955fdf8215d0ec48265d669b01e05179e2043",
+        "path": "io/kotest/kotest-assertions-shared-jvm/5.5.4/kotest-assertions-shared-jvm-5.5.4.jar"
+    },
+    {
+        "url": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar",
+        "hash": "a2a4d02b86b2e849e514d18dbdf4b29e2e9d091e3c6f4d9d028db9cdc55dd28b",
+        "path": "io/kotest/kotest-common-jvm/5.5.4/kotest-common-jvm-5.5.4.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-auth-jvm/3.1.3/ktor-client-auth-jvm-3.1.3.jar",
+        "hash": "202a46d169ce1472fef818c9c3d3cc30343fd308d45b6557ae8e0b4e48f07bc8",
+        "path": "io/ktor/ktor-client-auth-jvm/3.1.3/ktor-client-auth-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
+        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
+        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
+        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
+        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar",
+        "hash": "9a86341588057a23d3ba4562fdc8afcef6facd071678a0c20b3b28a19ec35c88",
+        "path": "io/ktor/ktor-client-cio-jvm/3.1.3/ktor-client-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-content-negotiation-jvm/3.1.3/ktor-client-content-negotiation-jvm-3.1.3.jar",
+        "hash": "9cbf59168645f54a9a9c21c1a0f15cd628234b20bbff3ec1bd64680f10aa779d",
+        "path": "io/ktor/ktor-client-content-negotiation-jvm/3.1.3/ktor-client-content-negotiation-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar",
+        "hash": "746e2a3dece87379d64c40999401969001d373de1458fe851c0d2e0f880b42ef",
+        "path": "io/ktor/ktor-client-core-jvm/3.1.3/ktor-client-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-encoding-jvm/3.1.3/ktor-client-encoding-jvm-3.1.3.jar",
+        "hash": "925decea3921e2b89a0cc0000feba3613c4b2d7c96945749d25fde3b8b69627f",
+        "path": "io/ktor/ktor-client-encoding-jvm/3.1.3/ktor-client-encoding-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar",
+        "hash": "4449fa59e5f4f9a18e18b5ed10db95dba3f65a825cfc32d053097d8bffccfbf1",
+        "path": "io/ktor/ktor-client-java-jvm/3.1.3/ktor-client-java-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-logging-jvm/3.1.3/ktor-client-logging-jvm-3.1.3.jar",
+        "hash": "ecabf013b137f1a69c39cffeae1ba9e365659357b21688f1876ee6cf50fd00b9",
+        "path": "io/ktor/ktor-client-logging-jvm/3.1.3/ktor-client-logging-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar",
+        "hash": "2ae0d57bb9fceb8ee2aeda6536acc6f3e1de355984b4c9da720566b85f1525e8",
+        "path": "io/ktor/ktor-client-mock-jvm/3.1.3/ktor-client-mock-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar",
+        "hash": "a3c111c85eabb8149c485c275768d57cd96a05b595ca1946781c0d4c5fb1654a",
+        "path": "io/ktor/ktor-client-okhttp-jvm/3.1.3/ktor-client-okhttp-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar",
+        "hash": "da7069c6e78809d7c37d104e415613cbd4cd5cec1ed54a332cb64ef6a864a060",
+        "path": "io/ktor/ktor-events-jvm/3.1.3/ktor-events-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar",
+        "hash": "b04aede18e9c008168096dc53a3fc016177b61a5ec3024afbf8caca0cd5dbf42",
+        "path": "io/ktor/ktor-http-cio-jvm/3.1.3/ktor-http-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar",
+        "hash": "8a50d94b46f91bd56580b9169272d6cd636f442032ba078a141da70413465946",
+        "path": "io/ktor/ktor-http-jvm/3.1.3/ktor-http-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar",
+        "hash": "bb2fb6c00afaa34b539cb30e7584d37bfcba171c266bbdb9990e003579dc24c1",
+        "path": "io/ktor/ktor-io-jvm/3.1.3/ktor-io-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
+        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
+        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
+        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
+        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
+        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
+        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
+        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
+        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar",
+        "hash": "fa4e6165b5ad4bf5db337ebd5f16f9b596dc5e401fbea343b9deacb6138240af",
+        "path": "io/ktor/ktor-network-jvm/3.1.3/ktor-network-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
+        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
+        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
+        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
+        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar",
+        "hash": "f67507a3e8bf52aa08d753682e6cdda0194e3abe750118b99c9336953e598be9",
+        "path": "io/ktor/ktor-network-tls-jvm/3.1.3/ktor-network-tls-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar",
+        "hash": "0d704bc1148a8fd9a1f2005e0b5189cdaed3030efe24b8236459c41c356f5620",
+        "path": "io/ktor/ktor-serialization-jvm/3.1.3/ktor-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-kotlinx-json-jvm/3.1.3/ktor-serialization-kotlinx-json-jvm-3.1.3.jar",
+        "hash": "9b810f01caa6e3f27e02d71caba8595e2b4b04071dba16e0e426e20115bed354",
+        "path": "io/ktor/ktor-serialization-kotlinx-json-jvm/3.1.3/ktor-serialization-kotlinx-json-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-serialization-kotlinx-jvm/3.1.3/ktor-serialization-kotlinx-jvm-3.1.3.jar",
+        "hash": "b4dc2f9d4d1dda8d481a054d7f833ba195f064f5115fde3ab0dfdb8b42f61fda",
+        "path": "io/ktor/ktor-serialization-kotlinx-jvm/3.1.3/ktor-serialization-kotlinx-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
+        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
+        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
+        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
+        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar",
+        "hash": "f1526fe94e8d76c5251b5a25e4b4bb72199a25d3e1f6045e4b9e42789293f069",
+        "path": "io/ktor/ktor-server-cio-jvm/3.1.3/ktor-server-cio-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
+        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
+        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
+        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
+        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar",
+        "hash": "bf582ba004634d0d343bb2dfa1edd0e8de18cdc2c607a4089db8b79d3085d10a",
+        "path": "io/ktor/ktor-server-core-jvm/3.1.3/ktor-server-core-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar",
+        "hash": "6f4932086ba785deeb74170140508156b21772cd2961a37e7b551eb5d2649a29",
+        "path": "io/ktor/ktor-server-host-common-jvm/3.1.3/ktor-server-host-common-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar",
+        "hash": "4c172eb930db7d7cfef36cf3ba7d5094ce08dea6fde2b4be7746680a2ebd7c05",
+        "path": "io/ktor/ktor-server-sse-jvm/3.1.3/ktor-server-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar",
+        "hash": "a2ae8a338bb1d446d16dcfea2189ef5a5be31a88123b3879562b7955667a5639",
+        "path": "io/ktor/ktor-sse-jvm/3.1.3/ktor-sse-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar",
+        "hash": "33333937b98fc0c8e943ee4b10b3ea66b49782dfb569c44c142da4f32d85dffc",
+        "path": "io/ktor/ktor-utils-jvm/3.1.3/ktor-utils-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar",
+        "hash": "67f0f566e2ed51717f6ed55f6d2b4dee1c84be4ea2cd96fc636d0bdf0fd43067",
+        "path": "io/ktor/ktor-websocket-serialization-jvm/3.1.3/ktor-websocket-serialization-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar",
+        "hash": "ef28b4f12054ee125765b72fe3230e215a60b73b2ff2072a5c280fcf09329077",
+        "path": "io/ktor/ktor-websockets-jvm/3.1.3/ktor-websockets-jvm-3.1.3.jar"
+    },
+    {
+        "url": "io/micrometer/micrometer-core/1.7.12/micrometer-core-1.7.12.jar",
+        "hash": "e7137f16fdbb183bf6608403f604036fa53971ca8635947745e8080039ab0533",
+        "path": "io/micrometer/micrometer-core/1.7.12/micrometer-core-1.7.12.jar"
+    },
+    {
+        "url": "io/micrometer/micrometer-registry-prometheus/1.7.12/micrometer-registry-prometheus-1.7.12.jar",
+        "hash": "1fd64ca17b7ec6235dae4bb080283dcd7866e929189d82f5ba8a201e41ca9848",
+        "path": "io/micrometer/micrometer-registry-prometheus/1.7.12/micrometer-registry-prometheus-1.7.12.jar"
+    },
+    {
+        "url": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar",
+        "hash": "a919a8fec03dfb0c084cb43dafcebe2dd9351431c7a08c2fc8147037de1d06b7",
+        "path": "io/mockk/mockk-agent-api-jvm/1.14.5/mockk-agent-api-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-agent-api/1.14.5/mockk-agent-api-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar",
+        "hash": "9f78e9988e84c98569edcf9a6225d5b7354939529642e54c2c58da3ef3913106",
+        "path": "io/mockk/mockk-agent-jvm/1.14.5/mockk-agent-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-agent/1.14.5/mockk-agent-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar",
+        "hash": "060fffe7452e74f6e18bb9dfe1221e92c4ec0de29a84b022fb562ec6cd954691",
+        "path": "io/mockk/mockk-core-jvm/1.14.5/mockk-core-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-core/1.14.5/mockk-core-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar",
+        "hash": "d01d6ce85f9824d8ddb22ea7f1bccd581b831ffad504f48a4f18abf9bc6f2eac",
+        "path": "io/mockk/mockk-dsl-jvm/1.14.5/mockk-dsl-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk-dsl/1.14.5/mockk-dsl-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar",
+        "hash": "74deb86cbab6871a3e4d0f97ba8eacbdae7aacd7537f142bcb083590465a6219",
+        "path": "io/mockk/mockk-jvm/1.14.5/mockk-jvm-1.14.5.jar"
+    },
+    {
+        "url": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar",
+        "hash": "089e24417bf9f6c34eec5720eebb2cbcc82ea2855ecef90133eb17e1079d5868",
+        "path": "io/mockk/mockk/1.14.5/mockk-1.14.5.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar",
+        "hash": "e88a667c25b8ebb7c81f76dd96cb34ea804754752b5533a842b99d0daea2be99",
+        "path": "io/modelcontextprotocol/kotlin-sdk-client-jvm/0.8.1/kotlin-sdk-client-jvm-0.8.1.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar",
+        "hash": "dd9a13ba6b0803040b6fea56b6db66bc9c4f31dacf678dac642aaaff8d88a543",
+        "path": "io/modelcontextprotocol/kotlin-sdk-core-jvm/0.8.1/kotlin-sdk-core-jvm-0.8.1.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar",
+        "hash": "095e5d11868ae359bd640c922c2d1ed7a20ba519496599ee697e81c468761339",
+        "path": "io/modelcontextprotocol/kotlin-sdk-jvm/0.8.1/kotlin-sdk-jvm-0.8.1.jar"
+    },
+    {
+        "url": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar",
+        "hash": "6086acf1d65bca24de344b493e3fc241f0db2b25fa0606057eee39e3a2264737",
+        "path": "io/modelcontextprotocol/kotlin-sdk-server-jvm/0.8.1/kotlin-sdk-server-jvm-0.8.1.jar"
+    },
+    {
+        "url": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar",
+        "hash": "c78613ac0db94650c03a37b2a35b3238b2d018fcac9f10e5fe268c3887cf5e0b",
+        "path": "io/netty/netty-all/4.1.117.Final/netty-all-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-all/4.2.0.RC2/netty-all-4.2.0.RC2.jar",
+        "hash": "4a12af2ac8345bfc7e0987ad8748787de033a9e27357cace7f45c7d40be522e0",
+        "path": "io/netty/netty-all/4.2.0.RC2/netty-all-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar",
+        "hash": "7d01bf0334ffa3ab55f3828bb50188bf9969774a23791a3df1905e53bfeea8f5",
+        "path": "io/netty/netty-buffer/4.1.117.Final/netty-buffer-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar",
+        "hash": "74d953cec00048b892112f9602fc7b1113ea55337dc1ede32e449efcb2b231c7",
+        "path": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar",
+        "hash": "74d953cec00048b892112f9602fc7b1113ea55337dc1ede32e449efcb2b231c7",
+        "path": "io/netty/netty-buffer/4.2.0.RC2/netty-buffer-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar",
+        "hash": "f39581a55f89fb0586373e237e1e4a9d5e2fe3b94167c7a6762552651e5a6038",
+        "path": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar",
+        "hash": "f39581a55f89fb0586373e237e1e4a9d5e2fe3b94167c7a6762552651e5a6038",
+        "path": "io/netty/netty-codec-base/4.2.0.RC2/netty-codec-base-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar",
+        "hash": "7251646a8ea8d56a2415311de6040159479ac0e35de36dab70b667ed899ac931",
+        "path": "io/netty/netty-codec-compression/4.2.0.RC2/netty-codec-compression-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar",
+        "hash": "a7e19945a6baa86ab285383a0bda632eae7703a889da1d20ea4eaad4c996cc21",
+        "path": "io/netty/netty-codec-http/4.1.117.Final/netty-codec-http-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar",
+        "hash": "a44d21dff0254e4f4f9ceb7870e8b27a403d7f1d6325ab03ae6c045302957761",
+        "path": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar",
+        "hash": "a44d21dff0254e4f4f9ceb7870e8b27a403d7f1d6325ab03ae6c045302957761",
+        "path": "io/netty/netty-codec-http/4.2.0.RC2/netty-codec-http-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar",
+        "hash": "c542657efd81b268535fb77e1866c8234c5a22de416ecbd8aea0e06e2c1588de",
+        "path": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar",
+        "hash": "c542657efd81b268535fb77e1866c8234c5a22de416ecbd8aea0e06e2c1588de",
+        "path": "io/netty/netty-codec-http2/4.2.0.RC2/netty-codec-http2-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar",
+        "hash": "c5fb188895ffdfd529473c5e7ba1c58da2f514a44134b15ad0d51efe3f28bb38",
+        "path": "io/netty/netty-codec-protobuf/4.2.0.RC2/netty-codec-protobuf-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar",
+        "hash": "0b93f01cff5bc2a64af829ca01c826e8e861a03b96a871fa2a240fa25681df78",
+        "path": "io/netty/netty-codec/4.1.117.Final/netty-codec-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar",
+        "hash": "b94f2d169acd04e8a41f1082e8f522529be1f5a10515473de9fb8d259afbfc77",
+        "path": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar",
+        "hash": "b94f2d169acd04e8a41f1082e8f522529be1f5a10515473de9fb8d259afbfc77",
+        "path": "io/netty/netty-codec/4.2.0.RC2/netty-codec-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar",
+        "hash": "5b4e125a341566b24d5030479da475b20ea1f6145bf7b3c3d69fe537088bb4c1",
+        "path": "io/netty/netty-common/4.1.117.Final/netty-common-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar",
+        "hash": "cc65afe17daf2f9380d3c64460f5b10ec279f98b9461fbf0ccf62b3cb3ee6c37",
+        "path": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar",
+        "hash": "cc65afe17daf2f9380d3c64460f5b10ec279f98b9461fbf0ccf62b3cb3ee6c37",
+        "path": "io/netty/netty-common/4.2.0.RC2/netty-common-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-handler-ssl-ocsp/4.2.0.RC2/netty-handler-ssl-ocsp-4.2.0.RC2.jar",
+        "hash": "c1d3051facf0297a3d7e15078a2c94f3650b6beddd398f21c591d098fd549922",
+        "path": "io/netty/netty-handler-ssl-ocsp/4.2.0.RC2/netty-handler-ssl-ocsp-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar",
+        "hash": "f3272149099883cf98ad8a2a82a08111a78d17e604aebc094c80592a730fcac5",
+        "path": "io/netty/netty-handler/4.1.117.Final/netty-handler-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar",
+        "hash": "3f1912b14a2fdd7ad2ef0bda9eeb1ae544c463857081d7dd69f9aa2b7137de6e",
+        "path": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar",
+        "hash": "3f1912b14a2fdd7ad2ef0bda9eeb1ae544c463857081d7dd69f9aa2b7137de6e",
+        "path": "io/netty/netty-handler/4.2.0.RC2/netty-handler-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-pkitesting/4.2.0.RC2/netty-pkitesting-4.2.0.RC2.jar",
+        "hash": "6d3fbdf60229ee2baafaa850bf46115923109c73d6d1b0fefdcce5a12ddd43e8",
+        "path": "io/netty/netty-pkitesting/4.2.0.RC2/netty-pkitesting-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar",
+        "hash": "0f5f7220d34d32751cc624bc9c47afdde7392f0d9551569c90a568309015d796",
+        "path": "io/netty/netty-resolver/4.1.117.Final/netty-resolver-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar",
+        "hash": "10fa70357cbfd55f52d64cf4bb4011e01ced0e0e5dea0bac77f73908cef676ff",
+        "path": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar",
+        "hash": "10fa70357cbfd55f52d64cf4bb4011e01ced0e0e5dea0bac77f73908cef676ff",
+        "path": "io/netty/netty-resolver/4.2.0.RC2/netty-resolver-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar",
+        "hash": "6d9ebbb6db1567ebc7e3561a555b2e80cded56002f16be4c152bb911f6952cee",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-aarch_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar",
+        "hash": "a700168761f778704d456e4b0cc9183a42a832ac4b970886663c6c855bf5461c",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-linux-x86_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar",
+        "hash": "a1158e70bb79d591c7d7fcc2ab0bcf6682500f7de4961fda4a9cc1b015cad65e",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-aarch_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar",
+        "hash": "f2cbc864db43bc57d13a79444b2f8d784a01345bbe259c9721be00935f8ba748",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-osx-x86_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar",
+        "hash": "6a8cb27bdd255a718ca100d52cfdac20cce70ab3a92c248efaee50f63eefd11e",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final-windows-x86_64.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar",
+        "hash": "cfd4332afd70ebb3041e244317dc790d8cb7bf6ddd05591cc1188b8052979946",
+        "path": "io/netty/netty-tcnative-boringssl-static/2.0.73.Final/netty-tcnative-boringssl-static-2.0.73.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar",
+        "hash": "6396a4e67269f3f35851c17613257964f46fd4e937cb3ffe73ddcd963c2a83a7",
+        "path": "io/netty/netty-tcnative-classes/2.0.73.Final/netty-tcnative-classes-2.0.73.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-classes-epoll/4.2.0.RC2/netty-transport-classes-epoll-4.2.0.RC2.jar",
+        "hash": "b28e39a15989b29683ccbc360d27cdb71fa992c16e50f2b331278a68267d110a",
+        "path": "io/netty/netty-transport-classes-epoll/4.2.0.RC2/netty-transport-classes-epoll-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-classes-kqueue/4.2.0.RC2/netty-transport-classes-kqueue-4.2.0.RC2.jar",
+        "hash": "15c46096b22d0fc833c09ce85d002cc8e171c9f1741030663899a6315997d5bd",
+        "path": "io/netty/netty-transport-classes-kqueue/4.2.0.RC2/netty-transport-classes-kqueue-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-aarch_64.jar",
+        "hash": "9ff603349365d28397dc239097cab0ceca3b27cacd13fb5f1afda8d4d7388194",
+        "path": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-aarch_64.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-riscv64.jar",
+        "hash": "c9fb752bd54bf2dae1e4330d2446202fdfb28e6a7f933248886de13d4b2f6959",
+        "path": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-riscv64.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-x86_64.jar",
+        "hash": "d57f64acefa1cebc8b18f1add825f4d965bb495a340eee69b9d626d54e161a24",
+        "path": "io/netty/netty-transport-native-epoll/4.2.0.RC2/netty-transport-native-epoll-4.2.0.RC2-linux-x86_64.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-aarch_64.jar",
+        "hash": "d942f12645bf694c5083e40d7ec2f1d03b897ceccb0d0acd9d1178bf4f72092d",
+        "path": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-aarch_64.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-x86_64.jar",
+        "hash": "2c80194e02e8f2424be3eb18be4514ece9fcaec79cb11a7d2f0dbe92fe86e283",
+        "path": "io/netty/netty-transport-native-kqueue/4.2.0.RC2/netty-transport-native-kqueue-4.2.0.RC2-osx-x86_64.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar",
+        "hash": "dfc1db2a05dafeba40987a76591004cc72d4a27062d874961fadc5059900f65d",
+        "path": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar",
+        "hash": "dfc1db2a05dafeba40987a76591004cc72d4a27062d874961fadc5059900f65d",
+        "path": "io/netty/netty-transport-native-unix-common/4.2.0.RC2/netty-transport-native-unix-common-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar",
+        "hash": "c07aac2ea55aa42c34fc6b53fbee661e0de077f45483133b6ca297c70a67a44a",
+        "path": "io/netty/netty-transport/4.1.117.Final/netty-transport-4.1.117.Final.jar"
+    },
+    {
+        "url": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar",
+        "hash": "9c86cf3a130237b059f5ef89661a4fbe715f5e8bce9626a6aded95a1c3775a47",
+        "path": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar",
+        "hash": "9c86cf3a130237b059f5ef89661a4fbe715f5e8bce9626a6aded95a1c3775a47",
+        "path": "io/netty/netty-transport/4.2.0.RC2/netty-transport-4.2.0.RC2.jar"
+    },
+    {
+        "url": "io/nlopez/compose/rules/common-detekt/0.4.27/common-detekt-0.4.27.jar",
+        "hash": "fa0b6f2a76b7c3768d5f3b6095b3deb756840a9251f8f750e344c5213382f2fd",
+        "path": "io/nlopez/compose/rules/common-detekt/0.4.27/common-detekt-0.4.27.jar"
+    },
+    {
+        "url": "io/nlopez/compose/rules/detekt/0.4.27/detekt-0.4.27.jar",
+        "hash": "3ebb866359b8ec9ba06e45eb27b1b88ee84dab7b052c3ddef57a0e5d12433fb5",
+        "path": "io/nlopez/compose/rules/detekt/0.4.27/detekt-0.4.27.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-api/1.42.1/opentelemetry-api-1.42.1.jar",
+        "hash": "6b0f9d067260ea3ed6c3960352b80800b993cb3962fa6fb1b6383cd04c3c0874",
+        "path": "io/opentelemetry/opentelemetry-api/1.42.1/opentelemetry-api-1.42.1.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-api/1.48.0/opentelemetry-api-1.48.0.jar",
+        "hash": "8d3781bda58892f7d14216908fc0d1faf6f4e6b806e6e73e23489e41c0ecf012",
+        "path": "io/opentelemetry/opentelemetry-api/1.48.0/opentelemetry-api-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-context/1.42.1/opentelemetry-context-1.42.1.jar",
+        "hash": "fc8f47bc94bec89a3dbdbcf631470fb7fd7d3e628b10d43bc376f17ebde4b405",
+        "path": "io/opentelemetry/opentelemetry-context/1.42.1/opentelemetry-context-1.42.1.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-context/1.48.0/opentelemetry-context-1.48.0.jar",
+        "hash": "1fcccff0f8171fe2001a17b99da229c12d0c4edcca617e453460344e92249d42",
+        "path": "io/opentelemetry/opentelemetry-context/1.48.0/opentelemetry-context-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar",
+        "hash": "bc7af4f3c4ba1a23c20a6e1945f3e17fd3f5719f6f17d62961b3167d939a18e2",
+        "path": "io/opentelemetry/opentelemetry-exporter-common/1.48.0/opentelemetry-exporter-common-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar",
+        "hash": "9b3211ad7f1508f6453d16922aad6c7dce5b2f9a88b7e272171f63875ee78efd",
+        "path": "io/opentelemetry/opentelemetry-exporter-otlp-common/1.48.0/opentelemetry-exporter-otlp-common-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar",
+        "hash": "2285ebfe8e0fd38e186b7033f6f6c542324c9bab23260b914b1b73eaf4492c5d",
+        "path": "io/opentelemetry/opentelemetry-extension-kotlin/1.48.0/opentelemetry-extension-kotlin-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-sdk-common/1.48.0/opentelemetry-sdk-common-1.48.0.jar",
+        "hash": "d8cfbfe6403965f68fc5efca0c9cb85c2cafd5facda9238cd83468692bc00109",
+        "path": "io/opentelemetry/opentelemetry-sdk-common/1.48.0/opentelemetry-sdk-common-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.45.0/opentelemetry-sdk-extension-autoconfigure-spi-1.45.0.jar",
+        "hash": "d55d8e2e877d5b0424375c79a891c82e78d00eb1b1273295763e1b55b0374123",
+        "path": "io/opentelemetry/opentelemetry-sdk-extension-autoconfigure-spi/1.45.0/opentelemetry-sdk-extension-autoconfigure-spi-1.45.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-sdk-logs/1.48.0/opentelemetry-sdk-logs-1.48.0.jar",
+        "hash": "3cb8107e3d142fb990ce7f7198cd051a3364fc9d254daa22d248215246857567",
+        "path": "io/opentelemetry/opentelemetry-sdk-logs/1.48.0/opentelemetry-sdk-logs-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-sdk-metrics/1.48.0/opentelemetry-sdk-metrics-1.48.0.jar",
+        "hash": "70622ff3bbeee435fba5c49d9ff6b056511a0f9982080aa5959ccfccb8650fd9",
+        "path": "io/opentelemetry/opentelemetry-sdk-metrics/1.48.0/opentelemetry-sdk-metrics-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-sdk-trace/1.48.0/opentelemetry-sdk-trace-1.48.0.jar",
+        "hash": "d575e493f6c2e89d3100b3e73d3a2ae720bb8f3ee2fa0f70a7d0da81d048c87a",
+        "path": "io/opentelemetry/opentelemetry-sdk-trace/1.48.0/opentelemetry-sdk-trace-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-sdk/1.48.0/opentelemetry-sdk-1.48.0.jar",
+        "hash": "668e78642d50709dd147406a197cfdd256b1d5931023a23f4a25ed88154c8089",
+        "path": "io/opentelemetry/opentelemetry-sdk/1.48.0/opentelemetry-sdk-1.48.0.jar"
+    },
+    {
+        "url": "io/opentelemetry/opentelemetry-semconv/1.30.1-alpha/opentelemetry-semconv-1.30.1-alpha.jar",
+        "hash": "aaa73f6c6a3a67cdc07870387383808826d8dae7a84e47cae182b7a88a08e513",
+        "path": "io/opentelemetry/opentelemetry-semconv/1.30.1-alpha/opentelemetry-semconv-1.30.1-alpha.jar"
+    },
+    {
+        "url": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar",
+        "hash": "99c2478a9b803b7d385d1624d5c1ab6f9a64cac5a2dc00f44a350744a1d858ac",
+        "path": "io/opentelemetry/semconv/opentelemetry-semconv/1.30.0/opentelemetry-semconv-1.30.0.jar"
+    },
+    {
+        "url": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar",
+        "hash": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "path": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar"
+    },
+    {
+        "url": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar",
+        "hash": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "path": "io/perfmark/perfmark-api/0.27.0/perfmark-api-0.27.0.jar"
+    },
+    {
+        "url": "io/prometheus/simpleclient/0.16.0/simpleclient-0.16.0.jar",
+        "hash": "22c374f237f7bc4fdb1f0ec2da379c0ba00e69ad2ffe8b6ade543d73062d377f",
+        "path": "io/prometheus/simpleclient/0.16.0/simpleclient-0.16.0.jar"
+    },
+    {
+        "url": "io/prometheus/simpleclient_common/0.10.0/simpleclient_common-0.10.0.jar",
+        "hash": "8f91f079b6d2e45af3a6ff2ad5cb6c039dce602c51d0923790a32482691e50ff",
+        "path": "io/prometheus/simpleclient_common/0.10.0/simpleclient_common-0.10.0.jar"
+    },
+    {
+        "url": "io/prometheus/simpleclient_guava/0.16.0/simpleclient_guava-0.16.0.jar",
+        "hash": "49959fe20423803b8958fe35ce6cdcc47e58e2251b191ad53eb7ef6fc46c4ae1",
+        "path": "io/prometheus/simpleclient_guava/0.16.0/simpleclient_guava-0.16.0.jar"
+    },
+    {
+        "url": "io/prometheus/simpleclient_tracer_common/0.16.0/simpleclient_tracer_common-0.16.0.jar",
+        "hash": "e84a784ac8e24f182ee62da80b6b5c8140774b75bfa4bf9cc3d3b8390db625f6",
+        "path": "io/prometheus/simpleclient_tracer_common/0.16.0/simpleclient_tracer_common-0.16.0.jar"
+    },
+    {
+        "url": "io/prometheus/simpleclient_tracer_otel/0.16.0/simpleclient_tracer_otel-0.16.0.jar",
+        "hash": "a2a84c59bef3796bb7f9c6f2ae8b7de8b905313ef28180ac3de7ff61dd68df3f",
+        "path": "io/prometheus/simpleclient_tracer_otel/0.16.0/simpleclient_tracer_otel-0.16.0.jar"
+    },
+    {
+        "url": "io/prometheus/simpleclient_tracer_otel_agent/0.16.0/simpleclient_tracer_otel_agent-0.16.0.jar",
+        "hash": "7ad2bb40df74a772d9f5445a3d03579b49d6b37a47d5e90f6cf3f59ecf41ad06",
+        "path": "io/prometheus/simpleclient_tracer_otel_agent/0.16.0/simpleclient_tracer_otel_agent-0.16.0.jar"
+    },
+    {
+        "url": "io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar",
+        "hash": "164e026e01338638e3433e4f6efbda52ed9a64a94ced649c3d0bbe02a7c61282",
+        "path": "io/takari/maven-wrapper/0.5.5/maven-wrapper-0.5.5.jar"
+    },
+    {
+        "url": "io/vavr/vavr-match/0.10.2/vavr-match-0.10.2.jar",
+        "hash": "5d7a9515b05e3291194e04e641acf74a9a544c1caa1e2c24f59a1424c6ec8288",
+        "path": "io/vavr/vavr-match/0.10.2/vavr-match-0.10.2.jar"
+    },
+    {
+        "url": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar",
+        "hash": "d46f96bf59ccd5800261eec5869a6877ee0a37ea781312e6735be55539f50354",
+        "path": "io/vavr/vavr-match/0.10.4/vavr-match-0.10.4.jar"
+    },
+    {
+        "url": "io/vavr/vavr/0.10.2/vavr-0.10.2.jar",
+        "hash": "1b2ae46cf352627e05b39ac1f1d3bda7b285a8f643cdc7472aea4aa279492e54",
+        "path": "io/vavr/vavr/0.10.2/vavr-0.10.2.jar"
+    },
+    {
+        "url": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar",
+        "hash": "12622deeea2618b59b284051a9484f1def8ccbebc847c350358f12d325ba9dd5",
+        "path": "io/vavr/vavr/0.10.4/vavr-0.10.4.jar"
+    },
+    {
+        "url": "isorelax/isorelax/20030108/isorelax-20030108.jar",
+        "hash": "3427152431cf7f967f92e69e5cac16147c5d8fb4b4e5a8a72f5291788efcff8c",
+        "path": "isorelax/isorelax/20030108/isorelax-20030108.jar"
+    },
+    {
+        "url": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar",
+        "hash": "733e1347e3ec909e8a7ee199e48a64d0180569461b3bc08c8a6bb1335f5ce1bd",
+        "path": "it/krzeminski/snakeyaml-engine-kmp-jvm/3.1.1/snakeyaml-engine-kmp-jvm-3.1.1.jar"
+    },
+    {
+        "url": "it/unimi/dsi/fastutil-core/8.5.14/fastutil-core-8.5.14.jar",
+        "hash": "8fb6fe5989a32a74df3158fd8d6b91a4dfc44348772a8654c47dcadd1090a4d8",
+        "path": "it/unimi/dsi/fastutil-core/8.5.14/fastutil-core-8.5.14.jar"
+    },
+    {
+        "url": "jakarta/activation/jakarta.activation-api/2.1.3/jakarta.activation-api-2.1.3.jar",
+        "hash": "01b176d718a169263e78290691fc479977186bcc6b333487325084d6586f4627",
+        "path": "jakarta/activation/jakarta.activation-api/2.1.3/jakarta.activation-api-2.1.3.jar"
+    },
+    {
+        "url": "jakarta/xml/bind/jakarta.xml.bind-api/2.3.3/jakarta.xml.bind-api-2.3.3.jar",
+        "hash": "c04539f472e9a6dd0c7685ea82d677282269ab8e7baca2e14500e381e0c6cec5",
+        "path": "jakarta/xml/bind/jakarta.xml.bind-api/2.3.3/jakarta.xml.bind-api-2.3.3.jar"
+    },
+    {
+        "url": "javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar",
+        "hash": "43fdef0b5b6ceb31b0424b208b930c74ab58fac2ceeb7b3f6fd3aeb8b5ca4393",
+        "path": "javax/activation/javax.activation-api/1.2.0/javax.activation-api-1.2.0.jar"
+    },
+    {
+        "url": "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar",
+        "hash": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
+        "path": "javax/annotation/javax.annotation-api/1.2/javax.annotation-api-1.2.jar"
+    },
+    {
+        "url": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
+        "hash": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+        "path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
+    },
+    {
+        "url": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar",
+        "hash": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+        "path": "javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar",
+        "hash": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+        "path": "javax/annotation/jsr250-api/1.0/jsr250-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar",
+        "hash": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+        "path": "javax/enterprise/cdi-api/1.0/cdi-api-1.0.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/inject/javax.inject/1/javax.inject-1.jar",
+        "hash": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+        "path": "javax/inject/javax.inject/1/javax.inject-1.jar"
+    },
+    {
+        "url": "javax/measure/unit-api/1.0/unit-api-1.0.jar",
+        "hash": "35da65fdbd3f9c1fe79cfc8399db975fd97660d8a219febfda9fd1a5fc058f10",
+        "path": "javax/measure/unit-api/1.0/unit-api-1.0.jar"
+    },
+    {
+        "url": "javax/measure/unit-api/1.0/unit-api-1.0.jar",
+        "hash": "35da65fdbd3f9c1fe79cfc8399db975fd97660d8a219febfda9fd1a5fc058f10",
+        "path": "javax/measure/unit-api/1.0/unit-api-1.0.jar"
+    },
+    {
+        "url": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
+        "hash": "88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06",
+        "path": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar"
+    },
+    {
+        "url": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar",
+        "hash": "88b955a0df57880a26a74708bc34f74dcaf8ebf4e78843a28b50eae945732b06",
+        "path": "javax/xml/bind/jaxb-api/2.3.1/jaxb-api-2.3.1.jar"
+    },
+    {
+        "url": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar",
+        "hash": "70feef9dd75ad064def05a3ce8975aeba515ee7d1be146d12199c8828a64174c",
+        "path": "jaxen/jaxen/1.2.0/jaxen-1.2.0.jar"
+    },
+    {
+        "url": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "ce4dc5b9232e9467373ef2e79cab9e3404db898ab45020ce14ef893944745331",
+        "path": "jetbrains/fleet/expects-compiler-plugin/2.2.20-0.1/expects-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "dda6a96d529f473c952ba7e8205509de29725ad40eff80af7d371df95ccb14c1",
+        "path": "jetbrains/fleet/noria-compiler-plugin/2.2.20-0.1/noria-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar",
+        "hash": "eaaae0ef5b03c8cf3d3978699c517f3e2199f50191568efaff4d525be963f544",
+        "path": "jetbrains/fleet/rhizomedb-compiler-plugin/2.2.20-0.1/rhizomedb-compiler-plugin-2.2.20-0.1.jar"
+    },
+    {
+        "url": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar",
+        "hash": "385282b005818cfaccdbe8bd2429811e7e641782f2b88932a6b8ff51d668f616",
+        "path": "joda-time/joda-time/2.12.7/joda-time-2.12.7.jar"
+    },
+    {
+        "url": "junit/junit/4.12/junit-4.12.jar",
+        "hash": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
+        "path": "junit/junit/4.12/junit-4.12.jar"
+    },
+    {
+        "url": "junit/junit/4.13.2/junit-4.13.2.jar",
+        "hash": "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
+        "path": "junit/junit/4.13.2/junit-4.13.2.jar"
+    },
+    {
+        "url": "net/arnx/jsonic/1.2.11/jsonic-1.2.11.jar",
+        "hash": "76a787944faab6c9bea64dc78400949027ed6fb686fe9b328d18f949852bc89f",
+        "path": "net/arnx/jsonic/1.2.11/jsonic-1.2.11.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar",
+        "hash": "2b309a9300092e0b696f7c471fd51d9969001df784c8ab9f07997437d757ad6d",
+        "path": "net/bytebuddy/byte-buddy-agent/1.14.12/byte-buddy-agent-1.14.12.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy-agent/1.17.4/byte-buddy-agent-1.17.4.jar",
+        "hash": "e1dae7efc5562c29ad3b625b90e6864208de69bad5632c3f93a547f17622ac51",
+        "path": "net/bytebuddy/byte-buddy-agent/1.17.4/byte-buddy-agent-1.17.4.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar",
+        "hash": "8a80959465bb09848cd41a89301490c55b9d940dc6ec30d8abac0f63b39fd5d0",
+        "path": "net/bytebuddy/byte-buddy-agent/1.17.6/byte-buddy-agent-1.17.6.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy-dep/1.14.5/byte-buddy-dep-1.14.5.jar",
+        "hash": "bd597c940f6c8d2e0100e576b0cca1a813e3133912882fc2d962c0fa39183cc8",
+        "path": "net/bytebuddy/byte-buddy-dep/1.14.5/byte-buddy-dep-1.14.5.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar",
+        "hash": "970636134d61c183b19f8f58fa631e30d2f2abca344b37848a393cac7863dd70",
+        "path": "net/bytebuddy/byte-buddy/1.14.12/byte-buddy-1.14.12.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy/1.17.4/byte-buddy-1.17.4.jar",
+        "hash": "74768731219a5b2e0cc9d2b1c9e2092e0622242e41b1925a6ba7346e160731bc",
+        "path": "net/bytebuddy/byte-buddy/1.17.4/byte-buddy-1.17.4.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar",
+        "hash": "71568c9f8396677219f650268fbf6493ded484edcdbdf2dae6129ca5be81e8db",
+        "path": "net/bytebuddy/byte-buddy/1.17.5/byte-buddy-1.17.5.jar"
+    },
+    {
+        "url": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar",
+        "hash": "3575dcb8a98faf943d3c1595c47a16047c4fce8a83ebbb26262f1a2f67546357",
+        "path": "net/bytebuddy/byte-buddy/1.17.7/byte-buddy-1.17.7.jar"
+    },
+    {
+        "url": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar",
+        "hash": "80a2f8918240a07d3a6fc7cdcc543d278013f6943c080835e43a22fc90462a9f",
+        "path": "net/fellbaum/jemoji/1.3.1/jemoji-1.3.1.jar"
+    },
+    {
+        "url": "net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar",
+        "hash": "4dda1120db856640dbec04140ed23242215a075fe127bdefa0dcfa29fb31267d",
+        "path": "net/i2p/crypto/eddsa/0.3.0/eddsa-0.3.0.jar"
+    },
+    {
+        "url": "net/java/dev/jna/jna-platform/5.12.1/jna-platform-5.12.1.jar",
+        "hash": "8ce969116cac95bd61b07a8d5e07174b352e63301473caac72c395e3c08488d2",
+        "path": "net/java/dev/jna/jna-platform/5.12.1/jna-platform-5.12.1.jar"
+    },
+    {
+        "url": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar",
+        "hash": "b7e3d46c87bad2eb409b0e704916bcd81206168e357312dfddd0e253679cd9e0",
+        "path": "net/java/dev/jna/jna-platform/5.17.0/jna-platform-5.17.0.jar"
+    },
+    {
+        "url": "net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar",
+        "hash": "91a814ac4f40d60dee91d842e1a8ad874c62197984403d0e3c30d39e55cf53b3",
+        "path": "net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar"
+    },
+    {
+        "url": "net/java/dev/jna/jna/5.15.0/jna-5.15.0.jar",
+        "hash": "a564158d28ab5127fc6a958028ed54279fe0999662c46425b6a3b09a2a52094d",
+        "path": "net/java/dev/jna/jna/5.15.0/jna-5.15.0.jar"
+    },
+    {
+        "url": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar",
+        "hash": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "path": "net/java/dev/jna/jna/5.17.0/jna-5.17.0.jar"
+    },
+    {
+        "url": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar",
+        "hash": "be5805392060c71474bf6c9a67a099471274d30b83eef84bfc4e0889a4f1dcc0",
+        "path": "net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar"
+    },
+    {
+        "url": "net/jqwik/jqwik-api/1.9.2/jqwik-api-1.9.2.jar",
+        "hash": "60244aefd583d349cb26e81f5cc3ef9f66d309d49b6534ab7c9b63be38954054",
+        "path": "net/jqwik/jqwik-api/1.9.2/jqwik-api-1.9.2.jar"
+    },
+    {
+        "url": "net/jqwik/jqwik-engine/1.9.2/jqwik-engine-1.9.2.jar",
+        "hash": "623d105e90cd94b688baaa527bd0c4e284001c07c1f53e3b9a2db179ea57a70a",
+        "path": "net/jqwik/jqwik-engine/1.9.2/jqwik-engine-1.9.2.jar"
+    },
+    {
+        "url": "net/jqwik/jqwik-time/1.9.2/jqwik-time-1.9.2.jar",
+        "hash": "3d5f67f87a7b305601a8aef6ec400df3ad400123af4e8459acf663126b08e05d",
+        "path": "net/jqwik/jqwik-time/1.9.2/jqwik-time-1.9.2.jar"
+    },
+    {
+        "url": "net/jqwik/jqwik-web/1.9.2/jqwik-web-1.9.2.jar",
+        "hash": "4f5006f8dd93a13ca59ef92d5476b9aca1c479c0b6d0beb7c3e64970f6b7e632",
+        "path": "net/jqwik/jqwik-web/1.9.2/jqwik-web-1.9.2.jar"
+    },
+    {
+        "url": "net/jqwik/jqwik/1.9.2/jqwik-1.9.2.jar",
+        "hash": "92c164d7c9d77b3883f3dd43cec9301603847c30c2e247782dc67fb86a4d8e36",
+        "path": "net/jqwik/jqwik/1.9.2/jqwik-1.9.2.jar"
+    },
+    {
+        "url": "net/loomchild/segment/2.0.3/segment-2.0.3.jar",
+        "hash": "a134be9884ddfa18304c8e437e64aa598d83ccfa439310029e61ea3fdae8b2ce",
+        "path": "net/loomchild/segment/2.0.3/segment-2.0.3.jar"
+    },
+    {
+        "url": "net/loomchild/segment/2.0.3/segment-2.0.3.jar",
+        "hash": "a134be9884ddfa18304c8e437e64aa598d83ccfa439310029e61ea3fdae8b2ce",
+        "path": "net/loomchild/segment/2.0.3/segment-2.0.3.jar"
+    },
+    {
+        "url": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar",
+        "hash": "12314fc6881d66a413fd66370787adba16e504fbf7e138690b0f3952e3fbd321",
+        "path": "net/minidev/accessors-smart/2.5.0/accessors-smart-2.5.0.jar"
+    },
+    {
+        "url": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar",
+        "hash": "432b9e545848c4141b80717b26e367f83bf33f19250a228ce75da6e967da2bc7",
+        "path": "net/minidev/json-smart/2.5.0/json-smart-2.5.0.jar"
+    },
+    {
+        "url": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar",
+        "hash": "df26cc58f235f477db07f753ba5a3ab243ebe5789d9f89ecf68dd62ea9a66c28",
+        "path": "net/sf/jopt-simple/jopt-simple/5.0.4/jopt-simple-5.0.4.jar"
+    },
+    {
+        "url": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar",
+        "hash": "f264dd9f79a1fde10ce5ecc53221eff24be4c9331c830b7d52f2f08a7b633de2",
+        "path": "net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.jar"
+    },
+    {
+        "url": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar",
+        "hash": "8d0fd2aeb48d19dc49c563ebc00f274947e45f716c107535c12ead63decd688d",
+        "path": "net/thauvin/erik/urlencoder/urlencoder-lib-jvm/1.6.0/urlencoder-lib-jvm-1.6.0.jar"
+    },
+    {
+        "url": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar",
+        "hash": "2bcbbf2f3227aa97527730eb92ca8724263e6d555b888fbb14aae52bc712d434",
+        "path": "nl/jqno/equalsverifier/equalsverifier/3.19.4/equalsverifier-3.19.4.jar"
+    },
+    {
+        "url": "one/util/streamex/0.8.4/streamex-0.8.4.jar",
+        "hash": "c8bcde95bb6c659bd611a5bc464380f38118a10a0443f3fc15304d91e5c9dd81",
+        "path": "one/util/streamex/0.8.4/streamex-0.8.4.jar"
+    },
+    {
+        "url": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar",
+        "hash": "bd7f7b5d07bc0b047f10915b32ca4bb1de9e57d8049098882e4453c88c076a5d",
+        "path": "org/antlr/antlr4-runtime/4.13.0/antlr4-runtime-4.13.0.jar"
+    },
+    {
+        "url": "org/apache/ant/ant-launcher/1.7.1/ant-launcher-1.7.1.jar",
+        "hash": "25eb5926c975ac6f4126feeb9d004f53f9ebf07dc117f5db9958a6bfb3110783",
+        "path": "org/apache/ant/ant-launcher/1.7.1/ant-launcher-1.7.1.jar"
+    },
+    {
+        "url": "org/apache/ant/ant/1.10.15/ant-1.10.15.jar",
+        "hash": "763acda4a69588c9ea8817a952851ff0c2fc4bffa1d081c2565dc407f29d5794",
+        "path": "org/apache/ant/ant/1.10.15/ant-1.10.15.jar"
+    },
+    {
+        "url": "org/apache/ant/ant/1.7.1/ant-1.7.1.jar",
+        "hash": "ebe592c9af9fdb6c55f0e6c6fabc76f6e0eec8efdec535398e86c3a883687ebf",
+        "path": "org/apache/ant/ant/1.7.1/ant-1.7.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar",
+        "hash": "293d80f54b536b74095dcd7ea3cf0a29bbfc3402519281332495f4420d370d16",
+        "path": "org/apache/commons/commons-compress/1.27.1/commons-compress-1.27.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
+        "hash": "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720",
+        "path": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
+        "hash": "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720",
+        "path": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
+        "hash": "4eeeae8d20c078abb64b015ec158add383ac581571cddc45c68f0c9ae0230720",
+        "path": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
+        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
+        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
+        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
+        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
+        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
+        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar",
+        "hash": "734c8356420cc8e30c795d64fd1fcd5d44ea9d90342a2cc3262c5158fbc6d98b",
+        "path": "org/apache/commons/commons-lang3/3.4/commons-lang3-3.4.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
+        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
+        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
+        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
+        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
+        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
+        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
+        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
+        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar",
+        "hash": "dac807f65b07698ff39b1b07bfef3d87ae3fd46d91bbf8a2bc02b2a831616f68",
+        "path": "org/apache/commons/commons-lang3/3.8.1/commons-lang3-3.8.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar",
+        "hash": "1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308",
+        "path": "org/apache/commons/commons-math3/3.6.1/commons-math3-3.6.1.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-pool2/2.12.0/commons-pool2-2.12.0.jar",
+        "hash": "6d3bd18df8410f3e31b031aca582cc109342358a62a2759ebd0c4cdf30d06f8b",
+        "path": "org/apache/commons/commons-pool2/2.12.0/commons-pool2-2.12.0.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-text/1.12.0/commons-text-1.12.0.jar",
+        "hash": "de023257ff166044a56bd1aa9124e843cd05dac5806cc705a9311f3556d5a15f",
+        "path": "org/apache/commons/commons-text/1.12.0/commons-text-1.12.0.jar"
+    },
+    {
+        "url": "org/apache/commons/commons-text/1.14.0/commons-text-1.14.0.jar",
+        "hash": "121fce2282910c8f0c3ba793a5436b31beb710423cbe2d574a3fb7a73c508e92",
+        "path": "org/apache/commons/commons-text/1.14.0/commons-text-1.14.0.jar"
+    },
+    {
+        "url": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar",
+        "hash": "c8bc7e1c51a6d4ce72f40d2ebbabf1c4b68bfe76e732104b04381b493478e9d6",
+        "path": "org/apache/httpcomponents/httpclient/4.5.14/httpclient-4.5.14.jar"
+    },
+    {
+        "url": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar",
+        "hash": "6c9b3dd142a09dc468e23ad39aad6f75a0f2b85125104469f026e52a474e464f",
+        "path": "org/apache/httpcomponents/httpcore/4.4.16/httpcore-4.4.16.jar"
+    },
+    {
+        "url": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar",
+        "hash": "d401243d5c6eae928a37121b6e819158c8c32ea0584793e7285bb489ab2a3d17",
+        "path": "org/apache/httpcomponents/httpmime/4.5.14/httpmime-4.5.14.jar"
+    },
+    {
+        "url": "org/apache/logging/log4j/log4j-api/2.20.0/log4j-api-2.20.0.jar",
+        "hash": "2f43eea679ea66f14ca0f13fec2a8600ac124f5a5231dcb4df8393eddcb97550",
+        "path": "org/apache/logging/log4j/log4j-api/2.20.0/log4j-api-2.20.0.jar"
+    },
+    {
+        "url": "org/apache/logging/log4j/log4j-api/2.24.2/log4j-api-2.24.2.jar",
+        "hash": "0ca3ecbd4c315bdd5f2ef6af127712df718c78334cce5bf6fb7b4aa17fdab126",
+        "path": "org/apache/logging/log4j/log4j-api/2.24.2/log4j-api-2.24.2.jar"
+    },
+    {
+        "url": "org/apache/logging/log4j/log4j-core/2.24.2/log4j-core-2.24.2.jar",
+        "hash": "7a7b90db866c86a1093b3fde758ca28398ebb2a533da0d79a30cc0a78506b9df",
+        "path": "org/apache/logging/log4j/log4j-core/2.24.2/log4j-core-2.24.2.jar"
+    },
+    {
+        "url": "org/apache/logging/log4j/log4j-to-slf4j/2.20.0/log4j-to-slf4j-2.20.0.jar",
+        "hash": "88e731d7f455da59dfa08769527f87d6c496053a712637df7b999f6977933a2c",
+        "path": "org/apache/logging/log4j/log4j-to-slf4j/2.20.0/log4j-to-slf4j-2.20.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar",
+        "hash": "124bddea3fa0683d3e174552fba5fcf0f24a2f57f1ccf6957010d010d246db8b",
+        "path": "org/apache/lucene/lucene-analysis-common/10.3.0/lucene-analysis-common-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-analyzers-common/8.11.1/lucene-analyzers-common-8.11.1.jar",
+        "hash": "1cdcc5a2d9cf4ffaf12fbf24bc2a18f2469cd295b60470ae8b97d1aa85dbad6f",
+        "path": "org/apache/lucene/lucene-analyzers-common/8.11.1/lucene-analyzers-common-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-backward-codecs/5.5.5/lucene-backward-codecs-5.5.5.jar",
+        "hash": "b62e089f505bc72dd8abb0ad55040604cdd92306e14871d7febcbf947dd9c6e5",
+        "path": "org/apache/lucene/lucene-backward-codecs/5.5.5/lucene-backward-codecs-5.5.5.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-backward-codecs/8.11.1/lucene-backward-codecs-8.11.1.jar",
+        "hash": "38e72688eef81efffb9c5ea68918f4d1adb2eb0de64ce6a8222abee036eb63cf",
+        "path": "org/apache/lucene/lucene-backward-codecs/8.11.1/lucene-backward-codecs-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar",
+        "hash": "0628a26040706fea7a222a91c8ca339aef9ea8ceda6d24527a817dc7e0ad5c92",
+        "path": "org/apache/lucene/lucene-codecs/10.3.0/lucene-codecs-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar",
+        "hash": "9d70afe194568ca0328b7f762e64eb8094a5e5a76ea3a30b7182f0e7d5f0dd35",
+        "path": "org/apache/lucene/lucene-core/10.3.0/lucene-core-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-core/2.4.1/lucene-core-2.4.1.jar",
+        "hash": "b85d6c2a6b4c29e90fa7c5d94b21fe796f9c6857870268b56904765126bae718",
+        "path": "org/apache/lucene/lucene-core/2.4.1/lucene-core-2.4.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-core/5.5.5/lucene-core-5.5.5.jar",
+        "hash": "8d27a8ab4ee8883282d7713f067e72d1cfde1e88d0f5701a119100ec9e86d7e1",
+        "path": "org/apache/lucene/lucene-core/5.5.5/lucene-core-5.5.5.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-core/8.11.1/lucene-core-8.11.1.jar",
+        "hash": "78a61d0b843c1cf1fe5be380a4d3a4c1602d3fbba4ca1185da8797c9bb115483",
+        "path": "org/apache/lucene/lucene-core/8.11.1/lucene-core-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar",
+        "hash": "acbf67631c42197791363ce8e8f155f62aeef51ade809e0847a89eba44785c7d",
+        "path": "org/apache/lucene/lucene-highlighter/10.3.0/lucene-highlighter-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-highlighter/8.11.1/lucene-highlighter-8.11.1.jar",
+        "hash": "c8e92e01b7443b2fd1698ac7b260b632197175143e13f0364b6f7258b9447307",
+        "path": "org/apache/lucene/lucene-highlighter/8.11.1/lucene-highlighter-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar",
+        "hash": "ea77d0b2eb0b3e1f7fa04f2fbe671f5af3ae836cc40320411e195bdc9421f17b",
+        "path": "org/apache/lucene/lucene-memory/10.3.0/lucene-memory-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-memory/8.11.1/lucene-memory-8.11.1.jar",
+        "hash": "b948478fe2e8e7f94fa7f533a14a526720701fe98627214c93d924faa4be78de",
+        "path": "org/apache/lucene/lucene-memory/8.11.1/lucene-memory-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar",
+        "hash": "c0c5891b390759a0cf503c7864e6eb4d8447cc8df20806a4254bfdf3d2f43a91",
+        "path": "org/apache/lucene/lucene-queries/10.3.0/lucene-queries-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-queries/8.11.1/lucene-queries-8.11.1.jar",
+        "hash": "11fb2e90da5b4e6a6c26120bb80a2937a20a585d32236ed7c277048ba65f07ca",
+        "path": "org/apache/lucene/lucene-queries/8.11.1/lucene-queries-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar",
+        "hash": "b4b57bc3d56c5a1ccc674f55a16086c37700eb151fa749b45887e391ec0f26f9",
+        "path": "org/apache/lucene/lucene-queryparser/10.3.0/lucene-queryparser-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-queryparser/8.11.1/lucene-queryparser-8.11.1.jar",
+        "hash": "23abf022a19e609fe3ca421ab6b6868a3250974d31c5b92f9879d97c127a77b8",
+        "path": "org/apache/lucene/lucene-queryparser/8.11.1/lucene-queryparser-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar",
+        "hash": "00aa7be5c214bff31d62b489fbb5f0c389545e9f455324b2b92681956d37c94f",
+        "path": "org/apache/lucene/lucene-sandbox/10.3.0/lucene-sandbox-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-sandbox/8.11.1/lucene-sandbox-8.11.1.jar",
+        "hash": "28bee2711947cf3a9957f3f77132ce37457894c1fb468b0a20e9a95788b11c87",
+        "path": "org/apache/lucene/lucene-sandbox/8.11.1/lucene-sandbox-8.11.1.jar"
+    },
+    {
+        "url": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar",
+        "hash": "4b53bf7160e8cdf2ae6bf1a27018bb4fbfdb1841fbdad988c5ff71c7920f4a84",
+        "path": "org/apache/lucene/lucene-suggest/10.3.0/lucene-suggest-10.3.0.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar",
+        "hash": "112e06e6acc1405ad3ba518442e835d1d42758ef31f0bbbdb32aa1e15a17d10f",
+        "path": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar",
+        "hash": "112e06e6acc1405ad3ba518442e835d1d42758ef31f0bbbdb32aa1e15a17d10f",
+        "path": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar",
+        "hash": "112e06e6acc1405ad3ba518442e835d1d42758ef31f0bbbdb32aa1e15a17d10f",
+        "path": "org/apache/maven/archetype/archetype-catalog/2.2/archetype-catalog-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-catalog/3.2.1/archetype-catalog-3.2.1.jar",
+        "hash": "2aa061856e5e124facf7bf16831069015f98406969a7ba534e1ee557950d6680",
+        "path": "org/apache/maven/archetype/archetype-catalog/3.2.1/archetype-catalog-3.2.1.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar",
+        "hash": "3a00a78157a82fff778334764255642585127443e0b3da56bcdb6f8a0f910220",
+        "path": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar",
+        "hash": "3a00a78157a82fff778334764255642585127443e0b3da56bcdb6f8a0f910220",
+        "path": "org/apache/maven/archetype/archetype-common/2.2/archetype-common-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-common/3.2.1/archetype-common-3.2.1.jar",
+        "hash": "7816a7d7c9a5c64b77a7fd1ebe203a1ce92b924638dd2216f81ea5bcebea6abc",
+        "path": "org/apache/maven/archetype/archetype-common/3.2.1/archetype-common-3.2.1.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar",
+        "hash": "162ff0cc80445307de05f5e0ce9c014e8cd22cfbd2ed610ae39806e4592c5255",
+        "path": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar",
+        "hash": "162ff0cc80445307de05f5e0ce9c014e8cd22cfbd2ed610ae39806e4592c5255",
+        "path": "org/apache/maven/archetype/archetype-descriptor/2.2/archetype-descriptor-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar",
+        "hash": "cf9bb9e523696557c20bd4c7f41b6adda6074c4da85a7070af2facbab28afaca",
+        "path": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar",
+        "hash": "cf9bb9e523696557c20bd4c7f41b6adda6074c4da85a7070af2facbab28afaca",
+        "path": "org/apache/maven/archetype/archetype-registry/2.2/archetype-registry-2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/indexer/indexer-core/6.2.2/indexer-core-6.2.2.jar",
+        "hash": "7f69b1b75cc171ec37a9377cf590077c10b6153337236a7a766df70eb9ec7786",
+        "path": "org/apache/maven/indexer/indexer-core/6.2.2/indexer-core-6.2.2.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-aether-provider/3.0.5/maven-aether-provider-3.0.5.jar",
+        "hash": "c74327cd5d7b137c8be3591c766271ac8ace1a617518f0410b8a95579f9839b0",
+        "path": "org/apache/maven/maven-aether-provider/3.0.5/maven-aether-provider-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
+        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
+        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
+        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
+        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
+        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
+        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar",
+        "hash": "f46962583d812cd4459a4cc963113b9c52f1f9b169172354693bc9efa0b3e3cb",
+        "path": "org/apache/maven/maven-aether-provider/3.3.9/maven-aether-provider-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-annotations/4.0.0-rc-4/maven-api-annotations-4.0.0-rc-4.jar",
+        "hash": "2937b37475450e47e1d9175733d6a1af8aa816889c2165e1a1bfc80461c66908",
+        "path": "org/apache/maven/maven-api-annotations/4.0.0-rc-4/maven-api-annotations-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-cli/4.0.0-rc-4/maven-api-cli-4.0.0-rc-4.jar",
+        "hash": "f019911b55edef8d2fd0770601cabd45b439b7833dc3e7cfc2922c9118993dea",
+        "path": "org/apache/maven/maven-api-cli/4.0.0-rc-4/maven-api-cli-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-core/4.0.0-rc-4/maven-api-core-4.0.0-rc-4.jar",
+        "hash": "ba5a77673592e9092247b08cf38b1069c03d31b9ac79bda81d08fb175f32964d",
+        "path": "org/apache/maven/maven-api-core/4.0.0-rc-4/maven-api-core-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-di/4.0.0-rc-4/maven-api-di-4.0.0-rc-4.jar",
+        "hash": "43a19d3d5f852fbd39f0da6b92e678c68648ae78c2e4b815a9de07be944c7c39",
+        "path": "org/apache/maven/maven-api-di/4.0.0-rc-4/maven-api-di-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-metadata/4.0.0-rc-4/maven-api-metadata-4.0.0-rc-4.jar",
+        "hash": "96eb305694b66dd7717f35b284122f4762c802a70da2d89e4ead82be5ea51ad0",
+        "path": "org/apache/maven/maven-api-metadata/4.0.0-rc-4/maven-api-metadata-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-model/4.0.0-rc-4/maven-api-model-4.0.0-rc-4.jar",
+        "hash": "74b6c10ba09f457a8130534e34dc3824aeacbc4767943a533b5ab88efb2f1359",
+        "path": "org/apache/maven/maven-api-model/4.0.0-rc-4/maven-api-model-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-plugin/4.0.0-rc-4/maven-api-plugin-4.0.0-rc-4.jar",
+        "hash": "f72e30329c609814745fc29a2ea3803f03a0312985b152e896af3b692b6eb08a",
+        "path": "org/apache/maven/maven-api-plugin/4.0.0-rc-4/maven-api-plugin-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-settings/4.0.0-rc-4/maven-api-settings-4.0.0-rc-4.jar",
+        "hash": "30d7850abf5bb66902a55c98041edccc50c85dfdbeac3abfd0f5febd2009f638",
+        "path": "org/apache/maven/maven-api-settings/4.0.0-rc-4/maven-api-settings-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-spi/4.0.0-rc-4/maven-api-spi-4.0.0-rc-4.jar",
+        "hash": "46b495fa82b53622aed8e2c1ac9b8b180c21abca6b620a536386917ccf7c0950",
+        "path": "org/apache/maven/maven-api-spi/4.0.0-rc-4/maven-api-spi-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-toolchain/4.0.0-rc-4/maven-api-toolchain-4.0.0-rc-4.jar",
+        "hash": "6e9132f8f32764692236e491eafa6c5ff14f0ed4ccf339fc20e3103f01f01076",
+        "path": "org/apache/maven/maven-api-toolchain/4.0.0-rc-4/maven-api-toolchain-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-api-xml/4.0.0-rc-4/maven-api-xml-4.0.0-rc-4.jar",
+        "hash": "a4c1edd5846995fde7bf068b9303bf0949d3cee60cf8a4b0ac385d8d3b3c2eed",
+        "path": "org/apache/maven/maven-api-xml/4.0.0-rc-4/maven-api-xml-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar",
+        "hash": "c6d5e244dd2329971f91b8df666ffe9e0b00a7dd014d6ee073b6f6cb82877f5c",
+        "path": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar",
+        "hash": "c6d5e244dd2329971f91b8df666ffe9e0b00a7dd014d6ee073b6f6cb82877f5c",
+        "path": "org/apache/maven/maven-artifact/3.0.5/maven-artifact-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
+        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
+        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
+        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
+        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
+        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
+        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar",
+        "hash": "1f702928f2233c6ecdf308fbd8f2932ea287c7062183d3c8364b0db7e9c4445d",
+        "path": "org/apache/maven/maven-artifact/3.3.9/maven-artifact-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
+        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
+        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
+        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
+        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
+        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
+        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar",
+        "hash": "3d5a0e77cde76d386b18c7400db1eb16aacef02e031ecd0d954477aeccc92155",
+        "path": "org/apache/maven/maven-artifact/3.6.0/maven-artifact-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.8.3/maven-artifact-3.8.3.jar",
+        "hash": "be0e20f86b22835a49a355de8912260dff0a7cd47c4605506cd286ed25a34508",
+        "path": "org/apache/maven/maven-artifact/3.8.3/maven-artifact-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/3.9.9/maven-artifact-3.9.9.jar",
+        "hash": "30f015d1c1a393e19c18cd4f43532089c36d4ca328608ce3dda78b74d3d31515",
+        "path": "org/apache/maven/maven-artifact/3.9.9/maven-artifact-3.9.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-artifact/4.0.0-rc-4/maven-artifact-4.0.0-rc-4.jar",
+        "hash": "257548f12bdbc89e0b0c7e0aaf76765f26ef2b114fcb650a2eea19bd46593419",
+        "path": "org/apache/maven/maven-artifact/4.0.0-rc-4/maven-artifact-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
+        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
+        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
+        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
+        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
+        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
+        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar",
+        "hash": "462a0d711a979c44791b97422ec4e91300ae555a598f684f116d725a2b9d297b",
+        "path": "org/apache/maven/maven-builder-support/3.3.9/maven-builder-support-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
+        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
+        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
+        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
+        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
+        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
+        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar",
+        "hash": "56affafea9c76168bbc5b8ee9d26dd2dbe95b8185b70d6b2a46dd9fc39d0dd53",
+        "path": "org/apache/maven/maven-builder-support/3.6.0/maven-builder-support-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.8.3/maven-builder-support-3.8.3.jar",
+        "hash": "b2e17c30158bcabad967c29ccc4f2c4e10065b03eedefdb1d8f901ddd3d12ca5",
+        "path": "org/apache/maven/maven-builder-support/3.8.3/maven-builder-support-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/3.9.9/maven-builder-support-3.9.9.jar",
+        "hash": "2ca4a967bdd12a9e85d40e012374f86e63d4a1030c199da4832e3d0a1c6770d8",
+        "path": "org/apache/maven/maven-builder-support/3.9.9/maven-builder-support-3.9.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-builder-support/4.0.0-rc-4/maven-builder-support-4.0.0-rc-4.jar",
+        "hash": "13faeb8b8bbfe402c376e326b89c9d27c927d94ac79424cbfb1141cc71656b5d",
+        "path": "org/apache/maven/maven-builder-support/4.0.0-rc-4/maven-builder-support-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-cli/4.0.0-rc-4/maven-cli-4.0.0-rc-4.jar",
+        "hash": "1628cf47fda9fde0e0d012a5020bedace2cecae7f4a216315e7e6001b2a1bf94",
+        "path": "org/apache/maven/maven-cli/4.0.0-rc-4/maven-cli-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar",
+        "hash": "2653f603b4aa7b521d8ad850c88a34dafd64aa79d7650399daa719de71cd1329",
+        "path": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar",
+        "hash": "2653f603b4aa7b521d8ad850c88a34dafd64aa79d7650399daa719de71cd1329",
+        "path": "org/apache/maven/maven-compat/3.3.9/maven-compat-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar",
+        "hash": "8f1a5d4daff952dabeb3acaa0aa642903702a1aa8b442fcd7a07a8cf9e3db48b",
+        "path": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar",
+        "hash": "8f1a5d4daff952dabeb3acaa0aa642903702a1aa8b442fcd7a07a8cf9e3db48b",
+        "path": "org/apache/maven/maven-compat/3.6.0/maven-compat-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.0.5/maven-core-3.0.5.jar",
+        "hash": "ac8e617f951ecde3c4f6bca4922fdd7861500fe7d58289f26ad5adac443075bc",
+        "path": "org/apache/maven/maven-core/3.0.5/maven-core-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
+        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
+        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
+        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
+        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
+        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
+        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar",
+        "hash": "070d55ec5a6f3e4a785564283a9704bb39a93f1a2f89cdf60a3b899fde563bf9",
+        "path": "org/apache/maven/maven-core/3.3.9/maven-core-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
+        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
+        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
+        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
+        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
+        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
+        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar",
+        "hash": "c7611780b8456e2b29284b8c0d37cdd5358facdc1091d64ab46a2feddd2cb6ae",
+        "path": "org/apache/maven/maven-core/3.6.0/maven-core-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/3.8.3/maven-core-3.8.3.jar",
+        "hash": "4b518631aa5bda90a90ef122fba5288438bbf160fcd628246638092fe3050e10",
+        "path": "org/apache/maven/maven-core/3.8.3/maven-core-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-core/4.0.0-rc-4/maven-core-4.0.0-rc-4.jar",
+        "hash": "ede5d3c2f31ca66769810b245bbdd524627b14c93cbc3d04e934aa9c033373f9",
+        "path": "org/apache/maven/maven-core/4.0.0-rc-4/maven-core-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-di/4.0.0-rc-4/maven-di-4.0.0-rc-4.jar",
+        "hash": "42b3b68b71a796d55381452f676c99176d1b4e4d5d2d28b6ba14dd2027c97bf3",
+        "path": "org/apache/maven/maven-di/4.0.0-rc-4/maven-di-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-embedder/3.3.9/maven-embedder-3.3.9.jar",
+        "hash": "6e1736c08f9798ed74efcdcdc435c640aca08af9b8c268dd7ea8ee8a3fef30a6",
+        "path": "org/apache/maven/maven-embedder/3.3.9/maven-embedder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-embedder/3.6.0/maven-embedder-3.6.0.jar",
+        "hash": "e41b031c1e5bc23dc94b67f678644d549b15461361789d592c54cc3939829945",
+        "path": "org/apache/maven/maven-embedder/3.6.0/maven-embedder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-embedder/4.0.0-rc-4/maven-embedder-4.0.0-rc-4.jar",
+        "hash": "e7ade06969b92d91941ff57d2d31eae2cf392cd7bcfa848d052859e523a581a2",
+        "path": "org/apache/maven/maven-embedder/4.0.0-rc-4/maven-embedder-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-impl/4.0.0-rc-4/maven-impl-4.0.0-rc-4.jar",
+        "hash": "a78370c3e52ef07a5fa1853bc0c6f4a54b0423d19b96b81880ed0bf047e8fdf5",
+        "path": "org/apache/maven/maven-impl/4.0.0-rc-4/maven-impl-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-jline/4.0.0-rc-4/maven-jline-4.0.0-rc-4.jar",
+        "hash": "5d431c9308cf60f4fbed6cb9a3e1c2b6b7b22318e0d9d5f4f53c8dcb40a77fcd",
+        "path": "org/apache/maven/maven-jline/4.0.0-rc-4/maven-jline-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-logging/4.0.0-rc-4/maven-logging-4.0.0-rc-4.jar",
+        "hash": "7284d8c4b0e2cb1e6becaf9877d590e6375278936a1dfcb78dc2f3f0e67d81b0",
+        "path": "org/apache/maven/maven-logging/4.0.0-rc-4/maven-logging-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.0.5/maven-model-builder-3.0.5.jar",
+        "hash": "45a2c6ff76e12678eaf576bd7a68d028c5a5ba85fdc216a381ea86e9187e1b51",
+        "path": "org/apache/maven/maven-model-builder/3.0.5/maven-model-builder-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
+        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
+        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
+        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
+        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
+        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
+        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar",
+        "hash": "6909cb229489e693df7960678528800a1759625835a1cb939c37b051c22193c3",
+        "path": "org/apache/maven/maven-model-builder/3.3.9/maven-model-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
+        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
+        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
+        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
+        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
+        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
+        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar",
+        "hash": "a7295f062b54d0cbd513ffbb6d21c9bc9e21d9904547f299831236a988e50ab3",
+        "path": "org/apache/maven/maven-model-builder/3.6.0/maven-model-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.8.3/maven-model-builder-3.8.3.jar",
+        "hash": "bb2baf84e3d6c584681220947160e6d53c2bca34208c0295bdc74ab4233d396c",
+        "path": "org/apache/maven/maven-model-builder/3.8.3/maven-model-builder-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/3.9.9/maven-model-builder-3.9.9.jar",
+        "hash": "a4377182ac2e5adfe16be3b3c81981a5ecddab014184de72ae1e522f04a77602",
+        "path": "org/apache/maven/maven-model-builder/3.9.9/maven-model-builder-3.9.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model-builder/4.0.0-rc-4/maven-model-builder-4.0.0-rc-4.jar",
+        "hash": "71ed7f3e049ef331f8cd10dc83fc53ee9e37c8b20da37e2f12987e85e4683671",
+        "path": "org/apache/maven/maven-model-builder/4.0.0-rc-4/maven-model-builder-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.0.5/maven-model-3.0.5.jar",
+        "hash": "876a76b663db6c7326ad234afe430c473d3261a06b3284f31d5eb4889d1c3084",
+        "path": "org/apache/maven/maven-model/3.0.5/maven-model-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
+        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
+        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
+        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
+        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
+        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
+        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar",
+        "hash": "15abde67fa7ea1e573e1f68c34921e995f0971351aaf1fb96790688ff510efcd",
+        "path": "org/apache/maven/maven-model/3.3.9/maven-model-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
+        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
+        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
+        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
+        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
+        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
+        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar",
+        "hash": "a1bf0c7856afd1f1b9c81c22818328fb7a796b4047010e08f2e859d1896080a9",
+        "path": "org/apache/maven/maven-model/3.6.0/maven-model-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.8.3/maven-model-3.8.3.jar",
+        "hash": "a5ce7648e89403e3b45a951648ee10d934b869001048ef05327be412860b50c5",
+        "path": "org/apache/maven/maven-model/3.8.3/maven-model-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.8.5/maven-model-3.8.5.jar",
+        "hash": "7c9eeb30ac1941ea9bdf76c08c162ed98c005913e5bff66de3f1027a304546dc",
+        "path": "org/apache/maven/maven-model/3.8.5/maven-model-3.8.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/3.9.9/maven-model-3.9.9.jar",
+        "hash": "8f59b0a16fe9c933be749a60ae0705a0cb337bb5abaf38801b40b740ff775727",
+        "path": "org/apache/maven/maven-model/3.9.9/maven-model-3.9.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-model/4.0.0-rc-4/maven-model-4.0.0-rc-4.jar",
+        "hash": "6406a14c084bd991cf25e145a2a4223c27367685442f9c86fae372bbafa93a72",
+        "path": "org/apache/maven/maven-model/4.0.0-rc-4/maven-model-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.0.5/maven-plugin-api-3.0.5.jar",
+        "hash": "469505f75b8526a338cfd7e0ec841655ae52ddbcc1b36482e97d72f52ce7d890",
+        "path": "org/apache/maven/maven-plugin-api/3.0.5/maven-plugin-api-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
+        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
+        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
+        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
+        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
+        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
+        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar",
+        "hash": "14cae18fd7125901b12fc914e30ea26ad9bd43dbd399dd6e8fcbc6c754ef2c9c",
+        "path": "org/apache/maven/maven-plugin-api/3.3.9/maven-plugin-api-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
+        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
+        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
+        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
+        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
+        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
+        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar",
+        "hash": "0062a08b463314a1b5f8eb1a56207efb830fbdf547c42a3191eb146c4db39b1a",
+        "path": "org/apache/maven/maven-plugin-api/3.6.0/maven-plugin-api-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/3.8.3/maven-plugin-api-3.8.3.jar",
+        "hash": "be2e329e86e7547d66d18fb206a2f8e06363774647aaf7da776cc19f589a0d4d",
+        "path": "org/apache/maven/maven-plugin-api/3.8.3/maven-plugin-api-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-plugin-api/4.0.0-rc-4/maven-plugin-api-4.0.0-rc-4.jar",
+        "hash": "b417dfdf78ae03e9f956f1c2826c253dc57169158478c0500e2d845fa094d86d",
+        "path": "org/apache/maven/maven-plugin-api/4.0.0-rc-4/maven-plugin-api-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.0.5/maven-repository-metadata-3.0.5.jar",
+        "hash": "c867b4e075a4548bf27422542f96b159f94c4e7ffaaf6427b10433afd6a3a38c",
+        "path": "org/apache/maven/maven-repository-metadata/3.0.5/maven-repository-metadata-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
+        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
+        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
+        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
+        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
+        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
+        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar",
+        "hash": "6dbcc3d3d1dfb34df46c1ddb080fdd09fb899c80207016419cf13236c6b10399",
+        "path": "org/apache/maven/maven-repository-metadata/3.3.9/maven-repository-metadata-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
+        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
+        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
+        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
+        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
+        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
+        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar",
+        "hash": "21702a5beccf3731ecdd6ed87f8fd0ae2bb7856b12fe91585b5513840722b0c3",
+        "path": "org/apache/maven/maven-repository-metadata/3.6.0/maven-repository-metadata-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.8.3/maven-repository-metadata-3.8.3.jar",
+        "hash": "bb01f1d30929db0d8ab4bbce0e3ed3a924fa1c22dd0dc26b0ff7e39a067c2f8d",
+        "path": "org/apache/maven/maven-repository-metadata/3.8.3/maven-repository-metadata-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/3.9.9/maven-repository-metadata-3.9.9.jar",
+        "hash": "137c297e6a52d489b76663c82324d54e40f5d498a8fc015c0203fd91df8623b0",
+        "path": "org/apache/maven/maven-repository-metadata/3.9.9/maven-repository-metadata-3.9.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-repository-metadata/4.0.0-rc-4/maven-repository-metadata-4.0.0-rc-4.jar",
+        "hash": "9cfdc674b846ecb95c26231998952af372e27cb151f75c9e628a4590fa66d8cc",
+        "path": "org/apache/maven/maven-repository-metadata/4.0.0-rc-4/maven-repository-metadata-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
+        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
+        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
+        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
+        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
+        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
+        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar",
+        "hash": "3e7d265ef4e9ade0f5de998961c6cac634cbf3fbdb839bb50a3a50b2ffbba7f8",
+        "path": "org/apache/maven/maven-resolver-provider/3.6.0/maven-resolver-provider-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-resolver-provider/3.8.3/maven-resolver-provider-3.8.3.jar",
+        "hash": "9f7a733bc6a8c91265c669e8a268e7800578cd43e1435088e07d73a9b067d1be",
+        "path": "org/apache/maven/maven-resolver-provider/3.8.3/maven-resolver-provider-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-resolver-provider/3.9.9/maven-resolver-provider-3.9.9.jar",
+        "hash": "5dea05049c94f952f48ce2bfe0111afdf986acc591fcc11d23fe3b8dcb70291e",
+        "path": "org/apache/maven/maven-resolver-provider/3.9.9/maven-resolver-provider-3.9.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.0.5/maven-settings-builder-3.0.5.jar",
+        "hash": "ac0e62e26b7f690e265ba75667531973b8a2da12b3b0ff102a612f05b42b6faf",
+        "path": "org/apache/maven/maven-settings-builder/3.0.5/maven-settings-builder-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
+        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
+        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
+        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
+        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
+        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
+        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar",
+        "hash": "b4da54d52e2996a8a77c4db1ca8e98fc31792f07eeff695776f00ecffc3d5b60",
+        "path": "org/apache/maven/maven-settings-builder/3.3.9/maven-settings-builder-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
+        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
+        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
+        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
+        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
+        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
+        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar",
+        "hash": "271a82555c399d9b06c7751a802c3b919081a06b7c9b839bd70e93ea2df386e3",
+        "path": "org/apache/maven/maven-settings-builder/3.6.0/maven-settings-builder-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/3.8.3/maven-settings-builder-3.8.3.jar",
+        "hash": "6c93c6336365e59841f4b879d08e027ba8f853f83889e2b374ced4de9c667749",
+        "path": "org/apache/maven/maven-settings-builder/3.8.3/maven-settings-builder-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings-builder/4.0.0-rc-4/maven-settings-builder-4.0.0-rc-4.jar",
+        "hash": "2d514a00ba75d149eee91c6be3db55721a0d7c1d6d8aca786df79e49aa60e355",
+        "path": "org/apache/maven/maven-settings-builder/4.0.0-rc-4/maven-settings-builder-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.0.5/maven-settings-3.0.5.jar",
+        "hash": "d8f9f237afc21d8202eedffa29cbf6e9d46c78b3c22b217d16267216988221b9",
+        "path": "org/apache/maven/maven-settings/3.0.5/maven-settings-3.0.5.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
+        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
+        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
+        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
+        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
+        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
+        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar",
+        "hash": "e4f569be53a076424e784222e7088f1827fcb2ef18d409132b3cda2fd92799e2",
+        "path": "org/apache/maven/maven-settings/3.3.9/maven-settings-3.3.9.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
+        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
+        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
+        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
+        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
+        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
+        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar",
+        "hash": "053655dc2890f119cb13ddb90b1888b9cfcf1cea3a374c0656d53595b4f37542",
+        "path": "org/apache/maven/maven-settings/3.6.0/maven-settings-3.6.0.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/3.8.3/maven-settings-3.8.3.jar",
+        "hash": "5a80a24569a0eb383b4da05ea1d306b37753ae111e833bef3a2585c78555e0e0",
+        "path": "org/apache/maven/maven-settings/3.8.3/maven-settings-3.8.3.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-settings/4.0.0-rc-4/maven-settings-4.0.0-rc-4.jar",
+        "hash": "f321dbde8f05187da1e1433f1f9f1a63e4ba93a25cfceed1969e7b23538817bb",
+        "path": "org/apache/maven/maven-settings/4.0.0-rc-4/maven-settings-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-support/4.0.0-rc-4/maven-support-4.0.0-rc-4.jar",
+        "hash": "3ce9be1890a4bcc8098c5f371f5b2106896e8d74b34266f6bc638c7cfb68e0e4",
+        "path": "org/apache/maven/maven-support/4.0.0-rc-4/maven-support-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-toolchain-builder/4.0.0-rc-4/maven-toolchain-builder-4.0.0-rc-4.jar",
+        "hash": "5be595d6457b69f9077bd94146b6ba74b46608fc7ceb32b5e977fd5dceadb476",
+        "path": "org/apache/maven/maven-toolchain-builder/4.0.0-rc-4/maven-toolchain-builder-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-toolchain-model/4.0.0-rc-4/maven-toolchain-model-4.0.0-rc-4.jar",
+        "hash": "800d06d1829ab661f39d940edd927da94c98e46d7c90899224ab521fad0bf55e",
+        "path": "org/apache/maven/maven-toolchain-model/4.0.0-rc-4/maven-toolchain-model-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/maven-xml/4.0.0-rc-4/maven-xml-4.0.0-rc-4.jar",
+        "hash": "0dc3833441ffdbd9f4e0b3f95a52f3ee1189c22f3125cc8a72ed68036abb36ea",
+        "path": "org/apache/maven/maven-xml/4.0.0-rc-4/maven-xml-4.0.0-rc-4.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
+        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
+        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
+        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
+        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
+        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
+        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar",
+        "hash": "6be437d670dffa24bac4187bc1567c34fab04fc569836f8b45b9d79cbfd493ea",
+        "path": "org/apache/maven/resolver/maven-resolver-api/1.3.1/maven-resolver-api-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.jar",
+        "hash": "d0b28ed944058ba4f9be4b54c25d6d5269cc4f3f3c49aa450d4dc2f7e0d552f6",
+        "path": "org/apache/maven/resolver/maven-resolver-api/1.6.3/maven-resolver-api-1.6.3.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/1.8.0/maven-resolver-api-1.8.0.jar",
+        "hash": "5c9df7e7f6122172d5d27ce3efb2bc58fc7f423c2fb7468bf75315d742ebb181",
+        "path": "org/apache/maven/resolver/maven-resolver-api/1.8.0/maven-resolver-api-1.8.0.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/1.9.22/maven-resolver-api-1.9.22.jar",
+        "hash": "63f5f665e44a09ef55463b3b91fda0b78ff07dd24b1060d56e79c10b6e32cbfb",
+        "path": "org/apache/maven/resolver/maven-resolver-api/1.9.22/maven-resolver-api-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-api/2.0.9/maven-resolver-api-2.0.9.jar",
+        "hash": "a0d83f087c27c57409690a0b2bf499908e17cae6d7e175e294476c9c7f4d9da7",
+        "path": "org/apache/maven/resolver/maven-resolver-api/2.0.9/maven-resolver-api-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-connector-basic/1.9.22/maven-resolver-connector-basic-1.9.22.jar",
+        "hash": "4ab68bdec97eec318b2a3bd27e7c954e316f890df92d544b68afd0bf666c9588",
+        "path": "org/apache/maven/resolver/maven-resolver-connector-basic/1.9.22/maven-resolver-connector-basic-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-connector-basic/2.0.9/maven-resolver-connector-basic-2.0.9.jar",
+        "hash": "544fcbcf39a7084881942bb3bc1f50d3af35eeabfa387f0fbe36965a3f70bd6f",
+        "path": "org/apache/maven/resolver/maven-resolver-connector-basic/2.0.9/maven-resolver-connector-basic-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
+        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
+        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
+        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
+        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
+        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
+        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar",
+        "hash": "aaa41b53ed4fcc13b3d719d85f45b0fba21ee026dd4b625dd82210a28ee8e2fe",
+        "path": "org/apache/maven/resolver/maven-resolver-impl/1.3.1/maven-resolver-impl-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.jar",
+        "hash": "17aaebe6e3e59df8cb5b4ec210196f7084637312b9bc4ff14cb77ad1ae3c381b",
+        "path": "org/apache/maven/resolver/maven-resolver-impl/1.6.3/maven-resolver-impl-1.6.3.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-impl/1.9.22/maven-resolver-impl-1.9.22.jar",
+        "hash": "e4dafb8acc13d736377c02d2170d869438dd74b98b860745909d238726babcbb",
+        "path": "org/apache/maven/resolver/maven-resolver-impl/1.9.22/maven-resolver-impl-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-impl/2.0.9/maven-resolver-impl-2.0.9.jar",
+        "hash": "dec26e3df2ce3f8d9d830c6fa88418c369dcac5b1aee43bfbf022ad2435e8109",
+        "path": "org/apache/maven/resolver/maven-resolver-impl/2.0.9/maven-resolver-impl-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-named-locks/1.9.22/maven-resolver-named-locks-1.9.22.jar",
+        "hash": "0685f29ec3b548d9b6917c527f13c667685a3394b955aaa5b25d0559818b7fc5",
+        "path": "org/apache/maven/resolver/maven-resolver-named-locks/1.9.22/maven-resolver-named-locks-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-named-locks/2.0.9/maven-resolver-named-locks-2.0.9.jar",
+        "hash": "3fb465f80c5a6328e88348edc30f44b43a239290b8023b70ddbe9d79897dae1b",
+        "path": "org/apache/maven/resolver/maven-resolver-named-locks/2.0.9/maven-resolver-named-locks-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
+        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
+        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
+        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
+        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
+        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
+        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar",
+        "hash": "d4d15a6d473d78608412818c091b3c01d37bdf4f0e453156a19724af843a03ea",
+        "path": "org/apache/maven/resolver/maven-resolver-spi/1.3.1/maven-resolver-spi-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.jar",
+        "hash": "17441a39045ac19bc4a8068fb7284facebf6337754bf2bf8f26a76b5f98ed108",
+        "path": "org/apache/maven/resolver/maven-resolver-spi/1.6.3/maven-resolver-spi-1.6.3.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-spi/1.9.22/maven-resolver-spi-1.9.22.jar",
+        "hash": "99ad721e4631d9bd0c4f9e29c869672577c66f2a674a5723ce38eff13c75cbfd",
+        "path": "org/apache/maven/resolver/maven-resolver-spi/1.9.22/maven-resolver-spi-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-spi/2.0.9/maven-resolver-spi-2.0.9.jar",
+        "hash": "cd4082fcd9036145a9d5c8d6942ed72ed4ed3655e2651fcbdf3dd7924eb86c4a",
+        "path": "org/apache/maven/resolver/maven-resolver-spi/2.0.9/maven-resolver-spi-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-transport-file/1.9.22/maven-resolver-transport-file-1.9.22.jar",
+        "hash": "4f2a857d8b832494bae9ef6d7db7bb8409378b28aabd3615f03faebe42a4ad1d",
+        "path": "org/apache/maven/resolver/maven-resolver-transport-file/1.9.22/maven-resolver-transport-file-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-transport-file/2.0.9/maven-resolver-transport-file-2.0.9.jar",
+        "hash": "4128a85241aa9809d4f63508c668ec5ab5d1d8e810393f2cebe6e3411e6699ee",
+        "path": "org/apache/maven/resolver/maven-resolver-transport-file/2.0.9/maven-resolver-transport-file-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-transport-http/1.9.22/maven-resolver-transport-http-1.9.22.jar",
+        "hash": "1cf2a88c984e0eae8b3f13e1eec904eedead2f076d1f3c1d5cb5103a21538bd1",
+        "path": "org/apache/maven/resolver/maven-resolver-transport-http/1.9.22/maven-resolver-transport-http-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-transport-jdk/2.0.9/maven-resolver-transport-jdk-2.0.9.jar",
+        "hash": "6bcfea0808e2693b67a66f23f0e9a9b7b28302465913fa12f27d787f7d34af81",
+        "path": "org/apache/maven/resolver/maven-resolver-transport-jdk/2.0.9/maven-resolver-transport-jdk-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
+        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
+        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
+        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
+        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
+        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
+        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar",
+        "hash": "a7c2d81cd7d6df38e2997bf09507e0bca6fa85dfb635de4bf28a7c501cb574f4",
+        "path": "org/apache/maven/resolver/maven-resolver-util/1.3.1/maven-resolver-util-1.3.1.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.jar",
+        "hash": "cdcad9355b625743f40e4cead9a96353404e010c39c808d23b044be331afa251",
+        "path": "org/apache/maven/resolver/maven-resolver-util/1.6.3/maven-resolver-util-1.6.3.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/1.8.0/maven-resolver-util-1.8.0.jar",
+        "hash": "3468ec7ca9ee97878e61f26905546cdd709de778b8884777516a1af2d4a32e4e",
+        "path": "org/apache/maven/resolver/maven-resolver-util/1.8.0/maven-resolver-util-1.8.0.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/1.9.22/maven-resolver-util-1.9.22.jar",
+        "hash": "4aaea1584c39294ca926fc474723d9684473609ef4490c4eb169d6ea7daca6b5",
+        "path": "org/apache/maven/resolver/maven-resolver-util/1.9.22/maven-resolver-util-1.9.22.jar"
+    },
+    {
+        "url": "org/apache/maven/resolver/maven-resolver-util/2.0.9/maven-resolver-util-2.0.9.jar",
+        "hash": "cb5b9ce3436e8db86705c8f3f38ba4ce2ce0cb753e34fb8a337da647cce95742",
+        "path": "org/apache/maven/resolver/maven-resolver-util/2.0.9/maven-resolver-util-2.0.9.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar",
+        "hash": "dbb8c53ccc0b16a9dd8370d6e7de63102468caedac1e5fa2eb418319a6875293",
+        "path": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar",
+        "hash": "dbb8c53ccc0b16a9dd8370d6e7de63102468caedac1e5fa2eb418319a6875293",
+        "path": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar",
+        "hash": "dbb8c53ccc0b16a9dd8370d6e7de63102468caedac1e5fa2eb418319a6875293",
+        "path": "org/apache/maven/shared/maven-dependency-tree/1.2/maven-dependency-tree-1.2.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
+        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
+        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
+        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar",
+        "hash": "3ba9c619893c767db0f9c3e826d5118b57c35229301bcd16d865a89cec16a7e5",
+        "path": "org/apache/maven/shared/maven-shared-utils/3.2.1/maven-shared-utils-3.2.1.jar"
+    },
+    {
+        "url": "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar",
+        "hash": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda",
+        "path": "org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar"
+    },
+    {
+        "url": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar",
+        "hash": "930b2e409513be03864d7a66e22dfdf5c086725e22ba3cf57ad45ed8af02996d",
+        "path": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar"
+    },
+    {
+        "url": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar",
+        "hash": "930b2e409513be03864d7a66e22dfdf5c086725e22ba3cf57ad45ed8af02996d",
+        "path": "org/apache/maven/wagon/wagon-provider-api/2.10/wagon-provider-api-2.10.jar"
+    },
+    {
+        "url": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar",
+        "hash": "21beff005c5b5754911b85f3a60480341b29a2faf1cf3b56260e6b646081a54f",
+        "path": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar"
+    },
+    {
+        "url": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar",
+        "hash": "21beff005c5b5754911b85f3a60480341b29a2faf1cf3b56260e6b646081a54f",
+        "path": "org/apache/maven/wagon/wagon-provider-api/3.2.0/wagon-provider-api-3.2.0.jar"
+    },
+    {
+        "url": "org/apache/maven/wagon/wagon-provider-api/3.5.2/wagon-provider-api-3.5.2.jar",
+        "hash": "c7daff38f15c754f609854a01365ced5ad182b5e12d88a6f6ad534c030147cca",
+        "path": "org/apache/maven/wagon/wagon-provider-api/3.5.2/wagon-provider-api-3.5.2.jar"
+    },
+    {
+        "url": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar",
+        "hash": "3c8a183f81e176d9c452c9bb94007574bc8188446b4fc98b527aa79074cd0dda",
+        "path": "org/apache/sshd/sshd-osgi/2.15.0/sshd-osgi-2.15.0.jar"
+    },
+    {
+        "url": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar",
+        "hash": "2b6e6550b40467ede7b3034a1a9eb9148fbf920cfdae5bf0b1d2bb3d4e780625",
+        "path": "org/apache/thrift/libthrift/0.19.0/libthrift-0.19.0.jar"
+    },
+    {
+        "url": "org/apache/velocity/velocity-engine-core/2.3/velocity-engine-core-2.3.jar",
+        "hash": "b086cee8fd8183e240b4afcf54fe38ec33dd8eb0da414636e5bf7aa4d9856629",
+        "path": "org/apache/velocity/velocity-engine-core/2.3/velocity-engine-core-2.3.jar"
+    },
+    {
+        "url": "org/apache/ws/xmlrpc/xmlrpc/2.0.1/xmlrpc-2.0.1.jar",
+        "hash": "36efda6efee96e83602c9ba246db19bf4c5e733324390d2fa8213417d6b681e7",
+        "path": "org/apache/ws/xmlrpc/xmlrpc/2.0.1/xmlrpc-2.0.1.jar"
+    },
+    {
+        "url": "org/apache/xmlbeans/xmlbeans/5.1.1/xmlbeans-5.1.1.jar",
+        "hash": "5f484a78bed71cbffe3709678b6bdd3463781a7c61c6d9872330aecbf150762a",
+        "path": "org/apache/xmlbeans/xmlbeans/5.1.1/xmlbeans-5.1.1.jar"
+    },
+    {
+        "url": "org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar",
+        "hash": "a9aae9ff8ae3e17a2a18f79175e82b16267c246fbbd3ca9dfbbb290b08dcfdd4",
+        "path": "org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar"
+    },
+    {
+        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
+        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+    },
+    {
+        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
+        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+    },
+    {
+        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
+        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+    },
+    {
+        "url": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar",
+        "hash": "b509448ac506d607319f182537f0b35d71007582ec741832a1f111e5b5b70b38",
+        "path": "org/apiguardian/apiguardian-api/1.1.2/apiguardian-api-1.1.2.jar"
+    },
+    {
+        "url": "org/assertj/assertj-core/3.17.2/assertj-core-3.17.2.jar",
+        "hash": "d9a978d559d0b52a87f419b3d8f5bb137b97c661f7be2134e0498b454e4b980e",
+        "path": "org/assertj/assertj-core/3.17.2/assertj-core-3.17.2.jar"
+    },
+    {
+        "url": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar",
+        "hash": "03852ab5b4419c1b0b3689930cdc1ac4f0c437a0c8094a900370dcb170cfbb46",
+        "path": "org/assertj/assertj-core/4.0.0-M1/assertj-core-4.0.0-M1.jar"
+    },
+    {
+        "url": "org/assertj/assertj-swing-junit/3.17.1/assertj-swing-junit-3.17.1.jar",
+        "hash": "e56fea51b7969240460d027a17f1c704b43e4eeca49a8c57206d573da3e30871",
+        "path": "org/assertj/assertj-swing-junit/3.17.1/assertj-swing-junit-3.17.1.jar"
+    },
+    {
+        "url": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar",
+        "hash": "e36445438d72d83cc48015dcb3f14d9a97eaa42c4663a9826db2bb50e4c7713b",
+        "path": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar"
+    },
+    {
+        "url": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar",
+        "hash": "e36445438d72d83cc48015dcb3f14d9a97eaa42c4663a9826db2bb50e4c7713b",
+        "path": "org/assertj/assertj-swing/3.17.1/assertj-swing-3.17.1.jar"
+    },
+    {
+        "url": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar",
+        "hash": "ac0192fd110a0363732b17ea94fd1ce8cfd85790c8e1551e14f866908b5d80e1",
+        "path": "org/atteo/evo-inflector/1.3/evo-inflector-1.3.jar"
+    },
+    {
+        "url": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar",
+        "hash": "4b9fb2e5a13b37cf8bd62eebada8d3485c3dc17df752783b68d89d657bcc01fd",
+        "path": "org/bidib/com/github/markusbernhardt/proxy-vole/1.1.6/proxy-vole-1.1.6.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar",
+        "hash": "ac2ddae3a844c1e2378604616dbe7cc17c64caaf9115d8c9c3b29db8b2982411",
+        "path": "org/bouncycastle/bcpg-jdk18on/1.81/bcpg-jdk18on-1.81.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcpkix-jdk18on/1.79/bcpkix-jdk18on-1.79.jar",
+        "hash": "3639a24ddf9ba4b7eba0659b44770e91eba816421888e571f285aadefe532cd6",
+        "path": "org/bouncycastle/bcpkix-jdk18on/1.79/bcpkix-jdk18on-1.79.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar",
+        "hash": "b38c604871f3690109a3c00982d9145634125de3365a817ba16eb90d88e242c9",
+        "path": "org/bouncycastle/bcpkix-jdk18on/1.81/bcpkix-jdk18on-1.81.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcprov-jdk18on/1.79/bcprov-jdk18on-1.79.jar",
+        "hash": "0d81ecc3124536b539bce9aa3fe9621b7f84c9cee371b635a5b31c78b79ab1da",
+        "path": "org/bouncycastle/bcprov-jdk18on/1.79/bcprov-jdk18on-1.79.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar",
+        "hash": "249f396412b0c0ce67f25c8197da757b241b8be3ec4199386c00704a2457459b",
+        "path": "org/bouncycastle/bcprov-jdk18on/1.81/bcprov-jdk18on-1.81.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcutil-jdk18on/1.79/bcutil-jdk18on-1.79.jar",
+        "hash": "c70b88ada58938cbc2f005d40329054078bcfa1149e6ffc03e9242eb6ab21836",
+        "path": "org/bouncycastle/bcutil-jdk18on/1.79/bcutil-jdk18on-1.79.jar"
+    },
+    {
+        "url": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar",
+        "hash": "31a5fe3a7ba42e3457b83930f0ff8d679fb5b76eaadf2b51f5740c92a394bf52",
+        "path": "org/bouncycastle/bcutil-jdk18on/1.81/bcutil-jdk18on-1.81.jar"
+    },
+    {
+        "url": "org/brotli/dec/0.1.2/dec-0.1.2.jar",
+        "hash": "615c0c3efef990d77831104475fba6a1f7971388691d4bad1471ad84101f6d52",
+        "path": "org/brotli/dec/0.1.2/dec-0.1.2.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-fsa-builders/2.1.9/morfologik-fsa-builders-2.1.9.jar",
+        "hash": "f418c519b49470c2ec7024086bf210ba370ff158732368005d3b8cef964d3fff",
+        "path": "org/carrot2/morfologik-fsa-builders/2.1.9/morfologik-fsa-builders-2.1.9.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-fsa-builders/2.1.9/morfologik-fsa-builders-2.1.9.jar",
+        "hash": "f418c519b49470c2ec7024086bf210ba370ff158732368005d3b8cef964d3fff",
+        "path": "org/carrot2/morfologik-fsa-builders/2.1.9/morfologik-fsa-builders-2.1.9.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-fsa/2.1.9/morfologik-fsa-2.1.9.jar",
+        "hash": "1bfefce937df14cc94d32a98ce59c33f4d5b6c0eddbb436b6bfe27ff2120a23d",
+        "path": "org/carrot2/morfologik-fsa/2.1.9/morfologik-fsa-2.1.9.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-fsa/2.1.9/morfologik-fsa-2.1.9.jar",
+        "hash": "1bfefce937df14cc94d32a98ce59c33f4d5b6c0eddbb436b6bfe27ff2120a23d",
+        "path": "org/carrot2/morfologik-fsa/2.1.9/morfologik-fsa-2.1.9.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-speller/2.1.9/morfologik-speller-2.1.9.jar",
+        "hash": "8d2566a216f401380878f25196f84bd351b807b11f18bc71acd1417e04a1ec29",
+        "path": "org/carrot2/morfologik-speller/2.1.9/morfologik-speller-2.1.9.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-speller/2.1.9/morfologik-speller-2.1.9.jar",
+        "hash": "8d2566a216f401380878f25196f84bd351b807b11f18bc71acd1417e04a1ec29",
+        "path": "org/carrot2/morfologik-speller/2.1.9/morfologik-speller-2.1.9.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-stemming/2.1.9/morfologik-stemming-2.1.9.jar",
+        "hash": "6170895b2315b697f4da5630caf57c6c441f1cb419d89d1cb5326b0673293e8a",
+        "path": "org/carrot2/morfologik-stemming/2.1.9/morfologik-stemming-2.1.9.jar"
+    },
+    {
+        "url": "org/carrot2/morfologik-stemming/2.1.9/morfologik-stemming-2.1.9.jar",
+        "hash": "6170895b2315b697f4da5630caf57c6c441f1cb419d89d1cb5326b0673293e8a",
+        "path": "org/carrot2/morfologik-stemming/2.1.9/morfologik-stemming-2.1.9.jar"
+    },
+    {
+        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
+        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
+        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
+    },
+    {
+        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
+        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
+        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
+    },
+    {
+        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
+        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
+        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
+    },
+    {
+        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
+        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
+        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
+    },
+    {
+        "url": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar",
+        "hash": "a40b2ce6d8551e5b90b1bf637064303f32944d61b52ab2014e38699df573941b",
+        "path": "org/checkerframework/checker-compat-qual/2.0.0/checker-compat-qual-2.0.0.jar"
+    },
+    {
+        "url": "org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar",
+        "hash": "3fbc2e98f05854c3df16df9abaa955b91b15b3ecac33623208ed6424640ef0f6",
+        "path": "org/checkerframework/checker-qual/3.43.0/checker-qual-3.43.0.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar",
+        "hash": "fd65c1a0cd1c60272b6ed0f45025d7afae8de20b5c11e2a131a7ccb4b0f1f1b2",
+        "path": "org/codehaus/groovy/groovy-ant/3.0.25/groovy-ant-3.0.25.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar",
+        "hash": "511cea72a464809d7e376968910fa704f9fa5afa8f2a94b53672a061b45475bb",
+        "path": "org/codehaus/groovy/groovy-json/3.0.25/groovy-json-3.0.25.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar",
+        "hash": "7d703a1d484ac1135b78b24a4880f5653161cda83454c0f484fa09e29311d3bd",
+        "path": "org/codehaus/groovy/groovy-jsr223/3.0.25/groovy-jsr223-3.0.25.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar",
+        "hash": "fd0e111cae80bd6285677759b72cb67e7da68ee779a90e51bee12a7011c28436",
+        "path": "org/codehaus/groovy/groovy-templates/3.0.25/groovy-templates-3.0.25.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar",
+        "hash": "d94e6ba5de99225d3d3fc8759d4480721402c7121d130d73d99d838e913500dd",
+        "path": "org/codehaus/groovy/groovy-xml/3.0.25/groovy-xml-3.0.25.jar"
+    },
+    {
+        "url": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar",
+        "hash": "ad009e985dd84e4f524f4ed1751866da5bef816b691851bfbcefa48a01180a07",
+        "path": "org/codehaus/groovy/groovy/3.0.25/groovy-3.0.25.jar"
+    },
+    {
+        "url": "org/codehaus/jettison/jettison/1.5.4/jettison-1.5.4.jar",
+        "hash": "fc3a68a7c17688ee50817340fef265d8d3f6c192c92bbee00d17f18a6d3dfeda",
+        "path": "org/codehaus/jettison/jettison/1.5.4/jettison-1.5.4.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar",
+        "hash": "2068320bd6bad744c3673ab048f67e30bef8f518996fa380033556600669905d",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar",
+        "hash": "c720e6e5bcbe6b2f48ded75a47bccdb763eede79d14330102e0d352e3d89ed92",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar"
+    },
+    {
+        "url": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar",
+        "hash": "c720e6e5bcbe6b2f48ded75a47bccdb763eede79d14330102e0d352e3d89ed92",
+        "path": "org/codehaus/mojo/animal-sniffer-annotations/1.24/animal-sniffer-annotations-1.24.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-archiver/4.8.0/plexus-archiver-4.8.0.jar",
+        "hash": "24513c9bc6d52716f5a22f7ef03e26c310f62ebcde309de9833deac6a4ac32e3",
+        "path": "org/codehaus/plexus/plexus-archiver/4.8.0/plexus-archiver-4.8.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.jar",
+        "hash": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a",
+        "path": "org/codehaus/plexus/plexus-cipher/2.0/plexus-cipher-2.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.jar",
+        "hash": "259d528a29722cab6349d7e7d432e3fd4877c087ffcb04985a6612e97023bba8",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.4/plexus-classworlds-2.4.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar",
+        "hash": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar",
+        "hash": "52f77c5ec49f787c9c417ebed5d6efd9922f44a202f217376e4f94c0d74f3549",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.6.0/plexus-classworlds-2.6.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-classworlds/2.9.0/plexus-classworlds-2.9.0.jar",
+        "hash": "1ad3292cd563381e3fd632f3fded1988f9e9b2be7a9f3db63ff4c4cedba13fa5",
+        "path": "org/codehaus/plexus/plexus-classworlds/2.9.0/plexus-classworlds-2.9.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
+        "hash": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
+        "hash": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
+        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
+        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
+        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar",
+        "hash": "2b3a6ca5f19a9ad490bc233f45e68d3093c8c01b4acc3c1d14bad4ca7c7ff438",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.6/plexus-component-annotations-1.6.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar",
+        "hash": "a7fee9435db716bff593e9fb5622bcf9f25e527196485929b0cd4065c43e61df",
+        "path": "org/codehaus/plexus/plexus-component-annotations/1.7.1/plexus-component-annotations-1.7.1.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar",
+        "hash": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac",
+        "path": "org/codehaus/plexus/plexus-component-annotations/2.1.0/plexus-component-annotations-2.1.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar",
+        "hash": "7fc63378d3e84663619b9bedace9f9fe78b276c2be3c62ca2245449294c84176",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.14/plexus-interpolation-1.14.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
+        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
+        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
+        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar",
+        "hash": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.21/plexus-interpolation-1.21.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
+        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
+        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
+        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar",
+        "hash": "e003802501574637f7abdc4e83e6d509a31e9ff825d12da6d1e419acf9688705",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.25/plexus-interpolation-1.25.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar",
+        "hash": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.26/plexus-interpolation-1.26.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar",
+        "hash": "3fb4fb6143fdf964024c3cb738551524b9ea84e5c211cd660c559ad0703e5230",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.27/plexus-interpolation-1.27.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-interpolation/1.28/plexus-interpolation-1.28.jar",
+        "hash": "ab2a8715570438a2e4164d85ad3e8d489eabc38ea5093c2eb8ab7f58403535b5",
+        "path": "org/codehaus/plexus/plexus-interpolation/1.28/plexus-interpolation-1.28.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.jar",
+        "hash": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb",
+        "path": "org/codehaus/plexus/plexus-sec-dispatcher/2.0/plexus-sec-dispatcher-2.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-sec-dispatcher/4.1.0/plexus-sec-dispatcher-4.1.0.jar",
+        "hash": "efc10a957d070940701a591685dab92c33f0ba3ffea9518b8d691b23897734fe",
+        "path": "org/codehaus/plexus/plexus-sec-dispatcher/4.1.0/plexus-sec-dispatcher-4.1.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.jar",
+        "hash": "b7554a41499282e3b2226a22aff3ebe984f7e159798c461d917c1b829b130cd1",
+        "path": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar",
+        "hash": "8b909f4ca9788647942f883d4e559bcc642123f7c6bcd3846983a2e465469c33",
+        "path": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar",
+        "hash": "8b909f4ca9788647942f883d4e559bcc642123f7c6bcd3846983a2e465469c33",
+        "path": "org/codehaus/plexus/plexus-utils/2.0.6/plexus-utils-2.0.6.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
+        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
+        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
+        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
+        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
+        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
+        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar",
+        "hash": "0f31c44b275f87e56d46a582ce96d03b9e2ab344cf87c4e268b34d3ad046beab",
+        "path": "org/codehaus/plexus/plexus-utils/3.0.22/plexus-utils-3.0.22.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
+        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
+        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
+        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
+        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
+        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
+        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar",
+        "hash": "0ffa0ad084ebff5712540a7b7ea0abda487c53d3a18f78c98d1a3675dab9bf61",
+        "path": "org/codehaus/plexus/plexus-utils/3.1.0/plexus-utils-3.1.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar",
+        "hash": "76d174792540e2775af94d03d10fb2d3c776e2cd0ac0ebf427d3e570072bb9ce",
+        "path": "org/codehaus/plexus/plexus-utils/3.3.0/plexus-utils-3.3.0.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar",
+        "hash": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
+        "path": "org/codehaus/plexus/plexus-utils/3.5.1/plexus-utils-3.5.1.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.jar",
+        "hash": "8957274e75fe2c278b1428dd16a0daeee1dd38152cb6eff816177ac28fccb697",
+        "path": "org/codehaus/plexus/plexus-utils/4.0.2/plexus-utils-4.0.2.jar"
+    },
+    {
+        "url": "org/codehaus/plexus/plexus-xml/4.1.0/plexus-xml-4.1.0.jar",
+        "hash": "86e6a7f07484e8b1f7af66d97d3ba3cb3d692a5461b4b1d0a2b7670cf5748e89",
+        "path": "org/codehaus/plexus/plexus-xml/4.1.0/plexus-xml-4.1.0.jar"
+    },
+    {
+        "url": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
+        "hash": "a61c48d553efad78bc01fffc4ac528bebbae64cbaec170b2a5e39cf61eb51abe",
+        "path": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar"
+    },
+    {
+        "url": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
+        "hash": "a61c48d553efad78bc01fffc4ac528bebbae64cbaec170b2a5e39cf61eb51abe",
+        "path": "org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar"
+    },
+    {
+        "url": "org/commonmark/commonmark-ext-autolink/0.24.0/commonmark-ext-autolink-0.24.0.jar",
+        "hash": "013ba4f3ba4850a1de35935d1501587c518f764331d279805da33473e79f5f33",
+        "path": "org/commonmark/commonmark-ext-autolink/0.24.0/commonmark-ext-autolink-0.24.0.jar"
+    },
+    {
+        "url": "org/commonmark/commonmark-ext-gfm-strikethrough/0.24.0/commonmark-ext-gfm-strikethrough-0.24.0.jar",
+        "hash": "7385cb637f04dc4cbda4ddca9c2fcd2af7ac536a50e4c8d2c77f4748bb14bf41",
+        "path": "org/commonmark/commonmark-ext-gfm-strikethrough/0.24.0/commonmark-ext-gfm-strikethrough-0.24.0.jar"
+    },
+    {
+        "url": "org/commonmark/commonmark-ext-gfm-tables/0.24.0/commonmark-ext-gfm-tables-0.24.0.jar",
+        "hash": "b54dc332f931e6d07c2766144c087b08f3693677e368151a67020b4e95bb4b99",
+        "path": "org/commonmark/commonmark-ext-gfm-tables/0.24.0/commonmark-ext-gfm-tables-0.24.0.jar"
+    },
+    {
+        "url": "org/commonmark/commonmark/0.24.0/commonmark-0.24.0.jar",
+        "hash": "679338e0b7fc15c02d275d598654b01a149893bc28a87992e90123c8d06af25b",
+        "path": "org/commonmark/commonmark/0.24.0/commonmark-0.24.0.jar"
+    },
+    {
+        "url": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar",
+        "hash": "63efc00da99774fb0253330ef9b5788b261022ba73f36bf76889ce7edf3d2b31",
+        "path": "org/easymock/easymock/5.6.0/easymock-5.6.0.jar"
+    },
+    {
+        "url": "org/easytesting/fest-reflect/1.4.1/fest-reflect-1.4.1.jar",
+        "hash": "c1ca19fcf0cd3555baf7c2af147c04ad22b4393ab75e5db0284e5170fb554c16",
+        "path": "org/easytesting/fest-reflect/1.4.1/fest-reflect-1.4.1.jar"
+    },
+    {
+        "url": "org/easytesting/fest-util/1.2.5/fest-util-1.2.5.jar",
+        "hash": "7b52f4d3ad41b7ed71f5b6b11833113b7e08326c8ef70d2dedf0b430c7ba5341",
+        "path": "org/easytesting/fest-util/1.2.5/fest-util-1.2.5.jar"
+    },
+    {
+        "url": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar",
+        "hash": "cadef0207077074b11a12be442f89ab6cf93fbc2f848702d9371a9611414d558",
+        "path": "org/ec4j/core/ec4j-core/0.3.0/ec4j-core-0.3.0.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.jar",
+        "hash": "e220097cffad96c2963ab12652ff8833ec6f40143d509f0a2ea59d22209b6ecd",
+        "path": "org/eclipse/aether/aether-api/0.9.0.M2/aether-api-0.9.0.M2.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
+        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
+        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
+        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
+        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
+        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
+        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar",
+        "hash": "3f74c7c7b9c924769cf3c5b4d52d21aa63e9a2ccbf16f5d26c30ebb31b99699d",
+        "path": "org/eclipse/aether/aether-api/1.0.2.v20150114/aether-api-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
+        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
+        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
+        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
+        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
+        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
+        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar",
+        "hash": "9a84f5863407acf2bf9cf280cd02f5a518952a386de61df3b8c5db8cfdec725d",
+        "path": "org/eclipse/aether/aether-impl/1.0.2.v20150114/aether-impl-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
+        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
+        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
+        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
+        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
+        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
+        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar",
+        "hash": "2cafa2629da49edd54eb4df6d15f628c2d80eec293f37cd561f1fe78e7bcff9d",
+        "path": "org/eclipse/aether/aether-spi/1.0.2.v20150114/aether-spi-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
+        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
+        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
+        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
+        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
+        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
+        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar",
+        "hash": "9e9a57439a98034732e94d841bb7065b56e3a065654361ca9cc07135e9fbe17c",
+        "path": "org/eclipse/aether/aether-util/1.0.2.v20150114/aether-util-1.0.2.v20150114.jar"
+    },
+    {
+        "url": "org/eclipse/angus/angus-activation/2.0.2/angus-activation-2.0.2.jar",
+        "hash": "6dd3bcffc22bce83b07376a0e2e094e4964a3195d4118fb43e380ef35436cc1e",
+        "path": "org/eclipse/angus/angus-activation/2.0.2/angus-activation-2.0.2.jar"
+    },
+    {
+        "url": "org/eclipse/elk/org.eclipse.elk.alg.common.compaction/0.3.0/org.eclipse.elk.alg.common.compaction-0.3.0.jar",
+        "hash": "7b5a2c04f1c942af3d8b891a9a535e74cfa45b4151b7835c3e9f63e96ec0332f",
+        "path": "org/eclipse/elk/org.eclipse.elk.alg.common.compaction/0.3.0/org.eclipse.elk.alg.common.compaction-0.3.0.jar"
     },
     {
         "url": "org/eclipse/elk/org.eclipse.elk.alg.layered/0.3.0/org.eclipse.elk.alg.layered-0.3.0.jar",
@@ -7205,19 +5450,409 @@
         "path": "org/eclipse/emf/org.eclipse.emf.ecore/2.12.0/org.eclipse.emf.ecore-2.12.0.jar"
     },
     {
-        "url": "org/eclipse/elk/org.eclipse.elk.alg.common.compaction/0.3.0/org.eclipse.elk.alg.common.compaction-0.3.0.jar",
-        "hash": "7b5a2c04f1c942af3d8b891a9a535e74cfa45b4151b7835c3e9f63e96ec0332f",
-        "path": "org/eclipse/elk/org.eclipse.elk.alg.common.compaction/0.3.0/org.eclipse.elk.alg.common.compaction-0.3.0.jar"
+        "url": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache.agent/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache.agent-6.6.1.202309021850-r.jar",
+        "hash": "4ddd0cf1a7ece350b33f0a6b865e8fb777c30a2282a0fbd1754020a4e06af481",
+        "path": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache.agent/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache.agent-6.6.1.202309021850-r.jar"
     },
     {
-        "url": "org/brotli/dec/0.1.2/dec-0.1.2.jar",
-        "hash": "615c0c3efef990d77831104475fba6a1f7971388691d4bad1471ad84101f6d52",
-        "path": "org/brotli/dec/0.1.2/dec-0.1.2.jar"
+        "url": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache-6.6.1.202309021850-r.jar",
+        "hash": "cc379265edb2b74850156c16fefd7990281bf47e33fe7665e838f8b5fdb94755",
+        "path": "org/eclipse/jgit/org.eclipse.jgit.ssh.apache/6.6.1.202309021850-r/org.eclipse.jgit.ssh.apache-6.6.1.202309021850-r.jar"
     },
     {
-        "url": "org/jetbrains/intellij/deps/android/tools/base/workmanager_inspector_proto/232.1.23.0/workmanager_inspector_proto-232.1.23.0.jar",
-        "hash": "ffbd4b4c8b7d246032a0d2e802594b18bc56a8cda069c0f0099a7d301dceeabb",
-        "path": "org/jetbrains/intellij/deps/android/tools/base/workmanager_inspector_proto/232.1.23.0/workmanager_inspector_proto-232.1.23.0.jar"
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
+        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
+        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
+        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar",
+        "hash": "66e87705a818da44eb080a7bb1fc431de987754b4f92aa85f69991bfc677d40d",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.2/org.eclipse.sisu.inject-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
+        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
+        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
+        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar",
+        "hash": "c6935e0b7d362ed4ca768c9b71d5d4d98788ff0a79c0d2bb954c221a078b166b",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.3/org.eclipse.sisu.inject-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.jar",
+        "hash": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.3.5/org.eclipse.sisu.inject-0.3.5.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar",
+        "hash": "15335c4dcf082f599fb8eddcfb58d6a7e9a9c97de2883c257089a479b9b24522",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar",
+        "hash": "15335c4dcf082f599fb8eddcfb58d6a7e9a9c97de2883c257089a479b9b24522",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.inject/0.9.0.M3/org.eclipse.sisu.inject-0.9.0.M3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
+        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
+        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
+        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar",
+        "hash": "f5cfe0d88e8276971db4ecff0e4186d5f2ec5fdb1b6bb8c2f359fdc4b43eb8b2",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.2/org.eclipse.sisu.plexus-0.3.2.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
+        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
+        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
+        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar",
+        "hash": "98045f5ecd802d6a96ba00394f8cb61259f9ac781ec2cb51ca0cb7b2c94ac720",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.3/org.eclipse.sisu.plexus-0.3.3.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.jar",
+        "hash": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.3.5/org.eclipse.sisu.plexus-0.3.5.jar"
+    },
+    {
+        "url": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M4/org.eclipse.sisu.plexus-0.9.0.M4.jar",
+        "hash": "b90579bc652eac7331436e0a25533fce14130b9c6e015f2dd3a3d4bb07e942b7",
+        "path": "org/eclipse/sisu/org.eclipse.sisu.plexus/0.9.0.M4/org.eclipse.sisu.plexus-0.9.0.M4.jar"
+    },
+    {
+        "url": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar",
+        "hash": "5a810154295fc20a0268cae4cbbc6e5a35a8b32480d8727dc8301910524e4b79",
+        "path": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.40.0/org.eclipse.xtext.xbase.lib-2.40.0.jar"
+    },
+    {
+        "url": "org/ehcache/sizeof/0.4.0/sizeof-0.4.0.jar",
+        "hash": "0429cb1f5cda94180007874ea926a88149fca2028e92b4556d35f0cfce310c53",
+        "path": "org/ehcache/sizeof/0.4.0/sizeof-0.4.0.jar"
+    },
+    {
+        "url": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
+        "hash": "04d65ec1bde6cea20e3495d5e78ef96ab774d9936434861d3254bd88e7e94f92",
+        "path": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar"
+    },
+    {
+        "url": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
+        "hash": "04d65ec1bde6cea20e3495d5e78ef96ab774d9936434861d3254bd88e7e94f92",
+        "path": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar"
+    },
+    {
+        "url": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar",
+        "hash": "04d65ec1bde6cea20e3495d5e78ef96ab774d9936434861d3254bd88e7e94f92",
+        "path": "org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar"
+    },
+    {
+        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
+        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
+        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
+    },
+    {
+        "url": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar",
+        "hash": "2e5e775a9dc58ffa6bbd6aa6f099d62f8b62dcdeb4c3c3bbbe5cf2301bc2dcc1",
+        "path": "org/fusesource/jansi/jansi/2.4.1/jansi-2.4.1.jar"
+    },
+    {
+        "url": "org/glassfish/jaxb/jaxb-core/4.0.5/jaxb-core-4.0.5.jar",
+        "hash": "ad3fd9bf00de3eda9859f70b6cfb011e2fe9904804e16a2665092888ece0fdca",
+        "path": "org/glassfish/jaxb/jaxb-core/4.0.5/jaxb-core-4.0.5.jar"
+    },
+    {
+        "url": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar",
+        "hash": "ba88e5bde7c0d878c3e1f2ec2fcabaf51d201eaf93b3bb9cfecfc1f11b2304d4",
+        "path": "org/glassfish/jaxb/jaxb-runtime/2.3.9/jaxb-runtime-2.3.9.jar"
+    },
+    {
+        "url": "org/glassfish/jaxb/jaxb-runtime/4.0.5/jaxb-runtime-4.0.5.jar",
+        "hash": "485d8940e76373a7f300815ea5504bf5b726c234425ad30971019d133124cca4",
+        "path": "org/glassfish/jaxb/jaxb-runtime/4.0.5/jaxb-runtime-4.0.5.jar"
+    },
+    {
+        "url": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar",
+        "hash": "973018b87af911ecf6e6d861dd0d6a477e4d8ae6a883ec5d073d3df1330b87f0",
+        "path": "org/glassfish/jaxb/txw2/2.3.9/txw2-2.3.9.jar"
+    },
+    {
+        "url": "org/glassfish/jaxb/txw2/4.0.5/txw2-4.0.5.jar",
+        "hash": "917355bc451481f30d043b24d123110517966af34383901773882810dca480e5",
+        "path": "org/glassfish/jaxb/txw2/4.0.5/txw2-4.0.5.jar"
+    },
+    {
+        "url": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+        "hash": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+        "path": "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
+    },
+    {
+        "url": "org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar",
+        "hash": "e09109e54a289d88506b9bfec987ddd199f4217c9464132668351b9a4f00bee9",
+        "path": "org/hamcrest/hamcrest-core/2.1/hamcrest-core-2.1.jar"
+    },
+    {
+        "url": "org/hamcrest/hamcrest-library/2.1/hamcrest-library-2.1.jar",
+        "hash": "b7e2b6895b3b679f0e47b6380fda391b225e9b78505db9d8bdde8d3cc8d52a21",
+        "path": "org/hamcrest/hamcrest-library/2.1/hamcrest-library-2.1.jar"
+    },
+    {
+        "url": "org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar",
+        "hash": "ba93b2e3a562322ba432f0a1b53addcc55cb188253319a020ed77f824e692050",
+        "path": "org/hamcrest/hamcrest/2.1/hamcrest-2.1.jar"
+    },
+    {
+        "url": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar",
+        "hash": "5e62846a89f05cd78cd9c1a553f340d002458380c320455dd1f8fc5497a8a1c1",
+        "path": "org/hamcrest/hamcrest/2.2/hamcrest-2.2.jar"
+    },
+    {
+        "url": "org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12.jar",
+        "hash": "9b47fbae444feaac4b7e04f0ea294569e4bc282bc69d8c2ce2ac3f23577281e2",
+        "path": "org/hdrhistogram/HdrHistogram/2.1.12/HdrHistogram-2.1.12.jar"
+    },
+    {
+        "url": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar",
+        "hash": "22d1d4316c4ec13a68b559e98c8256d69071593731da96136640f864fa14fad8",
+        "path": "org/hdrhistogram/HdrHistogram/2.2.2/HdrHistogram-2.2.2.jar"
+    },
+    {
+        "url": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar",
+        "hash": "6f128a71c5e87a16f810513a73ad3c77d0ee0bb622ee0ce1ead115bccbc76d0a",
+        "path": "org/imgscalr/imgscalr-lib/4.2/imgscalr-lib-4.2.jar"
+    },
+    {
+        "url": "org/ioperm/morphology-el/1.0.0/morphology-el-1.0.0.jar",
+        "hash": "caa36b7e96fd4c1804b3f4763de803ce87468d86908087087814f7d47caee668",
+        "path": "org/ioperm/morphology-el/1.0.0/morphology-el-1.0.0.jar"
+    },
+    {
+        "url": "org/jacoco/org.jacoco.agent/0.8.14/org.jacoco.agent-0.8.14.jar",
+        "hash": "20be9853385bdfc65a5929643412d09243d14514304b89ba23a265158cc8792b",
+        "path": "org/jacoco/org.jacoco.agent/0.8.14/org.jacoco.agent-0.8.14.jar"
+    },
+    {
+        "url": "org/jacoco/org.jacoco.ant/0.8.14/org.jacoco.ant-0.8.14.jar",
+        "hash": "9fff68954d5de3aad2bf838eaf886ed67d2c22a2d6c6f095548bade8c45caeae",
+        "path": "org/jacoco/org.jacoco.ant/0.8.14/org.jacoco.ant-0.8.14.jar"
+    },
+    {
+        "url": "org/jacoco/org.jacoco.core/0.8.14/org.jacoco.core-0.8.14.jar",
+        "hash": "28abbf0eea5a08e4f24097f2fbac663ca17c341c25c3a04d90d6cd325943c995",
+        "path": "org/jacoco/org.jacoco.core/0.8.14/org.jacoco.core-0.8.14.jar"
+    },
+    {
+        "url": "org/jacoco/org.jacoco.report/0.8.14/org.jacoco.report-0.8.14.jar",
+        "hash": "a3e2026060ab8b8d5c650706406234bb4c033dfd5376afeb8b1666e8ed27c453",
+        "path": "org/jacoco/org.jacoco.report/0.8.14/org.jacoco.report-0.8.14.jar"
+    },
+    {
+        "url": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar",
+        "hash": "eae29213e4f16515639c28957200f011b3967fffcada1962cf0255d24919c22f",
+        "path": "org/java-websocket/Java-WebSocket/1.6.0/Java-WebSocket-1.6.0.jar"
+    },
+    {
+        "url": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar",
+        "hash": "e22941d77d0d01dfc6ee5612ad421860baae8a3a0dea2eeb67658061f34527b4",
+        "path": "org/javadelight/delight-rhino-sandbox/0.0.17/delight-rhino-sandbox-0.0.17.jar"
+    },
+    {
+        "url": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar",
+        "hash": "0b20f45e3a0fd8f0d12cdc5316b06776e902b1365db00118876f9175c60f302c",
+        "path": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar"
+    },
+    {
+        "url": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar",
+        "hash": "0b20f45e3a0fd8f0d12cdc5316b06776e902b1365db00118876f9175c60f302c",
+        "path": "org/jdom/jdom2/2.0.6.1/jdom2-2.0.6.1.jar"
+    },
+    {
+        "url": "org/jeasy/easy-random-core/4.2.0/easy-random-core-4.2.0.jar",
+        "hash": "e37f9fd2680da69e6e4e0fef6472b53240a935a18804e957ef60ef20f36281de",
+        "path": "org/jeasy/easy-random-core/4.2.0/easy-random-core-4.2.0.jar"
+    },
+    {
+        "url": "org/jetbrains/annotations/13.0/annotations-13.0.jar",
+        "hash": "ace2a10dc8e2d5fd34925ecac03e4988b2c0f851650c94b8cef49ba1bd111478",
+        "path": "org/jetbrains/annotations/13.0/annotations-13.0.jar"
+    },
+    {
+        "url": "org/jetbrains/annotations/26.0.1/annotations-26.0.1.jar",
+        "hash": "2037be378980d3ba9333e97955f3b2cde392aa124d04ca73ce2eee6657199297",
+        "path": "org/jetbrains/annotations/26.0.1/annotations-26.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar",
+        "hash": "2037be378980d3ba9333e97955f3b2cde392aa124d04ca73ce2eee6657199297",
+        "path": "org/jetbrains/annotations/26.0.2/annotations-26.0.2.jar"
+    },
+    {
+        "url": "org/jetbrains/apple-notary-api-kotlin-client/2.0.1/apple-notary-api-kotlin-client-2.0.1.jar",
+        "hash": "46aa057f38b1cb2ac89d7e4b6357570b82bfd8e2b4d062ab40b09db3290d1c26",
+        "path": "org/jetbrains/apple-notary-api-kotlin-client/2.0.1/apple-notary-api-kotlin-client-2.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/animation/animation-core-desktop/1.10.0-rc01/animation-core-desktop-1.10.0-rc01.jar",
+        "hash": "41c0220ddbc55cb897feb0d5816b748f9c11162171f12743c04b50d0d84db628",
+        "path": "org/jetbrains/compose/animation/animation-core-desktop/1.10.0-rc01/animation-core-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/animation/animation-desktop/1.10.0-rc01/animation-desktop-1.10.0-rc01.jar",
+        "hash": "3ec5254288b1e872263009221f677063ea728f90969598f399a5b02500ebc014",
+        "path": "org/jetbrains/compose/animation/animation-desktop/1.10.0-rc01/animation-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/compiler/compiler-hosted/1.5.14/compiler-hosted-1.5.14.jar",
+        "hash": "1133b3191ec68f97cf326bf95cbe00cab5d2f39493812e8e36f0e42dad059f64",
+        "path": "org/jetbrains/compose/compiler/compiler-hosted/1.5.14/compiler-hosted-1.5.14.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/components/components-resources-desktop/1.10.0-rc01/components-resources-desktop-1.10.0-rc01.jar",
+        "hash": "7dbbe06683befa8110b4ac926a7432b7e2ee446ed156adf55ad17e9c868ae0e2",
+        "path": "org/jetbrains/compose/components/components-resources-desktop/1.10.0-rc01/components-resources-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/components/components-resources/1.10.0-rc01/components-resources-1.10.0-rc01.jar",
+        "hash": "7d2f02d5ecc865b8c9b81cc3026db4c0ba2ccf180c1be6844896e56581045b9a",
+        "path": "org/jetbrains/compose/components/components-resources/1.10.0-rc01/components-resources-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar",
+        "hash": "ca0857dcde7cffff8eea3cce2940a285f219f673829f7f9a3381f767d224f411",
+        "path": "org/jetbrains/compose/components/components-ui-tooling-preview-desktop/1.9.0/components-ui-tooling-preview-desktop-1.9.0.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/foundation/foundation-desktop/1.10.0-rc01/foundation-desktop-1.10.0-rc01.jar",
+        "hash": "f988ef9d9517dc26b360943349bf1412d5735beb8ecf4f5304f10ecfe6ca05db",
+        "path": "org/jetbrains/compose/foundation/foundation-desktop/1.10.0-rc01/foundation-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/foundation/foundation-layout-desktop/1.10.0-rc01/foundation-layout-desktop-1.10.0-rc01.jar",
+        "hash": "bd086a9f5ce453967ea1124bb709612bca14a4fbb6522a6023092a8866ee4ef0",
+        "path": "org/jetbrains/compose/foundation/foundation-layout-desktop/1.10.0-rc01/foundation-layout-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-backhandler-desktop/1.10.0-rc01/ui-backhandler-desktop-1.10.0-rc01.jar",
+        "hash": "1babf68f5a05cbe1ba8cf934f0e575bb0d0b184444514e6aa7ec1f8004c9ce33",
+        "path": "org/jetbrains/compose/ui/ui-backhandler-desktop/1.10.0-rc01/ui-backhandler-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-desktop/1.10.0-rc01/ui-desktop-1.10.0-rc01.jar",
+        "hash": "c699d8571082a7f507fbede0b9d567c661f47013a4f3f9b68109b8a0bd828ea8",
+        "path": "org/jetbrains/compose/ui/ui-desktop/1.10.0-rc01/ui-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-geometry-desktop/1.10.0-rc01/ui-geometry-desktop-1.10.0-rc01.jar",
+        "hash": "cdbfdabccac8abef2d9bc0420ec0c4be7a880f6d26b2d1cc4e2317c0d252ee27",
+        "path": "org/jetbrains/compose/ui/ui-geometry-desktop/1.10.0-rc01/ui-geometry-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-graphics-desktop/1.10.0-rc01/ui-graphics-desktop-1.10.0-rc01.jar",
+        "hash": "d1710a4a15b115fc4c37878b32b10a476a0ec3b8399fa1fb588181dba83dbdd2",
+        "path": "org/jetbrains/compose/ui/ui-graphics-desktop/1.10.0-rc01/ui-graphics-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-test-desktop/1.10.0-rc01/ui-test-desktop-1.10.0-rc01.jar",
+        "hash": "b7d61af17254d98ffb858ceb80bd38597c2486eead80c2cfe0a37ba3ee9724b2",
+        "path": "org/jetbrains/compose/ui/ui-test-desktop/1.10.0-rc01/ui-test-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-test-junit4-desktop/1.10.0-rc01/ui-test-junit4-desktop-1.10.0-rc01.jar",
+        "hash": "de2f63543b8f646b85c789e3bf53121e4e6d89d3c7c0afc0358954cc27316a71",
+        "path": "org/jetbrains/compose/ui/ui-test-junit4-desktop/1.10.0-rc01/ui-test-junit4-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-text-desktop/1.10.0-rc01/ui-text-desktop-1.10.0-rc01.jar",
+        "hash": "6ee18433659f389621386e759217b3ed5ef0f1e22ea177cad705457dc75aa27b",
+        "path": "org/jetbrains/compose/ui/ui-text-desktop/1.10.0-rc01/ui-text-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-unit-desktop/1.10.0-rc01/ui-unit-desktop-1.10.0-rc01.jar",
+        "hash": "f0f3439928b3d9132f07cb2d7a86091696372ebc8354d16b48830b6ce15e8161",
+        "path": "org/jetbrains/compose/ui/ui-unit-desktop/1.10.0-rc01/ui-unit-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/compose/ui/ui-util-desktop/1.10.0-rc01/ui-util-desktop-1.10.0-rc01.jar",
+        "hash": "7bfc93a8cad2974cdfd5a2c817e3083e0e3c48ef99e4dbba51eb98a14c92ed2d",
+        "path": "org/jetbrains/compose/ui/ui-util-desktop/1.10.0-rc01/ui-util-desktop-1.10.0-rc01.jar"
+    },
+    {
+        "url": "org/jetbrains/dokka/analysis-kotlin-descriptors/2.0.0/analysis-kotlin-descriptors-2.0.0.jar",
+        "hash": "829788c40891a2a3c4b9435cb9ec80d645560d926e9fbbd08ccc29e8e4f1eb7c",
+        "path": "org/jetbrains/dokka/analysis-kotlin-descriptors/2.0.0/analysis-kotlin-descriptors-2.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/dokka/dokka-base/2.0.0/dokka-base-2.0.0.jar",
+        "hash": "0411d1c38a1d100cbd346c6340c3c4b5f154a48a9c119ed11893d6fae94c91aa",
+        "path": "org/jetbrains/dokka/dokka-base/2.0.0/dokka-base-2.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/dokka/dokka-cli/2.0.0/dokka-cli-2.0.0.jar",
+        "hash": "5f70f358160b48ef9763b2ced4e96037f1bfc8d0122de692550ca320ab4b9f20",
+        "path": "org/jetbrains/dokka/dokka-cli/2.0.0/dokka-cli-2.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/dokka/javadoc-plugin/2.0.0/javadoc-plugin-2.0.0.jar",
+        "hash": "41055e59e3f0a6e04b77557641b9a2db0311e99f81c5bc7b1fcc3409bb23d99b",
+        "path": "org/jetbrains/dokka/javadoc-plugin/2.0.0/javadoc-plugin-2.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/dokka/kotlin-as-java-plugin/2.0.0/kotlin-as-java-plugin-2.0.0.jar",
+        "hash": "3d8931b3c03f84edbf72f67348265205d819d327bb110043ab11d840d59bde41",
+        "path": "org/jetbrains/dokka/kotlin-as-java-plugin/2.0.0/kotlin-as-java-plugin-2.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/idea/maven/maven-indexer-api-rt/2023.2/maven-indexer-api-rt-2023.2.jar",
+        "hash": "b9e8bb167267aa21219d9319d568d3e48198dde3756368e6102879d638248931",
+        "path": "org/jetbrains/idea/maven/maven-indexer-api-rt/2023.2/maven-indexer-api-rt-2023.2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/blockmap/1.0.7/blockmap-1.0.7.jar",
+        "hash": "7e3f98d3370551fea909ceb952e4797108a3a5ef67a1d7b5fb03a036eab24df9",
+        "path": "org/jetbrains/intellij/blockmap/1.0.7/blockmap-1.0.7.jar"
     },
     {
         "url": "org/jetbrains/intellij/deps/android/tools/base/backgroundtask_inspector_java_proto/232.1.23.0/backgroundtask_inspector_java_proto-232.1.23.0.jar",
@@ -7225,13 +5860,1933 @@
         "path": "org/jetbrains/intellij/deps/android/tools/base/backgroundtask_inspector_java_proto/232.1.23.0/backgroundtask_inspector_java_proto-232.1.23.0.jar"
     },
     {
-        "url": "com/ibm/db2/jcc/11.5.7.0/jcc-11.5.7.0.jar",
-        "hash": "1dbc8dc93441890f242be66983f1d1363fe6a80f8d1f0b7ca0e1063f42054bb0",
-        "path": "com/ibm/db2/jcc/11.5.7.0/jcc-11.5.7.0.jar"
+        "url": "org/jetbrains/intellij/deps/android/tools/base/libserver-flag-test-proto/232.1.23.0/libserver-flag-test-proto-232.1.23.0.jar",
+        "hash": "e7faa7021cfd9042231fbb5e6bbea2616f7c6947905e5db95c196e9a602f88a0",
+        "path": "org/jetbrains/intellij/deps/android/tools/base/libserver-flag-test-proto/232.1.23.0/libserver-flag-test-proto-232.1.23.0.jar"
     },
     {
-        "url": "com/jetbrains/intellij/platform/util-zip-squashed/252.16432/util-zip-squashed-252.16432.jar",
-        "hash": "7df07e447c1de46592dfe4b20345b61ff57c5f3b796b8e946086559b260f7690",
-        "path": "com/jetbrains/intellij/platform/util-zip-squashed/252.16432/util-zip-squashed-252.16432.jar"
+        "url": "org/jetbrains/intellij/deps/android/tools/base/traceprocessor_protos/232.1.23.0/traceprocessor_protos-232.1.23.0.jar",
+        "hash": "d34f8d993c5ad098050d512e3abfd2e6361b73e41b029f58af20dfc89e4ad62c",
+        "path": "org/jetbrains/intellij/deps/android/tools/base/traceprocessor_protos/232.1.23.0/traceprocessor_protos-232.1.23.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/base/workmanager_inspector_proto/232.1.23.0/workmanager_inspector_proto-232.1.23.0.jar",
+        "hash": "ffbd4b4c8b7d246032a0d2e802594b18bc56a8cda069c0f0099a7d301dceeabb",
+        "path": "org/jetbrains/intellij/deps/android/tools/base/workmanager_inspector_proto/232.1.23.0/workmanager_inspector_proto-232.1.23.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar",
+        "hash": "3b26dc266a24da542c012a08e445b8a212703d152d0f0e4663dd7d253bebe819",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar",
+        "hash": "3b26dc266a24da542c012a08e445b8a212703d152d0f0e4663dd7d253bebe819",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar",
+        "hash": "3b26dc266a24da542c012a08e445b8a212703d152d0f0e4663dd7d253bebe819",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-linux-x86_64/6.0-1.5.9-189/ffmpeg-linux-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar",
+        "hash": "9613ae5ae4f418e2cd0a4235bcd2911cb9b56ae9e42cc7e672fbc5031bd35d57",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar",
+        "hash": "9613ae5ae4f418e2cd0a4235bcd2911cb9b56ae9e42cc7e672fbc5031bd35d57",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar",
+        "hash": "9613ae5ae4f418e2cd0a4235bcd2911cb9b56ae9e42cc7e672fbc5031bd35d57",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-arm64/6.0-1.5.9-189/ffmpeg-macosx-arm64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar",
+        "hash": "949cf2be2d54ccd9e4f13f9df456190c85738bebb054f50c74e896e31c43d922",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar",
+        "hash": "949cf2be2d54ccd9e4f13f9df456190c85738bebb054f50c74e896e31c43d922",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar",
+        "hash": "949cf2be2d54ccd9e4f13f9df456190c85738bebb054f50c74e896e31c43d922",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-macosx-x86_64/6.0-1.5.9-189/ffmpeg-macosx-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar",
+        "hash": "c2dba4e82e5ad865412f72b8f02ff5462088666100f9734b46a4023bac3e2a5c",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar",
+        "hash": "c2dba4e82e5ad865412f72b8f02ff5462088666100f9734b46a4023bac3e2a5c",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar",
+        "hash": "c2dba4e82e5ad865412f72b8f02ff5462088666100f9734b46a4023bac3e2a5c",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg-windows-x86_64/6.0-1.5.9-189/ffmpeg-windows-x86_64-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar",
+        "hash": "38c437218569f861fd43f15aa810b3eb9af4bdb02a7003f54c4d454590378079",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar",
+        "hash": "38c437218569f861fd43f15aa810b3eb9af4bdb02a7003f54c4d454590378079",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar",
+        "hash": "38c437218569f861fd43f15aa810b3eb9af4bdb02a7003f54c4d454590378079",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/ffmpeg/6.0-1.5.9-189/ffmpeg-6.0-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar",
+        "hash": "433fd379cf807f5507318b77d83ad46c30a77b34beab868d5f925b939d73aef7",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar",
+        "hash": "433fd379cf807f5507318b77d83ad46c30a77b34beab868d5f925b939d73aef7",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar",
+        "hash": "433fd379cf807f5507318b77d83ad46c30a77b34beab868d5f925b939d73aef7",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-linux-x86_64/1.5.9-189/javacpp-linux-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar",
+        "hash": "d35f7a03198f8f71d20e0838c8feb1576680ec1e16693246f200afcfe69e7f2d",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar",
+        "hash": "d35f7a03198f8f71d20e0838c8feb1576680ec1e16693246f200afcfe69e7f2d",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar",
+        "hash": "d35f7a03198f8f71d20e0838c8feb1576680ec1e16693246f200afcfe69e7f2d",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-arm64/1.5.9-189/javacpp-macosx-arm64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar",
+        "hash": "974868dc67392dcf2c2443e0b75fe0840d114da7cd5a9b7ea3024b1cfa4ceef1",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar",
+        "hash": "974868dc67392dcf2c2443e0b75fe0840d114da7cd5a9b7ea3024b1cfa4ceef1",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar",
+        "hash": "974868dc67392dcf2c2443e0b75fe0840d114da7cd5a9b7ea3024b1cfa4ceef1",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-macosx-x86_64/1.5.9-189/javacpp-macosx-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar",
+        "hash": "3fa369db5c0cdeb9fe3382512b874a3ccddd5f2799a31b564c438102f1aa7b86",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar",
+        "hash": "3fa369db5c0cdeb9fe3382512b874a3ccddd5f2799a31b564c438102f1aa7b86",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar",
+        "hash": "3fa369db5c0cdeb9fe3382512b874a3ccddd5f2799a31b564c438102f1aa7b86",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp-windows-x86_64/1.5.9-189/javacpp-windows-x86_64-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar",
+        "hash": "1f85780cda084ba11fe0611558397d02486154777226eedee640d2867ce4231d",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar",
+        "hash": "1f85780cda084ba11fe0611558397d02486154777226eedee640d2867ce4231d",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar",
+        "hash": "1f85780cda084ba11fe0611558397d02486154777226eedee640d2867ce4231d",
+        "path": "org/jetbrains/intellij/deps/android/tools/streaming/ffmpeg-bundle/javacpp/1.5.9-189/javacpp-1.5.9-189.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/asm-all/9.6.1/asm-all-9.6.1.jar",
+        "hash": "a72e84efb1406a7ab326e0b28c4376e9e1ebfc08c09f23edff5e6e7249588df7",
+        "path": "org/jetbrains/intellij/deps/asm-all/9.6.1/asm-all-9.6.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar",
+        "hash": "ba1cb46e5494286940b016da372ae94a60d2dbc411b6dac5db1e40128725d501",
+        "path": "org/jetbrains/intellij/deps/commons-imaging/1.0-RC-1/commons-imaging-1.0-RC-1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar",
+        "hash": "f6f453ba3dc824d16ae0911e403dcde8e18e0ea7406c91e2832e8b6248a1f404",
+        "path": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar",
+        "hash": "f6f453ba3dc824d16ae0911e403dcde8e18e0ea7406c91e2832e8b6248a1f404",
+        "path": "org/jetbrains/intellij/deps/completion/completion-log-events/0.0.3/completion-log-events-0.0.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-cpp/0.1.5/completion-ranking-cpp-0.1.5.jar",
+        "hash": "2c09237e1e0e76d571b77c4f43371d8cd828903ffa442f0e3593894bce3021c3",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-cpp/0.1.5/completion-ranking-cpp-0.1.5.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-css/0.2.1/completion-ranking-css-0.2.1.jar",
+        "hash": "82245f691b5db3a47a6bc0ad260b0b04ba5c929c28293edb8bbbc70d1aeb7d7a",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-css/0.2.1/completion-ranking-css-0.2.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-dart/0.0.2/completion-ranking-dart-0.0.2.jar",
+        "hash": "024322c6d09f72f9bddeb94d52e803d235a9afc284bc3efe7dfbc9de58d4fa6f",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-dart/0.0.2/completion-ranking-dart-0.0.2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-go/0.2.4/completion-ranking-go-0.2.4.jar",
+        "hash": "a5b09d91c7633fa4dede7c640f189dce258c69aa65874f4eaca0a799a5fc35f9",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-go/0.2.4/completion-ranking-go-0.2.4.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-html/0.0.1/completion-ranking-html-0.0.1.jar",
+        "hash": "c0cd887da7112e3f079e2a5ae28856869f7f1a6919473a4c95d85db5cf85c4aa",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-html/0.0.1/completion-ranking-html-0.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.8.2/completion-ranking-java-0.8.2.jar",
+        "hash": "c1686a3bfa4f29059b39ec51c6d6774fe11933d11aebd95bdb0d94e3ad9d3905",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.8.2/completion-ranking-java-0.8.2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.2/completion-ranking-java-0.9.2.jar",
+        "hash": "2492dead3c2800e114634681b25b6e718df17005107ed4f1d30403e3aedffeb9",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.2/completion-ranking-java-0.9.2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.3/completion-ranking-java-0.9.3.jar",
+        "hash": "e3dcfee71eb13467139a1385152bd28554c79c677738cb617a91a772ea6e9f87",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-java/0.9.3/completion-ranking-java-0.9.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-js/0.3.0/completion-ranking-js-0.3.0.jar",
+        "hash": "e73816d0b63fa701e916b89f44559f6b8f104501f8b4f2feb300ac513e7a3850",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-js/0.3.0/completion-ranking-js-0.3.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.0/completion-ranking-kotlin-0.4.0.jar",
+        "hash": "1849979a0cd2a997e1071ac79741b1a77781357e254138f30eabffebccddfec8",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.0/completion-ranking-kotlin-0.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.1/completion-ranking-kotlin-0.4.1.jar",
+        "hash": "0be44fc263b4f59517a6dc0c4102d5743dc309ac049ac894f2bea7cd83e570d2",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-kotlin/0.4.1/completion-ranking-kotlin-0.4.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-php/0.2.4/completion-ranking-php-0.2.4.jar",
+        "hash": "b73ea2290e95b8f8350a3bcf1c1ab260aed8a249049501f4b175c8dda0f04a78",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-php/0.2.4/completion-ranking-php-0.2.4.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-python-with-full-line/0.2.1/completion-ranking-python-with-full-line-0.2.1.jar",
+        "hash": "141df5d2e70b27911bb5b601e1574623dc43b31bc6b4160f164ddd6f2ca27e6f",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-python-with-full-line/0.2.1/completion-ranking-python-with-full-line-0.2.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-python/0.2.4/completion-ranking-python-0.2.4.jar",
+        "hash": "6e6dda035d972c2ff061c5d90decea9fcaf693b0946fc8c35ef27ef452de7008",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-python/0.2.4/completion-ranking-python-0.2.4.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-ruby/0.2.4/completion-ranking-ruby-0.2.4.jar",
+        "hash": "10392061789cf7c0101931dbfe851355b3fd33c9249947586d855a9180c439a7",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-ruby/0.2.4/completion-ranking-ruby-0.2.4.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-rust/0.4.0/completion-ranking-rust-0.4.0.jar",
+        "hash": "1a220f42926fc3ac2bfce50c521aced95821ef8e8e7478a00e884acbbdc98248",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-rust/0.4.0/completion-ranking-rust-0.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-scala/0.4.1/completion-ranking-scala-0.4.1.jar",
+        "hash": "2bbdd2aeaa31dc35180490ba20ee3096097e8ca4bcecdd1b80a1c162487d3c15",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-scala/0.4.1/completion-ranking-scala-0.4.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.1/completion-ranking-sh-0.0.1.jar",
+        "hash": "2ab8007555b8fdedb7efce607cc77c03da85fcf4ea2e8376b9a352bed5f04f4a",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.1/completion-ranking-sh-0.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.2/completion-ranking-sh-0.0.2.jar",
+        "hash": "5fd26c04cdbab4538e6ececc33e373094d151de42d5032fb6027de01bc4692b1",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-sh/0.0.2/completion-ranking-sh-0.0.2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-swift/0.1.3/completion-ranking-swift-0.1.3.jar",
+        "hash": "c1d511070b2900ced87e03443091640ff7758f5064ff14d3503d6c8f50d28c1b",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-swift/0.1.3/completion-ranking-swift-0.1.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/completion-ranking-typescript/0.4.0/completion-ranking-typescript-0.4.0.jar",
+        "hash": "1ad40bce28263d3e4ff3e140949211d8812b05a6a0f121e92cb23980832838fc",
+        "path": "org/jetbrains/intellij/deps/completion/completion-ranking-typescript/0.4.0/completion-ranking-typescript-0.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar",
+        "hash": "4ac10d8fb7e6326e09179fd83e664610a3362dc1d661fb32e5b2a19bcb9fc867",
+        "path": "org/jetbrains/intellij/deps/completion/ngram-slp/0.0.3/ngram-slp-0.0.3.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/completion/performance-kotlin/0.0.9/performance-kotlin-0.0.9.jar",
+        "hash": "fabf4f175e25ea01a72fb18e6ba1479ebbbd555245021a83174089dc4fac1f5f",
+        "path": "org/jetbrains/intellij/deps/completion/performance-kotlin/0.0.9/performance-kotlin-0.0.9.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar",
+        "hash": "8627281c15b1b5347ca618d0dbc2090aa92a096a867c1d030198a51efcc33bfe",
+        "path": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar",
+        "hash": "8627281c15b1b5347ca618d0dbc2090aa92a096a867c1d030198a51efcc33bfe",
+        "path": "org/jetbrains/intellij/deps/coverage-report/1.0.25/coverage-report-1.0.25.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/debugger-agent/1.79/debugger-agent-1.79.jar",
+        "hash": "ba7a0aa7bbb813acab3b0edf36c0a15449f41896993c97e0d133fa4ea0a3e6d9",
+        "path": "org/jetbrains/intellij/deps/debugger-agent/1.79/debugger-agent-1.79.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/debugger-memory-agent/1.0.51/debugger-memory-agent-1.0.51.jar",
+        "hash": "1408ae6528102c098971bde601f99c791cd1c57cc2485516f75f4ccbb45202ef",
+        "path": "org/jetbrains/intellij/deps/debugger-memory-agent/1.0.51/debugger-memory-agent-1.0.51.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar",
+        "hash": "63aca730b99bb849f4efb87e61765a050b4a46c7d3f2969054e49439cb0132f8",
+        "path": "org/jetbrains/intellij/deps/fastutil/intellij-deps-fastutil/8.5.16-jb1/intellij-deps-fastutil-8.5.16-jb1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/filePrediction/model/file-prediction-model/0.3.0/file-prediction-model-0.3.0.jar",
+        "hash": "e506fd77462afcdb16f0ccfe7c96c1549443580a3be240c5dcff1ae2bfac0555",
+        "path": "org/jetbrains/intellij/deps/filePrediction/model/file-prediction-model/0.3.0/file-prediction-model-0.3.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar",
+        "hash": "b21806c4075aa42d4534ba7257097aea091ab99c40466b0f850872cfc07e7507",
+        "path": "org/jetbrains/intellij/deps/gradle-api/9.0.0/gradle-api-9.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar",
+        "hash": "648eaffe833416e2accea4bf82b980f0e91ae51ef065f5bc74fa3481c373e9fd",
+        "path": "org/jetbrains/intellij/deps/ift/git-learning-project/212.0.2/git-learning-project-212.0.2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/ini4j/0.5.5-2/ini4j-0.5.5-2.jar",
+        "hash": "6d342a8599aed6e2871c638c87e2533647d6a32aec1e0feaa871133ae21517a4",
+        "path": "org/jetbrains/intellij/deps/ini4j/0.5.5-2/ini4j-0.5.5-2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar",
+        "hash": "52f66c83318dcacb879f2a07fe448eccd1313b077809190810c83aa4b875611c",
+        "path": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar",
+        "hash": "52f66c83318dcacb879f2a07fe448eccd1313b077809190810c83aa4b875611c",
+        "path": "org/jetbrains/intellij/deps/intellij-coverage-agent/1.0.766/intellij-coverage-agent-1.0.766.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.766/intellij-coverage-reporter-1.0.766.jar",
+        "hash": "25393a60c2f7552955e7f5719a73b044cec83e05a62a3b0b1c75ad3e6953275b",
+        "path": "org/jetbrains/intellij/deps/intellij-coverage-reporter/1.0.766/intellij-coverage-reporter-1.0.766.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar",
+        "hash": "de175ebed73336e126ecba42c8b93a6566f65b169c6b4a4deb8099fe28e944de",
+        "path": "org/jetbrains/intellij/deps/intellij-test-discovery-agent/1.0.763/intellij-test-discovery-agent-1.0.763.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar",
+        "hash": "1f799c9e7691a4dcddb1cb3e28e8517d5e6b27c2ac75093f39714afdc9216950",
+        "path": "org/jetbrains/intellij/deps/java-compatibility/1.0.1/java-compatibility-1.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar",
+        "hash": "f31793446f372ee33659fc7a4ce93a079fa520ae89ddf6f6280ea50425c408d4",
+        "path": "org/jetbrains/intellij/deps/jb-jdi/2.45/jb-jdi-2.45.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/jcef/jcef/137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13/jcef-137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13.jar",
+        "hash": "7ff53ee6af9a9b3dcf9ce5366b9e803398d61460840a4232fa7bf3b9ef1388e5",
+        "path": "org/jetbrains/intellij/deps/jcef/jcef/137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13/jcef-137.0.17-gf354b0e-chromium-137.0.7151.104-api-1.20-253-b13.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-be/6.7.20/language-be-6.7.20.jar",
+        "hash": "f24b9d99f0b9dddbe1d63118dce0af30fd32cb6228f949cfbbad9902e2bfa169",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-be/6.7.20/language-be-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-de/6.7.20/language-de-6.7.20.jar",
+        "hash": "91d7d42c173b92d918cdf4266f7f6b468726445dca98740976002745ebdd9678",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-de/6.7.20/language-de-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-de/6.7.20/language-de-6.7.20.jar",
+        "hash": "91d7d42c173b92d918cdf4266f7f6b468726445dca98740976002745ebdd9678",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-de/6.7.20/language-de-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-el/6.7.20/language-el-6.7.20.jar",
+        "hash": "da622c6b8d7581a1ce9d58e3cab8c7e9b6770cbe994bb2982d1d82d743dfc436",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-el/6.7.20/language-el-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-en/6.7.20/language-en-6.7.20.jar",
+        "hash": "572cb63055eaa335522e9f3983d457c9acc24672edfc629cc82277d46b455702",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-en/6.7.20/language-en-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-it/6.7.20/language-it-6.7.20.jar",
+        "hash": "6b25433cf377e3fafce95f772aec21fec29c0267bf1b651834d74309700b34a5",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-it/6.7.20/language-it-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-pt/6.7.20/language-pt-6.7.20.jar",
+        "hash": "2878fbeeeff14a74a970a2a1c477a9cd5fd74a432c015ca810a85eaeaa078186",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-pt/6.7.20/language-pt-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-ru/6.7.20/language-ru-6.7.20.jar",
+        "hash": "37ee7871b86ded531c364ab448ebf446a1666aef088ecbd35c9bebd25f7239f4",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-ru/6.7.20/language-ru-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-ru/6.7.20/language-ru-6.7.20.jar",
+        "hash": "37ee7871b86ded531c364ab448ebf446a1666aef088ecbd35c9bebd25f7239f4",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-ru/6.7.20/language-ru-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-uk/6.7.20/language-uk-6.7.20.jar",
+        "hash": "bc94dd9aaee1f3e076d55bc91872d383cd92c9293cc7efd2e316915690963280",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-uk/6.7.20/language-uk-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-uk/6.7.20/language-uk-6.7.20.jar",
+        "hash": "bc94dd9aaee1f3e076d55bc91872d383cd92c9293cc7efd2e316915690963280",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-uk/6.7.20/language-uk-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/language-zh/6.7.20/language-zh-6.7.20.jar",
+        "hash": "c04ded4e5f33399dc14a52e4d4b13d6a4bfaa817f91efb26aaf208a4bbfdb42b",
+        "path": "org/jetbrains/intellij/deps/languagetool/language-zh/6.7.20/language-zh-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.20/languagetool-core-6.7.20.jar",
+        "hash": "2ceb4fddcf6e6943e8e418a417caf05affd239c9f7855ba22aa8494aa0668256",
+        "path": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.20/languagetool-core-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.20/languagetool-core-6.7.20.jar",
+        "hash": "2ceb4fddcf6e6943e8e418a417caf05affd239c9f7855ba22aa8494aa0668256",
+        "path": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.20/languagetool-core-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.20/languagetool-core-6.7.20.jar",
+        "hash": "2ceb4fddcf6e6943e8e418a417caf05affd239c9f7855ba22aa8494aa0668256",
+        "path": "org/jetbrains/intellij/deps/languagetool/languagetool-core/6.7.20/languagetool-core-6.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar",
+        "hash": "84f1d58dbf19cd7d42a5301bd256d589af1f520b4c90b8836cee7747f8726992",
+        "path": "org/jetbrains/intellij/deps/org.eclipse.jgit/6.6.1.202309021850-r-jb-202407181518/org.eclipse.jgit-6.6.1.202309021850-r-jb-202407181518.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar",
+        "hash": "61cd5eee5367d10e0cca664afdc4bbde2ff7aab9c175c5b520aac8b5315d874d",
+        "path": "org/jetbrains/intellij/deps/rwmutex-idea/0.0.10/rwmutex-idea-0.0.10.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/sa-jdwp/1.24/sa-jdwp-1.24.jar",
+        "hash": "2334e030f1ebdaddbd84aa8cd3af514a3b80d674b343532187b6d6bdff24329d",
+        "path": "org/jetbrains/intellij/deps/sa-jdwp/1.24/sa-jdwp-1.24.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/scenebuilderkit/11.0.5/scenebuilderkit-11.0.5.jar",
+        "hash": "36cd8f5bc933bcf726fadfc5276f0efcc7873d3a532e4e164674d2e8919f4781",
+        "path": "org/jetbrains/intellij/deps/scenebuilderkit/11.0.5/scenebuilderkit-11.0.5.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.0/find-action-model-252.0.0.jar",
+        "hash": "0e2660aabf41c984a38cf8b19f5cfd8ef714d29ed614b47e27547a9319fa4104",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.0/find-action-model-252.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.1/find-action-model-252.0.1.jar",
+        "hash": "f8544a3f781d84ff4983cd72cd5822d581aab0855857db31a3a358b6f1035492",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-action-model/252.0.1/find-action-model-252.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-all-model/252.0.1/find-all-model-252.0.1.jar",
+        "hash": "9670b6befe4aa52df008d6612095d1db587880b42d36550794a3db43ff55c377",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-all-model/252.0.1/find-all-model-252.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.0/find-classes-model-252.0.0.jar",
+        "hash": "925e272431706c9044c296f007249f360b57acdf0f762eeb29fa451f4a955adc",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.0/find-classes-model-252.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.1/find-classes-model-252.0.1.jar",
+        "hash": "808170665e62250dcf80bb5d2adc56105a5d9c0a550bfba8e901f1563479858f",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-classes-model/252.0.1/find-classes-model-252.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-ec-model/252.0.1/find-ec-model-252.0.1.jar",
+        "hash": "7c49ae42530a312fd8bcb0e63be01b8bae3f2daded8524ba599cd023b376edb2",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-ec-model/252.0.1/find-ec-model-252.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.0/find-file-model-252.0.0.jar",
+        "hash": "79a649df8091ebf33aecb28d91eabd8f0b9fb3f6f6aa834665855aacf0dc2044",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.0/find-file-model-252.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.1/find-file-model-252.0.1.jar",
+        "hash": "a90e92a95dc07a7dfdea9e7fd274c7d64678bb89effc4b756b52acb7137782fa",
+        "path": "org/jetbrains/intellij/deps/searchEverywhere/model/find-file-model/252.0.1/find-file-model-252.0.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/sshj/0.38.0-idea2/sshj-0.38.0-idea2.jar",
+        "hash": "bd0bf08b2b4aca35a87ec2bee62920fb0478d5b21c97f6ece04739bf5b4aeefc",
+        "path": "org/jetbrains/intellij/deps/sshj/0.38.0-idea2/sshj-0.38.0-idea2.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar",
+        "hash": "21a748abc565fd6d97d90f2547d0fd1da36810171050b2a337cbc02799cfe482",
+        "path": "org/jetbrains/intellij/deps/studio-platform/2025.1.2-287/studio-platform-2025.1.2-287.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/studio-test-platform/2025.1.2-287/studio-test-platform-2025.1.2-287.jar",
+        "hash": "146d8ebb454cccee149a81cc47026b6a576953aeb811f2ef6979bb44a5e4b50f",
+        "path": "org/jetbrains/intellij/deps/studio-test-platform/2025.1.2-287/studio-test-platform-2025.1.2-287.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar",
+        "hash": "c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d",
+        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar",
+        "hash": "c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d",
+        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar",
+        "hash": "c5fd725bffab51846bf3c77db1383c60aaaebfe1b7fe2f00d23fe1b7df0a439d",
+        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20200330/trove4j-1.0.20200330.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/trove4j/1.0.20221201/trove4j-1.0.20221201.jar",
+        "hash": "3d1ce86790d123de204215c4b2b8896afaed63abfdece24393e2183df5394c32",
+        "path": "org/jetbrains/intellij/deps/trove4j/1.0.20221201/trove4j-1.0.20221201.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/deps/winp/winp/1.30.1/winp-1.30.1.jar",
+        "hash": "9e2d7a23a1d3921861939509108606ad1cf6b10c64d65ac91958a62043cfa253",
+        "path": "org/jetbrains/intellij/deps/winp/winp/1.30.1/winp-1.30.1.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar",
+        "hash": "83789c1710426adb1637f773ec79e46ad0acf845e77e7964d7f2030cc2fd25c9",
+        "path": "org/jetbrains/intellij/plugins/structure-base/3.316/structure-base-3.316.jar"
+    },
+    {
+        "url": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar",
+        "hash": "0efe45aca820a2f722f29a49e5ffe5cd14f06c51ad60842247fcb15f8048e28a",
+        "path": "org/jetbrains/intellij/plugins/structure-intellij/3.316/structure-intellij-3.316.jar"
+    },
+    {
+        "url": "org/jetbrains/jediterm/jediterm-core/3.59/jediterm-core-3.59.jar",
+        "hash": "83247c676405d5c5c1764454d35f2bec4f70b72f1b75046d4c43bdbc49eb9587",
+        "path": "org/jetbrains/jediterm/jediterm-core/3.59/jediterm-core-3.59.jar"
+    },
+    {
+        "url": "org/jetbrains/jediterm/jediterm-ui/3.59/jediterm-ui-3.59.jar",
+        "hash": "e94b38d2e49e405a93eff2b264692d148fc996d3e72051e145d31215326186a9",
+        "path": "org/jetbrains/jediterm/jediterm-ui/3.59/jediterm-ui-3.59.jar"
+    },
+    {
+        "url": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar",
+        "hash": "c5f95c97171311066a13eb750a6bb999fa7eeb43c1394705034926336c0b7b0f",
+        "path": "org/jetbrains/jetCheck/0.2.2/jetCheck-0.2.2.jar"
+    },
+    {
+        "url": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar",
+        "hash": "86b9d2a2378cff951f3bd0750d56ff4cef64f78dbb33e9f7abd9c7e6e14d99de",
+        "path": "org/jetbrains/jps/jps-javac-extension/10/jps-javac-extension-10.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-87/allopen-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "f7374912dbbcfc18686114a78804a7f4ba91aa54b6f3bf4be10a54bb643f8a61",
+        "path": "org/jetbrains/kotlin/allopen-compiler-plugin-for-ide/2.3.20-ij253-87/allopen-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-87/analysis-api-fe10-for-ide-2.3.20-ij253-87.jar",
+        "hash": "a43d956c010eedbf6df9e7050705c13abade18f3803264ac26cfa3fc00c72dd7",
+        "path": "org/jetbrains/kotlin/analysis-api-fe10-for-ide/2.3.20-ij253-87/analysis-api-fe10-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-87/analysis-api-for-ide-2.3.20-ij253-87.jar",
+        "hash": "956c4e4e9c423e4a3a4f90a6436aabc6f377765621bfdc9eb862207160216b02",
+        "path": "org/jetbrains/kotlin/analysis-api-for-ide/2.3.20-ij253-87/analysis-api-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-87/analysis-api-impl-base-for-ide-2.3.20-ij253-87.jar",
+        "hash": "4954ca1501a0963e7e0ac3c9ef633e1976f795e8c6bf1c52d0a28b08e5751ffb",
+        "path": "org/jetbrains/kotlin/analysis-api-impl-base-for-ide/2.3.20-ij253-87/analysis-api-impl-base-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-87/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-87.jar",
+        "hash": "c6deada2fac53b8ea6523dbda77597b128006674616f140f04df23264c6d1aa3",
+        "path": "org/jetbrains/kotlin/analysis-api-impl-base-tests-for-ide/2.3.20-ij253-87/analysis-api-impl-base-tests-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-87/analysis-api-k2-for-ide-2.3.20-ij253-87.jar",
+        "hash": "fa5e5854a339d3c76c89987f638df5b64b27b888272ec7162763981fae7d06ae",
+        "path": "org/jetbrains/kotlin/analysis-api-k2-for-ide/2.3.20-ij253-87/analysis-api-k2-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-87/analysis-api-k2-tests-for-ide-2.3.20-ij253-87.jar",
+        "hash": "725800ece6c76c3de403c1a936e415770a8bd5512d138b8491eb5433c5cd666d",
+        "path": "org/jetbrains/kotlin/analysis-api-k2-tests-for-ide/2.3.20-ij253-87/analysis-api-k2-tests-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-87/analysis-api-platform-interface-for-ide-2.3.20-ij253-87.jar",
+        "hash": "33db5c2be1f298109a32c67efc9ff9f2351812cd18b1d3e3b6142b8c1f6562a0",
+        "path": "org/jetbrains/kotlin/analysis-api-platform-interface-for-ide/2.3.20-ij253-87/analysis-api-platform-interface-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-87/assignment-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "a1c99ebaca3f02a43d27c295ff6481a860c8e1e9f3b5a67dca2d6a01d5d977e5",
+        "path": "org/jetbrains/kotlin/assignment-compiler-plugin-for-ide/2.3.20-ij253-87/assignment-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-87/compose-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "32ce7920a16422638113923f434afffa11f1e65306548ed4044bab4be9ee17be",
+        "path": "org/jetbrains/kotlin/compose-compiler-plugin-for-ide/2.3.20-ij253-87/compose-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-87/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-87.jar",
+        "hash": "9d2369a7e71ff367dbed384ee50976c25743b09e4be68a58f9412ad165d8e0d7",
+        "path": "org/jetbrains/kotlin/incremental-compilation-impl-tests-for-ide/2.3.20-ij253-87/incremental-compilation-impl-tests-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/js-plain-objects-compiler-plugin-for-ide/2.3.20-ij253-87/js-plain-objects-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "c3c265fa976e6e50758aece13351510a9b9a7f0de3ac476f5de7d617e926d3f4",
+        "path": "org/jetbrains/kotlin/js-plain-objects-compiler-plugin-for-ide/2.3.20-ij253-87/js-plain-objects-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-87/kotlin-build-common-tests-for-ide-2.3.20-ij253-87.jar",
+        "hash": "d0d925a63436683c9ba594cdef82902d0186c38b28d40489f358ca94989012f1",
+        "path": "org/jetbrains/kotlin/kotlin-build-common-tests-for-ide/2.3.20-ij253-87/kotlin-build-common-tests-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-87/kotlin-compiler-cli-for-ide-2.3.20-ij253-87.jar",
+        "hash": "fb52f096c512486941155004f0f90522eda247f61014235860a7d95011600f56",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-cli-for-ide/2.3.20-ij253-87/kotlin-compiler-cli-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-87/kotlin-compiler-common-for-ide-2.3.20-ij253-87.jar",
+        "hash": "777ab6852e6054d338ab20b59aa75f92244a116a465d247e8366571e231f7968",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-common-for-ide/2.3.20-ij253-87/kotlin-compiler-common-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar",
+        "hash": "9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar",
+        "hash": "9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar",
+        "hash": "9fa8cdd1de0dccffe154c997d423ec6b5f53cd6d9177e3a77a9b0de03fb1bc81",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-embeddable/2.0.21/kotlin-compiler-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-87/kotlin-compiler-fe10-for-ide-2.3.20-ij253-87.jar",
+        "hash": "862a7043999f5212182d41840e25c81f7bb837302d7d7ad1907c82154900ef92",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-fe10-for-ide/2.3.20-ij253-87/kotlin-compiler-fe10-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-87/kotlin-compiler-fir-for-ide-2.3.20-ij253-87.jar",
+        "hash": "c1246e36061a25d2d33ac251b57c017b180b2c00dff873a58bd28d82ac5391f2",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-fir-for-ide/2.3.20-ij253-87/kotlin-compiler-fir-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-87/kotlin-compiler-ir-for-ide-2.3.20-ij253-87.jar",
+        "hash": "3e864a41449ef1e2f106473953950d34e6278aa1350b5671357b30e7afbb1be1",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-ir-for-ide/2.3.20-ij253-87/kotlin-compiler-ir-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-87/kotlin-compiler-tests-for-ide-2.3.20-ij253-87.jar",
+        "hash": "f3e930788cd79cb3e5123b7b95d34ed8dc2deedfd42e9565ba097c953e32674d",
+        "path": "org/jetbrains/kotlin/kotlin-compiler-tests-for-ide/2.3.20-ij253-87/kotlin-compiler-tests-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar",
+        "hash": "d99052e257681e496590c5c724e1324eb511e4205f5fd413b5f503d8e932b698",
+        "path": "org/jetbrains/kotlin/kotlin-compose-compiler-plugin/2.2.20/kotlin-compose-compiler-plugin-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar",
+        "hash": "b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03",
+        "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar",
+        "hash": "b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03",
+        "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar",
+        "hash": "b1a0a73c5022f8dd05a638c6b76b2bd7361818a1f3860ff2644133b1dd2bdb03",
+        "path": "org/jetbrains/kotlin/kotlin-daemon-embeddable/2.0.21/kotlin-daemon-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-87/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "5be504a59ebb1faaad1b947e70da101b79554cee42c6f7c4738bffed5babedcf",
+        "path": "org/jetbrains/kotlin/kotlin-dataframe-compiler-plugin-for-ide/2.3.20-ij253-87/kotlin-dataframe-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar",
+        "hash": "0070e80f9fed930c7209b15a5590f178acfc56028f2b6dd447c2c7cae1fc058d",
+        "path": "org/jetbrains/kotlin/kotlin-dist-for-ide/2.2.20/kotlin-dist-for-ide-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar",
+        "hash": "3841d6ad1fdd4bf90143ac6012146d291409b431e837f143c023135bd24b79a6",
+        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/1.9.20-dev-8162/kotlin-gradle-plugin-idea-proto-1.9.20-dev-8162.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar",
+        "hash": "8d1af87632d95148f122a9fa0ae2903c19ee6fab7d01e017f76e0d2c9a022c20",
+        "path": "org/jetbrains/kotlin/kotlin-gradle-plugin-idea/1.9.20-dev-8162/kotlin-gradle-plugin-idea-1.9.20-dev-8162.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-87/kotlin-gradle-statistics-for-ide-2.3.20-ij253-87.jar",
+        "hash": "5ed51fde2e2c308a5e51c93f0c306e2df361d995358fe320e0fee3eafd88d0a7",
+        "path": "org/jetbrains/kotlin/kotlin-gradle-statistics-for-ide/2.3.20-ij253-87/kotlin-gradle-statistics-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-jps-common-for-ide/2.3.20-ij253-87/kotlin-jps-common-for-ide-2.3.20-ij253-87.jar",
+        "hash": "4c42b6d0419bbdcb988df9ee3bd1d4f10fd90a3b1985966f66a9400d9c7a4ab0",
+        "path": "org/jetbrains/kotlin/kotlin-jps-common-for-ide/2.3.20-ij253-87/kotlin-jps-common-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.0/kotlin-jps-plugin-classpath-2.2.0.jar",
+        "hash": "61002bb21cc3c512bd7c9d532f3932e33e019e58d554bc4d3c208ebec5c11284",
+        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.0/kotlin-jps-plugin-classpath-2.2.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar",
+        "hash": "fa31a084adbecaaf98166e734fba1bf964e04e22671d70230ed9598cecd22124",
+        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.2.20/kotlin-jps-plugin-classpath-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-87/kotlin-jps-plugin-classpath-2.3.20-ij253-87.jar",
+        "hash": "c398467118f90fa52609c09fd853bbab73fa826fb6ba3193581d93007d3793d0",
+        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-classpath/2.3.20-ij253-87/kotlin-jps-plugin-classpath-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar",
+        "hash": "2074392bf202ae0cea075828e8739a17642eb3093db5f40e46b955937fbd8cdf",
+        "path": "org/jetbrains/kotlin/kotlin-jps-plugin-tests-for-ide/2.2.20/kotlin-jps-plugin-tests-for-ide-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21.jar",
+        "hash": "36fef581638be9c674295c176f10bc9f13025e5e1160030200991ded62ed6c29",
+        "path": "org/jetbrains/kotlin/kotlin-main-kts/2.0.21/kotlin-main-kts-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.0.0/kotlin-metadata-jvm-2.0.0.jar",
+        "hash": "ad8f1c7dbc5ac46f5cbd2d2e5de39c56c9db65dd7de716a84e01ce208758aee6",
+        "path": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.0.0/kotlin-metadata-jvm-2.0.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar",
+        "hash": "8524eac90f7e8e0f1366883f2c6c820c93bfa61df3d76857c8d3e803cf67315d",
+        "path": "org/jetbrains/kotlin/kotlin-metadata-jvm/2.2.20/kotlin-metadata-jvm-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar",
+        "hash": "38135d3f995fc505d604aed2e82ac5ba858b2a6a3e476899c3b8be47fd222b68",
+        "path": "org/jetbrains/kotlin/kotlin-project-model/1.6.0/kotlin-project-model-1.6.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar",
+        "hash": "3277ac102ae17aad10a55abec75ff5696c8d109790396434b496e75087854203",
+        "path": "org/jetbrains/kotlin/kotlin-reflect/1.6.10/kotlin-reflect-1.6.10.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.jar",
+        "hash": "99672410459045090d062a0194ed87008e2371f06946b6bfa7287c697f924bea",
+        "path": "org/jetbrains/kotlin/kotlin-reflect/1.8.10/kotlin-reflect-1.8.10.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar",
+        "hash": "a133e049f0a4e249651582428e166de4dfac9546adf436b6172119255ede510f",
+        "path": "org/jetbrains/kotlin/kotlin-reflect/1.9.21/kotlin-reflect-1.9.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.jar",
+        "hash": "3ad2fcad0c09ddc0922debab4444d612144b7b465b75a8bb7587e20ddfafd799",
+        "path": "org/jetbrains/kotlin/kotlin-reflect/2.0.21/kotlin-reflect-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar",
+        "hash": "8209083a4a7c4e476d9842b078308fa96a96f07a6bd99f05f3586ee13289ab26",
+        "path": "org/jetbrains/kotlin/kotlin-reflect/2.2.20/kotlin-reflect-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar",
+        "hash": "9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3",
+        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar",
+        "hash": "9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3",
+        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar",
+        "hash": "9c111f8d08ade455566272d561921adc2b2cb6b7a4ccee38d9829c5e3a1ca6a3",
+        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.0.21/kotlin-script-runtime-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar",
+        "hash": "5c8bd5dd7ae1ea2eeb2778fdbeaa19a562184975f6cab8a0bb6779e4190731ae",
+        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.2.20/kotlin-script-runtime-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-87/kotlin-script-runtime-2.3.20-ij253-87.jar",
+        "hash": "4708769225877c79239dfae72bf61947ef9834615d73d9e770e867ff2f4a5f10",
+        "path": "org/jetbrains/kotlin/kotlin-script-runtime/2.3.20-ij253-87/kotlin-script-runtime-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21.jar",
+        "hash": "f87deb2b14d068f99cba18217d80af85481c029c731ad8704458e9add9ca20f8",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-common/2.0.21/kotlin-scripting-common-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-87/kotlin-scripting-common-2.3.20-ij253-87.jar",
+        "hash": "4232986f099ea03551b0090173ac8712eb0b154782cb3cb340073487f9b4b52e",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-common/2.3.20-ij253-87/kotlin-scripting-common-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21.jar",
+        "hash": "2413c230fdd8cd47ebbeba273e4df94cf3b44cb3ec95d2cb35472c93768c9f1c",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.0.21/kotlin-scripting-compiler-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21.jar",
+        "hash": "6ed0fa5beb25466883989b5641f36809479260b7014535502fd387ce6c7ba833",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.0.21/kotlin-scripting-compiler-impl-embeddable-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-87/kotlin-scripting-compiler-impl-2.3.20-ij253-87.jar",
+        "hash": "284946efda62391471de3d4d7d64b4a807ce1f0f9fc7c31b049aed4d00e78a24",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-compiler-impl/2.3.20-ij253-87/kotlin-scripting-compiler-impl-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-87/kotlin-scripting-dependencies-2.3.20-ij253-87.jar",
+        "hash": "8614dddf67f21aa730e3030dbe3d58e92986660043e470c4c5b4c136a5254710",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-dependencies/2.3.20-ij253-87/kotlin-scripting-dependencies-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21.jar",
+        "hash": "88427f0f7a4c47845fa2221d29f6e0e0d7cbe73c3edf8bca30b4d8b3a336a77c",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.0.21/kotlin-scripting-jvm-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-87/kotlin-scripting-jvm-2.3.20-ij253-87.jar",
+        "hash": "92c88ac1306aeffa70e74eb65d5b1c2cce32c963cae728284c5a22d96bb30019",
+        "path": "org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.20-ij253-87/kotlin-scripting-jvm-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20.jar",
+        "hash": "e0e91962bc0007338bf5b1739f62927ac32d14ba3d827fa608ab4e5351729d5d",
+        "path": "org/jetbrains/kotlin/kotlin-stdlib-common/1.7.20/kotlin-stdlib-common-1.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20.jar",
+        "hash": "524da3c1a2ad56fd52c4ae2272ef3de421de8d2047ab1c51fc306d351243f2f5",
+        "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.7.20/kotlin-stdlib-jdk7-1.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20.jar",
+        "hash": "1da0d306c995945e1f807240ef64b5cd2dd5ac58612afb1a8596143d10b7ded5",
+        "path": "org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.7.20/kotlin-stdlib-jdk8-1.7.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar",
+        "hash": "f31cc53f105a7e48c093683bbd5437561d1233920513774b470805641bedbc09",
+        "path": "org/jetbrains/kotlin/kotlin-stdlib/2.0.21/kotlin-stdlib-2.0.21.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar",
+        "hash": "8836ccffd3585fadda9901244b20d42901d2f3cd581058d8434e2ffabcf3a3e7",
+        "path": "org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar",
+        "hash": "6842753b11a1544198f4a14b0f8820728327939b859c23c50b5fd4179c693900",
+        "path": "org/jetbrains/kotlin/kotlin-test-junit/2.2.20/kotlin-test-junit-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar",
+        "hash": "0054c51c672512a918440703e35ea946a8e7a210872f2196dbd6b9f2959198b0",
+        "path": "org/jetbrains/kotlin/kotlin-test/2.2.20/kotlin-test-2.2.20.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar",
+        "hash": "8938eb97e36320daa3e6fb2a60fd2a05b232ff4a557173c5019f045b8832d9f4",
+        "path": "org/jetbrains/kotlin/kotlin-tooling-core/1.9.20-dev-8162/kotlin-tooling-core-1.9.20-dev-8162.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-87/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "7810d0e3a97b3722d380c5a95e13936b3320acabd1123b80214bde25ea21345b",
+        "path": "org/jetbrains/kotlin/kotlinx-serialization-compiler-plugin-for-ide/2.3.20-ij253-87/kotlinx-serialization-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-87/lombok-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "8bc0ca5c9bb47b4ae74ab75306e8c0481d2748b3165dc850165d72d199540653",
+        "path": "org/jetbrains/kotlin/lombok-compiler-plugin-for-ide/2.3.20-ij253-87/lombok-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-87/low-level-api-fir-for-ide-2.3.20-ij253-87.jar",
+        "hash": "2014b8257d0ecc50c3204a716028d629c6b31052922e6a8662ec02812fb7ada6",
+        "path": "org/jetbrains/kotlin/low-level-api-fir-for-ide/2.3.20-ij253-87/low-level-api-fir-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-87/noarg-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "261a90d908355e185f0a291aa71b3ce1f4e3c67aa31411244ef8c124958b0c77",
+        "path": "org/jetbrains/kotlin/noarg-compiler-plugin-for-ide/2.3.20-ij253-87/noarg-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-87/parcelize-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "c4e51a757d46f19bdc2264c7be0cba0cc52eb52c9047c0be9b1df91eb8195f4e",
+        "path": "org/jetbrains/kotlin/parcelize-compiler-plugin-for-ide/2.3.20-ij253-87/parcelize-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-87/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "98457d26126f1095049a8769d78168ff7d0907f0b472ee28967073709b4b4607",
+        "path": "org/jetbrains/kotlin/sam-with-receiver-compiler-plugin-for-ide/2.3.20-ij253-87/sam-with-receiver-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-87/scripting-compiler-plugin-for-ide-2.3.20-ij253-87.jar",
+        "hash": "75048ae78a873e992533ba3c376a65701cff28fbcafd79d587efc999a638e0bd",
+        "path": "org/jetbrains/kotlin/scripting-compiler-plugin-for-ide/2.3.20-ij253-87/scripting-compiler-plugin-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-87/symbol-light-classes-for-ide-2.3.20-ij253-87.jar",
+        "hash": "298e61756dab332adc36712f14803e47f65f114f736c41cace04eaef2cce380e",
+        "path": "org/jetbrains/kotlin/symbol-light-classes-for-ide/2.3.20-ij253-87/symbol-light-classes-for-ide-2.3.20-ij253-87.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar",
+        "hash": "b3d9ec0298e84ed09e0448c52a643bfdad7f3d8096f1303592a3046e711551af",
+        "path": "org/jetbrains/kotlinx/atomicfu-jvm/0.20.2/atomicfu-jvm-0.20.2.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/atomicfu-jvm/0.23.2/atomicfu-jvm-0.23.2.jar",
+        "hash": "101ff43ff563fca167af5ade98c3b69bf569010eab745013b84d8955034d3b3c",
+        "path": "org/jetbrains/kotlinx/atomicfu-jvm/0.23.2/atomicfu-jvm-0.23.2.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/binary-compatibility-validator/0.17.0/binary-compatibility-validator-0.17.0.jar",
+        "hash": "0c8d35914a9094ab7071001c5b789e20d5f80d284c70a915a1ecb8fcecf92031",
+        "path": "org/jetbrains/kotlinx/binary-compatibility-validator/0.17.0/binary-compatibility-validator-0.17.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar",
+        "hash": "d767014ad0c9a27d27d26fd38e7afa030aee0d141338f108781ff02ecf2fdab5",
+        "path": "org/jetbrains/kotlinx/kotlinx-collections-immutable-jvm/0.4.0/kotlinx-collections-immutable-jvm-0.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar",
+        "hash": "c24c8bb27bb320c4a93871501a7e5e0c61607638907b197aef675513d4c820be",
+        "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar",
+        "hash": "c24c8bb27bb320c4a93871501a7e5e0c61607638907b197aef675513d4c820be",
+        "path": "org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.4/kotlinx-coroutines-core-jvm-1.6.4.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar",
+        "hash": "102764921129e1e44a74f408b7a0b8dac6d1892c6042e0e48f8bdbbbf78c6d2e",
+        "path": "org/jetbrains/kotlinx/kotlinx-datetime-jvm/0.6.2/kotlinx-datetime-jvm-0.6.2.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.jar",
+        "hash": "f854126f39acbd963fd54e0cd226000a151a76f7225ee28185d52f44e262befb",
+        "path": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.12.0/kotlinx-html-jvm-0.12.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1.jar",
+        "hash": "98bda1c78a5028a134ceb25b63f5c130c89349730d35fd47ef7490b6bf0b63b3",
+        "path": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.8.1/kotlinx-html-jvm-0.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1/kotlinx-html-jvm-0.9.1.jar",
+        "hash": "b68f39cd9ad7b46de0a0e77e7f5908d4e7661f3d0c85d2d9171543fcd5b156fb",
+        "path": "org/jetbrains/kotlinx/kotlinx-html-jvm/0.9.1/kotlinx-html-jvm-0.9.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar",
+        "hash": "ea38a66b0ff46ed82dded9e81d2dce70e5fbe03bd6cc52b4fc8869381dea7b7d",
+        "path": "org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.7.0/kotlinx-io-bytestring-jvm-0.7.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar",
+        "hash": "6ededc9be4d878aea80c7dd609f91bfc47fcd3d36cc91fd0f3f328fbd6656c8f",
+        "path": "org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.7.0/kotlinx-io-core-jvm-0.7.0.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar",
+        "hash": "604c4130ca7a0e979a449cf550087a5c2c586485e8af01dcf24b03b7b287306d",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.8.1/kotlinx-serialization-cbor-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar",
+        "hash": "eba7f1c854296e4ce1418fb01360f8f10c5683e7c45aa3472018417a067636f3",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.4.1/kotlinx-serialization-core-jvm-1.4.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar",
+        "hash": "3565b6d4d789bf70683c45566944287fc1d8dc75c23d98bd87d01059cc76f2b3",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar",
+        "hash": "3565b6d4d789bf70683c45566944287fc1d8dc75c23d98bd87d01059cc76f2b3",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.8.1/kotlinx-serialization-core-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar",
+        "hash": "ab5ec8ea48815197c46a7df9f418a62791fe91cda5023b941ce4de872d810cc1",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.8.1/kotlinx-serialization-json-io-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar",
+        "hash": "af604c46737121d4225fdb60ef0e17766a3c94b7c1c9ef76b4e3a5c7733d557e",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.4.1/kotlinx-serialization-json-jvm-1.4.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar",
+        "hash": "8769e5647557e3700919c32d508f5c5dad53c5d8234cd10846354fbcff14aa24",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.8.1/kotlinx-serialization-json-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar",
+        "hash": "fbd174f72ea82364baa112069f2d7b361758f6b68bd81d2ac51b02c66a48e924",
+        "path": "org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.8.1/kotlinx-serialization-protobuf-jvm-1.8.1.jar"
+    },
+    {
+        "url": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar",
+        "hash": "2dd9c390e2de0acbdd2fce1aabadd378fa75a9cf73ee723dd8cecbe5c8480457",
+        "path": "org/jetbrains/kotlinx/lincheck-jvm/2.33/lincheck-jvm-2.33.jar"
+    },
+    {
+        "url": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar",
+        "hash": "02e0f9bf95e4b9f81e34593691a5c0ff14604db39fb8446fe9a4efa66553f3ac",
+        "path": "org/jetbrains/markdown-jvm/0.7.2/markdown-jvm-0.7.2.jar"
+    },
+    {
+        "url": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar",
+        "hash": "7db707d839949384760b0f3e58eff49bfedea05f822e4f3361c4b540aa5dcc16",
+        "path": "org/jetbrains/marketplace-zip-signer/0.1.43/marketplace-zip-signer-0.1.43.jar"
+    },
+    {
+        "url": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar",
+        "hash": "8d715c487c8908a8b3b1d982f013f5ec39fb9033eb4272fdb251d648b5ede48c",
+        "path": "org/jetbrains/nativecerts/jvm-native-trusted-roots/1.1.7/jvm-native-trusted-roots-1.1.7.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar",
+        "hash": "9d0f4c74e96787499fcc2462c32afeb7f4db97db30042e2578f205f61e5898fb",
+        "path": "org/jetbrains/packagesearch/packagesearch-api-client-jvm/3.4.0/packagesearch-api-client-jvm-3.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar",
+        "hash": "22022fe954980d8e183b252889719fc6ca71a13e91b8e869d92532da308e3da1",
+        "path": "org/jetbrains/packagesearch/packagesearch-api-models-jvm/3.4.0/packagesearch-api-models-jvm-3.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar",
+        "hash": "0318b967115de0c7c8fbd93bc6e3d279c82de2954f90794146962921de45972d",
+        "path": "org/jetbrains/packagesearch/packagesearch-http-models-jvm/3.4.0/packagesearch-http-models-jvm-3.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar",
+        "hash": "4c86546693efaeb889e02d043521cda15da5f10853b0471095b7db80dc0540e7",
+        "path": "org/jetbrains/packagesearch/packagesearch-version-utils-jvm/3.4.0/packagesearch-version-utils-jvm-3.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/pty4j/pty4j/0.13.11/pty4j-0.13.11.jar",
+        "hash": "0329ee5520f3b0177a0b2bdefac3c4c69cc9d3915e4f210a8bf39be7ab3887c8",
+        "path": "org/jetbrains/pty4j/pty4j/0.13.11/pty4j-0.13.11.jar"
+    },
+    {
+        "url": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar",
+        "hash": "7e37284e33b5b304ee6174dcaa92db949b257cc4c8991ca865e7daf5113d8279",
+        "path": "org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar"
+    },
+    {
+        "url": "org/jetbrains/skiko/skiko-awt-runtime-all/0.9.37.3/skiko-awt-runtime-all-0.9.37.3.jar",
+        "hash": "920a8209561ed5dcf362b227bdb337c358402dc8914a08e507bdbbdbbd3bbe06",
+        "path": "org/jetbrains/skiko/skiko-awt-runtime-all/0.9.37.3/skiko-awt-runtime-all-0.9.37.3.jar"
+    },
+    {
+        "url": "org/jetbrains/skiko/skiko-awt/0.9.37.3/skiko-awt-0.9.37.3.jar",
+        "hash": "cdfe998711c8f0fa84f21745ebcfe6d840d307c4ceea7f0dda3158be2bb2193d",
+        "path": "org/jetbrains/skiko/skiko-awt/0.9.37.3/skiko-awt-0.9.37.3.jar"
+    },
+    {
+        "url": "org/jetbrains/skiko/skiko-awt/0.9.4/skiko-awt-0.9.4.jar",
+        "hash": "8e26ab1ae75f65786f6b973a66e89a2836d199a5561c4c2edbc1f3f67ad2197f",
+        "path": "org/jetbrains/skiko/skiko-awt/0.9.4/skiko-awt-0.9.4.jar"
+    },
+    {
+        "url": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar",
+        "hash": "5280d3e4bae23c4f1cc59bab77dab9f7a9626aeceeaa0bb07a9868bcedae2da9",
+        "path": "org/jetbrains/teamcity/serviceMessages/2024.07/serviceMessages-2024.07.jar"
+    },
+    {
+        "url": "org/jetbrains/terminal/completion-db-with-extensions/0.5.0/completion-db-with-extensions-0.5.0.jar",
+        "hash": "c92b8e860be7195d184ff7e29aac2b8d6fe09003921271a3174a5a443eb6a887",
+        "path": "org/jetbrains/terminal/completion-db-with-extensions/0.5.0/completion-db-with-extensions-0.5.0.jar"
+    },
+    {
+        "url": "org/jetbrains/terminal/completion-spec/0.4.0/completion-spec-0.4.0.jar",
+        "hash": "ddc6f43ff83efb9ac3d61db3f8ec7b74326b780323bf2b49383a75b6c5756397",
+        "path": "org/jetbrains/terminal/completion-spec/0.4.0/completion-spec-0.4.0.jar"
+    },
+    {
+        "url": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar",
+        "hash": "5ed74de192bd48546a6bc6e1c9f8f508663d8506ad9ef257aebbd6e829fdea36",
+        "path": "org/jetbrains/testDiscovery/test-discovery-plugin-base/0.1.191/test-discovery-plugin-base-0.1.191.jar"
+    },
+    {
+        "url": "org/jline/jansi-core/3.30.4/jansi-core-3.30.4.jar",
+        "hash": "c7ff9f2ae789def538cb68c32d25f5df5839cb25c8fe0550306c4611b4ec9adf",
+        "path": "org/jline/jansi-core/3.30.4/jansi-core-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-builtins/3.30.4/jline-builtins-3.30.4.jar",
+        "hash": "17d62755cdab34f26975615a97ef07d395c2d384639ae6c89e9fde97fd5a093f",
+        "path": "org/jline/jline-builtins/3.30.4/jline-builtins-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-console-ui/3.30.4/jline-console-ui-3.30.4.jar",
+        "hash": "cc5e3d2f5305021d4c1757bc82b4beab16d6ad99a8a6b970f94bc410f5069161",
+        "path": "org/jline/jline-console-ui/3.30.4/jline-console-ui-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-console/3.30.4/jline-console-3.30.4.jar",
+        "hash": "8bf80257f33db9f0f411562feb5c804327c8622f23d9570b3cf2f1c25b5da1d5",
+        "path": "org/jline/jline-console/3.30.4/jline-console-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
+        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
+        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
+        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
+        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar",
+        "hash": "d8bc77bc80edc7d9a02a06a069b2d7085629421db0843aba7c153a869ffe525d",
+        "path": "org/jline/jline-native/3.27.0/jline-native-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-native/3.30.4/jline-native-3.30.4.jar",
+        "hash": "12075e489a0a70c14885b864a73a70f1da479bc1325522374e0cf53032f66fe9",
+        "path": "org/jline/jline-native/3.30.4/jline-native-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-reader/3.30.4/jline-reader-3.30.4.jar",
+        "hash": "6989455b7a250698451f08cc59d3797f0fb581eb451e0fae4305a43473b8a668",
+        "path": "org/jline/jline-reader/3.30.4/jline-reader-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-style/3.30.4/jline-style-3.30.4.jar",
+        "hash": "fe24ab7f37be8a807bb2ad32468f985efa9fa21910249788f75f91af146d948c",
+        "path": "org/jline/jline-style/3.30.4/jline-style-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar",
+        "hash": "a7b369a2e697215fed314a58b736f10ae8bdedf218096916a6bdb7bc886fe470",
+        "path": "org/jline/jline-terminal-jansi/3.27.0/jline-terminal-jansi-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal-jna/3.27.0/jline-terminal-jna-3.27.0.jar",
+        "hash": "e7322e6d8dc1bd69f507b91865af741af4a95c649ccab36e79e8be89696bb432",
+        "path": "org/jline/jline-terminal-jna/3.27.0/jline-terminal-jna-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal-jni/3.30.4/jline-terminal-jni-3.30.4.jar",
+        "hash": "23c4a1631d005c22a509536ae14e1aa3c07fb6a958ac083f1221b9e9db7b2932",
+        "path": "org/jline/jline-terminal-jni/3.30.4/jline-terminal-jni-3.30.4.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
+        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
+        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
+        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
+        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar",
+        "hash": "2f461c75091ec3810a42184afc80c96910f54e9dd2110e9ecb9902a5ee6c244b",
+        "path": "org/jline/jline-terminal/3.27.0/jline-terminal-3.27.0.jar"
+    },
+    {
+        "url": "org/jline/jline-terminal/3.30.4/jline-terminal-3.30.4.jar",
+        "hash": "1131990dddfd04b27df96ecdb71cfe098a0af2f6285af7359c38174887dc3527",
+        "path": "org/jline/jline-terminal/3.30.4/jline-terminal-3.30.4.jar"
+    },
+    {
+        "url": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar",
+        "hash": "c53b16b999d3b2f1aa273bf5c560273d23e1fa21ce493ba7cbf5243118386b88",
+        "path": "org/jmock/jmock-junit4/2.5.1/jmock-junit4-2.5.1.jar"
+    },
+    {
+        "url": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar",
+        "hash": "0c8d23755cd08d23c3ea194773a08b2c322d2b70cc8c86ac02b424d8a50c9118",
+        "path": "org/jmock/jmock-legacy/2.5.1/jmock-legacy-2.5.1.jar"
+    },
+    {
+        "url": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar",
+        "hash": "d96425f4bab28798162e59fffbe7e16ea6c2aab303ee8dfb0a2ec38a5a4e2f36",
+        "path": "org/jmock/jmock/2.5.1/jmock-2.5.1.jar"
+    },
+    {
+        "url": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar",
+        "hash": "3238c68a2f86cec53cc184ad26df8352db87bb22a419bd17fb4acdfbb0bc40f0",
+        "path": "org/jruby/jcodings/jcodings/1.0.61/jcodings-1.0.61.jar"
+    },
+    {
+        "url": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar",
+        "hash": "7ea54221f5f91deff2e860fe986eefe208b59fa04300e54c505c5c0c08d55e9a",
+        "path": "org/jruby/joni/joni/2.2.3/joni-2.2.3.jar"
+    },
+    {
+        "url": "org/json/json/20231013/json-20231013.jar",
+        "hash": "0f18192df289114e17aa1a0d0a7f8372cc9f5c7e4f7e39adcf8906fe714fa7d3",
+        "path": "org/json/json/20231013/json-20231013.jar"
+    },
+    {
+        "url": "org/json/json/20240205/json-20240205.jar",
+        "hash": "e89df61466f0807f8a86db0e8805a837e59462c8ca47c67786e432133c490aca",
+        "path": "org/json/json/20240205/json-20240205.jar"
+    },
+    {
+        "url": "org/json/json/20240303/json-20240303.jar",
+        "hash": "3cf6cd6892e32e2b4c1c39e0f52f5248a2f5b37646fdfbb79a66b46b618414ed",
+        "path": "org/json/json/20240303/json-20240303.jar"
+    },
+    {
+        "url": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar",
+        "hash": "f05496e255734759f0d4b5632da7b24f81313147c78c69e90ad045d096191344",
+        "path": "org/jsoup/jsoup/1.21.2/jsoup-1.21.2.jar"
+    },
+    {
+        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
+        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+    },
+    {
+        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
+        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+    },
+    {
+        "url": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar",
+        "hash": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "path": "org/jspecify/jspecify/1.0.0/jspecify-1.0.0.jar"
+    },
+    {
+        "url": "org/junit-pioneer/junit-pioneer/2.3.0/junit-pioneer-2.3.0.jar",
+        "hash": "8b09db32c8cf5b2112a00262411ccd4ef6ca3bae695a0015ecad4def23dea9fd",
+        "path": "org/junit-pioneer/junit-pioneer/2.3.0/junit-pioneer-2.3.0.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar",
+        "hash": "afff77c186cd317275803872fa5133aa801fd6ac40bd91c78a6cf8009b4b17cc",
+        "path": "org/junit/jupiter/junit-jupiter-api/5.10.2/junit-jupiter-api-5.10.2.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar",
+        "hash": "d1bb81abfd9e03418306b4e6a3390c8db52c58372e749c2980ac29f0c08278f1",
+        "path": "org/junit/jupiter/junit-jupiter-api/5.13.4/junit-jupiter-api-5.13.4.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar",
+        "hash": "88d690d2d373cd66170770c317977196ce9e465f2388930f4bc9665e887385f6",
+        "path": "org/junit/jupiter/junit-jupiter-api/6.0.0/junit-jupiter-api-6.0.0.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar",
+        "hash": "027404a92fe618b72465792a257951495c503a7d5751e2791e0f51c87f67f5bc",
+        "path": "org/junit/jupiter/junit-jupiter-engine/5.13.4/junit-jupiter-engine-5.13.4.jar"
+    },
+    {
+        "url": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar",
+        "hash": "3a8c6365716dbb698c0d49a05456c1e1ad05c406613c550f9dd50037872efc41",
+        "path": "org/junit/jupiter/junit-jupiter-params/5.13.4/junit-jupiter-params-5.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.jar",
+        "hash": "b56a5ec000a479df4973b18bba24c98fe0db8faa14c8907d3ef451d8c71fd8ae",
+        "path": "org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar",
+        "hash": "1c25ca641ebaae44ff3ad21ca1b2ef68d0dd84bfeb07c4805ba7840899b77408",
+        "path": "org/junit/platform/junit-platform-commons/1.13.4/junit-platform-commons-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar",
+        "hash": "86e8faf87f3151a3d545850852a0f2cc55ea8a2434eee9e08f83881c52d55992",
+        "path": "org/junit/platform/junit-platform-commons/6.0.0/junit-platform-commons-6.0.0.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar",
+        "hash": "390c5f77b84283a64b644f88251b397e0b0debb80bdcc50f899881aecff43a5a",
+        "path": "org/junit/platform/junit-platform-engine/1.13.4/junit-platform-engine-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar",
+        "hash": "702868ed7e86b9b4672ede0f1e185e905baca9afab57746a7c650be3c7bca047",
+        "path": "org/junit/platform/junit-platform-engine/1.8.1/junit-platform-engine-1.8.1.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar",
+        "hash": "6f81842e9c13e997cac66b44614522f3639419e2388ae2d000c4bc0a6b92d93f",
+        "path": "org/junit/platform/junit-platform-engine/6.0.0/junit-platform-engine-6.0.0.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar",
+        "hash": "0b0beaeb6880a31149641d2d848b863712885469670c12099586d7f798522564",
+        "path": "org/junit/platform/junit-platform-launcher/1.13.4/junit-platform-launcher-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar",
+        "hash": "5f097b00c6714bb71ecfb5dec62b59bb4c2f789763fafd1ece96c4ef0e6c280f",
+        "path": "org/junit/platform/junit-platform-launcher/6.0.0/junit-platform-launcher-6.0.0.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar",
+        "hash": "9a05bf77e128371f5b3e25ffc89f7af467a9f68dd365fdfced469ebcf533abc9",
+        "path": "org/junit/platform/junit-platform-suite-api/1.13.4/junit-platform-suite-api-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar",
+        "hash": "e7dacfcfa3bc692c0a7a413cefd5f51ae420415a14d39091bdf88aebfdba70b6",
+        "path": "org/junit/platform/junit-platform-suite-commons/1.13.4/junit-platform-suite-commons-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar",
+        "hash": "3b34fd8172d70d0d7c59155e487bd8e77d43bdbfdcfe1d78c2b4eea55e9acb92",
+        "path": "org/junit/platform/junit-platform-suite-engine/1.13.4/junit-platform-suite-engine-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar",
+        "hash": "8088a80b47f5a7e73fa107f466dfa6a86776ca496fc2e7724aba65202d467913",
+        "path": "org/junit/platform/junit-platform-suite/1.13.4/junit-platform-suite-1.13.4.jar"
+    },
+    {
+        "url": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar",
+        "hash": "066b702d850ebcde36f2a8181b46a2f0f1416129d1dc63c3a1e1531006e74739",
+        "path": "org/junit/vintage/junit-vintage-engine/5.13.4/junit-vintage-engine-5.13.4.jar"
+    },
+    {
+        "url": "org/languagetool/english-pos-dict/0.6/english-pos-dict-0.6.jar",
+        "hash": "2a3e96b49854e5275f8eb7a1bb5b3b85b82f687fed272f3043882ccc0b1634b1",
+        "path": "org/languagetool/english-pos-dict/0.6/english-pos-dict-0.6.jar"
+    },
+    {
+        "url": "org/languagetool/portuguese-pos-dict/1.2.0/portuguese-pos-dict-1.2.0.jar",
+        "hash": "fe8da88bb31b6372855741fbd81ee1c7477b4f8a0624d3dafd20ee23e184650e",
+        "path": "org/languagetool/portuguese-pos-dict/1.2.0/portuguese-pos-dict-1.2.0.jar"
+    },
+    {
+        "url": "org/latencyutils/LatencyUtils/2.0.3/LatencyUtils-2.0.3.jar",
+        "hash": "a32a9ffa06b2f4e01c5360f8f9df7bc5d9454a5d373cd8f361347fa5a57165ec",
+        "path": "org/latencyutils/LatencyUtils/2.0.3/LatencyUtils-2.0.3.jar"
+    },
+    {
+        "url": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar",
+        "hash": "488f51ed95f0fac48d1d87cb0e3bac08c012dcbf6ef3c1688685d708cdbccd56",
+        "path": "org/lwjgl/lwjgl-tinyfd/3.3.1/lwjgl-tinyfd-3.3.1.jar"
+    },
+    {
+        "url": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar",
+        "hash": "d74a3334fb35195009b338a951f918203d6bbca3d1d359033dc33edd1cadc9ef",
+        "path": "org/lz4/lz4-java/1.8.0/lz4-java-1.8.0.jar"
+    },
+    {
+        "url": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar",
+        "hash": "34d626ffa4a27ec49e47de7d760f1df30223ecb8944b6472941f5c73ec68dfbd",
+        "path": "org/mockito/kotlin/mockito-kotlin/6.0.0/mockito-kotlin-6.0.0.jar"
+    },
+    {
+        "url": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar",
+        "hash": "d875ff234a4b72e0eedfe170dd804797a4b87ba4c76207c9659d6f46b527877b",
+        "path": "org/mockito/mockito-core/5.19.0/mockito-core-5.19.0.jar"
+    },
+    {
+        "url": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar",
+        "hash": "7cfbb7a9c1198053c699c663479fd4836acc22c2650003c8dee20e7fbc55a65a",
+        "path": "org/mockito/mockito-junit-jupiter/5.19.0/mockito-junit-jupiter-5.19.0.jar"
+    },
+    {
+        "url": "org/mozilla/rhino-runtime/1.7.15/rhino-runtime-1.7.15.jar",
+        "hash": "4f38c96499c614145b87442700e196df39b0af808b1b1204eaccaa15bef17c2b",
+        "path": "org/mozilla/rhino-runtime/1.7.15/rhino-runtime-1.7.15.jar"
+    },
+    {
+        "url": "org/mozilla/rhino/1.7.14/rhino-1.7.14.jar",
+        "hash": "c9290b0d801bf0dbbbc44338e0f769b7650a0c5d04e6bb1aeb85775c0211b003",
+        "path": "org/mozilla/rhino/1.7.14/rhino-1.7.14.jar"
+    },
+    {
+        "url": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar",
+        "hash": "39c6588948ab31b98ab1fea4a6abab37243f387cb48cb50ae599410effb70038",
+        "path": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar"
+    },
+    {
+        "url": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar",
+        "hash": "39c6588948ab31b98ab1fea4a6abab37243f387cb48cb50ae599410effb70038",
+        "path": "org/nibor/autolink/autolink/0.11.0/autolink-0.11.0.jar"
+    },
+    {
+        "url": "org/objenesis/objenesis/3.1/objenesis-3.1.jar",
+        "hash": "cdb3d038c188de6f46ffd5cd930be2d5e5dba59c53b26437995d534e3db2fb80",
+        "path": "org/objenesis/objenesis/3.1/objenesis-3.1.jar"
+    },
+    {
+        "url": "org/objenesis/objenesis/3.3/objenesis-3.3.jar",
+        "hash": "02dfd0b0439a5591e35b708ed2f5474eb0948f53abf74637e959b8e4ef69bfeb",
+        "path": "org/objenesis/objenesis/3.3/objenesis-3.3.jar"
+    },
+    {
+        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
+        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
+        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
+    },
+    {
+        "url": "org/objenesis/objenesis/3.4/objenesis-3.4.jar",
+        "hash": "95488102feaf2e2858adf6b299353677dac6c15294006f8ed1c5556f8e3cd251",
+        "path": "org/objenesis/objenesis/3.4/objenesis-3.4.jar"
+    },
+    {
+        "url": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar",
+        "hash": "dc0eaf2bbf0036a70b60798c785d6e03a9daf06b68b8edb0f1ba9eb3421baeb3",
+        "path": "org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar"
+    },
+    {
+        "url": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar",
+        "hash": "c2a88cf8be1eb0870732a7b2e669972efc7f33a145998f568096137f16b20d79",
+        "path": "org/openjdk/jmh/jmh-generator-annprocess/1.36/jmh-generator-annprocess-1.36.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar",
+        "hash": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
+        "path": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar",
+        "hash": "58812de60898d976fb81ef3b62da05c6604c18fd4a249f5044282479fc286af2",
+        "path": "org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+    },
+    {
+        "url": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar",
+        "hash": "48e2df636cab6563ced64dcdff8abb2355627cb236ef0bf37598682ddf742f1b",
+        "path": "org/opentest4j/opentest4j/1.3.0/opentest4j-1.3.0.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar",
+        "hash": "d92832d7c37edc07c60e2559ac6118b31d642e337a6671edcb7ba9fae68edbbb",
+        "path": "org/ow2/asm/asm-analysis/9.6/asm-analysis-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar",
+        "hash": "e640732fbcd3c6271925a504f125e38384688f4dfbbf92c8622dfcee0d09edb9",
+        "path": "org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar",
+        "hash": "72eee9fbafb9de8d9463f20dd584a48ceeb7e5152ad4c987bfbe17dd4811c9ae",
+        "path": "org/ow2/asm/asm-commons/9.5/asm-commons-9.5.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar",
+        "hash": "7aefd0d5c0901701c69f7513feda765fb6be33af2ce7aa17c5781fc87657c511",
+        "path": "org/ow2/asm/asm-commons/9.6/asm-commons-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-commons/9.9/asm-commons-9.9.jar",
+        "hash": "db2f6f26150bbe7c126606b4a1151836bcc22a1e05a423b3585698bece995ff8",
+        "path": "org/ow2/asm/asm-commons/9.9/asm-commons-9.9.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar",
+        "hash": "c43ecf17b539c777e15da7b5b86553b377e2d39a683de6285567d5283888e7ef",
+        "path": "org/ow2/asm/asm-tree/9.6/asm-tree-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar",
+        "hash": "14b7880cb7c85eed101e2710432fc3ffb83275532a6a894dc4c4095d49ad59f1",
+        "path": "org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-tree/9.9/asm-tree-9.9.jar",
+        "hash": "42178f3775c9c63f9e5e1446747d29b4eca4d91bd6e75e5c43cfa372a47d38c6",
+        "path": "org/ow2/asm/asm-tree/9.9/asm-tree-9.9.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar",
+        "hash": "c635a7402f4aa9bf66b2f4230cea62025a0fe1cd63e8729adefc9b1994fac4c3",
+        "path": "org/ow2/asm/asm-util/9.6/asm-util-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm/9.5/asm-9.5.jar",
+        "hash": "b62e84b5980729751b0458c534cf1366f727542bb8d158621335682a460f0353",
+        "path": "org/ow2/asm/asm/9.5/asm-9.5.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm/9.6/asm-9.6.jar",
+        "hash": "3c6fac2424db3d4a853b669f4e3d1d9c3c552235e19a319673f887083c2303a1",
+        "path": "org/ow2/asm/asm/9.6/asm-9.6.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm/9.8/asm-9.8.jar",
+        "hash": "876eab6a83daecad5ca67eb9fcabb063c97b5aeb8cf1fca7a989ecde17522051",
+        "path": "org/ow2/asm/asm/9.8/asm-9.8.jar"
+    },
+    {
+        "url": "org/ow2/asm/asm/9.9/asm-9.9.jar",
+        "hash": "03d99a74ad1ee5c71334ef67437f4ef4fe3488caa7c96d8645abc73c8e2017d4",
+        "path": "org/ow2/asm/asm/9.9/asm-9.9.jar"
+    },
+    {
+        "url": "org/rnorth/duct-tape/duct-tape/1.0.8/duct-tape-1.0.8.jar",
+        "hash": "31cef12ddec979d1f86d7cf708c41a17da523d05c685fd6642e9d0b2addb7240",
+        "path": "org/rnorth/duct-tape/duct-tape/1.0.8/duct-tape-1.0.8.jar"
+    },
+    {
+        "url": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar",
+        "hash": "0a7e032bf5bcdd5b2bf8bf2e5cf02c5646f2aa6fee66933b8150dbe84e651e8a",
+        "path": "org/slf4j/log4j-over-slf4j/1.7.36/log4j-over-slf4j-1.7.36.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
+        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
+        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
+        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar",
+        "hash": "18c4a0095d5c1da6b817592e767bb23d29dd2f560ad74df75ff3961dbde25b79",
+        "path": "org/slf4j/slf4j-api/1.7.25/slf4j-api-1.7.25.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.jar",
+        "hash": "3624f8474c1af46d75f98bc097d7864a323c81b3808aa43689a6e1c601c027be",
+        "path": "org/slf4j/slf4j-api/1.7.32/slf4j-api-1.7.32.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar",
+        "hash": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
+        "path": "org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar",
+        "hash": "fe30825245d2336c859dc38d60c0fc5f3668dbf29cd586828d2b5667ec355b91",
+        "path": "org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar",
+        "hash": "e7c2a48e8515ba1f49fa637d57b4e2f590b3f5bd97407ac699c3aa5efb1204a9",
+        "path": "org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/2.0.16/slf4j-api-2.0.16.jar",
+        "hash": "a12578dde1ba00bd9b816d388a0b879928d00bab3c83c240f7013bf4196c579a",
+        "path": "org/slf4j/slf4j-api/2.0.16/slf4j-api-2.0.16.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar",
+        "hash": "7b751d952061954d5abfed7181c1f645d336091b679891591d63329c622eb832",
+        "path": "org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-api/2.0.7/slf4j-api-2.0.7.jar",
+        "hash": "5d6298b93a1905c32cda6478808ac14c2d4a47e91535e53c41f7feeb85d946f4",
+        "path": "org/slf4j/slf4j-api/2.0.7/slf4j-api-2.0.7.jar"
+    },
+    {
+        "url": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar",
+        "hash": "83f17205a6470c3cd4214306d3ed011651c173297f705acef544c01795f253cd",
+        "path": "org/slf4j/slf4j-jdk14/2.0.13/slf4j-jdk14-2.0.13.jar"
+    },
+    {
+        "url": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar",
+        "hash": "4053f878c171692aab8782f53a3974f43e55e2b6ed12c3682b36a46968c5ded1",
+        "path": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar"
+    },
+    {
+        "url": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar",
+        "hash": "4053f878c171692aab8782f53a3974f43e55e2b6ed12c3682b36a46968c5ded1",
+        "path": "org/snakeyaml/snakeyaml-engine/2.7/snakeyaml-engine-2.7.jar"
+    },
+    {
+        "url": "org/snakeyaml/snakeyaml-engine/2.9/snakeyaml-engine-2.9.jar",
+        "hash": "2f7a957461b6d70c0005e2c35b78a1c97bef6c446704c0ee9393ce98e4958ba8",
+        "path": "org/snakeyaml/snakeyaml-engine/2.9/snakeyaml-engine-2.9.jar"
+    },
+    {
+        "url": "org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.jar",
+        "hash": "ae8dc80232771f8913febfa410c5719e9ba8ded81fb99788e214fd676dbbe13f",
+        "path": "org/sonatype/aether/aether-api/1.13.1/aether-api-1.13.1.jar"
+    },
+    {
+        "url": "org/sonatype/aether/aether-impl/1.13.1/aether-impl-1.13.1.jar",
+        "hash": "865511994805827e88f327944a089142bb7f3d88cde271ba3dceb732cb137a93",
+        "path": "org/sonatype/aether/aether-impl/1.13.1/aether-impl-1.13.1.jar"
+    },
+    {
+        "url": "org/sonatype/aether/aether-spi/1.13.1/aether-spi-1.13.1.jar",
+        "hash": "d5de4e299be5a79feb1dbe8ff3814034c6e44314b4c00b92ffa8d97576ded5b3",
+        "path": "org/sonatype/aether/aether-spi/1.13.1/aether-spi-1.13.1.jar"
+    },
+    {
+        "url": "org/sonatype/aether/aether-util/1.13.1/aether-util-1.13.1.jar",
+        "hash": "687799a0ce988bee9e8eb9ae0ba870300adc0114248ad4a4327bdb625d27e010",
+        "path": "org/sonatype/aether/aether-util/1.13.1/aether-util-1.13.1.jar"
+    },
+    {
+        "url": "org/sonatype/nexus/nexus-indexer-artifact/1.0.1/nexus-indexer-artifact-1.0.1.jar",
+        "hash": "171035740322f96bd8c155cfb6050962dd61d7976a494c0aac6d46b3c83174c4",
+        "path": "org/sonatype/nexus/nexus-indexer-artifact/1.0.1/nexus-indexer-artifact-1.0.1.jar"
+    },
+    {
+        "url": "org/sonatype/nexus/nexus-indexer/3.0.4/nexus-indexer-3.0.4.jar",
+        "hash": "9d43a28d0758914fdcea28a436601ac26d06a3b55d283bb6be0321ccd3631a58",
+        "path": "org/sonatype/nexus/nexus-indexer/3.0.4/nexus-indexer-3.0.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar",
+        "hash": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+        "path": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar",
+        "hash": "114859861ff10f987b880d6f34e3215274af3cc92b3a73831c84d596e37c6511",
+        "path": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar",
+        "hash": "114859861ff10f987b880d6f34e3215274af3cc92b3a73831c84d596e37c6511",
+        "path": "org/sonatype/plexus/plexus-cipher/1.7/plexus-cipher-1.7.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar",
+        "hash": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar",
+        "hash": "da73e32b58132e64daf12269fd9d011c0b303f234840f179908725a632b6b57c",
+        "path": "org/sonatype/plexus/plexus-sec-dispatcher/1.4/plexus-sec-dispatcher-1.4.jar"
+    },
+    {
+        "url": "org/sonatype/sisu/sisu-guava/0.9.9/sisu-guava-0.9.9.jar",
+        "hash": "9897e80ff6c08fc45b5b5ebd81d9e943a1087bdf0ad50cda457d616abbdaacd9",
+        "path": "org/sonatype/sisu/sisu-guava/0.9.9/sisu-guava-0.9.9.jar"
+    },
+    {
+        "url": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0.jar",
+        "hash": "a263933f43e9c273161e0b99f553c33a80a0416ec0bd5dca17d54cf38ae5956f",
+        "path": "org/sonatype/sisu/sisu-guice/3.1.0/sisu-guice-3.1.0.jar"
+    },
+    {
+        "url": "org/sonatype/sisu/sisu-inject-bean/2.3.0/sisu-inject-bean-2.3.0.jar",
+        "hash": "75819b29737c2bee1bfbda1011d455c7036738e0ef32ffbf85ba1d8fa157ceb2",
+        "path": "org/sonatype/sisu/sisu-inject-bean/2.3.0/sisu-inject-bean-2.3.0.jar"
+    },
+    {
+        "url": "org/sonatype/sisu/sisu-inject-plexus/2.3.0/sisu-inject-plexus-2.3.0.jar",
+        "hash": "bf9083fb846993689409b2bdbc735048e53bac6cc32707cde7ef84817b6e9365",
+        "path": "org/sonatype/sisu/sisu-inject-plexus/2.3.0/sisu-inject-plexus-2.3.0.jar"
+    },
+    {
+        "url": "org/spdx/java-spdx-library/1.1.10/java-spdx-library-1.1.10.jar",
+        "hash": "ef116816a4d221933d34d9f113fd47f6780bca2b0c826545081d742f4e7178fb",
+        "path": "org/spdx/java-spdx-library/1.1.10/java-spdx-library-1.1.10.jar"
+    },
+    {
+        "url": "org/spdx/spdx-jackson-store/1.1.9/spdx-jackson-store-1.1.9.jar",
+        "hash": "f2fee72e08fd510479ac93e7e33694bdbc465b32a56896bf1ab8a8dfba366f18",
+        "path": "org/spdx/spdx-jackson-store/1.1.9/spdx-jackson-store-1.1.9.jar"
+    },
+    {
+        "url": "org/spdx/tools-java/1.1.8/tools-java-1.1.8.jar",
+        "hash": "deaca39f9ae12879f061c946d72641240e731dc9df0059d9b69472f43accb4a5",
+        "path": "org/spdx/tools-java/1.1.8/tools-java-1.1.8.jar"
+    },
+    {
+        "url": "org/spockframework/spock-core/2.1-groovy-3.0/spock-core-2.1-groovy-3.0.jar",
+        "hash": "fa8ff7446df04c51b3ccbc2a1bbc71f9c280878afe2d53be44d59d00b1b9828c",
+        "path": "org/spockframework/spock-core/2.1-groovy-3.0/spock-core-2.1-groovy-3.0.jar"
+    },
+    {
+        "url": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar",
+        "hash": "491c4ae84a1bad34c85624682a80def4f3a3a0fb9d517121d05c2dfeb94966f8",
+        "path": "org/sqlite/native/3.42.0-jb.1/native-3.42.0-jb.1.jar"
+    },
+    {
+        "url": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar",
+        "hash": "0df80935d9bc3b3841bc621c6fef6615c93aaf80393ccaa196db11bf97784f18",
+        "path": "org/swinglabs/swingx-core/1.6.2-2/swingx-core-1.6.2-2.jar"
+    },
+    {
+        "url": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar",
+        "hash": "3b0f0422993e571f3460d8436a0e56538bd474147084a6cbb244a6d5cb1a01a5",
+        "path": "org/testcontainers/junit-jupiter/1.20.3/junit-jupiter-1.20.3.jar"
+    },
+    {
+        "url": "org/testcontainers/testcontainers/1.20.3/testcontainers-1.20.3.jar",
+        "hash": "e1d89a13d93337e1b14000d6c7c3e8e047fe244db63231134e52fbc1c0ffc5f7",
+        "path": "org/testcontainers/testcontainers/1.20.3/testcontainers-1.20.3.jar"
+    },
+    {
+        "url": "org/testng/testng/7.8.0/testng-7.8.0.jar",
+        "hash": "dbbc43e2c64623661c3537f9d74061eb6c8fc3e5b4376f31fadb16de2b200f88",
+        "path": "org/testng/testng/7.8.0/testng-7.8.0.jar"
+    },
+    {
+        "url": "org/tukaani/xz/1.10/xz-1.10.jar",
+        "hash": "95c63c1a55b22dd6453890a419cc1a640f790bbf7d8ae82db1e30aefefb08888",
+        "path": "org/tukaani/xz/1.10/xz-1.10.jar"
+    },
+    {
+        "url": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar",
+        "hash": "da2381fbee4799631ba44d1f4d6487b886b22450c7fc85842c5fdfa03429b817",
+        "path": "org/webjars/jquery/3.6.1/jquery-3.6.1.jar"
+    },
+    {
+        "url": "org/xerial/sqlite-jdbc/3.50.3.0/sqlite-jdbc-3.50.3.0.jar",
+        "hash": "a3f53a2aa15ae9425a9e793bbe9c8e5288febeb4b65ef5c1a4e80d4c2045cf08",
+        "path": "org/xerial/sqlite-jdbc/3.50.3.0/sqlite-jdbc-3.50.3.0.jar"
+    },
+    {
+        "url": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar",
+        "hash": "ef779af5d29a9dde8cc70ce0341f5c6f7735e23edff9685ceaa9d35359b7bb7f",
+        "path": "org/yaml/snakeyaml/2.4/snakeyaml-2.4.jar"
+    },
+    {
+        "url": "oro/oro/2.0.8/oro-2.0.8.jar",
+        "hash": "e00ccdad5df7eb43fdee44232ef64602bf63807c2d133a7be83ba09fd49af26e",
+        "path": "oro/oro/2.0.8/oro-2.0.8.jar"
+    },
+    {
+        "url": "tech/units/indriya/1.3/indriya-1.3.jar",
+        "hash": "7cbaa6f42e2c8412ef13cd0fb7f81936d64a1c3ea7c4f69cf75bb4e9410cb76b",
+        "path": "tech/units/indriya/1.3/indriya-1.3.jar"
+    },
+    {
+        "url": "tech/units/indriya/1.3/indriya-1.3.jar",
+        "hash": "7cbaa6f42e2c8412ef13cd0fb7f81936d64a1c3ea7c4f69cf75bb4e9410cb76b",
+        "path": "tech/units/indriya/1.3/indriya-1.3.jar"
+    },
+    {
+        "url": "tech/uom/lib/uom-lib-common/1.1/uom-lib-common-1.1.jar",
+        "hash": "4add5fbcb7f548b79230ed7e01cb9fd4f9e2524bd1598dbcbfd8150563fe27f7",
+        "path": "tech/uom/lib/uom-lib-common/1.1/uom-lib-common-1.1.jar"
+    },
+    {
+        "url": "tech/uom/lib/uom-lib-common/1.1/uom-lib-common-1.1.jar",
+        "hash": "4add5fbcb7f548b79230ed7e01cb9fd4f9e2524bd1598dbcbfd8150563fe27f7",
+        "path": "tech/uom/lib/uom-lib-common/1.1/uom-lib-common-1.1.jar"
+    },
+    {
+        "url": "thaiopensource/jing/20030619/jing-20030619.jar",
+        "hash": "600acd9ebd37dd46e3a006bc6e748d68dfeb31cbf4881a84d06e6dc5cc5eed26",
+        "path": "thaiopensource/jing/20030619/jing-20030619.jar"
+    },
+    {
+        "url": "ua/net/nlp/morfologik-ukrainian-lt/6.7.1/morfologik-ukrainian-lt-6.7.1.jar",
+        "hash": "453886930ba7ba0d80d1158577e3e10d814e2c739ee17e297f062542d92dfd04",
+        "path": "ua/net/nlp/morfologik-ukrainian-lt/6.7.1/morfologik-ukrainian-lt-6.7.1.jar"
+    },
+    {
+        "url": "ua/net/nlp/morfologik-ukrainian-lt/6.7.1/morfologik-ukrainian-lt-6.7.1.jar",
+        "hash": "453886930ba7ba0d80d1158577e3e10d814e2c739ee17e297f062542d92dfd04",
+        "path": "ua/net/nlp/morfologik-ukrainian-lt/6.7.1/morfologik-ukrainian-lt-6.7.1.jar"
+    },
+    {
+        "url": "uk/org/webcompere/system-stubs-core/2.1.8/system-stubs-core-2.1.8.jar",
+        "hash": "9c27322cfc7043c75384ad444007b0880ca18fe7231d69bfa69616bc773cafe1",
+        "path": "uk/org/webcompere/system-stubs-core/2.1.8/system-stubs-core-2.1.8.jar"
+    },
+    {
+        "url": "uk/org/webcompere/system-stubs-jupiter/2.1.8/system-stubs-jupiter-2.1.8.jar",
+        "hash": "9a24867a51f5d22db67d9052a06bc5dd2e9a3e273bc2ee9814620f2d9f25d0a8",
+        "path": "uk/org/webcompere/system-stubs-jupiter/2.1.8/system-stubs-jupiter-2.1.8.jar"
+    },
+    {
+        "url": "xalan/serializer/2.7.3/serializer-2.7.3.jar",
+        "hash": "5f6804bacdfdb3ccc52d2538536fab8986696d61559b081054a420c653806667",
+        "path": "xalan/serializer/2.7.3/serializer-2.7.3.jar"
+    },
+    {
+        "url": "xalan/xalan/2.7.3/xalan-2.7.3.jar",
+        "hash": "febd48bb133a96c447282213951a6b74ea7fb45c0d896121296c014316bda6b0",
+        "path": "xalan/xalan/2.7.3/xalan-2.7.3.jar"
+    },
+    {
+        "url": "xerces/xercesImpl/2.12.2/xercesImpl-2.12.2.jar",
+        "hash": "6fc991829af1708d15aea50c66f0beadcd2cfeb6968e0b2f55c1b0909883fe16",
+        "path": "xerces/xercesImpl/2.12.2/xercesImpl-2.12.2.jar"
+    },
+    {
+        "url": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar",
+        "hash": "47dcde8986019314ef78ae7280a94973a21d2ed95075a40a000b42da956429e1",
+        "path": "xml-resolver/xml-resolver/1.2/xml-resolver-1.2.jar"
+    },
+    {
+        "url": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar",
+        "hash": "34e08ee62116071cbb69c0ed70d15a7a5b208d62798c59f2120bb8929324cb63",
+        "path": "xmlpull/xmlpull/1.1.3.1/xmlpull-1.1.3.1.jar"
     }
 ]

--- a/pkgs/applications/editors/jetbrains/source/sources.json
+++ b/pkgs/applications/editors/jetbrains/source/sources.json
@@ -27,11 +27,11 @@
     }
   },
   "pycharm-oss": {
-    "version": "2025.3.1",
-    "buildNumber": "253.29346.142",
+    "version": "2025.3.2.1",
+    "buildNumber": "253.30387.173",
     "buildType": "pycharm",
-    "ideaHash": "sha256-eAq/lgv6ZcN9SR2E1KYnnhDHe/rBQ3GqqbbF6GstDoU=",
-    "androidHash": "sha256-quMCzrjCKIo1pkzw4PWewAs5tz7A2aq7TI5zd+QaaUY=",
+    "ideaHash": "sha256-13da6xCaZfS7zwesqGJpwsKfUK61Vi7gtMgPKtve43U=",
+    "androidHash": "sha256-FA/6ry1M7+RISJL+2SR9QkDvAGJAkXhFMh9YoOEU5nk=",
     "jpsHash": "sha256-iHpt926BDLNUwHRXvkqVgwlWiLo1qSZEaGeJcS0Fjmk=",
     "restarterHash": "sha256-acCmC58URd6p9uKZrm0qWgdZkqu9yqCs23v8qgxV2Ag=",
     "mvnDeps": "pycharm_maven_artefacts.json",


### PR DESCRIPTION
Fixes #488993 for NixOS 25.11.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
