### PR TITLE
adminer: 5.4.1 -> 5.4.2

### DIFF
--- a/pkgs/by-name/ad/adminer/package.nix
+++ b/pkgs/by-name/ad/adminer/package.nix
@@ -9,12 +9,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "adminer";
-  version = "5.4.1";
+  version = "5.4.2";
 
   # not using fetchFromGitHub as the git repo relies on submodules that are included in the tar file
   src = fetchurl {
     url = "https://github.com/vrana/adminer/releases/download/v${finalAttrs.version}/adminer-${finalAttrs.version}.zip";
-    hash = "sha256-+Ki46mR+E82F/spU0DBM7kWelY3zA9bdFad44HeZ5Lo=";
+    hash = "sha256-nzMc1Iq9YxaKh4oYTCox5vVqV2yUn0o7XqMTLmTWkXs=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Update `adminer` from 5.4.1 to 5.4.2

- Fixes [CVE-2026-25892](https://nvd.nist.gov/vuln/detail/CVE-2026-25892)
- [GitHub Advisory](https://github.com/advisories/GHSA-q4f2-39gr-45jh)
- [Upstream Patch](https://github.com/vrana/adminer/commit/21d3a3150388677b18647d68aec93b7850e457d3)
- [Tracker Issue](https://github.com/NixOS/nixpkgs/issues/489343)

Closes https://github.com/NixOS/nixpkgs/issues/489343


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
