### PR TITLE
prometheus-bind-exporter: 0.7.0 -> 0.8.0, bind: add json_c support

### DIFF
--- a/nixos/modules/services/monitoring/prometheus/exporters/bind.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/bind.nix
@@ -17,7 +17,7 @@ in
       type = types.str;
       default = "http://localhost:8053/";
       description = ''
-        HTTP XML API address of an Bind server.
+        HTTP API address of a BIND server.
       '';
     };
     bindTimeout = mkOption {
@@ -29,13 +29,14 @@ in
     };
     bindVersion = mkOption {
       type = types.enum [
-        "xml.v2"
+        "json"
+        "xml"
         "xml.v3"
         "auto"
       ];
-      default = "auto";
+      default = "json";
       description = ''
-        BIND statistics version. Can be detected automatically.
+        BIND statistics version. Defaults to JSON.
       '';
     };
     bindGroups = mkOption {

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -108,7 +108,7 @@ let
           wait_for_unit("prometheus-bind-exporter.service")
           wait_for_open_port(9119)
           succeed(
-              "curl -sSf http://localhost:9119/metrics | grep 'bind_query_recursions_total 0'"
+              "curl -sSf http://localhost:9119/metrics | grep 'bind_up 1'"
           )
         '';
       };

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -9,6 +9,7 @@
   libidn2,
   libtool,
   libxml2,
+  json_c,
   openssl,
   liburcu,
   libuv,
@@ -59,6 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     libidn2
     libtool
     libxml2
+    json_c
     openssl
     liburcu
     libuv

--- a/pkgs/by-name/pr/prometheus-bind-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-bind-exporter/package.nix
@@ -7,16 +7,16 @@
 
 buildGoModule rec {
   pname = "bind_exporter";
-  version = "0.7.0";
+  version = "0.8.0";
 
   src = fetchFromGitHub {
     rev = "v${version}";
     owner = "prometheus-community";
     repo = "bind_exporter";
-    sha256 = "sha256-x/XGatlXCKo9cI92JzFItApsjuZAfZX+8IZRpy7PVUo=";
+    sha256 = "sha256-r1P+zy3iMgPmfvIBgycW8KS0gfNOxCT9YMmHdeY4uXA=";
   };
 
-  vendorHash = "sha256-f0ei/zotOj5ebURAOWUox/7J3jS2abQ5UgjninI9nRk=";
+  vendorHash = "sha256-/fPj5LOe3QdnVPdtYdaqtnGMJ7/SZ458mpvjwO8TxEI=";
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) bind; };
 


### PR DESCRIPTION
## Summary

Updates prometheus-bind-exporter to 0.8.0. This requires adding `json_c` to BIND for JSON statistics support, updating the NixOS module options, and fixing the test.

Closes #354165

### Commits

1. **bind: add json_c for JSON statistics channel support**
   - bind_exporter 0.8.0 defaults to JSON stats, requiring BIND to have json-c support
   - Without this, BIND returns 404 for `/json/v1/server` requests

2. **prometheus-bind-exporter: 0.7.0 -> 0.8.0**
   - https://github.com/prometheus-community/bind_exporter/releases/tag/v0.8.0
   - [CHANGE] Drop XML statistics v2 support
   - [CHANGE] Deprecate collection of task stats by default
   - [CHANGE] Update logging library
   - [ENHANCEMENT] Add metric `rpz_rewrites`
   - [BUGFIX] Make log level configurable via command-line flag

3. **nixos/prometheus-exporters/bind: update for bind_exporter 0.8.0**
   - Change default `bindVersion` from `auto` to `json` (new upstream default)
   - Add `json` and `xml` to `bindVersion` enum options
   - Remove deprecated `xml.v2` option (dropped in 0.8.0)

4. **nixosTests.prometheus-exporters.bind: check bind_up metric**
   - Check `bind_up 1` instead of `bind_query_recursions_total 0`
   - The latter is not emitted when there are no recursive queries

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test