### PR TITLE
command-not-found: enable and default to channel release's dbPath

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -101,6 +101,8 @@
 
 - `nodePackages.browserify` has been removed, as it was unmaintained within nixpkgs.
 
+- `command-not-found` package will be enabled by default if the source of nixpkgs contains the file `programs.sqlite`. This is the case if a nixpkgs tarball from https://channels.nixos.org is used. This usage will also make the database of `command-no-found` stateless.
+
 - `nodePackages.sass` has been removed, as it was unmaintained within nixpkgs.
 
 - All `@tailwindcss` packages in the `nodePackages` set have been removed, as they are libraries that should instead be locked by JS projects that utilize them.

--- a/nixos/modules/programs/command-not-found/command-not-found.nix
+++ b/nixos/modules/programs/command-not-found/command-not-found.nix
@@ -38,8 +38,6 @@ in
         Whether interactive shells should show which Nix package (if
         any) provides a missing command.
 
-        Requires nix-channels to be set and downloaded (sudo nix-channel --update.)
-
         See also nix-index and nix-index-database as an alternative for flakes-based systems.
 
         Additionally, having the env var NIX_AUTO_RUN set will automatically run the matching package, and with NIX_AUTO_RUN_INTERACTIVE it will confirm the package before running.
@@ -47,38 +45,48 @@ in
     };
 
     dbPath = lib.mkOption {
-      default = "/nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite";
       description = ''
-        Absolute path to programs.sqlite.
+        Absolute path to `programs.sqlite`, which contains mappings from binary names to package names.
 
-        By default this file will be provided by your channel
-        (nixexprs.tar.xz).
+        If a nixpkgs tarball from https://channels.nixos.org is used as the source of nixpkgs, this file will be provided and this option be set by default.
+
+        To use the stateful `programs.sqlite` database, set this option to
+        `/nix/var/nix/profiles/per-user/root/channels/nixos/programs.sqlite`.
+        If you do so, you can update it with `sudo nix-channels --update`.
       '';
       type = lib.types.path;
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    programs.bash.interactiveShellInit = ''
-      command_not_found_handle() {
-        '${commandNotFound}/bin/command-not-found' "$@"
-      }
-    '';
+  config = lib.mkMerge [
+    {
+      programs.command-not-found = {
+        enable = lib.mkOptionDefault (builtins.pathExists cfg.dbPath);
+        dbPath = pkgs.path + "/programs.sqlite";
+      };
+    }
 
-    programs.zsh.interactiveShellInit = ''
-      command_not_found_handler() {
-        '${commandNotFound}/bin/command-not-found' "$@"
-      }
-    '';
+    (lib.mkIf cfg.enable {
+      programs.bash.interactiveShellInit = ''
+        command_not_found_handle() {
+          '${commandNotFound}/bin/command-not-found' "$@"
+        }
+      '';
 
-    # NOTE: Fish by itself checks for nixos command-not-found, let's instead makes it explicit.
-    programs.fish.interactiveShellInit = ''
-      function fish_command_not_found
-         "${commandNotFound}/bin/command-not-found" $argv
-      end
-    '';
+      programs.zsh.interactiveShellInit = ''
+        command_not_found_handler() {
+          '${commandNotFound}/bin/command-not-found' "$@"
+        }
+      '';
 
-    environment.systemPackages = [ commandNotFound ];
-  };
+      # NOTE: Fish by itself checks for nixos command-not-found, let's instead makes it explicit.
+      programs.fish.interactiveShellInit = ''
+        function fish_command_not_found
+           "${commandNotFound}/bin/command-not-found" $argv
+        end
+      '';
 
+      environment.systemPackages = [ commandNotFound ];
+    })
+  ];
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

NixOS module "command-not-found" was disabled in #416425 because it didn't integrate out-of-the-box with flakes. This PR resolves this issue by pointing `dbPath` to the programs.sqlite in the nixpkgs sources.

Concretely:
- If you use flakes/npins/niv with channel releases: command-not-found will now work out of the box.
- If you use flakes/npins/niv with non channel releases (e.g. github releases): command-not-found will be disabled by default.
- If you use channels: command-not-found will work as previously, but you need to nixos-rebuild after updating the channel to get the script to point to the new programs.sqlite from the new nixpkgs.

## Implementation details

`programs.command-not-found.dbPath` now points to the database in the nixpkgs source (likely in the store). Only if this database exists, `programs.command-not-found.enable` will default to true. This also guarantees that the script uses the programs.sqlite database of the very same nixpkgs used to evaluate the system, providing more coherent results out-of-the-box.

I tested this by copying a `programs.sqlite` to the root of nixpkgs, similar to a release expression. The fish handler for unknown command builds and works correctly.

If this patch is accepted, we would need to revert #438654 which disables command-not-found for a perl-less build.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
