### PR TITLE
postgresql: change source back to tags

### DIFF
--- a/pkgs/servers/sql/postgresql/14.nix
+++ b/pkgs/servers/sql/postgresql/14.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "14.21";
-  # rev = "refs/tags/REL_14_21";
-  rev = "eb788b43371849237c61ba2747fc11e96c08d861";
+  rev = "refs/tags/REL_14_21";
   hash = "sha256-9uG32BVzXOL2yAJmFVkIvEZJrmI5ToL7ojtivWmufL8=";
   muslPatches = {
     disable-test-collate-icu-utf8 = {

--- a/pkgs/servers/sql/postgresql/15.nix
+++ b/pkgs/servers/sql/postgresql/15.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "15.16";
-  # rev = "refs/tags/REL_15_16";
-  rev = "78bc85dd4455c302c345c550e0628a1522df108d";
+  rev = "refs/tags/REL_15_16";
   hash = "sha256-ju/KkeBOumYHCarhqNA8jq+ceUo4y8g/SzjAMWm80ak=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/16.nix
+++ b/pkgs/servers/sql/postgresql/16.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "16.12";
-  # rev = "refs/tags/REL_16_12";
-  rev = "e15d96551f9760e62888b5082ad050329c1c4cdf";
+  rev = "refs/tags/REL_16_12";
   hash = "sha256-1jkVElZTtp60Jgl5RyPT+8lalDYtjRDe9MxO3KMYJmU=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/17.nix
+++ b/pkgs/servers/sql/postgresql/17.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "17.8";
-  # rev = "refs/tags/REL_17_8";
-  rev = "6af885119b52a2a6229959670ba3ae5e36bf9806";
+  rev = "refs/tags/REL_17_8";
   hash = "sha256-4lV1/xRmMsc5rgY3RB6WMigTXHgHjh9bmR6nzL82Rs4=";
   muslPatches = {
     dont-use-locale-a = {

--- a/pkgs/servers/sql/postgresql/18.nix
+++ b/pkgs/servers/sql/postgresql/18.nix
@@ -1,7 +1,6 @@
 import ./generic.nix {
   version = "18.2";
-  # rev = "refs/tags/REL_18_2";
-  rev = "5a461dc4dbf72a1ec281394a76eb36d68cbdd935";
+  rev = "refs/tags/REL_18_2";
   hash = "sha256-cvBXxA7/kEwDGxFv/YoZCIh17jzUujrCtfKAmtSxKTw=";
   muslPatches = {
     dont-use-locale-a = {


### PR DESCRIPTION
The tags for the recent minor version releases have now been pushed.

## Things done

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
