### PR TITLE
vulkanscenegraph: 1.1.12 → 1.1.13

### DIFF
--- a/pkgs/by-name/vu/vulkanscenegraph/package.nix
+++ b/pkgs/by-name/vu/vulkanscenegraph/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   glslang,
@@ -13,22 +12,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vulkanscenegraph";
-  version = "1.1.12";
+  version = "1.1.13";
 
   src = fetchFromGitHub {
     owner = "vsg-dev";
     repo = "VulkanSceneGraph";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DdTfn8URLJkF5Nhkl8ZCq+brKK/T+9FipaeTON4Dsfw=";
+    hash = "sha256-6Jxk94GPUaPxcv4dHTQKnE7n8b/2neG2Mrv94vc9ckU=";
   };
-
-  patches = [
-    # make it compatible with glslang 16.x
-    (fetchpatch {
-      url = "https://github.com/vsg-dev/VulkanSceneGraph/commit/313865d420bba7bb3327460c367c7526f566a74e.patch";
-      hash = "sha256-hytv79AE70S/yBiI+n9RHGbHmYZW5388BiFh9l1auzU=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
https://github.com/vsg-dev/VulkanSceneGraph/releases/tag/v1.1.13

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
