### PR TITLE
ntfy-desktop-qt: init at 1.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22317,6 +22317,12 @@
       { fingerprint = "66A8 1706 2227 9BD9 586A  CEDD 5B29 A881 3F47 65C4"; }
     ];
   };
+  reivilibre = {
+    email = "nix.oo@emunest.net";
+    github = "reivilibre";
+    githubId = 38398653;
+    name = "Olivier 'reivilibre'";
+  };
   relrod = {
     email = "ricky@elrod.me";
     github = "relrod";

--- a/pkgs/by-name/em/emojicpp/package.nix
+++ b/pkgs/by-name/em/emojicpp/package.nix
@@ -1,0 +1,32 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gperf,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "emojicpp";
+  version = "3.0.0";
+
+  src = fetchFromGitHub {
+    owner = "emmaexe";
+    repo = "emojicpp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2jFHRJvD/YQTFvjStGVm6ea/7+Tb3U9TF/JDlmFe0zY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gperf
+  ];
+
+  meta = {
+    description = "A C++ library for parsing emoji names into emoji";
+    homepage = "https://github.com/emmaexe/emojicpp";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ reivilibre ];
+  };
+})

--- a/pkgs/by-name/nt/ntfy-desktop-qt/package.nix
+++ b/pkgs/by-name/nt/ntfy-desktop-qt/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  curl,
+  nlohmann_json,
+  kdePackages,
+  emojicpp,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  # There are several projects called Ntfy Desktop
+  # https://docs.ntfy.sh/integrations/#clis-guis
+  # So disambiguate this one as using the Qt toolkit.
+  # At the time of writing, the other options are GTK or Electron.
+  pname = "ntfy-desktop-qt";
+  version = "1.6.0";
+
+  src = fetchFromGitHub {
+    owner = "emmaexe";
+    repo = "ntfyDesktop";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DUOoMAKvnKtM6Y8rW84mqcKaqc2OzO+H6YHaFO3bf4Q=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    kdePackages.extra-cmake-modules
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    curl
+    emojicpp
+    nlohmann_json
+    kdePackages.kcoreaddons
+    kdePackages.ki18n
+    kdePackages.knotifications
+    kdePackages.kxmlgui
+    kdePackages.qtbase
+  ];
+
+  cmakeFlags = [
+    # Avoids use of CPM, instead using our provided packages for emojicpp
+    # and nlohmann_json
+    # https://github.com/emmaexe/ntfyDesktop/blob/dee9bbe7663bd7a74f018089b2f57393662a7f09/CMakeLists.txt#L33-L34
+    "-DND_BUILD_TYPE=Flatpak"
+  ];
+
+  strictDeps = true;
+
+  meta = {
+    description = "A desktop client for the ntfy.sh push notification system, built with the Qt framework";
+    homepage = "https://github.com/emmaexe/ntfyDesktop";
+    changelog = "https://github.com/emmaexe/ntfyDesktop/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "ntfyDesktop";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This packages https://github.com/emmaexe/ntfyDesktop (with one of its dependencies).
It's a Qt client for the [Ntfy](https://ntfy.sh) push notification system, one of 3 listed on https://docs.ntfy.sh/integrations/#clis-guis that currently bears the name 'Ntfy Desktop'. For that reason I have disambiguated the package name in advance, with `-qt` suffix (the other two options are GTK and Electron, currently).

It's not an official Ntfy project, but it's listed on the Ntfy docs site (as the other 2 are) under this name, so I guess Ntfy is not unhappy with the name. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
