### PR TITLE
python3Packages.cffconvert: 2.0.0-unstable-2024-02-12 -> 2.0.0-unstable-2024-04-19

### DIFF
--- a/pkgs/development/python-modules/cffconvert/default.nix
+++ b/pkgs/development/python-modules/cffconvert/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "cffconvert";
-  version = "2.0.0-unstable-2024-02-12";
+  version = "2.0.0-unstable-2024-04-19";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "citation-file-format";
     repo = "cffconvert";
-    rev = "5295f87c0e261da61a7b919fc754e3a77edd98a7";
-    hash = "sha256-/2qhWVNylrqPSf1KmuZQahzq+YH860cohVSfJsDm1BE=";
+    rev = "b6045d78aac9e02b039703b030588d54d53262ac";
+    hash = "sha256-zgH9q/Jj/AFoTqi9GJQognngIKtzPvYSWJWVsBdL6xg=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/cffconvert/default.nix
+++ b/pkgs/development/python-modules/cffconvert/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  nix-update-script,
   setuptools,
   click,
   requests,
@@ -45,6 +46,10 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "cffconvert" ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = {
     changelog = "https://github.com/citation-file-format/cffconvert/blob/${src.rev}/CHANGELOG.md";


### PR DESCRIPTION
Update cffconvert to latest unstable commit and add nix-update-script for future updates.

Closes https://github.com/NixOS/nixpkgs/pull/435940

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test