### PR TITLE
chromium,chromedriver: 145.0.7632.45 -> 145.0.7632.67

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "145.0.7632.45",
+    "version": "145.0.7632.67",
     "chromedriver": {
-      "version": "145.0.7632.46",
-      "hash_darwin": "sha256-YlrKWY4DAef7/GsKtieINI2JUrHpWhVaC80rkYIkyVI=",
-      "hash_darwin_aarch64": "sha256-6TJw2tYOYXmIANa2X7pZHCrIcW8fKHo5b8ReHepVlhE="
+      "version": "145.0.7632.68",
+      "hash_darwin": "sha256-ZdAqfL/eWKZPl8+8aFDRfNIE40WWrHGEICo3IuJJbSQ=",
+      "hash_darwin_aarch64": "sha256-4/IK3uZs4PPuZoxJrJXhxEvJay2HfAk272S143SLnZA="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "7ad2aeb6be38786b2bf653d667d3df01e68d3c40",
-        "hash": "sha256-l/gxUE0itdUQXLRAR2cp72hu21dgecZvWLC5Br0SPuo=",
+        "rev": "87da8db4955d72b610645049c3458f787e7aaf0e",
+        "hash": "sha256-1yOwFxisQ8QHQ0OZ2bhmZtxTPzPAiHnbDdHha8A8sFU=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop_12.html

Contains a hotfix for https://issues.chromium.org/issues/483672730

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
