### PR TITLE
nixos-rebuild-ng: add missing FLAKE_FLAGS in `nix eval` calls

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -201,7 +201,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
         "--diff",
         action="store_true",
         help="prints out the diff between the current system "
-        "and the newly built one using nix store diff-closures"
+        "and the newly built one using nix store diff-closures",
     )
     main_parser.add_argument("action", choices=Action.values(), nargs="?")
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -314,6 +314,7 @@ def get_build_image_name_flake(
     r = run_wrapper(
         [
             "nix",
+            *FLAKE_FLAGS,
             "eval",
             "--json",
             flake.to_attr(
@@ -365,6 +366,7 @@ def get_build_image_variants_flake(
     r = run_wrapper(
         [
             "nix",
+            *FLAKE_FLAGS,
             "eval",
             "--json",
             flake.to_attr("config.system.build.images"),

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/nix.py
@@ -1,7 +1,7 @@
-import sys
 import json
 import logging
 import os
+import sys
 import textwrap
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -540,12 +540,13 @@ def list_generations(profile: Profile) -> list[GenerationJson]:
             reverse=True,
         )
 
-def diff_closures(current_config: Path, new_config: Path, target_host: Remote | None = None):
-    print(
-        f"<<< {current_config}\n"
-        f">>> {new_config}",
-        file=sys.stderr
-    )
+
+def diff_closures(
+    current_config: Path,
+    new_config: Path,
+    target_host: Remote | None = None,
+) -> None:
+    print(f"<<< {current_config}\n>>> {new_config}", file=sys.stderr)
     run_wrapper(
         [
             "nix",
@@ -556,7 +557,7 @@ def diff_closures(current_config: Path, new_config: Path, target_host: Remote | 
             new_config,
         ],
         remote=target_host,
-        stdout=sys.stderr
+        stdout=sys.stderr,
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -8,7 +8,7 @@ import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
 from ipaddress import AddressValueError, IPv6Address
-from typing import Final, Self, TypedDict, Unpack
+from typing import Final, Self, TextIO, TypedDict, Unpack
 
 from . import tmpdir
 
@@ -85,8 +85,8 @@ class Remote:
 # Not exhaustive, but we can always extend it later.
 class RunKwargs(TypedDict, total=False):
     capture_output: bool
-    stderr: int | None
-    stdout: int | None
+    stderr: int | TextIO | None
+    stdout: int | TextIO | None
 
 
 def cleanup_ssh() -> None:

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/services.py
@@ -324,9 +324,15 @@ def build_and_activate_system(
     current_config = Path("/run/current-system")
     if args.diff:
         if current_config.exists():
-            nix.diff_closures(current_config=current_config.readlink(), new_config=path_to_config, target_host=target_host)
+            nix.diff_closures(
+                current_config=current_config.readlink(),
+                new_config=path_to_config,
+                target_host=target_host,
+            )
         else:
-            logger.warning(f"missing '{str(current_config)}', skipping configuration diff...")
+            logger.warning(
+                f"missing '{current_config!s}', skipping configuration diff..."
+            )
 
     _activate_system(
         path_to_config=path_to_config,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -386,6 +386,8 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
             call(
                 [
                     "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
                     "eval",
                     "--json",
                     '/path/to/config#nixosConfigurations."hostname".config.system.build.images',
@@ -412,6 +414,8 @@ def test_execute_nix_build_image_flake(mock_run: Mock, tmp_path: Path) -> None:
             call(
                 [
                     "nix",
+                    "--extra-experimental-features",
+                    "nix-command flakes",
                     "eval",
                     "--json",
                     '/path/to/config#nixosConfigurations."hostname".config.system.build.images.azure.passthru.filePath',

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -556,11 +556,9 @@ def test_list_generations(mock_get_generations: Mock, tmp_path: Path) -> None:
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_diff_closures(mock_run: Mock) -> None:
 
-    assert n.diff_closures(
-        Path("/run/current-system"),
-        Path("/nix/var/nix/profiles/system"),
-        None
-    ) == None
+    n.diff_closures(
+        Path("/run/current-system"), Path("/nix/var/nix/profiles/system"), None
+    )
     mock_run.assert_called_with(
         [
             "nix",
@@ -572,7 +570,7 @@ def test_diff_closures(mock_run: Mock) -> None:
             Path("/nix/var/nix/profiles/system"),
         ],
         remote=None,
-        stdout=sys.stderr
+        stdout=sys.stderr,
     )
 
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -394,6 +394,8 @@ def test_get_build_image_variants_flake(mock_run: Mock) -> None:
     mock_run.assert_called_with(
         [
             "nix",
+            "--extra-experimental-features",
+            "nix-command flakes",
             "eval",
             "--json",
             "/flake.nix#myAttr.config.system.build.images",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I just noted there are some missing `FLAKE_FLAGS` in `nix eval` calls. This PR should fix this issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
