### PR TITLE
tor: 0.4.8.22 -> 0.4.9.5

### DIFF
--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -46,11 +46,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "tor";
-  version = "0.4.8.22";
+  version = "0.4.9.5";
 
   src = fetchurl {
     url = "https://dist.torproject.org/tor-${finalAttrs.version}.tar.gz";
-    hash = "sha256-yIYg2SeKJ549In/2CXW4SqQTWSEfjs/2hgGZI7mSkzI=";
+    hash = "sha256-yUnC+Gs0jmSJGXb2seScF3ZVsj35cZMEm/G4zTCZ4Xk=";
   };
 
   outputs = [


### PR DESCRIPTION
Release notes: https://gitlab.torproject.org/tpo/core/tor/-/raw/tor-0.4.9.5/ReleaseNotes

This is a minor release containing various bugfixes and new features. The most prominent new features are the Counter Galois Onion (CGO) encryption method (https://blog.torproject.org/introducing-cgo/) and the Happy Families certificate scheme for relay management (https://blog.torproject.org/happy-families/).

Tested by:
- Operating a relay with the NixOS module (aarch64-linux)
- Basic usage via `curl` for both clearnet sites and onion services (x86_64-linux)
	- command: `tor --SocksPort 9052` and then `curl --socks5-hostname localhost:9052 https://check.torproject.org/api/ip`
	- command: `tor --SocksPort 9052` and then `curl --socks5-hostname localhost:9052 http://2gzyxa5ihm7nsggfxnu52rck2vv4rvmdlkiu3zzui5du4xyclen53wid.onion` (Tor Project homepage)
- Usage with Tor Browser as a managed proxy (x86_64-linux)
	- command: `tor --SocksPort 9050` and then `TOR_PROVIDER=none TOR_SOCKS_PORT=9050 tor-browser`

We've also been using the 0.4.9.4-rc release on all of our machines since its release (i.e. for the last two weeks) and have encountered no issues.

**Backporting:** We believe this release *can and should* be backported, despite its "removed features." The most prominent reason is to give users to add features such as CGO encryption and Happy Families, as well as the variety of bug fixes included here. Both are good for the network, and require support by both clients and relays. Accelerating their adoption is beneficial, and the former leads to better security for clients. Additionally, I expect that all of the removed features are entirely non-issues (i.e. don't break any real users), given that they either require decade-old Tor clients or were never used at all.

<details>
<summary>We go through them one by one under the collapsed element to justify this:</summary>

> o Removed features (directory authority):
> We include a new consensus method that removes support for computing "package" lines in consensus documents. This feature was never used, and support for including it in our votes was removed in 0.4.2.1-alpha. Finishes implementation of proposal 301."

(0.4.9.1-alpha) This was never used, and is only for use by dirauths (who we *strongly* doubt are using stock Nixpkgs tor :p).

> o Removed features (directory authorities):
> - Directory authorities no longer support consensus methods before method 32. Closes ticket 40835.

Same as above. This affects a tiny number of individuals (the nine directory authority operators) who I strongly doubt are using Nixpkgs, let alone stock Nixpkgs `tor`.

> o Removed features (obsolete):
> - Relays no longer support the obsolete TAP circuit extension protocol. (For backward compatibility, however, relays still continue to include TAP keys in their descriptors.) Implements part of proposal 350.
> - Removed some vestigial code for selecting the TAP circuit extension protocol.

(0.4.9.1-alpha) The TAP protocol is [negotiated by clients and relays](https://spec.torproject.org/tor-spec/obsolete-circuit-extension.html#TAP), and this simply makes sure that relays never agree to it. Given that the keys are still around, this is not a breaking change at all.

> o Removed features:
> - Relays no longer support the obsolete "RSA-SHA256-TLSSecret" authentication method, which used a dangerously short RSA key, and which required access TLS session internals. The current method ("Ed25519-SHA256-RFC5705") has been supported since 0.3.0.1-alpha. Closes ticket 41020.

(0.4.9.2-alpha) This feature was already insecure, and clients have had support for more secure methods since 0.3.0.1-alpha (released in December 2016) and 0.3.0.6 (released in April 2017). Clients this old are almost certainly hilariously insecure (if they can even connect to the Tor network), and I don't think it's worth worrying about them.

> o Removed features:
> - Relays no longer support clients that falsely advertise TLS ciphers they don't really support. (Clients have not done this since 0.2.3.17-beta). Part of ticket 41031.
> - Relays no longer support clients that require obsolete v1 and v2 link handshakes. (The v3 link handshake has been supported since 0.2.3.6-alpha). Part of ticket 41031.

(0.4.9.3-alpha) I believe the same applies as the previous issue. 0.2.3.6-alpha was released in October 2011, and 0.2.3.17-beta in June 2012. The corresponding stable release, 0.2.3.25, was released in November 2012.

Given that all of these features which were dropped were only used by decade-old clients, if at all, I think it is entirely fine to accept these *technically*-breaking changes and will affect approximately no one in practice.
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
