### PR TITLE
simpledbus: rename from simpleDBus, correct license

### DIFF
--- a/pkgs/by-name/si/simpledbus/package.nix
+++ b/pkgs/by-name/si/simpledbus/package.nix
@@ -40,7 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "C++ wrapper for libdbus-1";
     homepage = "https://github.com/OpenBluetoothToolbox/SimpleBLE";
-    license = lib.licenses.gpl3Only;
+    # SimpleBLE (which SimpleDBus is part of) is under the Business Source License 1.1 (BUSL-1.1)
+    # since version 0.9.0
+    license = lib.licenses.bsl11;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ aciceri ];
   };

--- a/pkgs/by-name/si/simpledbus/package.nix
+++ b/pkgs/by-name/si/simpledbus/package.nix
@@ -8,7 +8,7 @@
   lib,
 }:
 stdenv.mkDerivation (finalAttrs: {
-  pname = "simpleDBus";
+  pname = "simpledbus";
 
   version = "0.10.4";
 

--- a/pkgs/by-name/zm/zmkBATx/package.nix
+++ b/pkgs/by-name/zm/zmkBATx/package.nix
@@ -6,7 +6,7 @@
   pkg-config,
   dbus,
   simpleBluez,
-  simpleDBus,
+  simpledbus,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "zmkBATx";
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
     qt6.qtconnectivity
     dbus.lib
     simpleBluez
-    simpleDBus
+    simpledbus
   ];
 
   postPatch = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1702,6 +1702,7 @@ mapAliases {
   siduck76-st = throw "'siduck76-st' has been renamed to/replaced by 'st-snazzy'"; # Converted to throw 2025-10-27
   sierra-breeze-enhanced = throw "'sierra-breeze-enhanced' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20
   signal-desktop-source = throw "'signal-desktop-source' has been renamed to/replaced by 'signal-desktop'"; # Converted to throw 2025-10-27
+  simpleDBus = warnAlias "'simpleDBus' has been renamed to 'simpledbus'" simpledbus; # Added 2026-02-12
   simplesamlphp = throw "'simplesamlphp' was removed because it was unmaintained in nixpkgs"; # Added 2025-10-17
   sioclient = throw "'sioclient' has been removed as it is no longer used by freedv, and doesn't build with newer asio"; # Added 2025-12-03
   siproxd = throw "'siproxd' has been removed as it was unmaintained and incompatible with newer libosip versions"; # Added 2025-05-18


### PR DESCRIPTION
rename to lowercase to fit package naming conventions

see https://github.com/simpleble/simpleble/releases/tag/v0.9.0 for license change


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
