### PR TITLE
circuit-artist: init at 1.0.5-unstable-2026-07-07

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -117,6 +117,11 @@
     github = "einetuer";
     githubId = 54070204;
   };
+  _0xAdk = {
+    github = "0xAdk";
+    githubId = 29005635;
+    name = "0xAdk";
+  };
   _0xB10C = {
     email = "nixpkgs@b10c.me";
     name = "0xB10C";

--- a/pkgs/by-name/ci/circuit-artist/package.nix
+++ b/pkgs/by-name/ci/circuit-artist/package.nix
@@ -1,0 +1,85 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  rapidjson,
+  buildPackages,
+  makeDesktopItem,
+  copyDesktopItems,
+  unstableGitUpdater,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "circuit-artist";
+  version = "1.0.5-unstable-2026-07-07";
+
+  src = fetchFromGitHub {
+    owner = "lets-all-be-stupid-forever";
+    repo = "circuit-artist";
+    fetchSubmodules = true;
+    rev = "abfbbcaea303b457c9fe7e4750096b262f0b9038";
+    hash = "sha256-LZL4yO4vN2QJb23LEj8kQ5zavnCqc3TMMZ9vm3dv5dM=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+
+    # override doesn't preserve splicing https://github.com/NixOS/nixpkgs/issues/132651
+    # Has to use `makeShellWrapper` from `buildPackages` even though `makeShellWrapper` from the inputs is spliced because `propagatedBuildInputs` would pick the wrong one because of a different offset.
+    (buildPackages.wrapGAppsHook3.override { makeWrapper = buildPackages.makeShellWrapper; })
+    copyDesktopItems
+  ];
+
+  buildInputs = [ rapidjson ];
+
+  preFixup = ''
+    gappsWrapperArgs+=(
+      --run "export CA_ASSET_DIR=\''${CA_ASSET_DIR:-"$out/share/circuit-artist/assets"}"
+      --run 'export CA_DATA_DIR=''${CA_DATA_DIR:-''${XDG_DATA_HOME:-~/.local/share}/circuit-artist}'
+    )
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cd ..
+
+    install -Dm755 -T "./build/ca" "$out/bin/circuit-artist"
+
+    install -Dm444 -T "./assets/imgs/icon2.png" "$out/share/icons/hicolor/16x16/apps/circuit-artist.png"
+    install -Dm444 -T "./assets/imgs/icon32.png" "$out/share/icons/hicolor/32x32/apps/circuit-artist.png"
+
+    mkdir -p "$out/share/circuit-artist"
+    mv "./assets" "$out/share/circuit-artist"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "circuit-artist";
+      icon = "circuit-artist";
+      exec = "circuit-artist";
+      desktopName = "Circuit Artist";
+      genericName = "Circuit Simulator";
+      comment = finalAttrs.meta.description;
+      categories = [ "Game" ];
+    })
+  ];
+
+  passthru.updateScript = unstableGitUpdater { tagPrefix = "v"; };
+
+  meta = {
+    mainProgram = "circuit-artist";
+    description = "Digital circuit drawing and simulation game";
+    homepage = "https://github.com/lets-all-be-stupid-forever/circuit-artist";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ _0xAdk ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds circuit-artist a circuit game and simulator. https://github.com/lets-all-be-stupid-forever/circuit-artist

The README says it can be built for mac, but as I am unable to test that I left supported platforms as just linux.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
