### PR TITLE
dolt: 1.59.10 -> 1.81.2

### DIFF
--- a/pkgs/by-name/do/dolt/package.nix
+++ b/pkgs/by-name/do/dolt/package.nix
@@ -1,25 +1,28 @@
 {
   fetchFromGitHub,
+  icu,
   lib,
   buildGoModule,
 }:
 
 buildGoModule (finalAttrs: {
   pname = "dolt";
-  version = "1.59.10";
+  version = "1.81.2";
 
   src = fetchFromGitHub {
     owner = "dolthub";
     repo = "dolt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DfocUOHpPdNeMcL7kVm7ggm2cVgWp/ifvCFyFosxhcs=";
+    hash = "sha256-dL6WJvApRGC8ADFowms81YbJpLbbTyNQfI/RIotgTdc=";
   };
 
   modRoot = "./go";
   subPackages = [ "cmd/dolt" ];
-  vendorHash = "sha256-yZ+q4KNfIiR2gpk10dpZOMiEN3V/Lk/pzhgaqp7lKag=";
+  vendorHash = "sha256-wufwBlRiRiNVZgkBFRqZIB6vNeWBBaCDdV2tcynhatk=";
   proxyVendor = true;
   doCheck = false;
+
+  buildInputs = [ icu ];
 
   meta = {
     description = "Relational database with version control and CLI a-la Git";


### PR DESCRIPTION
## Description

Add `icu` to `buildInputs` for the dolt package. Since [v1.59.13](https://github.com/dolthub/dolt/releases/tag/v1.59.13), dolt depends on [`dolthub/go-icu-regex`](https://github.com/dolthub/go-icu-regex) which requires ICU C headers (`unicode/uregex.h`) at build time via CGO.

## Motivation

The [nixpkgs-update bot logs](https://nixpkgs-update-logs.nix-community.org/dolt/) show **~21 consecutive weekly update failures** since September 2025, all failing with:

```
unicode/uregex.h: No such file or directory
```

The dolt package has been stuck at v1.59.10 since 2025-09-16, while upstream is now at v1.81.7. This one-line fix unblocks the automated update pipeline.

The ICU dependency was introduced upstream in [dolthub/dolt#8681](https://github.com/dolthub/dolt/pull/8681) (December 2024). Dolt's own CI and Docker builds also require ICU — see their [serverDockerfile](https://github.com/dolthub/dolt/blob/main/docker/serverDockerfile) which installs `libicu-dev`.

## Changes

- Added `icu` to function inputs
- Added `buildInputs = [ icu ];`

No version bump in this PR — the current v1.59.10 builds fine with the extra input (it's a no-op for this version). Once this lands, the nixpkgs-update bot should be able to bump to the latest version in its next cycle.

## Testing

- [ ] Built on x86_64-linux

cc @danbst (listed maintainer)