### PR TITLE
frankenphp: 1.11.1 -> 1.11.2

### DIFF
--- a/pkgs/by-name/fr/frankenphp/package.nix
+++ b/pkgs/by-name/fr/frankenphp/package.nix
@@ -6,8 +6,6 @@
   php,
   brotli,
   watcher,
-  testers,
-  frankenphp,
   cctools,
   darwin,
   libiconv,
@@ -15,6 +13,7 @@
   makeBinaryWrapper,
   runCommand,
   writeText,
+  versionCheckHook,
 }:
 
 let
@@ -29,18 +28,18 @@ let
   phpConfig = "${phpUnwrapped.dev}/bin/php-config";
   pieBuild = stdenv.hostPlatform.isMusl;
 in
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "frankenphp";
-  version = "1.11.1";
+  version = "1.11.2";
 
   src = fetchFromGitHub {
-    owner = "dunglas";
+    owner = "php";
     repo = "frankenphp";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-JzZXg/tkSZqLZn56RyLb8Q8SaeG/tHA8Sqxu99s5ks0=";
   };
 
-  sourceRoot = "${src.name}/caddy";
+  sourceRoot = "${finalAttrs.src.name}/caddy";
 
   # frankenphp requires C code that would be removed with `go mod tidy`
   # https://github.com/golang/go/issues/26366
@@ -60,6 +59,7 @@ buildGoModule rec {
     pkg-config
     cctools
     darwin.autoSignDarwinBinariesHook
+    libiconv
   ];
 
   subPackages = [ "frankenphp" ];
@@ -77,21 +77,16 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${version} PHP ${phpUnwrapped.version} Caddy'"
+    "-X 'github.com/caddyserver/caddy/v2.CustomVersion=FrankenPHP ${finalAttrs.version} PHP ${phpUnwrapped.version} Caddy'"
     # pie mode is only available with pkgsMusl, it also automatically add -buildmode=pie to $GOFLAGS
   ]
   ++ (lib.optional pieBuild [ "-static-pie" ]);
 
   preBuild = ''
     export CGO_CFLAGS="$(${phpConfig} --includes)"
-    export CGO_LDFLAGS="-DFRANKENPHP_VERSION=${version} \
+    export CGO_LDFLAGS="-DFRANKENPHP_VERSION=${finalAttrs.version} \
       $(${phpConfig} --ldflags) \
       $(${phpConfig} --libs)"
-  ''
-  + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    # replace hard-code homebrew path
-    substituteInPlace ../frankenphp.go \
-      --replace "-L/opt/homebrew/opt/libiconv/lib" "-L${libiconv}/lib"
   '';
 
   preFixup = ''
@@ -103,15 +98,14 @@ buildGoModule rec {
 
   doCheck = false;
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
   passthru = {
     php = phpEmbedWithZts;
     tests = {
       # TODO: real NixOS test with Symfony application
-      version = testers.testVersion {
-        inherit version;
-        package = frankenphp;
-        command = "frankenphp version";
-      };
       phpinfo =
         runCommand "php-cli-phpinfo"
           {
@@ -120,20 +114,18 @@ buildGoModule rec {
             '';
           }
           ''
-            ${lib.getExe frankenphp} php-cli $phpScript > $out
+            ${lib.getExe finalAttrs.finalPackage} php-cli $phpScript > $out
           '';
     };
   };
 
   meta = {
-    changelog = "https://github.com/dunglas/frankenphp/releases/tag/v${version}";
+    changelog = "https://github.com/php/frankenphp/releases/tag/v${finalAttrs.version}";
     description = "Modern PHP app server";
-    homepage = "https://github.com/dunglas/frankenphp";
+    homepage = "https://github.com/php/frankenphp";
     license = lib.licenses.mit;
     mainProgram = "frankenphp";
-    maintainers = with lib.maintainers; [
-      gaelreyrol
-    ];
+    maintainers = [ lib.maintainers.piotrkwiecinski ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
Backport of c9475372c206faaf0a21fe0cf073b7a169f22594, 70430db71fd49fbc70c7cd0bcf56aa8b1a690f35, ada3a4aa114f94d8b4125b2904e77f9324682454

Include security fixes:
 - https://github.com/advisories/GHSA-g966-83w7-6w38
 - https://github.com/advisories/GHSA-r3xh-3r3w-47gp
 - https://github.com/php/frankenphp/security/advisories/GHSA-x9p2-77v6-6vhf


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
