### PR TITLE
python3Packages.flet, python3Packages.flet-desktop: fix setuptools packaging

### DIFF
--- a/pkgs/development/python-modules/flet-desktop/default.nix
+++ b/pkgs/development/python-modules/flet-desktop/default.nix
@@ -4,7 +4,7 @@
   flet-client-flutter,
 
   # build-system
-  poetry-core,
+  setuptools,
 
   flet,
 }:
@@ -16,7 +16,7 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/sdk/python/packages/flet-desktop";
 
-  build-system = [ poetry-core ];
+  build-system = [ setuptools ];
 
   dependencies = [ flet ];
 
@@ -25,6 +25,10 @@ buildPythonPackage rec {
       os.environ['FLET_VIEW_PATH'] = '${flet-client-flutter}/bin'
   '';
   postPatch = ''
+    # pin release version in packaged builds
+    substituteInPlace src/flet_desktop/version.py \
+      --replace-fail 'version = ""' 'version = "${version}"'
+
     echo "$_flet_setup_view" >> src/flet_desktop/__init__.py
   '';
 

--- a/pkgs/development/python-modules/flet/default.nix
+++ b/pkgs/development/python-modules/flet/default.nix
@@ -4,8 +4,9 @@
   flet-client-flutter,
 
   # build-system
-  poetry-core,
+  setuptools,
   pytestCheckHook,
+  pytest-asyncio,
 
   # propagates
   fastapi,
@@ -14,6 +15,7 @@
   packaging,
   qrcode,
   repath,
+  msgpack,
   cookiecutter,
   uvicorn,
   watchdog,
@@ -28,9 +30,13 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/sdk/python/packages/flet";
 
-  build-system = [ poetry-core ];
+  build-system = [ setuptools ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+  ];
+  pytestFlagsArray = [ "tests" ];
 
   makeWrapperArgs = [
     "--prefix"
@@ -39,19 +45,17 @@ buildPythonPackage rec {
     "$PYTHONPATH"
   ];
 
-  _flet_version = ''
-    version = "${version}"
-    def update_version():
-      pass
-  '';
   _flet_utils_pip = ''
     def install_flet_package(name: str):
       pass
   '';
 
   postPatch = ''
-     # nerf out nagging about pip
-    echo "$_flet_version" > src/flet/version.py
+    # pin release version in packaged builds
+    substituteInPlace src/flet/version.py \
+      --replace-fail 'flet_version = ""' 'flet_version = "${version}"'
+
+    # nerf out nagging about pip
     echo "$_flet_utils_pip" >> src/flet/utils/pip.py
   '';
 
@@ -65,6 +69,7 @@ buildPythonPackage rec {
     httpx
     packaging
     repath
+    msgpack
     qrcode
     cookiecutter
     fastapi


### PR DESCRIPTION
`flet` and `flet-desktop` upstream switched to `setuptools.build_meta`, but nixpkgs was still using `poetry-core`, which caused:

- `pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'`

This PR aligns nixpkgs packaging with upstream metadata and fixes related regressions.

### What changed

- `python3Packages.flet`
  - switch `build-system` from `poetry-core` to `setuptools`
  - add missing runtime dependency `msgpack`
  - add `pytest-asyncio` to check inputs
  - limit checks to `tests/` via `pytestFlagsArray = [ "tests" ]` to avoid unrelated integration test dependencies
  - stop overwriting `src/flet/version.py`; instead patch only the `flet_version` placeholder with `${version}`
- `python3Packages.flet-desktop`
  - switch `build-system` from `poetry-core` to `setuptools`
  - patch `src/flet_desktop/version.py` to pin `${version}` in packaged builds

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
