### PR TITLE
decent-sampler: 1.15.0 -> 1.15.5

### DIFF
--- a/pkgs/by-name/de/decent-sampler/package.nix
+++ b/pkgs/by-name/de/decent-sampler/package.nix
@@ -7,6 +7,7 @@
   copyDesktopItems,
   buildFHSEnv,
   alsa-lib,
+  alsa-plugins,
   freetype,
   nghttp2,
   libx11,
@@ -15,7 +16,7 @@
 
 let
   pname = "decent-sampler";
-  version = "1.15.0";
+  version = "1.15.5";
   rlkey = "orvjprslmwn0dkfs0ncx6nxnm";
 
   icon = fetchurl {
@@ -28,8 +29,8 @@ let
 
     src = fetchzip {
       # dropbox links: https://www.dropbox.com/sh/dwyry6xpy5uut07/AABBJ84bjTTSQWzXGG5TOQpfa\
-      url = "https://www.dropbox.com/scl/fo/a0i0udw7ggfwnjoi05hh3/ABn4zZmR24tyJx0xaRS_lXg/Decent_Sampler-${version}-Linux-Static-x86_64.tar.gz?rlkey=${rlkey}&dl=0";
-      hash = "sha256-A+CBsGUtqXo7KAlx6BjbHGRZww73TlJCI68thicGKiE=";
+      url = "https://www.dropbox.com/scl/fo/a0i0udw7ggfwnjoi05hh3/ADKHnE9GsrZx5RepuBKy7dg/Decent_Sampler-${version}-Linux-Static-x86_64.tar.gz?rlkey=${rlkey}&dl=0";
+      hash = "sha256-uUEncrT0M4AmIokizrUdSATm8Dnvg3cBNGlH8wOPt+Y=";
     };
 
     nativeBuildInputs = [ copyDesktopItems ];
@@ -68,6 +69,7 @@ buildFHSEnv {
 
   targetPkgs = pkgs: [
     alsa-lib
+    alsa-plugins
     decent-sampler
     freetype
     nghttp2


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- 1.15.0 -> 1.15.5
https://www.decentsamples.com/product/decent-sampler-plugin/

- added alsa-plugins to fix following warning / error:
`ALSA lib pcm.c:2793:(snd_pcm_open_noupdate) [error.pcm] Unknown PCM pulse`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
