### PR TITLE
octodns-providers.hetzner: 1.0.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/oc/octodns/providers/hetzner/package.nix
+++ b/pkgs/by-name/oc/octodns/providers/hetzner/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  hcloud,
   octodns,
   pytestCheckHook,
   requests,
@@ -11,14 +12,14 @@
 
 buildPythonPackage rec {
   pname = "octodns-hetzner";
-  version = "1.0.0";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "octodns";
     repo = "octodns-hetzner";
     tag = "v${version}";
-    hash = "sha256-JYVztSO38y4F+p0glgtT9/QRdt9uDnOziMFXxBikzLg=";
+    hash = "sha256-aWWT/LShHxWOfNhBr7vCeG9bA6yXEutO2NJic18szL8=";
   };
 
   build-system = [
@@ -28,6 +29,7 @@ buildPythonPackage rec {
   dependencies = [
     octodns
     requests
+    hcloud
   ];
 
   pythonImportsCheck = [ "octodns_hetzner" ];


### PR DESCRIPTION
Upgrades the Hetzner provider for Octodns to the version that supports the new Hetzner Console DNS API.

Changelog: https://github.com/octodns/octodns-hetzner/blob/main/CHANGELOG.md

Hetzner is discontinuing the old DNS API and is migrating everyone to the new Console DNS API before May 2026 (in just a few months):
- [Shutdown of DNS Console (dns.hetzner.com) in May 2026](https://status.hetzner.com/incident/c2146c42-6dd2-4454-916a-19f07e0e5a44),
- [Migration process](https://docs.hetzner.com/networking/dns/migration-to-hetzner-console/process/)

If you're using [NixOS-DNS](https://github.com/Janik-Haag/NixOS-DNS), the migration process is:
- Click the button in the Hetzner DNS web interface to migrate a zone to Hetzner Console,
- Create a new API key in Hetzner Console in the new "DNS Migrated" project,
- Add the new key and `backend = "hcloud"` to your NixOS-DNS config:

```
          packages.octodns-config = generateDns.octodnsConfig {
            inherit dnsConfig;
            config = {
              providers = {
                hetzner = {
                  class = "octodns_hetzner.HetznerProvider";
                  # token = "env/HETZNER_DNS_API";
                  token = "env/HETZNER_CONSOLE_DNS_API";  # NEW API KEY
                  backend = "hcloud";                     # CONFIG OPTION THAT SWITCHES TO CONSOLE API
                };
              };
            };
            zones = {
```

The updated version of octodns-hetzner should still work with the old DNS API, although I haven't tried it.  The octodns docs also say you can migrate zones one at a time to the new `backend`, but I have no idea how to configure that in NixOS-DNS.

I tested this by migrating all my zones, changing a few records, and double-checking that what Hetzner shows in the Console web interface matches what I had in my configs.

I don't think this is a breaking package change, but it is a major one.  That said, I haven't added anything to the release notes because by the time 26.05 is out, the old DNS API will have already been discontinued, so everybody who cares will already know about this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
