### PR TITLE
mpvScripts.mpv-cheatsheet: use 'webpack-cli'

### DIFF
--- a/pkgs/by-name/mp/mpv/scripts/mpv-cheatsheet.nix
+++ b/pkgs/by-name/mp/mpv/scripts/mpv-cheatsheet.nix
@@ -2,8 +2,8 @@
   lib,
   fetchFromGitHub,
   gitUpdater,
-  nodePackages,
   stdenvNoCC,
+  webpack-cli,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "mpv-cheatsheet";
@@ -17,12 +17,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   };
   passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
-  nativeBuildInputs = [ nodePackages.browserify ];
+  nativeBuildInputs = [ webpack-cli ];
 
   buildPhase = ''
     runHook preBuild
 
-    make dist/${finalAttrs.passthru.scriptName}
+    # Generate readable output, similar to upstream's use of `browserify`
+    webpack --devtool source-map --mode development
 
     runHook postBuild
   '';
@@ -30,7 +31,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    install -D dist/${finalAttrs.passthru.scriptName} $out/share/mpv/scripts/${finalAttrs.passthru.scriptName}
+    install -D dist/main.js $out/share/mpv/scripts/${finalAttrs.passthru.scriptName}
 
     runHook postInstall
   '';


### PR DESCRIPTION
`browserify` has been unmaintained for a couple of years, and is on the cusp of being removed from Nixpkgs (as part of the effort to remove `nodePackages`).

## Things done

I have built the package, but not yet _tested_ it.

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
