### PR TITLE
cinny-desktop: use wrapper instead of symlink for bin on darwin

### DIFF
--- a/pkgs/by-name/ci/cinny-desktop/package.nix
+++ b/pkgs/by-name/ci/cinny-desktop/package.nix
@@ -7,6 +7,7 @@
   cinny,
   desktop-file-utils,
   wrapGAppsHook3,
+  makeBinaryWrapper,
   pkg-config,
   openssl,
   glib-networking,
@@ -52,7 +53,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   postInstall =
     lib.optionalString stdenv.hostPlatform.isDarwin ''
       mkdir -p "$out/bin"
-      ln -sf "$out/Applications/Cinny.app/Contents/MacOS/Cinny" "$out/bin/cinny"
+      makeWrapper "$out/Applications/Cinny.app/Contents/MacOS/Cinny" "$out/bin/cinny"
     ''
     + lib.optionalString stdenv.hostPlatform.isLinux ''
       desktop-file-edit \
@@ -74,6 +75,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
     desktop-file-utils
     pkg-config
     wrapGAppsHook3
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    makeBinaryWrapper
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`cinny-desktop` on darwin has the following structure:
```
result
├── Applications
│   └── Cinny.app
│       └── Contents
│           ├── Info.plist
│           ├── MacOS
│           │   └── Cinny
│           └── Resources
│               └── icon.icns
└── bin
    └── cinny -> ../Applications/Cinny.app/Contents/MacOS/Cinny
```
When launched via `result/bin/cinny` (or `cinny` from `$PATH`), Cinny stores its data in: `~/Library/WebKit/cinny`.
When launched directly from the app bundle (i.e. `result/Applications/Cinny.app/Contents/MacOS/Cinny`), it instead stores data in `~/Library/WebKit/in.cinny.app`.

This PR fixes the inconsistency by replacing `bin/cinny` from a symlink with a binary wrapper that `exec` the binary inside the bundle.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
