### PR TITLE
python313Packages.aranet4: 2.5.1 -> 2.6.0

### DIFF
--- a/pkgs/development/python-modules/aranet4/default.nix
+++ b/pkgs/development/python-modules/aranet4/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "aranet4";
   version = "2.6.0";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "Anrijs";
     repo = "Aranet4-Python";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-9dVa2RCsA+cs0fA8rLaOnikedEDz6fSfQ1tfAV0A7Eo=";
   };
 
@@ -39,9 +39,9 @@ buildPythonPackage rec {
   meta = {
     description = "Module to interact with Aranet4 devices";
     homepage = "https://github.com/Anrijs/Aranet4-Python";
-    changelog = "https://github.com/Anrijs/Aranet4-Python/releases/tag/v${version}";
+    changelog = "https://github.com/Anrijs/Aranet4-Python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "aranetctl";
   };
-}
+})

--- a/pkgs/development/python-modules/aranet4/default.nix
+++ b/pkgs/development/python-modules/aranet4/default.nix
@@ -3,7 +3,6 @@
   bleak,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
   pytestCheckHook,
   requests,
   setuptools,
@@ -11,24 +10,15 @@
 
 buildPythonPackage rec {
   pname = "aranet4";
-  version = "2.5.1";
+  version = "2.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Anrijs";
     repo = "Aranet4-Python";
     tag = "v${version}";
-    hash = "sha256-/FBrP4aceIX9dcZmm+k13PSAPuK4SQenjWqOAFPSvL8=";
+    hash = "sha256-9dVa2RCsA+cs0fA8rLaOnikedEDz6fSfQ1tfAV0A7Eo=";
   };
-
-  patches = [
-    # https://github.com/Anrijs/Aranet4-Python/pull/62
-    (fetchpatch {
-      name = "fix-for-failing-test-with-bleak-1.1.0.patch";
-      url = "https://github.com/Anrijs/Aranet4-Python/pull/62/commits/0117633682050c77cd00ead1bce93375367d7a3c.patch";
-      hash = "sha256-S4Di6bKbapCpDdOIy4sSiG9dO7OZq5ixjjK+ux4EEp0=";
-    })
-  ];
 
   build-system = [ setuptools ];
 
@@ -49,7 +39,8 @@ buildPythonPackage rec {
   meta = {
     description = "Module to interact with Aranet4 devices";
     homepage = "https://github.com/Anrijs/Aranet4-Python";
-    license = with lib.licenses; [ mit ];
+    changelog = "https://github.com/Anrijs/Aranet4-Python/releases/tag/v${version}";
+    license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
     mainProgram = "aranetctl";
   };


### PR DESCRIPTION
Changelog: https://github.com/Anrijs/Aranet4-Python/releases/tag/v2.6.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
