### PR TITLE
lib.systems: fix path to wine executable

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -384,7 +384,7 @@ let
             if pkgs.stdenv.hostPlatform.canExecute final then
               lib.getExe (pkgs.writeShellScriptBin "exec" ''exec "$@"'')
             else if final.isWindows then
-              "${wine}/bin/wine${optionalString (final.parsed.cpu.bits == 64) "64"}"
+              "${wine}/bin/wine"
             else if final.isLinux && pkgs.stdenv.hostPlatform.isLinux && final.qemuArch != null then
               "${pkgs.qemu-user}/bin/qemu-${final.qemuArch}"
             else if final.isWasi then


### PR DESCRIPTION
@hideyosh1 I think this should get the same treatment as https://github.com/NixOS/nixpkgs/commit/2f293e1fe3ec3dacd14da3d2f95161da4ddcc7b4



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
