### PR TITLE
treewide: move env variable(s) into env for structuredAttrs (F-G)

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -75,7 +75,7 @@ buildGoModule (finalAttrs: {
   ];
 
   # Passing boringcrypto to GOEXPERIMENT variable to build with goboring library
-  GOEXPERIMENT = "boringcrypto";
+  env.GOEXPERIMENT = "boringcrypto";
 
   # https://github.com/rancher/rke2/blob/104ddbf3de65ab5490aedff36df2332d503d90fe/scripts/build-binary#L27-L39
   ldflags =

--- a/pkgs/build-support/docker/tarsum.nix
+++ b/pkgs/build-support/docker/tarsum.nix
@@ -13,9 +13,11 @@ stdenv.mkDerivation {
 
   dontUnpack = true;
 
-  CGO_ENABLED = 0;
-  GOFLAGS = "-trimpath";
-  GO111MODULE = "off";
+  env = {
+    CGO_ENABLED = 0;
+    GOFLAGS = "-trimpath";
+    GO111MODULE = "off";
+  };
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/dw/dwarfs/package.nix
+++ b/pkgs/by-name/dw/dwarfs/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   # these fail inside of the sandbox due to missing access
   # to the FUSE device
-  GTEST_FILTER =
+  env.GTEST_FILTER =
     let
       disabledTests = [
         "dwarfs/tools_test.end_to_end/*"

--- a/pkgs/by-name/ed/edk2/package.nix
+++ b/pkgs/by-name/ed/edk2/package.nix
@@ -169,7 +169,7 @@ stdenv.mkDerivation (finalAttrs: {
           ++ attrs.nativeBuildInputs or [ ];
           strictDeps = true;
 
-          ${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
+          env.${"GCC5_${targetArch}_PREFIX"} = stdenv.cc.targetPrefix;
 
           prePatch = ''
             rm -rf BaseTools

--- a/pkgs/by-name/fi/fig2dev/package.nix
+++ b/pkgs/by-name/fi/fig2dev/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ libpng ];
 
-  GSEXE = "${ghostscript}/bin/gs";
+  env.GSEXE = "${ghostscript}/bin/gs";
 
   configureFlags = [ "--enable-transfig" ];
 

--- a/pkgs/by-name/fi/firefoxpwa/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa/package.nix
@@ -56,8 +56,10 @@ rustPlatform.buildRustPackage rec {
   ];
   buildInputs = [ openssl ];
 
-  FFPWA_EXECUTABLES = ""; # .desktop entries generated without any store path references
-  FFPWA_SYSDATA = "${placeholder "out"}/share/firefoxpwa";
+  env = {
+    FFPWA_EXECUTABLES = ""; # .desktop entries generated without any store path references
+    FFPWA_SYSDATA = "${placeholder "out"}/share/firefoxpwa";
+  };
   completions = "target/${stdenv.targetPlatform.config}/release/completions";
 
   gtk_modules = map (x: x + x.gtkModule) [ libcanberra-gtk3 ];

--- a/pkgs/by-name/gh/ghciwatch/package.nix
+++ b/pkgs/by-name/gh/ghciwatch/package.nix
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-kH5YTadpaUXDma+7SfBJxrOIsd9Gm0EU3MfhFmQ3U80=";
 
   # integration tests are not run but the macros need this variable to be set
-  GHC_VERSIONS = "";
+  env.GHC_VERSIONS = "";
   checkFlags = "--test \"unit\"";
 
   meta = {

--- a/pkgs/by-name/gi/gitlab/package.nix
+++ b/pkgs/by-name/gi/gitlab/package.nix
@@ -228,14 +228,16 @@ let
       chmod 777 ee/frontend_islands/yarn.lock
     '';
 
-    # One of the patches uses this variable - if it's unset, execution
-    # of rake tasks fails.
-    GITLAB_LOG_PATH = "log";
-    FOSS_ONLY = !gitlabEnterprise;
-    SKIP_FRONTEND_ISLANDS_BUILD = lib.optionalString (!gitlabEnterprise) "true";
+    env = {
+      # One of the patches uses this variable - if it's unset, execution
+      # of rake tasks fails.
+      GITLAB_LOG_PATH = "log";
+      FOSS_ONLY = !gitlabEnterprise;
+      SKIP_FRONTEND_ISLANDS_BUILD = lib.optionalString (!gitlabEnterprise) "true";
 
-    SKIP_YARN_INSTALL = 1;
-    NODE_OPTIONS = "--max-old-space-size=8192";
+      SKIP_YARN_INSTALL = 1;
+      NODE_OPTIONS = "--max-old-space-size=8192";
+    };
 
     postConfigure = ''
       # Some rake tasks try to run yarn automatically, which won't work

--- a/pkgs/by-name/gl/global-platform-pro/package.nix
+++ b/pkgs/by-name/gl/global-platform-pro/package.nix
@@ -26,7 +26,7 @@ in
 maven.buildMavenPackage rec {
   pname = "global-platform-pro";
   version = "25.10.20";
-  GPPRO_VERSION = "v25.10.20-0-g72f85b9"; # git describe --tags --always --long --dirty
+  env.GPPRO_VERSION = "v25.10.20-0-g72f85b9"; # git describe --tags --always --long --dirty
 
   src = fetchFromGitHub {
     owner = "martinpaljak";

--- a/pkgs/by-name/go/golem/package.nix
+++ b/pkgs/by-name/go/golem/package.nix
@@ -43,12 +43,14 @@ rustPlatform.buildRustPackage rec {
     (lib.getDev openssl)
   ];
 
-  # Required for golem-wasm-rpc's build.rs to find the required protobuf files
-  # https://github.com/golemcloud/wasm-rpc/blob/v1.0.6/wasm-rpc/build.rs#L7
-  GOLEM_WASM_AST_ROOT = "../golem-wasm-ast-1.1.0";
-  # Required for golem-examples's build.rs to find the required Wasm Interface Type (WIT) files
-  # https://github.com/golemcloud/golem-examples/blob/v1.0.6/build.rs#L9
-  GOLEM_WIT_ROOT = "../golem-wit-1.1.0";
+  env = {
+    # Required for golem-wasm-rpc's build.rs to find the required protobuf files
+    # https://github.com/golemcloud/wasm-rpc/blob/v1.0.6/wasm-rpc/build.rs#L7
+    GOLEM_WASM_AST_ROOT = "../golem-wasm-ast-1.1.0";
+    # Required for golem-examples's build.rs to find the required Wasm Interface Type (WIT) files
+    # https://github.com/golemcloud/golem-examples/blob/v1.0.6/build.rs#L9
+    GOLEM_WIT_ROOT = "../golem-wit-1.1.0";
+  };
 
   cargoHash = "sha256-zf/L7aNsfQXCdGpzvBZxgoatAGB92bvIuj59jANrXIc=";
 

--- a/pkgs/by-name/in/infnoise/package.nix
+++ b/pkgs/by-name/in/infnoise/package.nix
@@ -27,9 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  GIT_COMMIT = finalAttrs.src.rev;
-  GIT_VERSION = finalAttrs.version;
-  GIT_DATE = "2023-02-14";
+  env = {
+    GIT_COMMIT = finalAttrs.src.rev;
+    GIT_VERSION = finalAttrs.version;
+    GIT_DATE = "2023-02-14";
+  };
 
   buildInputs = [ libftdi ];
 

--- a/pkgs/by-name/ka/kanban/package.nix
+++ b/pkgs/by-name/ka/kanban/package.nix
@@ -16,7 +16,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-w1NoWgaUBny//3t1S5z/juPOYFomwJKtTq/M4qKoNv0=";
   };
 
-  GIT_COMMIT_HASH = finalAttrs.src.rev;
+  env.GIT_COMMIT_HASH = finalAttrs.src.rev;
 
   cargoHash = "sha256-N+c2jnJ7a+Nh2UibkaOByh4tKDX52VovYIpeHTpawXo=";
 

--- a/pkgs/by-name/ki/kinect-audio-setup/package.nix
+++ b/pkgs/by-name/ki/kinect-audio-setup/package.nix
@@ -17,7 +17,7 @@ let
   # redirects to the following url:
   licenseUrl = "https://www.microsoft.com/en-us/legal/terms-of-use";
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "kinect-audio-setup";
 
   # On update: Make sure that the `firmwareURL` is still in sync with upstream.
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
   version = "0.5";
 
   # This is an MSI or CAB file
-  FIRMWARE = requireFile {
+  env.FIRMWARE = requireFile {
     name = "UACFirmware";
     sha256 = "08a2vpgd061cmc6h3h8i6qj3sjvjr1fwcnwccwywqypz3icn8xw1";
     message = ''
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   src = fetchgit {
     url = "git://git.ao2.it/kinect-audio-setup.git";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-bFwmWh822KvFwP/0Gu097nF5K2uCwCLMB1RtP7k+Zt0=";
   };
 
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     install -Dm755 kinect_upload_fw/kinect_upload_fw $out/libexec/
 
     # 7z extract "assume yes on all queries" "only extract/keep files/directories matching UACFIRMWARE.* recursively"
-    7z e -y -r "${FIRMWARE}" "UACFirmware.*" >/dev/null
+    7z e -y -r "${finalAttrs.env.FIRMWARE}" "UACFirmware.*" >/dev/null
     # The filename is bound to change with the Firmware SDK
     mv UACFirmware.* $out/lib/firmware/UACFirmware
 
@@ -93,4 +93,4 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     license = lib.licenses.unfree;
   };
-}
+})

--- a/pkgs/by-name/ki/kitty/package.nix
+++ b/pkgs/by-name/ki/kitty/package.nix
@@ -150,8 +150,10 @@ buildPythonApplication rec {
     "fortify3"
   ];
 
-  env.CGO_ENABLED = 0;
-  GOFLAGS = "-trimpath";
+  env = {
+    CGO_ENABLED = 0;
+    GOFLAGS = "-trimpath";
+  };
 
   configurePhase = ''
     export GOCACHE=$TMPDIR/go-cache

--- a/pkgs/by-name/mm/mmtc/package.nix
+++ b/pkgs/by-name/mm/mmtc/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellCompletion artifacts/mmtc.{bash,fish} --zsh artifacts/_mmtc
   '';
 
-  GEN_ARTIFACTS = "artifacts";
+  env.GEN_ARTIFACTS = "artifacts";
 
   meta = {
     description = "Minimal mpd terminal client that aims to be simple yet highly configurable";

--- a/pkgs/by-name/mo/movit/package.nix
+++ b/pkgs/by-name/mo/movit/package.nix
@@ -26,8 +26,6 @@ stdenv.mkDerivation rec {
     "dev"
   ];
 
-  GTEST_DIR = "${gtest.src}/googletest";
-
   nativeBuildInputs = [
     pkg-config
   ];
@@ -45,13 +43,15 @@ stdenv.mkDerivation rec {
     libepoxy
   ];
 
-  env =
-    lib.optionalAttrs stdenv.cc.isGNU {
-      NIX_CFLAGS_COMPILE = "-std=c++17"; # needed for latest gtest
-    }
-    // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-      NIX_LDFLAGS = "-framework OpenGL";
-    };
+  env = {
+    GTEST_DIR = "${gtest.src}/googletest";
+  }
+  // lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_COMPILE = "-std=c++17"; # needed for latest gtest
+  }
+  // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    NIX_LDFLAGS = "-framework OpenGL";
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/ne/netcdffortran/package.nix
+++ b/pkgs/by-name/ne/netcdffortran/package.nix
@@ -27,8 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  FFLAGS = [ "-std=legacy" ];
-  FCFLAGS = [ "-std=legacy" ];
+  env = {
+    FFLAGS = toString [ "-std=legacy" ];
+    FCFLAGS = toString [ "-std=legacy" ];
+  };
 
   meta = {
     description = "Fortran API to manipulate netcdf files";

--- a/pkgs/by-name/ne/newsboat/package.nix
+++ b/pkgs/by-name/ne/newsboat/package.nix
@@ -66,12 +66,14 @@ stdenv.mkDerivation (finalAttrs: {
     gettext
   ];
 
-  # https://github.com/NixOS/nixpkgs/pull/98471#issuecomment-703100014 . We set
-  # these for all platforms, since upstream's gettext crate behavior might
-  # change in the future.
-  GETTEXT_LIB_DIR = "${lib.getLib gettext}/lib";
-  GETTEXT_INCLUDE_DIR = "${lib.getDev gettext}/include";
-  GETTEXT_BIN_DIR = "${lib.getBin gettext}/bin";
+  env = {
+    # https://github.com/NixOS/nixpkgs/pull/98471#issuecomment-703100014 . We set
+    # these for all platforms, since upstream's gettext crate behavior might
+    # change in the future.
+    GETTEXT_LIB_DIR = "${lib.getLib gettext}/lib";
+    GETTEXT_INCLUDE_DIR = "${lib.getDev gettext}/include";
+    GETTEXT_BIN_DIR = "${lib.getBin gettext}/bin";
+  };
 
   makeFlags = [ "prefix=$(out)" ];
   enableParallelBuilding = true;

--- a/pkgs/by-name/no/nostui/package.nix
+++ b/pkgs/by-name/no/nostui/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     hash = "sha256-7i76JPg6MAk4/sO8/JI4ody4iYFJPeLkD2SWncFhT4o=";
   };
 
-  GIT_HASH = "000000000000000000000000000000000000000000000000000";
+  env.GIT_HASH = "000000000000000000000000000000000000000000000000000";
 
   checkFlags = [
     # skip failing test due to nix build timestamps

--- a/pkgs/by-name/op/openzwave/package.nix
+++ b/pkgs/by-name/op/openzwave/package.nix
@@ -46,8 +46,10 @@ stdenv.mkDerivation {
     "PREFIX=${placeholder "out"}"
   ];
 
-  FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
-  FONTCONFIG_PATH = "${fontconfig.out}/etc/fonts/";
+  env = {
+    FONTCONFIG_FILE = "${fontconfig.out}/etc/fonts/fonts.conf";
+    FONTCONFIG_PATH = "${fontconfig.out}/etc/fonts/";
+  };
 
   postPatch = ''
     substituteInPlace cpp/src/Options.cpp \

--- a/pkgs/by-name/pr/proxysql/package.nix
+++ b/pkgs/by-name/pr/proxysql/package.nix
@@ -77,7 +77,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  GIT_VERSION = finalAttrs.version;
+  env.GIT_VERSION = finalAttrs.version;
 
   dontConfigure = true;
 

--- a/pkgs/by-name/qc/qcdnum/package.nix
+++ b/pkgs/by-name/qc/qcdnum/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ gfortran ];
   buildInputs = [ zlib ];
 
-  FFLAGS = [
+  env.FFLAGS = toString [
     "-std=legacy" # fix build with gfortran 10
   ];
 

--- a/pkgs/by-name/sa/sagoin/package.nix
+++ b/pkgs/by-name/sa/sagoin/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     installShellCompletion artifacts/sagoin.{bash,fish} --zsh artifacts/_sagoin
   '';
 
-  GEN_ARTIFACTS = "artifacts";
+  env.GEN_ARTIFACTS = "artifacts";
 
   meta = {
     description = "Command-line submission tool for the UMD CS Submit Server";

--- a/pkgs/by-name/ve/verible/package.nix
+++ b/pkgs/by-name/ve/verible/package.nix
@@ -19,15 +19,18 @@ let
     rev = "3f863a3f35f31b61982d813835d8637b3d93d87a";
     hash = "sha256-BsxP3GrS98ubIAkFx/c4pB1i97ZZL2TijS+2ORnooww=";
   };
-in
-buildBazelPackage rec {
-  pname = "verible";
-
-  # These environment variables are read in bazel/build-version.py to create
-  # a build string shown in the tools --version output.
-  # If env variables not set, it would attempt to extract it from .git/.
   GIT_DATE = "2025-08-29";
   GIT_VERSION = "v0.0-4023-gc1271a00";
+in
+buildBazelPackage {
+  pname = "verible";
+
+  env = {
+    # These environment variables are read in bazel/build-version.py to create
+    # a build string shown in the tools --version output.
+    # If env variables not set, it would attempt to extract it from .git/.
+    inherit GIT_DATE GIT_VERSION;
+  };
 
   # Derive nix package version from GIT_VERSION: "v1.2-345-abcde" -> "1.2.345"
   version = builtins.concatStringsSep "." (

--- a/pkgs/by-name/we/weblate/package.nix
+++ b/pkgs/by-name/we/weblate/package.nix
@@ -21,6 +21,15 @@ let
       django = prev.django_5;
     };
   };
+
+  GI_TYPELIB_PATH = lib.makeSearchPathOutput "out" "lib/girepository-1.0" [
+    pango
+    harfbuzz
+    librsvg
+    gdk-pixbuf
+    glib
+    gobject-introspection
+  ];
 in
 python.pkgs.buildPythonApplication rec {
   pname = "weblate";
@@ -157,14 +166,10 @@ python.pkgs.buildPythonApplication rec {
   };
 
   # We don't just use wrapGAppsNoGuiHook because we need to expose GI_TYPELIB_PATH
-  GI_TYPELIB_PATH = lib.makeSearchPathOutput "out" "lib/girepository-1.0" [
-    pango
-    harfbuzz
-    librsvg
-    gdk-pixbuf
-    glib
-    gobject-introspection
-  ];
+  env = {
+    inherit GI_TYPELIB_PATH;
+  };
+
   makeWrapperArgs = [ "--set GI_TYPELIB_PATH \"$GI_TYPELIB_PATH\"" ];
 
   passthru = {

--- a/pkgs/development/libraries/librsb/default.nix
+++ b/pkgs/development/libraries/librsb/default.nix
@@ -45,14 +45,16 @@ stdenv.mkDerivation rec {
   ];
 
   # Ensure C/Fortran code is position-independent.
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-fPIC"
-    "-Ofast"
-  ];
-  FCFLAGS = [
-    "-fPIC"
-    "-Ofast"
-  ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-fPIC"
+      "-Ofast"
+    ];
+    FCFLAGS = toString [
+      "-fPIC"
+      "-Ofast"
+    ];
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/libtool/libtool2.nix
+++ b/pkgs/development/tools/misc/libtool/libtool2.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
 
   # FILECMD was added in libtool 2.4.7; previous versions hardwired `/usr/bin/file`
   #   https://lists.gnu.org/archive/html/autotools-announce/2022-03/msg00000.html
-  FILECMD = "${file}/bin/file";
+  env.FILECMD = "${file}/bin/file";
 
   postPatch =
     # libtool commit da2e352735722917bf0786284411262195a6a3f6 changed

--- a/pkgs/tools/archivers/gnutar/default.nix
+++ b/pkgs/tools/archivers/gnutar/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
   # May have some issues with root compilation because the bootstrap tool
   # cannot be used as a login shell for now.
-  FORCE_UNSAFE_CONFIGURE = lib.optionalString (
+  env.FORCE_UNSAFE_CONFIGURE = lib.optionalString (
     stdenv.hostPlatform.system == "armv7l-linux" || stdenv.hostPlatform.isSunOS
   ) "1";
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
