### PR TITLE
python3Packages.rapidfuzz: fix atomic failures on darwin

### DIFF
--- a/pkgs/development/python-modules/rapidfuzz/default.nix
+++ b/pkgs/development/python-modules/rapidfuzz/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
+  clang-tools,
   cmake,
   cython,
   ninja,
@@ -53,6 +54,9 @@ buildPythonPackage rec {
     cython
     ninja
     scikit-build-core
+  ]
+  ++ lib.optionals stdenv.cc.isClang [
+    clang-tools # provides wrapped clang-scan-deps
   ];
 
   dontUseCmakeConfigure = true;


### PR DESCRIPTION
#484624 updated TaskFlow to 4.0.0.  During this time [a patch](https://github.com/rapidfuzz/RapidFuzz/commit/4b794e6168d98fff4c518a64c4d809238b17d8fe.patch) was applied to python3Packagtes.rapidfuzz to use `CMAKE_CXX_STANDARD 20` which enabled c++ modules.

With c++ module support the check for #include <atomic> was failing when calling an _unwrapped_ `clang-scan-deps`.   

```
Error while scanning dependencies for .../src.cxx:
fatal error: 'atomic' file not found
```

This adds `clang-tools` to `nativeBuildInputs` which provides a wrapped `clang-scan-deps` and the atomic module is now found.


Fixes: #489271

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
