### PR TITLE
nixos/tpm2: create tss user and group if either is required

### DIFF
--- a/nixos/modules/security/tpm2.nix
+++ b/nixos/modules/security/tpm2.nix
@@ -276,11 +276,11 @@ in
         services.udev.extraRules = lib.mkIf cfg.applyUdevRules (udevRules cfg.tssUser cfg.tssGroup);
 
         # Create the tss user and group only if the default value is used
-        users.users.${cfg.tssUser} = lib.mkIf (cfg.tssUser == "tss") {
+        users.users.tss = lib.mkIf (cfg.tssUser == "tss" || cfg.tssGroup == "tss") {
           isSystemUser = true;
           group = "tss";
         };
-        users.groups.${cfg.tssGroup} = lib.mkIf (cfg.tssGroup == "tss") { };
+        users.groups.tss = lib.mkIf (cfg.tssUser == "tss" || cfg.tssGroup == "tss") { };
 
         environment.variables = lib.mkIf cfg.tctiEnvironment.enable (
           lib.attrsets.genAttrs

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1633,7 +1633,7 @@ in
   tomcat = runTest ./tomcat.nix;
   tor = runTest ./tor.nix;
   tpm-ek = handleTest ./tpm-ek { };
-  tpm2 = runTest ./tpm2.nix;
+  tpm2 = import ./tpm2 { inherit runTest; };
   traccar = runTest ./traccar.nix;
   # tracee requires bpf
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };

--- a/nixos/tests/tpm2/default.nix
+++ b/nixos/tests/tpm2/default.nix
@@ -1,4 +1,5 @@
 { runTest }:
 {
   abrmd = runTest ./tpm2-abrmd.nix;
+  tpmrm = runTest ./tpm2-tpmrm.nix;
 }

--- a/nixos/tests/tpm2/default.nix
+++ b/nixos/tests/tpm2/default.nix
@@ -1,0 +1,4 @@
+{ runTest }:
+{
+  abrmd = runTest ./tpm2-abrmd.nix;
+}

--- a/nixos/tests/tpm2/tpm2-abrmd.nix
+++ b/nixos/tests/tpm2/tpm2-abrmd.nix
@@ -39,6 +39,10 @@
     machine.start()
     machine.wait_for_unit("multi-user.target")
 
+    with subtest("/dev/tpmrm0 has correct ownership"):
+        machine.succeed('[ `stat -c "%U" /dev/tpmrm0` = "tss" ]')
+        machine.succeed('[ `stat -c "%G" /dev/tpmrm0` = "tss" ]')
+
     with subtest("tabrmd service started properly"):
         machine.succeed('[ `systemctl show tpm2-abrmd.service --property=Result` = "Result=success" ]')
         machine.succeed('[ `journalctl -b -u tpm2-abrmd.service | grep -c "Starting"` = "1" ]')

--- a/nixos/tests/tpm2/tpm2-tpmrm.nix
+++ b/nixos/tests/tpm2/tpm2-tpmrm.nix
@@ -1,0 +1,72 @@
+{ lib, pkgs, ... }:
+{
+  name = "tpm2-tpmrm";
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      virtualisation = {
+        mountHostNixStore = true;
+        useEFIBoot = true;
+        tpm.enable = true;
+      };
+
+      users.users = {
+        tss-user = {
+          isNormalUser = true;
+          extraGroups = [ "tss" ];
+        };
+      };
+
+      security.sudo.wheelNeedsPassword = false;
+
+      security.tpm2 = {
+        enable = true;
+        pkcs11.enable = true;
+        tctiEnvironment.enable = true;
+        fapi.ekCertLess = true;
+      };
+
+      environment.systemPackages = [
+        pkgs.tpm2-tools
+        pkgs.openssl
+      ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("/dev/tpmrm0 has correct ownership"):
+        machine.succeed('[ `stat -c "%U" /dev/tpmrm0` = "root" ]')
+        machine.succeed('[ `stat -c "%G" /dev/tpmrm0` = "tss" ]')
+
+    with subtest("tpm2 cli works"):
+        machine.succeed('tpm2 createprimary --hierarchy=o --key-algorithm=aes256 --attributes="fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|decrypt" --key-context=owner_root_key.ctx')
+        machine.succeed('tpm2 create --parent-context=owner_root_key.ctx --key-algorithm=ecc256:ecdsa-sha256:null --attributes="fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|sign" --key-context=ecc_sign_key.ctx --creation-ticket=ecc_sign_key-creation_ticket.bin -f pem --output=ecc_sign_key_public.pem')
+        machine.succeed('echo "A very important message." > message.txt')
+        machine.succeed('tpm2 sign --key-context=ecc_sign_key.ctx --hash-algorithm=sha256 -f plain --signature message_signature.bin message.txt')
+        machine.succeed('openssl dgst -verify ecc_sign_key_public.pem -signature message_signature.bin message.txt')
+        machine.succeed('echo "evil addition!" >> message.txt')
+        machine.fail('openssl dgst -verify ecc_sign_key_public.pem -signature message_signature.bin message.txt')
+
+    def format_command(command, user):
+        return f"runuser -u {user} -- bash -c '{command}'"
+    def succeedu(command,user):
+        return machine.succeed(format_command(command,user))
+    def failu(command,user):
+        return machine.fail(format_command(command,user))
+
+    with subtest("tss2 cli works"):
+        machine.succeed('tss2 provision')
+        succeedu('tss2 createkey --path=HS/SRK/sign --type=sign --authValue=""',"tss-user")
+        succeedu('tss2 gettpmblobs --path=HS/SRK/sign --tpm2bPublic=$HOME/sign_key_public.bin',"tss-user")
+        succeedu('tpm2 print -t TPM2B_PUBLIC -f pem $HOME/sign_key_public.bin > $HOME/sign_key_public.pem',"tss-user")
+        succeedu('echo "A very important message." > $HOME/message.txt',"tss-user")
+        succeedu('tpm2 hash --hash-algorithm=sha256 --output=$HOME/message_hash.bin $HOME/message.txt',"tss-user")
+        succeedu('tss2 sign --keyPath=HS/SRK/sign --digest=$HOME/message_hash.bin --signature=$HOME/message_signature.bin',"tss-user")
+        succeedu('openssl dgst -verify $HOME/sign_key_public.pem -signature $HOME/message_signature.bin $HOME/message.txt',"tss-user")
+        succeedu('echo "evil addition!" >> $HOME/message.txt',"tss-user")
+        failu('openssl dgst -verify $HOME/sign_key_public.pem -signature $HOME/message_signature.bin $HOME/message.txt',"tss-user")
+  '';
+}


### PR DESCRIPTION
We only want to create users and groups in the module if they are the module defaults; if a user is specifying something else, we can presume that they are creating that themselves and don't want to conflict.

The previous implementation caused problems when the module was configured to use the /dev/tpmrm0 kernel resource manager. In this configuration, /dev/tpmrm0 would be owned by root, but in the group tss, which caused there to be no tss user created. This in turn caused the tss group to be a "normal" group, not a system group, and udev does not assign devices to normal groups. Unfortunately, there is no isSystemGroup option corresponding to the isSystemUser option. To avoid messing with the user system, we add the tss user if we need the group.

resolves #489756

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
