### PR TITLE
panache: init at 2.18.0

### DIFF
--- a/pkgs/by-name/pa/panache/package.nix
+++ b/pkgs/by-name/pa/panache/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "panache";
+  version = "2.18.0";
+
+  src = fetchFromGitHub {
+    owner = "jolars";
+    repo = "panache";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-VI4Ma0wSHeQc5Rofz2sIyUkHmZSBm5woMcHTEM/a9wk=";
+  };
+
+  cargoHash = "sha256-iliilk0uAOwdiYqJwkbdslwxcU6WLgReN2ZDEVki6js=";
+
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  postInstall = ''
+    installShellCompletion --cmd panache \
+      --bash target/completions/panache.bash \
+      --fish target/completions/panache.fish \
+      --zsh target/completions/_panache
+
+    installManPage target/man/*
+  '';
+
+  meta = {
+    description = "Language server, formatter, and linter for Pandoc, Quarto, and R Markdown";
+    homepage = "https://github.com/jolars/panache";
+    changelog = "https://github.com/jolars/panache/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jolars ];
+    mainProgram = "panache";
+  };
+})


### PR DESCRIPTION
panache is a formatter, LSP, and linter for Pandoc markdown, Quarto, and RMarkdown. The repo is at https://github.com/jolars/panache.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
