### PR TITLE
tuxbox: init at 3.0.1

### DIFF
--- a/pkgs/by-name/tu/tuxbox/Broaden-pgrep-patterns-to-detect-driver-on-NixOS.patch
+++ b/pkgs/by-name/tu/tuxbox/Broaden-pgrep-patterns-to-detect-driver-on-NixOS.patch
@@ -1,0 +1,86 @@
+From db2e25602339253c12ed65720bae7c793c044bdc Mon Sep 17 00:00:00 2001
+From: Scott Bowman <scott@bowmans.org>
+Date: Thu, 19 Feb 2026 16:58:03 -0600
+Subject: [PATCH] Broaden pgrep patterns to detect driver on NixOS and pip
+ entry points
+
+Use multiple pgrep patterns to find running driver processes,
+covering python -m invocation, pip console_scripts entry points,
+and NixOS wrapped executables.
+---
+ tuxbox/gui/driver_manager.py | 50 ++++++++++++++++++++++--------------
+ 1 file changed, 31 insertions(+), 19 deletions(-)
+
+diff --git a/tuxbox/gui/driver_manager.py b/tuxbox/gui/driver_manager.py
+index accb457..384c00e 100644
+--- a/tuxbox/gui/driver_manager.py
++++ b/tuxbox/gui/driver_manager.py
+@@ -82,6 +82,17 @@ class DriverManager:
+         DriverManager._systemctl_available = shutil.which('systemctl') is not None
+         return DriverManager._systemctl_available
+ 
++    # Patterns to match driver processes via pgrep -f (full command line match).
++    # Multiple patterns cover different invocation methods:
++    #   - "python -m tuxbox [args]"         (standard / systemd service)
++    #   - "/path/to/tuxbox [args]"          (pip entry point)
++    #   - "/path/to/.tuxbox-wrapped [args]" (NixOS wrapper)
++    # The patterns intentionally exclude GUI processes (tuxbox-gui, tuxbox.gui).
++    DRIVER_PGREP_PATTERNS = [
++        r'python.*-m\s+tuxbox(\s|$)',
++        r'[/.]tuxbox(-wrapped)?(\s|$)',
++    ]
++
+     @staticmethod
+     def _get_driver_pids() -> list:
+         """Get PIDs of running driver processes
+@@ -89,27 +100,28 @@ class DriverManager:
+         Returns:
+             List of PID strings for running tuxbox processes
+         """
+-        try:
+-            # Use pgrep to find Python processes running tuxbox
+-            # -f matches against full command line
+-            result = subprocess.run(
+-                ['pgrep', '-f', f'python.*-m.*{DriverManager.DRIVER_MODULE}'],
+-                capture_output=True,
+-                text=True,
+-                timeout=5
+-            )
++        all_pids = set()
++        our_pid = str(os.getpid())
++        parent_pid = str(os.getppid())
+ 
+-            if result.returncode == 0 and result.stdout.strip():
+-                pids = result.stdout.strip().split('\n')
+-                # Filter out our own process (the GUI)
+-                our_pid = str(os.getpid())
+-                parent_pid = str(os.getppid())
+-                return [pid for pid in pids if pid and pid != our_pid and pid != parent_pid]
+-            return []
++        for pattern in DriverManager.DRIVER_PGREP_PATTERNS:
++            try:
++                result = subprocess.run(
++                    ['pgrep', '-f', pattern],
++                    capture_output=True,
++                    text=True,
++                    timeout=5
++                )
+ 
+-        except Exception as e:
+-            logger.debug(f"pgrep failed: {e}")
+-            return []
++                if result.returncode == 0 and result.stdout.strip():
++                    for pid in result.stdout.strip().split('\n'):
++                        if pid and pid != our_pid and pid != parent_pid:
++                            all_pids.add(pid)
++
++            except Exception as e:
++                logger.debug(f"pgrep failed for pattern '{pattern}': {e}")
++
++        return list(all_pids)
+ 
+     @staticmethod
+     def stop_driver() -> Tuple[bool, str]:
+-- 
+2.52.0
+

--- a/pkgs/by-name/tu/tuxbox/package.nix
+++ b/pkgs/by-name/tu/tuxbox/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "tuxbox";
+  version = "3.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "AndyCappDev";
+    repo = "tuxbox";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hBk4KhLNMgk8bFCZPQMtQlJ1/RB9qcL4kiF+eb3n4LU=";
+  };
+
+  patches = [
+    ./Broaden-pgrep-patterns-to-detect-driver-on-NixOS.patch
+  ];
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    bleak
+    evdev
+    pyserial
+    pyside6
+  ];
+
+  meta = {
+    changelog = "https://github.com/AndyCappDev/tuxbox/releases/tag/${finalAttrs.version}";
+    description = "Linux driver for all TourBox models - Native feel with USB, Bluetooth, haptics and graphical configuration GUI";
+    homepage = "https://github.com/AndyCappDev/tuxbox";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ CompileTime ];
+    mainProgram = "tuxbox";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

# TuxBox

This pull request adds [TuxBox](https://github.com/AndyCappDev/tuxbox) - a Linux driver for TourBox devices - to nixpkgs.

This packages is only manually tested since it requires TourBox hardware for proper testing.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
