### PR TITLE
rumno: 0-unstable-2025-08-13 -> 0.1.3

### DIFF
--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -17,16 +17,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rumno";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitLab {
     owner = "ivanmalison";
     repo = "rumno";
     rev = "v${version}";
-    hash = "sha256-uA7ny6m4g8+If7AGhSOonn97F/bJfW2NB9b8xIp5qaU=";
+    hash = "sha256-vR6+dNq0sdVtzdBL6GTzqAhl0fE6ulF6UCqIH1fSte4=";
   };
 
-  cargoHash = "sha256-o5KdjDxXfIQJkPsRgL13tcew53/iXKTNGrOVHA1prUA=";
+  cargoHash = "sha256-1FyDMdOO7m6y2oX/+VH5LxBwimz7fXM59eOeiffBnOI=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -17,16 +17,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "rumno";
-  version = "0.1.1";
+  version = "0.1.2";
 
   src = fetchFromGitLab {
     owner = "ivanmalison";
     repo = "rumno";
     rev = "v${version}";
-    hash = "sha256-rwbZonmwoiVSQ5zHxHeJfdd5fb1zTZ638E841P1IoEA=";
+    hash = "sha256-uA7ny6m4g8+If7AGhSOonn97F/bJfW2NB9b8xIp5qaU=";
   };
 
-  cargoHash = "sha256-9O96f1CtS8KAZu9S7FJmMWrZW7LfTAvfPqehzj/Y5jE=";
+  cargoHash = "sha256-o5KdjDxXfIQJkPsRgL13tcew53/iXKTNGrOVHA1prUA=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -11,21 +11,22 @@
   atk,
   pango,
   harfbuzz,
+  gtk-layer-shell,
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage rec {
   pname = "rumno";
-  version = "0-unstable-2025-08-13";
+  version = "0.1.1";
 
   src = fetchFromGitLab {
     owner = "ivanmalison";
     repo = "rumno";
-    rev = "a70bf6f05976b07ae5fdced2ab80d2b9e684fb92";
-    hash = "sha256-reJIYlTR6fI42EcYGwb5BmEPVtls+s1+mFd7/34oXBw=";
+    rev = "v${version}";
+    hash = "sha256-rwbZonmwoiVSQ5zHxHeJfdd5fb1zTZ638E841P1IoEA=";
   };
 
-  cargoHash = "sha256-z9nGePcVc+RPSMPb7CAPOfUMoVlP1MKo57aVFkd1DmE=";
+  cargoHash = "sha256-9O96f1CtS8KAZu9S7FJmMWrZW7LfTAvfPqehzj/Y5jE=";
 
   nativeBuildInputs = [
     pkg-config
@@ -40,6 +41,7 @@ rustPlatform.buildRustPackage {
     atk
     pango
     harfbuzz
+    gtk-layer-shell
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -15,14 +15,14 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumno";
   version = "0.1.3";
 
   src = fetchFromGitLab {
     owner = "ivanmalison";
     repo = "rumno";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vR6+dNq0sdVtzdBL6GTzqAhl0fE6ulF6UCqIH1fSte4=";
   };
 
@@ -54,4 +54,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "rumno";
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Updates rumno from `0-unstable-2025-08-13` to `0.1.3`, using the upstream GitLab tag. This also adds `gtk-layer-shell` to `buildInputs`, which is required for the newer optional layer-shell overlay support on Wayland/wlroots compositors.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
