### PR TITLE
wayle: init at 0-unstable-2026-02-12

### DIFF
--- a/pkgs/by-name/wa/wayle/package.nix
+++ b/pkgs/by-name/wa/wayle/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+
+  clang,
+  llvmPackages,
+  pkg-config,
+
+  cacert,
+  dbus,
+  fftw,
+  gdk-pixbuf,
+  glib,
+  gtk4,
+  gtk4-layer-shell,
+  libnotify,
+  libxkbcommon,
+  pipewire,
+  pulseaudio,
+  wayland,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wayle";
+  version = "0-unstable-2026-02-12";
+  src = fetchFromGitHub {
+    owner = "Jas-SinghFSU";
+    repo = "wayle";
+    rev = "370f5caaa63704e02a2ba128e47cb8d06767804e";
+    hash = "sha256-1aW6JgMEIyFN29iALrY02HcpV+gw0ICyg2XrJifX7Nc=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-yM39WIKDTmXWLF4RU5Y3NZNa1qlA0QsBodtFBb0bYZs=";
+
+  cargoInstallFlags = [
+    "--path"
+    "wayle"
+    "--path"
+    "crates/wayle-shell"
+  ];
+
+  nativeBuildInputs = [
+    clang
+    llvmPackages.libclang
+    pkg-config
+  ];
+
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
+
+  buildInputs = [
+    cacert
+    dbus
+    fftw
+    gdk-pixbuf
+    glib
+    gtk4
+    gtk4-layer-shell
+    libnotify
+    libxkbcommon
+    pipewire
+    pulseaudio
+    wayland
+  ];
+
+  doCheck = false; # skip GUI tests that require fonts etc.
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Wayland Elements - A compositor agnostic shell with extensive customization ";
+    homepage = "https://github.com/Jas-SinghFSU/wayle";
+    maintainers = with lib.maintainers; [ lykos153 ];
+    license = lib.licenses.mit;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added [wayle](https://github.com/Jas-SinghFSU/wayle), a compositor agnostic shell with extensive customization.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
