### PR TITLE
papis: 0.14.1 -> 0.15.0

### DIFF
--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
-  pythonAtLeast,
 
   # build-system
   hatchling,
@@ -51,22 +49,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "papis";
-  version = "0.14.1";
+  version = "0.15.0";
   pyproject = true;
-
-  patches = [
-    (fetchpatch2 {
-      name = "fix-support-new-click-in-papisrunner.patch";
-      url = "https://github.com/papis/papis/commit/0e3ffff4bd1b62cdf0a9fdc7f54d6a2e2ab90082.patch?full_index=1";
-      hash = "sha256-KUw5U5izTTWqXHzGWLibtqHWAsVxla6SA8x6SJ07/zU=";
-    })
-  ];
 
   src = fetchFromGitHub {
     owner = "papis";
     repo = "papis";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-V4YswLNYwfBYe/Td0PEeDG++ClZoF08yxXjUXuyppPI=";
+    hash = "sha256-G+ryUMBUEbGxUG+u2YwZbT04IAzOmajtIPXP12MaXsY=";
   };
 
   build-system = [ hatchling ];
@@ -129,6 +119,10 @@ buildPythonPackage (finalAttrs: {
 
   disabledTests = [
     # Require network access
+    "test_add_folder_name_cli"
+    "test_add_link_cli"
+    "test_get_matching_importers_by_name"
+    "test_matching_importers_by_uri"
     "test_yaml_unicode_dump"
     # FileNotFoundError: Command not found: 'init'
     "test_git_cli"


### PR DESCRIPTION
Remove the patch taken from upstream between two releases.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] ~[Package tests] at `passthru.tests`.~
  - [x] ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - [x] ~Module addition: when adding a new NixOS module.~
  - [x] ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
