### PR TITLE
haskellPackages.ghc: bypass cc-wrapper for assembler

### DIFF
--- a/pkgs/development/compilers/ghc/common-hadrian.nix
+++ b/pkgs/development/compilers/ghc/common-hadrian.nix
@@ -315,7 +315,11 @@
       # Fix docs build with Sphinx >= 9 https://gitlab.haskell.org/ghc/ghc/-/issues/26810
       ++ [ ./ghc-9.6-or-later-docs-sphinx-9.patch ]
 
-      ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; });
+      ++ (import ./common-llvm-patches.nix { inherit lib version fetchpatch; })
+      # Allow configuring a separate assembler via an optional "assembler command"
+      # settings key in the GHC settings file, falling back to the C compiler.
+      # This is used to bypass the cc-wrapper for assembly (see postInstall).
+      ++ [ ./ghc-settings-separate-assembler.patch ];
 
     stdenv = stdenvNoCC;
   },
@@ -855,6 +859,15 @@ stdenv.mkDerivation (
         "Merge objects command" "${toolPath "ld${lib.optionalString useLdGold ".gold"}" installCC}" \
         "ar command" "${toolPath "ar" installCC}" \
         "ranlib command" "${toolPath "ranlib" installCC}"
+    ''
+    # Point the assembler directly at the unwrapped compiler binary, bypassing the
+    # cc-wrapper. The cc-wrapper adds ~20ms overhead per invocation for flag
+    # processing (hardening, include paths, library paths) that is irrelevant when
+    # assembling .s files. Both clang (integrated assembler) and gcc (--with-as
+    # baked in at build time) work without the wrapper for assembly.
+    + ''
+      ghc-settings-edit "$settingsFile" \
+        "assembler command" "${getToolExe installCC.cc (if installCC.isClang then "clang" else "gcc")}"
     ''
     + lib.optionalString (stdenv.targetPlatform.linker == "cctools") ''
       ghc-settings-edit "$settingsFile" \

--- a/pkgs/development/compilers/ghc/ghc-settings-separate-assembler.patch
+++ b/pkgs/development/compilers/ghc/ghc-settings-separate-assembler.patch
@@ -1,0 +1,9 @@
+--- a/compiler/GHC/Settings/IO.hs
++++ b/compiler/GHC/Settings/IO.hs
+@@ -156,1 +156,5 @@
+-  let   as_prog  = cc_prog
++  let   as_prog  =
++          case getRawFilePathSetting (escapeArg top_dir)
++                 settingsFile mySettings "assembler command" of
++            Right v -> v
++            Left _  -> cc_prog


### PR DESCRIPTION
Save 20ms for each module GHC compiles by pointing GHC's assembler setting directly at the unwrapped compiler binary, bypassing the cc-wrapper. The cc-wrapper adds ~20ms overhead per invocation for flag processing (hardening, include paths, library paths) that is irrelevant when assembling .s files

## To reproduce this:

First we need to get the assembler that is used by ghc (which is clang on mac)
```
# Get the settings file
$ ghc --print-libdir
/nix/store/77v4p34gs4ca7zyq8971g8vik80y9s47-ghc-9.10.3-with-packages/lib/ghc-9.10.3/lib

# Find the assembler command from the settings file, look for the entry ""C compiler command"
$ cat /nix/store/77v4p34gs4ca7zyq8971g8vik80y9s47-ghc-9.10.3-with-packages/lib/ghc-9.10.3/lib/settings| tr ',' '\n'
```

In my  case the `as` used by ghc is: `/nix/store/5yp55mb61iz4m2fh2p46zzx5ycgmp4vy-clang-wrapper-21.1.7/bin/cc`

Now let's look at the start time via hyperfine:
```
$ hyperfine --runs 20 '/nix/store/5yp55mb61iz4m2fh2p46zzx5ycgmp4vy-clang-wrapper-21.1.7/bin/cc --version'

Benchmark 1: /nix/store/5yp55mb61iz4m2fh2p46zzx5ycgmp4vy-clang-wrapper-21.1.7/bin/cc --version
  Time (mean ± σ):      44.7 ms ±   4.9 ms    [User: 28.9 ms, System: 12.0 ms]
  Range (min … max):    41.5 ms …  64.6 ms    20 runs
```

**44.7ms** 

Now let's benchmark the unwrapped binary:

```
$ hyperfine --runs 20 '/nix/store/dj17z73wacgqcnrynj964p8j9lj4gpb4-clang-21.1.7/bin/clang --version'
Benchmark 1: /nix/store/dj17z73wacgqcnrynj964p8j9lj4gpb4-clang-21.1.7/bin/clang --version
  Time (mean ± σ):      25.1 ms ±   0.5 ms    [User: 19.1 ms, System: 4.9 ms]
  Range (min … max):    24.4 ms …  26.0 ms    20 runs
```

**25.1ms**

So about 20ms overhead. The wrapper script does a lot of work setting up library paths etc. All this is not needed for just doing `as`. So we can save about 20ms for each `as` call. For every 50 haskell modules we compile with GHC this patch saves about 1 sec of compile time.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
