### PR TITLE
vm-curator: init at 0.4.7

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18535,6 +18535,12 @@
     githubId = 15896005;
     name = "Vladyslav Burzakovskyy";
   };
+  mroboff = {
+    email = "mark.roboff@bluecircuit.ai";
+    github = "mroboff";
+    githubId = 81203001;
+    name = "Mark Roboff";
+  };
   mrsmoer = {
     email = "mrsmoer@protonmail.com";
     github = "MrSmoer";

--- a/pkgs/by-name/vm/vm-curator/package.nix
+++ b/pkgs/by-name/vm/vm-curator/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  udev,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "vm-curator";
+  version = "0.4.9";
+
+  src = fetchFromGitHub {
+    owner = "mroboff";
+    repo = "vm-curator";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PIpAagUuwduyEUHncjazYFyNqGa1hkZvO+KXJkaKNMM=";
+  };
+
+  cargoHash = "sha256-gk5iFT8lV9/uB3s0/s1//q6G/cPFALXGuaSJpTkigwQ=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ udev ];
+
+  meta = {
+    description = "TUI application for managing QEMU/KVM virtual machines";
+    homepage = "https://github.com/mroboff/vm-curator";
+    changelog = "https://github.com/mroboff/vm-curator/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ mroboff ];
+    mainProgram = "vm-curator";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Description

Add [vm-curator](https://github.com/mroboff/vm-curator), a feature-rich TUI application for managing QEMU/KVM virtual machines.

Features include:
- Automatic VM discovery and hierarchical organization by OS family
- 5-step VM creation wizard with 121 pre-configured OS profiles
- Snapshot management (create, restore, delete)
- USB passthrough with persistent configuration
- 3D graphics acceleration with NVIDIA GPUs
- 238 OS metadata entries with ASCII art for 50+ operating systems
- Full CLI for scripting (list, launch, info, snapshot, emulators)

## Things done

- Built on x86_64-linux: **yes**
- Tested `vm-curator --help`, `vm-curator list`, `vm-curator emulators`: **all pass**
- All 77 cargo tests pass during build

<!-- This is a new package, not an update -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)