### PR TITLE
dbmail: init at 3.5.5

### DIFF
--- a/pkgs/by-name/db/dbmail/package.nix
+++ b/pkgs/by-name/db/dbmail/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+
+  pkg-config,
+  curlMinimal,
+  glib,
+  gmime3,
+  libevent,
+  libmhash,
+  libxcrypt,
+  libzdb,
+  openssl,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dbmail";
+  version = "3.5.5";
+
+  src = fetchFromGitHub {
+    owner = "dbmail";
+    repo = "dbmail";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-uoK+sj/CQ2CcliQ+vtE9Q3BWVbzpQ5MP8xHVIxe6w2o=";
+  };
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    curlMinimal
+    glib
+    gmime3
+    libmhash
+    libevent
+    libxcrypt
+    libzdb
+    openssl
+  ];
+
+  strictDeps = true;
+  __structuredAttrs = true;
+  enableParallelBuilding = true;
+
+  configureFlags = [ "--with-zdb=${libzdb}" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Highly available Message Delivery Agent using SQL storage";
+    homepage = "https://dbmail.org";
+    downloadPage = "https://github.com/dbmail/dbmail";
+    license = lib.licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    mainProgram = "dbmail-imapd";
+    maintainers = with lib.maintainers; [ maevii ];
+  };
+})


### PR DESCRIPTION
https://dbmail.org
https://github.com/dbmail/dbmail

Probably not going to use this myself, but I feel like it has a place in nixpkgs. Currently nothing else depends on `libzdb`, so it's also useful for making sure that lib works.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
