### PR TITLE
nixos/stalwart: add module-specific `stateVersion`, clean up and switch logging from stdout to journal

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -162,6 +162,10 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
 - `services.stalwart-mail` has been renamed to `services.stalwart` to align with upstream re-brand as an e-mail and collaboration server. Other notable breaking changes to module:
 
+  - Addition of module-specific `stateVersion` option, which on existing installations of Stalwart must be set to the same as `system.stateVersion`.
+
+    This enables manually and carefully migrating Stalwart to a new `stateVersion` or newly enabling the Stalwart module with a newer `stateVersion` than `system.stateVersion`.
+
   - `systemd.services.stalwart` owned by `stalwart:stalwart`. The `user` and `group` are configurable via `services.stalwart.user` and `services.stalwart.group`, respectively. By default, if `stateVersion` is older than `26.05`, will fallback to legacy value of `stalwart-mail` for both `user` and `group`.
   - Default value for `services.stalwart.dataDir` has changed to `/var/lib/stalwart`. If `stateVersion` is older than `26.05`, will fallback to legacy value of `/var/lib/stalwart-mail`.
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -168,6 +168,7 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
   - `systemd.services.stalwart` owned by `stalwart:stalwart`. The `user` and `group` are configurable via `services.stalwart.user` and `services.stalwart.group`, respectively. By default, if `stateVersion` is older than `26.05`, will fallback to legacy value of `stalwart-mail` for both `user` and `group`.
   - Default value for `services.stalwart.dataDir` has changed to `/var/lib/stalwart`. If `stateVersion` is older than `26.05`, will fallback to legacy value of `/var/lib/stalwart-mail`.
+  - Default tracer name and type have changed to `journal`. If `stateVersion` is older than `26.05`, will fallback to legacy value of `stdout`.
 
 - `services.eintopf` has been renamed to `services.lauti` to align with upstream re-brand as a community online calendar.
 

--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -11,6 +11,7 @@ let
   useLegacyStorage = lib.versionOlder cfg.stateVersion "24.11";
   pre2605 = lib.versionOlder cfg.stateVersion "26.05";
   stalwartIdentifier = if pre2605 then "stalwart-mail" else "stalwart";
+  stalwartIdentifierText = ''if lib.versionOlder config.services.stalwart.stateVersion "26.05" then "stalwart-mail" else "stalwart"'';
 
   parsePorts =
     listeners:
@@ -65,6 +66,7 @@ in
     dataDir = lib.mkOption {
       type = lib.types.path;
       default = "/var/lib/${stalwartIdentifier}";
+      defaultText = lib.literalExpression "/var/lib/\${${stalwartIdentifierText}}";
       description = ''
         Data directory for stalwart
       '';
@@ -73,6 +75,7 @@ in
     user = lib.mkOption {
       type = lib.types.str;
       default = stalwartIdentifier;
+      defaultText = lib.literalExpression stalwartIdentifierText;
       description = ''
         User ownership of service
       '';
@@ -81,6 +84,7 @@ in
     group = lib.mkOption {
       type = lib.types.str;
       default = stalwartIdentifier;
+      defaultText = lib.literalExpression stalwartIdentifierText;
       description = ''
         Group ownership of service
       '';

--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -8,9 +8,9 @@ let
   cfg = config.services.stalwart;
   configFormat = pkgs.formats.toml { };
   configFile = configFormat.generate "stalwart.toml" cfg.settings;
-  useLegacyStorage = lib.versionOlder config.system.stateVersion "24.11";
-  useLegacyDefault = lib.versionOlder config.system.stateVersion "26.05";
-  default = if useLegacyDefault then "stalwart-mail" else "stalwart";
+  useLegacyStorage = lib.versionOlder cfg.stateVersion "24.11";
+  useLegacyIdentifier = lib.versionOlder cfg.stateVersion "26.05";
+  stalwartIdentifier = if useLegacyIdentifier then "stalwart-mail" else "stalwart";
 
   parsePorts =
     listeners:
@@ -30,6 +30,15 @@ in
   ];
   options.services.stalwart = {
     enable = lib.mkEnableOption "the all-in-one collaboration and mail server, Stalwart";
+
+    stateVersion = lib.mkOption {
+      type = lib.types.str;
+      description = ''
+        The version of this module (=version of NixOS) when this module was first enabled on this particular machine, used to maintain compatibility with application data created on older versions of this module.
+
+        See {option}`system.stateVersion` for details on the NixOS-global equivalent to this option.
+      '';
+    };
 
     package = lib.mkPackageOption pkgs "stalwart" { };
 
@@ -55,7 +64,7 @@ in
 
     dataDir = lib.mkOption {
       type = lib.types.path;
-      default = if useLegacyDefault then "/var/lib/stalwart-mail" else "/var/lib/stalwart";
+      default = "/var/lib/${stalwartIdentifier}";
       description = ''
         Data directory for stalwart
       '';
@@ -63,7 +72,7 @@ in
 
     user = lib.mkOption {
       type = lib.types.str;
-      inherit default;
+      default = stalwartIdentifier;
       description = ''
         User ownership of service
       '';
@@ -71,7 +80,7 @@ in
 
     group = lib.mkOption {
       type = lib.types.str;
-      inherit default;
+      default = stalwartIdentifier;
       description = ''
         Group ownership of service
       '';
@@ -155,7 +164,7 @@ in
           );
         in
         {
-          path = "/var/cache/${default}";
+          path = "/var/cache/${stalwartIdentifier}";
           resource = lib.mkIf hasHttpListener (lib.mkDefault "file://${cfg.package.webadmin}/webadmin.zip");
         };
     };
@@ -165,10 +174,10 @@ in
     # service is restarted on a potentially large number of files.
     # That would cause unnecessary and unwanted delays.
     users = {
-      groups = lib.mkIf (cfg.group == default) {
+      groups = lib.mkIf (cfg.group == stalwartIdentifier) {
         ${cfg.group} = { };
       };
-      users = lib.mkIf (cfg.user == default) {
+      users = lib.mkIf (cfg.user == stalwartIdentifier) {
         ${cfg.user} = {
           isSystemUser = true;
           inherit (cfg) group;
@@ -197,7 +206,7 @@ in
           KillSignal = "SIGINT";
           Restart = "on-failure";
           RestartSec = 5;
-          SyslogIdentifier = default;
+          SyslogIdentifier = stalwartIdentifier;
 
           ExecStartPre =
             if useLegacyStorage then
@@ -217,8 +226,8 @@ in
           ReadWritePaths = [
             cfg.dataDir
           ];
-          CacheDirectory = default;
-          StateDirectory = default;
+          CacheDirectory = stalwartIdentifier;
+          StateDirectory = stalwartIdentifier;
 
           # Upstream uses "stalwart" as the username since 0.12.0
           User = cfg.user;

--- a/nixos/modules/services/mail/stalwart.nix
+++ b/nixos/modules/services/mail/stalwart.nix
@@ -9,8 +9,8 @@ let
   configFormat = pkgs.formats.toml { };
   configFile = configFormat.generate "stalwart.toml" cfg.settings;
   useLegacyStorage = lib.versionOlder cfg.stateVersion "24.11";
-  useLegacyIdentifier = lib.versionOlder cfg.stateVersion "26.05";
-  stalwartIdentifier = if useLegacyIdentifier then "stalwart-mail" else "stalwart";
+  pre2605 = lib.versionOlder cfg.stateVersion "26.05";
+  stalwartIdentifier = if pre2605 then "stalwart-mail" else "stalwart";
 
   parsePorts =
     listeners:
@@ -123,12 +123,24 @@ in
 
     # Default config: all local
     services.stalwart.settings = {
-      tracer.stdout = {
-        type = lib.mkDefault "stdout";
-        level = lib.mkDefault "info";
-        ansi = lib.mkDefault false; # no colour markers to journald
-        enable = lib.mkDefault true;
-      };
+      tracer =
+        if pre2605 then
+          {
+            stdout = {
+              type = lib.mkDefault "stdout";
+              level = lib.mkDefault "info";
+              ansi = lib.mkDefault false; # no colour markers to journald
+              enable = lib.mkDefault true;
+            };
+          }
+        else
+          {
+            journal = {
+              type = lib.mkDefault "journal";
+              level = lib.mkDefault "info";
+              enable = lib.mkDefault true;
+            };
+          };
       store =
         if useLegacyStorage then
           {

--- a/nixos/tests/stalwart/stalwart-config.nix
+++ b/nixos/tests/stalwart/stalwart-config.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ lib, ... }:
 
 let
   certs = import ../common/acme/server/snakeoil-certs.nix;
@@ -9,6 +9,9 @@ in
 
   services.stalwart = {
     enable = true;
+
+    stateVersion = lib.trivial.release; # Only for the test; please don't do in production
+
     settings = {
       server.hostname = domain;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Sorry for a PR with multiple changes... Title basically says it.

> journald's centralized logging has many advantages:
> - External centralized logging can simply source from journald
> - journald's auto-vacuum options (e.g. SystemMaxUse) can make sure logs don't take up too much space
> - Logs are in a single timeline, which is useful for analysis

This is also the first module-specific `stateVersion` in Nixpkgs. [It has been planned before](https://github.com/NixOS/rfcs/pull/155#pullrequestreview-1522580985) (ping @infinisil @KFearsoff). Basically it makes migrating easier/possible and also makes possible using newer state versions with an old `system.stateVersion`. The `stateVersion` doesn't have defaults (not just set to follow `config.system.stateVersion` by the module) so the user explicitly sets it to the version they first installed Stalwart on or the current NixOS version for new installs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
