### PR TITLE
pcmciautils: rename from pcmciaUtils

### DIFF
--- a/nixos/modules/hardware/pcmcia.nix
+++ b/nixos/modules/hardware/pcmcia.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  pcmciaUtils = pkgs.pcmciaUtils.overrideAttrs {
+  pcmciautils = pkgs.pcmciautils.overrideAttrs {
     inherit (config.hardware.pcmcia) firmware config;
   };
 in
@@ -48,9 +48,9 @@ in
 
     boot.kernelModules = [ "pcmcia" ];
 
-    services.udev.packages = [ pcmciaUtils ];
+    services.udev.packages = [ pcmciautils ];
 
-    environment.systemPackages = [ pcmciaUtils ];
+    environment.systemPackages = [ pcmciautils ];
 
   };
 

--- a/pkgs/by-name/pc/pcmciautils/package.nix
+++ b/pkgs/by-name/pc/pcmciautils/package.nix
@@ -9,8 +9,9 @@
   kmod,
   udev,
   udevCheckHook,
-  firmware ? config.pcmciaUtils.firmware or [ ], # Special pcmcia cards.
-  configOpts ? config.pcmciaUtils.config or null, # Special hardware (map memory & port & irq)
+  # config.pcmciaUtils as backwards compat for renamed package
+  firmware ? config.pcmcia-utils.firmware or config.pcmciaUtils.firmware or [ ], # Special pcmcia cards.
+  configOpts ? config.pcmcia-utils.config or config.pcmciaUtils.config or null, # Special hardware (map memory & port & irq)
 }: # used to generate postInstall script.
 
 # FIXME: should add an option to choose between hotplug and udev.

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1473,6 +1473,7 @@ mapAliases {
   patchelfStable = throw "'patchelfStable' has been renamed to/replaced by 'patchelf'"; # Converted to throw 2025-10-27
   path-of-building = lib.warnOnInstantiate "'path-of-building' has been replaced by 'rusty-path-of-building'" rusty-path-of-building; # Added 2025-10-30
   paup = throw "'paup' has been renamed to/replaced by 'paup-cli'"; # Converted to throw 2025-10-27
+  pcmciaUtils = warnAlias "'pcmciaUtils' has been renamed to 'pcmciautils'" pcmciautils; # Added 2026-02-12
   pcp = throw "'pcp' has been removed because the upstream repo was archived and it hasn't been updated since 2021"; # Added 2025-09-23
   pcre16 = throw "'pcre16' has been removed because it is obsolete. Consider migrating to 'pcre2' instead."; # Added 2025-05-29
   pcsctools = throw "'pcsctools' has been renamed to/replaced by 'pcsc-tools'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
fit attrname to pname


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
