### PR TITLE
spidermonkey: fix 32bit corss-compiling

### DIFF
--- a/pkgs/development/interpreters/spidermonkey/common.nix
+++ b/pkgs/development/interpreters/spidermonkey/common.nix
@@ -68,6 +68,9 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://src.fedoraproject.org/rpms/mozjs140/raw/49492baa47bc1d7b7d5bc738c4c81b4661302f27/f/9aa8b4b051dd539e0fbd5e08040870b3c712a846.patch";
         hash = "sha256-SsyO5g7wlrxE7y2+VTHfmUDamofeZVqge8fv2y0ZhuU=";
       })
+    ]
+    ++ lib.optionals (lib.versionAtLeast version "140" && stdenv.hostPlatform.is32bit) [
+      ./fix-32bit-build.patch
     ];
 
   nativeBuildInputs = [

--- a/pkgs/development/interpreters/spidermonkey/fix-32bit-build.patch
+++ b/pkgs/development/interpreters/spidermonkey/fix-32bit-build.patch
@@ -1,0 +1,11 @@
+--- a/js/src/xsum/xsum.cpp
++++ b/js/src/xsum/xsum.cpp
+@@ -266,7 +266,7 @@
+ 
+   /* At this point, sacc->chunk[u] must be non-zero */
+ 
+-  if (xsum_debug) printf("u: %d, sacc->chunk[u]: %ld", u, sacc->chunk[u]);
++  if (xsum_debug) printf("u: %d, sacc->chunk[u]: %lld", u, sacc->chunk[u]);
+ 
+   /* Carry propagate, starting at the low-order chunks.  Note that the
+      loop limit of u may be increased inside the loop. */


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- tried to cross-compile to armv7l, failed with Werror=format= 
- searched source code for this line causing it
- changed ld → lld in format string to match types on a 32bit system
- added patch file

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-linux → pkgsCross armv7l-hf-multiplatform 
  - [ ] x86_64-darwin (shouldnt be effected at all by this, but i dont have a device for testing)
  - [ ] aarch64-darwin (same as other darwin)
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test