### PR TITLE
haskellPackages.tailwind: Remove override

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1909,30 +1909,6 @@ builtins.intersectAttrs super {
     broken = false;
   }) super.cabal-install;
 
-  tailwind =
-    addBuildDepend
-      # Overrides for tailwindcss copied from:
-      # https://github.com/EmaApps/emanote/blob/master/nix/tailwind.nix
-      (pkgs.tailwindcss.overrideAttrs (old: {
-        plugins = [
-          pkgs.nodePackages."@tailwindcss/aspect-ratio"
-          pkgs.nodePackages."@tailwindcss/forms"
-          pkgs.nodePackages."@tailwindcss/line-clamp"
-          pkgs.nodePackages."@tailwindcss/typography"
-        ];
-        # Added a shim for the `tailwindcss` CLI entry point
-        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.buildPackages.makeBinaryWrapper ];
-        postInstall = (old.postInstall or "") + ''
-          nodePath=""
-          for p in "$out" "${pkgs.postcss}" $plugins; do
-            nodePath="$nodePath''${nodePath:+:}$p/lib/node_modules"
-          done
-          makeWrapper "$out/bin/tailwindcss" "$out/bin/tailwind" --prefix NODE_PATH : "$nodePath"
-          unset nodePath
-        '';
-      }))
-      super.tailwind;
-
   keid-render-basic = addBuildTool pkgs.glslang super.keid-render-basic;
 
   # Disable checks to break dependency loop with SCalendar


### PR DESCRIPTION
According to #489959 it is my responsibility to do something about `haskellPackages.tailwind` depending on `pkgs.nodePackages."@tailwindcss/*"`.

I have no capacity or interest to maintain `haskellPackages.tailwind` so I am removing the override.

This breaks `haskellPackages.tailwind`, which at least seems to compiling rn.

If anyone cares about this package I’d be happy for them to find a better solution.