### PR TITLE
treewide: move env variable(s) into env for structuredAttrs (N-O) 

### DIFF
--- a/pkgs/by-name/ac/acpica-tools/package.nix
+++ b/pkgs/by-name/ac/acpica-tools/package.nix
@@ -34,20 +34,22 @@ stdenv.mkDerivation (finalAttrs: {
     "iasl"
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-O3"
-  ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-O3"
+    ];
+
+    # i686 builds fail with hardening enabled (due to -Wformat-overflow). Disable
+    # -Werror altogether to make this derivation less fragile to toolchain
+    # updates.
+    NOWERROR = "TRUE";
+
+    # We can handle stripping ourselves.
+    # Unless we are on Darwin. Upstream makefiles degrade coreutils install to cp if _APPLE is detected.
+    INSTALLFLAGS = lib.optionals (!stdenv.hostPlatform.isDarwin) "-m 555";
+  };
 
   enableParallelBuilding = true;
-
-  # i686 builds fail with hardening enabled (due to -Wformat-overflow). Disable
-  # -Werror altogether to make this derivation less fragile to toolchain
-  # updates.
-  NOWERROR = "TRUE";
-
-  # We can handle stripping ourselves.
-  # Unless we are on Darwin. Upstream makefiles degrade coreutils install to cp if _APPLE is detected.
-  INSTALLFLAGS = lib.optionals (!stdenv.hostPlatform.isDarwin) "-m 555";
 
   installFlags = [ "PREFIX=${placeholder "out"}" ];
 

--- a/pkgs/by-name/bo/botamusique/package.nix
+++ b/pkgs/by-name/bo/botamusique/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
       --replace "version = 'git'" "version = '${version}'"
   '';
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/by-name/cl/clmagma/package.nix
+++ b/pkgs/by-name/cl/clmagma/package.nix
@@ -60,12 +60,14 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  MKLROOT = "${mkl}";
-  clBLAS = "${clblas}";
+  env = {
+    MKLROOT = mkl;
+    clBLAS = clblas;
 
-  # Otherwise build looks for it in /run/opengl-driver/etc/OpenCL/vendors,
-  # which is not available.
-  OPENCL_VENDOR_PATH = "${intel-ocl}/etc/OpenCL/vendors";
+    # Otherwise build looks for it in /run/opengl-driver/etc/OpenCL/vendors,
+    # which is not available.
+    OPENCL_VENDOR_PATH = "${intel-ocl}/etc/OpenCL/vendors";
+  };
 
   preBuild = ''
     # By default it tries to use GPU, and thus fails for CPUs

--- a/pkgs/by-name/co/coc-emmet/package.nix
+++ b/pkgs/by-name/co/coc-emmet/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs
   ];
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/co/coc-r-lsp/package.nix
+++ b/pkgs/by-name/co/coc-r-lsp/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs
   ];
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/co/coc-spell-checker/package.nix
+++ b/pkgs/by-name/co/coc-spell-checker/package.nix
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs
   ];
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 

--- a/pkgs/by-name/co/coc-stylelint/package.nix
+++ b/pkgs/by-name/co/coc-stylelint/package.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs
   ];
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/co/coc-vimlsp/package.nix
+++ b/pkgs/by-name/co/coc-vimlsp/package.nix
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs
   ];
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 

--- a/pkgs/by-name/co/coc-wxml/package.nix
+++ b/pkgs/by-name/co/coc-wxml/package.nix
@@ -38,7 +38,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     nodejs
   ];
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/do/docbook2x/package.nix
+++ b/pkgs/by-name/do/docbook2x/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   # configure tries to find osx in PATH and hardcodes the resulting path
   # (if any) on the Perl code. this fails under strictDeps, so override
   # the autoconf test:
-  OSX = "${opensp}/bin/osx";
+  env.OSX = "${opensp}/bin/osx";
 
   postConfigure = ''
     # Broken substitution is used for `perl/config.pl', which leaves literal

--- a/pkgs/by-name/dr/drill/package.nix
+++ b/pkgs/by-name/dr/drill/package.nix
@@ -24,8 +24,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     pkg-config
   ];
 
-  OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
-  OPENSSL_DIR = "${lib.getDev openssl}";
+  env = {
+    OPENSSL_LIB_DIR = "${lib.getLib openssl}/lib";
+    OPENSSL_DIR = "${lib.getDev openssl}";
+  };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     openssl

--- a/pkgs/by-name/er/ergogen/package.nix
+++ b/pkgs/by-name/er/ergogen/package.nix
@@ -24,7 +24,8 @@ buildNpmPackage (finalAttrs: {
   makeCacheWritable = true;
   dontNpmBuild = true;
   npmPackFlags = [ "--ignore-scripts" ];
-  NODE_OPTIONS = "--openssl-legacy-provider";
+
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   doInstallCheck = true;
   nativeInstallCheckInputs = [ versionCheckHook ];

--- a/pkgs/by-name/er/ergoscf/package.nix
+++ b/pkgs/by-name/er/ergoscf/package.nix
@@ -35,12 +35,14 @@ stdenv.mkDerivation (finalAttrs: {
   env = {
     # Required for compilation with gcc-14
     NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
-    LDFLAGS = "-lblas -llapack";
+    LDFLAGS = toString [
+      "-lblas"
+      "-llapack"
+    ];
+    OMP_NUM_THREADS = 2; # required for check phase
   };
 
   enableParallelBuilding = true;
-
-  OMP_NUM_THREADS = 2; # required for check phase
 
   # With "fortify3", there are test failures, such as:
   # Testing cnof CAMB3LYP/6-31G using FMM

--- a/pkgs/by-name/ho/honeycomb-refinery/package.nix
+++ b/pkgs/by-name/ho/honeycomb-refinery/package.nix
@@ -17,7 +17,7 @@ buildGoModule (finalAttrs: {
     hash = "sha256-JHjjaK5WFRzDYuVkenfYowFsPnrF+Wjo85gQAbaVxO8=";
   };
 
-  NO_REDIS_TEST = true;
+  env.NO_REDIS_TEST = true;
 
   patches = [
     # Allows turning off the one test requiring a Redis service during build.

--- a/pkgs/by-name/is/isso/package.nix
+++ b/pkgs/by-name/is/isso/package.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     npmHooks.npmConfigHook
   ];
 
-  NODE_PATH = "$npmDeps";
+  env.NODE_PATH = "$npmDeps";
 
   preBuild = ''
     ln -s ${finalAttrs.npmDeps}/node_modules ./node_modules

--- a/pkgs/by-name/mi/mirakurun/package.nix
+++ b/pkgs/by-name/mi/mirakurun/package.nix
@@ -37,7 +37,7 @@ buildNpmPackage rec {
   ];
 
   # workaround for https://github.com/webpack/webpack/issues/14532
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   postInstall =
     let

--- a/pkgs/by-name/mk/mktemp/package.nix
+++ b/pkgs/by-name/mk/mktemp/package.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.7";
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
-  NROFF = "${groff}/bin/nroff";
+  env.NROFF = "${groff}/bin/nroff";
 
   patches = [
     # Pull upstream fix for parallel install failures.

--- a/pkgs/by-name/ni/nix-heuristic-gc/package.nix
+++ b/pkgs/by-name/ni/nix-heuristic-gc/package.nix
@@ -20,7 +20,7 @@ python3Packages.buildPythonPackage rec {
 
   # NIX_SYSTEM suggested at
   # https://github.com/NixOS/nixpkgs/issues/386184#issuecomment-2692433531
-  NIX_SYSTEM = nixVersions.nixComponents_2_30.nix-store.stdenv.hostPlatform.system;
+  env.NIX_SYSTEM = nixVersions.nixComponents_2_30.nix-store.stdenv.hostPlatform.system;
 
   buildInputs = [
     boost

--- a/pkgs/by-name/ni/nix-web/package.nix
+++ b/pkgs/by-name/ni/nix-web/package.nix
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoBuildFlags = cargoFlags;
   cargoTestFlags = cargoFlags;
 
-  NIX_WEB_BUILD_NIX_CLI_PATH = "${nixPackage}/bin/nix";
+  env.NIX_WEB_BUILD_NIX_CLI_PATH = "${nixPackage}/bin/nix";
 
   meta = {
     description = "Web interface for the Nix store";

--- a/pkgs/by-name/op/opentabletdriver/package.nix
+++ b/pkgs/by-name/op/opentabletdriver/package.nix
@@ -67,7 +67,7 @@ buildDotnetModule (finalAttrs: {
 
   buildInputs = finalAttrs.runtimeDeps;
 
-  OTD_CONFIGURATIONS = "${finalAttrs.src}/OpenTabletDriver.Configurations/Configurations";
+  env.OTD_CONFIGURATIONS = "${finalAttrs.src}/OpenTabletDriver.Configurations/Configurations";
 
   doCheck = true;
   testProjectFile = "OpenTabletDriver.Tests/OpenTabletDriver.Tests.csproj";

--- a/pkgs/by-name/pr/prisma-engines_7/package.nix
+++ b/pkgs/by-name/pr/prisma-engines_7/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-U5d/HkuWnD/XSrAJr5AYh+WPVGDOcK/e4sC0udPZoyU=";
 
   # Use system openssl.
-  OPENSSL_NO_VENDOR = 1;
+  env.OPENSSL_NO_VENDOR = 1;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/re/readeck/package.nix
+++ b/pkgs/by-name/re/readeck/package.nix
@@ -27,7 +27,7 @@ buildGoModule (finalAttrs: {
 
   npmRoot = "web";
 
-  NODE_PATH = "$npmDeps";
+  env.NODE_PATH = "$npmDeps";
 
   preBuild = ''
     make generate

--- a/pkgs/by-name/se/send/package.nix
+++ b/pkgs/by-name/se/send/package.nix
@@ -28,13 +28,13 @@ buildNpmPackage rec {
 
   env = {
     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = "true";
+
+    NODE_OPTIONS = "--openssl-legacy-provider";
   };
 
   makeCacheWritable = true;
 
   npmPackFlags = [ "--ignore-scripts" ];
-
-  NODE_OPTIONS = "--openssl-legacy-provider";
 
   postInstall = ''
     cp -r dist $out/lib/node_modules/send/

--- a/pkgs/by-name/sh/sharing/package.nix
+++ b/pkgs/by-name/sh/sharing/package.nix
@@ -22,7 +22,7 @@ buildNpmPackage rec {
   # The prepack script runs the build script, which we'd rather do in the build phase.
   npmPackFlags = [ "--ignore-scripts" ];
 
-  NODE_OPTIONS = "--openssl-legacy-provider";
+  env.NODE_OPTIONS = "--openssl-legacy-provider";
 
   meta = {
     description = "Command-line tool to share directories and files to mobile devices";

--- a/pkgs/by-name/sq/squeezelite/package.nix
+++ b/pkgs/by-name/sq/squeezelite/package.nix
@@ -72,23 +72,31 @@ stdenv.mkDerivation {
       --replace "<opusfile.h>" "<opus/opusfile.h>"
   '';
 
-  EXECUTABLE = binName;
+  env = {
+    EXECUTABLE = binName;
 
-  OPTS = [
-    "-DLINKALL"
-    "-DGPIO"
-  ]
-  ++ optional dsdSupport "-DDSD"
-  ++ optional (!faad2Support) "-DNO_FAAD"
-  ++ optional ffmpegSupport "-DFFMPEG"
-  ++ optional opusSupport "-DOPUS"
-  ++ optional portaudioSupport "-DPORTAUDIO"
-  ++ optional pulseSupport "-DPULSEAUDIO"
-  ++ optional resampleSupport "-DRESAMPLE"
-  ++ optional sslSupport "-DUSE_SSL"
-  ++ optional (stdenv.hostPlatform.isAarch32 or stdenv.hostPlatform.isAarch64) "-DRPI";
-
-  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin { LDADD = "-lportaudio -lpthread"; };
+    OPTS = toString (
+      [
+        "-DLINKALL"
+        "-DGPIO"
+      ]
+      ++ optional dsdSupport "-DDSD"
+      ++ optional (!faad2Support) "-DNO_FAAD"
+      ++ optional ffmpegSupport "-DFFMPEG"
+      ++ optional opusSupport "-DOPUS"
+      ++ optional portaudioSupport "-DPORTAUDIO"
+      ++ optional pulseSupport "-DPULSEAUDIO"
+      ++ optional resampleSupport "-DRESAMPLE"
+      ++ optional sslSupport "-DUSE_SSL"
+      ++ optional (stdenv.hostPlatform.isAarch32 or stdenv.hostPlatform.isAarch64) "-DRPI"
+    );
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    LDADD = toString [
+      "-lportaudio"
+      "-lpthread"
+    ];
+  };
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/st/stalwart/webadmin.nix
+++ b/pkgs/by-name/st/stalwart/webadmin.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zip
   ];
 
-  NODE_PATH = "$npmDeps";
+  env.NODE_PATH = "$npmDeps";
 
   buildPhase = ''
     trunk build --offline --frozen --release


### PR DESCRIPTION
Skipped most `NIX_` variables for now, there are still some PRs waiting and some may require special attention.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
