### PR TITLE
abseil-cpp: update

### DIFF
--- a/pkgs/by-name/ab/abseil-cpp/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp/package.nix
@@ -5,4 +5,4 @@
 # library.”  Therefore, we keep packages `abseil-cpp_YYYYMM` for each
 # required LTS branch, leaving `abseil-cpp` as an alias.
 
-{ abseil-cpp_202508 }: abseil-cpp_202508
+{ abseil-cpp_202601 }: abseil-cpp_202601

--- a/pkgs/by-name/ab/abseil-cpp_202505/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp_202505/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "abseil-cpp";
-  version = "20250512.1";
+  version = "20250512.2";
 
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
     tag = finalAttrs.version;
-    hash = "sha256-eB7OqTO9Vwts9nYQ/Mdq0Ds4T1KgmmpYdzU09VPWOhk=";
+    hash = "sha256-NMdCALDFGGNNGyN17nwpRYBh/hoQoU7YMk66YDJndxQ=";
   };
 
   cmakeFlags = [

--- a/pkgs/by-name/ab/abseil-cpp_202508/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp_202508/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "abseil-cpp";
-  version = "20250814.1";
+  version = "20250814.2";
 
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
     tag = finalAttrs.version;
-    hash = "sha256-SCQDORhmJmTb0CYm15zjEa7dkwc+lpW2s1d4DsMRovI=";
+    hash = "sha256-PCospVD/hnbT/87tRtvick+RIuwAv7DDPGnLG3ZMb3g=";
   };
 
   outputs = [

--- a/pkgs/by-name/ab/abseil-cpp_202601/package.nix
+++ b/pkgs/by-name/ab/abseil-cpp_202601/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  gtest,
+  static ? stdenv.hostPlatform.isStatic,
+  cxxStandard ? null,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "abseil-cpp";
+  version = "20260107.1";
+
+  src = fetchFromGitHub {
+    owner = "abseil";
+    repo = "abseil-cpp";
+    tag = finalAttrs.version;
+    hash = "sha256-TJT2Kzc64zI42FAbbGWP3Sshh1dU/D/AtEpgZrrhebg=";
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ABSL_BUILD_TEST_HELPERS" true)
+    (lib.cmakeBool "ABSL_USE_EXTERNAL_GOOGLETEST" true)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" (!static))
+  ]
+  ++ lib.optionals (cxxStandard != null) [
+    (lib.cmakeFeature "CMAKE_CXX_STANDARD" cxxStandard)
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ gtest ];
+
+  meta = {
+    description = "Open-source collection of C++ code designed to augment the C++ standard library";
+    homepage = "https://abseil.io/";
+    changelog = "https://github.com/abseil/abseil-cpp/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.all;
+    maintainers = [ lib.maintainers.GaetanLepage ];
+  };
+})

--- a/pkgs/development/libraries/abseil-cpp/202407.nix
+++ b/pkgs/development/libraries/abseil-cpp/202407.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "abseil-cpp";
-  version = "20240722.1";
+  version = "20240722.2";
 
   src = fetchFromGitHub {
     owner = "abseil";
     repo = "abseil-cpp";
     tag = finalAttrs.version;
-    hash = "sha256-ir4hG2VIPv3se7JfWqCM/siLqFEFkmhMW/IGCocy6Pc=";
+    hash = "sha256-PuS7MLwi824c4z4Cubh029DEUVYSNPD3MwCDsgzsp3Y=";
   };
 
   patches = [


### PR DESCRIPTION
## Things done

- **abseil-cpp_202407: 20240722.1 -> 20240722.2**
  - Diff: https://github.com/abseil/abseil-cpp/compare/20240722.1...20240722.2
  - Changelog: https://github.com/abseil/abseil-cpp/releases/tag/20240722.2
- **abseil-cpp_202505: 20250512.1 -> 20250512.2**
  - Diff: https://github.com/abseil/abseil-cpp/compare/20250512.1...20250512.2
  - Changelog: https://github.com/abseil/abseil-cpp/releases/tag/20250512.2
- **abseil-cpp_202508: 20250814.1 -> 20250814.2**
  - Diff: https://github.com/abseil/abseil-cpp/compare/20250814.1...20250814.2
  - Changelog: https://github.com/abseil/abseil-cpp/releases/tag/20250814.2
- **abseil-cpp_202601: init at 20260107.1**
  - Changelog: https://github.com/abseil/abseil-cpp/releases/tag/20260107.1
- **abseil-cpp: 20250814.2 -> 20260107.1**
  - Diff: https://github.com/abseil/abseil-cpp/compare/20250814.2...20260107.1
  - Changelog: https://github.com/abseil/abseil-cpp/releases/tag/20250814.2

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
