### PR TITLE
cdktf-cli: fix: use nodejs_20

### DIFF
--- a/pkgs/by-name/cd/cdktf-cli/package.nix
+++ b/pkgs/by-name/cd/cdktf-cli/package.nix
@@ -8,7 +8,7 @@
   fixup-yarn-lock,
   go,
   makeWrapper,
-  nodejs,
+  nodejs_20,
   nix-update-script,
   patchelf,
   removeReferencesTo,
@@ -63,10 +63,10 @@ stdenv.mkDerivation (finalAttrs: {
     fixup-yarn-lock
     go
     makeWrapper
-    nodejs
+    nodejs_20
     patchelf
     removeReferencesTo
-    yarn
+    (yarn.override { nodejs = nodejs_20; })
   ];
 
   postPatch = ''
@@ -129,7 +129,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p "$out/lib/node_modules/cdktf-cli"
     cp -rL node_modules packages/cdktf-cli/bundle packages/cdktf-cli/package.json "$out/lib/node_modules/cdktf-cli/"
 
-    makeWrapper "${lib.getExe nodejs}" "$out/bin/cdktf" \
+    makeWrapper "${lib.getExe nodejs_20}" "$out/bin/cdktf" \
       --add-flags "$out/lib/node_modules/cdktf-cli/bundle/bin/cdktf.js"
 
     runHook postInstall


### PR DESCRIPTION
i noticed that hydra hasn't been able to build cdktf-cli on aarch64 and looked in to it, it turns out cdktf-cli is unmaintained and one of its dependencies only supports node 20 on aarch64-linux. this change should make it build successfully again.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

 - replaced `nodejs` dependency with `nodejs_20`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
