### PR TITLE
jxscout: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13699,6 +13699,13 @@
     matrix = "@katexochen:matrix.org";
     name = "Paul Meyer";
   };
+  katok = {
+    name = "katok";
+    email = "kat.ok.timofey@gmail.com";
+    matrix = "@kat.ok:matrix.org";
+    github = "Hi-Timofey";
+    githubId = 43324422;
+  };
   katrinafyi = {
     name = "katrinafyi";
     github = "katrinafyi";

--- a/pkgs/by-name/jx/jxscout/package.nix
+++ b/pkgs/by-name/jx/jxscout/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  makeWrapper,
+  prettier,
+  bun,
+  nodejs,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "jxscout";
+  version = "0.9.4";
+
+  src = fetchFromGitHub {
+    owner = "francisconeves97";
+    repo = "jxscout";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-DvvhcnjBHRHUEW5mWHLa7ufC+7yzYwKKOV79Syk5zME=";
+  };
+
+  subPackages = [ "cmd/jxscout" ];
+
+  vendorHash = null;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  doCheck = true;
+
+  postInstall = ''
+    wrapProgram $out/bin/jxscout --prefix PATH : ${
+      lib.makeBinPath [
+        prettier
+        bun
+        nodejs
+      ]
+    }
+  '';
+
+  meta = {
+    description = "jxscout superpowers JavaScript analysis for security researchers (free version)";
+    homepage = "https://jxscout.app/";
+    downloadPage = "https://github.com/francisconeves97/jxscout";
+    changelog = "https://github.com/francisconeves97/jxscout/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "jxscout";
+    maintainers = with lib.maintainers; [ katok ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin ++ lib.platforms.windows;
+  };
+})


### PR DESCRIPTION
Tool to perform JavaScript analysis for security researchers

https://github.com/francisconeves97/jxscout

Related to https://github.com/NixOS/nixpkgs/issues/81418

Closes https://github.com/NixOS/nixpkgs/issues/403287

Finished work from https://github.com/NixOS/nixpkgs/pull/403921

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
