### PR TITLE
ollama: fix sandboxed build on darwin

### DIFF
--- a/pkgs/by-name/ol/ollama/package.nix
+++ b/pkgs/by-name/ol/ollama/package.nix
@@ -192,6 +192,7 @@ goBuild (finalAttrs: {
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     rm ml/backend/ggml/ggml_test.go
     rm ml/nn/pooling/pooling_test.go
+    rm model/models/qwen3next/checkpoints_test.go
   '';
 
   overrideModAttrs = (


### PR DESCRIPTION
Ollama fails to build on Darwin, because a test added in version 0.15.5 of Ollama fails to run.

The test failure is caused by the build sandbox preventing access to the Metal compiler service (`MTLCompilerService`). A similar issue was solved [here](https://github.com/NixOS/nixpkgs/commit/275411d99d123478fad2c77b916cf7c886f41d38), also by removing the test. I believe this is the correct cause of action, as the build sandbox should prevent such service access, so the test itself cannot be salvaged.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.