### PR TITLE
Upgrade ntopng to 6.6

### DIFF
--- a/pkgs/by-name/nd/ndpi/package.nix
+++ b/pkgs/by-name/nd/ndpi/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ndpi";
-  version = "4.10";
+  version = "5.0";
 
   src = fetchFromGitHub {
     owner = "ntop";
     repo = "nDPI";
     tag = finalAttrs.version;
-    hash = "sha256-iXqvDMJsOXcg9YkqKFgInLLfH6j/HEp4bEaIl6dpVtc=";
+    hash = "sha256-Elnj6qDuT8UWDxmasiHOt5DxC7GcH5zgrp3J3LYcl0c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/nt/ntopng/package.nix
+++ b/pkgs/by-name/nt/ntopng/package.nix
@@ -23,17 +23,18 @@
   sqlite,
   which,
   zeromq,
+  cmake,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "ntopng";
-  version = "6.2";
+  version = "6.6";
 
   src = fetchFromGitHub {
     owner = "ntop";
     repo = "ntopng";
     tag = finalAttrs.version;
-    hash = "sha256-8PG18mOV/6EcBpKt9kLyI40OLDnpnc2b4IUu9JbK/Co=";
+    hash = "sha256-BYJtsEuxmo6jzqCoC/A5vDAiFSGqy8XFyqooGDTZE40=";
     fetchSubmodules = true;
   };
 
@@ -47,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     git
     pkg-config
     which
+    cmake
   ];
 
   buildInputs = [
@@ -91,6 +93,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp -r doc/README.geolocation.md "$out/share/ntopng/doc/"
   '';
 
+  dontUseCmakeConfigure = true;
   enableParallelBuilding = true;
 
   meta = {


### PR DESCRIPTION
## Things done

Upgrade ntopng. Also upgrade nDPI because they need to be upgraded in lockstep.


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
