### PR TITLE
grub2: Fix wrong freetype getting linked in cross

### DIFF
--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -596,7 +596,10 @@ stdenv.mkDerivation rec {
         echo 'echo "Compile grub2 with { kbdcompSupport = true; } to enable support for this command."' >> util/grub-kbdcomp.in
       '';
 
-  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  depsBuildBuild = [
+    buildPackages.stdenv.cc
+    pkg-config
+  ];
   nativeBuildInputs = [
     bison
     flex
@@ -661,6 +664,12 @@ stdenv.mkDerivation rec {
     ./bootstrap --no-git --gnulib-srcdir=${gnulib}
 
     substituteInPlace ./configure --replace '/usr/share/fonts/unifont' '${unifont}/share/fonts'
+  ''
+  # build-grub-mkfont is built & run during build, need to find freetype for buildPlatform
+  + lib.optionalString (!lib.systems.equals stdenv.buildPlatform stdenv.hostPlatform) ''
+    configureFlagsArray+=(
+      "BUILD_PKG_CONFIG=$PKG_CONFIG_FOR_BUILD"
+    )
   '';
 
   postConfigure = ''


### PR DESCRIPTION
GRUB allows setting `BUILD_PKG_CONFIG` to a `pkg-config` that provides libraries for the building platform, which is needed to get the correct `freetype` for `build-grub-mkfont`.

I don't *quite* know why this isn't a problem for a cross target like aarch64 (maybe the dynamic linker just doesn't care enough?), but `build-grub-mkfont` definitely still gets wrong flags for something that gets executed on the `buildPlatform`:

```
gcc -o build-grub-mkfont -I./include -std=gnu99 -fno-common  -DGRUB_FILE=\"util/grub-mkfont.c\" -I. -I. -I. -I. -I./include -I./include -I./grub-core/lib/libgcrypt-grub/src/  -DGRUB_MKFONT=1 -DGRUB_BUILD=1 -DGRUB_UTIL=1 -DGRUB_BUILD_PROGRAM_NAME=\"build-grub-mkfont\" util/grub-mkfont.c grub-core/unidata.c grub-core/kern/emu/misc.c util/misc.c -I/nix/store/cc1p26vnf53s7rk01hazvi1x6r90rhw8-freetype-aarch64-unknown-linux-gnu-2.13.3-dev/include/freetype2 -L/nix/store/x49s38xdy4h12k0ynrfh5z6xv9qhppjb-freetype-aarch64-unknown-linux-gnu-2.13.3/lib -lfreetype
[...]
./build-grub-mkfont -o unicode.pf2 /nix/store/6d4rjzwgsh8vlr8pmzikxzlm5jrnd4lc-unifont-aarch64-unknown-linux-gnu-16.0.03/share/fonts/unifont.pcf.gz || (rm -f unicode.pf2; exit 1)
```

For ppc64 cross targets, this causes an error when running `build-grub-mkfont`:

```
gcc -o build-grub-mkfont -I./include -std=gnu99 -fno-common  -DGRUB_FILE=\"util/grub-mkfont.c\" -I. -I. -I. -I. -I./include -I./include -I./grub-core/lib/libgcrypt-grub/src/  -DGRUB_MKFONT=1 -DGRUB_BUILD=1 -DGRUB_UTIL=1 -DGRUB_BUILD_PROGRAM_NAME=\"build-grub-mkfont\" util/grub-mkfont.c grub-core/unidata.c grub-core/kern/emu/misc.c util/misc.c -I/nix/store/6sw4qcy17mgw5gdva8g50rkkq8j89qsp-freetype-powerpc64-unknown-linux-gnuabielfv1-2.13.3-dev/include/freetype2 -L/nix/store/xh8s5fl77zhif8js3hffnqq5jsybasj6-freetype-powerpc64-unknown-linux-gnuabielfv1-2.13.3/lib -lfreetype
[...]
./build-grub-mkfont -o unicode.pf2 /nix/store/ggkdqg1333pvvbf1ivik789jvb3v8rkx-unifont-powerpc64-unknown-linux-gnuabielfv1-16.0.03/share/fonts/unifont.pcf.gz || (rm -f unicode.pf2; exit 1)
./build-grub-mkfont: error while loading shared libraries: /nix/store/xh8s5fl77zhif8js3hffnqq5jsybasj6-freetype-powerpc64-unknown-linux-gnuabielfv1-2.13.3/lib/libfreetype.so.6: ELF file data encoding not little-endian
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
