### PR TITLE
docker_29: 29.2.0 -> 29.2.1, docker: add update script

### DIFF
--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -367,6 +367,8 @@ let
           # Exposed for tarsum build on non-linux systems (build-support/docker/default.nix)
           inherit moby-src;
           tests = lib.optionalAttrs (!clientOnly) { inherit (nixosTests) docker; };
+          # run with: nix-shell ./maintainers/scripts/update.nix --argstr package docker
+          updateScript = ./update.sh;
         };
 
         meta = docker-meta // {

--- a/pkgs/applications/virtualization/docker/default.nix
+++ b/pkgs/applications/virtualization/docker/default.nix
@@ -438,14 +438,14 @@ in
 
   docker_29 =
     let
-      version = "29.2.0";
+      version = "29.2.1";
     in
     callPackage dockerGen {
       inherit version;
       cliRev = "v${version}";
-      cliHash = "sha256-GbXPe8DlhV4WnwJO8OVAdbXZ18IOUlXszenMGvPvSMQ=";
+      cliHash = "sha256-9foA1MThtq1sQnwki+cxPuU1dZbukOgdMg99Z1EElxk=";
       mobyRev = "docker-v${version}";
-      mobyHash = "sha256-Uilc5cxKuctSkjVxY3R5aezlmGHhLhHY4opVkTYRVIY=";
+      mobyHash = "sha256-LN/IVgKdBwpTR2fUq2Syi6zWP4YN7DQS4bfJVk8Agtg=";
       runcRev = "v1.3.4";
       runcHash = "sha256-1IfY08sBoDpbLrwz1AKBRSTuCZyOgQzYPHTDUI6fOZ8=";
       containerdRev = "v2.2.1";

--- a/pkgs/applications/virtualization/docker/update.sh
+++ b/pkgs/applications/virtualization/docker/update.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix-prefetch-github gawk
+
+set -euo pipefail
+
+# Updates docker packages (docker_29, docker_30, etc.)
+# Fetches component versions from moby's Dockerfile and updates all hashes
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_NIX="$SCRIPT_DIR/default.nix"
+
+# Determine which docker version to update
+ATTR="${1:-${UPDATE_NIX_ATTR_PATH:-docker}}"
+
+# Handle "docker" alias -> use the last docker_XX in the file (latest version)
+if [[ "$ATTR" == "docker" ]]; then
+    ATTR=$(grep -oE 'docker_[0-9]+' "$DEFAULT_NIX" | tail -1)
+fi
+ATTR=$(echo "$ATTR" | grep -oE 'docker_[0-9]+' | head -1)
+
+[[ -z "$ATTR" ]] && { echo "Error: Could not determine docker version"; exit 1; }
+
+MAJOR="${ATTR#docker_}"
+echo "Updating $ATTR (major version: $MAJOR)"
+
+# Get current and latest versions
+CURRENT=$(awk -v a="$ATTR" '$0~a" ="{f=1} f&&/version = "/{match($0,/"[^"]+"/);print substr($0,RSTART+1,RLENGTH-2);exit}' "$DEFAULT_NIX")
+LATEST=$(curl -s ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} "https://api.github.com/repos/moby/moby/releases" | \
+    jq -r --arg m "$MAJOR" '[.[]|select(.tag_name|startswith("docker-v"+$m+"."))|select(.prerelease==false)][0].tag_name|sub("docker-v";"")')
+
+echo "Current: $CURRENT, Latest: $LATEST"
+[[ "$CURRENT" == "$LATEST" ]] && { echo "Already up to date!"; exit 0; }
+
+# Fetch component versions from Dockerfile
+DOCKERFILE=$(curl -sL "https://raw.githubusercontent.com/moby/moby/docker-v$LATEST/Dockerfile")
+RUNC_REV=$(echo "$DOCKERFILE" | sed -n 's/^ARG RUNC_VERSION=//p' | head -1)
+CONTAINERD_REV=$(echo "$DOCKERFILE" | sed -n 's/^ARG CONTAINERD_VERSION=//p' | head -1)
+
+echo "Components: runc=$RUNC_REV, containerd=$CONTAINERD_REV"
+
+# Prefetch helper
+prefetch() { nix-prefetch-github "$1" "$2" --rev "$3" 2>/dev/null | jq -r '.hash'; }
+
+echo "Prefetching sources..."
+CLI_HASH=$(prefetch docker cli "v$LATEST")
+MOBY_HASH=$(prefetch moby moby "docker-v$LATEST")
+RUNC_HASH=$(prefetch opencontainers runc "$RUNC_REV")
+CONTAINERD_HASH=$(prefetch containerd containerd "$CONTAINERD_REV")
+
+# Validate all hashes
+for h in "$CLI_HASH" "$MOBY_HASH" "$RUNC_HASH" "$CONTAINERD_HASH"; do
+    [[ -z "$h" || "$h" == "null" ]] && { echo "Failed to prefetch a source"; exit 1; }
+done
+
+# Update default.nix
+echo "Updating $DEFAULT_NIX..."
+awk -v attr="$ATTR" -v ver="$LATEST" -v cli="$CLI_HASH" -v moby="$MOBY_HASH" \
+    -v runcR="$RUNC_REV" -v runcH="$RUNC_HASH" -v ctrdR="$CONTAINERD_REV" -v ctrdH="$CONTAINERD_HASH" \
+    -v old="$CURRENT" '
+    $0 ~ attr" =" { in_block=1 }
+    in_block && /^  docker_[0-9]/ && $0 !~ attr { in_block=0 }
+    in_block && /^}$/ { in_block=0 }
+    in_block && /version = "/ { gsub(old, ver) }
+    in_block && /cliHash = "sha256-/ { gsub(/sha256-[^"]*/, cli) }
+    in_block && /mobyHash = "sha256-/ { gsub(/sha256-[^"]*/, moby) }
+    in_block && /runcRev = "/ { gsub(/"v[^"]*"/, "\"" runcR "\"") }
+    in_block && /runcHash = "sha256-/ { gsub(/sha256-[^"]*/, runcH) }
+    in_block && /containerdRev = "/ { gsub(/"v[^"]*"/, "\"" ctrdR "\"") }
+    in_block && /containerdHash = "sha256-/ { gsub(/sha256-[^"]*/, ctrdH) }
+    { print }
+' "$DEFAULT_NIX" > "$DEFAULT_NIX.tmp" && mv "$DEFAULT_NIX.tmp" "$DEFAULT_NIX"
+
+echo "Updated $ATTR to $LATEST (cli=$CLI_HASH, moby=$MOBY_HASH, runc=$RUNC_REV, containerd=$CONTAINERD_REV)"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://docs.docker.com/engine/release-notes/29/

`docker_29` changelog / milestones:

https://github.com/moby/moby/compare/docker-v29.2.0...docker-v29.2.1
https://github.com/moby/moby/milestone/230?closed=1

https://github.com/docker/cli/compare/v29.2.0...v29.2.1
https://github.com/docker/cli/milestone/172?closed=1

Thanks to @vdemeester for the update script.
Closes: https://github.com/NixOS/nixpkgs/pull/489069


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
