### PR TITLE
envoluntary: init at 0.1.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3577,6 +3577,12 @@
     githubId = 77934086;
     keys = [ { fingerprint = "4CA3 48F6 8FE1 1777 8EDA 3860 B9A2 C1B0 25EC 2C55"; } ];
   };
+  blemouzy = {
+    email = "blemouzy.ml@gmail.com";
+    github = "blemouzy";
+    githubId = 124877155;
+    name = "Benjamin Lemouzy";
+  };
   blenderfreaky = {
     name = "blenderfreaky";
     email = "nix@blenderfreaky.de";

--- a/pkgs/by-name/en/envoluntary/package.nix
+++ b/pkgs/by-name/en/envoluntary/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  bash,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "envoluntary";
+  version = "0.1.4";
+
+  src = fetchFromGitHub {
+    owner = "dfrankland";
+    repo = "envoluntary";
+    tag = "envoluntary-v${version}";
+    hash = "sha256-ccMXrR7PnV3aCehJtsJyXx5ZiCz/KrHkKDLQSV3sMYU=";
+  };
+
+  cargoHash = "sha256-AXWOU8UduQZxZWcTaOyxilbdz4BMnZlrJEFTUakFa4w=";
+
+  preCheck = ''
+    export NIX_BIN_BASH="${bash}/bin/bash"
+  '';
+
+  meta = {
+    description = "Automatic Nix development environments for your shell";
+    longDescription = ''
+      Envoluntary seamlessly loads and unloads Nix development environments based on directory
+      patterns, eliminating the need for per-project .envrc / flake.nix files while giving you
+      centralized control over your development tooling.
+    '';
+    homepage = "https://github.com/dfrankland/envoluntary";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ blemouzy ];
+    mainProgram = "envoluntary";
+  };
+}


### PR DESCRIPTION
Add envoluntary, a tool to load and unload Nix development environments based on directory patterns.
https://github.com/dfrankland/envoluntary

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
