### PR TITLE
python3Packages.xai-sdk: init at 1.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30694,4 +30694,11 @@
     name = "Mathias Zhang";
   };
   # keep-sorted end
+
+  aaronsox = {
+    email = "aaronsox23@yahoo.com";
+    github = "aaronsox";
+    githubId = 225702220;
+    name = "Aaron";
+  };
 }

--- a/pkgs/development/python-modules/xai-sdk/default.nix
+++ b/pkgs/development/python-modules/xai-sdk/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  hatchling,
+  hatch-fancy-pypi-readme,
+  grpcio,
+  protobuf,
+  googleapis-common-protos,
+  pydantic,
+  requests,
+  aiohttp,
+  packaging,
+  opentelemetry-sdk,
+  pytestCheckHook,
+  pytest-asyncio,
+  portpicker,
+}:
+
+buildPythonPackage rec {
+  pname = "xai-sdk";
+  version = "1.10.0";
+  pyproject = true;
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    pname = "xai_sdk";
+    inherit version;
+    hash = "sha256-DdtN7zQpS6EVc7Ok792FEEVr4wSxdd26lqHWh7neow4=";
+  };
+
+  nativeBuildInputs = [
+    hatchling
+    hatch-fancy-pypi-readme
+    pytestCheckHook
+  ];
+
+  pythonRelaxDeps = [ "opentelemetry-sdk" ];
+
+  propagatedBuildInputs = [
+    grpcio
+    protobuf
+    googleapis-common-protos
+    pydantic
+    requests
+    aiohttp
+    packaging
+    opentelemetry-sdk
+  ];
+
+  checkInputs = [
+    pytest-asyncio
+    portpicker
+  ];
+
+  pythonImportsCheck = [ "xai_sdk" ];
+
+  meta = with lib; {
+    description = "Official Python SDK for the xAI API (gRPC client)";
+    homepage = "https://github.com/xai-org/xai-sdk-python";
+    changelog = "https://github.com/xai-org/xai-sdk-python/blob/main/CHANGELOG.md";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ aaronsox ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -21764,4 +21764,6 @@ self: super: with self; {
   zxing-cpp = callPackage ../development/python-modules/zxing-cpp { libzxing-cpp = pkgs.zxing-cpp; };
 
   # keep-sorted end
+
+  xai-sdk = callPackage ../development/python-modules/xai-sdk { };
 }


### PR DESCRIPTION
Add the official Python SDK for the xAI API (gRPC-based client).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [x] Ran `nixpkgs-review` on this PR (4 packages built successfully)
  - [x] Package tests enabled and passing (upstream tests run in Nix sandbox)
  - [x] `pythonImportsCheck` passes
- [x] Tested basic functionality of all binary files (no executables in package)
- [x] Fits [CONTRIBUTING.md].

### Details
- Uses `buildPythonPackage` + `hatchling` + `hatch-fancy-pypi-readme`
- `pythonRelaxDepsHook` for `opentelemetry-sdk` (temporary until #489017)
- Disabled for Python < 3.10 per upstream `requires-python`
- Optional OpenTelemetry HTTP/gRPC exporters included

**Upstream**
- [GitHub](https://github.com/xai-org/xai-sdk-python)
- [PyPI](https://pypi.org/project/xai-sdk/)
- [Docs](https://docs.x.ai/docs)

[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md