### PR TITLE
znc: add argon2

### DIFF
--- a/pkgs/applications/networking/znc/default.nix
+++ b/pkgs/applications/networking/znc/default.nix
@@ -18,6 +18,8 @@
   withZlib ? true,
   zlib,
   withIPv6 ? true,
+  withArgon ? true,
+  libargon2,
   withDebug ? false,
   testers,
 }:
@@ -53,7 +55,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional withTcl tcl
   ++ lib.optional withCyrus cyrus_sasl
   ++ lib.optional withUnicode icu
-  ++ lib.optional withZlib zlib;
+  ++ lib.optional withZlib zlib
+  ++ lib.optional withArgon libargon2;
 
   configureFlags = [
     (lib.enableFeature withPerl "perl")
@@ -61,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.enableFeature withTcl "tcl")
     (lib.withFeatureAs withTcl "tcl" "${tcl}/lib")
     (lib.enableFeature withCyrus "cyrus")
+    (lib.enableFeature withArgon "argon")
   ]
   ++ lib.optionals (!withIPv6) [ "--disable-ipv6" ]
   ++ lib.optionals withDebug [ "--enable-debug" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Compile ZNC with support for argon2 password hashes instead of SHA56, introduced in 1.9.0-rc1 with commit [a1a254b].

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[a1a254b]: https://github.com/znc/znc/commit/a1a254bef1ad017b75ee912bfb33ae16234402c6