### PR TITLE
torch-mlir: init at unstable-2026-02-12

### DIFF
--- a/pkgs/by-name/to/torch-mlir/package.nix
+++ b/pkgs/by-name/to/torch-mlir/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  pkg-config,
+  gitMinimal,
+  nix-update-script,
+  python3,
+  python3Packages,
+  zlib,
+  libxml2,
+  ncurses,
+}:
+
+stdenv.mkDerivation {
+  pname = "torch-mlir";
+  version = "0-unstable-2026-02-12";
+
+  src = fetchFromGitHub {
+    owner = "llvm";
+    repo = "torch-mlir";
+    rev = "59c249e5cc2025acca81bdcf1596b8dd36a5c0f9";
+    fetchSubmodules = true;
+    hash = "sha256-o1HG5JuKRMEnl2PrEu5KQi4iqBe0Doh1SET2W/OjGoI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    gitMinimal
+    python3
+    python3Packages.nanobind
+  ];
+
+  buildInputs = [
+    zlib
+    libxml2
+    ncurses
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    cmake -G Ninja \
+      -S externals/llvm-project/llvm \
+      -B build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=$out \
+      -DLLVM_ENABLE_ASSERTIONS=ON \
+      -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
+      -DLLVM_TARGETS_TO_BUILD=host \
+      -DLLVM_ENABLE_PROJECTS=mlir \
+      -DLLVM_EXTERNAL_PROJECTS=torch-mlir \
+      -DLLVM_EXTERNAL_TORCH_MLIR_SOURCE_DIR=$PWD \
+      -DPython3_EXECUTABLE=${python3}/bin/python3 \
+      -DPython_EXECUTABLE=${python3}/bin/python3 \
+      -DPython3_FIND_VIRTUALENV=ONLY \
+      -DPython_FIND_VIRTUALENV=ONLY
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cmake --build build --target tools/torch-mlir/all TorchMLIRPythonModules -- -j''${NIX_BUILD_CORES:-1}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for component in torch-mlir-headers torch-mlir-opt torch-mlir-lsp-server TorchMLIRPythonModules; do
+      cmake --install build --prefix "$out" --component "$component"
+    done
+
+    if [ -d "$out/python_packages" ]; then
+      mv "$out/python_packages" "$out/python-packages"
+    fi
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
+
+  meta = {
+    description = "Torch-MLIR compiler infrastructure and Python bindings";
+    homepage = "https://github.com/llvm/torch-mlir";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ rcoeurjoly ];
+  };
+}


### PR DESCRIPTION
New package torch-mlir: https://github.com/llvm/torch-mlir

I have taken inspiration from `circt` (https://github.com/NixOS/nixpkgs/blob/nixos-25.11/pkgs/by-name/ci/circt/package.nix#L144), which also has `llvm` as a submodule.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
