### PR TITLE
pulumi.pkgs.mkPulumiPackage: allow overriding the Python SDK's args

### DIFF
--- a/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
+++ b/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildGoModule,
   fetchFromGitHub,
   python3Packages,
@@ -118,6 +119,7 @@ in
   env ? { },
   meta,
   fetchSubmodules ? false,
+  pythonArgs ? { },
   ...
 }@args:
 let
@@ -175,11 +177,14 @@ mkBasePackage (
       VERSION=v${version} go generate cmd/${cmdRes}/main.go
     '';
 
-    passthru.sdks.python = mkPythonPackage {
-      inherit meta src version;
+    passthru.sdks.python = mkPythonPackage (
+      {
+        inherit meta src version;
 
-      pname = repo;
-    };
+        pname = repo;
+      }
+      // pythonArgs
+    );
   }
-  // args
+  // (lib.removeAttrs args [ "pythonArgs" ])
 )

--- a/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
+++ b/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
@@ -48,7 +48,7 @@ let
       src,
       version,
       ...
-    }:
+    }@args:
     python3Packages.callPackage (
       {
         buildPythonPackage,
@@ -58,52 +58,55 @@ let
         semver,
         setuptools,
       }:
-      buildPythonPackage {
-        inherit
-          pname
-          meta
-          src
-          version
-          ;
-        pyproject = true;
+      buildPythonPackage (
+        {
+          inherit
+            pname
+            meta
+            src
+            version
+            ;
+          pyproject = true;
 
-        sourceRoot = "${src.name}/sdk/python";
+          sourceRoot = "${src.name}/sdk/python";
 
-        propagatedBuildInputs = [
-          parver
-          pulumi
-          semver
-          setuptools
-        ];
+          propagatedBuildInputs = [
+            parver
+            pulumi
+            semver
+            setuptools
+          ];
 
-        postPatch = ''
-          if [[ -e "pyproject.toml" ]]; then
-            sed -i \
-              -e 's/^  version = .*/  version = "${version}"/g' \
-              pyproject.toml
-          else
-            sed -i \
-               -e 's/^VERSION = .*/VERSION = "${version}"/g' \
-               -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "${version}"/g' \
-               setup.py
-          fi
-        '';
+          postPatch = ''
+            if [[ -e "pyproject.toml" ]]; then
+              sed -i \
+                -e 's/^  version = .*/  version = "${version}"/g' \
+                pyproject.toml
+            else
+              sed -i \
+                 -e 's/^VERSION = .*/VERSION = "${version}"/g' \
+                 -e 's/^PLUGIN_VERSION = .*/PLUGIN_VERSION = "${version}"/g' \
+                 setup.py
+            fi
+          '';
 
-        # Auto-generated; upstream does not have any tests.
-        # Verify that the version substitution works
-        checkPhase = ''
-          runHook preCheck
+          # Auto-generated; upstream does not have any tests.
+          # Verify that the version substitution works
+          checkPhase = ''
+            runHook preCheck
 
-          ${pip}/bin/pip show "${pname}" | grep "Version: ${version}" > /dev/null \
-            || (echo "ERROR: Version substitution seems to be broken"; exit 1)
+            ${pip}/bin/pip show "${pname}" | grep "Version: ${version}" > /dev/null \
+              || (echo "ERROR: Version substitution seems to be broken"; exit 1)
 
-          runHook postCheck
-        '';
+            runHook postCheck
+          '';
 
-        pythonImportsCheck = [
-          (builtins.replaceStrings [ "-" ] [ "_" ] pname)
-        ];
-      }
+          pythonImportsCheck = [
+            (builtins.replaceStrings [ "-" ] [ "_" ] pname)
+          ];
+        }
+        // args
+      )
     ) { };
 in
 {


### PR DESCRIPTION
- “Pulumiverse” packages typically have a Python package name of `pulumiverse_${repo}`, unlike SDKs for official Pulumi providers ; see #489848
- some Python SDKs may have additional dependencies ; see #489894

## Things done
- No build or test needed, since none of the derivations changed (as per CI's eval)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
