### PR TITLE
initrd: unsafeDiscardReferences.out = true

### DIFF
--- a/pkgs/build-support/kernel/make-initrd.sh
+++ b/pkgs/build-support/kernel/make-initrd.sh
@@ -1,9 +1,5 @@
 set -o pipefail
 
-objects=($objects)
-symlinks=($symlinks)
-suffices=($suffices)
-
 mkdir root
 
 # Needed for splash_helper, which gets run before init.
@@ -12,14 +8,14 @@ mkdir root/sys
 mkdir root/proc
 
 
-for ((n = 0; n < ${#objects[*]}; n++)); do
-    object=${objects[$n]}
-    symlink=${symlinks[$n]}
-    suffix=${suffices[$n]}
-    if test "$suffix" = none; then suffix=; fi
+for ((n = 0; n < ${#objects[@]}; n++)); do
+  object=${objects[n]}
+  symlink=${symlinks[n]}
+  suffix=${suffices[n]}
+  if test "$suffix" = none; then suffix=; fi
 
-    mkdir -p $(dirname root/$symlink)
-    ln -s $object$suffix root/$symlink
+  mkdir -p $(dirname root/$symlink)
+  ln -s $object$suffix root/$symlink
 done
 
 
@@ -34,16 +30,16 @@ storePaths="$(cat $closureInfo/store-paths)"
 
 # Put the closure in a gzipped cpio archive.
 mkdir -p $out
-for PREP in $prepend; do
+for PREP in ${prepend[@]}; do
   cat $PREP >> $out/initrd
 done
 (cd root && find * .[^.*] -exec touch -h -d '@1' '{}' +)
 (cd root && find * .[^.*] -print0 | sort -z | cpio --quiet -o -H newc -R +0:+0 --reproducible --null | eval -- $compress >> "$out/initrd")
 
 if [ -n "$makeUInitrd" ]; then
-    mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
-    # Compatibility symlink
-    ln -sf "initrd.img" "$out/initrd"
+  mkimage -A "$uInitrdArch" -O linux -T ramdisk -C "$uInitrdCompression" -d "$out/initrd" $out/initrd.img
+  # Compatibility symlink
+  ln -sf "initrd.img" "$out/initrd"
 else
-    ln -s "initrd" "$out/initrd$extension"
+  ln -s "initrd" "$out/initrd$extension"
 fi


### PR DESCRIPTION
```
 nix-store -q --references /run/current-system/initrd | cat
/nix/store/210hmbyxa134a1kndsb7g5fvclhsgcvl-xz-5.8.2
/nix/store/4jnrsvmqinp7wj6h4mivypddg74nrr12-zstd-1.5.7
/nix/store/dwwm78qhv3748m6z3kp8ylxfv7mbyxf1-util-linux-minimal-2.41.3-login
/nix/store/ilpbfm149dh2m4plzx94irdi56qw3nz9-bzip2-1.0.8
/nix/store/mxl77659cz6bc7w4h6lgz3rsivwa502q-acl-2.3.2
/nix/store/nad982d4v9pcyp9n4sd7x43w9sn1fjz4-kbd-2.9.0
/nix/store/pjibnm0q0kfdyqb9ynq478rgk39fxihw-libseccomp-2.6.0-lib
/nix/store/w9gfwrbvng3ghqgl32jkp14706b3v6x6-linux-6.19-modules-shrunk
/nix/store/yz13xad19n2z5h3rs5k1qqqj29b5ikw8-etc-modprobe.d-nixos.conf
```

Initrd has runtime dependencies now.  Initrd should ideally be self-contained

After enabling  `__structuredAttrs = true; unsafeDiscardReferences.out = true`  like [repart-image.nix](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/image/repart-image.nix)
```
nix-store -q --references /run/current-system/initrd | wc -l
0
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
