### PR TITLE
ntfy: add nginx support

### DIFF
--- a/nixos/modules/services/misc/ntfy-sh.nix
+++ b/nixos/modules/services/misc/ntfy-sh.nix
@@ -28,6 +28,26 @@ in
       description = "Primary group of ntfy-sh user.";
     };
 
+    nginx = {
+      enable = lib.mkOption {
+        default = false;
+        type = lib.types.bool;
+        description = "Whether to set up an nginx virtual host.";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 2586;
+        description = "Internal port for ntfy to listen to.";
+      };
+
+      virtualHost = lib.mkOption {
+        type = lib.types.nonEmptyStr;
+        example = "push.example.com";
+        description = "Virtual host to use for nginx.";
+      };
+    };
+
     settings = lib.mkOption {
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
@@ -88,7 +108,7 @@ in
 
       services.ntfy-sh.settings = {
         auth-file = lib.mkDefault "/var/lib/ntfy-sh/user.db";
-        listen-http = lib.mkDefault "127.0.0.1:2586";
+        listen-http = if cfg.nginx.enable then "[::1]:${cfg.nginx.port}" else lib.mkDefault "[::1]:2586";
         attachment-cache-dir = lib.mkDefault "/var/lib/ntfy-sh/attachments";
         cache-file = lib.mkDefault "/var/lib/ntfy-sh/cache-file.db";
       };
@@ -133,6 +153,24 @@ in
         ntfy-sh = {
           isSystemUser = true;
           group = cfg.group;
+        };
+      };
+
+      services.nginx = lib.mkIf cfg.nginx.enable {
+        enable = true;
+        virtualHosts."${cfg.nginx.virtualHost}" = {
+          forceSSL = true;
+
+          locations."/" = {
+            proxyPass = "http://[::1]:${cfg.nginx.port}";
+            proxyWebsockets = true;
+            extraConfig = ''
+              proxy_connect_timeout 3m;
+              proxy_send_timeout 3m;
+              proxy_read_timeout 3m;
+              client_max_body_size 0;
+            '';
+          };
         };
       };
     };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds `services.ntfy.nginx` options to automatically set up nginx for ntfy-sh.

Configuration largely follows [upstream recommendations](https://docs.ntfy.sh/config/?h=nginx#__tabbed_14_2). I tested that this works for delivering UnifiedPush notifications as intended.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
