### PR TITLE
terminusdb: 12.0.2 -> 12.0.4

### DIFF
--- a/pkgs/by-name/te/terminusdb/package.nix
+++ b/pkgs/by-name/te/terminusdb/package.nix
@@ -71,13 +71,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "terminusdb";
-  version = "12.0.2";
+  version = "12.0.4";
 
   src = fetchFromGitHub {
     owner = "terminusdb";
     repo = "terminusdb";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-l573Drc76KSUXxhdleU/IBscDTul8VtgkZdrRPvNuNc=";
+    hash = "sha256-vJifp0U4FrbtI86M8pt022BQWIIeK8jWWFG1Ch1m7IQ=";
     leaveDotGit = true;
     postFetch = ''
       # Will be used for `TERMINUSDB_GIT_HASH`
@@ -90,17 +90,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src cargoRoot;
-    hash = "sha256-zF506S4SiWx/uYyN2Trm4XPVUIU2K/qoNSjfKthLVuw=";
+    hash = "sha256-SvWS18amC4FHuXc/N6e+tomwnVfJ/KlTLIACfl72Nqc=";
   };
 
-  # TODO: remove if/when merged upstream https://github.com/terminusdb/terminusdb/pull/2360
-  patches = [
-    # Avoid building bundled GMP/MPFR/MPC in gmp-mpfr-sys during the Rust build
-    (fetchpatch2 {
-      url = "https://github.com/terminusdb/terminusdb/commit/b84dc6b28ef3fd0ef76db2cf7f69537b95af07cc.patch?full_index=1";
-      hash = "sha256-L3U/MHZgMSoXIy6j+1+gKKY2+2obKgaJ3HdJOoMe2Sw=";
-    })
-  ];
+  postPatch = ''
+    # Fix MAKEFLAGS order in vendored tikv-jemalloc-sys
+    # TODO: remove when tikv-jemalloc-sys 0.6.2+ is released
+    # equivalent to https://github.com/tikv/jemallocator/pull/152
+    substituteInPlace $cargoDepsCopy/tikv-jemalloc-sys-*/build.rs \
+      --replace-fail 'format!("{orig_makeflags} {makeflags}")' \
+                     'format!("{makeflags} {orig_makeflags}")'
+  '';
 
   strictDeps = true;
 
@@ -122,11 +122,16 @@ stdenv.mkDerivation (finalAttrs: {
     libmpc
   ];
 
-  # Darwin: gmp-mpfr-sys (use-system-libs) runs raw `$CC ... -lgmp` probes without
-  # propagating `CFLAGS`/`CPPFLAGS`, so we must provide include/lib paths via
-  # compiler-native env vars
-  # https://gitlab.com/tspiteri/gmp-mpfr-sys/-/blob/v1.5.3/build.rs#L187
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+  env = {
+    # Use system GMP/MPFR/MPC
+    # Overrides FEATURES ?= in Makefile.rust
+    FEATURES = "--features terminusdb-community/use-system-gmp";
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # Darwin: gmp-mpfr-sys (use-system-libs) runs raw `$CC ... -lgmp` probes without
+    # propagating `CFLAGS`/`CPPFLAGS`, so we must provide include/lib paths via
+    # compiler-native env vars
+    # https://gitlab.com/tspiteri/gmp-mpfr-sys/-/blob/v1.5.3/build.rs#L187
     C_INCLUDE_PATH = lib.makeSearchPath "include" [
       (lib.getDev gmp)
       (lib.getDev mpfr)

--- a/pkgs/by-name/te/terminusdb/tests.nix
+++ b/pkgs/by-name/te/terminusdb/tests.nix
@@ -19,18 +19,9 @@ buildNpmPackage {
 
   sourceRoot = "${terminusdb.src.name}/tests";
 
-  npmDepsHash = "sha256-vNafxS19++AszhcYTw1jnfI4HMUyy5lOgKvjHHcGpWg=";
+  npmDepsHash = "sha256-R2kbwHhlja5mH2AGpyiiVCz3YmSWF9cWptOTdcZb0PM=";
 
   # Test-only JS adjustments live here so the runtime package stays untouched
-  patches = [
-    # TODO: remove if/when merged upstream https://github.com/terminusdb/terminusdb/pull/2362
-    # Prefer an injected TerminusDB binary path in tests
-    (fetchpatch2 {
-      url = "https://github.com/terminusdb/terminusdb/commit/8ffe22b3e20bff8fe8efb1a2b8236bb8b40c0bc3.patch?full_index=1";
-      relative = "tests";
-      hash = "sha256-NrFQknjdrRJjHvkOrutSkzxkUwcC6S+S0kHuK/xQTj0=";
-    })
-  ];
   postPatch = ''
     # Read git hash from the COMMIT file in the source
     substituteInPlace lib/info.js --replace-fail \


### PR DESCRIPTION
Release notes: https://github.com/terminusdb/terminusdb/releases/tag/v12.0.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
