### PR TITLE
dazel: migrate to by-name and modernize

### DIFF
--- a/pkgs/by-name/da/dazel/package.nix
+++ b/pkgs/by-name/da/dazel/package.nix
@@ -3,7 +3,7 @@
   python3Packages,
   fetchPypi,
 }:
-python3Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication (finalAttrs: {
   pname = "dazel";
   version = "0.0.43";
   pyproject = true;
@@ -13,7 +13,7 @@ python3Packages.buildPythonApplication rec {
   ];
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-2enQRKg4CAPGHte02io+EfiW9AmuP3Qi41vNQeChg+8=";
   };
 
@@ -25,4 +25,4 @@ python3Packages.buildPythonApplication rec {
       malt3
     ];
   };
-}
+})

--- a/pkgs/by-name/da/dazel/package.nix
+++ b/pkgs/by-name/da/dazel/package.nix
@@ -1,15 +1,16 @@
 {
   lib,
-  buildPythonApplication,
+  python3Packages,
   fetchPypi,
-  setuptools,
 }:
-buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "dazel";
   version = "0.0.43";
   pyproject = true;
 
-  build-system = [ setuptools ];
+  build-system = [
+    python3Packages.setuptools
+  ];
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1468,8 +1468,6 @@ with pkgs;
 
   inherit (cue) writeCueValidator;
 
-  dazel = python3Packages.callPackage ../development/tools/dazel { };
-
   detect-secrets = with python3Packages; toPythonApplication detect-secrets;
 
   deterministic-host-uname = deterministic-uname.override {


### PR DESCRIPTION
This pull request refactors the packaging of the `dazel` Python application to align with the new package structure and modern Nix conventions. The most important changes include renaming and relocating the package, updating the build process to use `python3Packages`, and removing the old package reference from the top-level package list.

Packaging refactor:

* Renamed and moved the `dazel` package from `pkgs/development/tools/dazel/default.nix` to `pkgs/by-name/da/dazel/package.nix`, following the new naming and directory conventions.
* Updated the build process to use `python3Packages.buildPythonApplication` and `python3Packages.setuptools` instead of the older `buildPythonApplication` and direct `setuptools` reference, improving compatibility and maintainability. 

Top-level package list update:

* Removed the old reference to `dazel` from `pkgs/top-level/all-packages.nix`, reflecting the package's migration and preventing duplicate or outdated entries.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
