### PR TITLE
Revert "applyPatches: fix operator precedence"

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1080,7 +1080,7 @@ rec {
 
         # Carry (and merge) information from the underlying `src` if present.
         # If there is not src.meta, this meta block will be blank regardless.
-        meta = lib.optionalAttrs (finalAttrs.src ? meta) (removeAttrs finalAttrs.src.meta [ "position" ]);
+        meta = lib.optionalAttrs (finalAttrs.src ? meta) removeAttrs finalAttrs.src.meta [ "position" ];
       };
   };
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#489842. Needed to revert https://github.com/NixOS/nixpkgs/pull/488861 which has a bunch more issues.