### PR TITLE
prometheus-adguard-exporter: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9114,6 +9114,13 @@
     githubId = 77672306;
     name = "Florian Agbuya";
   };
+  fschn90 = {
+    email = "nix@fschn.org";
+    github = "fschn90";
+    githubId = 79014934;
+    name = "Florian Schneider";
+    matrix = "@fschn:matrix.org";
+  };
   fsnkty = {
     name = "fsnkty";
     github = "fsnkty";

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -56,6 +56,8 @@
 
 - [Shoko](https://shokoanime.com), an anime management system. Available as [services.shoko](#opt-services.shoko.enable).
 
+- [Prometheus Adguard Exporter](https://github.com/henrywhitaker3/adguard-exporter), a Prometheus exporter for AdGuardHome metrics.
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -48,6 +48,7 @@ let
   exporterOpts =
     (genAttrs
       [
+        "adguard"
         "apcupsd"
         "artifactory"
         "bind"

--- a/nixos/modules/services/monitoring/prometheus/exporters/adguard.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/adguard.nix
@@ -1,0 +1,69 @@
+{ config
+, lib
+, pkgs
+, options
+, ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.adguard;
+  inherit (lib)
+    mkOption
+    types
+    mkRemovedOptionModule
+    ;
+in
+{
+  imports = [
+    (mkRemovedOptionModule [ "interval" ] "This option has been removed.")
+    {
+      options.warnings = options.warnings;
+      options.assertions = options.assertions;
+    }
+  ];
+
+  port = 9618;
+  extraOpts = {
+    servers = mkOption {
+      type = types.str;
+      default = "http://127.0.0.1";
+      example = "https://adguard.example.org";
+      description = ''
+        The servers you want the exporter to scrape. Must include the scheme http(s) and port if non-standard.
+      '';
+    };
+    users = mkOption {
+      type = types.str;
+      default = "";
+      example = "adguard";
+      description = ''
+        The username to connect to the adguard api with. Must be in the same order as servers if scraping multiple instances
+      '';
+    };
+    passwordFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/path/to/password-file";
+      description = ''
+        File containing the password for connecting to adguard home. Make sure that this file is readable by the exporter user.
+        The password to connect to the adguard api with. Must be in the same order as servers if scraping multiple instances.
+      '';
+    };
+  };
+  serviceOpts = {
+    script = ''
+      passwordfile="$CREDENTIALS_DIRECTORY/password-file"
+      export ADGUARD_PASSWORDS="$(cat "$passwordfile")"
+      exec ${pkgs.prometheus-adguard-exporter}/bin/adguard-exporter
+    '';
+    serviceConfig = {
+      LoadCredential = [
+        "password-file:${config.services.prometheus.exporters.adguard.passwordFile}"
+      ];
+      Environment = [
+        "ADGUARD_SERVERS=${cfg.servers}"
+        "ADGUARD_USERNAMES=${cfg.users}"
+      ];
+    };
+  };
+}

--- a/pkgs/by-name/pr/prometheus-adguard-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-adguard-exporter/package.nix
@@ -1,0 +1,41 @@
+{ lib
+, buildGoModule
+, fetchFromGitHub
+, nixosTests
+,
+}:
+
+buildGoModule rec {
+  pname = "adguard-exporter";
+  version = "1.2.1";
+  rev = "v${version}";
+
+  src = fetchFromGitHub {
+    inherit rev;
+    owner = "henrywhitaker3";
+    repo = "adguard-exporter";
+    sha256 = "sha256-OltYzxBOOcaW3oYNFvxxjG1qRvuLaZfReSeQaNGiRDc=";
+  };
+
+  vendorHash = "sha256-fDSR0+INsVBD5XauPdSETMNJZkrIbpKwZ/6Tb2Po4fY=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/prometheus/common/version.Version=${version}"
+    "-X github.com/prometheus/common/version.Revision=${rev}"
+    "-X github.com/prometheus/common/version.Branch=unknown"
+    "-X github.com/prometheus/common/version.BuildUser=nix@nixpkgs"
+    "-X github.com/prometheus/common/version.BuildDate=unknown"
+  ];
+
+  meta = with lib; {
+    description = "A Prometheus exporter for AdGuard Home.";
+    mainProgram = "adguard-exporter";
+    homepage = "https://github.com/henrywhitaker3/adguard-exporter";
+    license = licenses.asl20;
+    maintainers = with maintainers; [
+      fschn90
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR introduces a new package and NixOS module for monitoring AdGuardHome with Prometheus, via https://github.com/henrywhitaker3/adguard-exporter.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
