### PR TITLE
openra: patch to build with .NET 8 (from EOL .NET 6)

### DIFF
--- a/pkgs/games/openra/build-engine.nix
+++ b/pkgs/games/openra/build-engine.nix
@@ -35,6 +35,12 @@ buildDotnetModule {
 
   nugetDeps = engine.deps;
 
+  # Retarget from net6.0 to net8.0 (net6.0 is EOL)
+  postPatch = ''
+    substituteInPlace Directory.Build.props \
+      --replace-fail ">net6.0<" ">net8.0<"
+  '';
+
   useAppHost = false;
 
   dotnetFlags = [ "-p:Version=0.0.0.0" ]; # otherwise dotnet build complains, version is saved in VERSION file anyway

--- a/pkgs/games/openra/engines/release/default.nix
+++ b/pkgs/games/openra/engines/release/default.nix
@@ -5,5 +5,5 @@ buildOpenRAEngine {
   version = "20250330";
   hash = "sha256-chWkzn/NLZh2gOua9kE0ubRGjGCC0LvtZSWHBgXKqHw=";
   deps = ./deps.json;
-  dotnet-sdk = dotnetCorePackages.sdk_6_0-bin;
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
 }


### PR DESCRIPTION
Upstream release-20250330 still targets net6.0, which went EOL in November 2024. The bleed engine already uses .NET 8.

Patch Directory.Build.props to retarget net6.0 -> net8.0. The code uses C# language version 9, which is compatible with .NET 8. Build tested on x86_64-linux with no errors (only deprecation warnings for SYSLIB0051, which also appear in the bleed build).

Related: https://github.com/NixOS/nixpkgs/issues/326335


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
