### PR TITLE
nautilus-admin-gtk4: init at 1.2.0

### DIFF
--- a/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
+++ b/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gettext,
+  glib,
+  nautilus,
+  nautilus-python,
+  python3,
+  gedit,
+  wrapGAppsHook3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nautilus-admin";
+  version = "1.2.0";
+  src = fetchFromGitHub {
+    owner = "MacTavishAO";
+    repo = "nautilus-admin-gtk4";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-UJe9gbMm2Dt4JVJ7GI7DX4+3W5W4WZP4JcJ5iN3e3G4=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gettext
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    glib
+    nautilus
+    nautilus-python
+    python3
+    gedit
+  ];
+
+  postPatch = ''
+    sed -i 's/cmake_minimum_required(VERSION [0-9.]*)/cmake_minimum_required(VERSION 3.5)/' CMakeLists.txt
+
+    substituteInPlace CMakeLists.txt \
+      --replace "DESTINATION /usr/share" "DESTINATION share"
+  '';
+
+  cmakeFlags = [
+    "-DNAUTILUS_PATH=${nautilus}/bin/nautilus"
+    "-DGEDIT_PATH=${gedit}/bin/gedit"
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+  ];
+
+  meta = with lib; {
+    description = "Extension for Nautilus to do administrative operations";
+    homepage = "https://github.com/MacTavishAO/nautilus-admin-gtk4";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+})

--- a/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
+++ b/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/MacTavishAO/nautilus-admin-gtk4";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ verantor ];
+    maintainers = with lib.maintainers; [ "verantor" ];
   };
 })

--- a/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
+++ b/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/MacTavishAO/nautilus-admin-gtk4";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = with lib.maintainers; [ "verantor" ];
+    maintainers = with lib.maintainers; [ verantor ];
   };
 })

--- a/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
+++ b/pkgs/by-name/na/nautilus-admin-gtk4/package.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/MacTavishAO/nautilus-admin-gtk4";
     license = licenses.gpl3;
     platforms = platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ verantor ];
   };
 })


### PR DESCRIPTION
saw that this package isnt in the repos and i like using the admin functionality so figured i might do a quick package 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
