### PR TITLE
wasilibc: fix override of fetchgit

### DIFF
--- a/pkgs/by-name/wa/wasilibc/package.nix
+++ b/pkgs/by-name/wa/wasilibc/package.nix
@@ -1,6 +1,6 @@
 {
   stdenvNoLibc,
-  fetchFromGitHub,
+  buildPackages,
   lib,
   firefox-unwrapped,
   firefox-esr-unwrapped,
@@ -11,7 +11,10 @@ stdenvNoLibc.mkDerivation (finalAttrs: {
   pname = "wasilibc";
   version = "27";
 
-  src = fetchFromGitHub {
+  # following evaluation leads to an infinte recursion, if fetchFromGutHub
+  # is used instead of buildPackages.fetchFromGitHub:
+  # nix eval --impure --expr '(import ./. { overlays = [ (_: prev: { fetchgit = prev.fetchgit.override { cacert = prev.hello; }; }) ]; }).pkgs.firefox'
+  src = buildPackages.fetchFromGitHub {
     owner = "WebAssembly";
     repo = "wasi-libc";
     tag = "wasi-sdk-${finalAttrs.version}";


### PR DESCRIPTION
Since commit https://github.com/NixOS/nixpkgs/commit/d8603c74deac7e0a7a9b4d202dd30ae91a136810
following Nix evaluation fails:

```
nix eval --impure --expr '(import ./. { overlays = [ (_: prev: { fetchgit = prev.fetchgit.override { cacert = prev.hello; }; }) ]; }).pkgs.firefox'
«error: infinite recursion encountered»
``` 

This PR reverts the change regarding fetchFromGitHub.

cc: @wucke13 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
