### PR TITLE
nixos/acme: drop email requirement

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -15,9 +15,21 @@ let
   numCerts = lib.length (builtins.attrNames cfg.certs);
   _24hSecs = 60 * 60 * 24;
 
+  # The placerholder email address used by lego in case none gets passed
+  placeholderEmail = "noemail@example.com";
+
   # Used to make unique paths for each cert/account config set
   mkHash = with builtins; val: lib.substring 0 20 (hashString "sha256" val);
-  mkAccountHash = acmeServer: data: mkHash "${toString acmeServer} ${data.keyType} ${data.email}";
+  mkAccountHash =
+    acmeServer: data:
+    mkHash (
+      lib.concatStringsSep " " [
+        (toString acmeServer)
+        data.keyType
+        (if (data.email != null) then data.email else placeholderEmail)
+      ]
+
+    );
   accountDirRoot = "/var/lib/acme/.lego/accounts/";
 
   # Lockdir is acme-setup.service's RuntimeDirectory.
@@ -263,6 +275,8 @@ let
         "--accept-tos" # Checking the option is covered by the assertions
         "--path"
         "."
+      ]
+      ++ lib.optionals (data.email != null) [
         "--email"
         data.email
       ]
@@ -544,7 +558,12 @@ let
           # Check if a new order is needed
           # We can only renew if the list of domains has not changed.
           # We also need an account key. Avoids #190493
-          if cmp -s domainhash.txt certificates/domainhash.txt && [ -e '${certificateKey}' ] && [ -e 'certificates/${keyName}.crt' ] && [ -n "$(find accounts -name '${data.email}.key')" ]; then
+          if cmp -s domainhash.txt certificates/domainhash.txt && [ -e '${certificateKey}' ] && \
+            [ -e 'certificates/${keyName}.crt' ] && \
+            [ -n "$(find accounts -name '${
+              if (data.email != null) then data.email else placeholderEmail
+            }.key')" ];
+          then
             # Even if a cert is not expired, it may be revoked by the CA.
             # Try to renew, and silently fail if the cert is not expired.
             # Avoids #85794 and resolves #129838
@@ -1062,14 +1081,6 @@ in
           certs = lib.attrValues cfg.certs;
         in
         [
-          {
-            assertion = cfg.defaults.email != null || lib.all (certOpts: certOpts.email != null) certs;
-            message = ''
-              You must define `security.acme.certs.<name>.email` or
-              `security.acme.defaults.email` to register with the CA. Note that using
-              many different addresses for certs may trigger account rate limits.
-            '';
-          }
           {
             assertion = cfg.acceptTerms;
             message = ''

--- a/nixos/tests/acme/http01-builtin.nix
+++ b/nixos/tests/acme/http01-builtin.nix
@@ -51,7 +51,14 @@ in
           };
 
           accountchange.configuration = {
-            security.acme.certs."${config.networking.fqdn}".email = "admin@example.test";
+            # Providing an email address is optional
+            security.acme.certs."${config.networking.fqdn}".email = null;
+          };
+
+          emailplaceholder.configuration = {
+            # but Lego will default to this email address, which should not
+            # result in any change when configured
+            security.acme.certs."${config.networking.fqdn}".email = "noemail@example.com";
           };
 
           keytype.configuration = {
@@ -154,6 +161,7 @@ in
       certName = nodes.builtin.networking.fqdn;
       caDomain = nodes.acme.test-support.acme.caDomain;
     in
+    # python
     ''
       ${(import ./utils.nix).pythonUtils}
 
@@ -212,11 +220,23 @@ in
           hash_after = builtin.succeed(f"sha256sum /var/lib/acme/{cert}/cert.pem")
           # Has to do a full run to register account, which creates new certs.
           assert hash != hash_after, "Certificate was not renewed"
+          hash = hash_after
+
+          builtin.succeed("systemctl stop renew-triggered.target")
+          switch_to(builtin, "emailplaceholder")
+          builtin.wait_for_unit("renew-triggered.target")
+
+          # Check that there are still two account directories
+          builtin.succeed("test $(ls -1 /var/lib/acme/.lego/accounts | tee /dev/stderr | wc -l) -eq 2")
+          hash_after = builtin.succeed(f"sha256sum /var/lib/acme/{cert}/cert.pem")
+          assert hash == hash_after, "Implicit to explicit email placeholder renewed the certificate"
+
           # Remove the new account directory
           builtin.succeed(
               "cd /var/lib/acme/.lego/accounts"
               " && ls -1 --sort=time | tee /dev/stderr | head -1 | xargs rm -rf"
           )
+
           # old_hash will be used in the preservation tests later
           old_hash = hash_after
 


### PR DESCRIPTION
Let's Encrypt does not require email addreses any longer, so we should allow users not to provide any.

Unsetting the email adress will change the account hash and Lego will start using a dummy email address instead. The address is hardcoded in the Lego source code in the userIDPlaceholder constant.

This is supported since Lego 4.30.1.

https://github.com/go-acme/lego/commit/bc163db9edd23bbfc3521086c0b570f468b9a87b


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
