### PR TITLE
lnreader: init at 1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29382,6 +29382,12 @@
     githubId = 8006928;
     name = "Yuannan (Brandon) Lin";
   };
+  yujonpradhananga = {
+    email = "yujonpradhan123@gmail.com";
+    github = "Yujonpradhananga";
+    githubId = 139200034;
+    name = "Yujon Pradhananga";
+  };
   yuka = {
     email = "yuka@yuka.dev";
     matrix = "@yuka:yuka.dev";

--- a/pkgs/by-name/ln/lnreader/package.nix
+++ b/pkgs/by-name/ln/lnreader/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  mupdf,
+  pkg-config,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "lnreader";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "Yujonpradhananga";
+    repo = "CLI-PDF-EPUB-reader";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-JeVS0wnShlD4+UfnMsuHMYi6R7pse4Gvh0PdREwmG6k=";
+  };
+
+  vendorHash = "sha256-66rqTJeV6u4aVciifp41n2onx81w9KE0PGYHlVwsl54=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    mupdf
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Lightweight, fast and responsive terminal PDF/EPUB viewer with image support";
+    homepage = "https://github.com/Yujonpradhananga/CLI-PDF-EPUB-reader";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yujonpradhananga ];
+    mainProgram = "lnreader";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
lnreader: init at 1.0

Add lnreader, a lightweight terminal PDF/EPUB viewer with image support.

I'm the author of this project. lnreader is a Go-based terminal reader that supports:
- PDF and EPUB documents
- Fuzzy file search
- High-resolution image rendering via terminal graphics protocols (Kitty, iTerm2, Sixel)
- Intelligent text reflow

Homepage: https://github.com/Yujonpradhananga/CLI-PDF-EPUB-reader

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
