### PR TITLE
{awscli2, python3Packages.botocore}: replace vendored certs

### DIFF
--- a/pkgs/by-name/aw/awscli2/package.nix
+++ b/pkgs/by-name/aw/awscli2/package.nix
@@ -12,6 +12,7 @@
   awscli2,
   addBinToPathHook,
   writableTmpDirAsHomeHook,
+  cacert,
 }:
 
 let
@@ -81,6 +82,8 @@ py.pkgs.buildPythonApplication rec {
     # with a configure script, but we don't as we provide all of the packages
     # through PYTHONPATH
     sed -i '/pip>=/d' requirements/bootstrap.txt
+
+    ln -sf ${cacert}/etc/ssl/certs/ca-bundle.crt awscli/botocore/cacert.pem
   '';
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/botocore/default.nix
+++ b/pkgs/development/python-modules/botocore/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   awscrt,
+  cacert,
   buildPythonPackage,
   fetchFromGitHub,
 
@@ -28,6 +29,10 @@ buildPythonPackage rec {
     tag = version;
     hash = "sha256-avuv1uXKMeSr3SL+BI9XW8tDCQM/dlXFn590di3S03k=";
   };
+
+  postPatch = ''
+    ln -sf ${cacert}/etc/ssl/certs/ca-bundle.crt botocore/cacert.pem
+  '';
 
   build-system = [
     setuptools


### PR DESCRIPTION
cacert is a central authority of what certs to trust. Making sure programs use that instead of their own vendored copies makes it easier for enterprises or very security-conscious users to expand or reduce the trust.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
