### PR TITLE
obsidian: to finalAttrs, clean-up

### DIFF
--- a/pkgs/by-name/ob/obsidian/package.nix
+++ b/pkgs/by-name/ob/obsidian/package.nix
@@ -1,19 +1,103 @@
 {
-  stdenv,
+  stdenvNoCC,
   fetchurl,
   lib,
   makeWrapper,
   electron,
   makeDesktopItem,
+  copyDesktopItems,
   imagemagick,
   writeScript,
   _7zz,
   commandLineArgs ? "",
 }:
 let
+  icon = fetchurl {
+    url = "https://obsidian.md/images/obsidian-logo-gradient.svg";
+    hash = "sha256-EZsBuWyZ9zYJh0LDKfRAMTtnY70q6iLK/ggXlplDEoA=";
+  };
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "obsidian";
   version = "1.11.5";
-  appname = "Obsidian";
+
+  src =
+    let
+      filename =
+        if stdenvNoCC.hostPlatform.isDarwin then
+          "Obsidian-${finalAttrs.version}.dmg"
+        else
+          "obsidian-${finalAttrs.version}.tar.gz";
+    in
+    fetchurl {
+      url = "https://github.com/obsidianmd/obsidian-releases/releases/download/v${finalAttrs.version}/${filename}";
+      hash =
+        if stdenvNoCC.hostPlatform.isDarwin then
+          "sha256-5orx4Fbf7t87dPC4lHO205tnLZ5zhtpxKGOIAva9K/Q="
+        else
+          "sha256-j1hMEey5Z0gHkOZTGWdDQL/NKjT7S3qVu3Cpb88Zq68=";
+    };
+
+  sourceRoot = lib.optionalString stdenvNoCC.hostPlatform.isDarwin "Obsidian.app";
+
+  strictDeps = true;
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isLinux [
+    imagemagick
+    copyDesktopItems
+  ]
+  ++ lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    _7zz
+  ];
+
+  installPhase = lib.concatStringsSep "\n" [
+    "runHook preInstall"
+    (lib.optionalString stdenvNoCC.hostPlatform.isLinux ''
+      mkdir -p $out/bin
+
+      makeWrapper ${electron}/bin/electron $out/bin/obsidian \
+        --add-flags $out/share/obsidian/app.asar \
+        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}" \
+        --add-flags ${lib.escapeShellArg commandLineArgs}
+
+      install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
+      install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar
+
+      for size in 16 24 32 48 64 128 256 512; do
+        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+        magick -background none ${icon} -resize "$size"x"$size" $out/share/icons/hicolor/"$size"x"$size"/apps/obsidian.png
+      done
+    '')
+    (lib.optionalString stdenvNoCC.hostPlatform.isDarwin ''
+      mkdir -p $out/{Applications/Obsidian.app,bin}
+      cp -R . $out/Applications/Obsidian.app
+      makeWrapper $out/Applications/Obsidian.app/Contents/MacOS/Obsidian $out/bin/obsidian
+    '')
+    "runHook postInstall"
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "obsidian";
+      desktopName = "Obsidian";
+      comment = "Knowledge base";
+      icon = "obsidian";
+      exec = "obsidian %u";
+      categories = [ "Office" ];
+      mimeTypes = [ "x-scheme-handler/obsidian" ];
+    })
+  ];
+
+  passthru.updateScript = writeScript "updater" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p curl jq common-updater-scripts
+    set -eu -o pipefail
+    latestVersion="$(curl -sS https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json | jq -r '.latestVersion')"
+    update-source-version obsidian "$latestVersion"
+  '';
+
   meta = {
     description = "Powerful knowledge base that works on top of a local folder of plain text Markdown files";
     homepage = "https://obsidian.md";
@@ -36,93 +120,4 @@ let
       "aarch64-darwin"
     ];
   };
-
-  filename =
-    if stdenv.hostPlatform.isDarwin then "Obsidian-${version}.dmg" else "obsidian-${version}.tar.gz";
-  src = fetchurl {
-    url = "https://github.com/obsidianmd/obsidian-releases/releases/download/v${version}/${filename}";
-    hash =
-      if stdenv.hostPlatform.isDarwin then
-        "sha256-5orx4Fbf7t87dPC4lHO205tnLZ5zhtpxKGOIAva9K/Q="
-      else
-        "sha256-j1hMEey5Z0gHkOZTGWdDQL/NKjT7S3qVu3Cpb88Zq68=";
-  };
-
-  icon = fetchurl {
-    url = "https://obsidian.md/images/obsidian-logo-gradient.svg";
-    hash = "sha256-EZsBuWyZ9zYJh0LDKfRAMTtnY70q6iLK/ggXlplDEoA=";
-  };
-
-  desktopItem = makeDesktopItem {
-    name = "obsidian";
-    desktopName = "Obsidian";
-    comment = "Knowledge base";
-    icon = "obsidian";
-    exec = "obsidian %u";
-    categories = [ "Office" ];
-    mimeTypes = [ "x-scheme-handler/obsidian" ];
-  };
-
-  linux = stdenv.mkDerivation {
-    inherit
-      pname
-      version
-      src
-      desktopItem
-      icon
-      meta
-      ;
-    nativeBuildInputs = [
-      makeWrapper
-      imagemagick
-    ];
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/bin
-      makeWrapper ${electron}/bin/electron $out/bin/obsidian \
-        --add-flags $out/share/obsidian/app.asar \
-        --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform=wayland --enable-wayland-ime=true --wayland-text-input-version=3}}" \
-        --add-flags ${lib.escapeShellArg commandLineArgs}
-      install -m 444 -D resources/app.asar $out/share/obsidian/app.asar
-      install -m 444 -D resources/obsidian.asar $out/share/obsidian/obsidian.asar
-      install -m 444 -D "${desktopItem}/share/applications/"* \
-        -t $out/share/applications/
-      for size in 16 24 32 48 64 128 256 512; do
-        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
-        magick -background none ${icon} -resize "$size"x"$size" $out/share/icons/hicolor/"$size"x"$size"/apps/obsidian.png
-      done
-      runHook postInstall
-    '';
-
-    passthru.updateScript = writeScript "updater" ''
-      #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl jq common-updater-scripts
-      set -eu -o pipefail
-      latestVersion="$(curl -sS https://raw.githubusercontent.com/obsidianmd/obsidian-releases/master/desktop-releases.json | jq -r '.latestVersion')"
-      update-source-version obsidian "$latestVersion"
-    '';
-  };
-
-  darwin = stdenv.mkDerivation {
-    inherit
-      pname
-      version
-      src
-      appname
-      meta
-      ;
-    sourceRoot = "${appname}.app";
-    nativeBuildInputs = [
-      makeWrapper
-      _7zz
-    ];
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/{Applications/${appname}.app,bin}
-      cp -R . $out/Applications/${appname}.app
-      makeWrapper $out/Applications/${appname}.app/Contents/MacOS/${appname} $out/bin/${pname}
-      runHook postInstall
-    '';
-  };
-in
-if stdenv.hostPlatform.isDarwin then darwin else linux
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Refactors the derivation to `finalAttrs` 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
