### PR TITLE
bluej: add darwin support

### DIFF
--- a/pkgs/by-name/bl/bluej/package.nix
+++ b/pkgs/by-name/bl/bluej/package.nix
@@ -15,10 +15,14 @@
   nix-update-script,
 }:
 let
-  openjdk = openjdk21.override {
-    enableJavaFX = true;
-    openjfx_jdk = openjfx21.override { withWebKit = true; };
-  };
+  openjdk = openjdk21.override (
+    {
+      enableJavaFX = true;
+    }
+    // lib.optionalAttrs stdenv.isLinux {
+      openjfx_jdk = openjfx21.override { withWebKit = true; };
+    }
+  );
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bluej";
@@ -103,8 +107,11 @@ stdenv.mkDerivation (finalAttrs: {
       classpathException20
     ];
     mainProgram = "bluej";
-    maintainers = with lib.maintainers; [ weirdrock ];
-    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      weirdrock
+      eveeifyeve # Darwin
+    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 
 })


### PR DESCRIPTION
Added darwin support to bluej

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
