### PR TITLE
[Backport release-25.11] cargo-tauri: 2.9.4 -> 2.9.6

### DIFF
--- a/pkgs/by-name/ca/cargo-tauri/gst-plugin.nix
+++ b/pkgs/by-name/ca/cargo-tauri/gst-plugin.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  gst_all_1,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tauri-asset-gst-plugin";
+  version = "0.1.0";
+
+  # From upstream PR https://github.com/tauri-apps/tauri/pull/14402
+  src = fetchFromGitHub {
+    owner = "aaalloc";
+    repo = "tauri";
+    rev = "bc502b45a6995aab5687ce3e50b3d218ca5ee105";
+    hash = "sha256-H27n2rsqmGbk7ru8K7LhEvvftpz6mxgTow/18SpQn1Q=";
+  };
+
+  cargoHash = "sha256-n9CZ92ezRP9i4JpARwLpW4KIo9/6cB481YuG3qN1BKo=";
+
+  cargoBuildFlags = [ "--package tauri-asset-gst-plugin" ];
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+  ];
+
+  postInstall = ''
+    mkdir $out/lib/gstreamer-1.0
+    mv $out/lib/*.so $out/lib/gstreamer-1.0/
+  '';
+
+  meta = {
+    description = "GStreamer plugin to handle the tauri asset:// protocol";
+    homepage = "https://github.com/tauri-apps/tauri/pull/14402";
+    license = [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
+    maintainers = with lib.maintainers; [ snu ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ca/cargo-tauri/hook.nix
+++ b/pkgs/by-name/ca/cargo-tauri/hook.nix
@@ -18,6 +18,9 @@ makeSetupHook {
   propagatedBuildInputs = [
     cargo
     cargo-tauri
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    cargo-tauri.gst-plugin
   ];
 
   substitutions = {
@@ -32,6 +35,14 @@ makeSetupHook {
         linux = "deb";
       }
       .${kernelName} or (throw "${kernelName} is not supported by cargo-tauri.hook");
+
+    fixupScript = lib.optionalString stdenv.hostPlatform.isLinux ''
+      gappsWrapperArgs+=(
+        --prefix WEBKIT_GST_ALLOWED_URI_PROTOCOLS : "asset"
+        # Not picked up automatically by the wrappers from the propagatedBuildInputs.
+        --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${cargo-tauri.gst-plugin}/lib/gstreamer-1.0/"
+      )
+    '';
 
     # $targetDir is the path to the build artifacts (i.e., `./target/release`)
     installScript =

--- a/pkgs/by-name/ca/cargo-tauri/hook.sh
+++ b/pkgs/by-name/ca/cargo-tauri/hook.sh
@@ -93,6 +93,8 @@ tauriInstallHook() {
 }
 
 tauriFixupHook() {
+  echo "Executing tauriFixupHook"
+
   # NOTE: This runs as a preFixupPhase and does not replace the original hook.
   @fixupScript@
 }

--- a/pkgs/by-name/ca/cargo-tauri/hook.sh
+++ b/pkgs/by-name/ca/cargo-tauri/hook.sh
@@ -92,8 +92,17 @@ tauriInstallHook() {
     echo "Finished tauriInstallHook"
 }
 
+tauriFixupHook() {
+  # NOTE: This runs as a preFixupPhase and does not replace the original hook.
+  @fixupScript@
+}
+
 if [ -z "${dontTauriBuild:-}" ] && [ -z "${buildPhase:-}" ]; then
     buildPhase=tauriBuildHook
+fi
+
+if [ -z "${dontTauriFixup:-}" ] && [ -z "${fixupPhase:-}" ]; then
+    preFixupPhases+=(tauriFixupHook)
 fi
 
 if [ -z "${dontTauriInstall:-}" ] && [ -z "${installPhase:-}" ]; then

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tauri";
-  version = "2.9.4";
+  version = "2.9.5";
 
   src = fetchFromGitHub {
     owner = "tauri-apps";
     repo = "tauri";
     tag = "tauri-cli-v${finalAttrs.version}";
-    hash = "sha256-A4Y9oRSzUP0Xm4BMXRzG1670GQk4yxxHJRkgIj5ExRg=";
+    hash = "sha256-RWKgQYUua3bfir/hAjI4TWWMRG5KOksJSG1wD5SSva0=";
   };
 
-  cargoHash = "sha256-dOiqNmDYOzVadeoDefZauw0zSwuxnl3VO0KeKUJbx0E=";
+  cargoHash = "sha256-A85t5tAuAphTHRJ2N010r911QeM3CKf+JIAN//y2TWw=";
 
   nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isLinux) [
     pkg-config

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -14,16 +14,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tauri";
-  version = "2.9.5";
+  version = "2.9.6";
 
   src = fetchFromGitHub {
     owner = "tauri-apps";
     repo = "tauri";
     tag = "tauri-cli-v${finalAttrs.version}";
-    hash = "sha256-RWKgQYUua3bfir/hAjI4TWWMRG5KOksJSG1wD5SSva0=";
+    hash = "sha256-VtZxFkxOLMNwl3A/2qoNJ/HXr5FXFKQYw+ri5Yp8eOE=";
   };
 
-  cargoHash = "sha256-A85t5tAuAphTHRJ2N010r911QeM3CKf+JIAN//y2TWw=";
+  cargoHash = "sha256-uAjEQBHDpVv73MbeoU86tObiXSUKKjImpMTLHXKMRNs=";
 
   nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isLinux) [
     pkg-config

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -49,6 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   passthru = {
     # See ./doc/hooks/tauri.section.md
     hook = callPackage ./hook.nix { cargo-tauri = finalAttrs.finalPackage; };
+    gst-plugin = callPackage ./gst-plugin.nix { };
 
     tests = {
       hook = callPackage ./test-app.nix { cargo-tauri = finalAttrs.finalPackage; };

--- a/pkgs/by-name/ca/cargo-tauri/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri/package.nix
@@ -39,7 +39,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
       zstd
     ];
 
-  cargoBuildFlags = [ "--package tauri-cli" ];
+  cargoBuildFlags = [
+    "--package"
+    "tauri-cli"
+  ];
   cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   env = lib.optionalAttrs stdenv.hostPlatform.isLinux {


### PR DESCRIPTION
Required to backport `opencode-desktop`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
