### PR TITLE
python314Packages.pyecharts: 2.0.9 -> 2.1.0

### DIFF
--- a/pkgs/development/python-modules/pyecharts/default.nix
+++ b/pkgs/development/python-modules/pyecharts/default.nix
@@ -2,44 +2,35 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  pythonAtLeast,
-
-  # build-system
-  setuptools,
-
-  # dependencies
   jinja2,
-  prettytable,
-  simplejson,
-
-  # optional-dependencies
-  pillow,
-
-  # tests
   numpy,
   pandas,
+  pillow,
+  prettytable,
   pytestCheckHook,
+  pythonAtLeast,
   requests,
+  setuptools-scm,
+  setuptools,
+  simplejson,
 }:
 
-let
-  optional-dependencies = {
-    images = [ pillow ];
-  };
-in
 buildPythonPackage (finalAttrs: {
   pname = "pyecharts";
-  version = "2.0.9";
+  version = "2.1.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pyecharts";
     repo = "pyecharts";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-AMdPsTQsndc0fr4NF2AnJy98k4I2832/GNWeY4IWSRA=";
+    hash = "sha256-49ALxObzUuw3N81ZTgtQYtqTA1CTu7Qz9E6OkkJyEnc=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
 
   dependencies = [
     jinja2
@@ -47,7 +38,9 @@ buildPythonPackage (finalAttrs: {
     simplejson
   ];
 
-  inherit optional-dependencies;
+  optional-dependencies = {
+    images = [ pillow ];
+  };
 
   nativeCheckInputs = [
     numpy
@@ -55,7 +48,7 @@ buildPythonPackage (finalAttrs: {
     pytestCheckHook
     requests
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   pythonImportsCheck = [ "pyecharts" ];
 


### PR DESCRIPTION
Changelog: https://github.com/pyecharts/pyecharts/releases/tag/v2.1.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
