### PR TITLE
python314Packages.pytest-aio: 2.0.0 -> 2.1.7

### DIFF
--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -4,29 +4,29 @@
   buildPythonPackage,
   curio-compat,
   fetchFromGitHub,
+  hatchling,
   hypothesis,
   pytest,
   pytestCheckHook,
   pythonOlder,
-  poetry-core,
-  trio,
   trio-asyncio,
+  trio,
   uvloop,
 }:
 
 buildPythonPackage rec {
   pname = "pytest-aio";
-  version = "2.0.0";
+  version = "2.1.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "klen";
     repo = "pytest-aio";
-    rev = "43681bcfc6d2ee07bf9397a1b42d1ccfbb891deb";
-    hash = "sha256-IBtiy4pyXblIkYQunFO6HpBkCnBcEpTqcFtVELrULkk=";
+    tag = version;
+    hash = "sha256-HvD7bBT8QX9Au5TON4yLit2AOLVSRGqdkkwenyqzhpo=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   buildInputs = [ pytest ];
 

--- a/pkgs/development/python-modules/pytest-aio/default.nix
+++ b/pkgs/development/python-modules/pytest-aio/default.nix
@@ -14,7 +14,7 @@
   uvloop,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pytest-aio";
   version = "2.1.7";
   pyproject = true;
@@ -22,7 +22,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "klen";
     repo = "pytest-aio";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-HvD7bBT8QX9Au5TON4yLit2AOLVSRGqdkkwenyqzhpo=";
   };
 
@@ -45,15 +45,15 @@ buildPythonPackage rec {
   ++ lib.optionals (pythonOlder "3.14") [
     trio-asyncio
   ]
-  ++ lib.concatAttrValues optional-dependencies;
+  ++ lib.flatten (builtins.attrValues finalAttrs.passthru.optional-dependencies);
 
   pythonImportsCheck = [ "pytest_aio" ];
 
   meta = {
     description = "Pytest plugin for aiohttp support";
     homepage = "https://github.com/klen/pytest-aio";
-    changelog = "https://github.com/klen/pytest-aio/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/klen/pytest-aio/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})


### PR DESCRIPTION
Diff: https://github.com/klen/pytest-aio/compare/43681bcfc6d2ee07bf9397a1b42d1ccfbb891deb...43681bcfc6d2ee07bf9397a1b42d1ccfbb891deb

Changelog: https://github.com/klen/pytest-aio/blob/2.1.7/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
