### PR TITLE
applyPatches: to extendMkDerivation, fix meta.position [v2]

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1063,7 +1063,15 @@ rec {
           ;
         preferLocalBuild = true;
         allowSubstitutes = false;
-        phases = "unpackPhase patchPhase installPhase";
+
+        # unconditionally disable phases that are we don't want
+        dontConfigure = true;
+        dontBuild = true;
+        doCheck = false;
+        doInstallCheck = false;
+        dontFixup = true;
+        doDist = false;
+
         installPhase = "cp -R ./ $out";
       }
       # Carry (and merge) information from the underlying `src` if present.

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1019,33 +1019,34 @@ rec {
       ];
     }
   */
-  applyPatches =
-    {
-      src,
-      name ?
-        (
-          if builtins.typeOf src == "path" then
-            baseNameOf src
-          else if builtins.isAttrs src && builtins.hasAttr "name" src then
-            src.name
-          else
-            throw "applyPatches: please supply a `name` argument because a default name can only be computed when the `src` is a path or is an attribute set with a `name` attribute."
-        )
-        + "-patched",
-      patches ? [ ],
-      prePatch ? "",
-      postPatch ? "",
-      ...
-    }@args:
-    assert lib.assertMsg (
-      !args ? meta
-    ) "applyPatches will not merge 'meta', change it in 'src' instead";
-    assert lib.assertMsg (
-      !args ? passthru
-    ) "applyPatches will not merge 'passthru', change it in 'src' instead";
-    if patches == [ ] && prePatch == "" && postPatch == "" then
-      src # nothing to do, so use original src to avoid additional drv
-    else
+  applyPatches = lib.extendMkDerivation {
+    constructDrv = stdenvNoCC.mkDerivation;
+
+    extendDrvArgs =
+      finalAttrs:
+      {
+        src,
+        name ?
+          (
+            if builtins.typeOf src == "path" then
+              baseNameOf src
+            else if builtins.isAttrs src && builtins.hasAttr "name" src then
+              src.name
+            else
+              throw "applyPatches: please supply a `name` argument because a default name can only be computed when the `src` is a path or is an attribute set with a `name` attribute."
+          )
+          + "-patched",
+        patches ? [ ],
+        prePatch ? "",
+        postPatch ? "",
+        ...
+      }@args:
+      assert lib.assertMsg (
+        !args ? meta
+      ) "applyPatches will not merge 'meta', change it in 'src' instead";
+      assert lib.assertMsg (
+        !args ? passthru
+      ) "applyPatches will not merge 'passthru', change it in 'src' instead";
       let
         keepAttrs = names: lib.filterAttrs (name: val: lib.elem name names);
         # enables tools like nix-update to determine what src attributes to replace
@@ -1059,36 +1060,35 @@ rec {
           ] src
         );
       in
-      stdenvNoCC.mkDerivation (
-        {
-          inherit
-            name
-            src
-            patches
-            prePatch
-            postPatch
-            ;
-          preferLocalBuild = true;
-          allowSubstitutes = false;
-          phases = "unpackPhase patchPhase installPhase";
-          installPhase = "cp -R ./ $out";
-        }
-        # Carry (and merge) information from the underlying `src` if present.
-        // (optionalAttrs (src ? meta) {
-          inherit (src) meta;
-        })
-        // (optionalAttrs (extraPassthru != { } || src ? passthru) {
-          passthru = extraPassthru // src.passthru or { };
-        })
-        # Forward any additional arguments to the derivation
-        // (removeAttrs args [
-          "src"
-          "name"
-          "patches"
-          "prePatch"
-          "postPatch"
-        ])
-      );
+      {
+        inherit
+          name
+          src
+          patches
+          prePatch
+          postPatch
+          ;
+        preferLocalBuild = true;
+        allowSubstitutes = false;
+        phases = "unpackPhase patchPhase installPhase";
+        installPhase = "cp -R ./ $out";
+      }
+      # Carry (and merge) information from the underlying `src` if present.
+      // (optionalAttrs (src ? meta) {
+        inherit (src) meta;
+      })
+      // (optionalAttrs (extraPassthru != { } || src ? passthru) {
+        passthru = extraPassthru // src.passthru or { };
+      })
+      # Forward any additional arguments to the derivation
+      // (removeAttrs args [
+        "src"
+        "name"
+        "patches"
+        "prePatch"
+        "postPatch"
+      ]);
+  };
 
   # TODO: move docs to Nixpkgs manual
   # An immutable file in the store with a length of 0 bytes.

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1026,16 +1026,6 @@ rec {
       finalAttrs:
       {
         src,
-        name ?
-          (
-            if builtins.typeOf src == "path" then
-              baseNameOf src
-            else if builtins.isAttrs src && builtins.hasAttr "name" src then
-              src.name
-            else
-              throw "applyPatches: please supply a `name` argument because a default name can only be computed when the `src` is a path or is an attribute set with a `name` attribute."
-          )
-          + "-patched",
         ...
       }@args:
       assert lib.assertMsg (
@@ -1058,9 +1048,23 @@ rec {
         );
       in
       {
-        inherit
-          name
-          ;
+        name =
+          args.name or (
+            if builtins.isPath src then
+              baseNameOf src + "-patched"
+            else if builtins.isAttrs src && (src ? name) then
+              let
+                srcName = builtins.parseDrvName src;
+              in
+              "${srcName.name}-patched${lib.optionalString (srcName.version != "") "-${srcName.version}"}"
+            else
+              throw "applyPatches: please supply a `name` argument because a default name can only be computed when the `src` is a path or is an attribute set with a `name` attribute."
+          );
+
+        # Manually setting `name` can mess up positioning.
+        # This should fix it.
+        pos = builtins.unsafeGetAttrPos "src" args;
+
         preferLocalBuild = true;
         allowSubstitutes = false;
 

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1076,7 +1076,7 @@ rec {
       }
       # Carry (and merge) information from the underlying `src` if present.
       // (optionalAttrs (src ? meta) {
-        inherit (src) meta;
+        meta = removeAttrs src.meta [ "position" ];
       })
       // (optionalAttrs (extraPassthru != { } || src ? passthru) {
         passthru = extraPassthru // src.passthru or { };

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1036,9 +1036,6 @@ rec {
               throw "applyPatches: please supply a `name` argument because a default name can only be computed when the `src` is a path or is an attribute set with a `name` attribute."
           )
           + "-patched",
-        patches ? [ ],
-        prePatch ? "",
-        postPatch ? "",
         ...
       }@args:
       assert lib.assertMsg (
@@ -1063,10 +1060,6 @@ rec {
       {
         inherit
           name
-          src
-          patches
-          prePatch
-          postPatch
           ;
         preferLocalBuild = true;
         allowSubstitutes = false;
@@ -1079,15 +1072,7 @@ rec {
       })
       // (optionalAttrs (extraPassthru != { } || src ? passthru) {
         passthru = extraPassthru // src.passthru or { };
-      })
-      # Forward any additional arguments to the derivation
-      // (removeAttrs args [
-        "src"
-        "name"
-        "patches"
-        "prePatch"
-        "postPatch"
-      ]);
+      });
   };
 
   # TODO: move docs to Nixpkgs manual

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1077,14 +1077,12 @@ rec {
         doDist = false;
 
         installPhase = "cp -R ./ $out";
-      }
-      # Carry (and merge) information from the underlying `src` if present.
-      // (optionalAttrs (src ? meta) {
-        meta = removeAttrs src.meta [ "position" ];
-      })
-      // (optionalAttrs (extraPassthru != { } || src ? passthru) {
+
         passthru = extraPassthru // src.passthru or { };
-      });
+
+        # Carry (and merge) information from the underlying `src` if present.
+        meta = lib.optionalAttrs (src ? meta) (removeAttrs src.meta) [ "position" ];
+      };
   };
 
   # TODO: move docs to Nixpkgs manual

--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -1053,10 +1053,7 @@ rec {
             if builtins.isPath finalAttrs.src then
               baseNameOf finalAttrs.src + "-patched"
             else if builtins.isAttrs finalAttrs.src && (finalAttrs.src ? name) then
-              let
-                srcName = builtins.parseDrvName finalAttrs.src.name;
-              in
-              "${srcName.name}-patched${lib.optionalString (srcName.version != "") "-${srcName.version}"}"
+              finalAttrs.src.name + "-patched"
             else
               throw "applyPatches: please supply a `name` argument because a default name can only be computed when the `src` is a path or is an attribute set with a `name` attribute."
           );
@@ -1082,7 +1079,7 @@ rec {
         passthru = extraPassthru // finalAttrs.src.passthru or { };
 
         # Carry (and merge) information from the underlying `src` if present.
-        meta = lib.optionalAttrs (src ? meta) (removeAttrs finalAttrs.src.meta) [ "position" ];
+        meta = lib.optionalAttrs (src ? meta) (removeAttrs finalAttrs.src.meta [ "position" ]);
       };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. To extendMkDerivation #489490
2. Clean up once in extendMkDerivation
3. Add fix so that `meta.position` gets filled properly #488794
4. Disable all phases that we do not want unconditionally #489860

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
