### PR TITLE
python3Packages.pyzotero: init at 1.10.0

### DIFF
--- a/pkgs/development/python-modules/pyzotero/default.nix
+++ b/pkgs/development/python-modules/pyzotero/default.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  uv-build,
+  bibtexparser,
+  click,
+  feedparser,
+  httpx,
+  mcp,
+  whenever,
+  pythonOlder,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "pyzotero";
+  version = "1.10.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
+
+  src = fetchFromGitHub {
+    owner = "urschrei";
+    repo = "pyzotero";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-61FvzGUd0cThYu8LxhZO+ChTywTgkYtuXo4DBJpxT1A=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv_build>=0.8.14,<0.9.0" "uv_build"
+
+    # Remove entrypoints that depend on optional dependencies (click, mcp)
+    # to avoid ModuleNotFoundError at runtime
+    substituteInPlace pyproject.toml \
+      --replace-fail 'pyzotero = "pyzotero.cli:main"' "" \
+      --replace-fail 'pyzotero-mcp = "pyzotero.mcp_server:main"' ""
+  '';
+
+  build-system = [ uv-build ];
+
+  dependencies = [
+    bibtexparser
+    feedparser
+    httpx
+    whenever
+  ];
+
+  optional-dependencies = {
+    cli = [ click ];
+    mcp = [ mcp ];
+  };
+
+  # Tests require network access (Zotero API)
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyzotero" ];
+
+  meta = {
+    description = "Pyzotero: a Python client for the Zotero API";
+    homepage = "https://github.com/urschrei/pyzotero";
+    changelog = "https://github.com/urschrei/pyzotero/blob/${finalAttrs.src.tag}/CHANGES.md";
+    license = lib.licenses.blueOak100;
+    maintainers = with lib.maintainers; [ mulatta ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16055,6 +16055,8 @@ self: super: with self; {
 
   pyzmq = callPackage ../development/python-modules/pyzmq { };
 
+  pyzotero = callPackage ../development/python-modules/pyzotero { };
+
   pyzstd = callPackage ../development/python-modules/pyzstd { zstd-c = pkgs.zstd; };
 
   pyzx = callPackage ../development/python-modules/pyzx { };


### PR DESCRIPTION
init python3Packages.pyzotero 
- build wiith uv_build build-system (patch uv_build for pyzotero requirements)
- patch cli entrypoint to avoud runtime error
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
