### PR TITLE
nixos-rebuild-ng: add --diff argument

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -308,6 +308,14 @@ It must be one of the following:
 	option, it is possible to build non-flake NixOS configurations even if
 	the current NixOS systems uses flakes.
 
+*--diff*
+	show the diff between the system closure in /run/current-system
+	and the newly built system closure.
+	(avaliable for actions: build, boot, test, switch)
+
+	This is similar to running:
+	"nix store diff-closures /run/current-system result" after build
+
 In addition, *nixos-rebuild* accepts following options from nix commands that
 the tool calls:
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -266,10 +266,16 @@ def parse_args(
         parser_warn("--no-build-nix is deprecated, we do not build nix anymore")
 
     if args.diff and args.action not in (
+        # case for calling build_and_activate_system
+        # except excluding DRY_BUILD and DRY_ACTIVATE,
+        # in which --diff is uniquely a no-op
         Action.SWITCH.value,
         Action.BOOT.value,
+        Action.TEST.value,
         Action.BUILD.value,
-        Action.TEST.value
+        Action.BUILD_IMAGE.value,
+        Action.BUILD_VM.value,
+        Action.BUILD_VM_WITH_BOOTLOADER.value,
     ):
         parser_warn(f"--diff is a no-op with '{args.action}'")
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -197,6 +197,12 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
         help="Selects an image variant to build from the "
         "config.system.build.images attribute of the given configuration",
     )
+    main_parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="prints out the diff between the current system "
+        "and the newly built one using nix store diff-closures"
+    )
     main_parser.add_argument("action", choices=Action.values(), nargs="?")
 
     return main_parser, sub_parsers
@@ -258,6 +264,14 @@ def parse_args(
 
     if args.no_build_nix:
         parser_warn("--no-build-nix is deprecated, we do not build nix anymore")
+
+    if args.diff and args.action not in (
+        Action.SWITCH.value,
+        Action.BOOT.value,
+        Action.BUILD.value,
+        Action.TEST.value
+    ):
+        parser_warn(f"--diff is a no-op with '{args.action}'")
 
     if args.action == Action.EDIT.value and (args.file or args.attr):
         parser.error("--file and --attr are not supported with 'edit'")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -540,7 +540,7 @@ def list_generations(profile: Profile) -> list[GenerationJson]:
 
 def diff_closures(current_config: Path, new_config: Path, target_host: Remote | None = None):
     print(
-        f"<<< {current_config}"
+        f"<<< {current_config}\n"
         f">>> {new_config}",
         file=sys.stderr
     )
@@ -554,6 +554,7 @@ def diff_closures(current_config: Path, new_config: Path, target_host: Remote | 
             new_config,
         ],
         remote=target_host,
+        stdout=sys.stderr
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -1,3 +1,4 @@
+import sys
 import json
 import logging
 import os
@@ -538,6 +539,11 @@ def list_generations(profile: Profile) -> list[GenerationJson]:
         )
 
 def diff_closures(current_config: Path, new_config: Path, target_host: Remote | None = None):
+    print(
+        f"<<< {current_config}"
+        f">>> {new_config}",
+        file=sys.stderr
+    )
     run_wrapper(
         [
             "nix",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -537,6 +537,18 @@ def list_generations(profile: Profile) -> list[GenerationJson]:
             reverse=True,
         )
 
+def diff_closures(path_to_config: Path):
+    run_wrapper(
+        [
+            "nix",
+            *FLAKE_FLAGS,
+            "store",
+            "diff-closures",
+            "/run/current-system",
+            path_to_config
+        ]
+    )
+
 
 def repl(build_attr: BuildAttr, nix_flags: Args | None = None) -> None:
     run_args = ["nix", "repl", "--file", build_attr.path]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -537,16 +537,17 @@ def list_generations(profile: Profile) -> list[GenerationJson]:
             reverse=True,
         )
 
-def diff_closures(path_to_config: Path):
+def diff_closures(current_config: Path, new_config: Path, target_host: Remote | None = None):
     run_wrapper(
         [
             "nix",
             *FLAKE_FLAGS,
             "store",
             "diff-closures",
-            "/run/current-system",
-            path_to_config
-        ]
+            current_config,
+            new_config,
+        ],
+        remote=target_host,
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -321,12 +321,12 @@ def build_and_activate_system(
             grouped_nix_args=grouped_nix_args,
         )
 
-    current_config = Path("/run/current-system")
+    current_config = Path("/run/current-system").readlink()
     if args.diff:
         if current_config.exists():
             nix.diff_closures(current_config=current_config, new_config=path_to_config, target_host=target_host)
         else:
-            logger.warn(f"missing '{str(current_config)}', skipping configuration diff...")
+            logger.warning(f"missing '{str(current_config)}', skipping configuration diff...")
 
     _activate_system(
         path_to_config=path_to_config,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -321,6 +321,14 @@ def build_and_activate_system(
             grouped_nix_args=grouped_nix_args,
         )
 
+    if args.diff and args.action in (
+        Action.SWITCH.value,
+        Action.BOOT.value,
+        Action.BUILD.value,
+        Action.TEST.value
+    ):
+        nix.diff_closures(path_to_config)
+
     _activate_system(
         path_to_config=path_to_config,
         action=action,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -321,13 +321,12 @@ def build_and_activate_system(
             grouped_nix_args=grouped_nix_args,
         )
 
-    if args.diff and args.action in (
-        Action.SWITCH.value,
-        Action.BOOT.value,
-        Action.BUILD.value,
-        Action.TEST.value
-    ):
-        nix.diff_closures(path_to_config)
+    current_config = Path("/run/current-system")
+    if args.diff:
+        if current_config.exists():
+            nix.diff_closures(current_config=current_config, new_config=path_to_config, target_host=target_host)
+        else:
+            logger.warn(f"missing '{str(current_config)}', skipping configuration diff...")
 
     _activate_system(
         path_to_config=path_to_config,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -321,10 +321,10 @@ def build_and_activate_system(
             grouped_nix_args=grouped_nix_args,
         )
 
-    current_config = Path("/run/current-system").readlink()
+    current_config = Path("/run/current-system")
     if args.diff:
         if current_config.exists():
-            nix.diff_closures(current_config=current_config, new_config=path_to_config, target_host=target_host)
+            nix.diff_closures(current_config=current_config.readlink(), new_config=path_to_config, target_host=target_host)
         else:
             logger.warning(f"missing '{str(current_config)}', skipping configuration diff...")
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -1,3 +1,4 @@
+import sys
 import textwrap
 import uuid
 from pathlib import Path
@@ -568,7 +569,8 @@ def test_diff_closures(mock_run: Mock) -> None:
             Path("/run/current-system"),
             Path("/nix/var/nix/profiles/system"),
         ],
-        remote=None
+        remote=None,
+        stdout=sys.stderr
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -551,6 +551,28 @@ def test_list_generations(mock_get_generations: Mock, tmp_path: Path) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
+def test_diff_closures(mock_run: Mock) -> None:
+
+    assert n.diff_closures(
+        Path("/run/current-system"),
+        Path("/nix/var/nix/profiles/system"),
+        None
+    ) == None
+    mock_run.assert_called_with(
+        [
+            "nix",
+            "--extra-experimental-features",
+            "nix-command flakes",
+            "store",
+            "diff-closures",
+            Path("/run/current-system"),
+            Path("/nix/var/nix/profiles/system"),
+        ],
+        remote=None
+    )
+
+
+@patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_repl(mock_run: Mock) -> None:
     n.repl(m.BuildAttr("<nixpkgs/nixos>", None), {"nix_flag": True})
     mock_run.assert_called_with(


### PR DESCRIPTION
It's a nice way to see what packages have been updated, which is something nixos generally lacks.
It's not perfect, since unlike a traditional package manager this way of showing updates cannot happen before all the downloads/builds happen, so suggestions are welcome.

On an unrelated note, I was impressed by the code quality in `nixos-rebuild-ng`. Doing this was very easy compared to the hours I spent trying to make a satisfactory bash wrapper to do the same thing.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added a new argument to nixos-rebuild, which excecutes `nix store diff-closures /run/current-system path_to_config` where `path_to_config` is a python variable within `nixos-rebuild`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
