### PR TITLE
hittekaart: init at 0.1.0

### DIFF
--- a/pkgs/by-name/hi/hittekaart/package.nix
+++ b/pkgs/by-name/hi/hittekaart/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitea,
+  python3,
+  sqlite,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "hittekaart";
+  version = "0.1.0";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "dunj3";
+    repo = "hittekaart";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bog00/pkpTaUtLDfuR9d8yEhDt9mn9YDyF17ojZMM38=";
+  };
+
+  cargoHash = "sha256-Izcgxkl7QdNWYRrz9+nKMlCkEDtqiZTIAnJO/b7ZJKs=";
+
+  nativeBuildInputs = [ python3 ];
+
+  buildInputs = [ sqlite ];
+
+  meta = {
+    description = "Renders heatmaps by reading GPX files and generating OSM overlay tiles";
+    homepage = "https://codeberg.org/dunj3/hittekaart";
+    license = lib.licenses.gpl3Plus;
+    teams = [ lib.teams.geospatial ];
+    mainProgram = "hittekaart";
+  };
+})


### PR DESCRIPTION
**[hittekaart](https://codeberg.org/dunj3/hittekaart)** - A GPX track heatmap generator.

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
