### PR TITLE
versitygw: Add version check hook and Nix update script

### DIFF
--- a/pkgs/by-name/ve/versitygw/package.nix
+++ b/pkgs/by-name/ve/versitygw/package.nix
@@ -2,6 +2,8 @@
   lib,
   fetchFromGitHub,
   buildGoModule,
+  nix-update-script,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -17,12 +19,25 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-z+m5ez17yF+GcUHyKU6a3Q69A6ACBVk0gCjKIaIJ554=";
 
-  doCheck = false; # Require access to online S3 services
+  # Require access to online S3 services
+  doCheck = false;
 
-  ldFlags = [
-    "-s"
-    "-w"
+  # Needed for "versitygw --version" to not show placeholders
+  ldflags = [
+    "-X main.Build=v${finalAttrs.version}"
+    "-X main.BuildTime=1980-01-01T00:00:02Z"
+    "-X main.Version=v${finalAttrs.version}"
   ];
+
+  doInstallCheck = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgramArg = "--version";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Versity S3 gateway, a high-performance S3 translation service";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add version check hook and Nix update script.

`versitygw --version` currently shows placeholders since the [ldflags for version information](https://github.com/versity/versitygw/blob/7f7b80495816f0942506fecfd51c9000fffccbe4/Makefile#L31) aren't being set.

```console
Version  : git
Build    : norev
BuildTime: none
```

In fact, no ldflags are being passed at all due to an attribute name typo (`ldFlags` instead of `ldflags`). Fixing the typo and passing the version info.

```console
Version  : v1.2.0
Build    : v1.2.0
BuildTime: 1980-01-01T00:00:02Z
```

Note that we can't make `Build` show the Git rev since we shouldn't reference `finalAttrs.src` to account for overrides (https://github.com/NixOS/nixpkgs/issues/367739).

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
