### PR TITLE
axel: migrate to by-name, modernize

### DIFF
--- a/pkgs/by-name/ax/axel/package.nix
+++ b/pkgs/by-name/ax/axel/package.nix
@@ -10,15 +10,15 @@
   txt2man,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "axel";
   version = "2.17.14";
 
   src = fetchFromGitHub {
     owner = "axel-download-accelerator";
-    repo = pname;
-    rev = "v${version}";
-    sha256 = "sha256-5GUna5k8GhAx1Xe8n9IvXT7IO6gksxCLh+sMANlxTBM=";
+    repo = "axel";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-5GUna5k8GhAx1Xe8n9IvXT7IO6gksxCLh+sMANlxTBM=";
   };
 
   postPatch = ''
@@ -53,4 +53,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl2Plus;
     mainProgram = "axel";
   };
-}
+})

--- a/pkgs/by-name/ax/axel/package.nix
+++ b/pkgs/by-name/ax/axel/package.nix
@@ -6,7 +6,7 @@
   autoconf-archive,
   pkg-config,
   gettext,
-  libssl,
+  openssl,
   txt2man,
 }:
 
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     gettext
-    libssl
+    openssl
   ];
 
   installFlags = [ "ETCDIR=${placeholder "out"}/etc" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1559,10 +1559,6 @@ with pkgs;
     withLibdnssdCompat = true;
   };
 
-  axel = callPackage ../tools/networking/axel {
-    libssl = openssl;
-  };
-
   babelfish = callPackage ../shells/fish/babelfish.nix { };
 
   bat-extras = recurseIntoAttrs (lib.makeScope newScope (import ../tools/misc/bat-extras));


### PR DESCRIPTION
This pull request reorganizes the `axel` package and updates its dependencies to improve maintainability and consistency. The package definition has been moved and renamed, and the dependency on `libssl` has been replaced with `openssl`. Additionally, the package expression has been updated to follow modern conventions.

Package restructuring and modernization:

* Renamed and moved the `axel` package from `pkgs/tools/networking/axel/default.nix` to `pkgs/by-name/ax/axel/package.nix`, aligning it with the new package organization scheme.
* Updated the package expression to use the `finalAttrs` argument style instead of `rec`, modernizing the Nix expression.

Dependency updates:

* Replaced the `libssl` dependency with `openssl` in both the `buildInputs` and the package call, ensuring compatibility and consistency with other packages.

Repository source improvements:

* Changed the GitHub source fetch to use `repo = "axel"` and `tag = "v${finalAttrs.version}"` for improved clarity and accuracy.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
