### PR TITLE
ignition: 2.2.0 -> 2.3.1

### DIFF
--- a/pkgs/by-name/ig/ignition/fix-gjs.patch
+++ b/pkgs/by-name/ig/ignition/fix-gjs.patch
@@ -1,22 +1,24 @@
 diff --git a/src/io.github.flattool.Ignition.in b/src/io.github.flattool.Ignition.in
-index 5c71c3c..0b2ec00 100644
+index 40b474b..e8e5cd7 100755
 --- a/src/io.github.flattool.Ignition.in
 +++ b/src/io.github.flattool.Ignition.in
-@@ -1,7 +1,8 @@
+@@ -1,9 +1,10 @@
 -#!@GJS@ -m
 +#!/usr/bin/env gjs -m
  
- import { exit, programArgs, programInvocationName } from "system";
+ import Gio from "gi://Gio?version=2.0"
+ 
+ import { exit, programArgs, programInvocationName } from "system"
  
 +imports.package._findEffectiveEntryPointName = () => 'io.github.flattool.Ignition';
  imports.package.init({
-   name: "@PACKAGE_NAME@",
-   version: "@PACKAGE_VERSION@",
+        name: "@PACKAGE_NAME@",
+        version: "@VERSION@",
 diff --git a/src/meson.build b/src/meson.build
-index 488fa06..751f8ed 100644
+index dc242fb..7334af7 100644
 --- a/src/meson.build
 +++ b/src/meson.build
-@@ -23,7 +23,6 @@ data_res = gnome.compile_resources('io.github.flattool.Ignition.data',
+@@ -37,7 +37,6 @@ install_subdir(
  )
  
  bin_conf = configuration_data()
@@ -24,3 +26,4 @@ index 488fa06..751f8ed 100644
  bin_conf.set('PACKAGE_VERSION', meson.project_version())
  bin_conf.set('PACKAGE_NAME', meson.project_name())
  bin_conf.set('prefix', get_option('prefix'))
+

--- a/pkgs/by-name/ig/ignition/package.nix
+++ b/pkgs/by-name/ig/ignition/package.nix
@@ -20,14 +20,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ignition";
-  version = "2.2.0";
+  version = "2.3.1";
 
   src = fetchFromGitHub {
     owner = "flattool";
     repo = "ignition";
     tag = finalAttrs.version;
     fetchSubmodules = true;
-    hash = "sha256-GDoF6NcFzMGzvYYoHwSctLlXCqsbfnUFdT9AIGcUkIQ=";
+    hash = "sha256-bkH8nxvqzxzYse7HNRWi79FfuMmLxd/CppKJQk2rTbo=";
   };
 
   patches = [
@@ -57,6 +57,9 @@ stdenv.mkDerivation (finalAttrs: {
     gtk4
     libadwaita
   ];
+
+  # Needed since Jasmine is not in nixpkgs
+  mesonFlags = [ "-Dtests=false" ];
 
   meta = {
     description = "Manage startup apps and scripts";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Updates the ignition package to 2.3.1
Changelog: https://github.com/flattool/ignition/releases/tag/2.3.1
The patch was changed to match the new directory structure. 
Since Jasmine is not in nixpkgs, the tests have to be disabled.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
