### PR TITLE
python3Packages.qcs-api-client-common: 0.11.8 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/qcs-api-client-common/default.nix
+++ b/pkgs/development/python-modules/qcs-api-client-common/default.nix
@@ -9,7 +9,6 @@
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
-  pythonAtLeast,
   rustc,
   rustPlatform,
   syrupy,
@@ -17,22 +16,19 @@
 
 buildPythonPackage rec {
   pname = "qcs-api-client-common";
-  version = "0.11.8";
+  version = "0.15.0";
   pyproject = true;
-
-  # error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
-  disabled = pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "rigetti";
     repo = "qcs-api-client-rust";
     tag = "common/v${version}";
-    hash = "sha256-IJaclIGuLWyTaVnnK1MblSZjIqjaMjLCFfY1CLn6Rao=";
+    hash = "sha256-ksB71Vd9PbKAHll2Y5VrCspsyUyhXwthHl2yVl6MQ7U=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-luLg4VR7Nwm6g1UYckKmN9iy1MvNezYh9g21ADMX/yU=";
+    hash = "sha256-QvMeCzpHGMVjqYs0i3gpzY6Zk4rGiXyTopzaQMLWBcA=";
   };
 
   buildAndTestSubdir = "qcs-api-client-common";
@@ -52,8 +48,6 @@ buildPythonPackage rec {
 
   preCheck = ''
     cd ${buildAndTestSubdir}
-    # import from $out
-    rm -r qcs_api_client_common
   '';
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/qcs-sdk-python/default.nix
+++ b/pkgs/development/python-modules/qcs-sdk-python/default.nix
@@ -7,6 +7,7 @@
   opentelemetry-sdk,
   pytest-asyncio,
   pytestCheckHook,
+  pythonAtLeast,
   qcs-api-client-common,
   quil,
   rustPlatform,
@@ -17,6 +18,9 @@ buildPythonPackage rec {
   pname = "qcs-sdk-python";
   version = "0.21.22";
   pyproject = true;
+
+  # error: the configured Python interpreter version (3.13) is newer than PyO3's maximum supported version (3.12)
+  disabled = pythonAtLeast "3.13";
 
   src = fetchFromGitHub {
     owner = "rigetti";


### PR DESCRIPTION
Diff: https://github.com/rigetti/qcs-api-client-rust/compare/common/v0.11.8...common/v0.15.0

Changelog: https://github.com/rigetti/qcs-api-client-rust/blob/common/v0.15.0/qcs-api-client-common/CHANGELOG-py.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
