### PR TITLE
cinnamon-settings-daemon: Fix backlight keys with polkit 127

### DIFF
--- a/pkgs/by-name/ci/cinnamon-settings-daemon/csd-backlight-helper-fix.patch
+++ b/pkgs/by-name/ci/cinnamon-settings-daemon/csd-backlight-helper-fix.patch
@@ -6,15 +6,14 @@ Subject: [PATCH] fix: use an impure path to csd-backlight-helper to fix
 
 ---
  plugins/power/csd-power-manager.c                             | 4 ++--
- .../org.cinnamon.settings-daemon.plugins.power.policy.in      | 2 +-
- 2 files changed, 3 insertions(+), 3 deletions(-)
+ 1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/plugins/power/csd-power-manager.c b/plugins/power/csd-power-manager.c
-index 33f4489..84dd98b 100644
+index e80ea05..f02454e 100644
 --- a/plugins/power/csd-power-manager.c
 +++ b/plugins/power/csd-power-manager.c
-@@ -2529,7 +2529,7 @@ backlight_helper_get_value (const gchar *argument, CsdPowerManager* manager,
- #endif
+@@ -2481,7 +2481,7 @@ backlight_helper_get_value (const gchar *argument, CsdPowerManager* manager,
+         gchar *endptr = NULL;
  
          /* get the data */
 -        command = g_strdup_printf (LIBEXECDIR "/csd-backlight-helper --%s %s",
@@ -22,7 +21,7 @@ index 33f4489..84dd98b 100644
                                     argument,
                                     manager->priv->backlight_helper_preference_args);
          ret = g_spawn_command_line_sync (command,
-@@ -2619,7 +2619,7 @@ backlight_helper_set_value (const gchar *argument,
+@@ -2571,7 +2571,7 @@ backlight_helper_set_value (const gchar *argument,
  #endif
  
          /* get the data */
@@ -31,19 +30,3 @@ index 33f4489..84dd98b 100644
                                     argument, value,
                                     manager->priv->backlight_helper_preference_args);
          ret = g_spawn_command_line_sync (command,
-diff --git a/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in b/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in
-index 504f017..3569e8c 100644
---- a/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in
-+++ b/plugins/power/org.cinnamon.settings-daemon.plugins.power.policy.in
-@@ -25,7 +25,7 @@
-       <allow_inactive>no</allow_inactive>
-       <allow_active>yes</allow_active>
-     </defaults>
--    <annotate key="org.freedesktop.policykit.exec.path">@libexecdir@/csd-backlight-helper</annotate>
-+    <annotate key="org.freedesktop.policykit.exec.path">/run/current-system/sw/bin/cinnamon-settings-daemon/csd-backlight-helper</annotate>
-   </action>
- 
- </policyconfig>
--- 
-2.30.0
-


### PR DESCRIPTION
pkexec now uses realpath when comparing org.freedesktop.policykit.exec.path

ref: 180e8ae2a0d6c600712480fcf116a50e99381875
ref: e3bdc06f8bf0690776d03c535e8cafafb3cf1389




## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested the  nixos-rebuild switch case
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
