### PR TITLE
nixos/go-avahi-cname: init

### DIFF
--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -62,6 +62,24 @@
   "module-boot-plymouth-tpm2-totp-quick-start-enable": [
     "index.html#module-boot-plymouth-tpm2-totp-quick-start-enable"
   ],
+  "module-services-go-avahi-cname": [
+    "index.html#module-services-go-avahi-cname"
+  ],
+  "module-services-go-avahi-cname-configuration": [
+    "index.html#module-services-go-avahi-cname-configuration"
+  ],
+  "module-services-go-avahi-cname-configuration-basic-implementation": [
+    "index.html#module-services-go-avahi-cname-configuration-basic-implementation"
+  ],
+  "module-services-go-avahi-cname-configuration-mode": [
+    "index.html#module-services-go-avahi-cname-configuration-mode"
+  ],
+  "module-services-go-avahi-cname-configuration-prerequisites": [
+    "index.html#module-services-go-avahi-cname-configuration-prerequisites"
+  ],
+  "module-services-go-avahi-cname-motivation": [
+    "index.html#module-services-go-avahi-cname-motivation"
+  ],
   "module-services-keycloak-unix-socket": [
     "index.html#module-services-keycloak-unix-socket"
   ],

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -38,6 +38,8 @@
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.
 
+- [go-avahi-cname](https://github.com/grishy/go-avahi-cname), a multicast DNS publisher of subdomains via CNAME records. Available as [services.go-avahi-cname](#opt-services.go-avahi-cname.enable).
+
 - [Stump](https://www.stumpapp.dev/), a free and open source comics, manga and digital book server with OPDS support. Available as [services.stump](#opt-services.stump.enable).
 
 - [Freescout](https://freescout.net/), a free, open source Helpdesk and shared mailbox. Available as [services.freescout](#opt-services.freescout.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1234,6 +1234,7 @@
   ./services/networking/gns3-server.nix
   ./services/networking/gnunet.nix
   ./services/networking/go-autoconfig.nix
+  ./services/networking/go-avahi-cname.nix
   ./services/networking/go-camo.nix
   ./services/networking/go-neb.nix
   ./services/networking/go-shadowsocks2.nix

--- a/nixos/modules/services/networking/go-avahi-cname.md
+++ b/nixos/modules/services/networking/go-avahi-cname.md
@@ -1,0 +1,64 @@
+# go-avahi-cname {#module-services-go-avahi-cname}
+
+[go-avahi-cname](https://github.com/grishy/go-avahi-cname) allows you to publish CNAME records that point to your local host via the multicast DNS (mDNS) service provided by `avahi-daemon`.
+
+## Motivation {#module-services-go-avahi-cname-motivation}
+
+The use of a mDNS service, such as `avahi`, allows for device-to-device communication via domain names without having to use a centralised DNS server.
+However, the [RFC](https://datatracker.ietf.org/doc/html/rfc6762) for mDNS does not provide delegation of subdomains like traditional DNS does.
+In short, `hostname.local` will work over mDNS whereas `subdomain.hostname.local` will not.
+The program [go-avahi-cname](https://github.com/grishy/go-avahi-cname) enables subdomains over mDNS for a list of specified subdomains.
+
+This service, `services.go-avahi-cname`, provides a background implementation of the program, with a module based interface.
+
+## Configuration {#module-services-go-avahi-cname-configuration}
+
+### Mode {#module-services-go-avahi-cname-configuration-mode}
+
+The service supports two modes: `interval-publishing` and `subdomain-reply`.
+Only one mode can be active at any one time.
+Set the mode by configuring `services.go-avahi-cname.mode` with the desired value.
+
+In `interval-publishing` mode, the service will periodically broadcast CNAME records for the subdomains to the local network.
+In `subdomain-reply` mode, the service listens for mDNS requests and responds with the corresponding hostname.
+For example, a request for `git.hostname.local` will be resolved to `hostname.local`.
+
+### Prerequisites {#module-services-go-avahi-cname-configuration-prerequisites}
+
+The service requires that the `avahi` service be enabled with publishing of user services and the (full) mDNS NSS plug-in active.
+Additionally, the contents of the `mdns.allow` file should be set to allow for the request to have in excess of two labels, as discussed [here](https://github.com/avahi/nss-mdns/tree/master#etcmdnsallow).
+This provides the system mDNS implementation.
+
+```nix
+{
+  services.avahi = {
+    enable = true;
+    nssmdns4 = true;
+    nssmdnsFull = true;
+    openFirewall = true;
+    publish = {
+      enable = true;
+      userServices = true;
+    };
+  };
+
+  environment.etc."mdns.allow".text = ''
+    .local.
+    .local
+  '';
+}
+```
+
+### Basic Implementation {#module-services-go-avahi-cname-configuration-basic-implementation}
+
+This example enables the service in `interval-publishing` mode for a single subdomain `git`, which will resolve to `<hostname>.local` on your local network.
+
+```nix
+{
+  services.go-avahi-cname = {
+    enable = true;
+    mode = "interval-publishing";
+    subdomains = [ "git" ];
+  };
+}
+```

--- a/nixos/modules/services/networking/go-avahi-cname.nix
+++ b/nixos/modules/services/networking/go-avahi-cname.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.go-avahi-cname;
+in
+{
+  options.services.go-avahi-cname = {
+    enable = lib.mkEnableOption "go-avahi-cname";
+
+    package = lib.mkPackageOption pkgs "go-avahi-cname" { };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      example = true;
+      description = "Whether debug mode should be enabled.";
+    };
+
+    mode = lib.mkOption {
+      type = lib.types.enum [
+        "interval-publishing"
+        "subdomain-reply"
+      ];
+      default = "subdomain-reply";
+      example = "interval-publishing";
+      description = ''
+        The mode of operation for the mDNS subdomain publisher.
+
+        - "subdomain-reply": Responds to the incoming DNS queries for subdomains
+          (e.g. `name.hostname.local`) with a CNAME pointing to the base domain.
+
+        - "interval-publishing": Periodically broadcasts CNAME records for the
+          specified subdomains to the network using mDNS.
+      '';
+    };
+
+    ttl = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 600;
+      example = 300;
+      description = "The Time to Live (TTL) of the CNAME records in seconds.";
+    };
+
+    fqdn = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.networking.hostName}.local.";
+      defaultText = lib.literalExpression "<config.networking.hostName>.local";
+      example = "printer.local.";
+      description = "The Fully Qualified Domain Name (FQDN) that is used for the CNAME record.";
+    };
+
+    interval = lib.mkOption {
+      type = lib.types.ints.positive;
+      default = 300;
+      example = 150;
+      description = ''
+        The period in seconds to publish CNAME records to the network.
+        Only used when the mode is set to "interval-publishing".
+      '';
+    };
+
+    subdomains = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "git" ];
+      description = ''
+        The list of subdomains to be published.
+
+        For example, if `git` is specified on a device with a hostname `lab`,
+        the request for `git.lab.local` will be redirected to `lab.local`.
+
+        Only used when the mode is set to "interval-publishing".
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+
+    systemd.services.go-avahi-cname = {
+      description = "Go Avahi CNAME Publisher";
+      after = [
+        "dbus.service"
+        "avahi-daemon.service"
+        "network-online.target"
+      ];
+      requires = [
+        "dbus.service"
+        "avahi-daemon.service"
+        "network-online.target"
+      ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig =
+        let
+          flags = lib.concatStringsSep " " (
+            [
+              (if cfg.debug then "--debug" else "")
+              (if cfg.mode == "interval-publishing" then "cname" else "subdomain")
+              "--ttl ${toString cfg.ttl}"
+              "--fqdn ${lib.escapeShellArg cfg.fqdn}"
+            ]
+            ++ lib.optional (cfg.mode == "interval-publishing") "--interval ${toString cfg.interval}"
+            ++ lib.optionals (cfg.mode == "interval-publishing") (map lib.escapeShellArg cfg.subdomains)
+          );
+        in
+        {
+          CapabilityBoundingSet = "";
+          DynamicUser = true;
+          ExecStart = "${lib.getExe cfg.package} ${flags}";
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          PrivateDevices = true;
+          PrivateTmp = true;
+          PrivateUsers = true;
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          ProtectSystem = true;
+          UMask = "0027";
+          Restart = "on-failure";
+          RestartSec = 10;
+          RestrictAddressFamilies = [
+            "AF_INET"
+            "AF_INET6"
+            "AF_UNIX"
+            "AF_NETLINK"
+          ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SupplementaryGroups = [
+            "avahi"
+            "messagebus"
+          ];
+          StartLimitBurst = 3;
+        };
+    };
+  };
+
+  meta = {
+    doc = ./go-avahi-cname.md;
+    maintainers = with lib.maintainers; [ magicquark ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -698,6 +698,7 @@ in
   gnome-flashback = runTest ./gnome-flashback.nix;
   gns3-server = runTest ./gns3-server.nix;
   gnupg = runTest ./gnupg.nix;
+  go-avahi-cname = runTest ./go-avahi-cname.nix;
   go-camo = runTest ./go-camo.nix;
   go-csp-collector = runTest ./go-csp-collector.nix;
   go-httpbin = runTest ./go-httpbin.nix;

--- a/nixos/tests/go-avahi-cname.nix
+++ b/nixos/tests/go-avahi-cname.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  ...
+}:
+let
+  avahi_config = {
+    enable = true;
+    nssmdns4 = true;
+    nssmdnsFull = true;
+    publish = {
+      enable = true;
+      userServices = true;
+    };
+  };
+in
+{
+  name = "go-avahi-cname";
+
+  meta.maintainers = with lib.maintainers; [ magicquark ];
+
+  nodes = {
+    machineIntervalPublishing = {
+      services.avahi = avahi_config;
+
+      services.go-avahi-cname = {
+        enable = true;
+        debug = true;
+        mode = "interval-publishing";
+        subdomains = [
+          "paperless"
+          "printer"
+        ];
+      };
+
+      environment.etc."mdns.allow".text = ''
+        .local.
+        .local
+      '';
+    };
+    machineSubdomainReply = {
+      services.avahi = avahi_config;
+
+      services.go-avahi-cname = {
+        enable = true;
+        debug = true;
+        mode = "subdomain-reply";
+      };
+
+      environment.etc."mdns.allow".text = ''
+        .local.
+        .local
+      '';
+    };
+  };
+
+  testScript = ''
+    machineIntervalPublishing.start()
+
+    machineIntervalPublishing.wait_for_unit("avahi-daemon.service")
+    machineIntervalPublishing.wait_for_unit("go-avahi-cname.service")
+
+    hostname = machineIntervalPublishing.succeed("hostname").strip()
+    machineIntervalPublishing.wait_until_succeeds(f"getent hosts paperless.{hostname}.local")
+    machineIntervalPublishing.wait_until_succeeds(f"getent hosts printer.{hostname}.local")
+    machineIntervalPublishing.wait_until_fails(f"getent hosts git.{hostname}.local")
+
+
+    machineSubdomainReply.start()
+
+    machineSubdomainReply.wait_for_unit("avahi-daemon.service")
+    machineSubdomainReply.wait_for_unit("go-avahi-cname.service")
+
+    hostname = machineSubdomainReply.succeed("hostname").strip()
+    machineSubdomainReply.wait_until_succeeds(f"getent hosts git.{hostname}.local")
+    machineSubdomainReply.wait_until_succeeds(f"getent hosts grafana.{hostname}.local")
+  '';
+}

--- a/pkgs/by-name/go/go-avahi-cname/package.nix
+++ b/pkgs/by-name/go/go-avahi-cname/package.nix
@@ -3,6 +3,7 @@
   buildGoModule,
   fetchFromGitHub,
   nix-update-script,
+  nixosTests,
 }:
 
 buildGoModule (finalAttrs: {
@@ -30,7 +31,10 @@ buildGoModule (finalAttrs: {
   # bind: operation not permitted
   __darwinAllowLocalNetworking = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = nixosTests.go-avahi-cname;
+  };
 
   meta = {
     description = "Lightweight mDNS publisher of subdomains for your machine";


### PR DESCRIPTION
# nixos/go-avahi-cname: init

`go-avahi-cname` is a mDNS publisher of subdomains for a machine via CNAME records.

Homepage: https://github.com/grishy/go-avahi-cname

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
