### PR TITLE
mobilizon: fix permissions on /var/lib/mobilizon/uploads folder

### DIFF
--- a/nixos/modules/services/web-apps/mobilizon.nix
+++ b/nixos/modules/services/web-apps/mobilizon.nix
@@ -398,7 +398,10 @@ in
     };
 
     systemd.tmpfiles.rules = [
+      "d /var/lib/mobilizon 700 mobilizon mobilizon - -"
       "d /var/lib/mobilizon/sitemap 700 mobilizon mobilizon - -"
+      "d /var/lib/mobilizon/uploads 700 mobilizon mobilizon - -"
+      "d /var/lib/mobilizon/uploads/exports 700 mobilizon mobilizon - -"
       "d /var/lib/mobilizon/uploads/exports/csv 700 mobilizon mobilizon - -"
       "Z /var/lib/mobilizon 700 mobilizon mobilizon - -"
     ];

--- a/nixos/tests/mobilizon.nix
+++ b/nixos/tests/mobilizon.nix
@@ -43,5 +43,11 @@ in
     server.wait_for_unit("mobilizon.service")
     server.wait_for_open_port(${toString port})
     server.succeed("curl --fail https://${mobilizonDomain}/")
+
+    # Verify ownership is set up correctly
+    owner = server.succeed("stat -c '%U' /var/lib/mobilizon/sitemap").rstrip()
+    assert owner == "mobilizon", f"unexpected owner: {owner}"
+    owner = server.succeed("stat -c '%U' /var/lib/mobilizon/uploads").rstrip()
+    assert owner == "mobilizon", f"unexpected owner: {owner}"
   '';
 }


### PR DESCRIPTION
Image uploads were broken due to `/var/lib/mobilizon/uploads` being root-owned.

The root cause is that systemd doesn't always process tmpfiles rules in the listed order[^1]. The "Z" rule is actually applied first, so it didn't have any effect on first run (when the directory doesn't exist). The other rules would then proceed to create the directory structure, but any parent directories that aren't explicitly listed would be root-owned.

`systemd-tmpfiles` also flagged an "unsafe path transition" about this before: 
```
Detected unsafe path transition /var/lib/mobilizon (owned by mobilizon) → /var/lib/mobilizon/uploads (owned by root) during canonicalization of var/lib/mobilizon/uploads/exports.
```

[^1]: man page: `When two lines are prefix path and suffix path of each other, then the prefix line is always created first`

The fix is to explicitly list parent directories with the proper owner, which is also suggested by the tmpfiles.d man page[^2].

[^2]: `Note that for all line types that result in creation of any kind of file node (i.e.  f, d/D/v/q/Q, p, L, c/b and C) leading directories are implicitly created if needed, owned by root with an access mode of 0755. In order to create them with different modes or ownership make sure to add appropriate d lines.`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
