### PR TITLE
treewide: remove thiagokokada from maintainers

### DIFF
--- a/maintainers/team-list.nix
+++ b/maintainers/team-list.nix
@@ -386,7 +386,6 @@ with lib.maintainers;
     members = [
       leona
       theCapypara
-      thiagokokada
       jamesward
     ];
     shortName = "Jetbrains";

--- a/nixos/modules/config/qt.nix
+++ b/nixos/modules/config/qt.nix
@@ -74,7 +74,6 @@ in
 {
   meta.maintainers = with lib.maintainers; [
     romildo
-    thiagokokada
   ];
 
   imports = [

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     description = "Free MASM-compatible assembler based on JWasm";
     mainProgram = "uasm";
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ thiagokokada ];
+    maintainers = [ ];
     license = lib.licenses.watcom;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/wl/wl-clipboard-rs/package.nix
+++ b/pkgs/by-name/wl/wl-clipboard-rs/package.nix
@@ -82,7 +82,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
     mainProgram = "wl-clip";
     maintainers = with lib.maintainers; [
-      thiagokokada
       donovanglover
     ];
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Remove myself from some packages that I am not using anymore.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
