### PR TITLE
update cross-seed 6.13.5 -> 6.13.6

### DIFF
--- a/nixos/modules/services/torrent/cross-seed.nix
+++ b/nixos/modules/services/torrent/cross-seed.nix
@@ -105,7 +105,7 @@ in
           };
 
           outputDir = mkOption {
-            type = types.path;
+            type = types.nullOr types.path;
             default = "${cfg.configDir}/output";
             defaultText = "\${cfg.configDir}/output";
             description = "Directory where cross-seed will place torrent files it finds.";
@@ -193,7 +193,8 @@ in
           inherit (cfg) group user;
           mode = "700";
         };
-
+      }
+      // lib.optionalAttrs (cfg.settings.outputDir != null) {
         ${cfg.settings.outputDir}.d = {
           inherit (cfg) group user;
           mode = "750";
@@ -222,7 +223,7 @@ in
           LoadCredential = lib.mkIf (cfg.settingsFile != null) "secretSettingsFile:${cfg.settingsFile}";
 
           StateDirectory = "cross-seed";
-          ReadWritePaths = [ cfg.settings.outputDir ];
+          ReadWritePaths = lib.optional (cfg.settings.outputDir != null) cfg.settings.outputDir;
           ReadOnlyPaths = lib.optional (cfg.settings.torrentDir != null) cfg.settings.torrentDir;
         };
 
@@ -231,7 +232,7 @@ in
           RequiresMountsFor = lib.flatten [
             cfg.settings.dataDirs
             cfg.settings.linkDirs
-            cfg.settings.outputDir
+            (lib.optional (cfg.settings.outputDir != null) cfg.settings.outputDir)
           ];
         };
       };

--- a/pkgs/by-name/cr/cross-seed/package.nix
+++ b/pkgs/by-name/cr/cross-seed/package.nix
@@ -8,16 +8,16 @@
 
 buildNpmPackage rec {
   pname = "cross-seed";
-  version = "6.13.5";
+  version = "6.13.6";
 
   src = fetchFromGitHub {
     owner = "cross-seed";
     repo = "cross-seed";
     tag = "v${version}";
-    hash = "sha256-WdKd20vzJfWvnZKBID6IzXOScrZgPKDDafzT2PY9N9k=";
+    hash = "sha256-E2tnlDU2/msNcSsoDXvwGWFhWpXEByloUmlVp2tckwo=";
   };
 
-  npmDepsHash = "sha256-iTho+dbJAt7B2R+dN2xo6jnRo/psjQE76GHYksoojdA=";
+  npmDepsHash = "sha256-tR7zPoIX6yjlRx8QbRSxskvueQ1BsP3gGAlonKHH0RY=";
 
   passthru = {
     updateScript = nix-update-script;


### PR DESCRIPTION
cross-seed was updated from `6.13.5` to `6.13.6` in `pkgs/by-name/cr/cross-seed/package.nix`, including refreshed `src.hash` and `npmDepsHash` for the new upstream release.

The NixOS module in `nixos/modules/services/torrent/cross-seed.nix` was also updated to make `services.cross-seed.settings.outputDir` nullable (`types.nullOr types.path`). Related module logic was adjusted so `tmpfiles`, `ReadWritePaths`, and `RequiresMountsFor` only include `outputDir` when it is not `null`. This avoids evaluation/runtime issues when users intentionally set `outputDir = null`.: 
<img width="787" height="580" alt="image" src="https://github.com/user-attachments/assets/e20b8234-a4dc-490e-95e2-e7c0e5b81370" />


## Upstream release/changelog:
- https://github.com/cross-seed/cross-seed/releases/tag/v6.13.6
- https://github.com/cross-seed/cross-seed/compare/v6.13.5...v6.13.6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
