### PR TITLE
nono: init at 0.4.1

### DIFF
--- a/pkgs/by-name/no/nono/package.nix
+++ b/pkgs/by-name/no/nono/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  pkg-config,
+
+  dbus,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nono";
+  version = "0.4.1";
+
+  src = fetchFromGitHub {
+    owner = "always-further";
+    repo = "nono";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-siZK9ELU5RsX2Dc1T8LpOFNVR0Qo3xJ2LfIrqb6abSk=";
+  };
+
+  cargoHash = "sha256-3xuZMXX9YTHY4HsFuOdzbykqOVH/PWuFyLhPbl7baqY=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+  ];
+
+  meta = {
+    description = "Secure, kernel-enforced sandbox for AI agents, MCP and LLM workloads";
+    homepage = "https://github.com/always-further/nono";
+    changelog = "https://github.com/always-further/nono/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      jk
+    ];
+    mainProgram = "nono";
+    # https://github.com/always-further/nono#platform-support
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package `nono`.

Sandboxing for programs that could do weird stuff e.g. claude code

```
λ ./result/bin/nono shell

  ▄█▄   nono v0.4.1
 ▀▄^▄▀  - The opposite of yolo

Current directory '/home/USER/projects/personal/nixpkgs' will be shared with read access.
tip: use --allow-cwd to skip this prompt
  Proceed? [y/N]: y
Capabilities:
  Filesystem:
    /home/USER/projects/personal/nixpkgs [read] (dir)
  Network:
    outbound: allowed

Exit the shell with Ctrl-D or 'exit'.

Applying Kernel sandbox protections.
2026-02-13T11:16:33.244691Z  WARN Skipping system path /etc/nsswitch.conf (symlink alias)
2026-02-13T11:16:33.244705Z  WARN Skipping system path /etc/hosts (symlink alias)
2026-02-13T11:16:33.244740Z  WARN Skipping system path /etc/hostname (symlink alias)
2026-02-13T11:16:33.244753Z  WARN Skipping system path /etc/localtime (symlink alias)
2026-02-13T11:16:33.254770Z  WARN Skipping system path /etc/terminfo (symlink alias)
2026-02-13T11:16:33.254819Z  WARN Skipping system path /dev/stdin (symlink alias)
2026-02-13T11:16:33.254824Z  WARN Skipping system path /dev/stdout (symlink alias)
2026-02-13T11:16:33.254829Z  WARN Skipping system path /dev/stderr (symlink alias)
2026-02-13T11:16:33.254833Z  WARN Skipping system path /dev/fd (symlink alias)
2026-02-13T11:16:33.254848Z  WARN Skipping system path /var/run (symlink alias)
Sandbox active. Restrictions are now in effect.

bash: /dev/null: Permission denied

$ rm -rf flake.nix
rm: cannot remove 'flake.nix': Permission denied
```

```
λ ./result/bin/nono shell --allow-cwd --net-block

  ▄█▄   nono v0.4.1
 ▀▄^▄▀  - Trust in the nono

Capabilities:
  Filesystem:
    /home/USER/projects/personal/nixpkgs [read] (dir)
  Network:
    outbound: blocked

Exit the shell with Ctrl-D or 'exit'.

Applying Kernel sandbox protections.
2026-02-13T11:18:12.463270Z  WARN Skipping system path /etc/nsswitch.conf (symlink alias)
2026-02-13T11:18:12.463289Z  WARN Skipping system path /etc/hosts (symlink alias)
2026-02-13T11:18:12.463298Z  WARN Skipping system path /etc/hostname (symlink alias)
2026-02-13T11:18:12.463317Z  WARN Skipping system path /etc/localtime (symlink alias)
2026-02-13T11:18:12.463338Z  WARN Skipping system path /etc/terminfo (symlink alias)
2026-02-13T11:18:12.463393Z  WARN Skipping system path /dev/stdin (symlink alias)
2026-02-13T11:18:12.463403Z  WARN Skipping system path /dev/stdout (symlink alias)
2026-02-13T11:18:12.463412Z  WARN Skipping system path /dev/stderr (symlink alias)
2026-02-13T11:18:12.463418Z  WARN Skipping system path /dev/fd (symlink alias)
2026-02-13T11:18:12.463439Z  WARN Skipping system path /var/run (symlink alias)
Sandbox active. Restrictions are now in effect.

bash: /dev/null: Permission denied

$ curl -L https://google.com
curl: (7) Failed to connect to google.com port 443 after 17 ms: Could not connect to server
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
