### PR TITLE
balatro: fix rebase errors

### DIFF
--- a/pkgs/by-name/ba/balatro/package.nix
+++ b/pkgs/by-name/ba/balatro/package.nix
@@ -100,6 +100,14 @@ stdenv.mkDerivation (finalAttrs: {
     tmpdir=$(mktemp -d)
     7z x ${finalAttrs.src} -o$tmpdir -y
 
+    if [ -d "$tmpdir/assets" ]; then
+      mv "$tmpdir/assets/"* "$tmpdir/"
+      rmdir "$tmpdir/assets"
+    elif [ -d "$tmpdir/Assets" ]; then
+      mv "$tmpdir/Assets/"* "$tmpdir/"
+      rmdir "$tmpdir/Assets"
+    fi
+
     ${lib.optionalString withBridgePatch ''
       cp ${./bridge_detour.lua} $tmpdir/bridge_detour.lua
 

--- a/pkgs/by-name/ba/balatro/package.nix
+++ b/pkgs/by-name/ba/balatro/package.nix
@@ -153,7 +153,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     makeWrapper $out/share/Balatro $out/bin/balatro ${lib.optionalString withMods ''
       --prefix LD_PRELOAD : '${lovely-injector}/lib/liblovely.so' \
-      --prefix LD_LIBRARY_PATH : '${lib.makeLibraryPath [ curl ]}''}
+      --prefix LD_LIBRARY_PATH : '${lib.makeLibraryPath [ curl ]}'
+    ''}
 
     runHook postInstall
   '';


### PR DESCRIPTION
Looks like a hunk was dropped while I was rebasing changes on the PR, and a `'` disappeared.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
