### PR TITLE
top-level/stage: assert no callPackage with by-name paths

### DIFF
--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -185,7 +185,23 @@ let
           overlays
           ;
       } res self super;
+      # Check for callPackage calls that reference by-name paths
+      allPackagesPath = toString ./all-packages.nix;
+      allPackagesLines = lib.splitString "\n" (builtins.readFile ./all-packages.nix);
+      callPackageByNameAttrs = lib.filter (
+        name:
+        let
+          pos = builtins.unsafeGetAttrPos name res;
+          isFromAllPackages = pos != null && pos.file == allPackagesPath;
+          lineContent = if isFromAllPackages then lib.elemAt allPackagesLines (pos.line - 1) else "";
+          usesCallPackage = lib.hasInfix "callPackage" lineContent;
+          callsByName = lib.hasInfix "by-name" lineContent;
+        in
+        isFromAllPackages && usesCallPackage && callsByName
+      ) (lib.attrNames res);
     in
+    assert lib.assertMsg (callPackageByNameAttrs == [ ])
+      "The following attributes in `pkgs/top-level/all-packages.nix` used `callPackage` with a `pkgs/by-name/` path. Use `<package>.override { }` instead: ${lib.concatStringsSep ", " callPackageByNameAttrs}";
     res;
 
   aliases = self: super: lib.optionalAttrs config.allowAliases (import ./aliases.nix lib self super);


### PR DESCRIPTION
## Motivation

When packages are moved to `pkgs/by-name/`, they should no longer be called using `callPackage` in `all-packages.nix`. Instead, variants and customizations should use `<package>.override { }`.

Using `callPackage` with by-name paths:
- Bypasses the by-name auto-calling mechanism
- Creates redundant code that duplicates what by-name already provides
- Makes it harder to maintain consistency across the codebase

This PR adds an assertion that detects and reports all attributes in `all-packages.nix` that use `callPackage` with a path pointing to `pkgs/by-name/`.

This is the next step after #483820 

## Remaining packages (122 total)

- [ ] alacritty-graphics
- [ ] anki-utils
- [ ] ankiAddons
- [ ] apple-sdk_14, apple-sdk_15, apple-sdk_26
- [ ] asio_1_32_0, asio_1_36_0
- [ ] authentik-outposts
- [ ] avahi-compat
- [ ] blightmud-tts
- [ ] bucklespring-x11
- [ ] c-aresMinimal
- [ ] cgal_5
- [ ] clickhouse-lts
- [ ] cmakeMinimal
- [ ] comet-gog_heroic
- [ ] crawlTiles
- [ ] davinci-resolve-studio
- [ ] dprint-plugins
- [ ] drawterm-wayland
- [ ] dune_2, dune_3
- [ ] factorio-utils
- [ ] foomatic-db-ppds-withNonfreeDb
- [ ] forgejo-lts
- [ ] gamescope-wsi
- [ ] gamt
- [ ] gancioPlugins, gaugePlugins
- [ ] geoipWithDatabase
- [ ] ghdl-gcc, ghdl-llvm, ghdl-mcode
- [ ] gimagereader-qt
- [ ] git-credential-aol, git-credential-gmail, git-credential-outlook, git-credential-yahoo, git-msgraph, git-protonmail
- [ ] gitlab-ee, gitlab-workhorse
- [ ] glfw3-minecraft
- [ ] glib
- [ ] glm_1_0_1
- [ ] gnome-panel-with-modules, gnome-session-ctl
- [ ] goattracker-stereo
- [ ] gopro-tool
- [ ] gpac-unstable
- [ ] hareHook
- [ ] hunspellDicts
- [ ] incus-lts
- [ ] iortcw_sp
- [ ] isabelle-components
- [ ] jamesdsp-pulse
- [ ] kbdVlock
- [ ] kicadAddons
- [ ] koboredux-free
- [ ] ldmud-full
- [ ] lgogdownloader-gui
- [ ] libcamera-qcam
- [ ] libpostalWithData
- [ ] lima-additional-guestagents
- [ ] lxappearance-gtk2
- [ ] mediaelch-qt5
- [ ] mindustry-server, mindustry-wayland
- [ ] mkspiffs-presets
- [ ] mpvScripts
- [ ] mumps-mpi
- [ ] nanopbMalloc
- [ ] ncdu_1
- [ ] netcap-nodpi
- [ ] nextpnrWithGui
- [ ] ninja_1_11
- [ ] noto-fonts-cjk-sans-static, noto-fonts-cjk-serif-static, noto-fonts-lgc-plus
- [ ] ollama-cpu, ollama-cuda, ollama-rocm, ollama-vulkan
- [ ] opaline
- [ ] openjfx17, openjfx25
- [ ] openvswitch-dpdk
- [ ] qadwaitadecorations-qt6
- [ ] racket-minimal
- [ ] rat-king-adventure
- [ ] reposilitePlugins
- [ ] ringboard-wayland
- [ ] rkpd2
- [ ] rmg-wayland
- [ ] rott-shareware
- [ ] run-npush
- [ ] segger-jlink-headless
- [ ] sgt-puzzles-mobile
- [ ] shorter-pixel-dungeon
- [ ] siesta-mpi
- [ ] simulide_0_4_15, simulide_1_0_0, simulide_1_1_0, simulide_1_2_0
- [ ] squeezelite-pulse
- [ ] sshd-openpgp-auth
- [ ] stlink-gui
- [ ] torcs-without-data
- [ ] tower-pixel-dungeon
- [ ] tracy-glfw, tracy-wayland
- [ ] tsm-client-withGui
- [ ] uiua-unstable
- [ ] valeStyles
- [ ] vapoursynth-editor
- [ ] vencord-web-extension
- [ ] wesnoth-devel
- [ ] xarMinimal
- [ ] xkeyboard-config_custom
- [ ] xyce-parallel
- [ ] yarn-berry_3-fetcher, yarn-berry_4-fetcher
- [ ] yaziPlugins

## How to fix

Replace:
```nix
foo-variant = callPackage ../by-name/fo/foo/package.nix { someArg = value; };
```

With:
```nix
foo-variant = foo.override { someArg = value; };
```