### PR TITLE
python3Packages.pyrsistent: 0.20.0 -> 0.21.0

### DIFF
--- a/pkgs/development/python-modules/pyrsistent/default.nix
+++ b/pkgs/development/python-modules/pyrsistent/default.nix
@@ -1,33 +1,31 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
-  isPy27,
+  fetchFromGitHub,
   setuptools,
-  six,
+  typing-extensions,
   pytestCheckHook,
   hypothesis,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyrsistent";
-  version = "0.20.0";
+  version = "0.21.0";
   pyproject = true;
 
-  disabled = isPy27;
-
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-TEj3j2KrWWxnkIYITQ3RMlSuTz1scqg//fXr3vjyZaQ=";
+  src = fetchFromGitHub {
+    owner = "tobgu";
+    repo = "pyrsistent";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8fLyz8ELOg5GCrBHLSl4iiCgEZ6MuFoBwNKns5AI5Ps=";
   };
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [ six ];
+  build-system = [ setuptools ];
 
   nativeCheckInputs = [
     pytestCheckHook
     hypothesis
+    typing-extensions
   ];
 
   pythonImportsCheck = [ "pyrsistent" ];
@@ -35,6 +33,7 @@ buildPythonPackage rec {
   meta = {
     homepage = "https://github.com/tobgu/pyrsistent/";
     description = "Persistent/Functional/Immutable data structures";
+    changelog = "https://github.com/tobgu/pyrsistent/blob/${finalAttrs.src.tag}/CHANGES.txt";
     license = lib.licenses.mit;
   };
-}
+})


### PR DESCRIPTION
This update fixes compatibility with Python 3.13+; in the previous version, the C-extension would not be built, thus degrading performance significantly.

Changelog: https://github.com/tobgu/pyrsistent/blob/v0.21.0/CHANGES.txt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
