### PR TITLE
pulumi.pkgs.mkPulumiPackage: cleanup unnecessary `inherit`s

### DIFF
--- a/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
+++ b/pkgs/by-name/pu/pulumi/extra/mk-pulumi-package.nix
@@ -16,15 +16,7 @@ let
       ...
     }@args:
     buildGoModule (
-      rec {
-        inherit
-          pname
-          src
-          vendorHash
-          version
-          env
-          ;
-
+      {
         sourceRoot = "${src.name}/provider";
 
         subPackages = [ "cmd/${cmd}" ];
@@ -147,16 +139,8 @@ let
 in
 mkBasePackage (
   {
-    inherit
-      meta
-      src
-      version
-      vendorHash
-      extraLdflags
-      env
-      ;
-
     pname = repo;
+    inherit env src;
 
     nativeBuildInputs = [
       pulumi-gen


### PR DESCRIPTION
Inherited attributes are always superfluous in
```nix
{ inherit (x) a b c; ... } // x
```

## Things done

- Evaluated with no changed derivation on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
