### PR TITLE
mermaid-rs-renderer: init at 0.3.0

### DIFF
--- a/pkgs/by-name/me/mermaid-rs-renderer/package.nix
+++ b/pkgs/by-name/me/mermaid-rs-renderer/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mermaid-rs-renderer";
+  version = "0.3.0";
+
+  src = fetchFromGitHub {
+    owner = "1jehuang";
+    repo = "mermaid-rs-renderer";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-rmfnyGjJDzL+p0MlkVAf8h8+3r9k17HcKtaapkpiYq8=";
+  };
+
+  cargoHash = "sha256-F2hVrRfSpesFC3JV4DQtVcDq/hGX4Y2xCNv/gflu/cw=";
+
+  checkFlags = [
+    # Known-failing upstream layout-routing heuristics; the rest of the suite passes.
+    "--skip=layout::tests::cycle_fixture_subgraph_entry_aligns_with_spine"
+    "--skip=layout::tests::dense_flowchart_avoids_crossing_between_middle_and_far_edges"
+    # ER-diagram attribute rows render into per-column tspans, so this parity check
+    # cannot match the joined multi-line entity block even though the labels are present.
+    "--skip=every_fixture_renders_validly_and_preserves_content"
+    # Upstream routing-quality invariant trips on a self-loop fixture (soft
+    # geometry-debt metric only, no hard violations).
+    "--skip=flowchart_fixtures_have_zero_hard_routing_violations"
+  ];
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "A fast native Rust Mermaid diagram renderer. No browser required. 500-1000x faster than mermaid-cli";
+    homepage = "https://github.com/1jehuang/mermaid-rs-renderer";
+    changelog = "https://github.com/1jehuang/mermaid-rs-renderer/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ kiara ];
+    mainProgram = "mmdr";
+  };
+})


### PR DESCRIPTION
Adds package [mermaid-rs-renderer](https://github.com/1jehuang/mermaid-rs-renderer), a fast Mermaid diagram renderer that does not require a browser.

Disclaimer: I used a coding agent in the creation of this patch.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
