### PR TITLE
OVMF: build with -D QEMU_PV_VARS=TRUE

### DIFF
--- a/pkgs/applications/virtualization/OVMF/default.nix
+++ b/pkgs/applications/virtualization/OVMF/default.nix
@@ -142,6 +142,7 @@ edk2.mkDerivation projectDscPath (finalAttrs: {
   buildFlags =
     # IPv6 has no reason to be disabled.
     [ "-D NETWORK_IP6_ENABLE=TRUE" ]
+    ++ [ "-D QEMU_PV_VARS=TRUE" ]
     ++ lib.optionals debug [ "-D DEBUG_ON_SERIAL_PORT=TRUE" ]
     ++ lib.optionals sourceDebug [ "-D SOURCE_DEBUG_ENABLE=TRUE" ]
     ++ lib.optionals secureBoot [ "-D SECURE_BOOT_ENABLE=TRUE" ]


### PR DESCRIPTION
Fixes: #489197

Qemu is moving to a new way of doing UEFI var storage:
Context:
* https://www.qemu.org/docs/master/devel/uefi-vars.html
* https://gitlab.com/qemu-project/edk2/-/blob/master/OvmfPkg/QEMU_PV_VARS.md
* https://gitlab.com/kraxel/virt-firmware-rs/-/blob/main/varstore/README.md?ref_type=heads

This attempts to do so, but the build hangs on `aarch64-linux`.

I suspect this is because of the edk2-var-generator usage inside the derivation:
1. It shouldn't be necessary, if we move to the json var storage.
2. It's... vastly overkill. `virt-firmware` has a python script that can do this, seemingly without running qemu...

So this is a draft, because there's more work/consideration that needs to happen, hopefully from EDK2/OVMF/qemu maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
