### PR TITLE
nacrypt: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3005,6 +3005,11 @@
     github = "joealsubash";
     githubId = 98759349;
   };
+  basicallygit = {
+    name = "basicallygit";
+    github = "basicallygit";
+    githubId = 91993321;
+  };
   bastaynav = {
     name = "Ivan Bastrakov";
     email = "bastaynav@proton.me";

--- a/pkgs/by-name/na/nacrypt/package.nix
+++ b/pkgs/by-name/na/nacrypt/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  clangStdenv,
+  fetchFromGitHub,
+  buildPackages,
+  libsodium,
+  libseccomp,
+  libcap,
+}:
+
+clangStdenv.mkDerivation (finalAttrs: {
+  pname = "nacrypt";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "basicallygit";
+    repo = "nacrypt";
+    tag = finalAttrs.version;
+    hash = "sha256-wR+41Ev7LFaSIEuJckJbiFPj57WeiE1xhcB1/k1ktyU=";
+  };
+
+  nativeBuildInputs = [
+    buildPackages.bash
+    buildPackages.clang-tools
+  ];
+
+  buildInputs = [
+    libsodium
+    libseccomp
+    libcap
+  ];
+
+  postPatch = ''
+    chmod +x format.sh
+    patchShebangs format.sh
+  '';
+
+  # Allow sandbox fail for systems without unprivileged usernamespaces enabled
+  makeFlags = [
+    "CLANG_CFI=y"
+    "TIGHTENED_SANDBOX=y"
+    "ALLOW_SANDBOX_FAIL=y"
+  ];
+
+  doCheck = true;
+  checkTarget = "test";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 nacrypt $out/bin/nacrypt
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Simple and secure file encryption utility";
+    homepage = "https://github.com/basicallygit/nacrypt";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ basicallygit ];
+    mainProgram = "nacrypt";
+  };
+})


### PR DESCRIPTION
https://github.com/basicallygit/nacrypt

Nacrypt is a simple & secure file encryption program intended for long-term confidentiality on potentially untrusted cloud storage or other media

This PR adds nacrypt as a new package and adds myself to the maintainers list

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [X] Verified build and internal test suite (make test) with nix-build -A nacrypt 
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
