### PR TITLE
althttpd: fix updateScript to strip time from date

### DIFF
--- a/pkgs/by-name/al/althttpd/update.sh
+++ b/pkgs/by-name/al/althttpd/update.sh
@@ -21,7 +21,7 @@ json_output=$(echo "$output" | gawk '/^{/{p=1} p')
 full_rev=$(echo "$json_output" | jq -r '.rev')
 new_rev="${full_rev:0:16}"  # Use 16-char prefix for consistency
 new_hash=$(echo "$json_output" | jq -r '.hash')
-commit_date=$(echo "$json_output" | jq -r '.date')
+commit_date=$(echo "$json_output" | jq -r '.date' | cut -dT -f1)
 
 # Fallback to current date if extraction fails
 if [ -z "$commit_date" ] || [ "$commit_date" = "null" ]; then

--- a/pkgs/by-name/pi/pikchr/update.sh
+++ b/pkgs/by-name/pi/pikchr/update.sh
@@ -21,7 +21,7 @@ json_output=$(echo "$output" | gawk '/^{/{p=1} p')
 full_rev=$(echo "$json_output" | jq -r '.rev')
 new_rev="${full_rev:0:16}"  # Use 16-char prefix for consistency
 new_hash=$(echo "$json_output" | jq -r '.hash')
-commit_date=$(echo "$json_output" | jq -r '.date')
+commit_date=$(echo "$json_output" | jq -r '.date' | cut -dT -f1)
 
 # Fallback to current date if extraction fails
 if [ -z "$commit_date" ] || [ "$commit_date" = "null" ]; then


### PR DESCRIPTION
`nix-prefetch-fossil` returns an ISO 8601 timestamp (e.g. `2026-01-27T19:34:19Z`) in its `.date` JSON field. Both `althttpd` and `pikchr` update scripts were using this directly, producing invalid version strings like `0-unstable-2026-01-27T19:34:19Z`. Fix by piping through `cut -dT -f1` to extract just the `YYYY-MM-DD` date portion.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
