### PR TITLE
sdl3:  use yad instead of zenity to reduce closure size

### DIFF
--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -38,7 +38,7 @@
   vulkan-loader,
   wayland,
   wayland-scanner,
-  zenity,
+  yad,
   # for passthru.tests
   SDL_compat,
   sdl2-compat,
@@ -92,11 +92,10 @@ stdenv.mkDerivation (finalAttrs: {
       substituteInPlace test/CMakeLists.txt \
         --replace-fail 'set(noninteractive_timeout 10)' 'set(noninteractive_timeout 30)'
     ''
+    # Use `yad` -- gtk3 fork of zenity, to not increase closure size unnecessarily with gtk4
     + lib.optionalString waylandSupport ''
-      substituteInPlace src/dialog/unix/SDL_zenitymessagebox.c \
-        --replace-fail '"zenity"' '"${lib.getExe zenity}"'
-      substituteInPlace src/dialog/unix/SDL_zenitydialog.c \
-        --replace-fail '"zenity"' '"${lib.getExe zenity}"'
+      substituteInPlace src/dialog/unix/{SDL_zenitydialog,SDL_zenitymessagebox}.c \
+        --replace-fail '"zenity"' '"${lib.getExe yad}"'
     ''
     # https://github.com/libsdl-org/SDL/issues/14805
     + lib.optionalString vulkanSupport ''


### PR DESCRIPTION
Use `yad` (gtk3 fork of zenity) to reduce resulting closure size: from 980mb to 765mb.

(libdecor pulling gtk3 anyway, so no furthter growing anyway)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
