### PR TITLE
grype: 0.105.0 -> 0.108.0

### DIFF
--- a/pkgs/by-name/gr/grype/package.nix
+++ b/pkgs/by-name/gr/grype/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "grype";
-  version = "0.105.0";
+  version = "0.108.0";
 
   src = fetchFromGitHub {
     owner = "anchore";
     repo = "grype";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+8fCQ/9S4qwPfq/XM5G7LdNl8VQvBxIl67RMqlB6rUI=";
+    hash = "sha256-5TYQKLVl3iM1Litp86n0aAaj3p2yKA1fbJ6bduIjfp8=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
 
   proxyVendor = true;
 
-  vendorHash = "sha256-dYtTYkSVIO5k9kkodhIUWrlNXfQNCUjTUwz4+n6IMtY=";
+  vendorHash = "sha256-8LVpcSjWdGwYv8CMuMZyaHC9+wMJNPDSNV6a8VsmA0M=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -88,6 +88,7 @@ buildGoModule (finalAttrs: {
       --replace-fail "TestSyftLocationExcludes" "SkipSyftLocationExcludes"
     substituteInPlace test/cli/cmd_test.go \
       --replace-fail "Test_descriptorNameAndVersionSet" "Skip_descriptorNameAndVersionSet"
+
     # remove tests that depend on git
     substituteInPlace test/cli/db_validations_test.go \
       --replace-fail "TestDBValidations" "SkipDBValidations"
@@ -104,6 +105,9 @@ buildGoModule (finalAttrs: {
       --replace-fail "TestVersionCmdPrintsToStdout" "SkipVersionCmdPrintsToStdout"
     substituteInPlace grype/presenter/sarif/presenter_test.go \
       --replace-fail "Test_SarifIsValid" "SkipTest_SarifIsValid"
+    substituteInPlace test/cli/config_test.go \
+      --replace-fail "Test_dpkgUseCPEsForEOLEnvVar" "SkipTest_dpkgUseCPEsForEOLEnvVar" \
+      --replace-fail "Test_rpmUseCPEsForEOLEnvVar" "SkipTest_rpmUseCPEsForEOLEnvVar"
 
     # May fail on NixOS, probably due bug in how syft handles tmpfs.
     # See https://github.com/anchore/grype/issues/1822


### PR DESCRIPTION
Diff: https://github.com/anchore/grype/compare/v0.105.0...v0.108.0

Changelog: https://github.com/anchore/grype/releases/tag/v0.108.0

Resolves https://github.com/NixOS/nixpkgs/issues/489275

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
