### PR TITLE
overturemaps: 0.17.0 -> 0.19.0

### DIFF
--- a/pkgs/by-name/ov/overturemaps/package.nix
+++ b/pkgs/by-name/ov/overturemaps/package.nix
@@ -6,21 +6,27 @@
 
 python3Packages.buildPythonPackage rec {
   pname = "overturemaps";
-  version = "0.17.0";
+  version = "0.19.0";
   pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-s8/yV3eneSsQgK8vJqhEBoidgLurz84XgS7qiuLWOEQ=";
+    hash = "sha256-y91x+S6YKBldy7OWIXCJQ5HuR3KrFRdfBkfMmkaeXy8=";
   };
 
-  build-system = with python3Packages; [ poetry-core ];
+  nativeBuildInputs = with python3Packages; [
+    hatchling
+  ];
 
   dependencies = with python3Packages; [
     click
+    geopandas
+    numpy
     pyarrow
     shapely
   ];
+
+  pythonImportsCheck = [ "overturemaps" ];
 
   meta = {
     description = "Official command-line tool of the Overture Maps Foundation";


### PR DESCRIPTION
Update to [overturemaps v0.19.0](https://github.com/OvertureMaps/overturemaps-py/releases/tag/v0.19.0).

This update includes some changes to the project dependencies and a switch to a different build system (uv, hatchling).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
