### PR TITLE
cardinal: fix carla-based modules

### DIFF
--- a/pkgs/by-name/ca/cardinal/package.nix
+++ b/pkgs/by-name/ca/cardinal/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchurl,
+  carla,
   cmake,
   dbus,
   fftwFloat,
@@ -37,6 +38,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   prePatch = ''
     patchShebangs ./dpf/utils/generate-ttl.sh
+
+    substituteInPlace plugins/Cardinal/src/Carla.cpp \
+      --replace-fail "/usr/lib/carla" "${carla}/bin" \
+      --replace-fail "/usr/share/carla/resources" "${carla}/share"
+
+    substituteInPlace plugins/Cardinal/src/Ildaeil.cpp \
+      --replace-fail "/usr/lib/carla" "${carla}/bin" \
+      --replace-fail "/usr/share/carla/resources" "${carla}/share"
   '';
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
Some Cardinal modules require Carla to work. This PR patches hardcoded paths for Carla in Cardinal.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.



[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
