### PR TITLE
python3Packages.osqp: 1.1.0 -> 1.1.1, add GaetanLepage to maintainers

### DIFF
--- a/pkgs/development/python-modules/osqp/default.nix
+++ b/pkgs/development/python-modules/osqp/default.nix
@@ -109,6 +109,8 @@ buildPythonPackage (finalAttrs: {
     downloadPage = "https://github.com/oxfordcontrol/osqp-python/releases";
     changelog = "https://github.com/osqp/osqp-python/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+    ];
   };
 })

--- a/pkgs/development/python-modules/osqp/default.nix
+++ b/pkgs/development/python-modules/osqp/default.nix
@@ -49,14 +49,14 @@ in
 
 buildPythonPackage (finalAttrs: {
   pname = "osqp";
-  version = "1.1.0";
+  version = "1.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "osqp";
     repo = "osqp-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-xdxQaL794rHQmdC0cua1C/IT1qQSzzhTEf7dLrjOV9o=";
+    hash = "sha256-v7Kyiu5L9/GvnJFx2e6G38hkQvFQeecZNy09NJRjuA0=";
   };
 
   patches = [


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/osqp/osqp-python/compare/v1.1.0...v1.1.1
Changelog: https://github.com/osqp/osqp-python/releases/tag/v1.1.1

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test