### PR TITLE
duckstation: fix linux build, 0.1-10413 -> 0.1-10693

### DIFF
--- a/pkgs/by-name/du/duckstation/package.nix
+++ b/pkgs/by-name/du/duckstation/package.nix
@@ -60,14 +60,14 @@ let
 
   linuxDrv = llvmPackages.stdenv.mkDerivation (finalAttrs: {
     pname = "duckstation";
-    version = "0.1-10413";
+    version = "0.1-10693";
 
     src = fetchFromGitHub {
       owner = "stenzek";
       repo = "duckstation";
       tag = "v${finalAttrs.version}";
       deepClone = true;
-      hash = "sha256-ksmxdYLFWYIA3Kp8dztyN4UxeJFvpNRmN79TspwZHuw=";
+      hash = "sha256-vDuiy3fmMsFpomgAUyTnt1vY/zjdVoH56UrFfuEwy6Q=";
 
       postFetch = ''
         cd $out

--- a/pkgs/by-name/du/duckstation/package.nix
+++ b/pkgs/by-name/du/duckstation/package.nix
@@ -67,7 +67,7 @@ let
       repo = "duckstation";
       tag = "v${finalAttrs.version}";
       deepClone = true;
-      hash = "sha256-ytJ0vaXXbbgSmZ42gQPlQY7p30hz7hx/+09TSvCKyEg=";
+      hash = "sha256-ksmxdYLFWYIA3Kp8dztyN4UxeJFvpNRmN79TspwZHuw=";
 
       postFetch = ''
         cd $out
@@ -137,6 +137,7 @@ let
         "lib"
         "dev"
       ];
+      doInstallCheck = false;
       postFixup = null;
     });
 

--- a/pkgs/by-name/du/duckstation/sources.json
+++ b/pkgs/by-name/du/duckstation/sources.json
@@ -1,7 +1,7 @@
 {
   "duckstation": {
-    "version": "0.1-10413",
-    "hash_darwin": "sha256-TGXLpbTFkrFQ42LpRx0TKBsbdIRuYtseR+v3W/t9M10="
+    "version": "0.1-10693",
+    "hash_darwin": "sha256-E63TIiS2uJ5Y4IogI8E7S6yVnXOqLLOM9Dbv58se7KI="
   },
   "discord_rpc": {
     "rev": "cc59d26d1d628fbd6527aac0ac1d6301f4978b92",
@@ -12,8 +12,8 @@
     "hash": "sha256-7PVrpS69pI5mi4aM1eNTAzZCMq6vuVl3mhTrc4U942w="
   },
   "chtdb": {
-    "date": "2025-12-31",
-    "rev": "696e985e027d8d43a84c65bd349802dfe0944674",
-    "hash": "sha256-4t0x0YYp7rURBqVWyMZpnOATpIYoILQagyMASaSWKWM="
+    "date": "2026-02-14",
+    "rev": "3ec3c5024aee424ce26e3b031ec68a790f29b094",
+    "hash": "sha256-HmgcUyo/otRWY0M69Lh9KVqZ97ERHg6Ts7rAir7elQ0="
   }
 }


### PR DESCRIPTION
WIP

- Fixes the build error with the vendored `shaderc`(fixes #490402 )
- Upgrades to the latest version (note: waiting for latest libpng #488962 to be in `master` - https://nixpkgs-tracker.ocfox.me/?pr=488962)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
