### PR TITLE
stestrCheckHook: init

### DIFF
--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -550,6 +550,7 @@ are used in [`buildPythonPackage`](#buildpythonpackage-function).
 - `pythonRemoveBinBytecode` to remove bytecode from the `/bin` folder.
 - `setuptoolsBuildHook` to build a wheel using `setuptools`.
 - `sphinxHook` to build documentation and manpages using Sphinx.
+- `stestrCheckHook` to run tests with `stestr`.
 - `venvShellHook` to source a Python 3 `venv` at the `venvDir` location. A
   `venv` is created if it does not yet exist. `postVenvCreation` can be used to
   to run commands only after venv is first created.

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -175,6 +175,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - Budgie has been updated to 10.10, please check the [upstream announcement](https://buddiesofbudgie.org/blog/budgie-10-10-released) for more details.
 
+- `stestrCheckHook` was added: This test hook runs `stestr run`. You can disable tests with `disabledTests` and `disabledTestsRegex`.
+
 - `services.frp` now supports multiple instances through `services.frp.instances` to make it possible to run multiple frp clients or servers at the same time.
 
 - `hyphen` now supports over 40 language variants through `hyphenDicts` and now allows to enable all supported languages through `hyphenDicts.all`.

--- a/pkgs/development/interpreters/python/hooks/default.nix
+++ b/pkgs/development/interpreters/python/hooks/default.nix
@@ -442,6 +442,17 @@ in
     } ./setuptools-build-hook.sh
   ) { };
 
+  stestrCheckHook = callPackage (
+    { makePythonHook }:
+    makePythonHook {
+      name = "stestr-check-hook";
+      propagatedBuildInputs = [ stestr ];
+      substitutions = {
+        inherit pythonCheckInterpreter;
+      };
+    } ./stestr-check-hook.sh
+  ) { };
+
   unittestCheckHook = callPackage (
     { makePythonHook }:
     makePythonHook {

--- a/pkgs/development/interpreters/python/hooks/stestr-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/stestr-check-hook.sh
@@ -1,0 +1,39 @@
+# Setup hook for stestr
+# shellcheck shell=bash
+
+echo "Sourcing stestr-check-hook"
+
+function stestrCheckPhase() {
+    echo "Executing stestrCheckPhase"
+    runHook preCheck
+
+    local -a patterns=()
+
+    # Append regex pattern
+    read -ra patterns <<< "$disabledTestsRegex"
+
+    # Sanitize disabledTests options
+    if [[ -n "${disabledTests[*]-}" ]] || [[ -n "${disabledTestsRegex[*]-}" ]]; then
+        # Prevent unintentional matching for specific tests
+        for test in ${disabledTests[@]-}; do
+            patterns+=("^${test}$")
+        done
+    fi
+
+    # Compose arguments
+    local -a flagsArray=()
+    if [[ -n "${patterns[*]}" ]]; then
+        flagsArray+=(--exclude-regex "($(concatStringsSep "|" patterns))")
+    fi
+
+    echoCmd 'stestr flags' "${flagsArray[@]}"
+    @pythonCheckInterpreter@ -m stestr run "${flagsArray[@]}"
+
+    runHook postCheck
+    echo "Finished executing stestrCheckPhase"
+}
+
+if [ -z "${dontUseStestrCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
+    echo "Using stestrCheckPhase"
+    appendToVar preDistPhases stestrCheckPhase
+fi

--- a/pkgs/development/python-modules/python-heatclient/default.nix
+++ b/pkgs/development/python-modules/python-heatclient/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   cliff,
-  fetchPypi,
+  fetchFromGitHub,
   iso8601,
   keystoneauth1,
   openstackdocstheme,
@@ -19,25 +19,30 @@
   requests,
   setuptools,
   sphinxHook,
-  stestr,
+  stestrCheckHook,
   testscenarios,
+  versionCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-heatclient";
   version = "5.0.0";
   pyproject = true;
 
-  src = fetchPypi {
-    pname = "python_heatclient";
-    inherit version;
-    hash = "sha256-q3CtG+bRPo9gNHl6KJSutDU33EKUun/7C0pBe1ahpx4=";
+  src = fetchFromGitHub {
+    owner = "openstack";
+    repo = "python-heatclient";
+    tag = finalAttrs.version;
+    hash = "sha256-BpxUUQTBZLR89ks31q5BcBajIP2vcD3Oot1dsXLalX4=";
   };
+
+  env.PBR_VERSION = finalAttrs.version;
 
   build-system = [
     openstackdocstheme
     python-openstackclient
     setuptools
+    pbr
     sphinxHook
   ];
 
@@ -51,7 +56,6 @@ buildPythonPackage rec {
     oslo-i18n
     oslo-serialization
     oslo-utils
-    pbr
     prettytable
     python-swiftclient
     pyyaml
@@ -59,29 +63,67 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    stestr
+    stestrCheckHook
     testscenarios
     requests-mock
   ];
 
-  checkPhase = ''
-    runHook preCheck
+  # These tests are failing on Python 3.14 because request.pathname2url fails to add // after the protocol's name.
+  # https://github.com/NixOS/nixpkgs/pull/488828#:~:text=discuss%2Epython%2Eorg%2Ft%2Fpathname2url%2Dchanges%2Din%2Dpython%2D3%2D14%2Dbreaking%2Dpip%2Dtests%2F97091
+  disabledTests = [
+    "heatclient.tests.unit.test_shell.ShellTestConfig.test_config_create"
+    "heatclient.tests.unit.test_shell.ShellTestStandaloneToken.test_stack_create_param_file"
+    "heatclient.tests.unit.test_shell.ShellTestStandaloneToken.test_stack_create_only_param_file"
+    "heatclient.tests.unit.test_shell.ShellTestToken.test_stack_create_only_param_file"
+    "heatclient.tests.unit.test_shell.ShellTestToken.test_stack_create_param_file"
+    "heatclient.tests.unit.test_shell.ShellTestUserPass.test_stack_create_param_file"
+    "heatclient.tests.unit.test_shell.ShellTestUserPass.test_stack_create_only_param_file"
+    "heatclient.tests.unit.test_shell.ShellTestUserPassKeystoneV3.test_stack_create_param_file"
+    "heatclient.tests.unit.test_shell.ShellTestUserPassKeystoneV3.test_stack_create_only_param_file"
+    "heatclient.tests.unit.test_template_utils.TestTemplateGetFileFunctions.test_hot_template"
+    "heatclient.tests.unit.test_template_utils.TestTemplateGetFileFunctions.test_hot_template_same_file"
+    "heatclient.tests.unit.test_template_utils.TestTemplateGetFileFunctions.test_hot_template_outputs"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_multiple_environments_empty_registry"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_multiple_environments_default_resources"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_ignore_env_keys"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_multiple_environments_and_files"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_environment_empty_file"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_environment_file"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_environment_relative_file"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_environment_relative_file_up"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_environment_relative_file_tracker"
+    "heatclient.tests.unit.test_template_utils.ShellEnvironmentTest.test_process_multiple_environments_and_files_tracker"
+    "heatclient.tests.unit.test_template_utils.TestTemplateTypeFunctions.test_hot_template"
+    "heatclient.tests.unit.test_template_utils.TestGetTemplateContents.test_get_template_contents_parse_error"
+    "heatclient.tests.unit.test_template_utils.TestGetTemplateContents.test_get_template_contents_file_empty"
+    "heatclient.tests.unit.test_template_utils.TestNestedIncludes.test_env_nested_includes"
+    "heatclient.tests.unit.test_template_utils.TestTemplateInFileFunctions.test_hot_template"
+    "heatclient.tests.unit.test_utils.TestURLFunctions.test_get_template_url"
+    "heatclient.tests.unit.test_utils.TestURLFunctions.test_normalise_file_path_to_url_absolute"
+    "heatclient.tests.unit.test_utils.TestURLFunctions.test_normalise_file_path_to_url_relative"
+  ];
 
-    stestr run -e <(echo "
-      heatclient.tests.unit.test_common_http.HttpClientTest.test_get_system_ca_file
-      heatclient.tests.unit.test_deployment_utils.TempURLSignalTest.test_create_temp_url
-    ")
+  pythonImportsCheck = [
+    "heatclient"
+    "heatclient.client"
+    "heatclient.common"
+    "heatclient.osc"
+    "heatclient.osc.v1"
+    "heatclient.tests"
+    "heatclient.tests.unit"
+  ];
 
-    runHook postCheck
-  '';
-
-  pythonImportsCheck = [ "heatclient" ];
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = {
-    description = "Library for Heat built on the Heat orchestration API";
+    description = "OpenStack Heat Client and bindings";
     mainProgram = "heat";
-    homepage = "https://github.com/openstack/python-heatclient";
+    homepage = "https://docs.openstack.org/python-heatclient/latest/";
+    downloadPage = "https://github.com/openstack/python-heatclient/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     teams = [ lib.teams.openstack ];
   };
-}
+})

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -75,13 +75,9 @@ buildPythonPackage (finalAttrs: {
     stestr
   ];
 
-  # test_module failures under python 3.14: https://bugs.launchpad.net/python-openstackclient/+bug/2137223
-  checkPhase = ''
-    runHook preCheck
-    stestr run -E \
-      "openstackclient.tests.unit.common.test_module.TestModuleList.(test_module_list_no_options|test_module_list_all)"
-    runHook postCheck
-  '';
+  disabledTestsRegex = [
+    "openstackclient.tests.unit.common.test_module.TestModuleList*"
+  ];
 
   pythonImportsCheck = [
     "openstackclient"

--- a/pkgs/development/python-modules/python-openstackclient/default.nix
+++ b/pkgs/development/python-modules/python-openstackclient/default.nix
@@ -19,7 +19,6 @@
   python-mistralclient,
   python-neutronclient,
   python-octaviaclient,
-  python-openstackclient,
   python-watcherclient,
   python-zaqarclient,
   python-zunclient,
@@ -28,8 +27,8 @@
   setuptools,
   sphinxHook,
   sphinxcontrib-apidoc,
-  stestr,
-  testers,
+  stestrCheckHook,
+  versionCheckHook,
 }:
 
 buildPythonPackage (finalAttrs: {
@@ -72,7 +71,7 @@ buildPythonPackage (finalAttrs: {
   nativeCheckInputs = [
     ddt
     requests-mock
-    stestr
+    stestrCheckHook
   ];
 
   disabledTestsRegex = [
@@ -112,12 +111,10 @@ buildPythonPackage (finalAttrs: {
     ];
   };
 
-  passthru = {
-    tests.version = testers.testVersion {
-      package = python-openstackclient;
-      command = "openstack --version";
-    };
-  };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = {
     description = "OpenStack Command-line Client";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This adds a useful hook to be used for projects that use stestr,
it is primiative at the moment but covers most scenarios for using
it.

This PR also changes a Python module to start using it, once it
lands, follow up PRs can update all of them to use it tree-wide.

This MR replaces https://github.com/NixOS/nixpkgs/pull/403456  
This also resolves build failure on Python 3.14 for OpenStack packages : https://github.com/NixOS/nixpkgs/issues/475732

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
