### PR TITLE
nvidia-x11: fix nvidia-open build on linux 6.19 based on the CachyOS …

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -1,68 +1,67 @@
-{
-  version,
-  url ? null,
-  sha256_32bit ? null,
-  sha256_64bit,
-  sha256_aarch64 ? null,
-  openSha256 ? null,
-  settingsSha256 ? null,
-  settingsVersion ? null,
-  persistencedSha256 ? null,
-  persistencedVersion ? null,
-  fabricmanagerSha256 ? null,
-  fabricmanagerVersion ? null,
-  useGLVND ? true,
-  useProfiles ? true,
-  preferGtk2 ? false,
-  settings32Bit ? false,
-  useSettings ? true,
-  usePersistenced ? true,
-  useFabricmanager ? false,
-  ibtSupport ? false,
-
-  prePatch ? null,
-  postPatch ? null,
-  patchFlags ? null,
-  patches ? [ ],
-  patchesOpen ? [ ],
-  preInstall ? null,
-  postInstall ? null,
-  broken ? false,
-  brokenOpen ? broken,
+{ version
+, url ? null
+, sha256_32bit ? null
+, sha256_64bit
+, sha256_aarch64 ? null
+, openSha256 ? null
+, settingsSha256 ? null
+, settingsVersion ? null
+, persistencedSha256 ? null
+, persistencedVersion ? null
+, fabricmanagerSha256 ? null
+, fabricmanagerVersion ? null
+, useGLVND ? true
+, useProfiles ? true
+, preferGtk2 ? false
+, settings32Bit ? false
+, useSettings ? true
+, usePersistenced ? true
+, useFabricmanager ? false
+, ibtSupport ? false
+, prePatch ? null
+, postPatch ? null
+, patchFlags ? null
+, patches ? [ ]
+, patchesOpen ? [ ]
+, preInstall ? null
+, postInstall ? null
+, broken ? false
+, brokenOpen ? broken
+,
 }@args:
 
-{
-  lib,
-  stdenv,
-  runCommandLocal,
-  patchutils,
-  callPackage,
-  pkgs,
-  pkgsi686Linux,
-  fetchurl,
-  fetchzip,
-  kernel ? null,
-  kernelModuleMakeFlags ? [ ],
-  perl,
-  nukeReferences,
-  which,
-  libarchive,
-  jq,
-  # Whether to build the libraries only (i.e. not the kernel module or
+{ lib
+, stdenv
+, runCommandLocal
+, patchutils
+, callPackage
+, pkgs
+, pkgsi686Linux
+, fetchurl
+, fetchzip
+, kernel ? null
+, kernelModuleMakeFlags ? [ ]
+, perl
+, nukeReferences
+, which
+, libarchive
+, jq
+, # Whether to build the libraries only (i.e. not the kernel module or
   # nvidia-settings).  Used to support 32-bit binaries on 64-bit
   # Linux.
-  libsOnly ? false,
-  # don't include the bundled 32-bit libraries on 64-bit platforms,
+  libsOnly ? false
+, # don't include the bundled 32-bit libraries on 64-bit platforms,
   # even if it’s in downloaded binary
-  disable32Bit ? stdenv.hostPlatform.system == "aarch64-linux",
-  # 32 bit libs only version of this package
-  lib32 ? null,
-  # Whether to extract the GSP firmware, datacenter drivers needs to extract the
+  disable32Bit ? stdenv.hostPlatform.system == "aarch64-linux"
+, # 32 bit libs only version of this package
+  lib32 ? null
+, # Whether to extract the GSP firmware, datacenter drivers needs to extract the
   # firmware
-  firmware ? openSha256 != null || useFabricmanager,
-  # Whether the user accepts the NVIDIA Software License
-  config,
-  acceptLicense ? config.nvidia.acceptLicense or false,
+  firmware ? openSha256 != null || useFabricmanager
+, # Whether the user accepts the NVIDIA Software License
+  config
+, acceptLicense ? config.nvidia.acceptLicense or false
+,
 }:
 
 assert !libsOnly -> kernel != null;
@@ -151,41 +150,44 @@ stdenv.mkDerivation (finalAttrs: {
     if !acceptLicense && (openSha256 == null) then
       throwLicense
     else if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl {
-        urls =
-          if args ? url then
-            [ args.url ]
-          else
-            [
-              "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-              "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-            ];
-        sha256 = sha256_64bit;
-      }
+      fetchurl
+        {
+          urls =
+            if args ? url then
+              [ args.url ]
+            else
+              [
+                "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+                "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+              ];
+          sha256 = sha256_64bit;
+        }
     else if stdenv.hostPlatform.system == "i686-linux" then
-      fetchurl {
-        urls =
-          if args ? url then
-            [ args.url ]
-          else
-            [
-              "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-              "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-            ];
-        sha256 = sha256_32bit;
-      }
+      fetchurl
+        {
+          urls =
+            if args ? url then
+              [ args.url ]
+            else
+              [
+                "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+                "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+              ];
+          sha256 = sha256_32bit;
+        }
     else if stdenv.hostPlatform.system == "aarch64-linux" && sha256_aarch64 != null then
-      fetchurl {
-        urls =
-          if args ? url then
-            [ args.url ]
-          else
-            [
-              "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-              "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-            ];
-        sha256 = sha256_aarch64;
-      }
+      fetchurl
+        {
+          urls =
+            if args ? url then
+              [ args.url ]
+            else
+              [
+                "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+                "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+              ];
+          sha256 = sha256_aarch64;
+        }
     else
       throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
 
@@ -245,11 +247,10 @@ stdenv.mkDerivation (finalAttrs: {
   passthru =
     let
       fetchFromGithubOrNvidia =
-        {
-          owner,
-          repo,
-          rev,
-          ...
+        { owner
+        , repo
+        , rev
+        , ...
         }@args:
         let
           args' = removeAttrs args [
@@ -273,24 +274,41 @@ stdenv.mkDerivation (finalAttrs: {
         );
     in
     {
-      open = lib.mapNullable (
-        hash:
-        callPackage ./open.nix {
-          inherit hash;
-          nvidia_x11 = finalAttrs.finalPackage;
-          patches =
-            (map (rewritePatch {
-              from = "kernel";
-              to = "kernel-open";
-            }) patches)
-            ++ patchesOpen
-            ++ lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.19") [
-              # THIS PATCH SHOULD BE REMOVED IF THIS IS EVER MERGED INTO MAINLINE NVIDIA-OPEN
-              ./kernel-6.19.patch
-            ];
-          broken = brokenOpen;
-        }
-      ) openSha256;
+      open = lib.mapNullable
+        (
+          hash:
+          callPackage ./open.nix {
+            inherit hash;
+            nvidia_x11 = finalAttrs.finalPackage;
+            patches =
+              (map
+                (rewritePatch {
+                  from = "kernel";
+                  to = "kernel-open";
+                })
+                patches)
+              ++ patchesOpen
+              ++ lib.optionals
+                (
+                  lib.versionAtLeast kernel.modDirVersion "6.19"
+                  && lib.versionOlder kernel.modDirVersion "6.20"
+                  && version == "580.126.09"
+                ) [
+                ./kernel-6.19-580.126.09.patch
+              ]
+              ++ lib.optionals
+                (
+                  lib.versionAtLeast kernel.modDirVersion "6.19"
+                  && lib.versionOlder kernel.modDirVersion "6.20"
+                  && version == "590.48.01"
+                ) [
+                ./kernel-6.19.patch
+              ];
+
+            broken = brokenOpen;
+          }
+        )
+        openSha256;
       settings =
         if useSettings then
           (if settings32Bit then pkgsi686Linux.callPackage else callPackage)
@@ -304,19 +322,23 @@ stdenv.mkDerivation (finalAttrs: {
           { };
       persistenced =
         if usePersistenced then
-          lib.mapNullable (
-            hash:
-            callPackage (import ./persistenced.nix finalAttrs.finalPackage hash) {
-              fetchFromGitHub = fetchFromGithubOrNvidia;
-            }
-          ) persistencedSha256
+          lib.mapNullable
+            (
+              hash:
+              callPackage (import ./persistenced.nix finalAttrs.finalPackage hash) {
+                fetchFromGitHub = fetchFromGithubOrNvidia;
+              }
+            )
+            persistencedSha256
         else
           { };
       fabricmanager =
         if useFabricmanager then
-          lib.mapNullable (
-            hash: callPackage (import ./fabricmanager.nix finalAttrs.finalPackage hash) { }
-          ) fabricmanagerSha256
+          lib.mapNullable
+            (
+              hash: callPackage (import ./fabricmanager.nix finalAttrs.finalPackage hash) { }
+            )
+            fabricmanagerSha256
         else
           { };
       settingsVersion = if settingsVersion != null then settingsVersion else finalAttrs.version;

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -283,7 +283,11 @@ stdenv.mkDerivation (finalAttrs: {
               from = "kernel";
               to = "kernel-open";
             }) patches)
-            ++ patchesOpen;
+            ++ patchesOpen
+            ++ lib.optionals (lib.versionAtLeast kernel.modDirVersion "6.19") [
+              # THIS PATCH SHOULD BE REMOVED IF THIS IS EVER MERGED INTO MAINLINE NVIDIA-OPEN
+              ./kernel-6.19.patch
+            ];
           broken = brokenOpen;
         }
       ) openSha256;

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -1,67 +1,67 @@
-{ version
-, url ? null
-, sha256_32bit ? null
-, sha256_64bit
-, sha256_aarch64 ? null
-, openSha256 ? null
-, settingsSha256 ? null
-, settingsVersion ? null
-, persistencedSha256 ? null
-, persistencedVersion ? null
-, fabricmanagerSha256 ? null
-, fabricmanagerVersion ? null
-, useGLVND ? true
-, useProfiles ? true
-, preferGtk2 ? false
-, settings32Bit ? false
-, useSettings ? true
-, usePersistenced ? true
-, useFabricmanager ? false
-, ibtSupport ? false
-, prePatch ? null
-, postPatch ? null
-, patchFlags ? null
-, patches ? [ ]
-, patchesOpen ? [ ]
-, preInstall ? null
-, postInstall ? null
-, broken ? false
-, brokenOpen ? broken
-,
+{
+  version,
+  url ? null,
+  sha256_32bit ? null,
+  sha256_64bit,
+  sha256_aarch64 ? null,
+  openSha256 ? null,
+  settingsSha256 ? null,
+  settingsVersion ? null,
+  persistencedSha256 ? null,
+  persistencedVersion ? null,
+  fabricmanagerSha256 ? null,
+  fabricmanagerVersion ? null,
+  useGLVND ? true,
+  useProfiles ? true,
+  preferGtk2 ? false,
+  settings32Bit ? false,
+  useSettings ? true,
+  usePersistenced ? true,
+  useFabricmanager ? false,
+  ibtSupport ? false,
+  prePatch ? null,
+  postPatch ? null,
+  patchFlags ? null,
+  patches ? [ ],
+  patchesOpen ? [ ],
+  preInstall ? null,
+  postInstall ? null,
+  broken ? false,
+  brokenOpen ? broken,
 }@args:
 
-{ lib
-, stdenv
-, runCommandLocal
-, patchutils
-, callPackage
-, pkgs
-, pkgsi686Linux
-, fetchurl
-, fetchzip
-, kernel ? null
-, kernelModuleMakeFlags ? [ ]
-, perl
-, nukeReferences
-, which
-, libarchive
-, jq
-, # Whether to build the libraries only (i.e. not the kernel module or
+{
+  lib,
+  stdenv,
+  runCommandLocal,
+  patchutils,
+  callPackage,
+  pkgs,
+  pkgsi686Linux,
+  fetchurl,
+  fetchzip,
+  kernel ? null,
+  kernelModuleMakeFlags ? [ ],
+  perl,
+  nukeReferences,
+  which,
+  libarchive,
+  jq,
+  # Whether to build the libraries only (i.e. not the kernel module or
   # nvidia-settings).  Used to support 32-bit binaries on 64-bit
   # Linux.
-  libsOnly ? false
-, # don't include the bundled 32-bit libraries on 64-bit platforms,
+  libsOnly ? false,
+  # don't include the bundled 32-bit libraries on 64-bit platforms,
   # even if it’s in downloaded binary
-  disable32Bit ? stdenv.hostPlatform.system == "aarch64-linux"
-, # 32 bit libs only version of this package
-  lib32 ? null
-, # Whether to extract the GSP firmware, datacenter drivers needs to extract the
+  disable32Bit ? stdenv.hostPlatform.system == "aarch64-linux",
+  # 32 bit libs only version of this package
+  lib32 ? null,
+  # Whether to extract the GSP firmware, datacenter drivers needs to extract the
   # firmware
-  firmware ? openSha256 != null || useFabricmanager
-, # Whether the user accepts the NVIDIA Software License
-  config
-, acceptLicense ? config.nvidia.acceptLicense or false
-,
+  firmware ? openSha256 != null || useFabricmanager,
+  # Whether the user accepts the NVIDIA Software License
+  config,
+  acceptLicense ? config.nvidia.acceptLicense or false,
 }:
 
 assert !libsOnly -> kernel != null;
@@ -150,44 +150,41 @@ stdenv.mkDerivation (finalAttrs: {
     if !acceptLicense && (openSha256 == null) then
       throwLicense
     else if stdenv.hostPlatform.system == "x86_64-linux" then
-      fetchurl
-        {
-          urls =
-            if args ? url then
-              [ args.url ]
-            else
-              [
-                "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-                "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
-              ];
-          sha256 = sha256_64bit;
-        }
+      fetchurl {
+        urls =
+          if args ? url then
+            [ args.url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-x86_64/${version}/NVIDIA-Linux-x86_64-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_64bit;
+      }
     else if stdenv.hostPlatform.system == "i686-linux" then
-      fetchurl
-        {
-          urls =
-            if args ? url then
-              [ args.url ]
-            else
-              [
-                "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-                "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
-              ];
-          sha256 = sha256_32bit;
-        }
+      fetchurl {
+        urls =
+          if args ? url then
+            [ args.url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-x86/${version}/NVIDIA-Linux-x86-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_32bit;
+      }
     else if stdenv.hostPlatform.system == "aarch64-linux" && sha256_aarch64 != null then
-      fetchurl
-        {
-          urls =
-            if args ? url then
-              [ args.url ]
-            else
-              [
-                "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-                "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
-              ];
-          sha256 = sha256_aarch64;
-        }
+      fetchurl {
+        urls =
+          if args ? url then
+            [ args.url ]
+          else
+            [
+              "https://us.download.nvidia.com/XFree86/aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+              "https://download.nvidia.com/XFree86/Linux-aarch64/${version}/NVIDIA-Linux-aarch64-${version}${pkgSuffix}.run"
+            ];
+        sha256 = sha256_aarch64;
+      }
     else
       throw "nvidia-x11 does not support platform ${stdenv.hostPlatform.system}";
 
@@ -247,10 +244,11 @@ stdenv.mkDerivation (finalAttrs: {
   passthru =
     let
       fetchFromGithubOrNvidia =
-        { owner
-        , repo
-        , rev
-        , ...
+        {
+          owner,
+          repo,
+          rev,
+          ...
         }@args:
         let
           args' = removeAttrs args [
@@ -274,41 +272,41 @@ stdenv.mkDerivation (finalAttrs: {
         );
     in
     {
-      open = lib.mapNullable
-        (
-          hash:
-          callPackage ./open.nix {
-            inherit hash;
-            nvidia_x11 = finalAttrs.finalPackage;
-            patches =
-              (map
-                (rewritePatch {
-                  from = "kernel";
-                  to = "kernel-open";
-                })
-                patches)
-              ++ patchesOpen
-              ++ lib.optionals
+      open = lib.mapNullable (
+        hash:
+        callPackage ./open.nix {
+          inherit hash;
+          nvidia_x11 = finalAttrs.finalPackage;
+          patches =
+            (map (rewritePatch {
+              from = "kernel";
+              to = "kernel-open";
+            }) patches)
+            ++ patchesOpen
+            ++
+              lib.optionals
                 (
                   lib.versionAtLeast kernel.modDirVersion "6.19"
                   && lib.versionOlder kernel.modDirVersion "6.20"
                   && version == "580.126.09"
-                ) [
-                ./kernel-6.19-580.126.09.patch
-              ]
-              ++ lib.optionals
+                )
+                [
+                  ./kernel-6.19-580.126.09.patch
+                ]
+            ++
+              lib.optionals
                 (
                   lib.versionAtLeast kernel.modDirVersion "6.19"
                   && lib.versionOlder kernel.modDirVersion "6.20"
                   && version == "590.48.01"
-                ) [
-                ./kernel-6.19.patch
-              ];
+                )
+                [
+                  ./kernel-6.19.patch
+                ];
 
-            broken = brokenOpen;
-          }
-        )
-        openSha256;
+          broken = brokenOpen;
+        }
+      ) openSha256;
       settings =
         if useSettings then
           (if settings32Bit then pkgsi686Linux.callPackage else callPackage)
@@ -322,23 +320,19 @@ stdenv.mkDerivation (finalAttrs: {
           { };
       persistenced =
         if usePersistenced then
-          lib.mapNullable
-            (
-              hash:
-              callPackage (import ./persistenced.nix finalAttrs.finalPackage hash) {
-                fetchFromGitHub = fetchFromGithubOrNvidia;
-              }
-            )
-            persistencedSha256
+          lib.mapNullable (
+            hash:
+            callPackage (import ./persistenced.nix finalAttrs.finalPackage hash) {
+              fetchFromGitHub = fetchFromGithubOrNvidia;
+            }
+          ) persistencedSha256
         else
           { };
       fabricmanager =
         if useFabricmanager then
-          lib.mapNullable
-            (
-              hash: callPackage (import ./fabricmanager.nix finalAttrs.finalPackage hash) { }
-            )
-            fabricmanagerSha256
+          lib.mapNullable (
+            hash: callPackage (import ./fabricmanager.nix finalAttrs.finalPackage hash) { }
+          ) fabricmanagerSha256
         else
           { };
       settingsVersion = if settingsVersion != null then settingsVersion else finalAttrs.version;

--- a/pkgs/os-specific/linux/nvidia-x11/kernel-6.19-580.126.09.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/kernel-6.19-580.126.09.patch
@@ -1,0 +1,35 @@
+--- a/kernel-open/nvidia-uvm/uvm_hmm.c	1970-01-01 01:00:01.000000000 +0100
++++ b/kernel-open/nvidia-uvm/uvm_hmm.c	2026-02-14 22:47:12.157977258 +0100
+@@ -56,6 +56,7 @@
+ #include <linux/userfaultfd_k.h>
+ #include <linux/memremap.h>
+ #include <linux/wait.h>
++#include <linux/version.h>
+ 
+ #include "uvm_common.h"
+ #include "uvm_gpu.h"
+@@ -78,12 +79,22 @@
+ // Pass 0 as the order, when actual large order support is added this
+ // function will need to be revisited
+ //
++
+ #if defined(NV_ZONE_DEVICE_PAGE_INIT_HAS_ORDER_ARG)
+-#define ZONE_DEVICE_PAGE_INIT(page)   zone_device_page_init(page, 0)
++# if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++#  define ZONE_DEVICE_PAGE_INIT(page) zone_device_page_init(page, page_pgmap(page), 0)
++# else
++#  define ZONE_DEVICE_PAGE_INIT(page) zone_device_page_init(page, 0)
++# endif
+ #else
+-#define ZONE_DEVICE_PAGE_INIT(page)   zone_device_page_init(page)
++# if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++#  define ZONE_DEVICE_PAGE_INIT(page) zone_device_page_init(page, page_pgmap(page), 0)
++# else
++#  define ZONE_DEVICE_PAGE_INIT(page) zone_device_page_init(page)
++# endif
+ #endif
+ 
++
+ // The function nv_PageSwapCache() wraps the check for page swap cache flag in
+ // order to support a wide variety of kernel versions.
+ // The function PageSwapCache() is removed after 32f51ead3d77 ("mm: remove

--- a/pkgs/os-specific/linux/nvidia-x11/kernel-6.19.patch
+++ b/pkgs/os-specific/linux/nvidia-x11/kernel-6.19.patch
@@ -1,0 +1,130 @@
+From c9457ce40a6af2ce74c520564e2d8775f49e3d27 Mon Sep 17 00:00:00 2001
+From: Eric Naim <dnaim@cachyos.org>
+Date: Thu, 18 Dec 2025 12:36:06 +0800
+Subject: [PATCH 3/3] Fix compile for 6.19
+
+Contains:
+- Rename page_free callback -> folio_free callback for 6.19+
+- Adjust zone_device_page_init() call for 6.19; it has one extra argument now
+- 6.19-rc8 introduced yet another argument for zone_device_page_init()
+
+Link: https://github.com/torvalds/linux/commit/12b2285bf3d14372238d36215b73af02ac3bdfc1
+Signed-off-by: Eric Naim <dnaim@cachyos.org>
+---
+ kernel-open/nvidia-uvm/uvm_hmm.c     |  4 ++++
+ kernel-open/nvidia-uvm/uvm_pmm_gpu.c | 34 ++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/kernel-open/nvidia-uvm/uvm_hmm.c b/kernel-open/nvidia-uvm/uvm_hmm.c
+index 9b676f971385..22db001384a4 100644
+--- a/kernel-open/nvidia-uvm/uvm_hmm.c
++++ b/kernel-open/nvidia-uvm/uvm_hmm.c
+@@ -2140,7 +2140,11 @@ static void fill_dst_pfn(uvm_va_block_t *va_block,
+ 
+         UVM_ASSERT(!page_count(dpage));
+         UVM_ASSERT(!dpage->zone_device_data);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++        zone_device_page_init(dpage, page_pgmap(dpage), 0);
++#else
+         zone_device_page_init(dpage);
++#endif
+         dpage->zone_device_data = gpu_chunk;
+         atomic64_inc(&va_block->hmm.va_space->hmm.allocated_page_count);
+     }
+diff --git a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+index 97ff13dcdd04..98423002776b 100644
+--- a/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
++++ b/kernel-open/nvidia-uvm/uvm_pmm_gpu.c
+@@ -177,6 +177,8 @@
+ #include "uvm_test.h"
+ #include "uvm_linux.h"
+ 
++#include <linux/version.h>
++
+ #if defined(CONFIG_PCI_P2PDMA) && defined(NV_STRUCT_PAGE_HAS_ZONE_DEVICE_DATA)
+ #include <linux/pci-p2pdma.h>
+ #endif
+@@ -2999,8 +3001,14 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+     return ret;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void devmem_folio_free(struct folio *folio)
++{
++    struct page *page = &folio->page;
++#else
+ static void devmem_page_free(struct page *page)
+ {
++#endif
+     uvm_gpu_chunk_t *chunk = uvm_pmm_devmem_page_to_chunk(page);
+     uvm_gpu_t *gpu = uvm_gpu_chunk_get_gpu(chunk);
+ 
+@@ -3060,7 +3068,11 @@ static vm_fault_t devmem_fault_entry(struct vm_fault *vmf)
+ 
+ static const struct dev_pagemap_ops uvm_pmm_devmem_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = devmem_folio_free,
++#else
+     .page_free = devmem_page_free,
++#endif
+     .migrate_to_ram = devmem_fault_entry,
+ };
+ 
+@@ -3148,8 +3160,14 @@ static void device_p2p_page_free_wake(struct nv_kref *ref)
+     wake_up(&p2p_mem->waitq);
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void device_p2p_folio_free(struct folio *folio)
++{
++    struct page *page = &folio->page;
++#else
+ static void device_p2p_page_free(struct page *page)
+ {
++#endif
+     uvm_device_p2p_mem_t *p2p_mem = page->zone_device_data;
+ 
+     page->zone_device_data = NULL;
+@@ -3158,14 +3176,26 @@ static void device_p2p_page_free(struct page *page)
+ #endif
+ 
+ #if UVM_CDMM_PAGES_SUPPORTED()
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++static void device_coherent_folio_free(struct folio *folio)
++{
++    device_p2p_folio_free(folio);
++}
++#else
+ static void device_coherent_page_free(struct page *page)
+ {
+     device_p2p_page_free(page);
+ }
++#endif
+ 
+ static const struct dev_pagemap_ops uvm_device_coherent_pgmap_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = device_coherent_folio_free,
++#else
+     .page_free = device_coherent_page_free,
++#endif
+ };
+ 
+ static NV_STATUS uvm_pmm_cdmm_init(uvm_parent_gpu_t *parent_gpu)
+@@ -3302,7 +3332,11 @@ static bool uvm_pmm_gpu_check_orphan_pages(uvm_pmm_gpu_t *pmm)
+ 
+ static const struct dev_pagemap_ops uvm_device_p2p_pgmap_ops =
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    .folio_free = device_p2p_folio_free,
++#else
+     .page_free = device_p2p_page_free,
++#endif
+ };
+ 
+ void uvm_pmm_gpu_device_p2p_init(uvm_parent_gpu_t *parent_gpu)
+-- 
+2.52.0
+


### PR DESCRIPTION
Based on the CachyOS patch, without this patch the nvidia-x11 package does not build on the 6.19 kernel.

I gated the patch on a conditional for a single kernel version, as I expect this patch to be temporary.

built and tested via 
`nix build -L .#legacyPackages.x86_64-linux.linuxKernel.packages.linux_6_19.nvidiaPackages.latest.open`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
