### PR TITLE
zulip-term: 0.7.0-unstable-2025-05-19 -> 0.7.0-unstable-2026-02-10

### DIFF
--- a/pkgs/by-name/zu/zulip-term/package.nix
+++ b/pkgs/by-name/zu/zulip-term/package.nix
@@ -29,14 +29,14 @@ with py.pkgs;
 
 buildPythonApplication rec {
   pname = "zulip-term";
-  version = "0.7.0-unstable-2025-05-19";
+  version = "0.7.0-unstable-2026-02-10";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "zulip";
     repo = "zulip-terminal";
-    rev = "8e5c0357c8746df64ac427d5db3d2cb0f002f975";
-    hash = "sha256-DW3GZ1hY/wZ6P/djPUlAvNIFcBV994FLJ3aiPfDVUBM=";
+    rev = "6a799870eccc00d612e25ff881d18f4ff66d92fa";
+    hash = "sha256-saimbccJ5iJITs/Bw97bOkGrVcko1kAl61nlxNwBrms=";
   };
 
   patches = [
@@ -99,6 +99,9 @@ buildPythonApplication rec {
     homepage = "https://github.com/zulip/zulip-terminal";
     changelog = "https://github.com/zulip/zulip-terminal/releases/tag/${version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ dotlambda ];
+    maintainers = with lib.maintainers; [
+      dotlambda
+      erooke
+    ];
   };
 }


### PR DESCRIPTION
Bumped the version to the newest main to incorporate [bugfix #1601](https://github.com/zulip/zulip-terminal/issues/1601). They do not seem to be cutting new releases (last release was 4 years ago, changelog has not been updated in 3) so there is no changelog to link to.

Built and tested locally, no obvious issues materialized.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
