### PR TITLE
mariokart64recomp: 0.9.1-unstable-2025-10-15 -> 0.9.2

### DIFF
--- a/pkgs/by-name/ma/mariokart64recomp/package.nix
+++ b/pkgs/by-name/ma/mariokart64recomp/package.nix
@@ -17,7 +17,6 @@
   makeDesktopItem,
   n64recomp,
   directx-shader-compiler,
-  forceX11 ? false,
 }:
 
 let
@@ -42,13 +41,13 @@ in
 
 llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
   pname = "mariokart64recomp";
-  version = "0.9.1-unstable-2025-10-15";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "sonicdcer";
     repo = "MarioKart64Recomp";
-    rev = "f019c3906d47cddbc8bcbea744948b9f4825f54d";
-    hash = "sha256-lMN7FY9EvFbHEc3bLiTWP9LS15syo7dANxeFOpS4YaA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-7h2dxa8yR5y03FGdoF9eLTv7ZQY7IkXPtkwu7Q+SbAo=";
     preFetch = ''
       export GIT_CONFIG_COUNT=1
       export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
@@ -82,7 +81,6 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
       icon = "MarioKart64Recompiled";
       exec = "MarioKart64Recompiled";
       comment = "Recompilation of MarioKart 64";
-      genericName = "Recompilation of MarioKart 64";
       desktopName = "MarioKart64Recompiled";
       categories = [ "Game" ];
     })
@@ -118,7 +116,7 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
 
     installBin MarioKart64Recompiled
     install -Dm644 -t $out/share ../recompcontrollerdb.txt
-    install -Dm644 ../icons/512.png $out/share/icons/hicolor/scalable/apps/MarioKart64Recompiled.png
+    install -Dm644 ../icons/512.png $out/share/icons/hicolor/512x512/apps/MarioKart64Recompiled.png
     install -Dm644 ../flatpak/io.github.mariokart64recomp.mariokart64recomp.desktop $out/share/applications/MarioKart64Recompiled.desktop
     cp -r ../assets $out/share/
     ln -s $out/share/recompcontrollerdb.txt $out/bin/recompcontrollerdb.txt
@@ -139,13 +137,9 @@ llvmPackages_19.stdenv.mkDerivation (finalAttrs: {
      )
   '';
 
-  # This is needed as MarioKart64Recompiled will segfault when not run from the same
-  # directory as the binary. It also used to exit when run without X11. Recent rt64
-  # updates enabled wayland support, but leave the option to disable this on the
-  # application level if desired.
+  # The game will segfault when not run from the same directory as the binary.
   postFixup = ''
-    wrapProgram $out/bin/MarioKart64Recompiled --chdir "$out/bin/" \
-        ${lib.optionalString forceX11 "--set SDL_VIDEODRIVER x11"}
+    wrapProgram $out/bin/MarioKart64Recompiled --chdir "$out/bin/"
   '';
 
   meta = {


### PR DESCRIPTION
https://github.com/sonicdcer/MarioKart64Recomp/releases/tag/v0.9.2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
