### PR TITLE
cursor-clip: init at 0-unstable-2026-02-10

### DIFF
--- a/pkgs/by-name/cu/cursor-clip/package.nix
+++ b/pkgs/by-name/cu/cursor-clip/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cairo,
+  glib,
+  pango,
+  gdk-pixbuf,
+  graphene,
+  gtk4,
+  gtk4-layer-shell,
+  libadwaita,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "cursor-clip";
+  version = "0-unstable-2026-02-10";
+
+  src = fetchFromGitHub {
+    owner = "sirulex";
+    repo = "cursor-clip";
+    rev = "ad677e4b65340647b95b02a3cd1d955111506695";
+    hash = "sha256-Hxg57v+gFjW7XyoGIGt7Pw4uXokBIWw88/0a00PzckI=";
+  };
+
+  cargoHash = "sha256-5p5tt3dnluRkY0/zIXv6p8mi/hd42yV2E8qsVy+lqz0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    glib
+  ];
+
+  buildInputs = [
+    cairo
+    pango
+    gdk-pixbuf
+    graphene
+    gtk4
+    gtk4-layer-shell
+    libadwaita
+  ];
+
+  meta = {
+    description = "Cursor Clip - GTK4 Clipboard Manager with dynamic positioning. Features a Windows 11–style clipboard history, adapted to native GNOME design";
+    homepage = "https://github.com/sirulex/cursor-clip";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ paperdigits ];
+    mainProgram = "cursor-clip";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package cursor-clip

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
