### PR TITLE
fetchMixDeps, mixRelease: move env variables into env

### DIFF
--- a/pkgs/development/beam-modules/fetch-mix-deps.nix
+++ b/pkgs/development/beam-modules/fetch-mix-deps.nix
@@ -53,17 +53,20 @@ stdenvNoCC.mkDerivation (
       git
     ];
 
-    MIX_ENV = mixEnv;
-    MIX_TARGET = mixTarget;
-    MIX_DEBUG = if debug then 1 else 0;
-    DEBUG = if debug then 1 else 0; # for rebar3
-    # the api with `mix local.rebar rebar path` makes a copy of the binary
-    MIX_REBAR = "${rebar}/bin/rebar";
-    MIX_REBAR3 = "${rebar3}/bin/rebar3";
-    # there is a persistent download failure with absinthe 1.6.3
-    # those defaults reduce the failure rate
-    HEX_HTTP_CONCURRENCY = 1;
-    HEX_HTTP_TIMEOUT = 120;
+    env = {
+      MIX_ENV = mixEnv;
+      MIX_TARGET = mixTarget;
+      MIX_DEBUG = if debug then 1 else 0;
+      DEBUG = if debug then 1 else 0; # for rebar3
+      # the api with `mix local.rebar rebar path` makes a copy of the binary
+      MIX_REBAR = "${rebar}/bin/rebar";
+      MIX_REBAR3 = "${rebar3}/bin/rebar3";
+      # there is a persistent download failure with absinthe 1.6.3
+      # those defaults reduce the failure rate
+      HEX_HTTP_CONCURRENCY = 1;
+      HEX_HTTP_TIMEOUT = 120;
+    }
+    // (attrs.env or { });
 
     configurePhase =
       attrs.configurePhase or ''

--- a/pkgs/development/beam-modules/mix-release.nix
+++ b/pkgs/development/beam-modules/mix-release.nix
@@ -123,28 +123,31 @@ stdenv.mkDerivation (
 
     buildInputs = buildInputs ++ lib.optionals (escriptBinName != null) [ erlang ];
 
-    MIX_ENV = mixEnv;
-    MIX_TARGET = mixTarget;
-    MIX_BUILD_PREFIX = (if mixTarget == "host" then "" else "${mixTarget}_") + "${mixEnv}";
-    MIX_DEBUG = if enableDebugInfo then 1 else 0;
-    HEX_OFFLINE = 1;
-
     __darwinAllowLocalNetworking = true;
 
-    DEBUG = if enableDebugInfo then 1 else 0; # for Rebar3 compilation
-    # The API with `mix local.rebar rebar path` makes a copy of the binary
-    # some older dependencies still use rebar.
-    MIX_REBAR = "${rebar}/bin/rebar";
-    MIX_REBAR3 = "${rebar3}/bin/rebar3";
+    env = {
+      MIX_ENV = mixEnv;
+      MIX_TARGET = mixTarget;
+      MIX_BUILD_PREFIX = (if mixTarget == "host" then "" else "${mixTarget}_") + "${mixEnv}";
+      MIX_DEBUG = if enableDebugInfo then 1 else 0;
+      HEX_OFFLINE = 1;
 
-    ERL_COMPILER_OPTIONS =
-      let
-        options = erlangCompilerOptions ++ lib.optionals erlangDeterministicBuilds [ "deterministic" ];
-      in
-      "[${lib.concatStringsSep "," options}]";
+      DEBUG = if enableDebugInfo then 1 else 0; # for Rebar3 compilation
+      # The API with `mix local.rebar rebar path` makes a copy of the binary
+      # some older dependencies still use rebar.
+      MIX_REBAR = "${rebar}/bin/rebar";
+      MIX_REBAR3 = "${rebar3}/bin/rebar3";
 
-    LANG = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "C";
-    LC_CTYPE = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "UTF-8";
+      ERL_COMPILER_OPTIONS =
+        let
+          options = erlangCompilerOptions ++ lib.optionals erlangDeterministicBuilds [ "deterministic" ];
+        in
+        "[${lib.concatStringsSep "," options}]";
+
+      LANG = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "C";
+      LC_CTYPE = if stdenv.hostPlatform.isLinux then "C.UTF-8" else "UTF-8";
+    }
+    // (attrs.env or { });
 
     postUnpack = ''
       # Mix and Hex


### PR DESCRIPTION
for structuredAttrs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
