### PR TITLE
python3Packages.libparse-python: refactor and add updateScript

### DIFF
--- a/pkgs/development/python-modules/libparse-python/package.nix
+++ b/pkgs/development/python-modules/libparse-python/package.nix
@@ -5,9 +5,10 @@
   pytestCheckHook,
   setuptools,
   pybind11,
+  unstableGitUpdater,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "libparse-python";
   version = "0-unstable-2025-08-30";
   pyproject = true;
@@ -38,6 +39,8 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "libparse" ];
 
+  passthru.updateScript = unstableGitUpdater { };
+
   meta = {
     description = "Python library for parsing Yosys output";
     homepage = "https://github.com/librelane/libparse-python";
@@ -45,4 +48,4 @@ buildPythonPackage {
     maintainers = with lib.maintainers; [ gonsolo ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
- Refactor to use finalAttrs for better maintainability.
- Add passthru.updateScript to support automated unstable updates.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
