### PR TITLE
jj-vine: init at 0.3.6

### DIFF
--- a/pkgs/by-name/jj/jj-vine/package.nix
+++ b/pkgs/by-name/jj/jj-vine/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromCodeberg,
+  jujutsu,
+  git,
+  writableTmpDirAsHomeHook,
+  cacert,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "jj-vine";
+  version = "0.3.6";
+
+  src = fetchFromCodeberg {
+    owner = "abrenneke";
+    repo = "jj-vine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vvNbeQvP205snAGiql/i8yFGyMw23YkSU4/uxOSnycY=";
+  };
+
+  cargoHash = "sha256-vcpaKlNeORnDpVqXxu0TrXWaWNfaK9QPVJOrty9WmcQ=";
+
+  nativeCheckInputs = [
+    jujutsu
+    git
+    writableTmpDirAsHomeHook
+  ];
+  checkFeatures = [ "no-e2e-tests" ];
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  meta = {
+    description = "Tool for submitting stacked Pull/Merge Requests from Jujutsu bookmarks";
+    homepage = "https://codeberg.org/abrenneke/jj-vine";
+    changelog = "https://codeberg.org/abrenneke/jj-vine/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "jj-vine";
+    maintainers = with lib.maintainers; [ winter ];
+  };
+})


### PR DESCRIPTION
[`jj-vine`](https://codeberg.org/abrenneke/jj-vine) is a stacked pull requests tool for jj.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
