### PR TITLE
swgp-go: 1.8.0-0-unstable-2026-01-24 -> 1.9.0

### DIFF
--- a/pkgs/by-name/sw/swgp-go/package.nix
+++ b/pkgs/by-name/sw/swgp-go/package.nix
@@ -1,23 +1,23 @@
 {
-  buildGoModule,
+  buildGo126Module,
   lib,
   fetchFromGitHub,
   # doubles the binary size
   withPprof ? false,
 }:
 
-buildGoModule {
+buildGo126Module (finalAttrs: {
   pname = "swgp-go";
-  version = "1.8.0-0-unstable-2026-01-24";
+  version = "1.9.0";
 
   src = fetchFromGitHub {
     owner = "database64128";
     repo = "swgp-go";
-    rev = "12be9c3ac0ea2c39b167cde708192935f7263a76";
-    hash = "sha256-0W7yioZc86xfjrJKeCAPT4mLWyrQDaBa9QbGjrR/Tpc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GnWcpAXViyO0T9u/AwVPr0SxvohuX+60C8j2kZbyKD0=";
   };
 
-  vendorHash = "sha256-Ghv5FwSPQSUFQ1t2zWTXpFggCA4/qrQmnVYkYBF8AQ4=";
+  vendorHash = "sha256-qiFFXL2nFZhsUsAZ98FRS2kF4ROaQUat5Skceh1DWaQ=";
 
   ldflags = [
     "-s"
@@ -41,4 +41,4 @@ buildGoModule {
     ];
     mainProgram = "swgp-go";
   };
-}
+})


### PR DESCRIPTION
 - switch to buildGo126Module, as 1.26 is required
 - use finalAttrs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
