### PR TITLE
azure-mgmt-resource-{deployments,deploymentscripts,deploymentstacks,templatespecs}: fix deleting leaf module `__init__.py`

### DIFF
--- a/pkgs/development/python-modules/azure-mgmt-resource-deployments/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource-deployments/default.nix
@@ -34,7 +34,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonNamespaces = [
-    "azure.mgmt.resource.deployments"
+    "azure.mgmt"
+    "azure.mgmt.resource"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/azure-mgmt-resource-deploymentscripts/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource-deploymentscripts/default.nix
@@ -34,7 +34,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonNamespaces = [
-    "azure.mgmt.resource.deploymentscripts"
+    "azure.mgmt"
+    "azure.mgmt.resource"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/azure-mgmt-resource-deploymentstacks/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource-deploymentstacks/default.nix
@@ -34,7 +34,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonNamespaces = [
-    "azure.mgmt.resource.deploymentstacks"
+    "azure.mgmt"
+    "azure.mgmt.resource"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/azure-mgmt-resource-templatespecs/default.nix
+++ b/pkgs/development/python-modules/azure-mgmt-resource-templatespecs/default.nix
@@ -34,7 +34,8 @@ buildPythonPackage rec {
   doCheck = false;
 
   pythonNamespaces = [
-    "azure.mgmt.resource.templatespecs"
+    "azure.mgmt"
+    "azure.mgmt.resource"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
pythonNamespacesHook removes `__init__.py` at every level of the specified namespace paths. Including the leaf module itself (e.g. "azure.mgmt.resource.deployments") causes its `__init__.py` to be deleted,
even though it contains actual module code (re-exports like DeploymentsMgmtClient). This results in runtime import errors in azure-cli. Fix by specifying only the ancestor namespace packages ("azure.mgmt" and "azure.mgmt.resource") instead of the leaf module, consistent with the parent azure-mgmt-resource package.

close #490035


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
