### PR TITLE
treewide: move env variable(s) into env for structuredAttrs (D-E)

### DIFF
--- a/pkgs/by-name/br/browserpass/package.nix
+++ b/pkgs/by-name/br/browserpass/package.nix
@@ -39,7 +39,7 @@ buildGoModule (finalAttrs: {
     sed -i -e 's/INSTALL =.*/INSTALL = install/' Makefile
   '';
 
-  DESTDIR = placeholder "out";
+  env.DESTDIR = placeholder "out";
 
   postConfigure = ''
     make configure

--- a/pkgs/by-name/br/bruno-cli/package.nix
+++ b/pkgs/by-name/br/bruno-cli/package.nix
@@ -42,7 +42,7 @@ buildNpmPackage {
     patchShebangs packages/*/node_modules
   '';
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -84,7 +84,7 @@ buildNpmPackage rec {
     patchShebangs packages/*/node_modules
   '';
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = 1;
 
   # remove giflib dependency
   npmRebuildFlags = [ "--ignore-scripts" ];

--- a/pkgs/by-name/bu/bupc/package.nix
+++ b/pkgs/by-name/bu/bupc/package.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Used during the configure phase
-  ENVCMD = "${coreutils}/bin/env";
+  env.ENVCMD = "${coreutils}/bin/env";
 
   buildInputs = [ perl ];
 

--- a/pkgs/by-name/ca/caprine/package.nix
+++ b/pkgs/by-name/ca/caprine/package.nix
@@ -20,7 +20,7 @@ buildNpmPackage rec {
     hash = "sha256-hBGsqOqKMHNy2SNw1kHCQq1lPDd2S36L5pdKgD2O8FA=";
   };
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   npmDepsHash = "sha256-FgOHuMMUX92VHF6hdznoi7bhO/27t6+l038kmpqjctQ=";
 

--- a/pkgs/by-name/ch/chatd/package.nix
+++ b/pkgs/by-name/ch/chatd/package.nix
@@ -24,7 +24,7 @@ buildNpmPackage rec {
   };
 
   makeCacheWritable = true; # sharp tries to build stuff in node_modules
-  ELECTRON_SKIP_BINARY_DOWNLOAD = true;
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = true;
 
   npmDepsHash = "sha256-jvGvhgNhY+wz/DFS7NDtmzKXbhHbNF3i0qVQoFFeB0M=";
 

--- a/pkgs/by-name/di/diffuse/package.nix
+++ b/pkgs/by-name/di/diffuse/package.nix
@@ -58,7 +58,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
   ];
 
   # to avoid running gtk-update-icon-cache, update-desktop-database and glib-compile-schemas
-  DESTDIR = "/";
+  env.DESTDIR = "/";
 
   makeWrapperArgs = [
     "--prefix XDG_DATA_DIRS : ${hicolor-icon-theme}/share"

--- a/pkgs/by-name/dr/drawio/package.nix
+++ b/pkgs/by-name/dr/drawio/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     darwin.autoSignDarwinBinariesHook
   ];
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = true;
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = true;
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/by-name/gl/glib/package.nix
+++ b/pkgs/by-name/gl/glib/package.nix
@@ -252,6 +252,7 @@ stdenv.mkDerivation (finalAttrs: {
       # we're using plain
       "-DG_DISABLE_CAST_CHECKS"
     ];
+    DETERMINISTIC_BUILD = 1;
   };
 
   postPatch = ''
@@ -279,8 +280,6 @@ stdenv.mkDerivation (finalAttrs: {
   postConfigure = ''
     patchShebangs gio/gdbus-2.0/codegen/gdbus-codegen gobject/glib-{genmarshal,mkenums}
   '';
-
-  DETERMINISTIC_BUILD = 1;
 
   postInstall = ''
     moveToOutput "share/glib-2.0" "$dev"

--- a/pkgs/by-name/ka/kaufkauflist/package.nix
+++ b/pkgs/by-name/ka/kaufkauflist/package.nix
@@ -39,7 +39,7 @@ buildNpmPackage rec {
 
   npmDepsHash = "sha256-HDv6sW6FmKZpUjymrUjz/WG9XrKgLmM6qHMAxP6gBtU=";
 
-  ESBUILD_BINARY_PATH = lib.getExe esbuild';
+  env.ESBUILD_BINARY_PATH = lib.getExe esbuild';
 
   postInstall = ''
     mkdir -p $out/share/kaufkauflist $out/share/pocketbase

--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
   ];
 
-  DEVINPUT_HEADER = "${linuxHeaders}/include/linux/input-event-codes.h";
+  env.DEVINPUT_HEADER = "${linuxHeaders}/include/linux/input-event-codes.h";
 
   configureFlags = [
     "--sysconfdir=/etc"

--- a/pkgs/by-name/ms/msieve/package.nix
+++ b/pkgs/by-name/ms/msieve/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     ecm
   ];
 
-  ECM = if ecm == null then "0" else "1";
+  env.ECM = if ecm == null then "0" else "1";
 
   # Doesn't hurt Linux but lets clang-based platforms like Darwin work fine too
   makeFlags = [

--- a/pkgs/by-name/po/podman-desktop/package.nix
+++ b/pkgs/by-name/po/podman-desktop/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./system-defaults-dir.patch
   ];
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   nativeBuildInputs = [
     makeBinaryWrapper

--- a/pkgs/by-name/rc/rcs/package.nix
+++ b/pkgs/by-name/rc/rcs/package.nix
@@ -17,16 +17,17 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-Q93+EHJKi4XiRo9kA7YABzcYbwHmDgvWL95p2EIjTMU=";
   };
 
-  ac_cv_path_ED = "${ed}/bin/ed";
-  DIFF = "${diffutils}/bin/diff";
-  DIFF3 = "${diffutils}/bin/diff3";
-
   disallowedReferences = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     buildPackages.diffutils
     buildPackages.ed
   ];
 
-  env.NIX_CFLAGS_COMPILE = "-std=c99";
+  env = {
+    NIX_CFLAGS_COMPILE = "-std=c99";
+    ac_cv_path_ED = "${ed}/bin/ed";
+    DIFF = "${diffutils}/bin/diff";
+    DIFF3 = "${diffutils}/bin/diff3";
+  };
 
   hardeningDisable = lib.optional stdenv.cc.isClang "format";
 

--- a/pkgs/by-name/sy/system76-scheduler/package.nix
+++ b/pkgs/by-name/sy/system76-scheduler/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage {
     pipewire
   ];
 
-  EXECSNOOP_PATH = "${bcc}/bin/execsnoop";
+  env.EXECSNOOP_PATH = "${bcc}/bin/execsnoop";
 
   # tests don't build
   doCheck = false;

--- a/pkgs/by-name/th/thc-hydra/package.nix
+++ b/pkgs/by-name/th/thc-hydra/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  DATADIR = "/share/${pname}";
+  env.DATADIR = "/share/${pname}";
 
   postInstall = lib.optionalString withGUI ''
     wrapProgram $out/bin/xhydra \

--- a/pkgs/by-name/yt/ytdownloader/package.nix
+++ b/pkgs/by-name/yt/ytdownloader/package.nix
@@ -45,7 +45,7 @@ buildNpmPackage rec {
     })
   ];
 
-  ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   dontNpmBuild = true;
 

--- a/pkgs/development/python-modules/nix-prefetch-github/default.nix
+++ b/pkgs/development/python-modules/nix-prefetch-github/default.nix
@@ -47,7 +47,7 @@ buildPythonPackage rec {
   sphinxRoot = "docs";
 
   # ignore tests which are impure
-  DISABLED_TESTS = "network requires_nix_build";
+  env.DISABLED_TESTS = "network requires_nix_build";
 
   meta = {
     description = "Prefetch sources from github";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
