### PR TITLE
emscripten: 4.0.23 -> 5.0.0

### DIFF
--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -22,7 +22,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "emscripten";
-  version = "4.0.23";
+  version = "5.0.0";
 
   llvmEnv = symlinkJoin {
     name = "emscripten-llvm-${version}";
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     name = "emscripten-node-modules-${version}";
     inherit pname version src;
 
-    npmDepsHash = "sha256-3P4H30nS6RBe2Bd3aqa2ueLOm/hxSBux53GgJu/D4Xc=";
+    npmDepsHash = "sha256-0erImaY5NixdzgazKI6JQ3mofGU+ZwMxMWh0zIcWdhY=";
 
     dontBuild = true;
 
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "emscripten-core";
     repo = "emscripten";
-    hash = "sha256-i65AWbKuh2KsnugGKmmpUON20He2kgPR6EzwKKA09nQ=";
+    hash = "sha256-Ff1SJ+zaKb77Qa2D9Yn0f1KGKNNF8DpslfNF2fFlrXw=";
     rev = version;
   };
 
@@ -79,12 +79,8 @@ stdenv.mkDerivation rec {
 
         patchShebangs .
 
-        # emscripten 4.0.12 requires LLVM tip-of-tree instead of LLVM 21
-        sed -i -e "s/EXPECTED_LLVM_VERSION = 22/EXPECTED_LLVM_VERSION = 21.1/g" tools/shared.py
-
-        # Verify LLVM version patch was applied (fail when nixpkgs has LLVM 22+)
-        grep -q "EXPECTED_LLVM_VERSION = 21.1" tools/shared.py || \
-          (echo "ERROR: LLVM version patch failed - check if still needed" && exit 1)
+        # emscripten 5.0.0 expects LLVM tip-of-tree instead of LLVM 22
+        sed -i -e "s/EXPECTED_LLVM_VERSION = 23/EXPECTED_LLVM_VERSION = 22/g" tools/shared.py
 
         # fixes cmake support
         sed -i -e "s/print \('emcc (Emscript.*\)/sys.stderr.write(\1); sys.stderr.flush()/g" emcc.py
@@ -106,14 +102,6 @@ stdenv.mkDerivation rec {
         sed -i "s|^EMXX =.*|EMXX='$out/bin/em++'|" tools/shared.py
         sed -i "s|^EMAR =.*|EMAR='$out/bin/emar'|" tools/shared.py
         sed -i "s|^EMRANLIB =.*|EMRANLIB='$out/bin/emranlib'|" tools/shared.py
-
-        # Remove --no-stack-first flag (not in LLVM 21, added in LLVM 22 when --stack-first became default)
-        # Replace else block with pass to avoid empty block syntax error
-        sed -i "s/cmd.append('--no-stack-first')/pass/" tools/building.py
-
-        # Verify --no-stack-first was removed (fail if patch is no longer needed)
-        grep -q "cmd.append('--no-stack-first')" tools/building.py && \
-          (echo "ERROR: --no-stack-first patch not needed anymore" && exit 1) || true
 
         # Fix /tmp symlink issue (macOS: /tmp -> /private/tmp) causing relpath miscalculation
         sed -i 's/os\.path\.relpath(source_dir, build_dir)/os.path.relpath(source_dir, os.path.realpath(build_dir))/' tools/system_libs.py

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2295,7 +2295,7 @@ with pkgs;
   buildEmscriptenPackage = callPackage ../development/em-modules/generic { };
 
   emscripten = callPackage ../development/compilers/emscripten {
-    llvmPackages = llvmPackages_21;
+    llvmPackages = llvmPackages_22;
   };
 
   emscriptenPackages = recurseIntoAttrs (callPackage ./emscripten-packages.nix { });


### PR DESCRIPTION
## Things done

Bumped version, removed or adapted outdated patches.

I should note that *I am not quite sure this actually works*. Trying to compile a trivial hello world program produces this linker error:

```
error: undefined symbol: _emscripten_memcpy_js (referenced by root reference (e.g. compiled C/C++ code))
warning: To disable errors for undefined symbols use `-sERROR_ON_UNDEFINED_SYMBOLS=0`
warning: __emscripten_memcpy_js may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
Error: Aborting compilation due to previous errors
    at finalCombiner (file:///nix/store/m6krjlnbjh3afk3ygn2di5ck43l2dfyi-emscripten-5.0.0/share/emscripten/src/jsifier.mjs:926:13)
    at Module.runJSify (file:///nix/store/m6krjlnbjh3afk3ygn2di5ck43l2dfyi-emscripten-5.0.0/share/emscripten/src/jsifier.mjs:962:5)
    at file:///nix/store/m6krjlnbjh3afk3ygn2di5ck43l2dfyi-emscripten-5.0.0/share/emscripten/tools/compiler.mjs:108:17
emcc: error: '/nix/store/9cyx2v23dip6p9q98384k9v06c96qskb-nodejs-24.13.0/bin/node /nix/store/m6krjlnbjh3afk3ygn2di5ck43l2dfyi-emscripten-5.0.0/share/emscripten/tools/compiler.mjs -' failed (returned 1)
```

My Emscripten enthusiasm exceeds my expertise, so maybe I am holding it wrong. I have seen similar errors with previous versions in Nixpkgs, although current `master` works. It would be appreciated if one of the maintainers (@qknight, @raitobezarius, @willcohen).

Also, the version number reported by `emcc` is wrong, because the version number in the Emscripten release tarball is wrong - I think they switched to 5.0.0 quite late in the process. We could patch that ourselves, of course.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
