### PR TITLE
shelter: init at 0-unstable-2026-06-05

### DIFF
--- a/pkgs/by-name/do/dorion/package.nix
+++ b/pkgs/by-name/do/dorion/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchurl,
   rustPlatform,
   cmake,
   ninja,
@@ -25,21 +24,13 @@
   pipewire,
   apple-sdk_15,
   darwin,
+  shelter,
+  nix-update-script,
 }:
 
 let
   webkitgtk_4_1' = webkitgtk_4_1.override {
     enableExperimental = true;
-  };
-
-  shelter = fetchurl {
-    url = "https://raw.githubusercontent.com/uwu/shelter-builds/7a1beaff4bb4ec5e8590d069549686fda4200e82/shelter.js";
-    hash = "sha256-LeZTxrGRQb0rl3BMP34UFHIEFnil4k3Fet3MTujvVB8=";
-    meta = {
-      homepage = "https://github.com/uwu/shelter";
-      sourceProvenance = [ lib.sourceTypes.binaryBytecode ]; # actually, minified JS
-      license = lib.licenses.cc0;
-    };
   };
 in
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -124,7 +115,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ' src-tauri/tauri.conf.json
 
     # link shelter injection
-    ln -s "${shelter}" src-tauri/injection/shelter.js
+    ln -s ${shelter}/shelter.js src-tauri/injection/shelter.js
 
     # link html/frontend data
     ln -s "$(pwd)/src" src-tauri/html
@@ -192,6 +183,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     TAURI_RESOURCE_DIR = "${placeholder "out"}/lib";
   };
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     homepage = "https://spikehd.github.io/projects/dorion/";
     description = "Tiny alternative Discord client";
@@ -201,10 +194,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     '';
     changelog = "https://github.com/SpikeHD/Dorion/releases/tag/v${finalAttrs.version}";
     downloadPage = "https://github.com/SpikeHD/Dorion/releases/tag/v${finalAttrs.version}";
-    license = [
-      lib.licenses.gpl3Only
-      shelter.meta.license
-    ];
+    license = lib.licenses.gpl3Only;
     mainProgram = "Dorion";
     maintainers = with lib.maintainers; [
       nyabinary
@@ -214,7 +204,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     ];
     platforms = lib.platforms.unix;
     sourceProvenance = [
-      lib.sourceTypes.binaryBytecode # actually, minified JS
       lib.sourceTypes.fromSource
     ];
   };

--- a/pkgs/by-name/sh/shelter/package.nix
+++ b/pkgs/by-name/sh/shelter/package.nix
@@ -1,0 +1,77 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nix-update-script,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_9,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "shelter";
+  version = "0-unstable-2026-04-15";
+  src = fetchFromGitHub {
+    owner = "uwu";
+    repo = "shelter";
+    rev = "62c630bed8d118c7061d45c583121703c60a8448";
+    hash = "sha256-pfA7D3b5hAca82hXkWv+Ysxy/pdHy4QaF1btiXM2YM4=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_9
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pnpmWorkspaces = [
+    "shelter"
+    "@uwu/shelter-ui"
+    "@uwu/shelter-storage"
+  ];
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    hash = "sha256-4ZKAMtbXLg/ZWUPxYRlBSyMOP5QQN3Cmcgl+EIOsFoI=";
+    pnpm = pnpm_9;
+    fetcherVersion = 3;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=@uwu/shelter-ui prepare
+    pnpm --filter=shelter build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r packages/shelter/dist $out
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=branch"
+      "--version-regex=(0.*)"
+    ];
+  };
+
+  meta = {
+    description = "New generation Discord client mod built to be essentially bulletproof";
+    homepage = "https://shelter.uwu.network/";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ bandithedoge ];
+  };
+})

--- a/pkgs/by-name/sh/shelter/package.nix
+++ b/pkgs/by-name/sh/shelter/package.nix
@@ -1,0 +1,67 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  nix-update-script,
+  nodejs,
+  pnpmConfigHook,
+  pnpm_9,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "shelter";
+  version = "0-unstable-2026-06-05";
+  src = fetchFromGitHub {
+    owner = "uwu";
+    repo = "shelter";
+    rev = "4c08e2e8ad5d7e8fe741be3c9e2151ec25d20d8d";
+    hash = "sha256-8poWWDuCOrgJYjwRfOPIXTdyVlau5SxG9FxjcN8o/wo=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_9
+  ];
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-tYeV62IZes8O5rN9uvpx0K72B88gftqpL2VXrOUxI8s=";
+    pnpm = pnpm_9;
+    fetcherVersion = 3;
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter=@uwu/shelter-ui prepare
+    pnpm --filter=shelter build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp -r packages/shelter/dist $out
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version=branch"
+      "--version-regex=(0.*)"
+    ];
+  };
+
+  meta = {
+    description = "New generation Discord client mod built to be essentially bulletproof";
+    homepage = "https://shelter.uwu.network/";
+    license = lib.licenses.cc0;
+    maintainers = with lib.maintainers; [ bandithedoge ];
+  };
+})


### PR DESCRIPTION
Sort of follow-up to #485959. Also makes Dorion use it instead of fetchurl'ing the prebuilt js. The primary motivation behind this was to allow @r-ryantm to update both independently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
