### PR TITLE
mujoco: 3.4.0 -> 3.5.0, python3Packages.dm-control: 1.0.36 -> 1.0.37

### DIFF
--- a/pkgs/by-name/mu/mujoco/package.nix
+++ b/pkgs/by-name/mu/mujoco/package.nix
@@ -19,8 +19,8 @@ let
     abseil-cpp = fetchFromGitHub {
       owner = "abseil";
       repo = "abseil-cpp";
-      rev = "d38452e1ee03523a208362186fd42248ff2609f6";
-      hash = "sha256-SCQDORhmJmTb0CYm15zjEa7dkwc+lpW2s1d4DsMRovI=";
+      rev = "255c84dadd029fd8ad25c5efb5933e47beaa00c7";
+      hash = "sha256-TJT2Kzc64zI42FAbbGWP3Sshh1dU/D/AtEpgZrrhebg=";
     };
     benchmark = fetchFromGitHub {
       owner = "google";
@@ -37,8 +37,8 @@ let
     eigen3 = fetchFromGitLab {
       owner = "libeigen";
       repo = "eigen";
-      rev = "49623d0c4e1af3c680845191948d10f6d3e92f8a";
-      hash = "sha256-jmPPyOHNP8Lrk5BKMhWW6KzizLF4dJB3txqOi2zBW40=";
+      rev = "75bcd155c40cb48e647c87c3f29052360255bc9e";
+      hash = "sha256-ZBm3ac6Kt7gOqNip6PeNNMiOF0fwG+7PJYA47KT0ogI=";
     };
     googletest = fetchFromGitHub {
       owner = "google";
@@ -87,7 +87,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "mujoco";
-  version = "3.4.0";
+  version = "3.5.0";
 
   # Bumping version? Make sure to look though the MuJoCo's commit
   # history for bumped dependency pins!
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "google-deepmind";
     repo = "mujoco";
     tag = finalAttrs.version;
-    hash = "sha256-mW1AZKRo5rC3q7VARNI3HNKYGXxnAX6R1AfmY8J1D/Q=";
+    hash = "sha256-5i+QQIwu8olwsMaYvO8b1vLkOkA4jZVR0xcFMuieF5w=";
   };
 
   patches = [ ./mujoco-system-deps-dont-fetch.patch ];

--- a/pkgs/development/python-modules/dm-control/default.nix
+++ b/pkgs/development/python-modules/dm-control/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "dm-control";
-  version = "1.0.36";
+  version = "1.0.37";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "google-deepmind";
     repo = "dm_control";
     tag = finalAttrs.version;
-    hash = "sha256-W6szuGayJRflA88VxYB1LcQE9jlNlz/3SWWAZEfrQKY=";
+    hash = "sha256-IRUAHadZMN9XCSoZj0m48lF/s/5s76Jlrdwe3BBmRNg=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   # in the project's CI.
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-Wm3Gt9tB6wq4ckzUd70DFrpLU96/wtgKLW9EShFvuNI=";
+    hash = "sha256-XIWm/HVgq1+kU081/0WeEtw2CWgfMH5FfbtJtiF/TXM=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
## Things done

- **mujoco: 3.4.0 -> 3.5.0**
  - Diff: https://github.com/google-deepmind/mujoco/compare/3.4.0...3.5.0
  - Changelog: https://mujoco.readthedocs.io/en/3.5.0/changelog.html
- **python3Packages.dm-control: 1.0.36 -> 1.0.37**
  - Diff: https://github.com/google-deepmind/dm_control/compare/1.0.36...1.0.37
  - Changelog: https://github.com/google-deepmind/dm_control/releases/tag/1.0.37

cc @samuela @tmplt

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test