### PR TITLE
aws-cloudformation-languageserver: init at 1.9.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16746,6 +16746,12 @@
     githubId = 613740;
     name = "Martin Baillie";
   };
+  mbarneyjr = {
+    email = "mbarneyme@gmail.com";
+    github = "mbarneyjr";
+    githubId = 11701776;
+    name = "Michael Barney";
+  };
   mbbx6spp = {
     email = "me@susanpotter.net";
     github = "mbbx6spp";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17427,6 +17427,12 @@
     githubId = 613740;
     name = "Martin Baillie";
   };
+  mbarneyjr = {
+    email = "mbarneyme@gmail.com";
+    github = "mbarneyjr";
+    githubId = 11701776;
+    name = "Michael Barney";
+  };
   mbe = {
     email = "brandonedens@gmail.com";
     github = "brandonedens";

--- a/pkgs/by-name/aw/aws-cloudformation-languageserver/package.nix
+++ b/pkgs/by-name/aw/aws-cloudformation-languageserver/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  buildNpmPackage,
+  nodejs,
+  makeWrapper,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "aws-cloudformation-languageserver";
+  version = "1.4.0";
+  __structuredAttrs = true;
+  src = fetchFromGitHub {
+    owner = "aws-cloudformation";
+    repo = "cloudformation-languageserver";
+    tag = "v${version}";
+    sha256 = "sha256-cPI6cRuLSFbL3G3peLkIeF+9BBJye7oURBQtuErs4gQ=";
+  };
+  npmDepsHash = "sha256-f7x+yXov2qswX7WEiWT6k0p4hVYF79iXStGHM8FkRBg=";
+  dontNpmBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    # disable webpack InstallDependencies hook,
+    # instead use buildNpmPackage node_modules
+    substituteInPlace webpack.config.js \
+      --replace-fail \
+        "compiler.hooks.beforeRun.tapAsync('InstallDependencies', (compilation, callback) => {" \
+        "compiler.hooks.beforeRun.tapAsync('InstallDependencies', (compilation, callback) => { return callback();" \
+      --replace-fail \
+        "compiler.hooks.done.tap('CleanupTemp', () => {" \
+        "compiler.hooks.done.tap('CleanupTemp', () => { return;" \
+      --replace-fail \
+        "path.join('tmp-node-modules', 'node_modules')" \
+        "'node_modules'" \
+      --replace-fail \
+        "'tmp-node-modules/package.json'" \
+        "'package.json'"
+
+    ./node_modules/.bin/webpack --env mode=production --env env=prod
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/aws-cloudformation-languageserver
+    cp -r bundle/production/* $out/lib/aws-cloudformation-languageserver/
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/cfn-lsp-server \
+      --add-flags "$out/lib/aws-cloudformation-languageserver/cfn-lsp-server-standalone.js"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "CloudFormation Language Server";
+    mainProgram = "cfn-lsp-server";
+    homepage = "https://github.com/aws-cloudformation/cloudformation-languageserver";
+    license = lib.licenses.asl20;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+    ];
+    maintainers = with lib.maintainers; [
+      mbarneyjr
+    ];
+  };
+}

--- a/pkgs/by-name/aw/aws-cloudformation-languageserver/package.nix
+++ b/pkgs/by-name/aw/aws-cloudformation-languageserver/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildNpmPackage,
+  nodejs,
+  makeWrapper,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "aws-cloudformation-languageserver";
+  version = "1.7.0";
+
+  src = fetchFromGitHub {
+    owner = "aws-cloudformation";
+    repo = "cloudformation-languageserver";
+    rev = "v${version}";
+    sha256 = "sha256-Oh9fuA3cDd9XWT0FaD4Anadx0CFTL6ggryYhP5pUAKk=";
+  };
+
+  npmDepsHash = "sha256-Qd6F5og3DwboWHq1t1bIqYsUUfS68f+e19L23t8/AqU=";
+
+  dontNpmBuild = true;
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+  buildPhase = ''
+    runHook preBuild
+
+    # disable webpack InstallDependencies hook,
+    # instead use buildNpmPackage node_modules
+    substituteInPlace webpack.config.js \
+      --replace-fail \
+        "compiler.hooks.beforeRun.tapAsync('InstallDependencies', (compilation, callback) => {" \
+        "compiler.hooks.beforeRun.tapAsync('InstallDependencies', (compilation, callback) => { return callback();" \
+      --replace-fail \
+        "compiler.hooks.done.tap('CleanupTemp', () => {" \
+        "compiler.hooks.done.tap('CleanupTemp', () => { return;" \
+      --replace-fail \
+        "path.join('tmp-node-modules', 'node_modules')" \
+        "'node_modules'" \
+      --replace-fail \
+        "'tmp-node-modules/package.json'" \
+        "'package.json'"
+
+    ./node_modules/.bin/webpack --env mode=production --env env=prod --env skipWheels=true
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/aws-cloudformation-languageserver
+    cp -r bundle/production/* $out/lib/aws-cloudformation-languageserver/
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/cfn-lsp-server \
+      --add-flags "$out/lib/aws-cloudformation-languageserver/cfn-lsp-server-standalone.js"
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "CloudFormation Language Server";
+    mainProgram = "cfn-lsp-server";
+    homepage = "https://github.com/aws-cloudformation/cloudformation-languageserver";
+    license = lib.licenses.asl20;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [
+      mbarneyjr
+    ];
+  };
+}

--- a/pkgs/by-name/aw/aws-cloudformation-languageserver/package.nix
+++ b/pkgs/by-name/aw/aws-cloudformation-languageserver/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  buildNpmPackage,
+  nodejs,
+  makeWrapper,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "aws-cloudformation-languageserver";
+  version = "1.9.0";
+
+  src = fetchFromGitHub {
+    owner = "aws-cloudformation";
+    repo = "cloudformation-languageserver";
+    rev = "v${version}";
+    sha256 = "sha256-ilFXxnaDIMI7QYrU6LkZDtrvxBDXujB09F509A4wp3Q=";
+  };
+
+  npmDepsHash = "sha256-5LK17ID6JUVowy6UcxzCgfTr85OwGCl4t8diWsYkaqQ=";
+
+  dontNpmBuild = true;
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+  buildPhase = ''
+    runHook preBuild
+
+    # disable webpack InstallDependencies hook,
+    # instead use buildNpmPackage node_modules
+    substituteInPlace webpack.config.js \
+      --replace-fail \
+        "compiler.hooks.beforeRun.tapAsync('InstallDependencies', (compilation, callback) => {" \
+        "compiler.hooks.beforeRun.tapAsync('InstallDependencies', (compilation, callback) => { return callback();" \
+      --replace-fail \
+        "compiler.hooks.done.tap('CleanupTemp', () => {" \
+        "compiler.hooks.done.tap('CleanupTemp', () => { return;" \
+      --replace-fail \
+        "path.join('tmp-node-modules', 'node_modules')" \
+        "'node_modules'" \
+      --replace-fail \
+        "'tmp-node-modules/package.json'" \
+        "'package.json'"
+
+    ./node_modules/.bin/webpack --env mode=production --env env=prod --env skipWheels=true
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/aws-cloudformation-languageserver
+    cp -r bundle/production/* $out/lib/aws-cloudformation-languageserver/
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/cfn-lsp-server \
+      --add-flags "$out/lib/aws-cloudformation-languageserver/cfn-lsp-server-standalone.js"
+
+    runHook postInstall
+  '';
+
+  __structuredAttrs = true;
+
+  meta = {
+    description = "CloudFormation Language Server";
+    mainProgram = "cfn-lsp-server";
+    homepage = "https://github.com/aws-cloudformation/cloudformation-languageserver";
+    license = lib.licenses.asl20;
+    platforms = with lib.platforms; linux ++ darwin;
+    maintainers = with lib.maintainers; [
+      mbarneyjr
+    ];
+  };
+}


### PR DESCRIPTION
This inits [aws-cloudformation-languageserver](https://github.com/aws-cloudformation/cloudformation-languageserver) at version 1.4.0 (latest as of creating this PR).

The AWS CloudFormation LanguageServer is an LSP server that works on CloudFormation files. I've been using this (packaged almost identically) in my personal Neovim configuration successfully.

Other notes:
- The actual [INSTALLATION.md](https://github.com/aws-cloudformation/cloudformation-languageserver/blob/main/INSTALLATION.md) guide recommends unzipping the release archive and running `node /path/to/install-location/cfn-lsp-server-standalone.js --stdio`. This derivation uses `makeWrapper` to use node from `nixpkgs` to run the `cfn-lsp-server-standalone.js` file. 
- There is an `update.sh` script to update the `sources.json` that the `package.nix` uses to pass the hashes into `fetchzip` and version to `mkDerivation`, etc. I've pointed `passthru.updateScript` to it too.

This is my first new package contribution, if I'm missing anything I'm more than happy to receive any feedback!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test