### PR TITLE
myman: init at 0.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24576,6 +24576,13 @@
     github = "Silver-Golden";
     githubId = 7858375;
   };
+  silverhadch = {
+    email = "hadichokr@icloud.com";
+    matrix = "@silverhadch07:matrix.org";
+    name = "Hadi Chokr";
+    github = "silverhadch";
+    githubId = 158838697;
+  };
   simarra = {
     name = "simarra";
     email = "loic.martel@protonmail.com";

--- a/pkgs/by-name/my/myman/package.nix
+++ b/pkgs/by-name/my/myman/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  ncurses,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "myman";
+  version = "0.7.0";
+
+  src = fetchurl {
+    url = "https://sourceforge.net/projects/myman/files/myman/myman-${finalAttrs.version}/myman-${finalAttrs.version}.tar.gz";
+    hash = "sha512-elJo+pqSdcjUa1fPcU6InCIVgaXL4Zs4jmpgI2Z/mUH3ZK9r5H+/HxGkMPFJ+/anoLtb4t2SsWwHAg+d6PyYtg==";
+  };
+
+  outputs = [
+    "out"
+    "doc"
+    "man"
+  ];
+
+  buildInputs = [ ncurses ];
+
+  configureFlags = [
+    "--with-xterm"
+    "--with-rxvt"
+    "--with-kterm"
+    "--with-ncurses"
+  ];
+
+  meta = {
+    description = "Pacman clone with an ncurses and a 'graphic' interface";
+    homepage = "http://myman.sourceforge.net/";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ silverhadch ];
+    platforms = lib.platforms.unix;
+    mainProgram = "myman";
+  };
+})


### PR DESCRIPTION
myman is a Pac‑Man‑like ncurses game from 1997 that still works great.

It additionaly comes with a bunch of X terminal wrappers (xmyman, xmyman2, xmyman4) that launch the game inside xterm, rxvt, etc. if you have them installed.
https://myman.sourceforge.io/

Small adjustments were changing the generated Makefile that tries to link with -lcurses instead of -lncurses and removing preformatted Manpages.

First‑time contributor, so let me know if I missed anything! 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
