### PR TITLE
playwright-cli: init at 0.1.0

### DIFF
--- a/nixos/modules/services/misc/rumno.nix
+++ b/nixos/modules/services/misc/rumno.nix
@@ -38,9 +38,12 @@ in
       after = [ "graphical-session-pre.target" ];
 
       serviceConfig = {
-        Type = "dbus";
-        BusName = "de.rumno.v1";
-        ExecStart = "${cfg.package}/bin/rumno daemon --foreground ${lib.escapeShellArgs cfg.extraArgs}";
+        Type = "forking";
+        PIDFile = "/tmp/rumno/rumno.pid";
+
+        # rumno-background daemonizes itself; make systemd track the daemon via PIDFile.
+        ExecStartPre = "${pkgs.coreutils}/bin/rm -f /tmp/rumno/rumno.pid";
+        ExecStart = "${cfg.package}/bin/rumno-background ${lib.escapeShellArgs cfg.extraArgs}";
         Restart = "on-failure";
         RestartSec = 1;
 

--- a/pkgs/by-name/pl/playwright-cli/package.nix
+++ b/pkgs/by-name/pl/playwright-cli/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "playwright-cli";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "playwright-cli";
+    tag = "v${version}";
+    hash = "sha256-9LuLQ2klYz91rEkxNDwcx0lYgE6GPoTJkwgxI/4EHgg=";
+  };
+
+  npmDepsHash = "sha256-DvorQ40CCNQJNQdTPFyMBErFNicSWkNT/e6S8cfZlRA=";
+
+  dontNpmBuild = true;
+
+  passthru = {
+    # Newer upstream tags intentionally print a deprecation message and exit.
+    skipBulkUpdate = true;
+  };
+
+  meta = {
+    description = "Playwright CLI for browser automation";
+    homepage = "https://github.com/microsoft/playwright-cli";
+    changelog = "https://github.com/microsoft/playwright-cli/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    mainProgram = "playwright-cli";
+  };
+}

--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -7,6 +7,7 @@
   gdk-pixbuf,
   glib,
   gtk3,
+  gtk-layer-shell,
   cairo,
   atk,
   pango,
@@ -16,16 +17,16 @@
 
 rustPlatform.buildRustPackage {
   pname = "rumno";
-  version = "0-unstable-2025-08-13";
+  version = "0-unstable-2026-02-13";
 
   src = fetchFromGitLab {
     owner = "ivanmalison";
     repo = "rumno";
-    rev = "a70bf6f05976b07ae5fdced2ab80d2b9e684fb92";
-    hash = "sha256-reJIYlTR6fI42EcYGwb5BmEPVtls+s1+mFd7/34oXBw=";
+    rev = "89b3df9f1e1a00418b2bf41f6de392956f1425b5";
+    hash = "sha256-vR6+dNq0sdVtzdBL6GTzqAhl0fE6ulF6UCqIH1fSte4=";
   };
 
-  cargoHash = "sha256-z9nGePcVc+RPSMPb7CAPOfUMoVlP1MKo57aVFkd1DmE=";
+  cargoHash = "sha256-1FyDMdOO7m6y2oX/+VH5LxBwimz7fXM59eOeiffBnOI=";
 
   nativeBuildInputs = [
     pkg-config
@@ -36,6 +37,7 @@ rustPlatform.buildRustPackage {
     gdk-pixbuf
     glib
     gtk3
+    gtk-layer-shell
     cairo
     atk
     pango

--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -28,6 +28,13 @@ rustPlatform.buildRustPackage {
 
   cargoHash = "sha256-1FyDMdOO7m6y2oX/+VH5LxBwimz7fXM59eOeiffBnOI=";
 
+  # rumno-background uses daemonize and sets an overly restrictive umask (0o777),
+  # resulting in an unreadable/unwritable PID file under /tmp/rumno.
+  postPatch = ''
+    substituteInPlace src/common/daemon.rs \
+      --replace-fail "        .umask(0o777)" "        .umask(0o077)"
+  '';
+
   nativeBuildInputs = [
     pkg-config
   ];

--- a/pkgs/by-name/ru/rumno/package.nix
+++ b/pkgs/by-name/ru/rumno/package.nix
@@ -33,6 +33,12 @@ rustPlatform.buildRustPackage {
   postPatch = ''
     substituteInPlace src/common/daemon.rs \
       --replace-fail "        .umask(0o777)" "        .umask(0o077)"
+
+    # Under Wayland (wlroots compositors), rumno uses layer-shell. The upstream default anchored
+    # the surface to the top edge; for volume/brightness OSD we want it centered.
+    substituteInPlace src/ui/app.rs \
+      --replace-fail "            window.set_anchor(Edge::Top, true);" "            window.set_anchor(Edge::Top, false);" \
+      --replace-fail "            window.set_layer_shell_margin(Edge::Top, 60);" "            window.set_layer_shell_margin(Edge::Top, 0);"
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Adds the Microsoft Playwright CLI (playwright-cli) as a Node package.

Notes:
- This packages the last functional upstream tag (v0.1.0). Newer tags intentionally exit with a deprecation message, so skipBulkUpdate is set.
- Browser binaries are not bundled; run `playwright-cli install-browser` at runtime as needed.

Tested:
- `nix run .#playwright-cli -- --help`