### PR TITLE
[25.11] winbox4: 4.0beta41 -> 4.0rc3

### DIFF
--- a/pkgs/by-name/wi/winbox4/build-from-zip.nix
+++ b/pkgs/by-name/wi/winbox4/build-from-zip.nix
@@ -17,6 +17,7 @@
   writeShellApplication,
   xorg,
   zlib,
+  dbus,
   metaCommon ? { },
 }:
 
@@ -50,6 +51,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     xorg.xcbutilrenderutil
     xorg.xcbutilwm
     zlib
+    dbus
   ];
 
   installPhase = ''

--- a/pkgs/by-name/wi/winbox4/package.nix
+++ b/pkgs/by-name/wi/winbox4/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "winbox";
-  version = "4.0beta41";
+  version = "4.0beta42";
 
   metaCommon = {
     description = "Graphical configuration utility for RouterOS-based devices";
@@ -23,13 +23,13 @@ let
   x86_64-zip = callPackage ./build-from-zip.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-oKDLNHQLMdZb18pPTpoSc5gwljHkSMmyITZ0ATBdR08=";
+    hash = "sha256-c+aewjTl+W/ahTdp9CIYT+MD4Nf+L58QONFCRifaOHI=";
   };
 
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-9jG+xlmRy011DA4BwOGRMpzU0qy0qbjiN3nR3xMJpbo=";
+    hash = "sha256-3/sdKhMw2vx3IQE5IucllXzJyBs1snxXjAXNqumPQk0=";
   };
 in
 (if stdenvNoCC.hostPlatform.isDarwin then x86_64-dmg else x86_64-zip).overrideAttrs (oldAttrs: {

--- a/pkgs/by-name/wi/winbox4/package.nix
+++ b/pkgs/by-name/wi/winbox4/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "winbox";
-  version = "4.0beta44";
+  version = "4.0rc3";
 
   metaCommon = {
     description = "Graphical configuration utility for RouterOS-based devices";
@@ -23,13 +23,13 @@ let
   x86_64-zip = callPackage ./build-from-zip.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-LPq7KPOj59NUhoQCxpAVW8qbjXJGxRw8fRJT7/qDtZM=";
+    hash = "sha256-BbdKrGMfHhm9DHCmQwfZhsjpJXamNYJ4Mh4z/fwDFlM=";
   };
 
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-96lb8a70dmqieKn5Nr61sZg/aVDLz0sY64sfN83rU+0=";
+    hash = "sha256-KBKl4KAOeXlZIW5NtFV2k/yf6Evbwf02viX4Z73Jub8=";
   };
 in
 (if stdenvNoCC.hostPlatform.isDarwin then x86_64-dmg else x86_64-zip).overrideAttrs (oldAttrs: {

--- a/pkgs/by-name/wi/winbox4/package.nix
+++ b/pkgs/by-name/wi/winbox4/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "winbox";
-  version = "4.0beta42";
+  version = "4.0beta44";
 
   metaCommon = {
     description = "Graphical configuration utility for RouterOS-based devices";
@@ -23,13 +23,13 @@ let
   x86_64-zip = callPackage ./build-from-zip.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-c+aewjTl+W/ahTdp9CIYT+MD4Nf+L58QONFCRifaOHI=";
+    hash = "sha256-LPq7KPOj59NUhoQCxpAVW8qbjXJGxRw8fRJT7/qDtZM=";
   };
 
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
 
-    hash = "sha256-3/sdKhMw2vx3IQE5IucllXzJyBs1snxXjAXNqumPQk0=";
+    hash = "sha256-96lb8a70dmqieKn5Nr61sZg/aVDLz0sY64sfN83rU+0=";
   };
 in
 (if stdenvNoCC.hostPlatform.isDarwin then x86_64-dmg else x86_64-zip).overrideAttrs (oldAttrs: {


### PR DESCRIPTION
Backports of:
- https://github.com/NixOS/nixpkgs/pull/467444
- https://github.com/NixOS/nixpkgs/pull/473835
- https://github.com/NixOS/nixpkgs/pull/487628
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
