### PR TITLE
fetchsvn: add tag parameter support

### DIFF
--- a/pkgs/build-support/fetchsvn/default.nix
+++ b/pkgs/build-support/fetchsvn/default.nix
@@ -10,8 +10,13 @@
 }:
 
 let
-  repoToName =
-    url: rev:
+  # Derive a base derivation name from a SVN URL. Examples:
+  #   svn://h/repo/trunk          -> repo
+  #   svn://h/repo/branches/foo   -> repo-foo
+  #   svn://h/repo/tags/v1.0      -> repo-v1.0
+  #   svn://h/repo                -> repo
+  repoBaseName =
+    url:
     let
       inherit (lib)
         removeSuffix
@@ -22,28 +27,28 @@ let
         elemAt
         ;
       base = removeSuffix "/" (last (splitString ":" url));
-      path = reverseList (splitString "/" base);
-      repoName =
-        # ../repo/trunk -> repo
-        if head path == "trunk" then
-          elemAt path 1
-        # ../repo/branches/branch -> repo-branch
-        else if elemAt path 1 == "branches" then
-          "${elemAt path 2}-${head path}"
-        # ../repo/tags/tag -> repo-tag
-        else if elemAt path 1 == "tags" then
-          "${elemAt path 2}-${head path}"
-        # ../repo (no trunk) -> repo
-        else
-          head path;
+      pathParts = reverseList (splitString "/" base);
     in
-    "${repoName}-r${toString rev}";
+    if head pathParts == "trunk" then
+      elemAt pathParts 1
+    else if elemAt pathParts 1 == "branches" then
+      "${elemAt pathParts 2}-${head pathParts}"
+    else if elemAt pathParts 1 == "tags" then
+      "${elemAt pathParts 2}-${head pathParts}"
+    else
+      head pathParts;
 in
 
 {
   url,
+  # Subdirectory path within the repository (e.g., "trunk", "branches/foo").
+  # Ignored if `tag` is set.
+  path ? "",
+  # Tag name to fetch. Sets path to "tags/${tag}".
+  # Mutually exclusive with `path`.
+  tag ? null,
   rev ? "HEAD",
-  name ? repoToName url rev,
+  name ? null,
   sha256 ? "",
   hash ? "",
   ignoreExternals ? false,
@@ -51,13 +56,38 @@ in
   preferLocalBuild ? true,
 }:
 
+assert tag == null || path == "" || throw "fetchsvn: `tag` and `path` are mutually exclusive";
+
 assert sshSupport -> openssh != null;
+
+let
+  # The final URL: appends `/tags/${tag}` if `tag` is set, otherwise
+  # `/${path}` when `path` is non-empty, otherwise the url unchanged.
+  fullURL =
+    let
+      baseUrl = lib.removeSuffix "/" url;
+    in
+    if tag != null then
+      "${baseUrl}/tags/${tag}"
+    else if path != "" then
+      "${baseUrl}/${path}"
+    else
+      url;
+in
 
 if hash != "" && sha256 != "" then
   throw "Only one of sha256 or hash can be set"
 else
   stdenvNoCC.mkDerivation {
-    inherit name;
+    # When `tag` pins the snapshot, omit the `-r${rev}` suffix — the tag
+    # already uniquely identifies the build, so `repo-v1.0-rHEAD` would be noise.
+    name =
+      if name != null then
+        name
+      else if tag != null then
+        repoBaseName fullURL
+      else
+        "${repoBaseName fullURL}-r${toString rev}";
     builder = ./builder.sh;
     nativeBuildInputs = [
       cacert
@@ -78,8 +108,9 @@ else
       else
         lib.fakeSha256;
 
+    url = fullURL;
+
     inherit
-      url
       rev
       ignoreExternals
       ignoreKeywords


### PR DESCRIPTION
## Description

Adds cleaner API for specifying SVN repository paths with two new parameters:

- `path`: subdirectory within the repo (e.g., `"trunk"`, `"branches/foo"`)
- `tag`: shorthand that expands to `"tags/${tag}"`

These are mutually exclusive.

When `tag` is set, the derivation `name` defaults to `${repo}-${tag}` (no `-r${rev}` suffix), since the tag already uniquely identifies the build.

## Usage

```nix
# Fetch from trunk (new style - cleaner base URL)
fetchsvn {
  url = "svn://svn.code.sf.net/p/msieve/code";
  path = "trunk";
  rev = "1056";
  hash = "...";
}

# Fetch a tag — derivation name is "code-1.53"
fetchsvn {
  url = "svn://svn.code.sf.net/p/msieve/code";
  tag = "1.53";
  hash = "...";
}

# Fetch a branch
fetchsvn {
  url = "svn://svn.code.sf.net/p/example/code";
  path = "branches/feature";
  rev = "456";
  hash = "...";
}
```

## Backwards Compatibility

Existing URLs with paths still work:

```nix
# This still works (no change needed)
fetchsvn {
  url = "svn://svn.code.sf.net/p/msieve/code/trunk";
  rev = "1056";
  hash = "...";
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test