### PR TITLE
mpvScripts.mpv-sub-select: init at 0-unstable-2025-04-04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15393,6 +15393,13 @@
     name = "Bernardo Meurer";
     keys = [ { fingerprint = "F193 7596 57D5 6DA4 CCD4  786B F4C0 D53B 8D14 C246"; } ];
   };
+  lovistovis = {
+    email = "love.lysell.berglund@gmail.com";
+    github = "lovistovis";
+    githubId = 64896699;
+    name = "Love Lysell Berglund";
+    keys = [ { fingerprint = "7958 2B47 1D85 3CC9 A3FB  30D5 7B54 D564 D46D 9880"; } ];
+  };
   lowfatcomputing = {
     email = "andreas.wagner@lowfatcomputing.org";
     github = "lowfatcomputing";

--- a/pkgs/by-name/mp/mpv/scripts/mpv-sub-select.nix
+++ b/pkgs/by-name/mp/mpv/scripts/mpv-sub-select.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildLua,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+buildLua (finalAttrs: {
+  pname = "mpv-sub-select";
+  version = "0-unstable-2025-04-04";
+
+  scriptPath = "sub-select.lua";
+  src = fetchFromGitHub {
+    owner = "CogentRedTester";
+    repo = "mpv-sub-select";
+    rev = "26d24a0fd1d69988eaedda6056a2c87d0a55b6cb";
+    hash = "sha256-+eVga4b7KIBnfrtmlgq/0HNjQVS3SK6YWVXCPvOeOOc=";
+  };
+
+  postPatch = ''
+    # changes default sub-select.json search location
+    substituteInPlace sub-select.lua \
+      --replace-fail '~~/script-opts' '${placeholder "out"}/share/mpv/script-opts'
+  '';
+
+  postInstall = ''
+    mkdir '${placeholder "out"}/share/mpv/script-opts'
+    cp sub-select.json '${placeholder "out"}/share/mpv/script-opts'
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "An advanced conditional subtitle track selector for mpv player";
+    homepage = "https://github.com/CogentRedTester/mpv-sub-select";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ lovistovis ];
+  };
+})


### PR DESCRIPTION
# Description of changes
Add new derivation mpvScripts.mpv-sub-select with myself as contributor

## Notes
Usage requires a config file at `~/.config/mpv/scripts-opts/sub-select.json`. This location can be changed using home-manager with `programs.mpv.scriptsOpts.sub_select.config = "path/to/config/dir/"`. The upstream project contains a default `sub-select.json`. Should this be placed at the default location somehow or is that up to home-manager/equivalent?

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (has no binaries)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
