### PR TITLE
nnn: 5.1 → 5.2

### DIFF
--- a/pkgs/by-name/nn/nnn/darwin-fix-file-mime-opts.patch
+++ b/pkgs/by-name/nn/nnn/darwin-fix-file-mime-opts.patch
@@ -1,12 +1,12 @@
 diff --git a/src/nnn.c b/src/nnn.c
-index b3c0f986..c74e1ec9 100644
+index 108e2995..eb5a440d 100644
 --- a/src/nnn.c
 +++ b/src/nnn.c
-@@ -508,9 +508,7 @@ alignas(max_align_t) static char g_pipepath[TMP_LEN_MAX];
+@@ -572,9 +572,7 @@ alignas(max_align_t) static char g_pipepath[TMP_LEN_MAX];
  static runstate g_state;
  
  /* Options to identify file MIME */
--#if defined(__APPLE__)
+-#ifdef __APPLE__
 -#define FILE_MIME_OPTS "-bIL"
 -#elif !defined(__sun) /* no MIME option for 'file' */
 +#if !defined(__sun) /* no MIME option for 'file' */

--- a/pkgs/by-name/nn/nnn/package.nix
+++ b/pkgs/by-name/nn/nnn/package.nix
@@ -10,7 +10,7 @@
   readline,
   which,
   musl-fts,
-  pcre,
+  pcre2,
   gnused,
   # options
   conf ? null,
@@ -28,13 +28,13 @@ assert withEmojis -> (!withIcons && !withNerdIcons);
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "nnn";
-  version = "5.1";
+  version = "5.2";
 
   src = fetchFromGitHub {
     owner = "jarun";
     repo = "nnn";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+2lFFBtaqRPBkEspCFtKl9fllbSR5MBB+4ks3Xh7vp4=";
+    hash = "sha256-u+88aDHfOZ6bSkg6ahS6eNZWj2QCwJXKW+8nHR99kic=";
   };
 
   patches = [
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
   ]
   ++ lib.optional stdenv.hostPlatform.isMusl musl-fts
-  ++ lib.optional withPcre pcre;
+  ++ lib.optional withPcre pcre2;
 
   env = lib.optionalAttrs stdenv.hostPlatform.isMusl {
     NIX_CFLAGS_COMPILE = "-I${musl-fts}/include";
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals withIcons [ "O_ICONS=1" ]
   ++ lib.optionals withNerdIcons [ "O_NERD=1" ]
   ++ lib.optionals withEmojis [ "O_EMOJI=1" ]
-  ++ lib.optionals withPcre [ "O_PCRE=1" ]
+  ++ lib.optionals withPcre [ "O_PCRE2=1" ]
   ++ extraMakeFlags;
 
   binPath = lib.makeBinPath [

--- a/pkgs/by-name/nn/nnn/package.nix
+++ b/pkgs/by-name/nn/nnn/package.nix
@@ -101,6 +101,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/jarun/nnn/blob/v${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.bsd2;
     platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ sikmir ];
     mainProgram = "nnn";
   };
 })


### PR DESCRIPTION
https://github.com/jarun/nnn/releases/tag/v5.2

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
