### PR TITLE
cups-brother-mfcl2710dw: init at 4.0.0-1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22960,6 +22960,12 @@
     matrix = "@emma:rory.gay"; # preferred
     name = "Rory&";
   };
+  rosebeats = {
+    name = "Sophie Doiron";
+    email = "sophie.d21401@gmail.com";
+    github = "rosebeats";
+    githubId = 39890784;
+  };
   rosehobgoblin = {
     name = "J. L. Bowden";
     github = "rosehobgoblin";

--- a/pkgs/by-name/cu/cups-brother-mfcl2710dw/package.nix
+++ b/pkgs/by-name/cu/cups-brother-mfcl2710dw/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  perl,
+  gnused,
+  ghostscript,
+  file,
+  coreutils,
+  gnugrep,
+  which,
+}:
+let
+  arches = [
+    "x86_64"
+    "i686"
+  ];
+  runtimeDeps = [
+    ghostscript
+    file
+    gnused
+    gnugrep
+    coreutils
+    which
+  ];
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cups-brother-mfcl2710dw";
+  version = "4.0.0-1";
+
+  nativeBuildInputs = [
+    dpkg
+    makeWrapper
+    autoPatchelfHook
+  ];
+  buildInputs = [ perl ];
+
+  dontUnpack = true;
+
+  src = fetchurl {
+    url = "https://download.brother.com/welcome/dlf103526/mfcl2710dwpdrv-${finalAttrs.version}.i386.deb";
+    hash = "sha256-OOTvbCuyxw4k01CTMuBqG2boMN13q5xC7LacaweGmyw=";
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    dpkg-deb -x $src $out
+
+    # delete unnecessary files for the current architecture
+  ''
+  + lib.concatMapStrings (arch: ''
+    echo Deleting files for ${arch}
+    rm -r "$out/opt/brother/Printers/MFCL2710DW/lpd/${arch}"
+  '') (builtins.filter (arch: arch != stdenv.hostPlatform.linuxArch) arches)
+  + ''
+
+    # bundled scripts don't understand the arch subdirectories for some reason
+    ln -s \
+      "$out/opt/brother/Printers/MFCL2710DW/lpd/${stdenv.hostPlatform.linuxArch}/"* \
+      "$out/opt/brother/Printers/MFCL2710DW/lpd/"
+
+    # Fix global references and replace auto discovery mechanism with hardcoded values
+    substituteInPlace $out/opt/brother/Printers/MFCL2710DW/lpd/lpdfilter \
+      --replace-fail /opt "$out/opt" \
+      --replace-fail "my \$BR_PRT_PATH =" "my \$BR_PRT_PATH = \"$out/opt/brother/Printers/MFCL2710DW\"; #" \
+      --replace-fail "PRINTER =~" "PRINTER = \"MFCL2710DW\"; #"
+
+    # Make sure all executables have the necessary runtime dependencies available
+    find "$out" -executable -and -type f | while read file; do
+      wrapProgram "$file" --prefix PATH : "${lib.makeBinPath runtimeDeps}"
+    done
+
+    # Symlink filter and ppd into a location where CUPS will discover it
+    mkdir -p $out/lib/cups/filter $out/share/cups/model
+
+    ln -s \
+      $out/opt/brother/Printers/MFCL2710DW/lpd/lpdfilter \
+      $out/lib/cups/filter/brother_lpdwrapper_MFCL2710DW
+
+    ln -s \
+      $out/opt/brother/Printers/MFCL2710DW/cupswrapper/brother-MFCL2710DW-cups-en.ppd \
+      $out/share/cups/model/
+
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother MFC-L2710DW printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfree;
+    platforms = map (arch: "${arch}-linux") arches;
+    maintainers = with lib.maintainers; [ rosebeats ];
+  };
+})


### PR DESCRIPTION
This PR adds the printer driver for the [Brother MFC-L2710DW printer](https://support.brother.com/g/b/downloadtop.aspx?c=us&lang=en&prod=mfcl2710dw_us_eu_as)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Note: no binaries, but I tested the printer driver works with my printer
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
