### PR TITLE
gitweb: set pname and version, modernize, update

### DIFF
--- a/pkgs/by-name/gi/gitweb/package.nix
+++ b/pkgs/by-name/gi/gitweb/package.nix
@@ -10,18 +10,19 @@ let
   gitwebThemeSrc = fetchFromGitHub {
     owner = "kogakure";
     repo = "gitweb-theme";
-    rev = "049b88e664a359f8ec25dc6f531b7e2aa60dd1a2";
+    rev = "d4cc1792f10dac16dbeee06d7e0902715e4fa51a";
     postFetch = ''
       mkdir -p "$TMPDIR/gitwebTheme"
       mv "$out"/* "$TMPDIR/gitwebTheme/"
       mkdir "$out/static"
       mv "$TMPDIR/gitwebTheme"/* "$out/static/"
     '';
-    sha256 = "17hypq6jvhy6zhh26lp3nyi52npfd5wy5752k6sq0shk4na2acqi";
+    hash = "sha256-+e8ZP8hVGWQsXgyWUd/rF9+GRHNHJLFpOr5nsNIieyo";
   };
 in
 buildEnv {
-  name = "gitweb-${lib.getVersion git}";
+  inherit (git) version;
+  pname = "gitweb";
 
   ignoreCollisions = true;
   paths = lib.optional gitwebTheme gitwebThemeSrc ++ [ "${git}/share/gitweb" ];


### PR DESCRIPTION
Part of #485742

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
