### PR TITLE
octodns-providers.ddns: 0.2.1 -> 0.3.0

### DIFF
--- a/pkgs/by-name/oc/octodns/providers/ddns/package.nix
+++ b/pkgs/by-name/oc/octodns/providers/ddns/package.nix
@@ -9,14 +9,14 @@
 }:
 buildPythonPackage rec {
   pname = "octodns-ddns";
-  version = "0.2.1";
+  version = "0.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "octodns";
     repo = "octodns-ddns";
     tag = "v${version}";
-    hash = "sha256-n4dTkJT5UmmEqtN5x2zkJe7NQtjXz3gPwwFnOmMIfIs=";
+    hash = "sha256-aIXRlQeh8GpbqxvgTSngFGpQt01K61Z7sVdAgIs7bkM=";
   };
 
   build-system = [
@@ -27,11 +27,6 @@ buildPythonPackage rec {
     octodns
     requests
   ];
-
-  postPatch = ''
-    substituteInPlace tests/test_octodns_source_ddns.py \
-      --replace-fail "assertEquals" "assertEqual"
-  '';
 
   env.OCTODNS_RELEASE = 1;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
