### PR TITLE
python3Packages.httplib2: use standard CA bundle

### DIFF
--- a/pkgs/development/python-modules/httplib2/default.nix
+++ b/pkgs/development/python-modules/httplib2/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
+  cacert,
   cryptography,
   fetchFromGitHub,
   mock,
@@ -11,6 +12,7 @@
   pytest-randomly,
   pytest-timeout,
   pytestCheckHook,
+  python,
   six,
 }:
 
@@ -59,6 +61,12 @@ buildPythonPackage rec {
   ];
 
   disabledTestPaths = [ "python2" ];
+
+  # Replace the bundled cacerts.txt with the one from cacert.
+  postFixup = ''
+    rm $out/${python.sitePackages}/httplib2/cacerts.txt
+    ln -s ${cacert}/etc/ssl/certs/ca-bundle.crt $out/${python.sitePackages}/httplib2/cacerts.txt
+  '';
 
   pythonImportsCheck = [ "httplib2" ];
 


### PR DESCRIPTION
`cacert` is a central authority of what certs to trust. Making sure programs use that instead of their own vendored copies makes it easier for enterprises or very security-conscious users to expand or reduce the trust.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
