### PR TITLE
ha-mcp: init at 6.6.1

### DIFF
--- a/pkgs/by-name/ha/ha-mcp/package.nix
+++ b/pkgs/by-name/ha/ha-mcp/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ha-mcp";
+  version = "6.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "homeassistant-ai";
+    repo = "ha-mcp";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-yAJbvfIH5ewRTip8whbOKxE479qAihESaiLFTnhpRkY=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      cryptography
+      fastmcp
+      httpx
+      jq
+      pydantic
+      python-dotenv
+      truststore
+      websockets
+    ]
+    ++ httpx.optional-dependencies.socks;
+
+  # Tests require a running Home Assistant instance
+  doCheck = false;
+
+  pythonImportsCheck = [ "ha_mcp" ];
+
+  meta = {
+    description = "MCP server for controlling Home Assistant via natural language";
+    homepage = "https://github.com/homeassistant-ai/ha-mcp";
+    changelog = "https://github.com/homeassistant-ai/ha-mcp/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+    mainProgram = "ha-mcp";
+  };
+})

--- a/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "homeassistant-ai";
+  domain = "ha_mcp_tools";
+  version = "6.6.1";
+
+  src = fetchFromGitHub {
+    owner = "homeassistant-ai";
+    repo = "ha-mcp";
+    tag = "v${version}";
+    hash = "sha256-yAJbvfIH5ewRTip8whbOKxE479qAihESaiLFTnhpRkY=";
+  };
+
+  meta = {
+    changelog = "https://github.com/homeassistant-ai/ha-mcp/releases/tag/v${version}";
+    description = "Home Assistant custom component for the MCP (Model Context Protocol) server";
+    homepage = "https://github.com/homeassistant-ai/ha-mcp";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}


### PR DESCRIPTION
Add two packages for [ha-mcp](https://github.com/homeassistant-ai/ha-mcp), an MCP server that lets AI assistants talk to Home Assistant.

`ha-mcp` is the server itself, and `home-assistant-custom-components.ha_mcp_tools` is an optional companion integration that registers a few extra services inside Home Assistant.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
