### PR TITLE
various: use finalAttrs instead of rec, part 1

### DIFF
--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio4.nix
@@ -28,12 +28,12 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bitwig-studio";
   version = "4.4.10";
 
   src = fetchurl {
-    url = "https://downloads.bitwig.com/stable/${version}/${pname}-${version}.deb";
+    url = "https://downloads.bitwig.com/stable/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.deb";
     sha256 = "sha256-gtQ1mhXk0AqGidZk5TCzSR58pD1JJoELMBmELtqyb4U=";
   };
 
@@ -101,7 +101,7 @@ stdenv.mkDerivation rec {
         "''${gappsWrapperArgs[@]}" \
         --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}" \
         --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
-        --suffix LD_LIBRARY_PATH : "${lib.strings.makeLibraryPath buildInputs}"
+        --suffix LD_LIBRARY_PATH : "${lib.strings.makeLibraryPath finalAttrs.buildInputs}"
     done
 
     find $out -type f -executable -name 'jspawnhelper' | \
@@ -127,4 +127,4 @@ stdenv.mkDerivation rec {
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
-}
+})

--- a/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
+++ b/pkgs/applications/audio/bitwig-studio/bitwig-studio5.nix
@@ -35,13 +35,13 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bitwig-studio-unwrapped";
   version = "5.3.13";
 
   src = fetchurl {
-    name = "bitwig-studio-${version}.deb";
-    url = "https://www.bitwig.com/dl/Bitwig%20Studio/${version}/installer_linux/";
+    name = "bitwig-studio-${finalAttrs.version}.deb";
+    url = "https://www.bitwig.com/dl/Bitwig%20Studio/${finalAttrs.version}/installer_linux/";
     hash = "sha256-tx+Dz9fTm4DIobwLa055ZOCMG+tU7vQl11NFnEKMAno=";
   };
 
@@ -117,7 +117,7 @@ stdenv.mkDerivation rec {
         "''${gappsWrapperArgs[@]}" \
         --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}" \
         --suffix PATH : "${lib.makeBinPath [ xdg-utils ]}" \
-        --suffix LD_LIBRARY_PATH : "${lib.strings.makeLibraryPath buildInputs}"
+        --suffix LD_LIBRARY_PATH : "${lib.strings.makeLibraryPath finalAttrs.buildInputs}"
     done
 
     find $out -type f -executable -name 'jspawnhelper' | \
@@ -143,4 +143,4 @@ stdenv.mkDerivation rec {
     ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
-}
+})

--- a/pkgs/applications/audio/codecserver/default.nix
+++ b/pkgs/applications/audio/codecserver/default.nix
@@ -8,14 +8,14 @@
   protobuf,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "codecserver";
   version = "0.2.0";
 
   src = fetchFromGitHub {
     owner = "jketterl";
     repo = "codecserver";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-JzaVBFl3JsFNDm4gy1qOKA9uAjUjNeMiI39l5gfH0aE=";
   };
 
@@ -43,4 +43,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "codecserver";
   };
-}
+})

--- a/pkgs/applications/audio/deadbeef/plugins/headerbar-gtk3.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/headerbar-gtk3.nix
@@ -12,14 +12,14 @@
   gtk3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deadbeef-headerbar-gtk3-plugin";
   version = "1.2";
 
   src = fetchFromGitHub {
     owner = "saivert";
     repo = "ddb_misc_headerbar_GTK3";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "1v1schvnps7ypjqgcbqi74a45w8r2gbhrawz7filym22h1qr9wn0";
   };
 
@@ -49,4 +49,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.jtojnar ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/audio/deadbeef/plugins/statusnotifier.nix
+++ b/pkgs/applications/audio/deadbeef/plugins/statusnotifier.nix
@@ -9,14 +9,14 @@
   libdbusmenu,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "deadbeef-statusnotifier-plugin";
   version = "1.6";
 
   src = fetchFromGitHub {
     owner = "vovochka404";
     repo = "deadbeef-statusnotifier-plugin";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-6WEbY59vPNrL3W5GUwFQJimmSS+td8Ob+G46fPAxfV4=";
   };
 
@@ -48,4 +48,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.kurnevsky ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/audio/espeak/default.nix
+++ b/pkgs/applications/audio/espeak/default.nix
@@ -6,12 +6,12 @@
   portaudio,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "espeak";
   version = "1.48.04";
 
   src = fetchurl {
-    url = "mirror://sourceforge/espeak/espeak-${version}-source.zip";
+    url = "mirror://sourceforge/espeak/espeak-${finalAttrs.version}-source.zip";
     sha256 = "0n86gwh9pw0jqqpdz7mxggllfr8k0r7pc67ayy7w5z6z79kig6mz";
   };
 
@@ -42,4 +42,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/audio/espeak/edit.nix
+++ b/pkgs/applications/audio/espeak/edit.nix
@@ -9,12 +9,12 @@
   sox,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "espeakedit";
   version = "1.48.03";
 
   src = fetchurl {
-    url = "mirror://sourceforge/espeak/espeakedit-${version}.zip";
+    url = "mirror://sourceforge/espeak/espeakedit-${finalAttrs.version}.zip";
     sha256 = "0x8s7vpb7rw5x37yjzy1f98m4f2csdg89libb74fm36gn8ly0hli";
   };
 
@@ -76,4 +76,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/audio/ladspa-plugins/default.nix
+++ b/pkgs/applications/audio/ladspa-plugins/default.nix
@@ -11,14 +11,14 @@
   perlPackages,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "swh-plugins";
   version = "0.4.17";
 
   src = fetchFromGitHub {
     owner = "swh";
     repo = "ladspa";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-eOtIhNcuItREUShI8JRlBVKfMfovpdfIYu+m37v4KLE=";
   };
 
@@ -57,4 +57,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/applications/audio/librespot/default.nix
+++ b/pkgs/applications/audio/librespot/default.nix
@@ -21,14 +21,14 @@
   tlsBackend ? "native-tls", # "native-tls" "rustls-tls-native-roots" "rustls-tls-webpki-roots"
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "librespot";
   version = "0.8.0";
 
   src = fetchFromGitHub {
     owner = "librespot-org";
     repo = "librespot";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-twWndV6z5Cdivz7pfAJzdlIjddEiZPEFnTzipMczmJo=";
   };
 
@@ -71,8 +71,8 @@ rustPlatform.buildRustPackage rec {
     description = "Open Source Spotify client library and playback daemon";
     mainProgram = "librespot";
     homepage = "https://github.com/librespot-org/librespot";
-    changelog = "https://github.com/librespot-org/librespot/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/librespot-org/librespot/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ bennofs ];
   };
-}
+})

--- a/pkgs/applications/audio/lmms/default.nix
+++ b/pkgs/applications/audio/lmms/default.nix
@@ -26,14 +26,14 @@
   SDL ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lmms";
   version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "LMMS";
     repo = "lmms";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "006hwv1pbh3y5whsxkjk20hsbgwkzr4dawz43afq1gil69y7xpda";
     fetchSubmodules = true;
   };
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     "-DWANT_QT5=ON"
   ]
-  ++ lib.optionals (lib.versionOlder version "11.4") [
+  ++ lib.optionals (lib.versionOlder finalAttrs.version "11.4") [
     # Fix the build with CMake 4.
     "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
   ];
@@ -96,4 +96,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CharacterCompressor/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "CharacterCompressor";
   version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "CharacterCompressor";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "1h0bhjhx023476gbijq842b6f8z71zcyn4c9mddwyb18w9cdamp5";
   };
 
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/CompBus/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "CompBus";
   version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "CompBus";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "0yhj680zgk4dn4fi8j3apm72f3z2mjk12amf2a7p0lwn9iyh4a2z";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/ConstantDetuneChorus/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "constant-detune-chorus";
   version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "constant-detune-chorus";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "1sipmc25fr7w7xqx1r0y6i2zwfkgszzwvhk1v15mnsb3cqvk8ybn";
   };
 
@@ -43,4 +43,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/LazyLimiter/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "LazyLimiter";
   version = "0.3.2";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "LazyLimiter";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "10xdydwmsnkx8hzsm74pa546yahp29wifydbc48yywv3sfj5anm7";
   };
 
@@ -43,4 +43,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/MBdistortion/default.nix
@@ -6,14 +6,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "MBdistortion";
   version = "1.1.1";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "MBdistortion";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "0mdzaqmxzgspfgx9w1hdip18y17hwpdcgjyq1rrfm843vkascwip";
   };
 
@@ -51,4 +51,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/RhythmDelay/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "RhythmDelay";
   version = "2.1";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "RhythmDelay";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "1j0bjl9agz43dcrcrbiqd7fv7xsxgd65s4ahhv5pvcr729y0fxg4";
   };
 
@@ -43,4 +43,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/VoiceOfFaust/default.nix
@@ -8,22 +8,22 @@
   puredata-with-plugins,
   jack-example-tools,
 }:
-stdenv.mkDerivation rec {
+let
+  plugins = [
+    helmholtz
+  ];
+  pitchTracker = puredata-with-plugins plugins;
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "VoiceOfFaust";
   version = "1.1.7";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "VoiceOfFaust";
-    tag = "V${version}";
+    tag = "V${finalAttrs.version}";
     sha256 = "sha256-wsc4yzytK2hPVBQwMhdhjnH1pDtpkNCFJnItyzszEs0=";
   };
-
-  plugins = [
-    helmholtz
-  ];
-
-  pitchTracker = puredata-with-plugins plugins;
 
   nativeBuildInputs = [
     faust2jack
@@ -52,4 +52,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.agpl3Only;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/faustCompressors/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "faustCompressors";
   version = "1.2";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "faustCompressors";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "144f6g17q4m50kxzdncsfzdyycdfprnpwdaxcwgxj4jky1xsha1d";
   };
 
@@ -55,4 +55,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/pluginUtils/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pluginUtils";
   version = "1.1";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "pluginUtils";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "1hnr5sp7k6ypf4ks61lnyqx44dkv35yllf3a3xcbrw7yqzagwr1c";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
+++ b/pkgs/applications/audio/magnetophonDSP/shelfMultiBand/default.nix
@@ -5,14 +5,14 @@
   faust2jaqt,
   faust2lv2,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "shelfMultiBand";
   version = "0.6.1";
 
   src = fetchFromGitHub {
     owner = "magnetophon";
     repo = "shelfMultiBand";
-    rev = "V${version}";
+    rev = "V${finalAttrs.version}";
     sha256 = "1b1h4z5fs2xm7wvw11p9wnd0bxs3m88124f5phh0gwvpsdrd0im5";
   };
 
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/midas/generic.nix
+++ b/pkgs/applications/audio/midas/generic.nix
@@ -26,7 +26,7 @@ let
       '') debs
     );
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "${lib.toLower type}-edit";
   inherit version;
 
@@ -40,9 +40,9 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp ${type}-Edit $out/bin/.${pname}
+    cp ${type}-Edit $out/bin/.${finalAttrs.pname}
 
-    cat >$out/bin/${pname} <<EOF
+    cat >$out/bin/${finalAttrs.pname} <<EOF
     #!${runtimeShell} -eu
     exec ${lib.getExe bubblewrap} \
       --dev-bind / / \
@@ -50,9 +50,9 @@ stdenv.mkDerivation rec {
       --ro-bind "${debian}/lib64" /lib64 \
       --tmpfs /usr \
       --ro-bind "${debian}/usr/lib" /usr/lib \
-      $out/bin/.${pname}
+      $out/bin/.${finalAttrs.pname}
     EOF
-    chmod 755 $out/bin/${pname}
+    chmod 755 $out/bin/${finalAttrs.pname}
   '';
 
   passthru.deps =
@@ -81,4 +81,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ magnetophon ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/bandcamp.nix
+++ b/pkgs/applications/audio/mopidy/bandcamp.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-bandcamp";
   version = "1.1.5";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-Bandcamp";
     hash = "sha256-wg9zcOKfZQRhpyA1Cu5wvdwKpmrlcr2m9mrqBHgUXAQ=";
   };
@@ -33,4 +33,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ desttinghim ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/iris.nix
+++ b/pkgs/applications/audio/mopidy/iris.nix
@@ -5,14 +5,14 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-iris";
   version = "3.70.0";
   pyproject = true;
 
   src = fetchPypi {
     pname = "mopidy_iris";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-md/1blTTtjiAAb/jiLE2EfiSlIUwEga8U7OiuKa466k=";
   };
 
@@ -38,4 +38,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.rvolosatovs ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/jellyfin.nix
+++ b/pkgs/applications/audio/mopidy/jellyfin.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-jellyfin";
   version = "1.0.6";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "mopidy_jellyfin";
     hash = "sha256-IKCPypMuluR0+mMALp8lB1oB1pSw4rN4rOl/eKn+Qvo=";
   };
@@ -34,4 +34,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.pstn ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/listenbrainz.nix
+++ b/pkgs/applications/audio/mopidy/listenbrainz.nix
@@ -5,7 +5,7 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-listenbrainz";
   version = "0.3.0";
   pyproject = true;
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "suaviloquence";
     repo = "mopidy-listenbrainz";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-kYZgG2KQMTxMR8tdwwCKkfexDcxcndXG9LSdlnoN/CY=";
   };
 
@@ -32,4 +32,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ bohanubis ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/local.nix
+++ b/pkgs/applications/audio/mopidy/local.nix
@@ -5,13 +5,13 @@
   fetchPypi,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-local";
   version = "3.3.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "mopidy_local";
     hash = "sha256-y6btbGk5UiVan178x7d9jq5OTnKMbuliHv0aRxuZK3o=";
   };
@@ -37,4 +37,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ ruuda ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/moped.nix
+++ b/pkgs/applications/audio/mopidy/moped.nix
@@ -6,13 +6,13 @@
   glibcLocales,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-moped";
   version = "0.7.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-Moped";
     sha256 = "15461174037d87af93dd59a236d4275c5abf71cea0670ffff24a7d0399a8a2e4";
   };
@@ -36,4 +36,4 @@ pythonPackages.buildPythonApplication rec {
     maintainers = [ ];
     hydraPlatforms = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/mopidy.nix
+++ b/pkgs/applications/audio/mopidy/mopidy.nix
@@ -11,7 +11,7 @@
   nixosTests,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy";
   version = "3.4.2";
   pyproject = true;
@@ -19,7 +19,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2OFav2HaQq/RphmZxLyL1n3suwzt1Y/d4h33EdbStjk=";
   };
 
@@ -70,4 +70,4 @@ pythonPackages.buildPythonApplication rec {
     maintainers = [ lib.maintainers.fpletz ];
     hydraPlatforms = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/mopify.nix
+++ b/pkgs/applications/audio/mopidy/mopify.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-mopify";
   version = "1.7.3";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-Mopify";
     hash = "sha256-RlCC+39zC+LeA/QDWPHYx5TrEwOgVrnvcH1Xg12qSLE=";
   };
@@ -36,4 +36,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.gpl3;
     maintainers = [ lib.maintainers.Gonzih ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/mpd.nix
+++ b/pkgs/applications/audio/mopidy/mpd.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-mpd";
   version = "3.3.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-MPD";
     hash = "sha256-CeLMRqj9cwBvQrOx7XHVV8MjDjwOosONVlsN2o+vTVM=";
   };
@@ -30,4 +30,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.tomahna ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/mpris.nix
+++ b/pkgs/applications/audio/mopidy/mpris.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-mpris";
   version = "3.0.3";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-MPRIS";
     hash = "sha256-rHQgNIyludTEL7RDC8dIpyGTMOt1Tazn6i/orKlSP4U=";
   };
@@ -35,4 +35,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.nickhu ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/muse.nix
+++ b/pkgs/applications/audio/mopidy/muse.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-muse";
   version = "0.0.33";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-Muse";
     hash = "sha256-CEPAPWtMrD+HljyqBB6EAyGVeOjzkvVoEywlE4XEJGs=";
   };
@@ -36,4 +36,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/musicbox-webclient.nix
+++ b/pkgs/applications/audio/mopidy/musicbox-webclient.nix
@@ -5,7 +5,7 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-musicbox-webclient";
   version = "3.1.0";
   pyproject = true;
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "pimusicbox";
     repo = "mopidy-musicbox-webclient";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "1lzarazq67gciyn6r8cdms0f7j0ayyfwhpf28z93ydb280mfrrb9";
   };
 
@@ -30,8 +30,8 @@ pythonPackages.buildPythonApplication rec {
   meta = {
     description = "Mopidy frontend extension and web client with additional features for Pi MusicBox";
     homepage = "https://github.com/pimusicbox/mopidy-musicbox-webclient";
-    changelog = "https://github.com/pimusicbox/mopidy-musicbox-webclient/blob/v${version}/CHANGELOG.rst";
+    changelog = "https://github.com/pimusicbox/mopidy-musicbox-webclient/blob/v${finalAttrs.version}/CHANGELOG.rst";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/notify.nix
+++ b/pkgs/applications/audio/mopidy/notify.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-notify";
   version = "0.2.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-Notify";
     hash = "sha256-8FT4O4k0wEsdHA1vJaOW9UamJ3QLyO47HwL5XcSU3Pc=";
   };
@@ -39,4 +39,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/podcast.nix
+++ b/pkgs/applications/audio/mopidy/podcast.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-podcast";
   version = "3.0.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-Podcast";
     hash = "sha256-grNPVEVM2PlpYhBXe6sabFjWVB9+q+apIRjcHUxH52A=";
   };
@@ -40,4 +40,4 @@ pythonPackages.buildPythonApplication rec {
       lib.maintainers.daneads
     ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/scrobbler.nix
+++ b/pkgs/applications/audio/mopidy/scrobbler.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-scrobbler";
   version = "2.0.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-Scrobbler";
     sha256 = "11vxgax4xgkggnq4fr1rh2rcvzspkkimck5p3h4phdj3qpnj0680";
   };
@@ -35,4 +35,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ jakeisnt ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/somafm.nix
+++ b/pkgs/applications/audio/mopidy/somafm.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-somafm";
   version = "2.0.2";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-SomaFM";
     sha256 = "DC0emxkoWfjGHih2C8nINBFByf521Xf+3Ks4JRxNPLM=";
   };
@@ -34,4 +34,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.nickhu ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/soundcloud.nix
+++ b/pkgs/applications/audio/mopidy/soundcloud.nix
@@ -5,7 +5,7 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-soundcloud";
   version = "3.0.2";
   pyproject = true;
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy-soundcloud";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-1Qqbfw6NZ+2K1w+abMBfWo0RAmIRbNyIErEmalmWJ0s=";
   };
 
@@ -35,4 +35,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/spotify.nix
+++ b/pkgs/applications/audio/mopidy/spotify.nix
@@ -6,7 +6,7 @@
   nix-update-script,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-spotify";
   version = "5.0.0a3";
   pyproject = true;
@@ -14,7 +14,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "mopidy";
     repo = "mopidy-spotify";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-pM+kqeWYiPXv9DZDBTgwiEwC6Sbqv6uz5vJ5odcixOw=";
   };
 
@@ -40,8 +40,8 @@ pythonPackages.buildPythonApplication rec {
   meta = {
     description = "Mopidy extension for playing music from Spotify";
     homepage = "https://github.com/mopidy/mopidy-spotify";
-    changelog = "https://github.com/mopidy/mopidy-spotify/releases/tag/v${version}";
+    changelog = "https://github.com/mopidy/mopidy-spotify/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ getchoo ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/subidy.nix
+++ b/pkgs/applications/audio/mopidy/subidy.nix
@@ -5,7 +5,7 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-subidy";
   version = "1.0.0";
   pyproject = true;
@@ -13,7 +13,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "Prior99";
     repo = "mopidy-subidy";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "0c5ghhhrj5v3yp4zmll9ari6r5c6ha8c1izwqshvadn40b02q7xz";
   };
 
@@ -38,4 +38,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ wenngle ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/tidal.nix
+++ b/pkgs/applications/audio/mopidy/tidal.nix
@@ -5,7 +5,7 @@
   mopidy,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "Mopidy-Tidal";
   version = "0.3.12";
   pyproject = true;
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "tehkillerbee";
     repo = "mopidy-tidal";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-1u1MMLtVNZkVhmUr5DW34TlJ2s/YGRKXjqi+SrtClR4=";
   };
 
@@ -34,8 +34,8 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "Mopidy extension for playing music from Tidal";
     homepage = "https://github.com/tehkillerbee/mopidy-tidal";
-    changelog = "https://github.com/tehkillerbee/mopidy-tidal/releases/tag/${src.tag}";
+    changelog = "https://github.com/tehkillerbee/mopidy-tidal/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/tunein.nix
+++ b/pkgs/applications/audio/mopidy/tunein.nix
@@ -5,13 +5,13 @@
   mopidy,
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-tunein";
   version = "1.1.0";
   pyproject = true;
 
   src = fetchPypi {
-    inherit version;
+    inherit (finalAttrs) version;
     pname = "Mopidy-TuneIn";
     sha256 = "01y1asylscr73yqx071imhrzfzlg07wmqqzkdvpgm6r35marc2li";
   };
@@ -32,4 +32,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/youtube.nix
+++ b/pkgs/applications/audio/mopidy/youtube.nix
@@ -7,7 +7,7 @@
   extraPkgs ? pkgs: [ ],
 }:
 
-pythonPackages.buildPythonApplication rec {
+pythonPackages.buildPythonApplication (finalAttrs: {
   pname = "mopidy-youtube";
   version = "3.7";
   pyproject = true;
@@ -15,7 +15,7 @@ pythonPackages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "natumbri";
     repo = "mopidy-youtube";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-iFt7r8Ljymc+grNJiOClTHkZOeo7AcYpcNc8tLMPROk=";
   };
 
@@ -69,4 +69,4 @@ pythonPackages.buildPythonApplication rec {
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/mopidy/ytmusic.nix
+++ b/pkgs/applications/audio/mopidy/ytmusic.nix
@@ -8,7 +8,7 @@
 let
   python = python3;
 in
-python.pkgs.buildPythonApplication rec {
+python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "mopidy-ytmusic";
   version = "0.3.9";
   pyproject = true;
@@ -16,7 +16,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "jmcdo29";
     repo = "mopidy-ytmusic";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-2o4fDtaIxRDvIiAGV/9qK/00BmYXasBUwW03fxFcDAU=";
   };
 
@@ -41,10 +41,10 @@ python.pkgs.buildPythonApplication rec {
   doCheck = false;
 
   meta = {
-    changelog = "https://github.com/jmcdo29/mopidy-ytmusic/releases/tag/${src.rev}";
+    changelog = "https://github.com/jmcdo29/mopidy-ytmusic/releases/tag/${finalAttrs.src.rev}";
     description = "Mopidy extension for playing music from YouTube Music";
     homepage = "https://github.com/jmcdo29/mopidy-ytmusic";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.nickhu ];
   };
-}
+})

--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -19,12 +19,12 @@
 
 assert withConplay -> !libOnly;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "${lib.optionalString libOnly "lib"}mpg123";
   version = "1.33.4";
 
   src = fetchurl {
-    url = "mirror://sourceforge/mpg123/mpg123-${version}.tar.bz2";
+    url = "mirror://sourceforge/mpg123/mpg123-${finalAttrs.version}.tar.bz2";
     hash = "sha256-OujJ/4Cpe/wOIuifvNdGh+yk/B2zFbEmB/J/ActaR9k=";
   };
 
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
       # Expect the text in format of '<a href="download/mpg123-1.32.6.tar.bz2">'
       new_version="$(curl -s https://mpg123.org/download.shtml |
           pcregrep -o1 '<a href="download/mpg123-([0-9.]+).tar.bz2">')"
-      update-source-version ${pname} "$new_version"
+      update-source-version ${finalAttrs.pname} "$new_version"
     '';
   };
 
@@ -99,4 +99,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ ftrvxmtrx ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/audio/pd-plugins/timbreid/default.nix
+++ b/pkgs/applications/audio/pd-plugins/timbreid/default.nix
@@ -7,12 +7,12 @@
   fftw,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "0.7.0";
   pname = "timbreid";
 
   src = fetchurl {
-    url = "http://williambrent.conflations.com/pd/timbreID-${version}-src.zip";
+    url = "http://williambrent.conflations.com/pd/timbreID-${finalAttrs.version}-src.zip";
     sha256 = "14k2xk5zrzrw1zprdbwx45hrlc7ck8vq4drpd3l455i5r8yk4y6b";
   };
 
@@ -53,4 +53,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.magnetophon ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/audio/pianoteq/default.nix
+++ b/pkgs/applications/audio/pianoteq/default.nix
@@ -41,7 +41,7 @@ let
       version,
       ...
     }:
-    stdenv.mkDerivation rec {
+    stdenv.mkDerivation (finalAttrs: {
       inherit src version;
 
       pname = "pianoteq-${name}";
@@ -66,11 +66,11 @@ let
 
       desktopItems = [
         (makeDesktopItem {
-          name = pname;
+          name = finalAttrs.pname;
           exec = ''"${mainProgram}"'';
           desktopName = mainProgram;
           icon = "pianoteq";
-          comment = meta.description;
+          comment = finalAttrs.meta.description;
           categories = [
             "AudioVideo"
             "Audio"
@@ -114,7 +114,7 @@ let
         ];
         sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
       };
-    };
+    });
 
   fetchWithCurlScript =
     {

--- a/pkgs/applications/audio/playbar2/default.nix
+++ b/pkgs/applications/audio/playbar2/default.nix
@@ -8,14 +8,14 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "playbar2";
   version = "2.5";
 
   src = fetchFromGitHub {
     owner = "jsmitar";
     repo = "PlayBar2";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "0iv2m4flgaz2r0k7f6l0ca8p6cw8j8j2gin1gci2pg3l5g5khbch";
   };
 
@@ -43,4 +43,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ pjones ];
   };
-}
+})

--- a/pkgs/applications/audio/quodlibet/default.nix
+++ b/pkgs/applications/audio/quodlibet/default.nix
@@ -44,7 +44,7 @@
   python3,
   xvfb-run,
 }:
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "quodlibet${tag}";
   version = "4.7.1";
   pyproject = true;
@@ -57,7 +57,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "quodlibet";
     repo = "quodlibet";
-    tag = "release-${version}";
+    tag = "release-${finalAttrs.version}";
     hash = "sha256-xr3c1e4tjw2YHuKbvNeUPBIFdHEcpztqXjHVDSSxYlo=";
   };
 
@@ -195,4 +195,4 @@ python3.pkgs.buildPythonApplication rec {
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/rakarrack/default.nix
+++ b/pkgs/applications/audio/rakarrack/default.nix
@@ -15,12 +15,12 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rakarrack";
   version = "0.6.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/rakarrack/${pname}-${version}.tar.bz2";
+    url = "mirror://sourceforge/rakarrack/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
     sha256 = "1rpf63pdn54c4yg13k7cb1w1c7zsvl97c4qxcpz41c8l91xd55kn";
   };
 
@@ -53,4 +53,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/audio/reaper/default.nix
+++ b/pkgs/applications/audio/reaper/default.nix
@@ -36,12 +36,12 @@ let
         builtins.replaceStrings [ "." ] [ "" ] version
       }_linux_${arch}.tar.xz";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "reaper";
   version = "7.59";
 
   src = fetchurl {
-    url = url_for_platform version stdenv.hostPlatform.qemuArch;
+    url = url_for_platform finalAttrs.version stdenv.hostPlatform.qemuArch;
     hash =
       if stdenv.hostPlatform.isDarwin then
         "sha256-S4RAXWss1tPzmO0zzKfkXPrcgBqwNN5EE1jpjEZ5mYk="
@@ -152,4 +152,4 @@ stdenv.mkDerivation rec {
       viraptor
     ];
   };
-}
+})

--- a/pkgs/applications/audio/sfxr-qt/default.nix
+++ b/pkgs/applications/audio/sfxr-qt/default.nix
@@ -14,14 +14,14 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sfxr-qt";
   version = "1.5.1";
 
   src = fetchFromGitHub {
     owner = "agateau";
     repo = "sfxr-qt";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-JAWDk7mGkPtQ5yaA6UT9hlAy770MHrTBhBP9G8UqFKg=";
     fetchSubmodules = true;
   };
@@ -68,4 +68,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ fgaz ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/audio/snapcast/default.nix
+++ b/pkgs/applications/audio/snapcast/default.nix
@@ -24,14 +24,14 @@
   openssl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "snapcast";
   version = "0.34.0";
 
   src = fetchFromGitHub {
     owner = "badaix";
     repo = "snapcast";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-BPsAGFLWUfONuyQ1pzsJzGV/Jlxv+4TkVT1KG7j8H0s=";
   };
 
@@ -84,4 +84,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     license = lib.licenses.gpl3Plus;
   };
-}
+})

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -64,14 +64,14 @@ let
 
   mruby-zest = callPackage ./mruby-zest { };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zynaddsubfx";
   version = "3.0.6";
 
   src = fetchFromGitHub {
     owner = "zynaddsubfx";
     repo = "zynaddsubfx";
-    tag = version;
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-0siAx141DZx39facXWmKbsi0rHBNpobApTdey07EcXg=";
   };
@@ -204,4 +204,4 @@ stdenv.mkDerivation rec {
     # - Zest UI fails to start on pulg_setup: Could not open display, aborting.
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
@@ -11,14 +11,14 @@
   libx11,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mruby-zest";
   version = "3.0.6";
 
   src = fetchFromGitHub {
-    owner = pname;
-    repo = "${pname}-build";
-    tag = version;
+    owner = "mruby-zest";
+    repo = "mruby-zest-build";
+    tag = finalAttrs.version;
     fetchSubmodules = true;
     sha256 = "sha256-rIb6tQimwrUj+623IU5zDyKNWsNYYBElLQClOsP+5Dc=";
   };
@@ -70,4 +70,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ kira-bruneau ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/blockchains/digibyte/default.nix
+++ b/pkgs/applications/blockchains/digibyte/default.nix
@@ -17,16 +17,16 @@
   wrapQtAppsHook ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "digibyte";
   version = "7.17.3";
 
-  name = pname + toString (lib.optional (!withGui) "d") + "-" + version;
+  name = finalAttrs.pname + toString (lib.optional (!withGui) "d") + "-" + finalAttrs.version;
 
   src = fetchFromGitHub {
     owner = "digibyte-core";
-    repo = pname;
-    rev = "v${version}";
+    repo = "digibyte";
+    rev = "v${finalAttrs.version}";
     sha256 = "zPwnC2qd28fA1saG4nysPlKU1nnXhfuSG3DpCY6T+kM=";
   };
 
@@ -69,4 +69,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.mmahut ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/blockchains/elements/default.nix
+++ b/pkgs/applications/blockchains/elements/default.nix
@@ -24,14 +24,14 @@
   withWallet ? true,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = if withGui then "elements" else "elementsd";
   version = "23.3.2";
 
   src = fetchFromGitHub {
     owner = "ElementsProject";
     repo = "elements";
-    rev = "elements-${version}";
+    rev = "elements-${finalAttrs.version}";
     sha256 = "sha256-NLLM+stYOXcnAjEfXRerjvgMXM8jFSOyZhu/A0ZTnRw=";
   };
 
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     "--with-boost-libdir=${boost.out}/lib"
     "--disable-bench"
   ]
-  ++ lib.optionals (!doCheck) [
+  ++ lib.optionals (!finalAttrs.doCheck) [
     "--disable-tests"
     "--disable-gui-tests"
   ]
@@ -112,4 +112,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/applications/blockchains/gridcoin-research/default.nix
+++ b/pkgs/applications/blockchains/gridcoin-research/default.nix
@@ -18,14 +18,14 @@
   hexdump,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gridcoin-research";
   version = "5.4.9.0";
 
   src = fetchFromGitHub {
     owner = "gridcoin-community";
     repo = "Gridcoin-Research";
-    rev = "${version}";
+    rev = "${finalAttrs.version}";
     hash = "sha256-nupZB4nNbitpf5EBCNy0e+ovjayAszup/r7qxbxA5jI=";
   };
 
@@ -70,4 +70,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ gigglesquid ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/blockchains/nano-wallet/default.nix
+++ b/pkgs/applications/blockchains/nano-wallet/default.nix
@@ -12,7 +12,7 @@
   python3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
 
   pname = "nano-wallet";
   version = "28.2";
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "nanocurrency";
     repo = "nano-node";
-    tag = "V${version}";
+    tag = "V${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-Wo1Gd6dOnCoPiGmuJQhZmKKSg7LrKpfdvLNNKBYTUWI=";
   };
@@ -82,5 +82,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ jluttine ];
   };
-
-}
+})

--- a/pkgs/applications/blockchains/optimism/default.nix
+++ b/pkgs/applications/blockchains/optimism/default.nix
@@ -5,14 +5,14 @@
   libpcap,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "optimism";
   version = "1.9.4";
 
   src = fetchFromGitHub {
     owner = "ethereum-optimism";
     repo = "optimism";
-    rev = "op-node/v${version}";
+    rev = "op-node/v${finalAttrs.version}";
     hash = "sha256-pAmstWA6up0CvHEQW5RnDYumdwKP0i6fpz59EYTBsmU=";
     fetchSubmodules = true;
   };
@@ -41,4 +41,4 @@ buildGoModule rec {
     maintainers = with lib.maintainers; [ happysalada ];
     mainProgram = "cmd";
   };
-}
+})

--- a/pkgs/applications/blockchains/optimism/geth.nix
+++ b/pkgs/applications/blockchains/optimism/geth.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "op-geth";
   version = "1.101305.3";
 
   src = fetchFromGitHub {
     owner = "ethereum-optimism";
     repo = "op-geth";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-AKVwwvt77FZlm7089EeayYVRYLo7c3v6LFVpsQN68Zk=";
     fetchSubmodules = true;
   };
@@ -46,4 +46,4 @@ buildGoModule rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ happysalada ];
   };
-}
+})

--- a/pkgs/applications/blockchains/vertcoin/default.nix
+++ b/pkgs/applications/blockchains/vertcoin/default.nix
@@ -19,15 +19,15 @@
   wrapQtAppsHook ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vertcoin";
   version = "0.18.0";
 
-  name = pname + toString (lib.optional (!withGui) "d") + "-" + version;
+  name = finalAttrs.pname + toString (lib.optional (!withGui) "d") + "-" + finalAttrs.version;
 
   src = fetchFromGitHub {
-    owner = pname + "-project";
-    repo = pname + "-core";
+    owner = "vertcoin-project";
+    repo = "vertcoin-core";
     rev = "2bd6dba7a822400581d5a6014afd671fb7e61f36";
     sha256 = "ua9xXA+UQHGVpCZL0srX58DDUgpfNa+AAIKsxZbhvMk=";
   };
@@ -86,4 +86,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.mmahut ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -25,14 +25,14 @@
   zeromq,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zcash";
   version = "5.4.2";
 
   src = fetchFromGitHub {
     owner = "zcash";
     repo = "zcash";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-XGq/cYUo43FcpmRDO2YiNLCuEQLsTFLBFC4M1wM29l8=";
   };
 
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
   ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-VBqasLpxqI4kr73Mr7OVuwb2OIhUwnY9CTyZZOyEElU=";
   };
 
@@ -115,4 +115,4 @@ stdenv.mkDerivation rec {
     # https://github.com/zcash/zcash/issues/4405
     broken = stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/applications/editors/cudatext/default.nix
+++ b/pkgs/applications/editors/cudatext/default.nix
@@ -40,14 +40,14 @@ let
     }
   ) (lib.importJSON ./deps.json);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cudatext";
   version = "1.202.1";
 
   src = fetchFromGitHub {
     owner = "Alexey-T";
     repo = "CudaText";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-ZFMO986D4RtrTnLFdcL0a2BNjcsB+9pIolylblku7j4=";
   };
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   env.NIX_LDFLAGS = toString [
     "--as-needed"
     "-rpath"
-    (lib.makeLibraryPath buildInputs)
+    (lib.makeLibraryPath finalAttrs.buildInputs)
   ];
 
   buildPhase =
@@ -146,4 +146,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "cudatext";
   };
-}
+})

--- a/pkgs/applications/editors/eclipse/build-eclipse.nix
+++ b/pkgs/applications/editors/eclipse/build-eclipse.nix
@@ -28,7 +28,7 @@
   version,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   inherit pname version src;
 
   desktopItem = makeDesktopItem {
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
 
     # Create desktop item.
     mkdir -p $out/share/applications
-    cp ${desktopItem}/share/applications/* $out/share/applications
+    cp ${finalAttrs.desktopItem}/share/applications/* $out/share/applications
     mkdir -p $out/share/pixmaps
     ln -s $out/eclipse/icon.xpm $out/share/pixmaps/eclipse.xpm
 
@@ -123,5 +123,4 @@ stdenv.mkDerivation rec {
     ];
     maintainers = [ lib.maintainers.jerith666 ];
   };
-
-}
+})

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ebuild-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/ebuild-mode/package.nix
@@ -4,12 +4,12 @@
   fetchzip,
 }:
 
-melpaBuild rec {
+melpaBuild (finalAttrs: {
   pname = "ebuild-mode";
   version = "1.81";
 
   src = fetchzip {
-    url = "https://gitweb.gentoo.org/proj/ebuild-mode.git/snapshot/ebuild-mode-${version}.tar.bz2";
+    url = "https://gitweb.gentoo.org/proj/ebuild-mode.git/snapshot/ebuild-mode-${finalAttrs.version}.tar.bz2";
     hash = "sha256-b+59Ec+NOHvFgbFOmnsvGjnq392VR1JCsPx/ORSdffo=";
   };
 
@@ -19,4 +19,4 @@ melpaBuild rec {
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/jam-mode/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/jam-mode/package.nix
@@ -4,12 +4,12 @@
   fetchurl,
 }:
 
-melpaBuild rec {
+melpaBuild (finalAttrs: {
   pname = "jam-mode";
   version = "0.3";
 
   src = fetchurl {
-    url = "https://dev.gentoo.org/~ulm/distfiles/${pname}-${version}.el.xz";
+    url = "https://dev.gentoo.org/~ulm/distfiles/${finalAttrs.pname}-${finalAttrs.version}.el.xz";
     hash = "sha256-0IlYqbPa4AAwOpjdd20k8hqtvDhZmcz1WHa/LHx8kMk=";
   };
 
@@ -32,4 +32,4 @@ melpaBuild rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ qyliss ];
   };
-}
+})

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/session-management-for-emacs/package.nix
@@ -4,14 +4,14 @@
   lib,
 }:
 
-melpaBuild rec {
+melpaBuild (finalAttrs: {
   pname = "session-management-for-emacs";
   ename = "session";
   version = "2.2a";
   melpaVersion = "2.2"; # default value derived from version is not valid for Emacs
 
   src = fetchzip {
-    url = "mirror://sourceforge/emacs-session/session-${version}.tar.gz";
+    url = "mirror://sourceforge/emacs-session/session-${finalAttrs.version}.tar.gz";
     hash = "sha256-lc6NIX+lx97qCs5JqG7x0iVE6ki09Gy7DEQuPW2c+7s=";
   };
 
@@ -28,4 +28,4 @@ melpaBuild rec {
     homepage = "https://emacs-session.sourceforge.net/";
     license = lib.licenses.gpl2;
   };
-}
+})

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/tsc/package.nix
@@ -10,20 +10,20 @@
 let
   libExt = stdenv.hostPlatform.extensions.sharedLibrary;
 
-  tsc-dyn = rustPlatform.buildRustPackage rec {
+  tsc-dyn = rustPlatform.buildRustPackage (finalAttrs: {
     pname = "tsc-dyn";
     version = "0.18.0";
 
     src = fetchFromGitHub {
       owner = "emacs-tree-sitter";
       repo = "emacs-tree-sitter";
-      tag = version;
+      tag = finalAttrs.version;
       hash = "sha256-LrakDpP3ZhRQqz47dPcyoQnu5lROdaNlxGaQfQT6u+k=";
     };
 
     cargoHash = "sha256-Tua3ZFfSyWVYXU9mPLWXE6ejGlXowTNe3nvZBaicmSQ=";
 
-    sourceRoot = "${src.name}/core";
+    sourceRoot = "${finalAttrs.src.name}/core";
 
     postInstall = ''
       pushd $out/lib
@@ -31,7 +31,7 @@ let
       echo -n $version > DYN-VERSION
       popd
     '';
-  };
+  });
 in
 melpaBuild {
   pname = "tsc";

--- a/pkgs/applications/editors/formiko/default.nix
+++ b/pkgs/applications/editors/formiko/default.nix
@@ -13,7 +13,7 @@
   webkitgtk_4_1,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "formiko";
   version = "1.5.0";
   format = "setuptools";
@@ -21,7 +21,7 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "ondratu";
     repo = "formiko";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-slfpkckCvxHJ/jlBP7QAhzaf9TAcS6biDQBZcBTyTKI=";
   };
 
@@ -50,4 +50,4 @@ buildPythonApplication rec {
     license = lib.licenses.bsd3;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/editors/jetbrains/plugins/default.nix
+++ b/pkgs/applications/editors/jetbrains/plugins/default.nix
@@ -23,8 +23,8 @@
 
       plugins = map processPlugin unprocessedPlugins;
     in
-    stdenv.mkDerivation rec {
-      pname = meta.mainProgram + "-with-plugins";
+    stdenv.mkDerivation (finalAttrs: {
+      pname = finalAttrs.meta.mainProgram + "-with-plugins";
       version = ide.version;
       src = ide;
       dontInstall = true;
@@ -45,7 +45,8 @@
       buildPhase =
         let
           appDir = lib.optionalString stdenv.hostPlatform.isDarwin "Applications/${lib.escapeShellArg ide.product}.app";
-          rootDir = if stdenv.hostPlatform.isDarwin then "${appDir}/Contents" else meta.mainProgram;
+          rootDir =
+            if stdenv.hostPlatform.isDarwin then "${appDir}/Contents" else finalAttrs.meta.mainProgram;
         in
         ''
           cp -r ${ide} $out
@@ -74,5 +75,5 @@
             done
           )
         '';
-    };
+    });
 }

--- a/pkgs/applications/editors/jetbrains/source/build.nix
+++ b/pkgs/applications/editors/jetbrains/source/build.nix
@@ -231,10 +231,10 @@ let
   };
 
 in
-stdenvNoCC.mkDerivation rec {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "${buildType}-oss";
   inherit version buildNumber;
-  name = "${pname}-${version}.tar.gz";
+  name = "${finalAttrs.pname}-${version}.tar.gz";
   inherit src;
   nativeBuildInputs = [
     p7zip
@@ -321,4 +321,4 @@ stdenvNoCC.mkDerivation rec {
       jps-bootstrap
       ;
   };
-}
+})

--- a/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
+++ b/pkgs/applications/editors/jupyter-kernels/octave/kernel.nix
@@ -6,14 +6,14 @@
 
 with python3Packages;
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "octave-kernel";
   version = "0.34.2";
   format = "setuptools";
 
   src = fetchPypi {
     pname = "octave_kernel";
-    inherit version;
+    inherit (finalAttrs) version;
     sha256 = "sha256-5ki2lekfK7frPsmPBIzYQOfANCUY9x+F2ZRAQSdPTxo=";
   };
 
@@ -33,4 +33,4 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ thomasjm ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/editors/jupyter-kernels/wolfram/kernel.nix
+++ b/pkgs/applications/editors/jupyter-kernels/wolfram/kernel.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wolfram-for-jupyter-kernel";
   version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "WolframResearch";
     repo = "WolframLanguageForJupyter";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "19d9dvr0bv7iy0x8mk4f576ha7z7h7id39nyrggwf9cp7gymxf47";
   };
 
@@ -33,4 +33,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ fbeffa ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
+++ b/pkgs/applications/editors/jupyter-kernels/xeus-cling/xeus-cling.nix
@@ -51,14 +51,14 @@ let
 
 in
 
-clangStdenv.mkDerivation rec {
+clangStdenv.mkDerivation (finalAttrs: {
   pname = "xeus-cling";
   version = "0.15.3";
 
   src = fetchFromGitHub {
     owner = "QuantStack";
     repo = "xeus-cling";
-    rev = "${version}";
+    rev = "${finalAttrs.version}";
     hash = "sha256-OfZU+z+p3/a36GntusBfwfFu3ssJW4Fu7SV3SMCoo1I=";
   };
 
@@ -109,4 +109,4 @@ clangStdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/applications/editors/kakoune/plugins/overrides.nix
+++ b/pkgs/applications/editors/kakoune/plugins/overrides.nix
@@ -45,14 +45,14 @@ self: super: {
     '';
   });
 
-  kak-ansi = stdenv.mkDerivation rec {
+  kak-ansi = stdenv.mkDerivation (finalAttrs: {
     pname = "kak-ansi";
     version = "0.2.4";
 
     src = fetchFromGitHub {
       owner = "eraserhd";
       repo = "kak-ansi";
-      rev = "v${version}";
+      rev = "v${finalAttrs.version}";
       sha256 = "kFjTYFy0KF5WWEHU4hHFAnD/03/d3ptjqMMbTSaGImE=";
     };
 
@@ -77,16 +77,16 @@ self: super: {
       ];
       platforms = lib.platforms.all;
     };
-  };
+  });
 
-  kak-plumb = stdenv.mkDerivation rec {
+  kak-plumb = stdenv.mkDerivation (finalAttrs: {
     pname = "kak-plumb";
     version = "0.1.1";
 
     src = fetchFromGitHub {
       owner = "eraserhd";
       repo = "kak-plumb";
-      rev = "v${version}";
+      rev = "v${finalAttrs.version}";
       sha256 = "1rz6pr786slnf1a78m3sj09axr4d2lb5rg7sfa4mfg1zcjh06ps6";
     };
 
@@ -110,7 +110,7 @@ self: super: {
       ];
       platforms = lib.platforms.all;
     };
-  };
+  });
 
   kakoune-rainbow = super.kakoune-rainbow.overrideAttrs (oldAttrs: {
     preFixup = ''

--- a/pkgs/applications/editors/manuskript/default.nix
+++ b/pkgs/applications/editors/manuskript/default.nix
@@ -6,7 +6,7 @@
   wrapQtAppsHook,
 }:
 
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "manuskript";
   version = "0.17.0";
 
@@ -15,7 +15,7 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     repo = "manuskript";
     owner = "olivierkes";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-jOhbN6lMx04q60S0VOABmSNE/x9Er9exFYvWJe2INlE=";
   };
 
@@ -66,4 +66,4 @@ python3Packages.buildPythonApplication rec {
     platforms = lib.platforms.unix;
     mainProgram = "manuskript";
   };
-}
+})

--- a/pkgs/applications/editors/molsketch/default.nix
+++ b/pkgs/applications/editors/molsketch/default.nix
@@ -11,12 +11,12 @@
   desktop-file-utils,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "molsketch";
   version = "0.8.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/molsketch/Molsketch-${version}-src.tar.gz";
+    url = "mirror://sourceforge/molsketch/Molsketch-${finalAttrs.version}-src.tar.gz";
     hash = "sha256-6wFvl3Aktv8RgEdI2ENsKallKlYy/f8Tsm5C0FB/igI=";
   };
 
@@ -62,4 +62,4 @@ stdenv.mkDerivation rec {
     mainProgram = "molsketch";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/applications/editors/neovim/gnvim/default.nix
+++ b/pkgs/applications/editors/neovim/gnvim/default.nix
@@ -7,14 +7,14 @@
   gtk4,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gnvim-unwrapped";
   version = "0.3.1";
 
   src = fetchFromGitHub {
     owner = "vhakulinen";
     repo = "gnvim";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-VyyHlyMW/9zYECobQwngFARQYqcoXmopyCHUwHolXfo=";
   };
 
@@ -52,4 +52,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ minijackson ];
   };
-}
+})

--- a/pkgs/applications/editors/notepadqq/default.nix
+++ b/pkgs/applications/editors/notepadqq/default.nix
@@ -13,7 +13,7 @@
   qtwebsockets,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "notepadqq";
   # shipping a beta build as there's no proper release which supports qtwebengine
   version = "2.0.0-beta";
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "notepadqq";
     repo = "notepadqq";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-XA9Ay9kJApY+bDeOf0iPv+BWYFuTmIuqsLEPgRTCZCE=";
   };
 
@@ -69,4 +69,4 @@ stdenv.mkDerivation rec {
     maintainers = [ lib.maintainers.rszibele ];
     mainProgram = "notepadqq";
   };
-}
+})

--- a/pkgs/applications/editors/okteta/default.nix
+++ b/pkgs/applications/editors/okteta/default.nix
@@ -18,12 +18,12 @@
   shared-mime-info,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "okteta";
   version = "0.26.25";
 
   src = fetchurl {
-    url = "mirror://kde/stable/okteta/${version}/src/${pname}-${version}.tar.xz";
+    url = "mirror://kde/stable/okteta/${finalAttrs.version}/src/${finalAttrs.pname}-${finalAttrs.version}.tar.xz";
     sha256 = "sha256-K+GJG/SYyzgDDKXbGtAixQJVfBwLj/asP9rIJUpbt2s=";
   };
 
@@ -62,4 +62,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/editors/qxmledit/default.nix
+++ b/pkgs/applications/editors/qxmledit/default.nix
@@ -10,7 +10,7 @@
   libGLU,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "qxmledit";
   version = "0.9.17";
 
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "lbellonda";
     repo = "qxmledit";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-UzN5U+aC/uKokSdeUG2zv8+mkaH4ndYZ0sfzkpQ3l1M=";
   };
 
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     homepage = "https://sourceforge.net/projects/qxmledit";
     license = lib.licenses.lgpl2;
     platforms = lib.platforms.unix;
-    changelog = "https://github.com/lbellonda/qxmledit/blob/${version}/NEWS";
+    changelog = "https://github.com/lbellonda/qxmledit/blob/${finalAttrs.version}/NEWS";
     mainProgram = "qxmledit";
   };
-}
+})

--- a/pkgs/applications/editors/rednotebook/default.nix
+++ b/pkgs/applications/editors/rednotebook/default.nix
@@ -14,7 +14,7 @@
   setuptools,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "rednotebook";
   version = "2.42";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "jendrikseipp";
     repo = "rednotebook";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-4e3LvBVrhqzNja9kOZ5xJVYvwjGkKNvIuXou4YfD6w4=";
   };
 
@@ -54,10 +54,10 @@ buildPythonApplication rec {
 
   meta = {
     homepage = "https://rednotebook.sourceforge.io/";
-    changelog = "https://github.com/jendrikseipp/rednotebook/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/jendrikseipp/rednotebook/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Modern journal that includes a calendar navigation, customizable templates, export functionality and word clouds";
     license = lib.licenses.gpl2Plus;
     maintainers = [ ];
     mainProgram = "rednotebook";
   };
-}
+})

--- a/pkgs/applications/editors/sublime/4/common.nix
+++ b/pkgs/applications/editors/sublime/4/common.nix
@@ -64,11 +64,11 @@ let
     sqlite
   ];
 
-  binaryPackage = stdenv.mkDerivation rec {
+  binaryPackage = stdenv.mkDerivation (finalAttrs: {
     pname = "${pnameBase}-bin";
     version = buildVersion;
 
-    src = passthru.sources.${stdenv.hostPlatform.system};
+    src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system};
 
     dontStrip = true;
     dontPatchELF = true;
@@ -135,9 +135,9 @@ let
         };
       };
     };
-  };
+  });
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = pnameBase;
   version = buildVersion;
 
@@ -191,7 +191,7 @@ stdenv.mkDerivation rec {
               exit 0
           fi
 
-          for platform in ${lib.escapeShellArgs meta.platforms}; do
+          for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
               update-source-version "${packageAttribute}".unwrapped "$latestVersion" --ignore-same-version --file="$versionFile" --version-key=buildVersion --source-key="sources.$platform"
           done
         '';
@@ -218,4 +218,4 @@ stdenv.mkDerivation rec {
       "x86_64-linux"
     ];
   };
-}
+})

--- a/pkgs/applications/editors/tiled/default.nix
+++ b/pkgs/applications/editors/tiled/default.nix
@@ -26,7 +26,7 @@ let
   ];
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tiled";
   # nixpkgs-update: no auto update
   version = "1.11.2";
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "mapeditor";
     repo = "tiled";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-9oUKn51MQcsStgIJrp9XW5YAIpAUcO0kzfGnYA3gz/E=";
   };
 
@@ -96,4 +96,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/editors/vim/vimacs.nix
+++ b/pkgs/applications/editors/vim/vimacs.nix
@@ -9,13 +9,13 @@
   vimacsExtraArgs ? "",
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vimacs";
-  version = lib.getVersion vimPackage;
+  version = lib.getVersion finalAttrs.vimPackage;
   vimPackage = if useMacvim then macvim else vim-full;
 
   buildInputs = [
-    vimPackage
+    finalAttrs.vimPackage
     vimPlugins.vimacs
   ];
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
       --replace '--cmd "let g:VM_Enabled = 1"' \
                 '--cmd "let g:VM_Enabled = 1" --cmd "set rtp^=@rtp@" ${vimacsExtraArgs}' \
       --replace @rtp@ ${vimPlugins.vimacs} \
-      --replace @bin@ ${vimPackage}
+      --replace @bin@ ${finalAttrs.vimPackage}
     for prog in vm gvm gvimacs vmdiff vimacsdiff
     do
       ln -s "$out"/bin/vimacs $out/bin/$prog
@@ -41,4 +41,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ millerjason ];
   };
-}
+})

--- a/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
+++ b/pkgs/applications/editors/vscode/extensions/chenglou92.rescript-vscode/rescript-editor-analysis.nix
@@ -5,7 +5,7 @@
   ocamlPackages,
 }:
 
-ocamlPackages.buildDunePackage rec {
+ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "analysis";
   version = "1.62.0";
 
@@ -14,7 +14,7 @@ ocamlPackages.buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "rescript-lang";
     repo = "rescript-vscode";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Tox5Qq0Kpqikac90sQww2cGr9RHlXnVy7GMnRA18CoA=";
   };
 
@@ -33,7 +33,7 @@ ocamlPackages.buildDunePackage rec {
   meta = {
     description = "Analysis binary for the ReScript VSCode plugin";
     homepage = "https://github.com/rescript-lang/rescript-vscode";
-    changelog = "https://github.com/rescript-lang/rescript-vscode/releases/tag/${version}";
+    changelog = "https://github.com/rescript-lang/rescript-vscode/releases/tag/${finalAttrs.version}";
     maintainers = with lib.maintainers; [
       jayesh-bhoot
       RossSmyth
@@ -41,4 +41,4 @@ ocamlPackages.buildDunePackage rec {
     license = lib.licenses.mit;
     mainProgram = "rescript-editor-analysis";
   };
-}
+})

--- a/pkgs/applications/editors/your-editor/default.nix
+++ b/pkgs/applications/editors/your-editor/default.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "your-editor";
   version = "1601";
 
   src = fetchFromGitHub {
     owner = "your-editor";
     repo = "yed";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-pa9ibXyuWq7jRYsn3bGdqvLWbwQO2VYsP6Bk+BayQ8o=";
   };
 
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Small and simple terminal editor core that is meant to be extended through a powerful plugin architecture";
     homepage = "https://your-editor.org/";
-    changelog = "https://github.com/your-editor/yed/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/your-editor/yed/blob/${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     platforms = lib.platforms.unix;
     mainProgram = "yed";
   };
-}
+})

--- a/pkgs/applications/emulators/cdemu/vhba.nix
+++ b/pkgs/applications/emulators/cdemu/vhba.nix
@@ -6,12 +6,12 @@
   kernelModuleMakeFlags,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vhba";
   version = "20250329";
 
   src = fetchurl {
-    url = "mirror://sourceforge/cdemu/vhba-module-${version}.tar.xz";
+    url = "mirror://sourceforge/cdemu/vhba-module-${finalAttrs.version}.tar.xz";
     hash = "sha256-piog1yDd8M/lpTIo9FE9SY2JwurZ6a8LG2lZ/4EmB14=";
   };
 
@@ -28,4 +28,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ bendlas ];
   };
-}
+})

--- a/pkgs/applications/emulators/firebird-emu/default.nix
+++ b/pkgs/applications/emulators/firebird-emu/default.nix
@@ -8,14 +8,14 @@
   qtquickcontrols,
   wrapQtAppsHook,
 }:
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "firebird-emu";
   version = "1.6";
 
   src = fetchFromGitHub {
     owner = "nspire-emus";
     repo = "firebird";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
     hash = "sha256-ZptjlnOiF+hKuKYvBFJL95H5YQuR99d4biOco/MVEmE=";
   };
@@ -33,15 +33,15 @@ stdenv.mkDerivation rec {
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/Applications
-    mv $out/bin/${pname}.app $out/Applications/
+    mv $out/bin/firebird-emu.app $out/Applications/
   '';
 
   meta = {
     homepage = "https://github.com/nspire-emus/firebird";
-    changelog = "https://github.com/nspire-emus/firebird/releases/tag/v${version}";
+    changelog = "https://github.com/nspire-emus/firebird/releases/tag/v${finalAttrs.version}";
     description = "Third-party multi-platform emulator of the ARM-based TI-Nspire™ calculators";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ pneumaticat ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/applications/emulators/goldberg-emu/default.nix
+++ b/pkgs/applications/emulators/goldberg-emu/default.nix
@@ -6,14 +6,14 @@
   protobuf,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "goldberg-emu";
   version = "0.2.5";
 
   src = fetchFromGitLab {
     owner = "mr_goldberg";
     repo = "goldberg_emulator";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-goOgMNjtDmIKOAv9sZwnPOY0WqTN90LFJ5iEp3Vkzog=";
   };
 
@@ -56,4 +56,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/emulators/wibo/default.nix
+++ b/pkgs/applications/emulators/wibo/default.nix
@@ -8,14 +8,14 @@
   unzip,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wibo";
   version = "0.6.14";
 
   src = fetchFromGitHub {
     owner = "decompals";
     repo = "wibo";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-6YcraHBFWmm8TBfuFHbM9jGvUm9KvTOplJrFSTQkt70=";
   };
 
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
         meta.license = lib.licenses.unfree;
       };
     in
-    lib.optionalString doCheck ''
+    lib.optionalString finalAttrs.doCheck ''
       MWCIncludes=../test ./wibo ${gc}/GC/2.7/mwcceppc.exe -c ../test/test.c
       file test.o | grep "ELF 32-bit"
     '';
@@ -56,4 +56,4 @@ stdenv.mkDerivation rec {
     platforms = [ "i686-linux" ];
     mainProgram = "wibo";
   };
-}
+})

--- a/pkgs/applications/emulators/wine/winetricks.nix
+++ b/pkgs/applications/emulators/wine/winetricks.nix
@@ -21,9 +21,9 @@
   versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "winetricks";
-  version = src.version;
+  version = finalAttrs.src.version;
 
   src = (callPackage ./sources.nix { }).winetricks;
 
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
     '';
 
   passthru = {
-    inherit (src) updateScript;
+    inherit (finalAttrs.src) updateScript;
   };
 
   meta = {
@@ -84,4 +84,4 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/Winetricks/winetricks";
     platforms = with lib.platforms; linux ++ darwin;
   };
-}
+})

--- a/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/silhouette/default.nix
@@ -22,7 +22,7 @@ let
     ./silhouette_multi.py "$@"
   '';
 in
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "inkscape-silhouette";
   version = "1.29";
   format = "setuptools";
@@ -30,7 +30,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "fablabnbg";
     repo = "inkscape-silhouette";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-MfR88BuaAx6n5XRIjslpIk4PnDf6TLU9AsmHxKkcFS0=";
   };
 
@@ -91,4 +91,4 @@ python3.pkgs.buildPythonApplication rec {
     maintainers = with lib.maintainers; [ jfly ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
@@ -19,7 +19,7 @@ let
     ./__main__.py $*
   '';
 in
-python3.pkgs.buildPythonApplication rec {
+python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "textext";
   version = "1.13.0";
   format = "setuptools";
@@ -27,7 +27,7 @@ python3.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "textext";
     repo = "textext";
-    tag = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-fEPSpI9uO+r3d5p+gV1XcorYvUPw0sLgG9nHUPeTtYs=";
   };
 
@@ -124,4 +124,4 @@ python3.pkgs.buildPythonApplication rec {
     maintainers = [ lib.maintainers.raboof ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/graphics/luminance-hdr/default.nix
+++ b/pkgs/applications/graphics/luminance-hdr/default.nix
@@ -18,14 +18,14 @@
   eigen,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "luminance-hdr";
   version = "2.6.1.1";
 
   src = fetchFromGitHub {
     owner = "LuminanceHDR";
     repo = "LuminanceHDR";
-    rev = "v.${version}";
+    rev = "v.${finalAttrs.version}";
     sha256 = "sha256-PWqtYGx8drfMVp7D7MzN1sIUTQ+Xz5yyeHN87p2r6PY=";
   };
 
@@ -87,4 +87,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/graphics/nufraw/default.nix
+++ b/pkgs/applications/graphics/nufraw/default.nix
@@ -22,12 +22,12 @@
   addThumbnailer ? false,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "nufraw";
   version = "0.43-3";
 
   src = fetchurl {
-    url = "mirror://sourceforge/nufraw/nufraw-${version}.tar.gz";
+    url = "mirror://sourceforge/nufraw/nufraw-${finalAttrs.version}.tar.gz";
     sha256 = "0b63qvw9r8kaqw36bk3a9zwxc41h8fr6498indkw4glrj0awqz9c";
   };
 
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   postInstall = lib.optionalString addThumbnailer ''
     mkdir -p $out/share/thumbnailers
-    substituteAll ${./nufraw.thumbnailer} $out/share/thumbnailers/${pname}.thumbnailer
+    substituteAll ${./nufraw.thumbnailer} $out/share/thumbnailers/nufraw.thumbnailer
   '';
 
   patches = [
@@ -93,4 +93,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ asbachb ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -35,14 +35,14 @@
   libjxl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "rawtherapee";
   version = "5.12";
 
   src = fetchFromGitHub {
     owner = "RawTherapee";
     repo = "RawTherapee";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-h8eWnw9I1R0l9WAI/DylsdA241qU9NhYGEPYz+JlE18=";
     # The developers ask not to use the tarball from Github releases, see
     # https://www.rawtherapee.com/downloads/5.10/#news-relevant-to-package-maintainers
@@ -51,13 +51,13 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     cat <<EOF > ReleaseInfo.cmake
-    set(GIT_DESCRIBE ${version})
-    set(GIT_BRANCH ${version})
-    set(GIT_VERSION ${version})
+    set(GIT_DESCRIBE ${finalAttrs.version})
+    set(GIT_BRANCH ${finalAttrs.version})
+    set(GIT_VERSION ${finalAttrs.version})
     # Missing GIT_COMMIT and GIT_COMMIT_DATE, which are not easy to obtain.
     set(GIT_COMMITS_SINCE_TAG 0)
     set(GIT_COMMITS_SINCE_BRANCH 0)
-    set(GIT_VERSION_NUMERIC_BS ${version})
+    set(GIT_VERSION_NUMERIC_BS ${finalAttrs.version})
     EOF
     substituteInPlace tools/osx/Info.plist.in rtgui/config.h.in \
       --replace "/Applications" "${placeholder "out"}/Applications"
@@ -141,4 +141,4 @@ stdenv.mkDerivation rec {
     ];
     platforms = with lib.platforms; unix;
   };
-}
+})

--- a/pkgs/applications/graphics/sane/frontends.nix
+++ b/pkgs/applications/graphics/sane/frontends.nix
@@ -11,12 +11,12 @@
   libusb-compat-0_1 ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sane-frontends";
   version = "1.0.14";
 
   src = fetchurl {
-    url = "https://alioth-archive.debian.org/releases/sane/${pname}/${version}/${pname}-${version}.tar.gz";
+    url = "https://alioth-archive.debian.org/releases/sane/${finalAttrs.pname}/${finalAttrs.version}/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1ad4zr7rcxpda8yzvfkq1rfjgx9nl6lan5a628wvpdbh3fn9v0z7";
   };
 
@@ -86,4 +86,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/applications/graphics/scantailor/advanced.nix
+++ b/pkgs/applications/graphics/scantailor/advanced.nix
@@ -10,14 +10,14 @@
   boost,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "scantailor-advanced";
   version = "1.0.19";
 
   src = fetchFromGitHub {
     owner = "vigri";
     repo = "scantailor-advanced";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-mvoCoYdRTgXW5t8yd9Y9TOl7D3RDVwcjUv2YDUWrtRI=";
   };
 
@@ -42,4 +42,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = with lib.platforms; gnu ++ linux ++ darwin;
   };
-}
+})

--- a/pkgs/applications/graphics/scantailor/universal.nix
+++ b/pkgs/applications/graphics/scantailor/universal.nix
@@ -14,14 +14,14 @@
   libcanberra,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "scantailor-universal";
   version = "0.2.14";
 
   src = fetchFromGitHub {
     owner = "trufanov-nok";
     repo = "scantailor-universal";
-    rev = version;
+    rev = finalAttrs.version;
     fetchSubmodules = true;
     hash = "sha256-n8NbokK+U0FAuYXtjRJcxlI1XAmI4hk5zV3sF86hB/s=";
   };
@@ -64,4 +64,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "scantailor-universal-cli";
   };
-}
+})

--- a/pkgs/applications/graphics/sxiv/default.nix
+++ b/pkgs/applications/graphics/sxiv/default.nix
@@ -9,19 +9,19 @@
   conf ? null,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sxiv";
   version = "26";
 
   src = fetchFromGitHub {
     owner = "muennich";
     repo = "sxiv";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "0xaawlfdy7b277m38mgg4423kd7p1ffn0dq4hciqs6ivbb3q9c4f";
   };
 
   configFile = lib.optionalString (conf != null) (builtins.toFile "config.def.h" conf);
-  preBuild = lib.optionalString (conf != null) "cp ${configFile} config.def.h";
+  preBuild = lib.optionalString (conf != null) "cp ${finalAttrs.configFile} config.def.h";
 
   buildInputs = [
     libxft
@@ -44,4 +44,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ h7x4 ];
     mainProgram = "sxiv";
   };
-}
+})

--- a/pkgs/applications/graphics/tesseract/tesseract3.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract3.nix
@@ -12,14 +12,14 @@
   opencl-headers,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tesseract";
   version = "3.05.02";
 
   src = fetchFromGitHub {
     owner = "tesseract-ocr";
     repo = "tesseract";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-28osuZnVwkJpNTYkU+5D5PI8xtViFzGCMScHzkS2H20=";
   };
 
@@ -57,4 +57,4 @@ stdenv.mkDerivation rec {
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "tesseract";
   };
-}
+})

--- a/pkgs/applications/graphics/tesseract/tesseract4.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract4.nix
@@ -13,14 +13,14 @@
   opencl-headers,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tesseract";
   version = "4.1.3";
 
   src = fetchFromGitHub {
     owner = "tesseract-ocr";
     repo = "tesseract";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-sV3w53ky13ESc0dGPutMGQ4TcmOeWJkvUwBPIyzSTc8=";
   };
 
@@ -63,4 +63,4 @@ stdenv.mkDerivation rec {
     platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "tesseract";
   };
-}
+})

--- a/pkgs/applications/graphics/tesseract/tesseract5.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract5.nix
@@ -14,14 +14,14 @@
   pango,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tesseract";
   version = "5.5.2";
 
   src = fetchFromGitHub {
     owner = "tesseract-ocr";
     repo = "tesseract";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-VLmKwycJK66fFkdWOSYO5OJkJC8MTWKTQWIVb243ekc=";
   };
 
@@ -51,4 +51,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "tesseract";
   };
-}
+})

--- a/pkgs/applications/graphics/unigine-superposition/default.nix
+++ b/pkgs/applications/graphics/unigine-superposition/default.nix
@@ -31,11 +31,11 @@ let
   pname = "unigine-superposition";
   version = "1.1";
 
-  superposition = stdenv.mkDerivation rec {
+  superposition = stdenv.mkDerivation (finalAttrs: {
     inherit pname version;
 
     src = fetchurl {
-      url = "https://assets.unigine.com/d/Unigine_Superposition-${version}.run";
+      url = "https://assets.unigine.com/d/Unigine_Superposition-${finalAttrs.version}.run";
       hash = "sha256-dJThxzv1nvIWFRPV1cudm/+9hHmSnUl2rFO2lV3lgPg=";
     };
 
@@ -82,7 +82,7 @@ let
     postPatchMkspecs = ''
       cp -f $name/bin/superposition $out/lib/unigine/superposition/bin/superposition
     '';
-  };
+  });
 
   desktopItem = makeDesktopItem {
     name = "Superposition";

--- a/pkgs/applications/graphics/zgv/default.nix
+++ b/pkgs/applications/graphics/zgv/default.nix
@@ -11,11 +11,11 @@
   libtiff,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "zgv";
   version = "5.9";
   src = fetchurl {
-    url = "https://www.svgalib.org/rus/zgv/${pname}-${version}.tar.gz";
+    url = "https://www.svgalib.org/rus/zgv/${finalAttrs.pname}-${finalAttrs.version}.tar.gz";
     sha256 = "1fk4i9x0cpnpn3llam0zy2pkmhlr2hy3iaxhxg07v9sizd4dircj";
   };
 
@@ -58,4 +58,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     mainProgram = "zgv";
   };
-}
+})

--- a/pkgs/applications/misc/ape/clex.nix
+++ b/pkgs/applications/misc/ape/clex.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "attempto-clex";
   version = "6.5-090528";
 
   src = fetchFromGitHub {
     owner = "Attempto";
     repo = "Clex";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-Oa1AMBaYpjd+U2k9lBnou4+4IgBwU8fojJ8bY9tf9ZE=";
   };
 
@@ -26,4 +26,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ yrashk ];
   };
-}
+})

--- a/pkgs/applications/misc/bfcal/default.nix
+++ b/pkgs/applications/misc/bfcal/default.nix
@@ -9,14 +9,14 @@
   qtbase,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bfcal";
   version = "1.0.1";
 
   src = fetchFromSourcehut {
     owner = "~bitfehler";
     repo = "bfcal";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-5xyBU+0XUNFUGgvw7U8YE64zncw6SvPmbJhc1LY2u/g=";
   };
 
@@ -39,4 +39,4 @@ stdenv.mkDerivation rec {
     platforms = qtbase.meta.platforms;
     maintainers = with lib.maintainers; [ laalsaas ];
   };
-}
+})

--- a/pkgs/applications/misc/bitwarden-menu/default.nix
+++ b/pkgs/applications/misc/bitwarden-menu/default.nix
@@ -8,14 +8,14 @@
   xdg-base-dirs,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "bitwarden-menu";
   version = "0.4.5";
   pyproject = true;
 
   src = fetchPypi {
     pname = "bitwarden_menu";
-    inherit version;
+    inherit (finalAttrs) version;
     hash = "sha256-vUlNqSVdGhfN5WjDjf1ub32Y2WoBndIdFzfCNwo5+Vg=";
   };
 
@@ -32,11 +32,11 @@ buildPythonApplication rec {
   doCheck = false;
 
   meta = {
-    changelog = "https://github.com/firecat53/bitwarden-menu/releases/tag/v${version}";
+    changelog = "https://github.com/firecat53/bitwarden-menu/releases/tag/v${finalAttrs.version}";
     description = "Dmenu/Rofi frontend for managing Bitwarden vaults. Uses the Bitwarden CLI tool to interact with the Bitwarden database";
     mainProgram = "bwm";
     homepage = "https://github.com/firecat53/bitwarden-menu";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ aman9das ];
   };
-}
+})

--- a/pkgs/applications/misc/bluetooth_battery/default.nix
+++ b/pkgs/applications/misc/bluetooth_battery/default.nix
@@ -5,14 +5,14 @@
   pybluez,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "bluetooth_battery";
   version = "1.3.1";
 
   src = fetchFromGitHub {
     owner = "TheWeirdDev";
     repo = "Bluetooth_Headset_Battery_Level";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "067qfxh228cy1x95bnjp88dx4k00ajj7ay7fz5vr1gkj2yfa203s";
   };
 
@@ -33,4 +33,4 @@ buildPythonApplication rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ cheriimoya ];
   };
-}
+})

--- a/pkgs/applications/misc/cask-server/default.nix
+++ b/pkgs/applications/misc/cask-server/default.nix
@@ -7,14 +7,14 @@
   wrapQtAppsHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cask-server";
   version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "Nitrux";
     repo = "cask-server";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-XUgLtZMcvzGewtUcgu7FbBCn/1zqOjWvw2AI9gUwWkc=";
   };
 
@@ -35,5 +35,4 @@ stdenv.mkDerivation rec {
     ];
     maintainers = with lib.maintainers; [ onny ];
   };
-
-}
+})

--- a/pkgs/applications/misc/chewing-editor/default.nix
+++ b/pkgs/applications/misc/chewing-editor/default.nix
@@ -11,14 +11,14 @@
   qttools,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "chewing-editor";
   version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "chewing";
     repo = "chewing-editor";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-gF3OotO/xb3Dc0YjVwAKIYnuEPIrgjpGR2tdjOBT4aI=";
   };
 
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.all;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/applications/misc/coolreader/default.nix
+++ b/pkgs/applications/misc/coolreader/default.nix
@@ -11,14 +11,14 @@
   zstd,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "coolreader";
   version = "3.2.59";
 
   src = fetchFromGitHub {
     owner = "buggins";
     repo = "coolreader";
-    rev = "cr${version}";
+    rev = "cr${finalAttrs.version}";
     sha256 = "sha256-RgVEOaNBaEuPBC75B8PdCkbqMvEzNmnEYmiI1ny/WFQ=";
   };
 
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.all;
   };
-}
+})

--- a/pkgs/applications/misc/cura/default.nix
+++ b/pkgs/applications/misc/cura/default.nix
@@ -12,14 +12,14 @@
   plugins ? [ ],
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cura";
   version = "4.13.1";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "Cura";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-R88SdAxx3tkQCDInrFTKad1tPSDTSYaVAPUVmdk94Xk=";
   };
 
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DURANIUM_DIR=${python3.pkgs.uranium.src}"
-    "-DCURA_VERSION=${version}"
+    "-DCURA_VERSION=${finalAttrs.version}"
   ];
 
   makeWrapperArgs = [
@@ -73,7 +73,7 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -p $out/share/cura/resources/materials
-    cp ${materials}/*.fdm_material $out/share/cura/resources/materials/
+    cp ${finalAttrs.materials}/*.fdm_material $out/share/cura/resources/materials/
     mkdir -p $out/lib/cura/plugins
     for plugin in ${toString plugins}; do
       ln -s $plugin/lib/cura/plugins/* $out/lib/cura/plugins
@@ -93,4 +93,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/applications/misc/curaengine/default.nix
+++ b/pkgs/applications/misc/curaengine/default.nix
@@ -9,14 +9,14 @@
   fetchpatch,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "curaengine";
   version = "4.13.1";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "CuraEngine";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-dx0Q6cuA66lG4nwR7quW5Tvs9sdxjdV4gtpxXirI4nY=";
   };
 
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     protobuf
   ];
 
-  cmakeFlags = [ "-DCURA_ENGINE_VERSION=${version}" ];
+  cmakeFlags = [ "-DCURA_ENGINE_VERSION=${finalAttrs.version}" ];
 
   # TODO already fixed in master, remove in next release
   patches = [
@@ -46,4 +46,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     mainProgram = "CuraEngine";
   };
-}
+})

--- a/pkgs/applications/misc/curaengine/stable.nix
+++ b/pkgs/applications/misc/curaengine/stable.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "curaengine";
   version = "15.04.6";
 
   src = fetchFromGitHub {
     owner = "Ultimaker";
     repo = "CuraEngine";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-8V21TRSqCN+hkTlz51d5A5oK5JOwEtx+ROt8cfJBL/0=";
   };
 
@@ -31,4 +31,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.agpl3Plus;
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/ma/mame/package.nix
+++ b/pkgs/by-name/ma/mame/package.nix
@@ -34,15 +34,15 @@
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "mame";
   version = "0.285";
-  srcVersion = builtins.replaceStrings [ "." ] [ "" ] version;
+  srcVersion = builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version;
 
   src = fetchFromGitHub {
     owner = "mamedev";
     repo = "mame";
-    rev = "mame${srcVersion}";
+    rev = "mame${finalAttrs.srcVersion}";
     hash = "sha256-vuGQ1VOjIAEopV4X+qP1k+bgH7lJJLZ9RtYevUxgIQg=";
   };
 
@@ -233,7 +233,7 @@ stdenv.mkDerivation rec {
       calculators, in addition to the arcade video games that were its initial
       focus.
     '';
-    changelog = "https://github.com/mamedev/mame/releases/download/mame${srcVersion}/whatsnew_${srcVersion}.txt";
+    changelog = "https://github.com/mamedev/mame/releases/download/mame${finalAttrs.srcVersion}/whatsnew_${finalAttrs.srcVersion}.txt";
     license = with lib.licenses; [
       bsd3
       gpl2Plus
@@ -245,4 +245,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.unix;
     mainProgram = "mame";
   };
-}
+})


### PR DESCRIPTION
Changes been done manually with assist from nixd
Some whitespaces after meta section were removed along the way

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
