### PR TITLE
linuxPackages.openafs: Patch for Linux kernel 6.19

### DIFF
--- a/pkgs/servers/openafs/1.8/module.nix
+++ b/pkgs/servers/openafs/1.8/module.nix
@@ -43,23 +43,47 @@ stdenv.mkDerivation {
       url = "https://github.com/openafs/openafs/commit/eb6753d93b930ad7d65772a9751117f6969a5e92.patch";
       hash = "sha256-97/MdG9DrHEtOKCRLCTgl6ZEtqLUsaNs9LcAzcyrTF4=";
     })
-    # Linux: mount_nodev removed, use new mount API
+    # Linux: Use get_tree_nodev
     (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16646/revisions/93db75395149e1f0dbdc3a0572f58449dd9da98d/patch";
+      url = "https://gerrit.openafs.org/changes/16646/revisions/d8202bcd24c90cfef138e54264355d242d8f2f2a/patch";
       decode = "base64 -d";
-      hash = "sha256-5eYliZV3WPjbQ3WGvZuqzeu060MHRof2yozSWPn+Njg=";
+      hash = "sha256-lj7tRCrgWFPFsd5cMg9CQAFOx3VYUf3fS4JGNyAgnWk=";
     })
-    # Linux: Rename LINUX_WRITEPAGES_USES_FOLIOS
+    # Linux: Introduce LINUX_WRITE_CACHE_PAGES_USES_FOLIOS
     (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16650/revisions/1e5801afe3069a9ca586c745ae1e26feb8f1048f/patch";
+      url = "https://gerrit.openafs.org/changes/16650/revisions/cef9524c481520040dc93a02f5df9cd9eb8907a2/patch";
       decode = "base64 -d";
-      hash = "sha256-qtqe64qhRwNBwfKkGhuEAKFDMFDirFxz9M0Wvtk+r1Q=";
+      hash = "sha256-SUJxhIL1vNDS8IO6GVGQ8aZOa6XabR3qFfTzWV6umao=";
     })
-    # Linux: Don't use write_cache_pages for writepages
+    # Linux: Avoid write_cache_pages() for ->writepages()
     (fetchpatch {
-      url = "https://gerrit.openafs.org/changes/16648/revisions/652674cec6c6c7349709dc080b6a2db3253424e6/patch";
+      url = "https://gerrit.openafs.org/changes/16648/revisions/dd83364354692eaa323b246df17fec2a3f11057d/patch";
       decode = "base64 -d";
-      hash = "sha256-5T4hOge3U5uk3NSFxocYEjgfXU1Se5FkQk2rCRZDlfU=";
+      hash = "sha256-3hPqwfkpRkS/XXmWjl+zy4KmVL8RkBuhmC+O0D/h85U=";
+    })
+    # Linux: Move afs_root()/afs_fill_super() in osi_vfsops
+    (fetchpatch {
+      url = "https://gerrit.openafs.org/changes/16673/revisions/dfd3e87daf227884fa0da7bbab83db1b9de9b882/patch";
+      decode = "base64 -d";
+      hash = "sha256-mWv/C5Yus4EZFrsQObCiOGA3nO2DAl1JWm8+YMHaabA=";
+    })
+    # Linux: Use sockaddr_unsized for socket->ops->bind
+    (fetchpatch {
+      url = "https://gerrit.openafs.org/changes/16683/revisions/1a5864a5ff777142de3110a6e7848fd5769f933a/patch";
+      decode = "base64 -d";
+      hash = "sha256-lHRxDUIyFZNAvJ8J+4SfP9ETU/wnjGh6s5E+bmrQG08=";
+    })
+    # Linux: Pass 3rd parameter to filemap_alloc_folio()
+    (fetchpatch {
+      url = "https://gerrit.openafs.org/changes/16684/revisions/870e0aeb9d6f26a814ee38ce1becf12b562b7fa1/patch";
+      decode = "base64 -d";
+      hash = "sha256-DZfi6OK9TYovwmYNrgI+WxGS13cQjdGODlSn3rQO/Gk=";
+    })
+    # Linux: implement aops->migrate_folio
+    (fetchpatch {
+      url = "https://gerrit.openafs.org/changes/16689/revisions/6d294581969039eea65c974c3a8c565917df9c6a/patch";
+      decode = "base64 -d";
+      hash = "sha256-XXzrDfoG4BbEDp6C4TElN0+3ytTu4VP5goDiZlq8DjU=";
     })
   ];
 


### PR DESCRIPTION
Update upstream patches from https://gerrit.openafs.org/#/q/topic:linux-6.18 and apply upstream patches from https://gerrit.openafs.org/#/q/topic:linux-6.19 needed to build the OpenAFS kernel module with Linux kernel 6.19.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
