### PR TITLE
nixos/uwsm: remove dependency on services.displayManager

### DIFF
--- a/nixos/modules/programs/wayland/uwsm.nix
+++ b/nixos/modules/programs/wayland/uwsm.nix
@@ -116,14 +116,17 @@ in
       {
         environment.systemPackages = [ cfg.package ];
         systemd.packages = [ cfg.package ];
-        environment.pathsToLink = [ "/share/uwsm" ];
+        environment.pathsToLink = [
+          "/share/uwsm"
+          "/share/wayland-sessions"
+        ];
 
         # UWSM recommends dbus broker for better compatibility
         services.dbus.implementation = "broker";
       }
 
       (lib.mkIf (cfg.waylandCompositors != { }) {
-        services.displayManager.sessionPackages = lib.mapAttrsToList (
+        environment.systemPackages = lib.mapAttrsToList (
           name: value:
           mk_uwsm_desktop_entry {
             inherit name;


### PR DESCRIPTION
Fixes: #485123

After #480050, enabling `services.displayManager` without configuring a valid display manager renders tty1 unusable

UWSM is not a valid display manager here, and so `services.displayManager` should no longer be used with UWSM, as stated in #484015

Currently, the UWSM module is broken as it depends on the display manager module to put the required desktop files into `XDG_DATA_DIRS` (see #485123)

~~This PR provides `programs.uwsm.sessionPackages` to substitute `services.displayManager.sessionPackages`, and updates `programs.hyprland.withUWSM` to make use of this new option~~

This PR instead sets `environment.pathsToLink = [ "/share/wayland-sessions" ]` so that compositors installed via `environment.systemPackages` can be detected by UWSM without relying on `XDG_DATA_DIRS`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
