### PR TITLE
grenedalf: 0.6.2 -> 0.6.3, fix build

### DIFF
--- a/pkgs/by-name/gr/grenedalf/fix-genesis-cmake.patch
+++ b/pkgs/by-name/gr/grenedalf/fix-genesis-cmake.patch
@@ -1,0 +1,16 @@
+diff --git a/libs/genesis/lib/genesis/CMakeLists.txt b/libs/genesis/lib/genesis/CMakeLists.txt
+index 8660c78..caa7618 100644
+--- a/libs/genesis/lib/genesis/CMakeLists.txt
++++ b/libs/genesis/lib/genesis/CMakeLists.txt
+@@ -66,11 +66,6 @@ if(${CMAKE_VERSION} VERSION_GREATER "3.9.0")
+     endif()
+ endif()
+ 
+-# Add htslib as a dependency, so that CMake realizes that it has to be built.
+-IF(GENESIS_USE_HTSLIB)
+-    add_dependencies( genesis_lib_obj htslib )
+-ENDIF()
+-
+ # Same for samtools. Not used at the moment though.
+ # IF(GENESIS_USE_SAMTOOLS)
+ #     add_dependencies( genesis_lib_obj samtools )

--- a/pkgs/by-name/gr/grenedalf/package.nix
+++ b/pkgs/by-name/gr/grenedalf/package.nix
@@ -26,19 +26,30 @@ let
       "--disable-libcurl"
       "--disable-plugins"
     ];
+    # Patches break the build
+    patches = [ ];
   });
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "grenedalf";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "lczech";
     repo = "grenedalf";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-DJ7nZjOvYFQlN/L+S2QcMVvH/M9Dhla4VXl2nxc22m4=";
+    hash = "sha256-RD2WYhGBPJuBmbqrjDqujKj/djnxA5ED/LFmhHYIFyE=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    ./fix-genesis-cmake.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "cmake_minimum_required (VERSION 2.8.12 FATAL_ERROR)" "cmake_minimum_required (VERSION 3.5 FATAL_ERROR)"
+  '';
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Changelog: https://github.com/lczech/grenedalf/releases/tag/v0.6.3
Diff: https://github.com/lczech/grenedalf/compare/v0.6.2...v0.6.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
