### PR TITLE
mktemp: 1.7 -> unstable-2025-06-12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2203,7 +2203,7 @@
     name = "Vikram Narayanan";
   };
   armeenm = {
-    email = "mahdianarmeen@gmail.com";
+    email = "armeen@fulminous-hill.com";
     github = "armeenm";
     githubId = 29145250;
     name = "Armeen Mahdian";

--- a/pkgs/by-name/mk/mktemp/package.nix
+++ b/pkgs/by-name/mk/mktemp/package.nix
@@ -1,35 +1,21 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchgit,
   groff,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mktemp";
-  version = "1.7";
+  version = "unstable-2025-06-12";
 
   # Have `configure' avoid `/usr/bin/nroff' in non-chroot builds.
   NROFF = "${groff}/bin/nroff";
 
-  patches = [
-    # Pull upstream fix for parallel install failures.
-    (fetchpatch {
-      name = "parallel-install.patch";
-      url = "https://www.mktemp.org/repos/mktemp/raw-rev/eb87d96ce8b7";
-      hash = "sha256-cJ/0pFj8tOkByUwhlMwLNSQgTHyAU8svEkjKWWwsNmY=";
-    })
-  ];
-
-  # Don't use "install -s"
-  postPatch = ''
-    substituteInPlace Makefile.in --replace " 0555 -s " " 0555 "
-  '';
-
-  src = fetchurl {
-    url = "ftp://ftp.mktemp.org/pub/mktemp/mktemp-${finalAttrs.version}.tar.gz";
-    sha256 = "0x969152znxxjbj7387xb38waslr4yv6bnj5jmhb4rpqxphvk54f";
+  src = fetchgit {
+    url = "https://git.mktemp.org/mktemp.git";
+    rev = "315362892afbdfdde0b20780fee7e5aabe2c4ef8";
+    hash = "sha256-GeFCqU+YXeQHi4Nt0o/ooKlddDhRbgyk1hICL/cdHjw=";
   };
 
   enableParallelBuilding = true;
@@ -39,6 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "mktemp";
     homepage = "https://www.mktemp.org";
     license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ armeenm ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
It looks like the mktemp derivation fetches a patch file that's no longer served via the current URL due to Mercurial deprecation ([link](https://www.mktemp.org/repos/mktemp/raw-rev/eb87d96ce8b7)) so I'm opting to 1) switch to git and 2) bump to latest master which doesn't appear to need patching anymore.

## Basic Testing
Appears to be working. macOS:
```
> result/bin/mktemp
/var/folders/sc/q6s8m7d13vz1z0qt503kr1j40000gp/T/tmp.VHUkN0agHp
> result/bin/mktemp -d
/var/folders/sc/q6s8m7d13vz1z0qt503kr1j40000gp/T/tmp.ppq29Yb9Bv
> stat /var/folders/sc/q6s8m7d13vz1z0qt503kr1j40000gp/T/tmp.VHUkN0agHp
16777229 13442117 -rw------- 1 armeen staff 0 0 "Feb 13 15:09:58 2026" "Feb 13 15:09:58 2026" "Feb 13 15:09:58 2026" "Feb 13 15:09:58 2026" 4096 0 0 /var/folders/sc/q6s8m7d13vz1z0qt503kr1j40000gp/T/tmp.VHUkN0agHp
> stat /var/folders/sc/q6s8m7d13vz1z0qt503kr1j40000gp/T/tmp.ppq29Yb9Bv
16777229 13442119 drwx------ 2 armeen staff 0 64 "Feb 13 15:10:00 2026" "Feb 13 15:10:00 2026" "Feb 13 15:10:00 2026" "Feb 13 15:10:00 2026" 4096 0 0 /var/folders/sc/q6s8m7d13vz1z0qt503kr1j40000gp/T/tmp.ppq29Yb9Bv
```
Linux:
```
> result/bin/mktemp
/tmp/tmp.wd4MdmWt9E
> result/bin/mktemp -d
/tmp/tmp.0E8okxvvyO
> stat /tmp/tmp.wd4MdmWt9E
  File: /tmp/tmp.wd4MdmWt9E
  Size: 0           Blocks: 0          IO Block: 4096   regular empty file
Device: 259,1   Inode: 29229993    Links: 1
Access: (0600/-rw-------)  Uid: ( 1000/  armeen)   Gid: (  100/   users)
Access: 2026-02-13 15:14:44.306107613 +0530
Modify: 2026-02-13 15:14:44.306107613 +0530
Change: 2026-02-13 15:14:44.306107613 +0530
 Birth: 2026-02-13 15:14:44.306107613 +0530
> stat /tmp/tmp.0E8okxvvyO
  File: /tmp/tmp.0E8okxvvyO
  Size: 4096        Blocks: 8          IO Block: 4096   directory
Device: 259,1   Inode: 29230017    Links: 2
Access: (0700/drwx------)  Uid: ( 1000/  armeen)   Gid: (  100/   users)
Access: 2026-02-13 15:14:47.822036442 +0530
Modify: 2026-02-13 15:14:47.822036442 +0530
Change: 2026-02-13 15:14:47.822036442 +0530
 Birth: 2026-02-13 15:14:47.822036442 +0530
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
