### PR TITLE
raffi: 0.12.0 -> 0.20.0

### DIFF
--- a/pkgs/by-name/ra/raffi/package.nix
+++ b/pkgs/by-name/ra/raffi/package.nix
@@ -3,32 +3,58 @@
   fetchFromGitHub,
   rustPlatform,
   makeBinaryWrapper,
+  pkg-config,
   fuzzel,
+  wayland,
+  libxkbcommon,
+  writableTmpDirAsHomeHook,
   additionalPrograms ? [ ],
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "raffi";
-  version = "0.12.0";
+  version = "0.20.0";
 
   src = fetchFromGitHub {
     owner = "chmouel";
     repo = "raffi";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-v+Y+x9DCxMDn8qtUmsq9c4Zbc5sG7mLX9Y1ZKgXcPEI=";
+    hash = "sha256-WAYSHQIQRd37xTpOs4EhK0V4wcBLWIRP7KvA7XjIZ0g=";
   };
 
-  cargoHash = "sha256-uXZ3OWLGrYUzS5eailvMvWpr2eadvG/bIs2ZdO1WCSo=";
+  cargoHash = "sha256-VPgMavPK6HGKICmGgPIM1YDvsRJrdndfbetAOqMAQ0M=";
 
   nativeBuildInputs = [
     makeBinaryWrapper
+    pkg-config
+    writableTmpDirAsHomeHook
   ];
 
-  checkFlags = [ "--skip=tests::test_read_config_from_reader" ];
+  buildInputs = [
+    wayland
+    libxkbcommon
+  ];
+
+  preCheck = ''
+    # Several tests use `firefox` in their config fixtures. The test parses configs
+    # via `read_config_from_reader` which validates that referenced binaries exist
+    # in PATH, filtering out entries with missing binaries. Provide a stub so these
+    # tests can run in the sandbox.
+    mkdir -p "$TMPDIR/fake-bin"
+    touch "$TMPDIR/fake-bin/firefox"
+    chmod +x "$TMPDIR/fake-bin/firefox"
+    export PATH="$TMPDIR/fake-bin:$PATH"
+  '';
 
   postFixup = ''
     wrapProgram $out/bin/raffi \
-      --prefix PATH : ${lib.makeBinPath ([ fuzzel ] ++ additionalPrograms)}
+      --prefix PATH : ${lib.makeBinPath ([ fuzzel ] ++ additionalPrograms)} \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          wayland
+          libxkbcommon
+        ]
+      }
   '';
 
   meta = {
@@ -36,7 +62,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/chmouel/raffi";
     changelog = "https://github.com/chmouel/raffi/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [ asl20 ];
-    maintainers = with lib.maintainers; [ aos ];
+    maintainers = with lib.maintainers; [
+      aos
+      chmouel
+      vdemeester
+    ];
     mainProgram = "raffi";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
Update raffi from 0.12.0 to 0.20.0.

### Changes since 0.12.0

- [v0.13.0](https://github.com/chmouel/raffi/releases/tag/v0.13.0)
- [v0.14.0](https://github.com/chmouel/raffi/releases/tag/v0.14.0)
- [v0.15.0](https://github.com/chmouel/raffi/releases/tag/v0.15.0)
- [v0.16.0](https://github.com/chmouel/raffi/releases/tag/v0.16.0)
- [v0.17.0](https://github.com/chmouel/raffi/releases/tag/v0.17.0)
- [v0.18.1](https://github.com/chmouel/raffi/releases/tag/v0.18.1)
- [v0.19.0](https://github.com/chmouel/raffi/releases/tag/v0.19.0) — Emoji & Nerd Fonts picker addon
- [v0.20.0](https://github.com/chmouel/raffi/releases/tag/v0.20.0) — New config format v1 with auto-migration, JSON Schema generation

A fake `firefox` binary stub is created in `preCheck` so tests that parse config fixtures with firefox entries can validate binary-exists checks in the sandbox.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test