### PR TITLE
ghc: 9.6.6-debian-binary for powerpc64le, too

### DIFF
--- a/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.6-debian-binary.nix
@@ -23,6 +23,33 @@ let
   # GHC upstream doesn't release bindist tarballs for some platforms.
   # We're using Debian's binary package, and patching it into a usable-in-Nixpkgs state.
   ghcDebs = {
+    powerpc64le-linux = {
+      src = {
+        urls = [
+          "http://ftp.debian.org/debian/pool/main/g/ghc/ghc_9.6.6-4_ppc64el.deb"
+        ];
+        sha256 = "6dd14937485831c72aef62851c4251f2afa2c7a06a2d4956e25a1f82ab195a01";
+      };
+      exePathForLibraryCheck = null;
+      archSpecificLibraries = [
+        {
+          nixPackage = gmp;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = ncurses6;
+          fileToCheckFor = "libtinfo.so.6";
+        }
+        {
+          nixPackage = numactl;
+          fileToCheckFor = null;
+        }
+        {
+          nixPackage = libffi;
+          fileToCheckFor = null;
+        }
+      ];
+    };
     powerpc64-linux = {
       src = {
         urls = [
@@ -50,6 +77,8 @@ let
           fileToCheckFor = null;
         }
       ];
+
+      platforms = lib.systems.inspect.patterns.isAbiElfv1;
     };
   };
 
@@ -191,11 +220,11 @@ stdenv.mkDerivation (finalAttrs: {
     # Patch ghc settings
     + ''
       substituteInPlace $out/lib/ghc/lib/settings \
-        --replace-fail powerpc64-linux-gnu-gcc gcc \
-        --replace-fail powerpc64-linux-gnu-g++ g++ \
-        --replace-fail powerpc64-linux-gnu-ld ld \
-        --replace-fail powerpc64-linux-gnu-ar ar \
-        --replace-fail powerpc64-linux-gnu-ranlib ranlib \
+        --replace-fail ${stdenv.hostPlatform.system}-gnu-gcc gcc \
+        --replace-fail ${stdenv.hostPlatform.system}-gnu-g++ g++ \
+        --replace-fail ${stdenv.hostPlatform.system}-gnu-ld ld \
+        --replace-fail ${stdenv.hostPlatform.system}-gnu-ar ar \
+        --replace-fail ${stdenv.hostPlatform.system}-gnu-ranlib ranlib \
         --replace-fail llc-18 llc \
         --replace-fail opt-18 opt
     '';
@@ -262,7 +291,25 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "http://haskell.org/ghc";
     description = "Glasgow Haskell Compiler";
     license = lib.licenses.bsd3;
-    platforms = builtins.attrNames ghcDebs;
+
+    # ghcDebs is keyed on the system double (cpu-kernel), and each entry may
+    # additionally constrain the choice of platforms with a system inspection
+    # pattern.
+    platforms = builtins.map (
+      system:
+      let
+        isThis = {
+          inherit (lib.systems.parse.mkSystemFromString system)
+            cpu
+            kernel
+            ;
+        };
+      in
+      if ghcDebs.${system} ? platforms then
+        lib.systems.inspect.patternLogicalAnd isThis ghcDebs.${system}.platforms
+      else
+        isThis
+    ) (builtins.attrNames ghcDebs);
     maintainers = [ lib.maintainers.OPNA2608 ];
     teams = [ lib.teams.haskell ];
   };

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -6,6 +6,7 @@
   newScope,
   stdenv,
   config,
+  lib,
 }:
 
 let
@@ -89,14 +90,29 @@ in
   compiler = pkgs.lib.recurseIntoAttrs (
     let
       bb = pkgsBuildBuild.haskell;
+
+      # No bindist from upstream, but sometimes we can "borrow" GHC from Debian
+      ghc966DebianBinary = callPackage ../development/compilers/ghc/9.6.6-debian-binary.nix { };
+
+      # Try using the given package to bootstrap, if that's available on the
+      # host platform.  Otherwise, try falling back to something else.  At the
+      # moment, the only fallback we know how to do is to borrow from Debian.
+      bootstrapViaOrFallback =
+        pkg:
+        if lib.meta.availableOn stdenv.hostPlatform pkg.ghc then
+          pkg
+        else if lib.meta.availableOn stdenv.hostPlatform ghc966DebianBinary then
+          bb.packages.ghc966DebianBinary
+        else
+          throw "No available bootstrap GHC for '${stdenv.hostPlatform.system}'";
     in
     {
+      inherit ghc966DebianBinary;
+
       # Required to bootstrap 9.4.8.
       ghc902Binary = callPackage ../development/compilers/ghc/9.0.2-binary.nix {
         inherit llvmPackages;
       };
-
-      ghc966DebianBinary = callPackage ../development/compilers/ghc/9.6.6-debian-binary.nix { };
 
       ghc984Binary = callPackage ../development/compilers/ghc/9.8.4-binary.nix { };
 
@@ -110,67 +126,31 @@ in
         inherit buildTargetLlvmPackages llvmPackages;
       };
       ghc967 = callPackage ../development/compilers/ghc/9.6.7.nix {
-        bootPkgs =
-          if
-            stdenv.buildPlatform.isPower64
-            && stdenv.buildPlatform.isBigEndian
-            && pkgs.stdenv.hostPlatform.isAbiElfv1
-          then
-            # No bindist, "borrowing" the GHC from Debian
-            bb.packages.ghc966DebianBinary
-          else
-            bb.packages.ghc948;
+        bootPkgs = bootstrapViaOrFallback bb.packages.ghc948;
         inherit (buildPackages.python3Packages) sphinx;
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;
       };
       ghc984 = callPackage ../development/compilers/ghc/9.8.4.nix {
-        bootPkgs =
-          if
-            stdenv.buildPlatform.isPower64
-            && stdenv.buildPlatform.isBigEndian
-            && pkgs.stdenv.hostPlatform.isAbiElfv1
-          then
-            # No bindist, "borrowing" the GHC from Debian
-            bb.packages.ghc966DebianBinary
-          else if stdenv.buildPlatform.isi686 then
-            bb.packages.ghc948
-          else
-            bb.packages.ghc984Binary;
+        bootPkgs = bootstrapViaOrFallback (
+          if stdenv.buildPlatform.isi686 then bb.packages.ghc948 else bb.packages.ghc984Binary
+        );
         inherit (buildPackages.python3Packages) sphinx;
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;
       };
       ghc9102 = callPackage ../development/compilers/ghc/9.10.2.nix {
-        bootPkgs =
-          if
-            stdenv.buildPlatform.isPower64
-            && stdenv.buildPlatform.isBigEndian
-            && pkgs.stdenv.hostPlatform.isAbiElfv1
-          then
-            # No bindist, "borrowing" the GHC from Debian
-            bb.packages.ghc966DebianBinary
-          else if stdenv.buildPlatform.isi686 then
-            bb.packages.ghc967
-          else
-            bb.packages.ghc984Binary;
+        bootPkgs = bootstrapViaOrFallback (
+          if stdenv.buildPlatform.isi686 then bb.packages.ghc967 else bb.packages.ghc984Binary
+        );
         inherit (buildPackages.python3Packages) sphinx;
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;
       };
       ghc9103 = callPackage ../development/compilers/ghc/9.10.3.nix {
-        bootPkgs =
-          if
-            stdenv.buildPlatform.isPower64
-            && stdenv.buildPlatform.isBigEndian
-            && pkgs.stdenv.hostPlatform.isAbiElfv1
-          then
-            # No bindist, "borrowing" the GHC from Debian
-            bb.packages.ghc966DebianBinary
-          else if stdenv.buildPlatform.isi686 then
-            bb.packages.ghc967
-          else
-            bb.packages.ghc984Binary;
+        bootPkgs = bootstrapViaOrFallback (
+          if stdenv.buildPlatform.isi686 then bb.packages.ghc967 else bb.packages.ghc984Binary
+        );
         inherit (buildPackages.python3Packages) sphinx;
         inherit (buildPackages.darwin) xattr autoSignDarwinBinariesHook;
         inherit buildTargetLlvmPackages llvmPackages;


### PR DESCRIPTION
Build on https://github.com/NixOS/nixpkgs/pull/439258 to bootstrap GHC on powerpc64le in the same way: using the Debian package.

Move the conditionals in top-level/haskell-packages.nix to probe for support from the 9.6.6-debian-binary.nix package so it's easier to do the same thing for other architectures, too, should anyone else need it.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] powerpc64le-linux
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
