### PR TITLE
katawa-shoujo-re-engineered: compile rpy files in the build phase

### DIFF
--- a/pkgs/by-name/ka/katawa-shoujo-re-engineered/package.nix
+++ b/pkgs/by-name/ka/katawa-shoujo-re-engineered/package.nix
@@ -25,26 +25,40 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       name = "katawa-shoujo-re-engineered";
       desktopName = "Katawa Shoujo: Re-Engineered";
       type = "Application";
-      icon = finalAttrs.meta.mainProgram;
+      icon = "katawa-shoujo-re-engineered";
       categories = [ "Game" ];
-      exec = finalAttrs.meta.mainProgram;
+      exec = "katawa-shoujo-re-engineered";
     })
   ];
 
   nativeBuildInputs = [
     makeWrapper
     copyDesktopItems
+    renpy
   ];
 
-  dontBuild = true;
+  postPatch = ''
+    substituteInPlace game/config.rpy --replace-fail 0.0.0-localbuild ${finalAttrs.version}
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    renpy . compile
+
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin
-    makeWrapper ${lib.getExe' renpy "renpy"} $out/bin/${finalAttrs.meta.mainProgram} \
-      --add-flags ${finalAttrs.src} --add-flags run
-    install -D $src/web-icon.png $out/share/icons/hicolor/512x512/apps/${finalAttrs.meta.mainProgram}.png
+    phome=$out/share/kataswa-shoujo-re-engineered
+    mkdir -p $phome
+    cp -r game $phome
+    find $phome -type f -name "*.rpy" -delete
+    makeWrapper ${lib.getExe renpy} $out/bin/katawa-shoujo-re-engineered \
+      --add-flags $phome --add-flags run
+    install -D $src/web-icon.png $out/share/icons/hicolor/512x512/apps/katawa-shoujo-re-engineered.png
 
     runHook postInstall
   '';
@@ -64,6 +78,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       quantenzitrone
       rapiteanu
+      ulysseszhan
     ];
     platforms = renpy.meta.platforms;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This significantly speeds up launching.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
