### PR TITLE
nixos/nixos-generate-config: Find LUKS devices recursively

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -352,6 +352,34 @@ sub findStableDevPath {
     return $dev;
 }
 
+# Recursively searches for any LUKS devices that would need to be decrypted
+# in order to accesss the passed in device
+sub findLuksDevices {
+    my ($deviceName) = @_;
+    my @entries;
+
+    my $dmUuid = read_file("/sys/class/block/$deviceName/dm/uuid",  err_mode => 'quiet');
+    if ($dmUuid =~ /^CRYPT-LUKS/)
+    {
+        my @slaves = glob("/sys/class/block/$deviceName/slaves/*");
+        if (scalar @slaves == 1) {
+            my $slave = "/dev/" . basename($slaves[0]);
+            if (-e $slave) {
+                my $dmName = read_file("/sys/class/block/$deviceName/dm/name");
+                chomp $dmName;
+                push @entries, { name => $dmName, slave => $slave }
+            }
+        }
+    }
+
+    my @slaves = glob("/sys/class/block/$deviceName/slaves/*");
+    for my $slave (@slaves) {
+        push @entries, findLuksDevices(basename($slave))
+    }
+
+    return @entries
+}
+
 push @attrs, "services.xserver.videoDrivers = [ \"$videoDriver\" ];" if $videoDriver;
 
 # Generate the swapDevices option from the currently activated swap
@@ -544,21 +572,12 @@ EOF
     # boot.initrd.luks.devices entry.
     if (-e $device) {
         my $deviceName = basename(abs_path($device));
-        my $dmUuid = read_file("/sys/class/block/$deviceName/dm/uuid",  err_mode => 'quiet');
-        if ($dmUuid =~ /^CRYPT-LUKS/)
-        {
-            my @slaves = glob("/sys/class/block/$deviceName/slaves/*");
-            if (scalar @slaves == 1) {
-                my $slave = "/dev/" . basename($slaves[0]);
-                if (-e $slave) {
-                    my $dmName = read_file("/sys/class/block/$deviceName/dm/name");
-                    chomp $dmName;
-                    # Ensure to add an entry only once
-                    my $luksDevice = "  boot.initrd.luks.devices.\"$dmName\".device";
-                    if ($fileSystems !~ /^\Q$luksDevice\E/m) {
-                        $fileSystems .= "$luksDevice = \"${\(findStableDevPath $slave)}\";\n\n";
-                    }
-                }
+        my @luksEntries = findLuksDevices($deviceName);
+        for my $entry (@luksEntries) {
+            # Ensure to add an entry only once
+            my $luksDevice = "  boot.initrd.luks.devices.\"$entry->{name}\".device";
+            if($fileSystems !~ /^\Q$luksDevice\E/m) {
+                $fileSystems .= "$luksDevice = \"${\(findStableDevPath $entry->{slave})}\";\n\n";
             }
         }
         if (-e "/sys/class/block/$deviceName/md/uuid") {

--- a/nixos/tests/nixos-generate-config.nix
+++ b/nixos/tests/nixos-generate-config.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 {
   name = "nixos-generate-config";
   meta.maintainers = with lib.maintainers; [ basvandijk ];
@@ -19,6 +19,8 @@
         services.desktopManager.gnome.enable = true;
       ''
     ];
+    environment.systemPackages = with pkgs; [ cryptsetup ];
+    virtualisation.emptyDiskImages = [ 32 ];
   };
   testScript = ''
     start_all()
@@ -52,5 +54,31 @@
     machine.succeed("nixos-generate-config")
     machine.succeed("nix-instantiate --parse /etc/nixos/flake.nix /etc/nixos/configuration.nix /etc/nixos/hardware-configuration.nix")
     machine.succeed("diff -r /etc/nixos /etc/nixos-with-flake-arg")
+
+    ### Test if script finds LVM on LUKS
+    # Set up LUKS device
+    machine.succeed("echo -n testpassword | cryptsetup luksFormat --batch-mode /dev/vdb -")
+    machine.succeed("echo -n testpassword | cryptsetup luksOpen /dev/vdb crypttest -")
+
+    # Create LVM on top of LUKS
+    machine.succeed("pvcreate /dev/mapper/crypttest")
+    machine.succeed("vgcreate testvg /dev/mapper/crypttest")
+    machine.succeed("lvcreate -l 100%FREE -n testlv testvg")
+
+    # Format and mount
+    machine.succeed("mkfs.ext4 /dev/testvg/testlv")
+    machine.succeed("mkdir -p /mnt/test")
+    machine.succeed("mount /dev/testvg/testlv /mnt/test")
+
+    # Re-run nixos-generate-config and check it found the LUKS device
+    machine.succeed("nixos-generate-config")
+    machine.succeed("grep 'luks' /etc/nixos/hardware-configuration.nix")
+    machine.succeed("grep 'crypttest' /etc/nixos/hardware-configuration.nix")
+
+    # Clean up
+    machine.succeed("umount /mnt/test")
+    machine.succeed("lvchange -an testvg/testlv")
+    machine.succeed("vgchange -an testvg")
+    machine.succeed("cryptsetup luksClose crypttest")
   '';
 }


### PR DESCRIPTION
Previously, if virtual devices (like LVM logical volumes) were contained within a LUKS device, mounting the virtual device would not pull in the hardware config to decrypt the LUKS device (when using the script to generate the hardware config). This would cause the OS to not decrypt the LUKS device and be unable to mount the currently mounted device after the next boot. Now, we will recursively search for any LUKS devices that needs to be decrypted in order to mount the device.

Fixes #490144

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests]. - Ran test nixos-generate-config (as well as added a new test for this case)
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test