### PR TITLE
mailspring: 1.16.0 -> 1.17.4

### DIFF
--- a/pkgs/by-name/ma/mailspring/darwin.nix
+++ b/pkgs/by-name/ma/mailspring/darwin.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/Foundry376/Mailspring/releases/download/${finalAttrs.version}/Mailspring-AppleSilicon.zip";
-    hash = "sha256-jbsU8pSvhPFKFjIr+2ZHETOihKKoqQiZmKQ6eGtAIKk=";
+    hash = "sha256-AwP5gVyqO3pjIXom5VQjxSZWu4IsG5O9zulqmC24lk0=";
   };
   dontUnpack = true;
 

--- a/pkgs/by-name/ma/mailspring/linux.nix
+++ b/pkgs/by-name/ma/mailspring/linux.nix
@@ -8,6 +8,7 @@
   autoPatchelfHook,
   alsa-lib,
   coreutils,
+  curl,
   db,
   dpkg,
   glib,
@@ -33,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/Foundry376/Mailspring/releases/download/${finalAttrs.version}/mailspring-${finalAttrs.version}-amd64.deb";
-    hash = "sha256-iJ6VzwvNTIRqUq9OWNOWOSuLbqhx+Lqx584kuyIslyA=";
+    hash = "sha256-PHxe44yzX9Zz+fQu30kX9epLEeG3wqqVL3p5+ZHMmos=";
   };
 
   nativeBuildInputs = [
@@ -57,6 +58,8 @@ stdenv.mkDerivation (finalAttrs: {
     libxshmfence
     libgbm
     libdrm
+    openssl
+    curl
   ];
 
   runtimeDependencies = [

--- a/pkgs/by-name/ma/mailspring/package.nix
+++ b/pkgs/by-name/ma/mailspring/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   pname = "mailspring";
-  version = "1.16.0";
+  version = "1.17.4";
 
   meta = {
     description = "Beautiful, fast and maintained fork of Nylas Mail by one of the original authors";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Update the mailspring package to 1.17.4
Release Notes: https://github.com/Foundry376/Mailspring/releases/tag/1.17.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
