### PR TITLE
picoleaf: init at 1.4.0

### DIFF
--- a/pkgs/by-name/pi/picoleaf/package.nix
+++ b/pkgs/by-name/pi/picoleaf/package.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  stdenv,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "picoleaf";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "tessro";
+    repo = "picoleaf";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-o1REM8Gfv+hJGVlo+c4gYr9U2MiTDwHLAx5SaBAN39s=";
+  };
+
+  vendorHash = "sha256-6/4xKZ/G8kTmQwdYmUOlZNQMJ/I8yThfLYjOPzyhlyQ=";
+
+  meta = {
+    description = "A tiny CLI tool for controlling Nanoleaf";
+    mainProgram = "picoleaf";
+    homepage = "https://github.com/tessro/picoleaf";
+    changelog = "https://github.com/tessro/picoleaf/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sfrijters ];
+  };
+})


### PR DESCRIPTION
https://github.com/tessro/picoleaf

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
