### PR TITLE
isabelle: don't use `/tmp` as a temp directory

### DIFF
--- a/pkgs/applications/science/logic/tlaplus/tlaps.nix
+++ b/pkgs/applications/science/logic/tlaplus/tlaps.nix
@@ -31,8 +31,13 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -pv "$out"
-    export HOME="$out"
+    export HOME="$TMPDIR"
     export PATH=$out/bin:$PATH
+
+    # Stop Isabelle trying to use `/tmp`.
+    user_home="$(isabelle getenv -b ISABELLE_HOME_USER)"
+    mkdir -p "$user_home/etc"
+    echo 'ISABELLE_TMP_PREFIX="$TMPDIR/isabelle"' > "$user_home/etc/settings"
 
     pushd zenon
     ./configure --prefix $out

--- a/pkgs/by-name/is/isabelle/package.nix
+++ b/pkgs/by-name/is/isabelle/package.nix
@@ -266,6 +266,11 @@ stdenv.mkDerivation (finalAttrs: {
     export HOME=$TMP # The build fails if home is not set
     setup_name=$(basename contrib/isabelle_setup*)
 
+    # Stop Isabelle trying to use `/tmp`.
+    user_home="$(bin/isabelle getenv -b ISABELLE_HOME_USER)"
+    mkdir -p "$user_home/etc"
+    echo 'ISABELLE_TMP_PREFIX="$TMPDIR/isabelle"' > "$user_home/etc/settings"
+
     #The following is adapted from https://isabelle.sketis.net/repos/isabelle/file/Isabelle2021-1/Admin/lib/Tools/build_setup
     TARGET_DIR="contrib/$setup_name/lib"
     rm -rf "$TARGET_DIR"


### PR DESCRIPTION
Isabelle uses `/tmp` no matter what on Unix platforms, apparently because using an arbitrary `$TMPDIR` can cause "path too long" errors on macOS (https://isabelle.in.tum.de/repos/isabelle/rev/ff92d6edff2c).

However, when not using the sandbox (i.e. on Darwin), this causes the build to fail if its temp directory (`/tmp/isabelle-`) has already been created by a previous build using a different build user. For example, this is the cause of https://hydra.nixos.org/build/321069301.

So, this PR changes it to use `$TMPDIR` during the build of Isabelle itself (but still use `/tmp` when using Isabelle normally). I had initially hoped this would also enable Isabelle to build within the Darwin sandbox, but something else seems to be wrong (I get an opaque `I/O error: Operation not permitted`).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
