### PR TITLE
[Backport release-25.11] gitcs: 1.2.0 -> 1.2.1

### DIFF
--- a/pkgs/by-name/gi/gitcs/package.nix
+++ b/pkgs/by-name/gi/gitcs/package.nix
@@ -1,30 +1,44 @@
 {
   lib,
+  gitMinimal,
   buildGoModule,
   fetchFromGitHub,
+  writableTmpDirAsHomeHook,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "gitcs";
-  version = "1.2.0";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
-    owner = "knbr13";
+    owner = "hrtsegv";
     repo = "gitcs";
-    rev = "v${version}";
-    hash = "sha256-IyhVVRTKftZIzqMH5pBUMLPIk8bk0rVAxPKD6bABP68=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eAza/ni8MYrve0YCTkleOyOXPWmH4CEh8j5L+78wzsQ=";
   };
 
-  vendorHash = "sha256-8yzPdVljnODOeI5yWh19BHsF4Pa9BWc49IwenMCVGZo=";
+  vendorHash = "sha256-bG0BaH8yYp8TUiK/7xvghB4T48LcBEvmF1uvY5eYkww=";
+
+  env.CGO_ENABLED = 0;
 
   ldflags = [ "-s" ];
 
+  nativeCheckInputs = [
+    gitMinimal
+    writableTmpDirAsHomeHook
+  ];
+
+  preCheck = ''
+    git config --global init.defaultBranch main
+    bash ./setup-test.sh
+  '';
+
   meta = {
+    changelog = "https://github.com/hrtsegv/gitcs/releases/tag/v${finalAttrs.version}";
     description = "Scan local git repositories and generate a visual contributions graph";
-    changelog = "https://github.com/knbr13/gitcs/releases/tag/v${version}";
-    homepage = "https://github.com/knbr13/gitcs";
+    homepage = "https://github.com/hrtsegv/gitcs";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ phanirithvij ];
     mainProgram = "gitcs";
+    maintainers = with lib.maintainers; [ phanirithvij ];
   };
-}
+})


### PR DESCRIPTION
Manual backport to release-25.11, for #490028.

Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md?rgh-link-date=2026-02-13T06%3A45%3A03Z#changes-acceptable-for-releases).

Even as a non-committer, if you find that it is not acceptable, leave a comment.
