### PR TITLE
treewide: move env variable(s) into env for structuredAttrs (H-J)

### DIFF
--- a/pkgs/by-name/ci/cilium-cli/package.nix
+++ b/pkgs/by-name/ci/cilium-cli/package.nix
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
 
   # Required to workaround install check error:
   # 2022/06/25 10:36:22 Unable to start gops: mkdir /homeless-shelter: permission denied
-  HOME = "$TMPDIR";
+  env.HOME = "$TMPDIR";
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cilium \

--- a/pkgs/by-name/ci/cilium-cli/package.nix
+++ b/pkgs/by-name/ci/cilium-cli/package.nix
@@ -5,6 +5,7 @@
   cilium-cli,
   fetchFromGitHub,
   installShellFiles,
+  writableTmpDirAsHomeHook,
   testers,
 }:
 
@@ -21,6 +22,10 @@ buildGoModule (finalAttrs: {
 
   nativeBuildInputs = [ installShellFiles ];
 
+  # Required to workaround install check error:
+  # 2022/06/25 10:36:22 Unable to start gops: mkdir /homeless-shelter: permission denied
+  nativeInstallCheckInputs = [ writableTmpDirAsHomeHook ];
+
   vendorHash = null;
 
   subPackages = [ "cmd/cilium" ];
@@ -30,10 +35,6 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X=github.com/cilium/cilium/cilium-cli/defaults.CLIVersion=${finalAttrs.version}"
   ];
-
-  # Required to workaround install check error:
-  # 2022/06/25 10:36:22 Unable to start gops: mkdir /homeless-shelter: permission denied
-  env.HOME = "$TMPDIR";
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd cilium \

--- a/pkgs/by-name/db/dbus_java/package.nix
+++ b/pkgs/by-name/db/dbus_java/package.nix
@@ -15,11 +15,14 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://dbus.freedesktop.org/releases/dbus-java/dbus-java-${finalAttrs.version}.tar.gz";
     sha256 = "0cyaxd8x6sxmi6pklkkx45j311a6w51fxl4jc5j3inc4cailwh5y";
   };
-  JAVA_HOME = jdk8;
-  JAVA = "${jdk8}/bin/java";
-  PREFIX = "\${out}";
-  JAVAUNIXLIBDIR = "${libmatthew_java}/lib/jni";
-  JAVAUNIXJARDIR = "${libmatthew_java}/share/java";
+
+  env = {
+    JAVA_HOME = jdk8;
+    JAVA = "${jdk8}/bin/java";
+    PREFIX = "\${out}";
+    JAVAUNIXLIBDIR = "${libmatthew_java}/lib/jni";
+    JAVAUNIXJARDIR = "${libmatthew_java}/share/java";
+  };
   buildInputs = [
     gettext
     jdk8

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -48,7 +48,7 @@ buildGoModule rec {
 
   # Required to workaround test error:
   #   panic: mkdir /homeless-shelter: permission denied
-  HOME = "$TMPDIR";
+  env.HOME = "$TMPDIR";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/fl/fluxcd/package.nix
+++ b/pkgs/by-name/fl/fluxcd/package.nix
@@ -5,6 +5,7 @@
   installShellFiles,
   lib,
   stdenv,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -46,11 +47,11 @@ buildGoModule rec {
 
   subPackages = [ "cmd/flux" ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   # Required to workaround test error:
   #   panic: mkdir /homeless-shelter: permission denied
-  env.HOME = "$TMPDIR";
-
-  nativeBuildInputs = [ installShellFiles ];
+  nativeCheckInputs = [ writableTmpDirAsHomeHook ];
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/by-name/hd/hdfview/package.nix
+++ b/pkgs/by-name/hd/hdfview/package.nix
@@ -40,8 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     stripJavaArchivesHook
   ];
 
-  HDFLIBS = (hdf4.override { javaSupport = true; }).out;
-  HDF5LIBS = (hdf5.override { javaSupport = true; }).out;
+  env = {
+    HDFLIBS = (hdf4.override { javaSupport = true; }).out;
+    HDF5LIBS = (hdf5.override { javaSupport = true; }).out;
+  };
 
   buildPhase =
     let

--- a/pkgs/by-name/ho/hottext/package.nix
+++ b/pkgs/by-name/ho/hottext/package.nix
@@ -19,7 +19,7 @@ buildNimPackage (finalAttrs: {
 
   lockFile = ./lock.json;
 
-  HOTTEXT_FONT_PATH = "${gentium-plus}/share/fonts/truetype/GentiumPlus-Regular.ttf";
+  env.HOTTEXT_FONT_PATH = "${gentium-plus}/share/fonts/truetype/GentiumPlus-Regular.ttf";
 
   desktopItem = makeDesktopItem {
     categories = [ "Utility" ];

--- a/pkgs/by-name/ju/juledoc/package.nix
+++ b/pkgs/by-name/ju/juledoc/package.nix
@@ -18,7 +18,7 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ julec.hook ];
 
-  JULE_OUT_NAME = "juledoc";
+  env.JULE_OUT_NAME = "juledoc";
 
   meta = {
     description = "Official documentation generator for the Jule programming language";

--- a/pkgs/by-name/ju/julefmt/package.nix
+++ b/pkgs/by-name/ju/julefmt/package.nix
@@ -18,7 +18,7 @@ clangStdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ julec.hook ];
 
-  JULE_OUT_NAME = "julefmt";
+  env.JULE_OUT_NAME = "julefmt";
 
   meta = {
     description = "Official formatter tool for the Jule programming language";

--- a/pkgs/by-name/ku/kubevela/package.nix
+++ b/pkgs/by-name/ku/kubevela/package.nix
@@ -30,10 +30,11 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "references/cmd/cli" ];
 
-  env.CGO_ENABLED = 0;
-
-  # Workaround for permission issue in shell completion
-  HOME = "$TMPDIR";
+  env = {
+    CGO_ENABLED = 0;
+    # Workaround for permission issue in shell completion
+    HOME = "$TMPDIR";
+  };
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/le/leiningen/package.nix
+++ b/pkgs/by-name/le/leiningen/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-tyGlc69jF4TyfMtS5xnm0Sh9nTlRrVbTFtOPfs+oGqI=";
   };
 
-  JARNAME = "leiningen-${finalAttrs.version}-standalone.jar";
+  env.JARNAME = "leiningen-${finalAttrs.version}-standalone.jar";
 
   dontUnpack = true;
 

--- a/pkgs/by-name/ns/nspr/package.nix
+++ b/pkgs/by-name/ns/nspr/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace configure.in --replace '@executable_path/' "$out/lib/"
   '';
 
-  HOST_CC = "cc";
+  env.HOST_CC = "cc";
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   configureFlags = [
     "--enable-optimize"

--- a/pkgs/by-name/op/open-scq30/package.nix
+++ b/pkgs/by-name/op/open-scq30/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-3K+/CpTGWSjCRa2vOEcDvLIiZMdntugIqnzkXF4wkng=";
 
-  INSTALL_PREFIX = placeholder "out";
+  env.INSTALL_PREFIX = placeholder "out";
 
   # Requires headphones
   doCheck = false;

--- a/pkgs/by-name/pk/pkl/package.nix
+++ b/pkgs/by-name/pk/pkl/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     gradleFlagsArray+=(-DcommitId=$(cat .commit-hash))
   '';
 
-  JAVA_TOOL_OPTIONS = "-Dfile.encoding=utf-8";
+  env.JAVA_TOOL_OPTIONS = "-Dfile.encoding=utf-8";
   __darwinAllowLocalNetworking = true;
 
   preCheck = ''

--- a/pkgs/by-name/py/pyprland/package.nix
+++ b/pkgs/by-name/py/pyprland/package.nix
@@ -33,7 +33,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   '';
 
   # NOTE: this is required for the imports check below to work properly
-  HYPRLAND_INSTANCE_SIGNATURE = "dummy";
+  env.HYPRLAND_INSTANCE_SIGNATURE = "dummy";
 
   pythonImportsCheck = [
     "pyprland"

--- a/pkgs/by-name/ri/ripe-atlas-tools/package.nix
+++ b/pkgs/by-name/ri/ripe-atlas-tools/package.nix
@@ -85,7 +85,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "tests/test_docs.py"
   ];
 
-  HOME = "$TMPDIR"; # for cache generation.
+  env.HOME = "$TMPDIR"; # for cache generation.
 
   # Necessary because it confuse the tests when it does "from ripe.atlas.sagan import X"
   # version.py is used by Sphinx tests.

--- a/pkgs/by-name/ri/ripe-atlas-tools/package.nix
+++ b/pkgs/by-name/ri/ripe-atlas-tools/package.nix
@@ -3,6 +3,7 @@
   python3,
   fetchFromGitHub,
   installShellFiles,
+  writableTmpDirAsHomeHook,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
@@ -61,6 +62,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
 
   nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
+    writableTmpDirAsHomeHook # for cache generation.
   ];
 
   disabledTests = [
@@ -84,8 +86,6 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     # We already build Sphinx so we do not need to test it
     "tests/test_docs.py"
   ];
-
-  env.HOME = "$TMPDIR"; # for cache generation.
 
   # Necessary because it confuse the tests when it does "from ripe.atlas.sagan import X"
   # version.py is used by Sphinx tests.

--- a/pkgs/by-name/sa/sailsd/package.nix
+++ b/pkgs/by-name/sa/sailsd/package.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsailing
   ];
 
-  INSTALL_PATH = "$(out)";
+  env.INSTALL_PATH = "$(out)";
 
   postUnpack = ''
     rmdir $sourceRoot/libsailing

--- a/pkgs/by-name/ti/timelimit/package.nix
+++ b/pkgs/by-name/ti/timelimit/package.nix
@@ -20,8 +20,11 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
 
   installFlags = [ "PREFIX=$(out)" ];
-  INSTALL_PROGRAM = "install -m755";
-  INSTALL_DATA = "install -m644";
+
+  env = {
+    INSTALL_PROGRAM = "install -m755";
+    INSTALL_DATA = "install -m644";
+  };
 
   meta = {
     description = "Execute a command and terminates the spawned process after a given time with a given signal";

--- a/pkgs/by-name/tu/tunefish/package.nix
+++ b/pkgs/by-name/tu/tunefish/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # silences build warnings
-  HOME = "/build";
+  env.HOME = "/build";
 
   postPatch = ''
     patchShebangs src/tunefish4/generate-lv2-ttl.py

--- a/pkgs/by-name/tu/tunefish/package.nix
+++ b/pkgs/by-name/tu/tunefish/package.nix
@@ -13,6 +13,7 @@
   libxext,
   libxinerama,
   libxrandr,
+  writableTmpDirAsHomeHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -32,6 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     pkg-config
     python3
+    writableTmpDirAsHomeHook # silences build warnings
   ];
 
   buildInputs = [
@@ -51,9 +53,6 @@ stdenv.mkDerivation (finalAttrs: {
     "src/tunefish4/Builds/LinuxMakefile"
     "CONFIG=Release"
   ];
-
-  # silences build warnings
-  env.HOME = "/build";
 
   postPatch = ''
     patchShebangs src/tunefish4/generate-lv2-ttl.py

--- a/pkgs/by-name/wi/wiimms-iso-tools/package.nix
+++ b/pkgs/by-name/wi/wiimms-iso-tools/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace Makefile --replace gcc "$CC"
   '';
 
-  INSTALL_PATH = "$out";
+  env.INSTALL_PATH = "$out";
 
   installPhase = ''
     mkdir "$out"

--- a/pkgs/by-name/xp/xpra/package.nix
+++ b/pkgs/by-name/xp/xpra/package.nix
@@ -126,7 +126,12 @@ effectiveBuildPythonApplication rec {
     patchShebangs --build fs/bin/build_cuda_kernels.py
   '';
 
-  INCLUDE_DIRS = "${pam}/include";
+  env = {
+    # error: 'import_cairo' defined but not used
+    NIX_CFLAGS_COMPILE = "-Wno-error=unused-function";
+
+    INCLUDE_DIRS = "${pam}/include";
+  };
 
   nativeBuildInputs = [
     clang
@@ -223,9 +228,6 @@ effectiveBuildPythonApplication rec {
         pynvml
       ]
     );
-
-  # error: 'import_cairo' defined but not used
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=unused-function";
 
   setupPyBuildFlags = [
     "--with-Xdummy"

--- a/pkgs/development/python-modules/hy/default.nix
+++ b/pkgs/development/python-modules/hy/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
   };
 
   # https://github.com/hylang/hy/blob/1.0a4/get_version.py#L9-L10
-  HY_VERSION = version;
+  env.HY_VERSION = version;
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
