### PR TITLE
inspectrum: build on darwin

### DIFF
--- a/pkgs/by-name/in/inspectrum/package.nix
+++ b/pkgs/by-name/in/inspectrum/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   gnuradioMinimal,
   thrift,
   fetchFromGitHub,
@@ -42,12 +43,16 @@ gnuradioMinimal.pkgs.mkDerivation rec {
     gnuradioMinimal.unwrapped.python.pkgs.thrift
   ];
 
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    ${stdenv.cc.targetPrefix}install_name_tool -change libliquid.dylib ${lib.getLib liquid-dsp}/lib/libliquid.dylib $out/bin/.inspectrum-wrapped
+  '';
+
   meta = {
     description = "Tool for analysing captured signals from sdr receivers";
     mainProgram = "inspectrum";
     homepage = "https://github.com/miek/inspectrum";
     maintainers = with lib.maintainers; [ mog ];
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin;
     license = lib.licenses.gpl3Plus;
   };
 }


### PR DESCRIPTION
Fixing the install name for libliquid allows running on darwin.

I'm not sure if directly pointing it at the unwrapped binary is the best approach,
but I see this done in other packages so suppose it's okay.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
