### PR TITLE
ugs-platform: init at 2.1.17

### DIFF
--- a/pkgs/by-name/ug/ugs-platform/package.nix
+++ b/pkgs/by-name/ug/ugs-platform/package.nix
@@ -1,0 +1,95 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  lib,
+  gtk3,
+  openjdk17,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+let
+  version = "2.1.20";
+
+  jdk = openjdk17.override {
+    enableJavaFX = true;
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "ugs-platform";
+    desktopName = "Universal Gcode Sender (Platform)";
+    genericName = "G-code Sender";
+    comment = "Universal G-code Sender Platform UI";
+    exec = "ugs-platform";
+    icon = "ugsplatform";
+    categories = [ "Utility" "Engineering" ];
+    startupWMClass = "UGSPlatform";
+    terminal = false;
+  };
+
+  platforms = {
+    "x86_64-linux" = fetchurl {
+      url = "https://github.com/winder/Universal-G-Code-Sender/releases/download/v${version}/linux-x64-ugs-platform-app-${version}.tar.gz";
+      sha256 = "sha256-dcFrrC/TBEJ2a1LsT+hLjiExTurEWX4QXXLWs55Ao4M=";
+    };
+    "aarch64-linux" = fetchurl {
+      url = "https://github.com/winder/Universal-G-Code-Sender/releases/download/v${version}/linux-aarch64-ugs-platform-app-${version}.tar.gz";
+      sha256 = "sha256-x7zFu632m/HBfwf/z+znoJ05TPH7CmpFphuZvQAkgeg=";
+    };
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "ugs-platform";
+  inherit version;
+
+  src = platforms.${stdenvNoCC.system};
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/opt/ugs-platform"
+    cp -ar . "$out/opt/ugs-platform/"
+
+    # Drop bundled runtime (massive) — we use Nix JDK instead.
+    rm -rf "$out/opt/ugs-platform/jdk"
+
+    rm -rf "$out/opt/ugs-platform/"{java/docs,platform/docs}
+
+    # Ensure it uses our Java, not any assumptions in the launcher.
+    substituteInPlace "$out/opt/ugs-platform/bin/ugsplatform" \
+      --replace "JAVA_HOME=" "JAVA_HOME=${jdk}\n"
+
+    mkdir -p "$out/bin"
+    makeWrapper "$out/opt/ugs-platform/bin/ugsplatform" "$out/bin/ugs-platform" \
+      --set JAVA_HOME "${jdk}" \
+      --add-flags "--jdkhome ${jdk}" \
+      --prefix PATH : ${lib.makeBinPath [ jdk ]} \
+      --prefix XDG_DATA_DIRS : ${gtk3}/share/gsettings-schemas/${gtk3.name}
+
+    mkdir -p "$out/share/icons/hicolor/scalable/apps"
+    cp "$out/opt/ugs-platform/bin/icon.svg" \
+      "$out/share/icons/hicolor/scalable/apps/ugsplatform.svg"
+
+    runHook postInstall
+  '';
+
+  desktopItems = [ desktopItem ];
+
+  meta = with lib; {
+    description = "Cross-platform G-Code sender for GRBL, Smoothieware, TinyG and G2core";
+    homepage = "https://github.com/winder/Universal-G-Code-Sender";
+    maintainers = with maintainers; [ srounce ];
+    sourceProvenance = with sourceTypes; [ binaryBytecode ];
+    license = licenses.gpl3;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    mainProgram = "ugs-platform";
+  };
+}


### PR DESCRIPTION
Adding UGS Platform from my dotfiles

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [xt] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
