### PR TITLE
various: remove `version` in bundlerEnv

### DIFF
--- a/pkgs/by-name/cf/cfn-nag/package.nix
+++ b/pkgs/by-name/cf/cfn-nag/package.nix
@@ -7,7 +7,6 @@
 
 bundlerEnv {
   pname = "cfn-nag";
-  version = "0.8.10";
 
   inherit ruby;
   gemdir = ./.;

--- a/pkgs/development/tools/compass/default.nix
+++ b/pkgs/development/tools/compass/default.nix
@@ -7,7 +7,6 @@
 
 bundlerEnv {
   pname = "compass";
-  version = "1.0.3";
 
   inherit ruby;
   gemdir = ./.;

--- a/pkgs/development/tools/license_finder/default.nix
+++ b/pkgs/development/tools/license_finder/default.nix
@@ -7,7 +7,6 @@
 
 bundlerEnv {
   pname = "license_finder";
-  version = "7.0.1";
 
   inherit ruby;
   gemdir = ./.;


### PR DESCRIPTION
- Following comment from https://github.com/NixOS/nixpkgs/pull/489565 / https://github.com/NixOS/nixpkgs/pull/489568, cleanup `version` attribute when it can be retrieve from the its gem file.

```
nix-repl> cfn-nag.version
"0.8.10"

nix-repl> compass.version
"1.0.3"

nix-repl> license_finder.version
"7.0.1"
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
