### PR TITLE
treewide: move env variable(s) into env for structuredAttrs (K-M)

### DIFF
--- a/pkgs/applications/graphics/tesseract/tesseract3.nix
+++ b/pkgs/applications/graphics/tesseract/tesseract3.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     opencl-headers
   ];
 
-  LIBLEPT_HEADERSDIR = "${leptonica}/include";
+  env.LIBLEPT_HEADERSDIR = "${leptonica}/include";
 
   meta = {
     description = "OCR engine";

--- a/pkgs/applications/window-managers/awesome/default.nix
+++ b/pkgs/applications/window-managers/awesome/default.nix
@@ -114,8 +114,6 @@ stdenv.mkDerivation rec {
     "doc"
   ];
 
-  FONTCONFIG_FILE = toString fontsConf;
-
   propagatedUserEnvPkgs = [ hicolor-icon-theme ];
   buildInputs = [
     cairo
@@ -150,11 +148,14 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional lua.pkgs.isLuaJIT "-DLUA_LIBRARY=${lua}/lib/libluajit-5.1.so";
 
-  GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";
-  # LUA_CPATH and LUA_PATH are used only for *building*, see the --search flags
-  # below for how awesome finds the libraries it needs at runtime.
-  LUA_CPATH = "${luaEnv}/lib/lua/${lua.luaversion}/?.so";
-  LUA_PATH = "${luaEnv}/share/lua/${lua.luaversion}/?.lua;;";
+  env = {
+    FONTCONFIG_FILE = toString fontsConf;
+    GI_TYPELIB_PATH = "${pango.out}/lib/girepository-1.0";
+    # LUA_CPATH and LUA_PATH are used only for *building*, see the --search flags
+    # below for how awesome finds the libraries it needs at runtime.
+    LUA_CPATH = "${luaEnv}/lib/lua/${lua.luaversion}/?.so";
+    LUA_PATH = "${luaEnv}/share/lua/${lua.luaversion}/?.lua;;";
+  };
 
   postInstall = ''
     # Don't use wrapProgram or the wrapper will duplicate the --search

--- a/pkgs/by-name/ar/ardour/package.nix
+++ b/pkgs/by-name/ar/ardour/package.nix
@@ -192,14 +192,17 @@ stdenv.mkDerivation (
     ]
     ++ lib.optional optimize "--optimize";
 
-    env.NIX_CFLAGS_COMPILE = toString [
-      # 'ioprio_set' syscall support:
-      "-D_GNU_SOURCE"
-      # compiler doesn't find headers without these:
-      "-I${lib.getDev serd}/include/serd-0"
-      "-I${lib.getDev sratom}/include/sratom-0"
-      "-I${lib.getDev sord}/include/sord-0"
-    ];
+    env = {
+      NIX_CFLAGS_COMPILE = toString [
+        # 'ioprio_set' syscall support:
+        "-D_GNU_SOURCE"
+        # compiler doesn't find headers without these:
+        "-I${lib.getDev serd}/include/serd-0"
+        "-I${lib.getDev sratom}/include/sratom-0"
+        "-I${lib.getDev sord}/include/sord-0"
+      ];
+      LINKFLAGS = "-lpthread";
+    };
 
     postInstall = ''
       # wscript does not install these for some reason
@@ -226,8 +229,6 @@ stdenv.mkDerivation (
           ]
         }"
     '';
-
-    LINKFLAGS = "-lpthread";
 
     meta = {
       description = "Multi-track hard disk recording software";

--- a/pkgs/by-name/ba/bant/package.nix
+++ b/pkgs/by-name/ba/bant/package.nix
@@ -33,7 +33,10 @@ buildBazelPackage rec {
     "--registry"
     "file://${registry}"
   ];
-  LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
+
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    LIBTOOL = "${cctools}/bin/libtool";
+  };
 
   postPatch = ''
     patchShebangs scripts/create-workspace-status.sh

--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -57,10 +57,12 @@ rustPlatform.buildRustPackage (finalAttrs: {
     };
   };
 
-  # `cargo-llvm-cov` reads these environment variables to find these binaries,
-  # which are needed to run the tests
-  LLVM_COV = "${llvm}/bin/llvm-cov";
-  LLVM_PROFDATA = "${llvm}/bin/llvm-profdata";
+  env = {
+    # `cargo-llvm-cov` reads these environment variables to find these binaries,
+    # which are needed to run the tests
+    LLVM_COV = "${llvm}/bin/llvm-cov";
+    LLVM_PROFDATA = "${llvm}/bin/llvm-profdata";
+  };
 
   nativeCheckInputs = [
     gitMinimal

--- a/pkgs/by-name/ch/chipsec/package.nix
+++ b/pkgs/by-name/ch/chipsec/package.nix
@@ -25,7 +25,9 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     ./log-path.diff
   ];
 
-  KSRC = lib.optionalString withDriver "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  env = lib.optionalAttrs withDriver {
+    KSRC = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+  };
 
   nativeBuildInputs = [
     nasm

--- a/pkgs/by-name/ci/circt/package.nix
+++ b/pkgs/by-name/ci/circt/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # cannot use lib.optionalString as it creates an empty string, disabling all tests
-  LIT_FILTER_OUT =
+  env.LIT_FILTER_OUT =
     let
       lit-filters =
         # There are some tests depending on `clang-tools` to work. They are activated only when detected

--- a/pkgs/by-name/dn/dnspeep/package.nix
+++ b/pkgs/by-name/dn/dnspeep/package.nix
@@ -18,8 +18,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-tZlh7+END6oOy3uWOrjle+nwqFhMU6bbXmr4hdt6gqY=";
 
-  LIBPCAP_LIBDIR = lib.makeLibraryPath [ libpcap ];
-  LIBPCAP_VER = libpcap.version;
+  env = {
+    LIBPCAP_LIBDIR = lib.makeLibraryPath [ libpcap ];
+    LIBPCAP_VER = libpcap.version;
+  };
 
   meta = {
     description = "Spy on the DNS queries your computer is making";

--- a/pkgs/by-name/ev/eventstore/package.nix
+++ b/pkgs/by-name/ev/eventstore/package.nix
@@ -27,7 +27,7 @@ buildDotnetModule rec {
   };
 
   # Fixes application reporting 0.0.0.0 as its version.
-  MINVERVERSIONOVERRIDE = version;
+  env.MINVERVERSIONOVERRIDE = version;
 
   dotnet-sdk = dotnetCorePackages.sdk_8_0;
   dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;

--- a/pkgs/by-name/fo/fortune-kind/package.nix
+++ b/pkgs/by-name/fo/fortune-kind/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildNoDefaultFeatures = true;
 
-  MAN_OUT = "./man";
+  env.MAN_OUT = "./man";
 
   preBuild = ''
     mkdir -p "./$MAN_OUT";

--- a/pkgs/by-name/gh/ghdl/package.nix
+++ b/pkgs/by-name/gh/ghdl/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-vPeODNTptxIjN6qLoIHaKOFf3P3iAK2GloVreHPaAz8=";
   };
 
-  LIBRARY_PATH = "${stdenv.cc.libc}/lib";
+  env.LIBRARY_PATH = "${stdenv.cc.libc}/lib";
 
   nativeBuildInputs = [
     gnat

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -103,10 +103,12 @@ buildDotnetModule (finalAttrs: {
                      'true'
   '';
 
-  DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = isNull glibcLocales;
-  LOCALE_ARCHIVE = lib.optionalString (
-    !finalAttrs.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
-  ) "${glibcLocales}/lib/locale/locale-archive";
+  env = {
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT = isNull glibcLocales;
+  }
+  // lib.optionalAttrs (!isNull glibcLocales) {
+    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  };
 
   postConfigure = ''
     # Generate src/Runner.Sdk/BuildConstants.cs
@@ -220,7 +222,7 @@ buildDotnetModule (finalAttrs: {
     "GitHub.Runner.Common.Tests.Worker.StepHostL0.DetermineNode20RuntimeVersionInAlpineContainerAsync"
     "GitHub.Runner.Common.Tests.Worker.StepHostL0.DetermineNode24RuntimeVersionInAlpineContainerAsync"
   ]
-  ++ lib.optionals finalAttrs.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT [
+  ++ lib.optionals finalAttrs.env.DOTNET_SYSTEM_GLOBALIZATION_INVARIANT [
     "GitHub.Runner.Common.Tests.Util.StringUtilL0.FormatUsesInvariantCulture"
     "GitHub.Runner.Common.Tests.Worker.VariablesL0.Constructor_SetsOrdinalIgnoreCaseComparer"
     "GitHub.Runner.Common.Tests.Worker.WorkerL0.DispatchCancellation"

--- a/pkgs/by-name/he/hentai-at-home/package.nix
+++ b/pkgs/by-name/he/hentai-at-home/package.nix
@@ -22,10 +22,12 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     makeWrapper
   ];
 
-  LANG = "en_US.UTF-8";
-  LOCALE_ARCHIVE = lib.optionalString (
-    stdenvNoCC.buildPlatform.libc == "glibc"
-  ) "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+  env = {
+    LANG = "en_US.UTF-8";
+  }
+  // lib.optionalAttrs (stdenvNoCC.buildPlatform.libc == "glibc") {
+    LOCALE_ARCHIVE = "${buildPackages.glibcLocales}/lib/locale/locale-archive";
+  };
 
   makeFlags = [ "all" ];
   enableParallelBuilding = false;

--- a/pkgs/by-name/in/intel-vaapi-driver/package.nix
+++ b/pkgs/by-name/in/intel-vaapi-driver/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   };
 
   # Set the correct install path:
-  LIBVA_DRIVERS_PATH = "${placeholder "out"}/lib/dri";
+  env.LIBVA_DRIVERS_PATH = "${placeholder "out"}/lib/dri";
 
   postInstall = lib.optionalString enableHybridCodec ''
     ln -s ${vaapi-intel-hybrid}/lib/dri/* $out/lib/dri/

--- a/pkgs/by-name/lc/lc3tools/package.nix
+++ b/pkgs/by-name/lc/lc3tools/package.nix
@@ -41,10 +41,12 @@ stdenv.mkDerivation {
     readline
   ];
 
-  # lumetta published this a while ago but handrolled his configure
-  # jank in the original packaging makes this necessary:
-  LIBS = "${flex}/lib:${ncurses}/lib:${readline}/lib";
-  INCLUDES = "${flex}/include:${ncurses}/include:${readline}/include";
+  env = {
+    # lumetta published this a while ago but handrolled his configure
+    # jank in the original packaging makes this necessary:
+    LIBS = "${flex}/lib:${ncurses}/lib:${readline}/lib";
+    INCLUDES = "${flex}/include:${ncurses}/include:${readline}/include";
+  };
 
   # it doesn't take `--prefix`
   prefixKey = "--installdir ";

--- a/pkgs/by-name/li/linuxdoc-tools/package.nix
+++ b/pkgs/by-name/li/linuxdoc-tools/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     ("--enable-docs=txt info lyx html rtf" + lib.optionalString withLatex " pdf")
   ];
 
-  LEX = "flex";
+  env.LEX = "flex";
 
   postInstall = ''
     wrapProgram $out/bin/linuxdoc \

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses ];
 
   # Stop build scripts from searching global include paths
-  LSOF_INCLUDE = "${lib.getDev stdenv.cc.libc}/include";
+  env.LSOF_INCLUDE = "${lib.getDev stdenv.cc.libc}/include";
   configurePhase =
     let
       genericFlags = "LSOF_CC=$CC LSOF_AR=\"$AR cr\" LSOF_RANLIB=$RANLIB";

--- a/pkgs/by-name/ma/materialize/package.nix
+++ b/pkgs/by-name/ma/materialize/package.nix
@@ -92,7 +92,6 @@ in
 rustPlatform.buildRustPackage rec {
   pname = "materialize";
   version = "0.87.2";
-  MZ_DEV_BUILD_SHA = "000000000000000000000000000000000000000000000000000";
 
   src = fetchFromGitHub {
     owner = "MaterializeInc";
@@ -112,6 +111,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   env = {
+    MZ_DEV_BUILD_SHA = "000000000000000000000000000000000000000000000000000";
     # needed for internal protobuf c wrapper library
     PROTOC = lib.getExe protobuf;
     PROTOC_INCLUDE = "${protobuf}/include";

--- a/pkgs/by-name/ms/msbuild/package.nix
+++ b/pkgs/by-name/ms/msbuild/package.nix
@@ -55,9 +55,11 @@ mkPackage rec {
     glibcLocales
   ];
 
-  # https://github.com/NixOS/nixpkgs/issues/38991
-  # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
-  LOCALE_ARCHIVE = lib.optionalString stdenv.hostPlatform.isLinux "${glibcLocales}/lib/locale/locale-archive";
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    # https://github.com/NixOS/nixpkgs/issues/38991
+    # bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
+    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  };
 
   postPatch = ''
     # not patchShebangs, there is /bin/bash in the body of the script as well

--- a/pkgs/by-name/ne/netop/package.nix
+++ b/pkgs/by-name/ne/netop/package.nix
@@ -16,8 +16,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-Rnp2VNAi8BNbKqkGFoYUb4C5db5BS1P1cqpWlroTmdQ=";
   };
 
-  LIBPCAP_LIBDIR = lib.makeLibraryPath [ libpcap ];
-  LIBPCAP_VER = libpcap.version;
+  env = {
+    LIBPCAP_LIBDIR = lib.makeLibraryPath [ libpcap ];
+    LIBPCAP_VER = libpcap.version;
+  };
 
   cargoHash = "sha256-WGwtRMARwRvcUflN3JYL32aib+IG1Q0j0D9BEfaiME4=";
 

--- a/pkgs/by-name/ni/nix-weather/package.nix
+++ b/pkgs/by-name/ni/nix-weather/package.nix
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   # This is where `build.rs` puts manpages
-  MAN_OUT = "./man";
+  env.MAN_OUT = "./man";
 
   postInstall = ''
     cd crates/nix-weather

--- a/pkgs/by-name/ns/nsis/package.nix
+++ b/pkgs/by-name/ns/nsis/package.nix
@@ -32,14 +32,16 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ scons ];
   buildInputs = [ zlib ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
-  CPPPATH = symlinkJoin {
-    name = "nsis-includes";
-    paths = [ zlib.dev ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
-  };
+  env = {
+    CPPPATH = symlinkJoin {
+      name = "nsis-includes";
+      paths = [ zlib.dev ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+    };
 
-  LIBPATH = symlinkJoin {
-    name = "nsis-libs";
-    paths = [ zlib ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+    LIBPATH = symlinkJoin {
+      name = "nsis-libs";
+      paths = [ zlib ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
+    };
   };
 
   sconsFlags = [

--- a/pkgs/by-name/nu/nushell-plugin-bson/package.nix
+++ b/pkgs/by-name/nu/nushell-plugin-bson/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     llvmPackages.libclang
   ];
 
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  env.LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
 
   passthru.update-script = nix-update-script { };
   meta = {

--- a/pkgs/by-name/pa/parseable/package.nix
+++ b/pkgs/by-name/pa/parseable/package.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-Asb6064TqvL9kNkWBMj4Z+1j1yIM+iBWsN+R5EuMOVA=";
   };
 
-  LOCAL_ASSETS_PATH = fetchzip {
+  env.LOCAL_ASSETS_PATH = fetchzip {
     url = "https://parseable-prism-build.s3.us-east-2.amazonaws.com/v${finalAttrs.version}/build.zip";
     hash = "sha256-gWzfucetsJJSSjI9nGm7I8xLo0t1VKb4AertiEGuLWA=";
   };

--- a/pkgs/by-name/pm/pmacct/package.nix
+++ b/pkgs/by-name/pm/pmacct/package.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional gnutlsSupport gnutls;
 
-  MYSQL_CONFIG = lib.optionalString withMysql "${lib.getDev libmysqlclient}/bin/mysql_config";
+  env.MYSQL_CONFIG = lib.optionalString withMysql "${lib.getDev libmysqlclient}/bin/mysql_config";
 
   configureFlags = [
     "--with-pcap-includes=${libpcap}/include"

--- a/pkgs/by-name/po/poco/package.nix
+++ b/pkgs/by-name/po/poco/package.nix
@@ -52,8 +52,10 @@ stdenv.mkDerivation rec {
     "dev"
   ];
 
-  MYSQL_DIR = libmysqlclient;
-  MYSQL_INCLUDE_DIR = "${MYSQL_DIR}/include/mysql";
+  env = {
+    MYSQL_DIR = libmysqlclient;
+    MYSQL_INCLUDE_DIR = "${env.MYSQL_DIR}/include/mysql";
+  };
 
   cmakeFlags =
     let

--- a/pkgs/by-name/pr/protoc-gen-js/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-js/package.nix
@@ -40,7 +40,9 @@ buildBazelPackage' rec {
   removeRulesCC = false;
   removeLocalConfigCC = false;
 
-  LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    LIBTOOL = "${cctools}/bin/libtool";
+  };
 
   fetchAttrs = {
     preInstall = ''

--- a/pkgs/by-name/ps/pspp/package.nix
+++ b/pkgs/by-name/ps/pspp/package.nix
@@ -55,9 +55,11 @@ stdenv.mkDerivation rec {
     iconv
   ];
 
-  C_INCLUDE_PATH =
-    "${libxml2.dev}/include/libxml2/:" + lib.makeSearchPathOutput "dev" "include" buildInputs;
-  LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+  env = {
+    C_INCLUDE_PATH =
+      "${libxml2.dev}/include/libxml2/:" + lib.makeSearchPathOutput "dev" "include" buildInputs;
+    LIBRARY_PATH = lib.makeLibraryPath buildInputs;
+  };
 
   doCheck = false;
 

--- a/pkgs/by-name/sm/smlpkg/package.nix
+++ b/pkgs/by-name/sm/smlpkg/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ mlton ];
 
   # Set as an environment variable in all the phase scripts.
-  MLCOMP = "mlton";
+  env.MLCOMP = "mlton";
 
   buildFlags = [ "all" ];
   installFlags = [ "prefix=$(out)" ];

--- a/pkgs/by-name/ve/verible/package.nix
+++ b/pkgs/by-name/ve/verible/package.nix
@@ -30,6 +30,9 @@ buildBazelPackage {
     # a build string shown in the tools --version output.
     # If env variables not set, it would attempt to extract it from .git/.
     inherit GIT_DATE GIT_VERSION;
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    LIBTOOL = "${cctools}/bin/libtool";
   };
 
   # Derive nix package version from GIT_VERSION: "v1.2-345-abcde" -> "1.2.345"
@@ -67,7 +70,6 @@ buildBazelPackage {
     flex # .. to compile with newer glibc
     python3
   ];
-  LIBTOOL = lib.optionalString stdenv.hostPlatform.isDarwin "${cctools}/bin/libtool";
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/by-name/vi/vice/package.nix
+++ b/pkgs/by-name/vi/vice/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-gif"
   ];
 
-  LIBS = "-lGL";
+  env.LIBS = "-lGL";
 
   preBuild = ''
     sed -i -e 's|#!/usr/bin/env bash|${runtimeShell}/bin/bash|' src/arch/gtk3/novte/box_drawing_generate.sh

--- a/pkgs/by-name/vi/virtiofsd/package.nix
+++ b/pkgs/by-name/vi/virtiofsd/package.nix
@@ -23,8 +23,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-AOWHlvFvKj05f4/KE1F37qkRstW5gUlRH0HZVZrg7Dg=";
 
-  LIBCAPNG_LIB_PATH = "${lib.getLib libcap_ng}/lib";
-  LIBCAPNG_LINK_TYPE = if stdenv.hostPlatform.isStatic then "static" else "dylib";
+  env = {
+    LIBCAPNG_LIB_PATH = "${lib.getLib libcap_ng}/lib";
+    LIBCAPNG_LINK_TYPE = if stdenv.hostPlatform.isStatic then "static" else "dylib";
+  };
 
   buildInputs = [
     libcap_ng

--- a/pkgs/by-name/wa/waypipe/package.nix
+++ b/pkgs/by-name/wa/waypipe/package.nix
@@ -38,7 +38,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   };
 
   strictDeps = true;
-  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+  env.LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   depsBuildBuild = [ pkg-config ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/emborg/default.nix
+++ b/pkgs/development/python-modules/emborg/default.nix
@@ -50,7 +50,7 @@ buildPythonPackage rec {
   ];
 
   # this disables testing fuse mounts
-  MISSING_DEPENDENCIES = "fuse";
+  env.MISSING_DEPENDENCIES = "fuse";
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/os-specific/linux/trace-cmd/default.nix
+++ b/pkgs/os-specific/linux/trace-cmd/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     "devman"
   ];
 
-  MANPAGE_DOCBOOK_XSL = "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl";
+  env.MANPAGE_DOCBOOK_XSL = "${docbook_xsl}/xml/xsl/docbook/manpages/docbook.xsl";
 
   dontConfigure = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
