### PR TITLE
inetutils: fix darwin builds not working due to warning

### DIFF
--- a/pkgs/by-name/in/inetutils/package.nix
+++ b/pkgs/by-name/in/inetutils/package.nix
@@ -10,7 +10,6 @@
   libxcrypt,
   util-linux,
 }:
-
 stdenv.mkDerivation rec {
   pname = "inetutils";
   version = "2.7";
@@ -78,6 +77,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-servers";
 
+  hardeningDisable = lib.optional stdenv.hostPlatform.isDarwin "format";
   doCheck = true;
 
   installFlags = [ "SUIDMODE=" ];

--- a/pkgs/by-name/in/inetutils/package.nix
+++ b/pkgs/by-name/in/inetutils/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     # https://git.congatec.com/yocto/meta-openembedded/commit/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3
     ./inetutils-1_9-PATH_PROCNET_DEV.patch
 
-    ./tests-libls.sh.patch
+    (if stdenv.isDarwin then ./tests-libls-2.sh.patch else ./tests-libls.sh.patch)
 
     (fetchpatch {
       name = "CVE-2026-24061_1.patch";
@@ -77,7 +77,8 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-servers";
 
-  hardeningDisable = lib.optional stdenv.hostPlatform.isDarwin "format";
+  ${if stdenv.isDarwin then "hardeningDisable" else null} = [ "format" ];
+
   doCheck = true;
 
   installFlags = [ "SUIDMODE=" ];

--- a/pkgs/by-name/in/inetutils/tests-libls-2.sh.patch
+++ b/pkgs/by-name/in/inetutils/tests-libls-2.sh.patch
@@ -1,0 +1,18 @@
+tests: Remove bogus test for unsorted file listing and tests for -u and -c, which fail on apfs.
+
+Minimized from what Debian applies:
+https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/tree/debian/patches/local/0006-tests-Remove-bogus-test-for-unsorted-file-listing.patch?id=8ab7f49fe5cf194e989ae6ae6a78eb65397c5778
+--- a/tests/libls.sh
++++ b/tests/libls.sh
+@@ -94 +93,0 @@ REPLY_C=`$LS -C $LSDIR`
+-REPLY_Cf=`$LS -Cf $LSDIR`
+@@ -108,2 +106,0 @@ REPLY_n=`$LS -n $LSDIR`
+-REPLY_Ccts=`$LS -Ccts $LSDIR`
+-REPLY_Cuts=`$LS -Cuts $LSDIR`
+@@ -133,2 +129,0 @@ test `echo "$diff" | $GREP -c -v '^[.]\{1,2\}$'` -eq 0 ||
+-test x"$REPLY_C" != x"$REPLY_Cf" ||
+-  { errno=1; echo >&2 'Failed to disable sorting with "-f".'; }
+@@ -153,3 +146,0 @@ test x"$REPLY_l" != x"$REPLY_n" ||
+-test x"$REPLY_Ccts" != x"$REPLY_Cuts" ||
+-  { errno=1; echo >&2 'Failed to distinguish "-u" from "-c".'; }
+-

--- a/pkgs/by-name/in/inetutils/tests-libls.sh.patch
+++ b/pkgs/by-name/in/inetutils/tests-libls.sh.patch
@@ -1,12 +1,49 @@
-tests: Remove bogus test for unsorted file listing
+tests: Remove bogus test for unsorted file listing and tests for -u and -c, which fail on apfs.
 
 Minimized from what Debian applies:
 https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/tree/debian/patches/local/0006-tests-Remove-bogus-test-for-unsorted-file-listing.patch?id=8ab7f49fe5cf194e989ae6ae6a78eb65397c5778
 --- a/tests/libls.sh
 +++ b/tests/libls.sh
-@@ -91,1 +91,0 @@
+@@ -91,7 +91,6 @@ REPLY_a1=`$LS -a1 $LSDIR`
+ REPLY_A1=`$LS -A1 $LSDIR`
+
+ REPLY_C=`$LS -C $LSDIR`
 -REPLY_Cf=`$LS -Cf $LSDIR`
-@@ -130,3 +129,0 @@
+ REPLY_Cr=`$LS -Cr $LSDIR`
+ REPLY_Ct=`$LS -Ct $LSDIR`
+ REPLY_x=`$LS -x $LSDIR`
+@@ -101,13 +100,6 @@ REPLY_l=`$LS -l $LSDIR`
+ REPLY_lT=`$LS -l $LSDIR`
+ REPLY_n=`$LS -n $LSDIR`
+
+-# In an attempt to counteract lack of subsecond accuracy,
+-# probe the parent directory where timing is known to be more
+-# varied, than in the subdirectory "tests/".
+-#
+-REPLY_Ccts=`$LS -Ccts $LSDIR`
+-REPLY_Cuts=`$LS -Cuts $LSDIR`
+-
+ # All the following failure causes are checked and possibly
+ # brought to attention, independently of the other instances.
+ #
+@@ -130,9 +122,6 @@ test `echo "$diff" | $GREP -c -v '^[.]\{1,2\}$'` -eq 0 ||
+     fi
+   }
+
 -test x"$REPLY_C" != x"$REPLY_Cf" ||
 -  { errno=1; echo >&2 'Failed to disable sorting with "-f".'; }
 -
+ test x"$REPLY_C" != x"$REPLY_Cr" ||
+   { errno=1; echo >&2 'Failed to reverse sorting with "-r".'; }
+
+@@ -150,9 +139,6 @@ test x"$REPLY_l" != x"$REPLY_n" ||
+   { id -u && ! id -u -n ;} ||
+   { errno=1; echo >&2 'Failed to distinguish "-l" from "-n".'; }
+
+-test x"$REPLY_Ccts" != x"$REPLY_Cuts" ||
+-  { errno=1; echo >&2 'Failed to distinguish "-u" from "-c".'; }
+-
+ test $errno -ne 0 || $silence echo "Successful testing".
+
+ exit $errno
+

--- a/pkgs/by-name/in/inetutils/tests-libls.sh.patch
+++ b/pkgs/by-name/in/inetutils/tests-libls.sh.patch
@@ -1,18 +1,12 @@
-tests: Remove bogus test for unsorted file listing and tests for -u and -c, which fail on apfs.
+tests: Remove bogus test for unsorted file listing
 
 Minimized from what Debian applies:
 https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/tree/debian/patches/local/0006-tests-Remove-bogus-test-for-unsorted-file-listing.patch?id=8ab7f49fe5cf194e989ae6ae6a78eb65397c5778
 --- a/tests/libls.sh
 +++ b/tests/libls.sh
-@@ -94 +93,0 @@ REPLY_C=`$LS -C $LSDIR`
+@@ -91,1 +91,0 @@
 -REPLY_Cf=`$LS -Cf $LSDIR`
-@@ -108,2 +106,0 @@ REPLY_n=`$LS -n $LSDIR`
--REPLY_Ccts=`$LS -Ccts $LSDIR`
--REPLY_Cuts=`$LS -Cuts $LSDIR`
-@@ -133,2 +129,0 @@ test `echo "$diff" | $GREP -c -v '^[.]\{1,2\}$'` -eq 0 ||
+@@ -130,3 +129,0 @@
 -test x"$REPLY_C" != x"$REPLY_Cf" ||
 -  { errno=1; echo >&2 'Failed to disable sorting with "-f".'; }
-@@ -153,3 +146,0 @@ test x"$REPLY_l" != x"$REPLY_n" ||
--test x"$REPLY_Ccts" != x"$REPLY_Cuts" ||
--  { errno=1; echo >&2 'Failed to distinguish "-u" from "-c".'; }
 -

--- a/pkgs/by-name/in/inetutils/tests-libls.sh.patch
+++ b/pkgs/by-name/in/inetutils/tests-libls.sh.patch
@@ -4,46 +4,15 @@ Minimized from what Debian applies:
 https://git.hadrons.org/cgit/debian/pkgs/inetutils.git/tree/debian/patches/local/0006-tests-Remove-bogus-test-for-unsorted-file-listing.patch?id=8ab7f49fe5cf194e989ae6ae6a78eb65397c5778
 --- a/tests/libls.sh
 +++ b/tests/libls.sh
-@@ -91,7 +91,6 @@ REPLY_a1=`$LS -a1 $LSDIR`
- REPLY_A1=`$LS -A1 $LSDIR`
-
- REPLY_C=`$LS -C $LSDIR`
+@@ -94 +93,0 @@ REPLY_C=`$LS -C $LSDIR`
 -REPLY_Cf=`$LS -Cf $LSDIR`
- REPLY_Cr=`$LS -Cr $LSDIR`
- REPLY_Ct=`$LS -Ct $LSDIR`
- REPLY_x=`$LS -x $LSDIR`
-@@ -101,13 +100,6 @@ REPLY_l=`$LS -l $LSDIR`
- REPLY_lT=`$LS -l $LSDIR`
- REPLY_n=`$LS -n $LSDIR`
-
--# In an attempt to counteract lack of subsecond accuracy,
--# probe the parent directory where timing is known to be more
--# varied, than in the subdirectory "tests/".
--#
+@@ -108,2 +106,0 @@ REPLY_n=`$LS -n $LSDIR`
 -REPLY_Ccts=`$LS -Ccts $LSDIR`
 -REPLY_Cuts=`$LS -Cuts $LSDIR`
--
- # All the following failure causes are checked and possibly
- # brought to attention, independently of the other instances.
- #
-@@ -130,9 +122,6 @@ test `echo "$diff" | $GREP -c -v '^[.]\{1,2\}$'` -eq 0 ||
-     fi
-   }
-
+@@ -133,2 +129,0 @@ test `echo "$diff" | $GREP -c -v '^[.]\{1,2\}$'` -eq 0 ||
 -test x"$REPLY_C" != x"$REPLY_Cf" ||
 -  { errno=1; echo >&2 'Failed to disable sorting with "-f".'; }
--
- test x"$REPLY_C" != x"$REPLY_Cr" ||
-   { errno=1; echo >&2 'Failed to reverse sorting with "-r".'; }
-
-@@ -150,9 +139,6 @@ test x"$REPLY_l" != x"$REPLY_n" ||
-   { id -u && ! id -u -n ;} ||
-   { errno=1; echo >&2 'Failed to distinguish "-l" from "-n".'; }
-
+@@ -153,3 +146,0 @@ test x"$REPLY_l" != x"$REPLY_n" ||
 -test x"$REPLY_Ccts" != x"$REPLY_Cuts" ||
 -  { errno=1; echo >&2 'Failed to distinguish "-u" from "-c".'; }
 -
- test $errno -ne 0 || $silence echo "Successful testing".
-
- exit $errno
-


### PR DESCRIPTION
Fixes #488689. When building on MacOS/darwin, the build uses clang reports a format-security error that upstream has stated [they won't fix](https://lists.gnu.org/r/bug-gnulib/2025-06/msg00327.html). This disables format-security to avoid that error and also tweaks the existing libls test patch ignore an error on APFS caused by -c ("last changed for sorting or printing) and -u ("last access time") having the same result.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. 
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

EDIT:
Apologies for the messy PR. Working my way around understanding the repo.