### PR TITLE
skim: fix build by skipping flaky listen_* tests

### DIFF
--- a/pkgs/by-name/sk/skim/package.nix
+++ b/pkgs/by-name/sk/skim/package.nix
@@ -82,6 +82,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
         "preview_window_down"
         "preview_window_left"
         "preview_window_up"
+        # Flaky: tmux-based listen tests with timing-sensitive IPC
+        "listen_"
       ];
       filterExpr =
         "not ("


### PR DESCRIPTION
The `listen_*` tests use tmux-based IPC with multiple race conditions:

In skim [tests/listen.rs](https://github.com/skim-rs/skim/blob/d48f3f5e32fb678d77b398fc20d15460cd169074/tests/listen.rs)
  1. `tmux.until()` polls for UI state without proper synchronization
  2. `--listen` socket may not be ready when `connect()` is called
  3. Nix sandbox adds latency to IPC operations

  These issues are exacerbated in Hydra's resource-constrained parallel build environment.
Hydra build failed: https://hydra.nixos.org/build/320874671

-> Skip all `listen_*` tests that are flaky in the Nix sandbox environment, causing Hydra builds to fail non-deterministically.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
