### PR TITLE
rocmPackages.rocm-runtime: backport CWSR/stack kernel discovery patch

### DIFF
--- a/pkgs/development/rocm-modules/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/rocm-runtime/default.nix
@@ -67,6 +67,30 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/ROCm/ROCR-Runtime/commit/41bfc66aef437a5b349f71105fa4b907cc7e17d5.patch";
       hash = "sha256-A7VhPR3eSsmjq2cTBSjBIz9i//WiNjoXm0EsRKtF+ns=";
     })
+    (fetchpatch {
+      # [PATCH] hsakmt: bump vgpr count for gfx1151 (#1807) (#1986)
+      # We apply only the change that adds a GFX_VERSION_GFX1151 define but
+      # *not* the default vgpr change which causes crashes on old kernels
+      # This was later partially reverted in # [PATCH] Revert "hsakmt: bump vgpr count for gfx1151 (#1807) (#1986)"
+      name = "rocr-runtime-gfx1151-vgpr.patch";
+      url = "https://github.com/ROCm/rocm-systems/commit/09ba45b3f43ec333a84a0ca178fcd1e3ea9400a9.patch";
+      relative = "projects/rocr-runtime";
+      includes = [ "libhsakmt/src/libhsakmt.h" ];
+      hash = "sha256-/V5i+sr88n7fK4yNjR/FpY0ZpiEG5xAD6Oq+9ZOikd4=";
+    })
+    (fetchpatch {
+      # [PATCH] hsakmt: Expose and use CWSR and Control stack sizes (#2200)
+      # Fixes potential mismatches between stack sizes configured in amdgpu kernel module
+      # and userspace by relying on kernel value when available
+      # Falls back to hardcoded size based on ISA if kernel is too old. For gfx1151, also prints:
+      # WARNING: KFD ABI 1.20+ is recommended … This may result in faults, crashes and other application instability
+      # This allows new kernels to work with this runtime detection mechanism
+      # Only gfx1151 warns loudly because only it has had the size updated in kernel…
+      name = "rocr-runtime-kernel-stack-size.patch";
+      url = "https://github.com/ROCm/rocm-systems/commit/7037a71f311c021974fafd13727dfefd8a1cc79d.patch";
+      relative = "projects/rocr-runtime";
+      hash = "sha256-EbDxuEvNu0fyQJZmqq0fbcCdNtaEWUbmyPLvcfqDPjc=";
+    })
     # This causes a circular dependency, aqlprofile relies on hsa-runtime64
     # which is part of rocm-runtime
     # Worked around by having rocprofiler load aqlprofile directly


### PR DESCRIPTION
Backport two patches from rocm-systems for gfx1151 (Strix Halo):

hsakmt: bump vgpr count for gfx1151
  We apply only the change that adds a GFX_VERSION_GFX1151 define but
  not the default vgpr change which causes crashes on old kernels.
  The vgpr change was later partially reverted upstream.

hsakmt: Expose and use CWSR and Control stack sizes
  Fixes potential mismatches between stack sizes configured in the
  amdgpu kernel module and userspace by relying on kernel value when
  available. Falls back to hardcoded size based on ISA if kernel is
  too old. For gfx1151, also prints a warning that KFD ABI 1.20+ is
  recommended. This allows new kernels to work with this runtime
  detection mechanism. Only gfx1151 warns loudly because only it has
  had the size updated in kernel.

Should hopefully:

- Warn and work on 6.12 kernel (+ old linux-firmware?)
- No warn and work on >=6.18 kernel + up to date linux-firmware

Needs tested on real gfx1151, marked draft until confirmed good.

See also: https://github.com/ROCm/TheRock/issues/2991

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
