### PR TITLE
cargo-tauri: patched setfile

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -39,6 +39,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       zstd
     ];
 
+  patches = [
+    ./skip-icon-macos.patch
+  ];
+
   cargoBuildFlags = [
     "--package"
     "tauri-cli"

--- a/pkgs/by-name/ca/cargo-tauri/skip-icon-macos.patch
+++ b/pkgs/by-name/ca/cargo-tauri/skip-icon-macos.patch
@@ -1,0 +1,29 @@
+diff --git a/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg b/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
+index fee840034..cfa584d52 100644
+--- a/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
++++ b/crates/tauri-bundler/src/bundle/macos/dmg/bundle_dmg
+@@ -461,12 +461,6 @@ if [[ -n "$QL_LINK" ]]; then
+ 	ln -s "/Library/QuickLook" "$MOUNT_DIR/QuickLook"
+ fi
+ 
+-if [[ -n "$VOLUME_ICON_FILE" ]]; then
+-	echo "Copying volume icon file '$VOLUME_ICON_FILE'..."
+-	cp "$VOLUME_ICON_FILE" "$MOUNT_DIR/.VolumeIcon.icns"
+-	SetFile -c icnC "$MOUNT_DIR/.VolumeIcon.icns"
+-fi
+-
+ if [[ -n "$ADD_FILE_SOURCES" ]]; then
+ 	echo "Copying custom files..."
+ 	for i in "${!ADD_FILE_SOURCES[@]}"; do
+@@ -538,11 +532,6 @@ else
+ 	echo "Skipping blessing on sandbox"
+ fi
+ 
+-if [[ -n "$VOLUME_ICON_FILE" ]]; then
+-	# Tell the volume that it has a special file attribute
+-	SetFile -a C "$MOUNT_DIR"
+-fi
+-
+ # Delete unnecessary file system events log if possible
+ echo "Deleting .fseventsd"
+ rm -rf "${MOUNT_DIR}/.fseventsd" || true


### PR DESCRIPTION
This patches a huge issue with 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
