### PR TITLE
element-{web-unwrapped,desktop}: 1.12.9 -> 1.12.10

### DIFF
--- a/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
+++ b/pkgs/by-name/el/element-desktop/element-desktop-pin.nix
@@ -1,7 +1,7 @@
 {
-  "version" = "1.12.9";
+  "version" = "1.12.10";
   "hashes" = {
-    "desktopSrcHash" = "sha256-VBlKFknwafXar05kEpwv0+9EwUPe9WQRMn8S8uhX2U8=";
-    "desktopYarnHash" = "sha256-tBO8rtz5/8OxmGsPmMEATqNVuBEcNp6L6lJCaJdPlNY=";
+    "desktopSrcHash" = "sha256-2LQBT3+2JTR3XHO3DynOp8cw2m2SB/mGH01e3SFD/IM=";
+    "desktopYarnHash" = "sha256-QIzuVKmUS4tqXAzhpfLZOp51kLbfC1M2nrff8e+sdg4=";
   };
 }

--- a/pkgs/by-name/el/element-desktop/package.nix
+++ b/pkgs/by-name/el/element-desktop/package.nix
@@ -5,7 +5,7 @@
   makeWrapper,
   makeDesktopItem,
   nodejs,
-  electron_39,
+  electron_40,
   element-web,
   sqlcipher,
   callPackage,
@@ -24,7 +24,7 @@ let
   pinData = import ./element-desktop-pin.nix;
   inherit (pinData.hashes) desktopSrcHash desktopYarnHash;
   executableName = "element-desktop";
-  electron = electron_39;
+  electron = electron_40;
   seshat = callPackage ./seshat { };
 in
 stdenv.mkDerivation (

--- a/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
+++ b/pkgs/by-name/el/element-web-unwrapped/element-web-pin.nix
@@ -1,8 +1,8 @@
 {
-  "version" = "1.12.9";
+  "version" = "1.12.10";
   "hashes" = {
-    "webSrcHash" = "sha256-txG91VN4b0ZtUnQp4IfN47YAn1WBI9UUxemReachcDo=";
-    "webYarnHash" = "sha256-Y2AvBlS7qdVUXalKet3Ud4a6MA4MKHM4ffRhB7Uq8Co=";
-    "webSharedComponentsYarnHash" = "sha256-yeFFVVMWyPN3BqOY46KAxPv7VRVrsFvPan5arTNd/GM";
+    "webSrcHash" = "sha256-qc17AK2HvTJi0r03VTH0D2QitdYcGNRObji9cm6XsFU=";
+    "webYarnHash" = "sha256-qdmdwjVXA+ZnNG3S9Pnm3JOrJXYXVdH+w7mccNjRmVM=";
+    "webSharedComponentsYarnHash" = "sha256-0sOF3w6BnY1WenDP+zqZAo1W4C91glMQSMQ22iYajTw=";
   };
 }


### PR DESCRIPTION
Release notes: https://github.com/element-hq/element-web/releases/tag/v1.12.10
Full changelog: https://github.com/element-hq/element-web/compare/v1.12.9...v1.12.10

Release notes: https://github.com/element-hq/element-desktop/releases/tag/v1.12.10
Full changelog: https://github.com/element-hq/element-desktop/compare/v1.12.9...v1.12.10

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
