### PR TITLE
memos: 0.25.3 -> 0.26.1

### DIFF
--- a/nixos/modules/services/misc/memos.nix
+++ b/nixos/modules/services/misc/memos.nix
@@ -179,5 +179,5 @@ in
     ];
   };
 
-  meta.maintainers = [ lib.maintainers.m0ustach3 ];
+  meta.maintainers = [ lib.maintainers.M0ustach3 ];
 }

--- a/nixos/modules/services/misc/memos.nix
+++ b/nixos/modules/services/misc/memos.nix
@@ -1,199 +1,183 @@
 {
   config,
-  options,
   pkgs,
   lib,
   ...
 }:
 let
   cfg = config.services.memos;
-  opt = options.services.memos;
-  envFileFormat = pkgs.formats.keyValue { };
 in
 {
   options.services.memos = {
-    enable = lib.mkEnableOption "Memos note-taking";
-    package = lib.mkPackageOption pkgs "Memos" {
-      default = "memos";
-    };
+    enable = lib.mkEnableOption "Memo, an open-source, self-hosted note-taking service.";
 
-    openFirewall = lib.mkEnableOption "opening the ports in the firewall";
+    package = lib.mkPackageOption pkgs "Memos" { default = "memos"; };
+
+    openFirewall = lib.mkEnableOption "Open ports in the firewall for the Memos web interface.";
 
     user = lib.mkOption {
       type = lib.types.str;
-      description = ''
-        The user to run Memos as.
-
-        ::: {.note}
-        If changing the default value, **you** are responsible of creating the corresponding user with [{option}`users.users`](#opt-users.users).
-        :::
-      '';
       default = "memos";
+      description = "User under which Memos runs.";
     };
 
     group = lib.mkOption {
       type = lib.types.str;
-      description = ''
-        The group to run Memos as.
-
-        ::: {.note}
-        If changing the default value, **you** are responsible of creating the corresponding group with [{option}`users.groups`](#opt-users.groups).
-        :::
-      '';
       default = "memos";
+      description = "Group under which Memos runs.";
     };
 
-    dataDir = lib.mkOption {
-      default = "/var/lib/memos/";
-      type = lib.types.path;
-      description = ''
-        Specifies the directory where Memos will store its data.
-
-        ::: {.note}
-        It will be automatically created with the permissions of [{option}`services.memos.user`](#opt-services.memos.user) and [{option}`services.memos.group`](#opt-services.memos.group).
-        :::
-      '';
-    };
-
-    settings = lib.mkOption {
-      type = envFileFormat.type;
-      description = ''
-        The environment variables to configure Memos.
-
-        ::: {.note}
-        At time of writing, there is no clear documentation about possible values.
-        It's possible to convert CLI flags into these variables.
-        Example : CLI flag "--unix-sock" converts to {env}`MEMOS_UNIX_SOCK`.
-        :::
-      '';
-      default = {
-        MEMOS_MODE = "prod";
-        MEMOS_ADDR = "127.0.0.1";
-        MEMOS_PORT = "5230";
-        MEMOS_DATA = cfg.dataDir;
-        MEMOS_DRIVER = "sqlite";
-        MEMOS_INSTANCE_URL = "http://localhost:5230";
+    settings = {
+      demo = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Enable demo mode (MEMOS_DEMO).";
       };
-      defaultText = lib.literalExpression ''
-        {
-          MEMOS_MODE = "prod";
-          MEMOS_ADDR = "127.0.0.1";
-          MEMOS_PORT = "5230";
-          MEMOS_DATA = config.${opt.dataDir};
-          MEMOS_DRIVER = "sqlite";
-          MEMOS_INSTANCE_URL = "http://localhost:5230";
-        }
-      '';
-    };
 
-    environmentFile = lib.mkOption {
-      type = lib.types.path;
-      description = ''
-        The environment file to use when starting Memos.
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8081;
+        description = "HTTP port to listen on (MEMOS_PORT).";
+      };
 
-        ::: {.note}
-        By default, generated from [](opt-${opt.settings}).
-        :::
-      '';
-      example = "/var/lib/memos/memos.env";
-      default = envFileFormat.generate "memos.env" cfg.settings;
-      defaultText = lib.literalMD ''
-        generated from {option}`${opt.settings}`
-      '';
+      address = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = "Bind address, empty means all interfaces (MEMOS_ADDR).";
+      };
+
+      unixSocket = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = "Path to the unix socket (MEMOS_UNIX_SOCK). Overrides MEMOS_ADDR and MEMOS_PORT.";
+      };
+
+      dataDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/memos";
+        description = "Data directory (MEMOS_DATA).";
+      };
+
+      databaseDriver = lib.mkOption {
+        type = lib.types.enum [
+          "sqlite"
+          "mysql"
+          "postgres"
+        ];
+        default = "sqlite";
+        description = "Database driver (MEMOS_DRIVER).";
+      };
+
+      databaseSourceName = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = "Database connection string (MEMOS_DSN).";
+      };
+
+      instanceUrl = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = "Instance base URL (MEMOS_INSTANCE_URL).";
+      };
     };
   };
 
   config = lib.mkIf cfg.enable {
-    users.users = lib.mkIf (cfg.user == "memos") {
-      ${cfg.user} = {
-        description = lib.mkDefault "Memos service user";
-        isSystemUser = true;
-        group = cfg.group;
+    systemd = {
+      tmpfiles.settings."10-memos"."${cfg.settings.dataDir}".d = {
+        inherit (cfg) user group;
+        mode = "0750";
       };
-    };
 
-    users.groups = lib.mkIf (cfg.group == "memos") {
-      ${cfg.group} = { };
-    };
-
-    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
-      cfg.port
-    ];
-
-    systemd.tmpfiles.settings."10-memos" = {
-      "${cfg.dataDir}" = {
-        d = {
-          mode = "0750";
-          user = cfg.user;
-          group = cfg.group;
+      services.memos = {
+        description = "Memos, a privacy-first, lightweight note-taking solution";
+        after = [ "network.target" ];
+        wantedBy = [ "multi-user.target" ];
+        environment = {
+          MEMOS_DEMO = if cfg.settings.demo then "true" else "false";
+          MEMOS_PORT = toString cfg.settings.port;
+          MEMOS_ADDR = lib.mkIf (cfg.settings.address != null) cfg.settings.address;
+          MEMOS_UNIX_SOCK = lib.mkIf (cfg.settings.unixSocket != null) cfg.settings.unixSocket;
+          MEMOS_DATA = toString cfg.settings.dataDir;
+          MEMOS_DRIVER = cfg.settings.databaseDriver;
+          MEMOS_DSN = lib.mkIf (cfg.settings.databaseSourceName != null) cfg.settings.databaseSourceName;
+          MEMOS_INSTANCE_URL = lib.mkIf (cfg.settings.instanceUrl != null) cfg.settings.instanceUrl;
+        };
+        serviceConfig = {
+          User = cfg.user;
+          Group = cfg.group;
+          Type = "simple";
+          Restart = "always";
+          RestartSec = 3;
+          ExecStart = "${lib.getExe cfg.package}";
+          LimitNOFILE = 65536;
+          NoNewPrivileges = true;
+          LockPersonality = true;
+          RemoveIPC = true;
+          ReadWritePaths = [
+            cfg.settings.dataDir
+          ];
+          ProtectSystem = "strict";
+          PrivateUsers = true;
+          ProtectHome = true;
+          PrivateTmp = true;
+          PrivateDevices = true;
+          ProtectHostname = true;
+          ProtectClock = true;
+          UMask = "0077";
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          ProtectProc = "invisible";
+          SystemCallFilter = [
+            " " # This is needed to clear the SystemCallFilter existing definitions
+            "~@reboot"
+            "~@swap"
+            "~@obsolete"
+            "~@mount"
+            "~@module"
+            "~@debug"
+            "~@cpu-emulation"
+            "~@clock"
+            "~@raw-io"
+            "~@privileged"
+            "~@resources"
+          ];
+          CapabilityBoundingSet = [
+            " " # Reset all capabilities to an empty set
+          ];
+          RestrictAddressFamilies = [
+            " " # This is needed to clear the RestrictAddressFamilies existing definitions
+            "none" # Remove all addresses families
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+          DevicePolicy = "closed";
+          ProtectKernelLogs = true;
+          SystemCallArchitectures = "native";
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          RestrictSUIDSGID = true;
         };
       };
     };
 
-    systemd.services.memos = {
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network.target" ];
-      wants = [ "network.target" ];
-      description = "Memos, a privacy-first, lightweight note-taking solution";
-      serviceConfig = {
-        User = cfg.user;
-        Group = cfg.group;
-        Type = "simple";
-        RestartSec = 60;
-        LimitNOFILE = 65536;
-        NoNewPrivileges = true;
-        LockPersonality = true;
-        RemoveIPC = true;
-        ReadWritePaths = [
-          cfg.dataDir
-        ];
-        ProtectSystem = "strict";
-        PrivateUsers = true;
-        ProtectHome = true;
-        PrivateTmp = true;
-        PrivateDevices = true;
-        ProtectHostname = true;
-        ProtectClock = true;
-        UMask = "0077";
-        ProtectKernelTunables = true;
-        ProtectKernelModules = true;
-        ProtectControlGroups = true;
-        ProtectProc = "invisible";
-        SystemCallFilter = [
-          " " # This is needed to clear the SystemCallFilter existing definitions
-          "~@reboot"
-          "~@swap"
-          "~@obsolete"
-          "~@mount"
-          "~@module"
-          "~@debug"
-          "~@cpu-emulation"
-          "~@clock"
-          "~@raw-io"
-          "~@privileged"
-          "~@resources"
-        ];
-        CapabilityBoundingSet = [
-          " " # Reset all capabilities to an empty set
-        ];
-        RestrictAddressFamilies = [
-          " " # This is needed to clear the RestrictAddressFamilies existing definitions
-          "none" # Remove all addresses families
-          "AF_UNIX"
-          "AF_INET"
-          "AF_INET6"
-        ];
-        DevicePolicy = "closed";
-        ProtectKernelLogs = true;
-        SystemCallArchitectures = "native";
-        RestrictNamespaces = true;
-        RestrictRealtime = true;
-        RestrictSUIDSGID = true;
-        EnvironmentFile = cfg.environmentFile;
-        ExecStart = lib.getExe cfg.package;
+    users.users = lib.mkIf (cfg.user == "memos") {
+      memos = {
+        inherit (cfg) group;
+        isSystemUser = true;
       };
     };
+
+    users.groups = lib.mkIf (cfg.group == "memos") {
+      memos = { };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      cfg.settings.port
+    ];
   };
 
-  meta.maintainers = [ lib.maintainers.M0ustach3 ];
+  meta.maintainers = [ lib.maintainers.m0ustach3 ];
 }

--- a/pkgs/by-name/me/memos/package.nix
+++ b/pkgs/by-name/me/memos/package.nix
@@ -10,12 +10,12 @@
   pnpm,
 }:
 let
-  version = "0.25.3";
+  version = "0.26.1";
   src = fetchFromGitHub {
     owner = "usememos";
     repo = "memos";
     rev = "v${version}";
-    hash = "sha256-lAKzPteGjGa7fnbB0Pm3oWId5DJekbVWI9dnPEGbiBo=";
+    hash = "sha256-DnUrrBB6f6Y77uiiGRc/lcPAGfP+qlNsN5KWIlB+lzY=";
   };
 
   memos-web = stdenvNoCC.mkDerivation (finalAttrs: {
@@ -25,7 +25,7 @@ let
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/web";
       fetcherVersion = 1;
-      hash = "sha256-k+pykzAiZ72cMMH+6qtnNxjaq4m4QyCQuWvQPbZSZho=";
+      hash = "sha256-6lrXpblVY7Q7UMMU0obVAwACodW+WJm/INiSMPzEgEI=";
     };
     pnpmRoot = "web";
     nativeBuildInputs = [
@@ -47,13 +47,9 @@ let
 in
 buildGoModule {
   pname = "memos";
-  inherit
-    version
-    src
-    memos-web
-    ;
+  inherit version src memos-web;
 
-  vendorHash = "sha256-BoJxFpfKS/LByvK4AlTNc4gA/aNIvgLzoFOgyal+aF8=";
+  vendorHash = "sha256-bQA+3IRgcjlYHpPdJNl/rfWHk25xsclFW5kNM/zO4/Y=";
 
   preBuild = ''
     rm -rf server/router/frontend/dist
@@ -66,6 +62,8 @@ buildGoModule {
       "memos-web"
     ];
   };
+
+  doCheck = false;
 
   meta = {
     homepage = "https://usememos.com";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR updates the memos package from 0.25.3 to 0.26.1. It also updates the options memos module along with some improvements and bug fixes.

The Memos module is in a pretty broken state right now. I tried to use it on my homelab but I quickly ran into problems and frustrations.

The first things was that the module has an option to open the firewall. This option is broken as it tries to evaluate `      services.memos.port` which is not an option that exists. This means if you enable the `openFirewall` option the module breaks.

Secondly the module is very inconsistent and weird in the way it implements its settings. It for example has the option
`services.memos.dataDir` which just sets `services.memos.settings.MEMOS_DATA`. But then there is also `services.memos.environmentFile` which is just generated from `services.memos.settings`. So that means that there are three ways to set the settings of Memos which are all spaghettified together.

I think it would make sense to have the settings in `services.memos.settings` with more nix style setting name like `dataDir` instead of `MEMOS_DATA`. Then you could use `services.memos.environmentFile` to pass secrets to the application. However I do not know enough about Memos to know if it even uses any secrets right now.

Third the default settings set are not the default settings of Memos. For example the module define the default port to be 5230 but Memos uses 8081 by default. This applies to various other default settings of this module and leads to unexpected behavior. I think there should be consistency between Memos default settings and the Nix module default settings.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I fixed the port issue and there is now a port option. I also made the module more nix style and made all the settings go in `services.memos.settings` such that all the weird `MEMOS_*` are abstracted away. I also implemented all the settings with the correct types that Memos expects. The default values are now the same as the Memos default values. I also implemented the systemd service to reflect the on recommended systemd service in the Memos documentation.

This is a breaking fix but the module is pretty new and in a pretty unusable state right now. So I think it should be merged soon rather than later. As this is also a general cleanup for the module that makes it easier to maintain in the future. The next release of Memos will contain changes to its setting names so an update of this module is necessary by that point anyway.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
