### PR TITLE
zabbix: Multiple Versions

### DIFF
--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -8,8 +8,8 @@ generic: {
     hash = "sha256-twEwY7nGJWoYX25gAe/31DuDGxg6o5Ez1u5STQVw6Fw=";
   };
   v70 = generic {
-    version = "7.0.22";
-    hash = "sha256-enR5SyEkYH2ANr42zBBNoFai+2U4EchKy+KfP22Xhgo=";
+    version = "7.0.23";
+    hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";
   };
   v60 = generic {
     version = "6.0.43";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -12,7 +12,7 @@ generic: {
     hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";
   };
   v60 = generic {
-    version = "6.0.43";
-    hash = "sha256-FsRgW9sd1AYIIUjyz+eM8zV6uJuDdpVS4xfw+MB+HpY=";
+    version = "6.0.44";
+    hash = "sha256-TveW2ofMnm3PXUPwoklTPe48tI6dED/dAQKjwO2P4F4=";
   };
 }

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -3,10 +3,6 @@ generic: {
     version = "7.4.6";
     hash = "sha256-zMGw1psEFzsOeu7KlHi7b11JmccdTtUPgXNRvwEaaYs=";
   };
-  v72 = generic {
-    version = "7.2.15";
-    hash = "sha256-twEwY7nGJWoYX25gAe/31DuDGxg6o5Ez1u5STQVw6Fw=";
-  };
   v70 = generic {
     version = "7.0.23";
     hash = "sha256-Q+pfyx5dsl50vcg+qJNtebgJO2FK9OiJQXSFvHTwYeI=";

--- a/pkgs/servers/monitoring/zabbix/versions.nix
+++ b/pkgs/servers/monitoring/zabbix/versions.nix
@@ -1,7 +1,7 @@
 generic: {
   v74 = generic {
-    version = "7.4.6";
-    hash = "sha256-zMGw1psEFzsOeu7KlHi7b11JmccdTtUPgXNRvwEaaYs=";
+    version = "7.4.7";
+    hash = "sha256-FsOZQv6yg9euoX6Ccfy0/9usBpkVYVjcs3IZZ095m9g=";
   };
   v70 = generic {
     version = "7.0.23";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2354,6 +2354,7 @@ mapAliases {
   youtube-music = lib.warnOnInstantiate "'youtube-music' has been renamed to 'pear-desktop'" pear-desktop; # Added 2025-12-23
   yubikey-manager-qt = throw "'yubikey-manager-qt' has been removed due to being archived upstream. Consider using 'yubioath-flutter' instead."; # Added 2025-06-07
   yubikey-personalization-gui = throw "'yubikey-personalization-gui' has been removed due to being archived upstream. Consider using 'yubioath-flutter' instead."; # Added 2025-06-07
+  zabbix72 = throw "'zabbix72' was removed as it has reached its end of life"; # Added 2026-02-11
   zandronum-alpha = throw "'zandronum-alpha' has been removed as it was broken and the stable version has caught up"; # Added 2025-10-19
   zandronum-alpha-server = throw "'zandronum-alpha-server' has been removed as it was broken and the stable version has caught up"; # Added 2025-10-19
   zashboard = throw "'zashboard' has been removed because upstream repository source code has been deleted"; # Added 2025-12-29

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8808,7 +8808,6 @@ with pkgs;
   };
 
   zabbix74 = recurseIntoAttrs (zabbixFor "v74");
-  zabbix72 = recurseIntoAttrs (zabbixFor "v72");
   zabbix70 = recurseIntoAttrs (zabbixFor "v70");
   zabbix60 = recurseIntoAttrs (zabbixFor "v60");
 


### PR DESCRIPTION
zabbix: 6.0.43 -> 6.0.44
zabbix70: 7.0.22 -> 7.0.23
zabbix74: 7.4.6 -> 7.4.7

Removed zabbix72 as no longer receiving security updates. Users should use 7.4 now

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
