### PR TITLE
python3Packages.ledger-bitcoin: add missing hidapi dependency

### DIFF
--- a/pkgs/development/python-modules/ledger-bitcoin/default.nix
+++ b/pkgs/development/python-modules/ledger-bitcoin/default.nix
@@ -8,6 +8,7 @@
   bip32,
   coincurve,
   typing-extensions,
+  hidapi,
 }:
 
 buildPythonPackage rec {
@@ -29,6 +30,7 @@ buildPythonPackage rec {
     bip32
     coincurve
     typing-extensions
+    hidapi
   ];
 
   pythonImportsCheck = [ "ledger_bitcoin" ];


### PR DESCRIPTION
Adds `hidapi` as a dependency to the ledger-bitcoin package.

The ledger-bitcoin package includes a btchip submodule that requires the hid module from hidapi for legacy Ledger device support. While upstream declares hidapi as an optional extra, the bundled btchip code imports it directly, causing ImportError when used by applications like Electrum.

The optional dependency is declared here: https://github.com/LedgerHQ/app-bitcoin-new/blob/a29cc918d2217210f35cb43fa35e29c4cd848503/bitcoin_client/setup.cfg#L29

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
