### PR TITLE
prettier: Remove references to dead prettier-plugin-toml package

### DIFF
--- a/pkgs/by-name/pr/prettier/package.nix
+++ b/pkgs/by-name/pr/prettier/package.nix
@@ -1,17 +1,3 @@
-/**
-  # Example
-
-  Prettier with plugins and Vim Home Manager configuration
-
-  ```nix
-  pkgs.prettier.override {
-    plugins = with pkgs.nodePackages; [
-      prettier-plugin-toml
-      # ...
-    ];
-  }
-  ```
-*/
 {
   fetchFromGitHub,
   lib,
@@ -23,26 +9,6 @@
   plugins ? [ ],
 }:
 let
-  /**
-    # Example
-
-    ```nix
-    exportRelativePathOf (builtins.fromJSON "./package.json")
-    =>
-    lib/node_modules/prettier-plugin-toml/./lib/index.cjs
-    ```
-
-    # Type
-
-    ```
-    exportRelativePathOf :: AttrSet => String
-    ```
-
-    # Arguments
-
-    packageJsonAttrs
-    : Attribute set with shape similar to `package.json` file
-  */
   ## Blame NodeJS
   exportRelativePathOf =
     let
@@ -80,26 +46,6 @@ let
       lib.attrByPath [ "prettier" "plugins" ] [ "null" ] packageJsonAttrs
     )) packageJsonAttrs;
 
-  /**
-    # Example
-
-    ```nix
-    nodeEntryPointOf pkgs.nodePackages.prettier-plugin-toml
-    =>
-    /nix/store/<NAR_HASH>-prettier-plugin-toml-<VERSION>/lib/node_modules/prettier-plugin-toml/./lib/index.cjs
-    ```
-
-    # Type
-
-    ```
-    nodeEntryPointOf :: AttrSet => String
-    ```
-
-    # Arguments
-
-    plugin
-    : Attribute set with `.pname` and `.outPath` defined
-  */
   nodeEntryPointOf =
     plugin:
     let


### PR DESCRIPTION
As requested in #489959.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
