### PR TITLE
wechat{-uos}: remove mitigated vulnerability

### DIFF
--- a/pkgs/by-name/we/wechat-uos/package.nix
+++ b/pkgs/by-name/we/wechat-uos/package.nix
@@ -194,14 +194,6 @@ let
           xddxdd
         ];
         mainProgram = "wechat-uos";
-        knownVulnerabilities = [
-          ''
-            CWE-78: Clicking on a file attachment whose name contains backtick-quoted
-            commands will cause it to be executed.
-
-            Reference: https://archive.ph/A5McZ (Chinese)
-          ''
-        ];
       };
     };
 in

--- a/pkgs/by-name/we/wechat/package.nix
+++ b/pkgs/by-name/we/wechat/package.nix
@@ -23,12 +23,6 @@ let
       "aarch64-linux"
       "x86_64-linux"
     ];
-    knownVulnerabilities = lib.optional stdenvNoCC.hostPlatform.isLinux ''
-      CWE-78: Clicking on a file attachment whose name contains backtick-quoted
-      commands will cause it to be executed.
-
-      Reference: https://archive.ph/A5McZ (Chinese)
-    '';
   };
 
   sources =


### PR DESCRIPTION
The vulnerability was resolved by stopping users from uploading files with malicious names to the server, and thus doesn't require changes to client itself.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
