### PR TITLE
ldmud: fix build, move off of Python310

### DIFF
--- a/pkgs/by-name/ld/ldmud/package.nix
+++ b/pkgs/by-name/ld/ldmud/package.nix
@@ -23,7 +23,7 @@
   tlsSupport ? false,
   openssl,
   pythonSupport ? false,
-  python310,
+  python3,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional postgresSupport libpq
   ++ lib.optional sqliteSupport sqlite
   ++ lib.optional tlsSupport openssl
-  ++ lib.optional pythonSupport python310
+  ++ lib.optional pythonSupport python3
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
   # To support systems without autoconf LD puts its configure.ac in a non-default
@@ -93,6 +93,10 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       export LDFLAGS="$LDFLAGS -L${libiconv}/lib -liconv"
     '';
+
+  env.NIX_CFLAGS_COMPILE =
+    # Required for legacy C code in source
+    "-std=gnu99";
 
   installTargets = [
     "install-driver"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Moved off of Python310 #488818
Fixed build by setting CFLAGS


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
