### PR TITLE
idmail: 1.0.1 -> 1.0.2 (remove nodePackages dependency)

### DIFF
--- a/pkgs/by-name/id/idmail/package.nix
+++ b/pkgs/by-name/id/idmail/package.nix
@@ -6,33 +6,22 @@
   rustc,
   makeWrapper,
   nix-update-script,
-  nodePackages,
   rustPlatform,
   tailwindcss_3,
-  wasm-bindgen-cli_0_2_100,
+  wasm-bindgen-cli_0_2_106,
 }:
-let
-  tailwindcss = tailwindcss_3.overrideAttrs (_prev: {
-    plugins = [
-      nodePackages."@tailwindcss/aspect-ratio"
-      nodePackages."@tailwindcss/forms"
-      nodePackages."@tailwindcss/line-clamp"
-      nodePackages."@tailwindcss/typography"
-    ];
-  });
-in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "idmail";
-  version = "1.0.1";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "oddlama";
     repo = "idmail";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-9rl2UG8DeWd8hVh3N+dqyV5gO0LErok+kZ1vQZnVAe8=";
+    hash = "sha256-b18Ic+wffCPfp1cDTxDe7IBigbS4X6t7KaAy7P4Uh28=";
   };
 
-  cargoHash = "sha256-UcS2gAoa2fzPu6hh8I5sXSHHbAmzsecT44Ju2CVsK0Q=";
+  cargoHash = "sha256-FU9CfOJ9tNY+97OZDw2qYZHTPoFp9Ch2VigXaxBnFCw=";
 
   env = {
     RUSTC_BOOTSTRAP = 1;
@@ -40,11 +29,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    wasm-bindgen-cli_0_2_100
+    wasm-bindgen-cli_0_2_106
     binaryen
     cargo-leptos
     rustc.llvmPackages.lld
-    tailwindcss
+    tailwindcss_3
     makeWrapper
   ];
   buildPhase = ''


### PR DESCRIPTION
update idmail and remove dependency on nodePackages (see #489959)

Closes #470855

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
