### PR TITLE
nixtamal: 0.3.1-beta → 1.0.0

### DIFF
--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -8,6 +8,7 @@
   makeBinaryWrapper,
   coreutils,
   nix-prefetch-darcs,
+  nix-prefetch-fossil,
   nix-prefetch-git,
   nix-prefetch-pijul,
   testers,
@@ -16,7 +17,7 @@
 
 ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "nixtamal";
-  version = "0.3.1-beta";
+  version = "1.0.0";
   release_year = 2026;
 
   minimalOCamlVersion = "5.3";
@@ -25,7 +26,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     url = "https://darcs.toastal.in.th/nixtamal/stable/";
     mirrors = [ "https://smeder.ee/~toastal/nixtamal.darcs" ];
     rev = finalAttrs.version;
-    hash = "sha256-ePJs3HygB1xwDzVM4KiqmhiLdZHUpZyzybEf23wmKm8=";
+    hash = "sha256-PJ03psJhRHq0ud/mXuUZSzpQ9RhO3p4s+lrGcHek3Rc=";
   };
 
   nativeBuildInputs = [
@@ -76,6 +77,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
       lib.makeBinPath [
         coreutils
         nix-prefetch-darcs
+        nix-prefetch-fossil
         nix-prefetch-git
         nix-prefetch-pijul
       ]
@@ -100,7 +102,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
       • Automate the manual work of input pinning, allowing to lock & refresh inputs
       • Declaritive KDL manifest file over imperative CLI flags
       • Host, forge, VCS-agnostic
-      • Choose eval time fetchers (builtins) or build time fetchers (Nixpkgs, default) — which opens up fetching Darcs & Pijul
+      • Choose eval time fetchers (builtins) or build time fetchers (Nixpkgs, default) — which opens up fetching Darcs, Pijul, & Fossil
       • Supports mirrors
       • Override hash algorithm on a per-project & per-input basis — including BLAKE3 support
       • Custom freshness commands


### PR DESCRIPTION
https://nixtamal.toast.al/changelog/

1.x + Fossil support

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.