### PR TITLE
pdfding: update patch hash

### DIFF
--- a/pkgs/by-name/pd/pdfding/package.nix
+++ b/pkgs/by-name/pd/pdfding/package.nix
@@ -26,8 +26,8 @@ python.pkgs.buildPythonPackage (finalAttrs: {
     # fixes two tests, remove patch in the next version
     # https://github.com/mrmn2/PdfDing/pull/248
     (fetchpatch2 {
-      url = "https://github.com/mrmn2/PdfDing/pull/248/commits/8f6900dddd1dbbe1a1024a484f63b792dd022f99.patch?full_index=1";
-      hash = "sha256-5oUC2TKL4X5IFy/41qViaafyUr4+bLBIovk9AWQmxZc=";
+      url = "https://github.com/mrmn2/PdfDing/commit/24df5a82ffb1d60162978791b716f67d20128a22.patch?full_index=1";
+      hash = "sha256-N3FtPQGSOFeUbVcinXK9kJM6hZOn4YdJJVWe4VXb8pE=";
     })
   ];
 


### PR DESCRIPTION
The hash of the patch has changed:

```
error: hash mismatch in fixed-output derivation '/nix/store/yazpj7m6v0shwrc2334skak2qijjz1zv-8f6900dddd1dbbe1a1024a484f63b792dd022f99.patch?full_index=1.drv':
         specified: sha256-5oUC2TKL4X5IFy/41qViaafyUr4+bLBIovk9AWQmxZc=
            got:    sha256-FTk3/cajMwOo75e/efMRgVh9kF9fAVLDlqhrIjD0Nbo=
```

[Hydra build](https://hydra.nixos.org/build/321684893)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

## `nixpkgs-review` result

### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 tests built:</summary>
  <ul>
    <li>pdfding.tests.basic</li>
    <li>pdfding.tests.e2e</li>
    <li>pdfding.tests.postgres</li>
    <li>pdfding.tests.s3-backups</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>pdfding</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
