### PR TITLE
libzdb: 3.4.1 -> 3.5.0, adopt; opendkim: mark insecure, adopt

### DIFF
--- a/pkgs/by-name/li/libzdb/package.nix
+++ b/pkgs/by-name/li/libzdb/package.nix
@@ -1,26 +1,51 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromBitbucket,
+  nix-update-script,
+  autoconf,
+  automake,
+  libtool,
+  re2c,
   sqlite,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "3.4.1";
+  version = "3.5.0";
   pname = "libzdb";
 
-  src = fetchurl {
-    url = "https://www.tildeslash.com/libzdb/dist/libzdb-${finalAttrs.version}.tar.gz";
-    sha256 = "sha256-W0Yz/CoWiA93YZf0BF9i7421Bi9jAw+iIQEdS4XXNss=";
+  src = fetchFromBitbucket {
+    owner = "tildeslash";
+    repo = "libzdb";
+    tag = "release-${lib.replaceString "." "-" finalAttrs.version}";
+    hash = "sha256-fZSTu/BGIFsbEHSB/+2SObb9myg+Iyc1IDxnpv/EEhU=";
   };
 
+  nativeBuildInputs = [
+    autoconf
+    automake
+    libtool
+    re2c
+  ];
   buildInputs = [ sqlite ];
 
+  strictDeps = true;
+
+  preConfigure = "sh ./bootstrap";
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "release-(\\d+)-(\\d+)-(\\d+)"
+    ];
+  };
+
   meta = {
-    homepage = "http://www.tildeslash.com/libzdb/";
     description = "Small, easy to use Open Source Database Connection Pool Library";
-    license = lib.licenses.gpl3;
+    homepage = "http://www.tildeslash.com/libzdb/";
+    downloadPage = "https://bitbucket.org/tildeslash/libzdb/";
+    license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ maevii ];
   };
 })

--- a/pkgs/by-name/op/opendkim/package.nix
+++ b/pkgs/by-name/op/opendkim/package.nix
@@ -2,13 +2,14 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pkg-config,
-  libbsd,
-  openssl,
-  libmilter,
+  nix-update-script,
   autoreconfHook,
-  perl,
+  pkg-config,
   makeWrapper,
+  libbsd,
+  libmilter,
+  openssl,
+  perl,
   unbound,
 }:
 
@@ -19,8 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "trusteddomainproject";
     repo = "OpenDKIM";
-    rev = "rel-opendkim-${lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
-    sha256 = "0nx3in8sa6xna4vfacj8g60hfzk61jpj2ldag80xzxip9c3rd2pw";
+    tag = "rel-opendkim-${lib.replaceString "." "-" finalAttrs.version}";
+    hash = "sha256-/IqWB0s39t8BeqpRIa8MZn4HgXlIMuU2UbYbpZGNo1s=";
   };
 
   configureFlags = [
@@ -49,11 +50,24 @@ stdenv.mkDerivation (finalAttrs: {
       --prefix PATH : ${openssl.bin}/bin
   '';
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=unstable"
+      "--version-regex=rel-opendkim-(\\d+)-(\\d+)-(.*)"
+    ];
+  };
+
   meta = {
     description = "C library for producing DKIM-aware applications and an open source milter for providing DKIM service";
     homepage = "http://www.opendkim.org/";
-    maintainers = [ ];
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
+    mainProgram = "opendkim";
+    knownVulnerabilities = [
+      "CVE-2020-35766: Privilege escalation in test suite"
+      "CVE-2022-48521: Specially crafted e-mails can bypass DKIM signature validation"
+      "Upstream OpenDKIM hasn't been updated in years, and is assumed to be unmaintained. Consider using an alternative such as rspamd."
+    ];
+    maintainers = with lib.maintainers; [ maevii ];
   };
 })


### PR DESCRIPTION
Related for `libzdb`: #489477
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
