### PR TITLE
nixos/etc: echo "setting up /etc..." into stderr

### DIFF
--- a/nixos/modules/system/etc/etc.nix
+++ b/nixos/modules/system/etc/etc.nix
@@ -357,7 +357,7 @@ in
       else
         ''
           # Set up the statically computed bits of /etc.
-          echo "setting up /etc..."
+          echo "setting up /etc..." >&2
           ${pkgs.perl.withPackages (p: [ p.FileSlurp ])}/bin/perl ${./setup-etc.pl} ${etc}/etc
         '';
 


### PR DESCRIPTION
nixos-rebuild specifically makes sure to:
"Print only the result to stdout to make it easier to script" while this echo pollutes the output upon running `nixos-rebuild switch`.

It means to use the resulting store path from `nixos-rebuild`, you would need to pipe it into `tail -n 1` or similar. This commit should make that unnecessary.

Here is output of `nixos-rebuild switch` demonstrating this problem:
```
building the system configuration...
Checking switch inhibitors... done
activating the configuration...
reloading user units for electria...
restarting sysinit-reactivation.target
the following new units were started: NetworkManager-dispatcher.service
error: 'setting up /etc...
       /nix/store/2xpv4wlyyhhhv84qn6s4s7pwf8gb4465-nixos-system-nixos-26.05.20260208.d6c7193' is not a valid URL
```
Notice that "setting up /etc..." gets into the captured output.

This PR isn't a perfect solution though, since there might be other places in the code where something prints to stdin. Perhaps instead of this it'd be best to redirect all output from "subprocesses" within `nixos-rebuild` to stderr?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

redirected `echo "setting up /etc..."` into stderr
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
