### PR TITLE
glances: 4.3.3 -> 4.5.0.5

### DIFF
--- a/pkgs/applications/system/glances/default.nix
+++ b/pkgs/applications/system/glances/default.nix
@@ -7,18 +7,19 @@
   defusedxml,
   packaging,
   psutil,
+  pyinstrument,
   setuptools,
   nixosTests,
   pytestCheckHook,
   which,
   podman,
   selenium,
+  python-jose,
   # Optional dependencies:
   fastapi,
   jinja2,
   pysnmp,
   hddtemp,
-  netifaces2, # IP module
   uvicorn,
   requests,
   prometheus-client,
@@ -27,7 +28,7 @@
 
 buildPythonApplication rec {
   pname = "glances";
-  version = "4.3.3";
+  version = "4.5.0.5";
   pyproject = true;
 
   disabled = isPyPy;
@@ -36,7 +37,7 @@ buildPythonApplication rec {
     owner = "nicolargo";
     repo = "glances";
     tag = "v${version}";
-    hash = "sha256-RmGbd8Aa2jJ2DMrBUUoa8mPBa6bGnQd0s0y3p/zP0ng=";
+    hash = "sha256-IHgMZw+X7C/72w4vXaP37GgnhLVg7EF5/sd9QlmE0NM=";
   };
 
   build-system = [ setuptools ];
@@ -56,14 +57,15 @@ buildPythonApplication rec {
 
   dependencies = [
     defusedxml
-    netifaces2
     packaging
     psutil
+    pyinstrument
     pysnmp
     fastapi
     uvicorn
     requests
     jinja2
+    python-jose
     which
     prometheus-client
     shtab
@@ -84,6 +86,20 @@ buildPythonApplication rec {
   disabledTestPaths = [
     # Message: Unable to obtain driver for chrome
     "tests/test_webui.py"
+  ];
+
+  disabledTests = [
+    # Upstream bug: diskio plugin doesn't check if args is None before accessing attributes
+    # Bug report: https://github.com/nicolargo/glances/issues/3429
+    "test_msg_curse_returns_list"
+    "test_msg_curse_with_max_width"
+    # Network test expects visible network interfaces
+    # Default config hides loopback and interfaces without IP (glances.conf)
+    # In Nix sandbox environment, this results in zero visible interfaces
+    "test_glances_api_plugin_network"
+    # Test always returns 3 plugin updates, but needs >=5 to not fail
+    # May be an upstream bug, see: https://github.com/nicolargo/glances/issues/3430
+    "test_perf_update"
   ];
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
supersedes https://github.com/NixOS/nixpkgs/pull/470558. 
Some tests are failing because of the nix sandbox (I believe?) and two because of a bug in the test itself, so they are ignored.

otherwise, the release notes are here: https://github.com/nicolargo/glances/blob/develop/NEWS.rst

However, to note:
-  ~~currently, there is a bug preventing glances from starting, when not disabling the new npu plugin for some AMD CPU users: https://github.com/nicolargo/glances/issues/3425~~
- the nixpkgs dependency on pysnmp is of version 7.1.x, while glances specifically pins version <=6.2.0 (6.1.4 being the newest): https://github.com/nicolargo/glances/issues/2874
	- this currently breaks the snmp features of glances, but I did not feel comfortable overriding the dependency to pin it to 6.1.4
	- happy to hear feedback on how this should/could be done
- I do not know why in the above linked PR @qubitnano added webdriver-manager, since it is only listed as a dev dependency, but maybe I overlooked something. Also happy to hear feedback about this.
- we do not have Docker as a dependency. Does that mean, that glances won't be able to provide information about docker containers? Maybe this should be changed? idk

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
