### PR TITLE
Update scipopt-{soplex,scip,gcg,ug}

### DIFF
--- a/pkgs/by-name/sc/scipopt-gcg/package.nix
+++ b/pkgs/by-name/sc/scipopt-gcg/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation rec {
   pname = "scipopt-gcg";
-  version = "4.0.0";
+  version = "4.0.1";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "gcg";
     tag = "v${version}";
-    hash = "sha256-HMhb35Zkjt3yzYk6X1OfigZjJrLuelrkQyCBs/UpFjc=";
+    hash = "sha256-eu7JHtG10/4rzr4xSdoFJjGQ+X5OeWelkEWJOO7QQmE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sc/scipopt-scip/package.nix
+++ b/pkgs/by-name/sc/scipopt-scip/package.nix
@@ -20,13 +20,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scipopt-scip";
-  version = "10.0.0";
+  version = "10.0.1";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "scip";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KW7N2ORspzkaR/gdU//p38BV4GyuhoSIVb6q9RTrCYQ=";
+    hash = "sha256-YbPGJl2q9Ja1WRhcmpMJgmfE8crY/dH05ayj/N2pQAY=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sc/scipopt-soplex/package.nix
+++ b/pkgs/by-name/sc/scipopt-soplex/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scipopt-soplex";
-  version = "8.0.0";
+  version = "8.0.1";
 
   src = fetchFromGitHub {
     owner = "scipopt";
     repo = "soplex";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AppJUule+0x23gF/PwjDMsZ194aqK91UTevQgjPZIgc=";
+    hash = "sha256-NN1UwwvLPfRIpL49UV8f2G4glUmTEywKNXK3m1LFHcg=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/sc/scipopt-ug/package.nix
+++ b/pkgs/by-name/sc/scipopt-ug/package.nix
@@ -11,15 +11,15 @@
 
 stdenv.mkDerivation rec {
   pname = "scipopt-ug";
-  version = "1.0.0";
+  version = "1.0.1";
 
   # To correlate scipVersion and version, check: https://scipopt.org/#news
-  scipVersion = "10.0.0";
+  scipVersion = "10.0.1";
 
   # Take the SCIPOptSuite source since no other source exists publicly.
   src = fetchzip {
     url = "https://github.com/scipopt/scip/releases/download/v${scipVersion}/scipoptsuite-${scipVersion}.tgz";
-    hash = "sha256-Nskb8quLsox7igz1UZCfd+VjR9Q8/oa8dZBYjAdc1EU=";
+    hash = "sha256-U5tbgGCzUkDL/22RwQLQmvCjSAhxehJe0P5rwNupW6Q=";
   };
 
   sourceRoot = "${src.name}/ug";


### PR DESCRIPTION
Just updating the following packages:
- `scipopt-soplex`
- `scipopt-scip`
- `scipopt-gcg`
- `scipopt-ug`

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
