### PR TITLE
ortie: init at 1.1.0

### DIFF
--- a/pkgs/by-name/or/ortie/package.nix
+++ b/pkgs/by-name/or/ortie/package.nix
@@ -1,0 +1,107 @@
+{
+  buildFeatures ? [ ],
+  buildNoDefaultFeatures ? false,
+  buildPackages,
+  dbus,
+  fetchFromGitHub,
+  installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellFiles,
+  lib,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
+
+let
+  version = "1.1.0";
+  hash = "sha256-DcSYPz3pgNaVZMvt9iqVsD8Dzrs1azk+ZYldQNYAMcU=";
+  cargoHash = "sha256-klIb4CkIs8hhjz5fFaUlyMR53/wAa2oCtk9Jp0fYVM0=";
+
+  inherit (stdenv.hostPlatform)
+    isLinux
+    isWindows
+    isAarch64
+    ;
+
+  emulator = stdenv.hostPlatform.emulator buildPackages;
+  exe = stdenv.hostPlatform.extensions.executable;
+
+  hasNativeTlsFeature = builtins.elem "native-tls" buildFeatures;
+  hasNotifyFeature = !buildNoDefaultFeatures || builtins.elem "notify" buildFeatures;
+
+  dbus' = dbus.overrideAttrs (old: {
+    env = (old.env or { }) // {
+      NIX_CFLAGS_COMPILE =
+        (old.env.NIX_CFLAGS_COMPILE or "")
+        # required for D-Bus on Linux AArch64
+        + lib.optionalString (isLinux && isAarch64) " -mno-outline-atomics";
+    };
+  });
+
+in
+rustPlatform.buildRustPackage {
+  inherit cargoHash version buildNoDefaultFeatures;
+
+  pname = "ortie";
+
+  src = fetchFromGitHub {
+    inherit hash;
+    owner = "pimalaya";
+    repo = "ortie";
+    rev = "v${version}";
+  };
+
+  env = {
+    # OpenSSL should not be provided by vendors, not even on Windows
+    OPENSSL_NO_VENDOR = "1";
+  };
+
+  nativeBuildInputs =
+    [ ]
+    ++ lib.optional (hasNativeTlsFeature || hasNotifyFeature) pkg-config
+    ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
+
+  buildInputs =
+    [ ]
+    ++ lib.optional hasNativeTlsFeature openssl
+    # D-Bus is provided by vendors on Windows
+    ++ lib.optional (hasNotifyFeature && !isWindows) dbus';
+
+  buildFeatures =
+    buildFeatures
+    # D-Bus is provided by vendors on Windows
+    ++ lib.optional (hasNotifyFeature && isWindows) "vendored";
+
+  doCheck = false;
+
+  postInstall =
+    lib.optionalString (lib.hasInfix "wine" emulator) ''
+      export WINEPREFIX="''${WINEPREFIX:-$(mktemp -d)}"
+      mkdir -p $WINEPREFIX
+    ''
+    + ''
+      mkdir -p $out/share/{completions,man}
+      ${emulator} "$out"/bin/ortie${exe} manuals "$out"/share/man
+      ${emulator} "$out"/bin/ortie${exe} completions -d "$out"/share/completions bash elvish fish powershell zsh
+    ''
+    + lib.optionalString installManPages ''
+      installManPage "$out"/share/man/*
+    ''
+    + lib.optionalString installShellCompletions ''
+      installShellCompletion --cmd ortie \
+        --bash "$out"/share/completions/ortie.bash \
+        --fish "$out"/share/completions/ortie.fish \
+        --zsh "$out"/share/completions/_ortie
+    '';
+
+  meta = {
+    description = "CLI to manage OAuth tokens";
+    mainProgram = "ortie";
+    homepage = "https://github.com/pimalaya/ortie";
+    changelog = "https://github.com/pimalaya/ortie/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ soywod ];
+  };
+}


### PR DESCRIPTION
Ortie CLI is a CLI to manage OAuth tokens.

https://github.com/pimalaya/ortie

https://github.com/pimalaya/ortie/releases/tag/v1.1.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
