### PR TITLE
treewide: remove meta = with lib; remainings

### DIFF
--- a/pkgs/by-name/gr/grok-cli/package.nix
+++ b/pkgs/by-name/gr/grok-cli/package.nix
@@ -35,7 +35,7 @@ buildNpmPackage rec {
     description = "AI agent CLI powered by Grok";
     homepage = "https://github.com/superagent-ai/grok-cli";
     license = lib.licenses.mit;
-    maintainers = with lib; [ maintainers.madebydamo ];
+    maintainers = with lib.maintainers; [ madebydamo ];
     mainProgram = "grok";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/re/remark42/package.nix
+++ b/pkgs/by-name/re/remark42/package.nix
@@ -95,12 +95,12 @@ buildGoModule (finalAttrs: {
     version = "v${finalAttrs.version}";
   };
 
-  meta = with lib; {
+  meta = {
     description = "Self-hosted comment engine that embeds a statically built frontend";
     homepage = "https://remark42.com/";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "remark42";
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ janhencic ];
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ janhencic ];
   };
 })

--- a/pkgs/by-name/st/steam-art-manager/package.nix
+++ b/pkgs/by-name/st/steam-art-manager/package.nix
@@ -24,11 +24,11 @@ appimageTools.wrapType2 {
       --replace 'Icon=Steam Art Manager' 'Icon=steam-art-manager'
   '';
 
-  meta = with lib; {
+  meta = {
     description = "A tool to manage and change Steam library artwork";
     homepage = "https://github.com/Tormak9970/Steam-Art-Manager";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ adam-tj ];
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ adam-tj ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "steam-art-manager";
   };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
