### PR TITLE
miktex: fix pdflatex segfault

### DIFF
--- a/pkgs/by-name/mi/miktex/package.nix
+++ b/pkgs/by-name/mi/miktex/package.nix
@@ -135,6 +135,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace Programs/TeXAndFriends/omega/otps/source/outocp.c \
       --replace-fail 'fprintf(stderr, s);' 'fprintf(stderr, "%s", s);'
+
+    # we use unsigned-char for all platform
+    substituteInPlace Programs/TeXAndFriends/Knuth/web/CMakeLists.txt \
+      --replace-fail '--using-namespace=MiKTeX::TeXAndFriends' '--using-namespace=MiKTeX::TeXAndFriends --chars-are-unsigned'
   '';
 
   strictDeps = true;
@@ -200,9 +204,9 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     LANG = "C.UTF-8";
     MIKTEX_REPOSITORY = "file://${miktexLocalRepository}/";
-    # force char to be unsigned on none x86 systems
+    # Force use of unsigned char for all platform
     # See https://github.com/MiKTeX/miktex/issues/1440
-    NIX_CFLAGS_COMPILE = "-fsigned-char";
+    NIX_CFLAGS_COMPILE = "-funsigned-char";
   };
 
   enableParallelBuilding = false;


### PR DESCRIPTION
we can't use the global NIX_CFLAGS_COMPILE="-fsingned-char" otherwise pdflatex will segfault.

we can use the global NIX_CFLAGS_COMPILE="-funsingned-char" and call c4p with -chars-are-unsigned. No segfault in pdflatex. And no guess on platform's default char style.

@xdadrm

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
