### PR TITLE
uasm: fix building with gcc > 13

### DIFF
--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -6,14 +6,14 @@
   uasm,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation(finalAttrs: {
   pname = "uasm";
   version = "2.57";
 
   src = fetchFromGitHub {
     owner = "Terraspace";
     repo = "uasm";
-    tag = "v${version}r";
+    tag = "v${finalAttrs.version}r";
     hash = "sha256-HaiK2ogE71zwgfhWL7fesMrNZYnh8TV/kE3ZIS0l85w=";
   };
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     install -Dt "$out/bin" -m0755 GccUnixR/uasm
-    install -Dt "$out/share/doc/${pname}" -m0644 {Readme,History}.txt Doc/*
+    install -Dt "$out/share/doc/uasm" -m0644 {Readme,History}.txt Doc/*
 
     runHook postInstall
   '';
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   passthru.tests.version = testers.testVersion {
     package = uasm;
     command = "uasm -h";
-    version = "v${version}";
+    version = "v${finalAttrs.version}";
   };
 
   meta = {
@@ -54,4 +54,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.watcom;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation(finalAttrs: {
     description = "Free MASM-compatible assembler based on JWasm";
     mainProgram = "uasm";
     platforms = lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.zane ];
     license = lib.licenses.watcom;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -6,7 +6,7 @@
   uasm,
 }:
 
-stdenv.mkDerivation(finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "uasm";
   version = "2.57";
 
@@ -20,10 +20,7 @@ stdenv.mkDerivation(finalAttrs: {
   enableParallelBuilding = true;
 
   makefile =
-    if stdenv.hostPlatform.isDarwin then
-      "Makefile-OSX-Clang-64.mak"
-    else
-      "Makefile-Linux-GCC-64.mak";
+    if stdenv.hostPlatform.isDarwin then "Makefile-OSX-Clang-64.mak" else "Makefile-Linux-GCC-64.mak";
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -1,14 +1,11 @@
 {
   lib,
-  gcc13Stdenv,
+  stdenv,
   fetchFromGitHub,
   testers,
   uasm,
 }:
 
-let
-  stdenv = gcc13Stdenv;
-in
 stdenv.mkDerivation rec {
   pname = "uasm";
   version = "2.57";
@@ -23,12 +20,15 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   makefile =
-    if gcc13Stdenv.hostPlatform.isDarwin then
+    if stdenv.hostPlatform.isDarwin then
       "Makefile-OSX-Clang-64.mak"
     else
       "Makefile-Linux-GCC-64.mak";
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  # Needed for compiling with GCC > 13
+  env.CFLAGS = "-std=c99 -Wno-incompatible-pointer-types -Wno-implicit-function-declaration -Wno-int-conversion";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
