### PR TITLE
amp-cli: remove dependency on nodePackages

### DIFF
--- a/pkgs/by-name/am/amp-cli/update.sh
+++ b/pkgs/by-name/am/amp-cli/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nodePackages.npm nix-update
+#!nix-shell -i bash -p nodejs nix-update
 
 set -euo pipefail
 


### PR DESCRIPTION
We migrate away from nodePackages as requested in https://github.com/NixOS/nixpkgs/issues/489959

## Things done

Ran the update.sh script which had the nodePackages dependency.