### PR TITLE
maintainers: drop danbst

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5800,12 +5800,6 @@
     name = "Daniil Berendeev";
     keys = [ { fingerprint = "60D7 0EE0 3BD4 A415 B255  1938 6556 0668 006B 4906"; } ];
   };
-  danbst = {
-    email = "abcz2.uprola@gmail.com";
-    github = "danbst";
-    githubId = 743057;
-    name = "Danylo Hlynskyi";
-  };
   danbulant = {
     name = "Daniel Bulant";
     email = "danbulant@gmail.com";

--- a/nixos/modules/services/web-servers/tomcat.nix
+++ b/nixos/modules/services/web-servers/tomcat.nix
@@ -14,7 +14,6 @@ in
 {
   meta = {
     maintainers = with lib.maintainers; [
-      danbst
       anthonyroussel
     ];
   };

--- a/nixos/tests/containers-reloadable.nix
+++ b/nixos/tests/containers-reloadable.nix
@@ -2,7 +2,7 @@
 {
   name = "containers-reloadable";
   meta = {
-    maintainers = with lib.maintainers; [ danbst ];
+    maintainers = [ ];
   };
 
   nodes = {

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -10,7 +10,6 @@
   meta = with pkgs.lib.maintainers; {
     maintainers = [
       mbbx6spp
-      danbst
     ];
   };
 

--- a/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-vtwheel/default.nix
+++ b/pkgs/applications/terminal-emulators/rxvt-unicode-plugins/urxvt-vtwheel/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     description = "Pass mouse wheel commands to secondary screens (screen, less, nano, etc)";
     homepage = "https://aur.archlinux.org/packages/urxvt-vtwheel";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ danbst ];
+    maintainers = [ ];
     platforms = with lib.platforms; unix;
   };
 

--- a/pkgs/by-name/do/dolt/package.nix
+++ b/pkgs/by-name/do/dolt/package.nix
@@ -26,6 +26,6 @@ buildGoModule (finalAttrs: {
     mainProgram = "dolt";
     homepage = "https://github.com/dolthub/dolt";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ danbst ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/to/tortoisehg/package.nix
+++ b/pkgs/by-name/to/tortoisehg/package.nix
@@ -76,7 +76,6 @@ python3Packages.buildPythonApplication {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      danbst
       gbtb
     ];
   };

--- a/pkgs/development/python-modules/iniparse/default.nix
+++ b/pkgs/development/python-modules/iniparse/default.nix
@@ -29,6 +29,6 @@ buildPythonPackage rec {
     description = "Accessing and Modifying INI files";
     homepage = "https://github.com/candlepin/python-iniparse";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ danbst ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/pg_repack.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_repack.nix
@@ -45,7 +45,7 @@ postgresqlBuildExtension (finalAttrs: {
     '';
     homepage = "https://github.com/reorg/pg_repack";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ danbst ];
+    maintainers = [ ];
     inherit (postgresql.meta) platforms;
     mainProgram = "pg_repack";
   };

--- a/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_similarity.nix
@@ -38,6 +38,6 @@ postgresqlBuildExtension {
     '';
     platforms = postgresql.meta.platforms;
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ danbst ];
+    maintainers = [ ];
   };
 }


### PR DESCRIPTION
[No comments since 2020](https://github.com/NixOS/nixpkgs/pulls?q=commenter%3Adanbst) despite [regular review requests](https://github.com/NixOS/nixpkgs/pulls?q=review-requested%3Adanbst+-commenter%3Adanbst+). No GitHub activity since 2023, which - given his mentioned location - is sadly not this surprising. Thus removing his maintainer status as per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md#losing-maintainer-status)

@danbst if you object to being dropped please respond saying so within a week. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
