### PR TITLE
syncthingtray: use cmake helpers

### DIFF
--- a/pkgs/by-name/sy/syncthingtray/package.nix
+++ b/pkgs/by-name/sy/syncthingtray/package.nix
@@ -83,20 +83,20 @@ stdenv.mkDerivation (finalAttrs: {
   doInstallCheck = true;
 
   cmakeFlags = [
-    "-DQT_PACKAGE_PREFIX=Qt${lib.versions.major kdePackages.qtbase.version}"
-    "-DKF_PACKAGE_PREFIX=KF${lib.versions.major kdePackages.qtbase.version}"
-    "-DBUILD_TESTING=ON"
+    (lib.cmakeFeature "QT_PACKAGE_PREFIX" "Qt${lib.versions.major kdePackages.qtbase.version}")
+    (lib.cmakeFeature "KF_PACKAGE_PREFIX" "KF${lib.versions.major kdePackages.qtbase.version}")
+    (lib.cmakeBool "BUILD_TESTING" (finalAttrs.doCheck or false))
     # See https://github.com/Martchus/syncthingtray/issues/208
-    "-DEXCLUDE_TESTS_FROM_ALL=OFF"
-    "-DAUTOSTART_EXEC_PATH=${autostartExecPath}"
+    (lib.cmakeBool "EXCLUDE_TESTS_FROM_ALL" false)
+    (lib.cmakeFeature "AUTOSTART_EXEC_PATH" autostartExecPath)
     # See https://github.com/Martchus/syncthingtray/issues/42
-    "-DQT_PLUGIN_DIR:STRING=${placeholder "out"}/${kdePackages.qtbase.qtPluginPrefix}"
-    "-DBUILD_SHARED_LIBS=ON"
-  ]
-  ++ lib.optionals (!plasmoidSupport) [ "-DNO_PLASMOID=ON" ]
-  ++ lib.optionals (!kioPluginSupport) [ "-DNO_FILE_ITEM_ACTION_PLUGIN=ON" ]
-  ++ lib.optionals systemdSupport [ "-DSYSTEMD_SUPPORT=ON" ]
-  ++ lib.optionals (!webviewSupport) [ "-DWEBVIEW_PROVIDER:STRING=none" ];
+    (lib.cmakeFeature "QT_PLUGIN_DIR" "${placeholder "out"}/${kdePackages.qtbase.qtPluginPrefix}")
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "NO_PLASMOID" (!plasmoidSupport))
+    (lib.cmakeBool "NO_FILE_ITEM_ACTION_PLUGIN" (!kioPluginSupport))
+    (lib.cmakeBool "SYSTEMD_SUPPORT" systemdSupport)
+    (lib.cmakeFeature "WEBVIEW_PROVIDER" (if webviewSupport then "webengine" else "none"))
+  ];
 
   qtWrapperArgs = [
     "--prefix PATH : ${lib.makeBinPath [ xdg-utils ]}"


### PR DESCRIPTION

We have helpers available for cmake options that make things much easier
to read and more ergonomic to use. So let's use them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test