### PR TITLE
elmPackages.*: remove myself as maintainer from packages where I was

### DIFF
--- a/pkgs/development/compilers/elm/packages/elm-analyse/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-analyse/default.nix
@@ -52,7 +52,7 @@ buildNpmPackage (finalAttrs: {
     description = "Analyse your Elm code, identify deficiencies and apply best practices";
     homepage = "https://stil4m.github.io/elm-analyse/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-analyse";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-doc-preview/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-doc-preview/default.nix
@@ -40,6 +40,6 @@ buildNpmPackage (finalAttrs: {
     description = "Elm offline documentation previewer";
     homepage = "https://github.com/dmy/elm-doc-preview";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-git-install/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-git-install/default.nix
@@ -27,7 +27,7 @@ buildNpmPackage (finalAttrs: {
     description = "Install private Elm packages from any git url";
     homepage = "https://github.com/robinheghan/elm-git-install";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-git-install";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-graphql/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-graphql/default.nix
@@ -43,7 +43,7 @@ buildNpmPackage (finalAttrs: {
     description = "Autogenerate type-safe GraphQL queries in Elm";
     homepage = "https://github.com/dillonkearns/elm-graphql";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-graphql";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-language-server/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-language-server/default.nix
@@ -30,6 +30,6 @@ buildNpmPackage (finalAttrs: {
     mainProgram = "elm-language-server";
     homepage = "https://github.com/elm-tooling/elm-language-server";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-live/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-live/default.nix
@@ -31,7 +31,7 @@ buildNpmPackage (finalAttrs: {
     description = "Flexible dev server for Elm with live-reload";
     homepage = "https://www.elm-live.com";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-live";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-optimize-level-2/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-optimize-level-2/default.nix
@@ -27,7 +27,7 @@ buildNpmPackage (finalAttrs: {
     description = "A second level of optimization for the Javascript that the Elm Compiler produces.";
     homepage = "https://github.com/mdgriffith/elm-optimize-level-2";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-optimize-level-2";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-spa/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-spa/default.nix
@@ -27,7 +27,7 @@ buildNpmPackage (finalAttrs: {
     description = "Elm single-page-apps made easy";
     homepage = "https://www.elm-spa.dev/";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-spa";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-upgrade/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-upgrade/default.nix
@@ -33,7 +33,7 @@ buildNpmPackage (finalAttrs: {
     description = "Upgrade your Elm 0.18 projects to Elm 0.19";
     homepage = "https://github.com/avh4/elm-upgrade";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-upgrade";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-verify-examples/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-verify-examples/default.nix
@@ -44,7 +44,7 @@ buildNpmPackage (finalAttrs: {
     description = "Verify examples in your docs";
     homepage = "https://github.com/stoeffel/elm-verify-examples";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-verify-examples";
   };
 })

--- a/pkgs/development/compilers/elm/packages/elm-xref/default.nix
+++ b/pkgs/development/compilers/elm/packages/elm-xref/default.nix
@@ -42,7 +42,7 @@ buildNpmPackage (finalAttrs: {
     description = "Cross referencing tool for Elm";
     homepage = "https://github.com/zwilias/elm-xref";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
     mainProgram = "elm-xref";
   };
 })


### PR DESCRIPTION
I never used any of these packages, and was simply the maintainer of convenience. Dropping myself from this, someone else can pick it up if they want to in the future.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
