### PR TITLE
mpvScripts.videoclip: fix missing version prefix

### DIFF
--- a/pkgs/by-name/mp/mpv/scripts/videoclip.nix
+++ b/pkgs/by-name/mp/mpv/scripts/videoclip.nix
@@ -10,7 +10,7 @@
 }:
 buildLua {
   pname = "videoclip";
-  version = "0-unstable-2026-01-22";
+  version = "0.2-unstable-2026-01-22";
 
   src = fetchFromGitHub {
     owner = "Ajatt-Tools";
@@ -31,7 +31,7 @@ buildLua {
   scriptPath = ".";
   passthru.scriptName = "videoclip";
   passthru.updateScript = unstableGitUpdater {
-    hardcodeZeroVersion = true;
+    tagPrefix = "v";
   };
 
   meta = {


### PR DESCRIPTION
follow-up to <https://github.com/NixOS/nixpkgs/pull/489997#pullrequestreview-3796113619>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
