### PR TITLE
prisma_6,prisma_7: use `pnpm pack` instead of `npm pack`

### DIFF
--- a/pkgs/by-name/pr/prisma_7/package.nix
+++ b/pkgs/by-name/pr/prisma_7/package.nix
@@ -73,13 +73,22 @@ stdenv.mkDerivation (finalAttrs: {
     pnpm install --offline --ignore-scripts --frozen-lockfile --prod
     cp -r node_modules $out/lib/prisma
 
+    # Resolve workspace references so pnpm pack works
+    for package in packages/*; do
+      jq --arg version $version '
+        def resolve_deps: with_entries(.value |= if . == "workspace:*" then $version else . end);
+        if has("dependencies") then .dependencies |= resolve_deps else . end
+        | if has("devDependencies") then .devDependencies |= resolve_deps else . end
+      ' $package/package.json | sponge $package/package.json
+    done
+
     # Only install cli and its workspace dependencies
     for package in cli $deps; do
-      filename=$(npm pack --json ./packages/$package | jq -r '.[].filename')
+      filename=$(cd packages/$package && pnpm pack | tail -1)
       mkdir -p $out/lib/prisma/packages/$package
       [ -d "packages/$package/node_modules" ] && \
         cp -r packages/$package/node_modules $out/lib/prisma/packages/$package
-      tar xf $filename --strip-components=1 -C $out/lib/prisma/packages/$package
+      tar xf "packages/$package/$filename" --strip-components=1 -C $out/lib/prisma/packages/$package
     done
 
     # Remove dangling symlinks to packages we didn't copy to $out


### PR DESCRIPTION
`prisma_6` and `prisma_7` packages incorrectly used `npm pack` in a pnpm workspace to create the package tarballs. This worked until it didn't in https://github.com/NixOS/nixpkgs/pull/488068. ~~This change unblocks updating pnpm in nixpkgs.~~ UPD: there are more issues in Prisma packages that block it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
