### PR TITLE
cups-brother-dcpl2550dw: init at 4.0.0-1

### DIFF
--- a/pkgs/by-name/cu/cups-brother-dcpl2550dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcpl2550dw/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  perl,
+  gnused,
+  ghostscript,
+  file,
+  coreutils,
+  gnugrep,
+  which,
+}:
+
+let
+  arches = [
+    "x86_64"
+    "i686"
+    "armv7l"
+  ];
+
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+
+stdenv.mkDerivation rec {
+  pname = "cups-brother-dcpl2550dw";
+  version = "4.0.0-1";
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103577/dcpl2550dwpdrv-${version}.i386.deb";
+    hash = "sha256-gGW8KDXlmYSMxvI29pfXd/lusg4rd4HaXiGkbBnUuQY=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    # delete unnecessary files for the current architecture
+  ''
+  + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/DCPL2550DW/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches)
+  + ''
+
+    # bundled scripts don't understand the arch subdirectories for some reason
+    ln -s \
+      "$out/opt/brother/Printers/DCPL2550DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+      "$out/opt/brother/Printers/DCPL2550DW/lpd/"
+
+    # Fix global references and replace auto discovery mechanism with hardcoded values
+    substituteInPlace $out/opt/brother/Printers/DCPL2550DW/lpd/lpdfilter \
+      --replace-fail /opt "$out/opt" \
+      --replace-fail "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/DCPL2550DW\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"DCPL2550DW\"; #"
+
+    # Make sure all executables have the necessary runtime dependencies available
+    find "$out" -executable -and -type f | while read file; do
+      wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+    done
+
+    # Symlink filter and ppd into a location where CUPS will discover it
+    mkdir -p $out/lib/cups/filter
+    mkdir -p $out/share/cups/model
+
+    ln -s \
+      $out/opt/brother/Printers/DCPL2550DW/lpd/lpdfilter \
+      $out/lib/cups/filter/brother_lpdwrapper_DCPL2550DW
+
+    ln -s \
+      $out/opt/brother/Printers/DCPL2550DW/cupswrapper/brother-DCPL2550DW-cups-en.ppd \
+      $out/share/cups/model/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother DCP-L2550DW printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = map (arch: "${arch}-linux") arches;
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=us&lang=en&prod=dcpl2550dw_us_as&os=128";
+    maintainers = with lib.maintainers; [ typedrat ];
+  };
+}


### PR DESCRIPTION
Add CUPS driver for the Brother DLP-L2550DW monochrome laser multi-function printer.

Follows the same pattern as other Brother CUPS drivers in nixpkgs (e.g., `cups-brother-hll2350dw`, `cups-brother-mfcl2750dw`).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
