### PR TITLE
python3Packages.onnx-asr: init at 0.10.2

### DIFF
--- a/pkgs/development/python-modules/onnx-asr/default.nix
+++ b/pkgs/development/python-modules/onnx-asr/default.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  hatchling,
+  hatch-vcs,
+
+  # build-time deps for the custom hatch build hook that generates
+  # ONNX preprocessor models (listed in pyproject.toml [dependency-groups] build)
+  numpy,
+  onnx,
+  onnxscript,
+  torch,
+  torchaudio,
+
+  # dependencies
+  onnxruntime,
+
+  # optional-dependencies
+  huggingface-hub,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "onnx-asr";
+  version = "0.10.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "istupakov";
+    repo = "onnx-asr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KumdelY9oNMAEBSGVdvbBH6SYi93n2cA/eEqaE8MmIU=";
+  };
+
+  build-system = [
+    hatchling
+    hatch-vcs
+    # The custom hatch build hook (hatch_build.py) generates ONNX preprocessor
+    # models at build time using these dependencies.
+    numpy
+    onnx
+    onnxscript
+    torch
+    torchaudio
+  ];
+
+  dependencies = [
+    numpy
+    onnxruntime
+  ];
+
+  optional-dependencies = {
+    cpu = [
+      onnxruntime
+    ];
+    hub = [
+      huggingface-hub
+    ];
+    # gpu extra installs onnxruntime-gpu; in nixpkgs users should use
+    # onnxruntime built with cudaSupport instead
+    gpu = [
+      onnxruntime
+    ];
+  };
+
+  # Most tests require downloading models from Hugging Face
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "onnx_asr"
+  ];
+
+  meta = {
+    description = "Lightweight Automatic Speech Recognition using ONNX models";
+    homepage = "https://github.com/istupakov/onnx-asr";
+    changelog = "https://github.com/istupakov/onnx-asr/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    mainProgram = "onnx-asr";
+    maintainers = with lib.maintainers; [ jaredmontoya ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11291,6 +11291,8 @@ self: super: with self; {
     };
   };
 
+  onnx-asr = callPackage ../development/python-modules/onnx-asr { };
+
   onnx-ir = callPackage ../development/python-modules/onnx-ir { };
 
   onnxconverter-common = callPackage ../development/python-modules/onnxconverter-common { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
**This package was tested in a running instance of `wyoming-faster-whisper` (3.1.0)**
It lets `wyoming-faster-whisper` use `istupakov/parakeet-tdt-0.6b-v2-onnx` and other onnx asr models from [huggingface](https://huggingface.co)

This was also made by AI just like #489829
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
