### PR TITLE
calibre: apply fix for CVE-2026-25731 and CVE-2026-25635

### DIFF
--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -61,6 +61,15 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/debian-calibre/calibre/raw/refs/tags/debian/${finalAttrs.version}+${debian-source}/debian/patches/hardening/0007-Hardening-Qt-code.patch";
         hash = "sha256-lKp/omNicSBiQUIK+6OOc8ysM6LImn5GxWhpXr4iX+U=";
       })
+      # Fix CVE-2026-25635
+      # http://tracker.security.nixos.org/issues/NIXPKGS-2026-0156
+      # https://github.com/NixOS/nixpkgs/issues/488046
+      # Fixed upstream in 9.2.0.
+      (fetchpatch {
+        name = "CVE-2026-25635.patch";
+        url = "https://github.com/kovidgoyal/calibre/commit/9739232fcb029ac15dfe52ccd4fdb4a07ebb6ce9.patch";
+        hash = "sha256-fzotxhfMF/DCMvpIfMSOGY8iVOybsYymRQvhXf7jQyc=";
+      })
       # Fix CVE-2026-25636
       # http://tracker.security.nixos.org/issues/NIXPKGS-2026-0160
       # https://github.com/NixOS/nixpkgs/issues/488052

--- a/pkgs/by-name/ca/calibre/package.nix
+++ b/pkgs/by-name/ca/calibre/package.nix
@@ -86,6 +86,15 @@ stdenv.mkDerivation (finalAttrs: {
         url = "https://github.com/kovidgoyal/calibre/commit/9484ea82c6ab226c18e6ca5aa000fa16de598726.patch";
         hash = "sha256-hpWFSQXyOAVRqou0v+5oT5zIrBbyP2Uv2z1Vg811ZG0=";
       })
+      # Fix CVE-2026-25731
+      # http://tracker.security.nixos.org/issues/NIXPKGS-2026-0155
+      # https://github.com/NixOS/nixpkgs/issues/488045
+      # Fixed upstream in 9.2.0.
+      (fetchpatch {
+        name = "CVE-2026-25731.patch";
+        url = "https://github.com/kovidgoyal/calibre/commit/f0649b27512e987b95fcab2e1e0a3bcdafc23379.patch";
+        hash = "sha256-G9H6hEN5cyFIqDmJZv+bgt+6ZF6/K2t9npYjksjcxTo=";
+      })
     ]
     ++ lib.optional (!unrarSupport) ./dont_build_unrar_plugin.patch;
 


### PR DESCRIPTION
First CVE:
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-25731
Upstream advisory: GHSA-xrh9-w7qx-3gcc
Nix security tracking issue: https://tracker.security.nixos.org/issues/NIXPKGS-2026-0155

Second CVE:
CVE: https://nvd.nist.gov/vuln/detail/CVE-2026-25635
Upstream advisory: GHSA-32vh-whvh-9fxr
Nix security tracking issue: https://tracker.security.nixos.org/issues/NIXPKGS-2026-0156

Fixes #488045
Fixes #488046

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
