### PR TITLE
unstableGitUpdater: pass --print-changes to update-source-version

### DIFF
--- a/pkgs/common-updater/unstable-updater.nix
+++ b/pkgs/common-updater/unstable-updater.nix
@@ -107,7 +107,7 @@ let
           git describe --tags --abbrev=0 --match "''${tag_format}" 2> /dev/null || true
       }
 
-      pushd "$tmpdir"
+      pushd "$tmpdir" >&2
       commit_date="$(git show -s --pretty='format:%cs')"
       commit_sha="$(git show -s --pretty='format:%H')"
       last_tag=""
@@ -135,11 +135,11 @@ let
               last_tag="0"
           fi
           if [[ -n "$tag_prefix" ]]; then
-              echo "Stripping prefix '$tag_prefix' from tag '$last_tag'"
+              echo "Stripping prefix '$tag_prefix' from tag '$last_tag'" >&2
               last_tag="''${last_tag#"''${tag_prefix}"}"
           fi
           if [[ -n "$tag_converter" ]]; then
-              echo "Running '$last_tag' through: $tag_converter"
+              echo "Running '$last_tag' through: $tag_converter" >&2
               last_tag="$(echo "''${last_tag}" | ''${tag_converter})"
           fi
       else
@@ -150,14 +150,15 @@ let
           exit 1
       fi
       new_version="$last_tag-unstable-$commit_date"
-      popd
+      popd >&2
       # rm -rf "$tmpdir"
 
       # update the nix expression
       update-source-version \
           "$UPDATE_NIX_ATTR_PATH" \
           "$new_version" \
-          --rev="$commit_sha"
+          --rev="$commit_sha" \
+          --print-changes
     '';
   };
 


### PR DESCRIPTION
This enables git commit message customization when writing a thin-wrapper around unstableGitUpdater with "commit" in supportedFeatures.

Passing --print-changes unconditionally is consistent with other updaters such as genericUpdater, which is used by many updaters.

We also redirect all non-json stdout to stderr so that the whole
stdout contains a valid json.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
