### PR TITLE
rememory: init at 0.0.7

### DIFF
--- a/pkgs/by-name/re/rememory/package.nix
+++ b/pkgs/by-name/re/rememory/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  pkgs,
+  buildGoModule,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+buildGoModule (finalAttrs: {
+  pname = "rememory";
+  version = "0.0.7";
+
+  src = fetchFromGitHub {
+    owner = "eljojo";
+    repo = "rememory";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MI2ono5hcEm+4oXq1HvSoNOZc8ALMV00dyo7JK80dnM=";
+  };
+
+  vendorHash = "sha256-/PnlHXAYlcR5jIKD5qwjKfv6/JldCXaorPSpW8GKXYo=";
+  proxyVendor = true;
+
+  nativeBuildInputs = with pkgs; [
+    esbuild
+  ];
+
+  preBuild = ''
+    make wasm
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/man/man1
+    $out/bin/rememory doc $out/share/man/man1
+  '';
+
+  subPackages = [ "cmd/rememory" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=v${finalAttrs.version}"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://eljojo.github.io/rememory";
+    description = "Tool that encrypts files and splits the decryption key among trusted friends using Shamir's Secret Sharing";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ rixxc ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
This pull request introduces the rememory package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
