### PR TITLE
python3Packages.torch: fix UB causing SIGTRAP on aarch64-darwin MPS

### DIFF
--- a/pkgs/development/python-modules/torch/source/default.nix
+++ b/pkgs/development/python-modules/torch/source/default.nix
@@ -302,6 +302,15 @@ buildPythonPackage.override { inherit stdenv; } rec {
 
   patches = [
     ./clang19-template-warning.patch
+
+    # Fix UB: std::vector::reserve() followed by operator[] access beyond size().
+    # reserve() only allocates capacity without changing size, so operator[] past
+    # size() is undefined behavior. nixpkgs' libc++ hardening
+    # (_LIBCPP_HARDENING_MODE_EXTENSIVE) catches this at runtime via
+    # __builtin_trap(), causing SIGTRAP (exit code 133) on aarch64-darwin MPS.
+    # Affects: aten/src/ATen/native/mps/operations/Shape.mm (MPS cat op)
+    #          aten/src/ATen/native/CPUBlas.cpp (brgemm, not triggered on darwin)
+    ./fix-vector-reserve-ub.patch
   ]
   ++ lib.optionals cudaSupport [
     ./fix-cmake-cuda-toolkit.patch

--- a/pkgs/development/python-modules/torch/source/fix-vector-reserve-ub.patch
+++ b/pkgs/development/python-modules/torch/source/fix-vector-reserve-ub.patch
@@ -1,0 +1,32 @@
+Fix UB: vector::reserve() followed by operator[] access
+
+reserve() only sets capacity, not size. Accessing elements via operator[]
+beyond size() is undefined behavior. With libc++ hardening
+(_LIBCPP_HARDENING_MODE_EXTENSIVE), this triggers __builtin_trap().
+
+Use resize() instead, which sets both capacity and size.
+
+diff --git a/aten/src/ATen/native/CPUBlas.cpp b/aten/src/ATen/native/CPUBlas.cpp
+--- a/aten/src/ATen/native/CPUBlas.cpp
++++ b/aten/src/ATen/native/CPUBlas.cpp
+@@ -1086,7 +1086,7 @@
+     // Create a scratchpad buffer for the brgemm execution
+     scratchpad = std::vector<uint8_t>(brg.get_scratchpad_size());
+     // Prepare default vector of pairs of tensors A and B offsets for each batch.
+-    A_B_offsets.reserve(1);
++    A_B_offsets.resize(1);
+     A_B_offsets[0] = std::make_pair(0, 0);
+   }
+   dnnl::ukernel::brgemm brg;
+diff --git a/aten/src/ATen/native/mps/operations/Shape.mm b/aten/src/ATen/native/mps/operations/Shape.mm
+--- a/aten/src/ATen/native/mps/operations/Shape.mm
++++ b/aten/src/ATen/native/mps/operations/Shape.mm
+@@ -271,7 +271,7 @@
+     auto cachedGraph = LookUpOrCreateCachedGraph<CachedGraph>(key, [&](auto mpsGraph, auto newCachedGraph) {
+       auto len_tensor_array = inputs.size() - skipped_tensor_indices.size();
+       std::vector<MPSGraphTensor*> castInputTensors(len_tensor_array);
+-      newCachedGraph->inputTensors_.reserve(len_tensor_array);
++      newCachedGraph->inputTensors_.resize(len_tensor_array);
+
+       for (const auto idx : c10::irange(len_tensor_array)) {
+         const Tensor& tensor = input_tensors[idx];


### PR DESCRIPTION
## Summary
- Fix undefined behavior in PyTorch's MPS `cat` operation and CPUBlas brgemm that causes SIGTRAP (exit code 133) on aarch64-darwin
- Root cause: `std::vector::reserve()` followed by `operator[]` access beyond `size()`
- nixpkgs' libc++ hardening (`_LIBCPP_HARDENING_MODE_EXTENSIVE`) catches this UB at runtime via `__builtin_trap()`

## Details
`reserve(n)` allocates capacity but keeps `size()` at 0. Accessing `[idx]` where `idx >= size()` is undefined behavior per the C++ standard. With `_LIBCPP_HARDENING_MODE_EXTENSIVE` (enabled in nixpkgs), libc++ adds bounds checking to `operator[]` that calls `__builtin_trap()` on violation, producing `brk #0x1` (SIGTRAP) on aarch64.

Two instances found:

1. **`aten/src/ATen/native/mps/operations/Shape.mm`**: MPS `torch.cat()` — triggers on any `torch.cat` call on MPS device. Fixed upstream by refactoring in pytorch/pytorch#165373 (not yet in 2.9.1).

2. **`aten/src/ATen/native/CPUBlas.cpp`**: OneDNN brgemm microkernel — not triggered on aarch64-darwin but same UB pattern. Still present in upstream main.

Fix: `reserve()` → `resize()` (one-line change per instance).

## Reproduction
```python
import torch
device = torch.device("mps")
t = torch.randn(1, 10, 384, device=device)
m = torch.ones(1, 10, device=device)
with torch.no_grad():
    e = m.unsqueeze(-1).expand(t.size()).to(t.dtype)
    s = torch.sum(t * e, 1)
    sm = e.sum(1).clamp(min=1e-9)
    r = s / sm
    o = torch.cat([r], 1)      # UB occurs here (Shape.mm reserve→operator[])
    torch.mps.synchronize()     # SIGTRAP when GPU executes
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
