### PR TITLE
ocamlPackages: disable auto update for extlib-1-7-7 and luv

### DIFF
--- a/pkgs/development/ocaml-modules/extlib/1.7.7.nix
+++ b/pkgs/development/ocaml-modules/extlib/1.7.7.nix
@@ -1,3 +1,4 @@
+# nixpkgs-update: no auto update
 # Older version of extlib for Haxe 4.0 and 4.1.
 # May be replaceable by the next extlib + extlib-base64 release.
 {

--- a/pkgs/development/ocaml-modules/luv/default.nix
+++ b/pkgs/development/ocaml-modules/luv/default.nix
@@ -1,3 +1,5 @@
+# nixpkgs-update: no auto update
+# haxe depends on specific version of luv
 {
   lib,
   buildDunePackage,


### PR DESCRIPTION
Disable nixpkgs-update auto updates for two OCaml packages:

- **ocamlPackages.extlib-1-7-7**: versioned attribute that should not be updated
- **ocamlPackages.luv**: haxe depends on specific version of luv

Closes https://github.com/NixOS/nixpkgs/pull/294917
Closes https://github.com/NixOS/nixpkgs/pull/307255