### PR TITLE
symlinkJoin: to extendMkDerivation, enable finalAttrs

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -584,12 +584,12 @@ rec {
 
     extendDrvArgs =
       finalAttrs:
-      args_@{
+      args@{
         name ?
           assert lib.assertMsg (
-            args_ ? pname && args_ ? version
+            args ? pname && args ? version
           ) "symlinkJoin requires either a `name` OR `pname` and `version`";
-          "${args_.pname}-${args_.version}",
+          "${args.pname}-${args.version}",
         paths,
         stripPrefix ? "",
         preferLocalBuild ? true,
@@ -634,12 +634,15 @@ rec {
           ${postBuild}
         '';
       }
-      // lib.optionalAttrs (!args_ ? meta) {
+      // lib.optionalAttrs (!args ? meta) {
         pos =
           let
-            args = builtins.attrNames args_;
+            argNames = builtins.attrNames args;
           in
-          if builtins.length args > 0 then builtins.unsafeGetAttrPos (builtins.head args) args_ else null;
+          if builtins.length argNames > 0 then
+            builtins.unsafeGetAttrPos (builtins.head argNames) args
+          else
+            null;
       };
   };
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -587,9 +587,9 @@ rec {
       args@{
         name ?
           assert lib.assertMsg (
-            args ? pname && args ? version
+            finalAttrs ? pname && finalAttrs ? version
           ) "symlinkJoin requires either a `name` OR `pname` and `version`";
-          "${args.pname}-${args.version}",
+          "${finalAttrs.pname}-${finalAttrs.version}",
         paths,
         stripPrefix ? "",
         preferLocalBuild ? true,

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -572,69 +572,81 @@ rec {
     other derivations.  A derivation created with linkFarm is often used in CI
     as a easy way to build multiple derivations at once.
   */
-  symlinkJoin =
-    args_@{
-      name ?
-        assert lib.assertMsg (
-          args_ ? pname && args_ ? version
-        ) "symlinkJoin requires either a `name` OR `pname` and `version`";
-        "${args_.pname}-${args_.version}",
-      paths,
-      stripPrefix ? "",
-      preferLocalBuild ? true,
-      allowSubstitutes ? false,
-      postBuild ? "",
-      failOnMissing ? stripPrefix == "",
-      ...
-    }:
-    assert lib.assertMsg (stripPrefix != "" -> (hasPrefix "/" stripPrefix && stripPrefix != "/")) ''
-      stripPrefix must be either an empty string (disable stripping behavior), or relative path prefixed with /.
+  symlinkJoin = lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
 
-      Ensure that the path starts with / and specifies path to the subdirectory.
-    '';
+    extendDrvArgs =
+      finalAttrs:
+      args_@{
+        name ?
+          assert lib.assertMsg (
+            args_ ? pname && args_ ? version
+          ) "symlinkJoin requires either a `name` OR `pname` and `version`";
+          "${args_.pname}-${args_.version}",
+        paths,
+        stripPrefix ? "",
+        preferLocalBuild ? true,
+        allowSubstitutes ? false,
+        postBuild ? "",
+        failOnMissing ? stripPrefix == "",
+        ...
+      }:
+      assert lib.assertMsg (stripPrefix != "" -> (hasPrefix "/" stripPrefix && stripPrefix != "/")) ''
+        stripPrefix must be either an empty string (disable stripping behavior), or relative path prefixed with /.
 
-    let
-      mapPaths =
-        f: paths:
-        map (
-          path:
-          if path == null then
-            null
-          else if isList path then
-            mapPaths f path
-          else
-            f path
-        ) paths;
-      args =
-        removeAttrs args_ [
-          "name"
-          "postBuild"
-          "stripPrefix"
-          "paths"
-          "failOnMissing"
-        ]
-        // {
-          # Allow getting the proper position of the output derivation.
-          # Since one of these are required, it should be fairly accurate.
-          pos =
-            if args_ ? pname then
-              builtins.unsafeGetAttrPos "pname" args_
+        Ensure that the path starts with / and specifies path to the subdirectory.
+      '';
+      let
+        mapPaths =
+          f: paths:
+          map (
+            path:
+            if path == null then
+              null
+            else if isList path then
+              mapPaths f path
             else
-              builtins.unsafeGetAttrPos "name" args_;
-          inherit preferLocalBuild allowSubstitutes;
-          paths = mapPaths (path: "${path}${stripPrefix}") paths;
-          passAsFile = [ "paths" ];
-        }; # pass the defaults
-    in
-    runCommand name args ''
-      mkdir -p $out
-      for i in $(cat $pathsPath); do
-        ${optionalString (!failOnMissing) "if test -d $i; then "}${lndir}/bin/lndir -silent $i $out${
-          optionalString (!failOnMissing) "; fi"
-        }
-      done
-      ${postBuild}
-    '';
+              f path
+          ) paths;
+        drvArgs =
+          removeAttrs args_ [
+            "name"
+            "postBuild"
+            "stripPrefix"
+            "paths"
+            "failOnMissing"
+          ]
+          // {
+            inherit preferLocalBuild allowSubstitutes;
+            paths = mapPaths (path: "${path}${stripPrefix}") paths;
+          }; # pass the defaults
+      in
+      {
+        enableParallelBuilding = true;
+        inherit name;
+        passAsFile = [
+          "buildCommand"
+          "paths"
+        ];
+        buildCommand = ''
+          mkdir -p $out
+          for i in $(cat $pathsPath); do
+            ${optionalString (!failOnMissing) "if test -d $i; then "}${lndir}/bin/lndir -silent $i $out${
+              optionalString (!failOnMissing) "; fi"
+            }
+          done
+          ${postBuild}
+        '';
+      }
+      // lib.optionalAttrs (!drvArgs ? meta) {
+        pos =
+          let
+            args = builtins.attrNames drvArgs;
+          in
+          if builtins.length args > 0 then builtins.unsafeGetAttrPos (builtins.head args) drvArgs else null;
+      }
+      // drvArgs;
+  };
 
   # TODO: move linkFarm docs to the Nixpkgs manual
   /*

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -636,13 +636,10 @@ rec {
       }
       // lib.optionalAttrs (!args ? meta) {
         pos =
-          let
-            argNames = builtins.attrNames args;
-          in
-          if builtins.length argNames > 0 then
-            builtins.unsafeGetAttrPos (builtins.head argNames) args
+          if args ? pname then
+            builtins.unsafeGetAttrPos "pname" args
           else
-            null;
+            builtins.unsafeGetAttrPos "name" args;
       };
   };
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -576,7 +576,6 @@ rec {
     constructDrv = stdenvNoCC.mkDerivation;
 
     excludeDrvArgNames = [
-      "name"
       "postBuild"
       "stripPrefix"
       "paths"
@@ -606,7 +605,7 @@ rec {
       '';
       let
         mapPaths =
-          f: paths:
+          f:
           map (
             path:
             if path == null then
@@ -615,7 +614,7 @@ rec {
               mapPaths f path
             else
               f path
-          ) paths;
+          );
       in
       {
         enableParallelBuilding = true;

--- a/pkgs/by-name/ka/kak-tree-sitter/package.nix
+++ b/pkgs/by-name/ka/kak-tree-sitter/package.nix
@@ -6,10 +6,10 @@
   kak-tree-sitter-unwrapped,
 }:
 
-symlinkJoin rec {
+symlinkJoin (finalAttrs: {
   pname = lib.replaceStrings [ "-unwrapped" ] [ "" ] kak-tree-sitter-unwrapped.pname;
   inherit (kak-tree-sitter-unwrapped) version;
-  name = "${pname}-${version}";
+  name = "${finalAttrs.pname}-${finalAttrs.version}";
 
   paths = [ kak-tree-sitter-unwrapped ];
   nativeBuildInputs = [ makeWrapper ];
@@ -24,4 +24,4 @@ symlinkJoin rec {
   '';
 
   inherit (kak-tree-sitter-unwrapped) meta;
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Recommend reviewing by commit. 

Goal: zero rebuilds since this is such a load-bearing builder. 

First commit is a naive translation that basically just inlines `runCommandWith`. The other commits just build on that to clean it up a bit. Finally I chose a random pacakge to migrate to confirm that moving to `finalAttrs` also does not cause any rebuilds.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
