### PR TITLE
xdg-user-dirs: re-enable xdg autostart

### DIFF
--- a/pkgs/by-name/xd/xdg-user-dirs/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs/package.nix
@@ -48,6 +48,10 @@ stdenv.mkDerivation (finalAttrs: {
 
     substituteInPlace "$out/lib/systemd/user/xdg-user-dirs.service" \
       --replace-fail "/usr/bin/xdg-user-dirs-update" "$out/bin/xdg-user-dirs-update"
+
+    # Autostart, because the installed service is never explicitly enabled in NixOS
+    substituteInPlace "$out/etc/xdg/autostart/xdg-user-dirs.desktop" \
+      --replace-fail "X-systemd-skip=true" "X-systemd-skip=false"
   '';
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changed desktop entry `X-systemd-skip=true` to `X-systemd-skip=false`.

In the recent [0.18 -> 0.19 update](https://github.com/NixOS/nixpkgs/pull/476704), a new user service `xdg-user-dirs.service` was introduced ([upstream ref](https://gitlab.freedesktop.org/xdg/xdg-user-dirs/-/commit/2a63d3f0ffb76135790bb1168a3270a599904380)). This service is meant to run during session startup.
On NixOS this service is installed but never enabled, and therefore never actually runs.

In the same update, the `xdg-user-dirs.desktop` desktop entry was also changed to include `X-systemd-skip=true`, which causes [systemd-xdg-autostart-generator](https://www.freedesktop.org/software/systemd/man/latest/systemd-xdg-autostart-generator.html) to skip this autostart entry entirely.

This results in `xdg-user-dirs-update` never being run at all, and therefore no user directories are created.
Not a big issue for previous installations, but on fresh systems this may cause headaches for end-users.

With this change, the desktop entry will not be skipped by `systemd-xdg-autostart-generator`, and so the user directories will be created if not already present. Essentially, the previous behavior is restored.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review --package xdg-user-dirs`
Commit: `aeab474bd3a118a239185071fcb516aacbcec6cb`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>xdg-user-dirs</li>
  </ul>
</details>