### PR TITLE
nsd: fix withSystemd = false config, add myself as maintainer

### DIFF
--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-+ezCz3m6UFgPLfYpGO/EQAhMW/EQV9tEwZqpZDzUteg=";
   };
 
-  nativeBuildInputs = lib.optionals withSystemd [
+  nativeBuildInputs = [
     pkg-config
   ];
 

--- a/pkgs/by-name/ns/nsd/package.nix
+++ b/pkgs/by-name/ns/nsd/package.nix
@@ -90,5 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Authoritative only, high performance, simple and open source name server";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ ruuda ];
   };
 })


### PR DESCRIPTION
## Things done

Without this, when setting `withSystemd = false` on x86_64-linux, the configure step fails:

```
       > checking for SSL_CTX_set_security_level... yes
       > checking for ERR_load_SSL_strings... yes
       > checking if ERR_load_SSL_strings is deprecated... no
       > checking for pkg-config... no
       > configure: error: pkg-config not found
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
