### PR TITLE
fstl: install desktop entry

### DIFF
--- a/pkgs/by-name/fs/fstl/package.nix
+++ b/pkgs/by-name/fs/fstl/package.nix
@@ -4,15 +4,23 @@
   fetchFromGitHub,
   cmake,
   libsForQt5,
+  xdg-utils,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fstl";
   version = "0.11.1";
 
+  postPatch = ''
+    patchShebangs --build xdg/xdg_install.sh
+    substituteInPlace xdg/fstlapp-fstl.desktop \
+      --replace-fail 'Exec=fstl' 'Exec=${placeholder "out"}/bin/fstl'
+  '';
+
   nativeBuildInputs = [
     cmake
     libsForQt5.wrapQtAppsHook
+    xdg-utils
   ];
 
   installPhase = lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -22,6 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
     mv fstl.app $out/Applications
 
     runHook postInstall
+  '';
+
+  postInstall = ''
+    env --chdir ../xdg XDG_DATA_HOME=$out/share ./xdg_install.sh fstl
   '';
 
   src = fetchFromGitHub {


### PR DESCRIPTION
Result:

```console
$ find "$(nix-build '<nixpkgs>' --attr 'fstl')" -type 'f'
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/bin/fstl
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/bin/.fstl-wrapped
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/applications/fstlapp-fstl.desktop
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/icons/hicolor/16x16/apps/fstlapp-fstl.png
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/icons/hicolor/22x22/apps/fstlapp-fstl.png
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/icons/hicolor/32x32/apps/fstlapp-fstl.png
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/icons/hicolor/48x48/apps/fstlapp-fstl.png
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/icons/hicolor/64x64/apps/fstlapp-fstl.png
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/icons/hicolor/128x128/apps/fstlapp-fstl.png
/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/share/icons/hicolor/256x256/apps/fstlapp-fstl.png
$ cat "$(nix-build '<nixpkgs>' --attr 'fstl')/share/applications/fstlapp-fstl.desktop"
[Desktop Entry]
Name=fstl
GenericName=Fast STL Viewer
Exec=/nix/store/ihk63shjdrp7gr83gnrm4av0fvgakjnf-fstl-0.11.1/bin/fstl %U
Terminal=false
Icon=fstlapp-fstl
Type=Application
MimeType=model/stl;
Categories=Utility;
$ xdg-mime query default 'model/stl'
fstlapp-fstl.desktop
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
