### PR TITLE
squashfs-tools: rename from squashfsTools, enable structuredAttrs

### DIFF
--- a/doc/build-helpers/images/portableservice.section.md
+++ b/doc/build-helpers/images/portableservice.section.md
@@ -68,7 +68,7 @@ See [](#ex-portableService-hello) to understand how to use the output of `portab
 
 : Allows you to override the package that provides {manpage}`mksquashfs(1)`, which is used internally by `portableService`.
 
-  _Default value:_ `pkgs.squashfsTools`.
+  _Default value:_ `pkgs.squashfs-tools`.
 
 `squash-compression` (String; _optional_)
 

--- a/nixos/lib/make-iso9660-image.nix
+++ b/nixos/lib/make-iso9660-image.nix
@@ -6,7 +6,7 @@
   xorriso,
   syslinux,
   libossp_uuid,
-  squashfsTools,
+  squashfs-tools,
 
   # The file name of the resulting ISO image.
   isoName ? "cd.iso",

--- a/nixos/lib/make-squashfs.nix
+++ b/nixos/lib/make-squashfs.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  squashfsTools,
+  squashfs-tools,
   closureInfo,
 
   fileName ? "squashfs",
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   # to the closure that was used to build it
   unsafeDiscardReferences.out = true;
 
-  nativeBuildInputs = [ squashfsTools ];
+  nativeBuildInputs = [ squashfs-tools ];
 
   buildCommand = ''
     closureInfo=${closureInfo { rootPaths = storeContents; }}

--- a/nixos/modules/image/repart-image.nix
+++ b/nixos/modules/image/repart-image.nix
@@ -17,7 +17,7 @@
   dosfstools,
   mtools,
   e2fsprogs,
-  squashfsTools,
+  squashfs-tools,
   erofs-utils,
   btrfs-progs,
   xfsprogs,
@@ -104,7 +104,7 @@ let
       mtools
     ];
     "ext4" = [ e2fsprogs.bin ];
-    "squashfs" = [ squashfsTools ];
+    "squashfs" = [ squashfs-tools ];
     "erofs" = [ erofs-utils ];
     "btrfs" = [ btrfs-progs ];
     "xfs" = [ xfsprogs ];

--- a/nixos/modules/virtualisation/incus.nix
+++ b/nixos/modules/virtualisation/incus.nix
@@ -61,7 +61,7 @@ let
       rsync
       skopeo
       squashfs-tools-ng
-      squashfsTools
+      squashfs-tools
       sshfs
       swtpm
       systemd

--- a/nixos/tests/non-default-filesystems.nix
+++ b/nixos/tests/non-default-filesystems.nix
@@ -179,7 +179,7 @@ with pkgs.lib;
           f.write("squashfs")
 
         subprocess.run([
-          "${pkgs.squashfsTools}/bin/mksquashfs",
+          "${pkgs.squashfs-tools}/bin/mksquashfs",
           "filesystem",
           "${fsImage}",
         ])

--- a/nixos/tests/rauc.nix
+++ b/nixos/tests/rauc.nix
@@ -44,7 +44,7 @@
         runtimeInputs = with pkgs; [
           config.services.rauc.package
           e2fsprogs
-          squashfsTools
+          squashfs-tools
         ];
 
         text = ''

--- a/pkgs/applications/virtualization/singularity/generic.nix
+++ b/pkgs/applications/virtualization/singularity/generic.nix
@@ -41,7 +41,7 @@
   # This is for nvidia-container-cli
   nvidia-docker,
   openssl,
-  squashfsTools,
+  squashfs-tools,
   squashfuse,
   # Test dependencies
   singularity-tools,
@@ -143,7 +143,7 @@ in
     gpgme
     libuuid
     openssl
-    squashfsTools # Required at build time by SingularityCE
+    squashfs-tools # Required at build time by SingularityCE
   ]
   # Optional dependencies.
   # Formatting: Optional dependencies are likely to increase.
@@ -179,7 +179,7 @@ in
     fuse2fs # Mount ext3 filesystems
     go
     mount # mount
-    squashfsTools # mksquashfs unsquashfs # Make / unpack squashfs image
+    squashfs-tools # mksquashfs unsquashfs # Make / unpack squashfs image
     squashfuse # squashfuse_ll squashfuse # Mount (without unpacking) a squashfs image without privileges
   ]
   ++ lib.optional enableNvidiaContainerCli nvidia-docker;

--- a/pkgs/build-support/appimage/default.nix
+++ b/pkgs/build-support/appimage/default.nix
@@ -6,7 +6,7 @@
   gawk,
   libarchive,
   pv,
-  squashfsTools,
+  squashfs-tools,
   buildFHSEnv,
   replaceVarsWith,
   runtimeShell,
@@ -27,7 +27,7 @@ rec {
         gawk
         libarchive
         pv
-        squashfsTools
+        squashfs-tools
       ];
     };
   };

--- a/pkgs/build-support/portable-service/default.nix
+++ b/pkgs/build-support/portable-service/default.nix
@@ -38,7 +38,7 @@
   contents ? [ ],
 
   # mksquashfs options
-  squashfsTools ? pkgs.squashfsTools,
+  squashfsTools ? pkgs.squashfs-tools,
   squash-compression ? "xz -Xdict-size 100%",
   squash-block-size ? "1M",
 }:

--- a/pkgs/by-name/bl/bluemail/package.nix
+++ b/pkgs/by-name/bl/bluemail/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchurl,
-  squashfsTools,
+  squashfs-tools,
   autoPatchelfHook,
   copyDesktopItems,
   pango,
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
     copyDesktopItems
     makeWrapper
-    squashfsTools
+    squashfs-tools
     wrapGAppsHook3
   ];
 

--- a/pkgs/by-name/ca/cargo-bundle/package.nix
+++ b/pkgs/by-name/ca/cargo-bundle/package.nix
@@ -7,7 +7,7 @@
   libxkbcommon,
   wayland,
   openssl,
-  squashfsTools,
+  squashfs-tools,
   makeBinaryWrapper,
   versionCheckHook,
   nix-update-script,
@@ -42,7 +42,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   # squashfs tools are needed to build appimages for Linux
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     wrapProgram $out/bin/cargo-bundle \
-      --prefix PATH : ${lib.makeBinPath [ squashfsTools ]}
+      --prefix PATH : ${lib.makeBinPath [ squashfs-tools ]}
   '';
 
   doInstallCheck = true;

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -66,7 +66,7 @@
   R,
   sng,
   sqlite,
-  squashfsTools,
+  squashfs-tools,
   systemdUkify,
   tcpdump,
   ubootTools,
@@ -188,7 +188,7 @@ python.pkgs.buildPythonApplication rec {
       pgpdump
       sng
       sqlite
-      squashfsTools
+      squashfs-tools
       unzip
       xxd
       xz

--- a/pkgs/by-name/di/distrobuilder/package.nix
+++ b/pkgs/by-name/di/distrobuilder/package.nix
@@ -13,7 +13,7 @@
   nix-update-script,
   nixosTests,
   pkg-config,
-  squashfsTools,
+  squashfs-tools,
   stdenv,
   wimlib,
 }:
@@ -24,7 +24,7 @@ let
     debootstrap
     gnupg
     gnutar
-    squashfsTools
+    squashfs-tools
   ]
   ++ lib.optionals stdenv.hostPlatform.isx86_64 [
     # repack-windows deps

--- a/pkgs/by-name/dr/dracut/package.nix
+++ b/pkgs/by-name/dr/dracut/package.nix
@@ -22,7 +22,7 @@
   gzip,
   lz4,
   lzop,
-  squashfsTools,
+  squashfs-tools,
   util-linux,
   xz,
   zstd,
@@ -111,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
         gzip
         lz4
         lzop
-        squashfsTools
+        squashfs-tools
         util-linux
         xz
         zstd

--- a/pkgs/by-name/du/dumpyara/package.nix
+++ b/pkgs/by-name/du/dumpyara/package.nix
@@ -10,7 +10,7 @@
   cpio,
   dumpyara,
   erofs-utils,
-  squashfsTools,
+  squashfs-tools,
   zip,
 }:
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -56,7 +56,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
           nativeBuildInputs = [
             android-tools
             dumpyara
-            squashfsTools
+            squashfs-tools
             zip
           ];
         }

--- a/pkgs/by-name/ge/gearlever/package.nix
+++ b/pkgs/by-name/ge/gearlever/package.nix
@@ -18,7 +18,7 @@
   bintools,
   libnotify,
   dwarfs,
-  squashfsTools,
+  squashfs-tools,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -86,7 +86,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
         bintools # readelf
         libnotify # notify-send
         dwarfs # dwarfsextract, dwarfsck
-        squashfsTools # unsquashfs
+        squashfs-tools # unsquashfs
       ]
     }"
   ];

--- a/pkgs/by-name/he/hey-mail/package.nix
+++ b/pkgs/by-name/he/hey-mail/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  squashfsTools,
+  squashfs-tools,
   makeWrapper,
   autoPatchelfHook,
   c-ares,
@@ -101,7 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    squashfsTools
+    squashfs-tools
     makeWrapper
     autoPatchelfHook
     wrapGAppsHook3

--- a/pkgs/by-name/no/nordpass/package.nix
+++ b/pkgs/by-name/no/nordpass/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  squashfsTools,
+  squashfs-tools,
   libxtst,
   libxscrnsaver,
   libxrender,
@@ -112,7 +112,7 @@ let
       hash = "sha256-t78kbKVI9WAhL1+1qZ4tJWXUoXhXUCuUYobbbm09peA=";
     };
 
-    nativeBuildInputs = [ squashfsTools ];
+    nativeBuildInputs = [ squashfs-tools ];
 
     dontStrip = true;
     dontPatchELF = true;

--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -18,7 +18,7 @@
   makeShellWrapper,
   minizip,
   nss,
-  squashfsTools,
+  squashfs-tools,
   stdenv,
   writeShellScript,
   xkeyboard_config,
@@ -73,7 +73,7 @@ let
     nativeBuildInputs = [
       autoPatchelfHook
       makeShellWrapper
-      squashfsTools
+      squashfs-tools
     ];
 
     buildInputs = [

--- a/pkgs/by-name/pl/plex-htpc/package.nix
+++ b/pkgs/by-name/pl/plex-htpc/package.nix
@@ -16,7 +16,7 @@
   makeShellWrapper,
   minizip,
   nss,
-  squashfsTools,
+  squashfs-tools,
   stdenv,
   writeShellScript,
   xkeyboard_config,
@@ -62,7 +62,7 @@ let
     nativeBuildInputs = [
       autoPatchelfHook
       makeShellWrapper
-      squashfsTools
+      squashfs-tools
     ];
 
     buildInputs = [

--- a/pkgs/by-name/sp/spotify/linux.nix
+++ b/pkgs/by-name/sp/spotify/linux.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  squashfsTools,
+  squashfs-tools,
   libxtst,
   libxscrnsaver,
   libxrender,
@@ -150,7 +150,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     wrapGAppsHook3
     makeShellWrapper
-    squashfsTools
+    squashfs-tools
   ];
 
   dontStrip = true;

--- a/pkgs/by-name/sq/squashfs-tools/package.nix
+++ b/pkgs/by-name/sq/squashfs-tools/package.nix
@@ -14,8 +14,10 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "squashfs";
+  pname = "squashfs-tools";
   version = "4.7.5";
+
+  __structuredAttrs = true;
 
   src = fetchFromGitHub {
     owner = "plougher";

--- a/pkgs/by-name/te/termius/package.nix
+++ b/pkgs/by-name/te/termius/package.nix
@@ -1,6 +1,6 @@
 {
   autoPatchelfHook,
-  squashfsTools,
+  squashfs-tools,
   alsa-lib,
   fetchurl,
   makeDesktopItem,
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   # TODO: migrate off autoPatchelfHook and use nixpkgs' electron
   nativeBuildInputs = [
     autoPatchelfHook
-    squashfsTools
+    squashfs-tools
     makeWrapper
     wrapGAppsHook3
   ];

--- a/pkgs/by-name/tk/tk-safe/package.nix
+++ b/pkgs/by-name/tk/tk-safe/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchurl,
-  squashfsTools,
+  squashfs-tools,
   autoPatchelfHook,
   copyDesktopItems,
   alsa-lib,
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
     autoPatchelfHook
     copyDesktopItems
     makeWrapper
-    squashfsTools
+    squashfs-tools
     wrapGAppsHook3
   ];
 

--- a/pkgs/by-name/tr/tradingview/package.nix
+++ b/pkgs/by-name/tr/tradingview/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   autoPatchelfHook,
-  squashfsTools,
+  squashfs-tools,
   makeBinaryWrapper,
   alsa-lib,
   atk,
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoPatchelfHook
     makeBinaryWrapper
-    squashfsTools
+    squashfs-tools
   ];
 
   buildInputs = [

--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/package.nix
@@ -1,7 +1,7 @@
 {
   fetchurl,
   lib,
-  squashfsTools,
+  squashfs-tools,
   stdenv,
 }:
 
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = sources."${stdenv.hostPlatform.system}";
 
-  buildInputs = [ squashfsTools ];
+  buildInputs = [ squashfs-tools ];
 
   unpackPhase = ''
     unsquashfs -dest . $src

--- a/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
+++ b/pkgs/by-name/vi/vivaldi-ffmpeg-codecs/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p gawk common-updater-scripts coreutils jq squashfsTools
+#!nix-shell -i bash -p gawk common-updater-scripts coreutils jq squashfs-tools
 
 set -eu -o pipefail
 

--- a/pkgs/by-name/wi/widevine-cdm/aarch64-linux.nix
+++ b/pkgs/by-name/wi/widevine-cdm/aarch64-linux.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   fetchFromGitHub,
-  squashfsTools,
+  squashfs-tools,
   python3,
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    squashfsTools
+    squashfs-tools
     python3
   ];
 

--- a/pkgs/by-name/xa/xapp-thumbnailers/package.nix
+++ b/pkgs/by-name/xa/xapp-thumbnailers/package.nix
@@ -12,7 +12,7 @@
   dcraw,
   gimp,
   libjxl,
-  squashfsTools,
+  squashfs-tools,
 
   # Exclude "raw" for now because dcraw is vulnerable.
   enabledThumbnailers ? [
@@ -95,7 +95,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   preFixup =
     let
       runtimeBinPackages =
-        lib.optional (builtins.elem "appimage" enabledThumbnailers) squashfsTools
+        lib.optional (builtins.elem "appimage" enabledThumbnailers) squashfs-tools
         ++ lib.optional (builtins.elem "gimp" enabledThumbnailers) gimp
         ++ lib.optional (builtins.elem "jxl" enabledThumbnailers) libjxl
         ++ lib.optional (builtins.elem "raw" enabledThumbnailers) dcraw;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -2318,6 +2318,7 @@ mapAliases {
   springLobby = throw "springLobby has been removed, as it had been broken since 2023"; # Added 2025-09-16
   sqlar = throw "'sqlar' has been removed, as it is umaintained upstream, and depends on fuse2. Consider using the sqlite builtin VACUUM";
   sqlbag = throw "sqlbag has been removed because it has been marked as broken since May 2024."; # Added 2025-10-11
+  squashfsTools = squashfs-tools; # Added 2026-07-05
   squirreldisk = throw "'squirreldisk' has been removed as it depended on webkitgtk 4.0"; # Added 2026-06-07
   src = throw "The \"src\" package has been renamed to \"simple-revision-control\". If you encounter this error and did not intend to use that package you may have a falsely constructed overlay."; # Added 2025-11-19
   ssh-ashkpass-fullscreen = throw "'ssh-askpass-fullscreen' has been removed as it depended on the deprecated GTK2 engine."; # Added 2026-08-03


### PR DESCRIPTION
upstream package is called squashfs-tools and other distros also call the package this way https://repology.org/project/squashfs-tools


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
