### PR TITLE
coc-*: remove myself from maintainers

### DIFF
--- a/pkgs/by-name/co/coc-clangd/package.nix
+++ b/pkgs/by-name/co/coc-clangd/package.nix
@@ -24,6 +24,6 @@ buildNpmPackage {
     description = "clangd extension for coc.nvim";
     homepage = "https://github.com/clangd/coc-clangd";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/coc-css/package.nix
+++ b/pkgs/by-name/co/coc-css/package.nix
@@ -38,6 +38,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Css language server extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-css";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-diagnostic/package.nix
+++ b/pkgs/by-name/co/coc-diagnostic/package.nix
@@ -43,6 +43,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Diagnostic-languageserver extension for coc.nvim";
     homepage = "https://github.com/iamcco/coc-diagnostic";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-docker/package.nix
+++ b/pkgs/by-name/co/coc-docker/package.nix
@@ -24,6 +24,6 @@ buildNpmPackage (finalAttrs: {
     description = "Docker language server extension using dockerfile-language-server-nodejs for coc.nvim";
     homepage = "https://github.com/josa42/coc-docker";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-emmet/package.nix
+++ b/pkgs/by-name/co/coc-emmet/package.nix
@@ -40,6 +40,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Emmet extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-emmet";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-eslint/package.nix
+++ b/pkgs/by-name/co/coc-eslint/package.nix
@@ -24,6 +24,6 @@ buildNpmPackage (finalAttrs: {
     description = "Eslint extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-eslint";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-explorer/package.nix
+++ b/pkgs/by-name/co/coc-explorer/package.nix
@@ -40,6 +40,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Explorer for coc.nvim";
     homepage = "https://github.com/weirongxu/coc-explorer";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-flutter/package.nix
+++ b/pkgs/by-name/co/coc-flutter/package.nix
@@ -67,6 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Flutter support for (Neo)vim";
     homepage = "https://github.com/iamcco/coc-flutter";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-git/package.nix
+++ b/pkgs/by-name/co/coc-git/package.nix
@@ -30,6 +30,6 @@ buildNpmPackage (finalAttrs: {
     description = "Git integration of coc.nvim";
     homepage = "https://github.com/neoclide/coc-git";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-haxe/package.nix
+++ b/pkgs/by-name/co/coc-haxe/package.nix
@@ -26,6 +26,6 @@ buildNpmPackage (finalAttrs: {
     description = "Haxe language server extension for coc.nvim";
     homepage = "https://github.com/vantreeseba/coc-haxe";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-highlight/package.nix
+++ b/pkgs/by-name/co/coc-highlight/package.nix
@@ -40,6 +40,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Highlight extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-highlight";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-html/package.nix
+++ b/pkgs/by-name/co/coc-html/package.nix
@@ -38,6 +38,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Html language server extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-html";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-java/package.nix
+++ b/pkgs/by-name/co/coc-java/package.nix
@@ -24,6 +24,6 @@ buildNpmPackage (finalAttrs: {
     description = "Java extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-java";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-jest/package.nix
+++ b/pkgs/by-name/co/coc-jest/package.nix
@@ -29,6 +29,6 @@ buildNpmPackage {
     description = "Jest extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-jest";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/coc-json/package.nix
+++ b/pkgs/by-name/co/coc-json/package.nix
@@ -26,6 +26,6 @@ buildNpmPackage (finalAttrs: {
     description = "JSON language extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-json";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-lists/package.nix
+++ b/pkgs/by-name/co/coc-lists/package.nix
@@ -26,6 +26,6 @@ buildNpmPackage (finalAttrs: {
     description = "Common lists for coc.nvim";
     homepage = "https://github.com/neoclide/coc-lists";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-markdownlint/package.nix
+++ b/pkgs/by-name/co/coc-markdownlint/package.nix
@@ -24,6 +24,6 @@ buildNpmPackage {
     description = "Markdownlint extension for coc.nvim";
     homepage = "https://github.com/fannheyward/coc-markdownlint";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/coc-nginx/package.nix
+++ b/pkgs/by-name/co/coc-nginx/package.nix
@@ -66,6 +66,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "nginx-language-server extension for coc.nvim";
     homepage = "https://github.com/yaegassy/coc-nginx";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-pairs/package.nix
+++ b/pkgs/by-name/co/coc-pairs/package.nix
@@ -27,6 +27,6 @@ buildNpmPackage (finalAttrs: {
     description = "Basic auto pairs extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-pairs";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-prettier/package.nix
+++ b/pkgs/by-name/co/coc-prettier/package.nix
@@ -26,6 +26,6 @@ buildNpmPackage (finalAttrs: {
     description = "Prettier extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-prettier";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-pyright/package.nix
+++ b/pkgs/by-name/co/coc-pyright/package.nix
@@ -25,6 +25,6 @@ buildNpmPackage {
     description = "Pyright extension for coc.nvim";
     homepage = "https://github.com/fannheyward/coc-pyright";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/coc-r-lsp/package.nix
+++ b/pkgs/by-name/co/coc-r-lsp/package.nix
@@ -40,6 +40,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "R LSP client for coc.nvim";
     homepage = "https://github.com/neoclide/coc-r-lsp";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-rust-analyzer/package.nix
+++ b/pkgs/by-name/co/coc-rust-analyzer/package.nix
@@ -24,6 +24,6 @@ buildNpmPackage {
     description = "Rust-analyzer extension for coc.nvim";
     homepage = "https://github.com/fannheyward/coc-rust-analyzer";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/co/coc-sh/package.nix
+++ b/pkgs/by-name/co/coc-sh/package.nix
@@ -29,6 +29,6 @@ buildNpmPackage (finalAttrs: {
     description = "bash-language-server for coc.nvim";
     homepage = "https://github.com/josa42/coc-sh";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-smartf/package.nix
+++ b/pkgs/by-name/co/coc-smartf/package.nix
@@ -66,6 +66,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Make jump to character easier";
     homepage = "https://github.com/neoclide/coc-smartf";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-snippets/package.nix
+++ b/pkgs/by-name/co/coc-snippets/package.nix
@@ -26,6 +26,6 @@ buildNpmPackage (finalAttrs: {
     description = "Snippets solution for coc.nvim";
     homepage = "https://github.com/neoclide/coc-snippets";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-solargraph/package.nix
+++ b/pkgs/by-name/co/coc-solargraph/package.nix
@@ -68,6 +68,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Solargraph extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-solargraph";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-spell-checker/package.nix
+++ b/pkgs/by-name/co/coc-spell-checker/package.nix
@@ -41,6 +41,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Basic spell checker that works well with camelCase code for (Neo)vim";
     homepage = "https://github.com/iamcco/coc-spell-checker";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-sqlfluff/package.nix
+++ b/pkgs/by-name/co/coc-sqlfluff/package.nix
@@ -66,6 +66,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "SQLFluff extension for coc.nvim";
     homepage = "https://github.com/yaegassy/coc-sqlfluff";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-stylelint/package.nix
+++ b/pkgs/by-name/co/coc-stylelint/package.nix
@@ -46,6 +46,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Stylelint extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-stylelint";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-tabnine/package.nix
+++ b/pkgs/by-name/co/coc-tabnine/package.nix
@@ -68,6 +68,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Tabnine extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-tabnine";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-texlab/package.nix
+++ b/pkgs/by-name/co/coc-texlab/package.nix
@@ -66,6 +66,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "TexLab extension for coc.nvim";
     homepage = "https://github.com/fannheyward/coc-texlab";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-vimlsp/package.nix
+++ b/pkgs/by-name/co/coc-vimlsp/package.nix
@@ -40,6 +40,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "vim-language-server extension for coc.nvim";
     homepage = "https://github.com/iamcco/coc-vimlsp";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-vimtex/package.nix
+++ b/pkgs/by-name/co/coc-vimtex/package.nix
@@ -36,6 +36,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "VimTeX extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-vimtex";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-wxml/package.nix
+++ b/pkgs/by-name/co/coc-wxml/package.nix
@@ -46,6 +46,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     description = "Wxml extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-wxml";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-yaml/package.nix
+++ b/pkgs/by-name/co/coc-yaml/package.nix
@@ -29,6 +29,6 @@ buildNpmPackage (finalAttrs: {
     description = "Yaml language server extension for coc.nvim";
     homepage = "https://github.com/neoclide/coc-yaml";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/co/coc-yank/package.nix
+++ b/pkgs/by-name/co/coc-yank/package.nix
@@ -57,6 +57,6 @@ buildNpmPackage (finalAttrs: {
     description = "Yank highlight and persist yank history support for vim";
     homepage = "https://github.com/neoclide/coc-yank";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ pyrox0 ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
I never used any of these packages, and its just easier for me if I'm no longer a maintainer. Either someone else can pick them up, or they can get dropped from the tree.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
