### PR TITLE
niks3: init at 1.3.0

### DIFF
--- a/pkgs/by-name/ni/niks3/package.nix
+++ b/pkgs/by-name/ni/niks3/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  nix,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "niks3";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "niks3";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-taQgMTbC+k/b+9mJH5vx7BMM3gKSI+MZWL26ZhePThk=";
+  };
+
+  vendorHash = "sha256-MoYTq1rY1GMmBBP/ypx6DqrHLGtccgsHa+2rpoztI4U=";
+
+  subPackages = [
+    "cmd/niks3"
+    "cmd/niks3-server"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # The niks3 client shells out to `nix path-info` which differs between Nix and Lix; pinning Nix
+  # here allows the format to be consistent. See https://github.com/Mic92/niks3/issues/181
+  postInstall = ''
+    wrapProgram $out/bin/niks3 --prefix PATH : ${lib.makeBinPath [ nix ]}
+  '';
+
+  meta = {
+    description = "S3-backed Nix binary cache with garbage collection";
+    homepage = "https://github.com/Mic92/niks3";
+    changelog = "https://github.com/Mic92/niks3/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mic92
+      philiptaron
+    ];
+    mainProgram = "niks3";
+  };
+})


### PR DESCRIPTION
It's a S3-backed Nix binary cache with garbage collection.

The derivation is mostly taken from https://github.com/Mic92/niks3/blob/main/nix/packages/niks3.nix and adapted for Nixpkgs.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test