### PR TITLE
pulumi.pkgs.pulumi-kubernetes: init at 4.25.0

### DIFF
--- a/pkgs/by-name/pu/pulumi/plugins/pulumi-kubernetes/package.nix
+++ b/pkgs/by-name/pu/pulumi/plugins/pulumi-kubernetes/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  mkPulumiPackage,
+  python3Packages,
+}:
+mkPulumiPackage rec {
+  owner = "pulumi";
+  repo = "pulumi-kubernetes";
+  version = "4.25.0";
+  rev = "v${version}";
+  hash = "sha256-CkNTMeiiM8Q4eIEugmid7IKVHplhOAg8YaANSEFodxE=";
+  vendorHash = "sha256-L4kJ+oKciJO0B05rcs4lbKpcINxC3gmvR0lC+LdSNeo=";
+  cmdGen = "pulumi-gen-kubernetes";
+  cmdRes = "pulumi-resource-kubernetes";
+  extraLdflags = [
+    "-X=github.com/pulumi/${repo}/provider/pkg/version.Version=${version}"
+  ];
+  pythonArgs.dependencies = with python3Packages; [
+    requests
+  ];
+  meta = {
+    description = "Kubernetes resource package, for the Pulumi infrastructure-as-code toolchain";
+    mainProgram = "pulumi-resource-kubernetes";
+    homepage = "https://www.pulumi.com/docs/reference/clouds/kubernetes/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ nicoo ];
+  };
+}


### PR DESCRIPTION
Packages a Pulumi resource provider for the Kubernetes system orchestrator.

Depends on #489840

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [Package tests] at `passthru.tests`.
- ~~Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].~~
  No derivation changed
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
