### PR TITLE
[Backport release-25.11] python3Packages.triton: fix libcublas dlopen, python3Packages.triton.gpuCheck: skip failing tests

### DIFF
--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -4,6 +4,7 @@
   config,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # patches
   replaceVars,
@@ -224,9 +225,63 @@ buildPythonPackage rec {
 
       doCheck = true;
 
-      preCheck = ''
-        cd python/test/unit
-      '';
+      disabledTests = [
+        # triton.runtime.errors.OutOfResources: out of resource: shared memory,
+        # Required: 131072, Hardware limit: 101376. Reducing block sizes or `num_stages` may help.
+        "test_gather"
+        "test_gather_warp_shuffle"
+        "test_tensor_descriptor_batched_gemm_2d_tma"
+        "test_tensor_descriptor_batched_gemm_3d_tma"
+
+        # AssertionError: assert all(delta == 0 for delta in diff.values())
+        # ----------------------------- Captured stdout call -----------------------------
+        # Expected line "pid (0, 0, 0) idx ( 0,   0) x: 1" 1 time(s), but saw 0 time(s)
+        # ...
+        "test_print"
+
+        # This test ensures that the ptxas binary is available under .../site-packages/triton/backends/nvidia/bin/ptxas
+        # Usually, this is where the install script downloads and copies ptxas to.
+        # However, this is not the case here, as triton is built with TRITON_OFFLINE_BUILD=1
+        # and TRITON_PTXAS_PATH=<path_to_nix_store_ptxas>
+        "test_nvidia_tool"
+      ]
+      ++ lib.optionals (pythonAtLeast "3.14") [
+        # triton.compiler.errors.CompilationError
+        # AttributeError("module 'ast' has no attribute 'Num'"
+        "test_aggregate_modification_in_for_loop"
+        "test_call"
+        "test_call_in_loop"
+        "test_compile_only_k_loop"
+        "test_dot_mulbroadcasted"
+        "test_globaltimer"
+        "test_host_tensor_descriptor_matmul"
+        "test_make_tensor_descriptor_matmul"
+        "test_nested_while"
+        "test_preshuffle_scale_mxfp_cdna4"
+        "test_temp_var_in_loop"
+        "test_tensor_descriptor_rank_reducing_matmul"
+        "test_tensor_descriptor_reshape_matmul"
+      ];
+
+      disabledTestPaths = [
+        # torch.AcceleratorError: CUDA error: device-side assert triggered
+        "python/test/unit/test_debug.py"
+
+        # ptxas fatal   : Unexpected non-ASCII character encountered on line 1
+        # ptxas fatal   : Ptx assembly aborted due to errors
+        "python/test/unit/language/test_line_info.py"
+
+        # Triton Error [CUDA]: \n
+        "python/test/unit/tools/test_aot.py"
+
+        # ptxas fatal   : Unknown option 'sass'
+        "python/test/unit/tools/test_disasm.py"
+      ];
+
+      enabledTestPaths = [
+        "python/test/unit"
+      ];
+
       checkPhase = "pytestCheckPhase";
 
       installPhase = "touch $out";

--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -317,6 +317,7 @@ buildPythonPackage rec {
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      GaetanLepage
       SomeoneSerge
       derdennisop
     ];

--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -276,6 +276,13 @@ buildPythonPackage rec {
 
         # ptxas fatal   : Unknown option 'sass'
         "python/test/unit/tools/test_disasm.py"
+
+        # assert 'mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32' in ptx
+        # AssertionError: assert 'mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32' in ...
+        "python/test/unit/language/test_core.py::test_dot[1-1-2-32-1-False-False-None-ieee-float8e5-float32-1-None]"
+
+        # AssertionError: Tensor-likes are not close!
+        "python/test/unit/language/test_core.py::test_scaled_dot[64-128-128-True-False-True-e4m3-fp16-4-16-1]"
       ];
 
       enabledTestPaths = [

--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -99,6 +99,13 @@ buildPythonPackage rec {
       substituteInPlace cmake/AddTritonUnitTest.cmake \
         --replace-fail "include(\''${PROJECT_SOURCE_DIR}/unittest/googletest.cmake)" ""\
         --replace-fail "include(GoogleTest)" "find_package(GTest REQUIRED)"
+    ''
+    # triton will try dlopening libcublas.so at runtime
+    + lib.optionalString cudaSupport ''
+      substituteInPlace third_party/nvidia/include/cublas_instance.h \
+        --replace-fail \
+          '"libcublas.so"' \
+          '"${lib.getLib cudaPackages.libcublas}/lib/libcublas.so"'
     '';
 
   build-system = [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This is a manual backport of the following two PRs:
- https://github.com/NixOS/nixpkgs/pull/488887
- https://github.com/NixOS/nixpkgs/pull/489387

It includes the following commits:
- **python3Packages.triton: add GaetanLepage to maintainers**
- **python3Packages.triton: fix libcublas dlopen**
- **python3Packages.triton.gpuCheck: skip failing tests**
- **python3Packages.triton.gpuCheck: skip flaky tests**

Hydra failure: https://hydra.nixos-cuda.org/build/173360

cc @NixOS/cuda-maintainers

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
