### PR TITLE
pulumi.pkgs.pulumiverse-talos: init at 0.7.1

### DIFF
--- a/pkgs/by-name/pu/pulumi/plugins/pulumiverse-talos/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumiverse-talos/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  mkPulumiPackage,
+}:
+mkPulumiPackage rec {
+  owner = "pulumiverse";
+  repo = "pulumi-talos";
+  version = "0.7.1";
+  rev = "v${version}"; # TODO: add support for `tag`
+  hash = "sha256-mk56p7vle61NdRKEaC8v0Eh9aJiilwdaDMwVvLaVRIM=";
+  vendorHash = "sha256-1xAIb7ZSsTqlVBpgFHc3RdQkNDngDT7A6tu7gEiGKjY=";
+  cmdGen = "pulumi-tfgen-talos";
+  cmdRes = "pulumi-resource-talos";
+  extraLdflags = [
+    "-X=github.com/${owner}/${repo}/provider/pkg/version.Version=${version}"
+  ];
+  pythonArgs.pname = "pulumiverse_talos";
+  meta = {
+    description = "Talos Linux resource package, providing IaC configuration of Talos k8s clusters";
+    mainProgram = cmdRes;
+    homepage = "https://www.pulumi.com/registry/packages/talos/";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [
+      nicoo
+    ];
+  };
+}


### PR DESCRIPTION
A Pulumi resource provider for installing, bootstrapping, and managing clusters running [Talos Linux](https://talos.dev), a Kubernetes distribution.

Depends on #489840

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
