### PR TITLE
generate-answer-file: init at 2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4211,6 +4211,12 @@
     githubId = 20440897;
     name = "Caique";
   };
+  Cairnstew = {
+    email = "sean.cairnsst@gmail.com";
+    github = "Cairnstew";
+    githubId = 15699393;
+    name = "Sean Cairns";
+  };
   CaitlinDavitt = {
     email = "CaitlinDavitt@gmail.com";
     github = "CaitlinDavitt";

--- a/pkgs/by-name/ge/generate-answer-file/deps.json
+++ b/pkgs/by-name/ge/generate-answer-file/deps.json
@@ -1,0 +1,117 @@
+[
+  {
+    "pname": "coverlet.collector",
+    "version": "6.0.4",
+    "hash": "sha256-ieiUl7G5pVKQ4V6rxhEe0ehep0/u1RBD3EAI63AQTI0="
+  },
+  {
+    "pname": "Microsoft.ApplicationInsights",
+    "version": "2.22.0",
+    "hash": "sha256-mUQ63atpT00r49ca50uZu2YCiLg3yd6r3HzTryqcuEA="
+  },
+  {
+    "pname": "Microsoft.CodeCoverage",
+    "version": "17.13.0",
+    "hash": "sha256-GKrIxeyQo5Az1mztfQgea1kGtJwonnNOrXK/0ULfu8o="
+  },
+  {
+    "pname": "Microsoft.NET.Test.Sdk",
+    "version": "17.13.0",
+    "hash": "sha256-sc2wvyV8cGm1FrNP2GGHEI584RCvRPu15erYCsgw5QY="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.Telemetry",
+    "version": "1.6.3",
+    "hash": "sha256-DVwTXRoWHt8Ybfz1gv/TzmX6VfxaUp9lGghDEoby0dg="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.TrxReport.Abstractions",
+    "version": "1.6.3",
+    "hash": "sha256-gv7aCP029oku6xwYKclY5hI+ewShrk4tVFbDEND4FJI="
+  },
+  {
+    "pname": "Microsoft.Testing.Extensions.VSTestBridge",
+    "version": "1.6.3",
+    "hash": "sha256-4FTZCHdI9WZwd3ejeFCVbx5O0UWLJwKJc6NduUQu0XE="
+  },
+  {
+    "pname": "Microsoft.Testing.Platform",
+    "version": "1.6.3",
+    "hash": "sha256-WJD2zC0b1jU5DRAFG3XmHiQJKdKnjDQB3xbdRmv8V9Q="
+  },
+  {
+    "pname": "Microsoft.Testing.Platform.MSBuild",
+    "version": "1.6.3",
+    "hash": "sha256-JK8l4K4uSO6mgsZ6Lo/Sv4VjaLGZjD5g/oZYy0iAYDs="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.ObjectModel",
+    "version": "17.13.0",
+    "hash": "sha256-6S0fjfj8vA+h6dJVNwLi6oZhYDO/I/6hBZaq2VTW+Uk="
+  },
+  {
+    "pname": "Microsoft.TestPlatform.TestHost",
+    "version": "17.13.0",
+    "hash": "sha256-L/CJzou7dhmShUgXq3aXL3CaLTJll17Q+JY2DBdUUpo="
+  },
+  {
+    "pname": "MSTest.Analyzers",
+    "version": "3.8.3",
+    "hash": "sha256-/Nf6E5zQib741BKu4IwRBz36lW9+krWLy2904MT3O1M="
+  },
+  {
+    "pname": "MSTest.TestAdapter",
+    "version": "3.8.3",
+    "hash": "sha256-pBfg41vnc9z1W2uMuXRUnulGycyXJpBATsBHEiOi9mg="
+  },
+  {
+    "pname": "MSTest.TestFramework",
+    "version": "3.8.3",
+    "hash": "sha256-3dhd6vk2KdMwe+JNSoUZZ4+P04jPKBl3HTuc9ZXBTlw="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "Ookii.BinarySize",
+    "version": "1.2.0",
+    "hash": "sha256-RJh18XANSBanOixPteZZe3m5oBcr4RkLxUlm++jmhWg="
+  },
+  {
+    "pname": "Ookii.CommandLine",
+    "version": "5.0.0",
+    "hash": "sha256-9iSS/YaB+rwChSn0PLUZXiBWDqJ4GyjnETwmemNG8b8="
+  },
+  {
+    "pname": "Ookii.Common",
+    "version": "1.0.0",
+    "hash": "sha256-u8J6JSAOp2gJBsmu9ZjiSgipoXOVpseqtYf38tlnN3g="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "5.0.0",
+    "hash": "sha256-6mW3N6FvcdNH/pB58pl+pFSCGWgyaP4hfVtC/SMWDV4="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "9.0.4",
+    "hash": "sha256-4E3H0n6UloSxvN41xi7hltJb9+hfaFbqwb/eOQOfNsI="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "1.6.0",
+    "hash": "sha256-JJfgaPav7UfEh4yRAQdGhLZF1brr0tUWPl6qmfNWq/E="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
+    "version": "9.0.4",
+    "hash": "sha256-NOxnuUHtLVT+aTaThLSw8UFgF3ViEL/0ZTliM42LnlQ="
+  },
+  {
+    "pname": "System.Text.Json",
+    "version": "9.0.4",
+    "hash": "sha256-oIOqfOIIUXXVkfFiTCI9wwIJBETQqF7ZcOJv2iYuq1s="
+  }
+]

--- a/pkgs/by-name/ge/generate-answer-file/package.nix
+++ b/pkgs/by-name/ge/generate-answer-file/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDotnetModule,
+  dotnetCorePackages,
+}:
+buildDotnetModule {
+  pname = "generate-answer-file";
+  version = "2.2";
+
+  src = fetchFromGitHub {
+    owner = "SvenGroot";
+    repo = "GenerateAnswerFile";
+    rev = "v2.2";
+    hash = "sha256-RWC2VOrt5HCLL56bjdF33+KDGpA14QIlVyxWDYA012k=";
+  };
+
+  sourceRoot = "source/src";
+
+  projectFile = [
+    "GenerateAnswerFile/GenerateAnswerFile.csproj"
+    "Ookii.AnswerFile/Ookii.AnswerFile.csproj"
+  ];
+
+  testProjectFile = "Ookii.AnswerFile.Tests/Ookii.AnswerFile.Tests.csproj";
+
+  dotnet-sdk = dotnetCorePackages.combinePackages [
+    dotnetCorePackages.sdk_8_0
+    dotnetCorePackages.sdk_9_0
+  ];
+  dotnet-runtime = dotnetCorePackages.runtime_9_0;
+
+  dotnetBuildFlags = [ "--framework net9.0" ];
+  dotnetInstallFlags = [ "--framework net9.0" ];
+
+  nugetDeps = ./deps.json;
+
+  meta = {
+    description = "CLI tool to generate answer files for Ookii.CommandLine";
+    homepage = "https://github.com/SvenGroot/GenerateAnswerFile";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Cairnstew ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
This PR adds `generate-answer-file`, a CLI tool for generating answer files for unattended Windows installations. These files are commonly called unattend.xml or autounattend.xml (depending on the installation method used).

GenerateAnswerFile is a .NET tool that creates answer files (similar to response files) containing command-line arguments for applications built with Ookii.CommandLine. This is useful for saving frequently-used argument combinations and simplifying complex command invocations.

Homepage: https://github.com/Cairnstew/GenerateAnswerFile
Source: https://github.com/SvenGroot/GenerateAnswerFile
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test