### PR TITLE
libudev-devd: init at 0.6.0

### DIFF
--- a/pkgs/by-name/li/libudev-devd/package.nix
+++ b/pkgs/by-name/li/libudev-devd/package.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  evdev-proto,
+  freebsd,
+}:
+
+stdenv.mkDerivation rec {
+  name = "libudev-devd";
+  version = "0.6.0";
+
+  src = fetchFromGitHub {
+    owner = "wulf7";
+    repo = "libudev-devd";
+    rev = "v${version}";
+    hash = "sha256-CrRPJMJRYiYyEIy5XPFk286S87/paf6OfGkEdRPv28I=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    freebsd.libdevinfo
+    evdev-proto
+  ];
+
+  mesonFlags = [
+    "-Denable-gpl=true"
+  ];
+
+  meta = {
+    description = "libudev-compatible interface for devd";
+    homepage = "https://github.com/wulf7/libudev-devd";
+    license = with lib.licenses; [
+      bsd2
+      gpl2
+    ];
+    maintainers = with lib.maintainers; [ artemist ];
+    platforms = lib.platforms.freebsd;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Create the new `libudev-devd` package. It will be needed to support libinput on FreeBSD.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (cross for x86_64-freebsd)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
