### PR TITLE
xygrib: migrate to by-name

### DIFF
--- a/pkgs/by-name/xy/xygrib/package.nix
+++ b/pkgs/by-name/xy/xygrib/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
     owner = "opengribs";
     repo = "XyGrib";
     rev = "88c425ca2d7f4ba5d7ab75bfa25e177bee02d310";
-    sha256 = "sha256-qMMeRYIQqJpVRE3YjbXIiXHwS/CHs9l2QihszwQIr/A=";
+    hash = "sha256-qMMeRYIQqJpVRE3YjbXIiXHwS/CHs9l2QihszwQIr/A=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/xy/xygrib/package.nix
+++ b/pkgs/by-name/xy/xygrib/package.nix
@@ -2,15 +2,13 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  wrapQtAppsHook,
   cmake,
   bzip2,
-  qtbase,
-  qttools,
   libnova,
   proj,
   libpng,
   openjpeg,
+  qt5,
 }:
 
 stdenv.mkDerivation {
@@ -26,12 +24,12 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     cmake
-    qttools
-    wrapQtAppsHook
+    qt5.qttools
+    qt5.wrapQtAppsHook
   ];
   buildInputs = [
     bzip2
-    qtbase
+    qt5.qtbase
     libnova
     proj
     openjpeg

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10969,8 +10969,6 @@ with pkgs;
     xppen_4
     ;
 
-  xygrib = libsForQt5.callPackage ../applications/misc/xygrib { };
-
   ydiff = with python3.pkgs; toPythonApplication ydiff;
 
   yokadi = python3Packages.callPackage ../applications/misc/yokadi { };


### PR DESCRIPTION
This pull request reorganizes and updates the packaging for `xygrib`, a weather application, in the Nixpkgs repository. The package definition has been moved and updated to use the `libsForQt5` set for its Qt dependencies, improving maintainability and compatibility with Qt5. The most important changes are grouped below:

**Package location and referencing:**
* Renamed and moved the package file from `pkgs/applications/misc/xygrib/default.nix` to `pkgs/by-name/xy/xygrib/package.nix`, aligning with the by-name directory convention.

**Qt dependency management:**
* Updated all Qt dependencies to use `libsForQt5` (e.g., `libsForQt5.qtbase`, `libsForQt5.qttools`, `libsForQt5.wrapQtAppsHook`), replacing direct references to `qtbase`, `qttools`, and `wrapQtAppsHook`. This ensures consistent Qt5 usage and easier upgrades

**Nixpkgs packaging improvements:**
* Changed the `sha256` attribute to `hash` in the `fetchFromGitHub` call, following modern Nixpkgs conventions.
* Removed the explicit `xygrib` definition from `pkgs/top-level/all-packages.nix`, as the new packaging approach leverages `libsForQt5.callPackage` and the by-name structure for improved package referencing.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
