### PR TITLE
Systemd componentization

### DIFF
--- a/nixos/lib/make-disk-image.nix
+++ b/nixos/lib/make-disk-image.nix
@@ -400,7 +400,7 @@ let
       config.system.build.nixos-install
       nixos-enter
       nix
-      systemdMinimal
+      systemd
     ]
     ++ lib.optional deterministic gptfdisk
     ++ stdenv.initialPath

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -636,6 +636,11 @@ in
         "systemd/user-preset/00-nixos.preset".text = ''
           ignore *
         '';
+      }
+      // lib.optionalAttrs cfg.package.withTimedated {
+        "systemd/ntp-units.d" = {
+          source = hooks "ntp-units.d" { };
+        };
       };
 
     services.dbus.enable = true;

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -494,7 +494,16 @@ in
         fsck = "${cfg.package.util-linux}/bin/fsck";
       };
 
-      managerEnvironment.PATH = "/bin:/sbin";
+      managerEnvironment = {
+        PATH = "/bin:/sbin";
+
+        # systemd is now built to look for these things under
+        # /run/current-system/systemd, but /run/current-system isn't available
+        # when PID 1 is launched, so we need to give it some clues.
+        SYSTEMD_UNIT_PATH = "${cfg.package}/lib/systemd/system:";
+        SYSTEMD_GENERATOR_PATH = "${cfg.package}/lib/systemd/system-generators:";
+        SYSTEMD_ENVIRONMENT_GENERATOR_PATH = "${cfg.package}/lib/systemd/system-environment-generators:";
+      };
       settings.Manager.ManagerEnvironment = lib.concatStringsSep " " (
         lib.mapAttrsToList (n: v: "${n}=${lib.escapeShellArg v}") cfg.managerEnvironment
       );
@@ -697,6 +706,26 @@ in
           before = [ "initrd-fs.target" ];
         }
       ];
+
+      services.link-run-current-system-systemd = {
+        description = "Temporary /run/current-system/systemd Symlink";
+        requiredBy = [ "sysinit.target" ];
+        before = [ "systemd-udevd.service" ];
+        conflicts = [ "initrd-nixos-activation.service" ];
+        unitConfig.DefaultDependencies = false;
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          mkdir /run/current-system
+          ln -s ${cfg.package} /run/current-system/systemd
+        '';
+        preStop = ''
+          rm /run/current-system/systemd
+          rmdir /run/current-system
+        '';
+      };
 
       services.initrd-nixos-activation = lib.mkIf (!config.system.nixos-init.enable) {
         after = [ "initrd-switch-root.target" ];

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -4,6 +4,7 @@ with lib;
 
 let
   cfg = config.services.timesyncd;
+  package = config.systemd.package.timesyncd;
 in
 {
 
@@ -61,7 +62,8 @@ in
 
   config = mkIf cfg.enable {
 
-    systemd.additionalUpstreamSystemUnits = [ "systemd-timesyncd.service" ];
+    systemd.packages = [ package ];
+    environment.systemPackages = [ package ]; # for dbus and polkit
 
     systemd.services.systemd-timesyncd = {
       wantedBy = [ "sysinit.target" ];

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -56,7 +56,7 @@
   sigtool,
   sqlite,
   replaceVars,
-  systemdLibs,
+  systemd,
   tree-sitter,
   texinfo,
   webkitgtk_4_1,
@@ -88,7 +88,7 @@
   withPgtk ? false,
   withSelinux ? stdenv.hostPlatform.isLinux,
   withSQLite3 ? true,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   withToolkitScrollBars ? true,
   withTreeSitter ? true,
   withWebP ? true,
@@ -324,7 +324,7 @@ stdenv.mkDerivation (finalAttrs: {
     sqlite
   ]
   ++ lib.optionals withSystemd [
-    systemdLibs
+    systemd
   ]
   ++ lib.optionals withTreeSitter [
     tree-sitter

--- a/pkgs/applications/editors/vscode/generic.nix
+++ b/pkgs/applications/editors/vscode/generic.nix
@@ -23,7 +23,7 @@
   libx11,
   libxkbfile,
   libxcb,
-  systemdLibs,
+  systemd,
   fontconfig,
   imagemagick,
   libdbusmenu,
@@ -248,13 +248,13 @@ stdenv.mkDerivation (
       libgbm
       nss
       nspr
-      systemdLibs
+      systemd
       webkitgtk_4_1
       libxkbfile
     ];
 
     runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
-      systemdLibs
+      (lib.getLib systemd)
       fontconfig.lib
       libdbusmenu
       wayland

--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -17,8 +17,8 @@
   libv4l,
   net-snmp,
   curl,
-  systemdLibs,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemd,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   libxml2,
   poppler,
   gawk,
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     net-snmp
   ]
   ++ lib.optionals withSystemd [
-    systemdLibs
+    systemd
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -96,8 +96,8 @@
   ungoogled-chromium,
   # Optional dependencies:
   libgcrypt ? null, # cupsSupport
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
 }:
 
 buildFun:
@@ -387,7 +387,7 @@ let
       libffi
       libevdev
     ]
-    ++ lib.optional systemdSupport systemdLibs
+    ++ lib.optional systemdSupport systemd
     ++ lib.optionals cupsSupport [
       libgcrypt
       cups
@@ -448,7 +448,7 @@ let
       libffi
       libevdev
     ]
-    ++ lib.optional systemdSupport systemdLibs
+    ++ lib.optional systemdSupport systemd
     ++ lib.optionals cupsSupport [
       libgcrypt
       cups

--- a/pkgs/applications/networking/cluster/k3s/builder.nix
+++ b/pkgs/applications/networking/cluster/k3s/builder.nix
@@ -81,7 +81,7 @@ lib:
   sqlite,
   stdenv,
   shadow,
-  systemdMinimal,
+  systemd,
   util-linuxMinimal,
   yq-go,
   zstd,
@@ -429,7 +429,7 @@ buildGoModule (finalAttrs: {
 
   k3sKillallDeps = [
     bash
-    systemdMinimal
+    systemd
     procps
     coreutils
     gnugrep

--- a/pkgs/applications/networking/instant-messengers/discord/linux.nix
+++ b/pkgs/applications/networking/instant-messengers/discord/linux.nix
@@ -49,7 +49,7 @@
   nspr,
   nss,
   pango,
-  systemdLibs,
+  systemd,
   libappindicator-gtk3,
   libdbusmenu,
   writeScript,
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
   libPath = lib.makeLibraryPath (
     [
       libcxx
-      systemdLibs
+      systemd
       libpulseaudio
       libdrm
       libgbm

--- a/pkgs/applications/networking/irc/weechat/default.nix
+++ b/pkgs/applications/networking/irc/weechat/default.nix
@@ -32,7 +32,7 @@
   tcl,
   phpSupport ? !stdenv.hostPlatform.isDarwin,
   php,
-  systemdLibs,
+  systemd,
   libxml2,
   pcre2,
   libargon2,
@@ -94,7 +94,7 @@ let
         pcre2
         libargon2
       ]
-      ++ lib.optionals stdenv.hostPlatform.isLinux [ systemdLibs ];
+      ++ lib.optionals stdenv.hostPlatform.isLinux [ systemd ];
     }
   ];
   enabledPlugins = builtins.filter (p: p.enabled) plugins;

--- a/pkgs/applications/networking/remote/citrix-workspace/generic.nix
+++ b/pkgs/applications/networking/remote/citrix-workspace/generic.nix
@@ -208,7 +208,7 @@ stdenv.mkDerivation rec {
     sane-backends
     speex
     stdenv.cc.cc
-    (lib.getLib systemd)
+    systemd
     woff2
     libxscrnsaver
     libxaw

--- a/pkgs/by-name/at/at-spi2-core/package.nix
+++ b/pkgs/by-name/at/at-spi2-core/package.nix
@@ -23,8 +23,8 @@
   libxi,
   libxext,
   gnome,
-  systemdLibs,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemd,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -65,7 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals systemdSupport [
     # libsystemd is a needed for dbus-broker support
-    systemdLibs
+    systemd
   ];
 
   # In atspi-2.pc dbus-1 glib-2.0

--- a/pkgs/by-name/ba/badgemagic-rs/package.nix
+++ b/pkgs/by-name/ba/badgemagic-rs/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   dbus,
-  systemdLibs,
+  systemd,
 }:
 
 rustPlatform.buildRustPackage {
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage {
 
   buildInputs = [
     dbus
-    systemdLibs
+    systemd
   ];
 
   meta = {

--- a/pkgs/by-name/bl/bluez-alsa/package.nix
+++ b/pkgs/by-name/bl/bluez-alsa/package.nix
@@ -17,7 +17,7 @@
   sbc,
   python3,
   systemdSupport ? true,
-  systemdLibs,
+  systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     python3
   ]
-  ++ lib.optional systemdSupport systemdLibs;
+  ++ lib.optional systemdSupport systemd;
 
   buildInputs = [
     alsa-lib

--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -15,6 +15,7 @@
   pkg-config,
   python3Packages,
   readline,
+  systemd,
   udev,
   # Test gobject-introspection instead of pygobject because the latter
   # causes an infinite recursion.
@@ -68,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace tools/hid2hci.rules \
-      --replace-fail /sbin/udevadm ${udev}/bin/udevadm \
+      --replace-fail /sbin/udevadm ${systemd}/bin/udevadm \
       --replace-fail "hid2hci " "$out/lib/udev/hid2hci "
   ''
   +

--- a/pkgs/by-name/br/brltty/package.nix
+++ b/pkgs/by-name/br/brltty/package.nix
@@ -13,8 +13,8 @@
   util-linux,
   alsaSupport ? stdenv.hostPlatform.isLinux,
   alsa-lib,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
-  systemdMinimal,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   ncurses,
   udevCheckHook,
   buildPackages,
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
     tcl # For TCL bindings
   ]
   ++ lib.optional alsaSupport alsa-lib
-  ++ lib.optional systemdSupport systemdMinimal;
+  ++ lib.optional systemdSupport systemd;
 
   doInstallCheck = true;
 
@@ -139,6 +139,6 @@ stdenv.mkDerivation (finalAttrs: {
      )
      substituteInPlace $out/libexec/brltty/systemd-wrapper \
        --replace 'logger' "${util-linux}/bin/logger" \
-       --replace 'udevadm' "${systemdMinimal}/bin/udevadm"
+       --replace 'udevadm' "${systemd}/bin/udevadm"
   '';
 })

--- a/pkgs/by-name/ce/cef-binary/package.nix
+++ b/pkgs/by-name/ce/cef-binary/package.nix
@@ -20,7 +20,7 @@
   cups,
   libGL,
   udev,
-  systemdLibs,
+  systemd,
   libxrandr,
   libxfixes,
   libxext,
@@ -61,7 +61,7 @@ let
     cups
     libGL
     udev
-    systemdLibs
+    systemd
     libxcb
     libx11
     libxcomposite

--- a/pkgs/by-name/co/conmon/package.nix
+++ b/pkgs/by-name/co/conmon/package.nix
@@ -6,7 +6,7 @@
   glib,
   glibc,
   libseccomp,
-  systemdMinimal,
+  systemd,
   nixosTests,
   versionCheckHook,
 }:
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     glib
     libseccomp
-    systemdMinimal
+    systemd
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isMusl) [
     glibc

--- a/pkgs/by-name/co/conntrack-tools/package.nix
+++ b/pkgs/by-name/co/conntrack-tools/package.nix
@@ -13,7 +13,7 @@
   libnetfilter_cthelper,
   libtirpc,
   systemdSupport ? true,
-  systemdLibs,
+  systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtirpc
   ]
   ++ lib.optionals systemdSupport [
-    systemdLibs
+    systemd
   ];
   nativeBuildInputs = [
     flex

--- a/pkgs/by-name/co/coroot-node-agent/package.nix
+++ b/pkgs/by-name/co/coroot-node-agent/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  systemdLibs,
+  systemd,
 }:
 
 buildGoModule (finalAttrs: {
@@ -18,9 +18,9 @@ buildGoModule (finalAttrs: {
 
   vendorHash = "sha256-sjdUjnBMzEfGCVOwuL9Zw/5Lup3yUf5LoBajLOCNteA=";
 
-  buildInputs = [ systemdLibs ];
+  buildInputs = [ systemd ];
 
-  CGO_CFLAGS = "-I ${systemdLibs}/include";
+  CGO_CFLAGS = "-I ${lib.getDev systemd}/include";
 
   ldflags = [
     "-extldflags='-Wl,-z,lazy'"

--- a/pkgs/by-name/co/coturn/package.nix
+++ b/pkgs/by-name/co/coturn/package.nix
@@ -9,7 +9,7 @@
   libmicrohttpd,
   sqlite,
   nixosTests,
-  systemdMinimal,
+  systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -34,8 +34,8 @@ stdenv.mkDerivation (finalAttrs: {
     libmicrohttpd
     sqlite.dev
   ]
-  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform systemdMinimal) [
-    systemdMinimal
+  ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform systemd) [
+    systemd
   ];
 
   patches = [

--- a/pkgs/by-name/cr/crun/package.nix
+++ b/pkgs/by-name/cr/crun/package.nix
@@ -8,7 +8,7 @@
   libcap,
   libseccomp,
   python3,
-  systemdMinimal,
+  systemd,
   yajl,
   nixosTests,
   criu,
@@ -68,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     criu
     libcap
     libseccomp
-    systemdMinimal
+    systemd
     yajl
   ];
 

--- a/pkgs/by-name/cu/cups/package.nix
+++ b/pkgs/by-name/cu/cups/package.nix
@@ -10,8 +10,8 @@
   libtiff,
   pam,
   dbus,
-  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   acl,
   gmp,
   darwin,
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     dbus
     acl
   ]
-  ++ lib.optional enableSystemd systemdLibs;
+  ++ lib.optional enableSystemd systemd;
 
   propagatedBuildInputs = [ gmp ];
 

--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -4,8 +4,9 @@
   fetchurl,
   pkg-config,
   expat,
-  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
-  systemdMinimal,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
+  systemdMinimal, # used at build time; don't add to buildInputs!
   audit,
   libcap_ng,
   libapparmor,
@@ -78,7 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
     libice
     libsm
   ]
-  ++ lib.optional enableSystemd systemdMinimal
+  ++ lib.optional enableSystemd systemd
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     audit
     libapparmor
@@ -123,12 +124,6 @@ stdenv.mkDerivation (finalAttrs: {
       [binaries]
       launchctl = 'true'
     ''}"
-  ]
-  ++ lib.optionals enableSystemd [
-    "--cross-file=${writeText "crossfile.ini" ''
-      [binaries]
-      systemctl = '${systemdMinimal}/bin/systemctl'
-    ''}"
   ];
 
   doCheck = true;
@@ -143,6 +138,13 @@ stdenv.mkDerivation (finalAttrs: {
       --replace-fail 'DBUS_BINDIR "/dbus-launch"' "\"$lib/bin/dbus-launch\""
     substituteInPlace ./tools/dbus-launch.c \
       --replace-fail 'DBUS_DAEMONDIR"/dbus-daemon"' '"/run/current-system/sw/bin/dbus-daemon"'
+  ''
+  # The reference to systemctl is only used in the ExecStartPost of a socket
+  # file, so it's fine to leave it as just an executable name; systemd will
+  # resolve the binary.
+  + lib.optionalString enableSystemd ''
+    substituteInPlace meson.build \
+      --replace-fail "systemctl = '/usr/bin/systemctl'" "systemctl = 'systemctl'"
   '';
 
   postFixup = ''

--- a/pkgs/by-name/de/deezer-enhanced/package.nix
+++ b/pkgs/by-name/de/deezer-enhanced/package.nix
@@ -26,7 +26,7 @@
   pango,
   cairo,
   expat,
-  systemdLibs,
+  systemd,
   alsa-lib,
   nwjs,
   libGL,
@@ -62,7 +62,7 @@ stdenvNoCC.mkDerivation rec {
     libxcb
 
     ### Systemd libs
-    systemdLibs
+    systemd
     dbus
 
     ### Other libs
@@ -105,7 +105,7 @@ stdenvNoCC.mkDerivation rec {
           libxcb
 
           ### Systemd libs
-          systemdLibs
+          systemd
           dbus
 
           ### Other libs

--- a/pkgs/by-name/de/detect-it-easy/package.nix
+++ b/pkgs/by-name/de/detect-it-easy/package.nix
@@ -7,7 +7,7 @@
   graphite2,
   icu,
   krb5,
-  systemdLibs,
+  systemd,
   imagemagick,
 }:
 
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     freetype
     icu
     krb5
-    systemdLibs
+    systemd
   ];
   nativeBuildInputs = [
     libsForQt5.wrapQtAppsHook

--- a/pkgs/by-name/eo/eos-installer/package.nix
+++ b/pkgs/by-name/eo/eos-installer/package.nix
@@ -12,7 +12,7 @@
   gnome-desktop,
   gnupg,
   gtk3,
-  systemdMinimal,
+  systemd,
   udisks,
   xz,
 }:
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gnome-desktop
     gtk3
-    systemdMinimal
+    systemd
     udisks
     xz
   ];

--- a/pkgs/by-name/gi/github-desktop/package.nix
+++ b/pkgs/by-name/gi/github-desktop/package.nix
@@ -16,7 +16,7 @@
   alsa-lib,
   cups,
   libgbm,
-  systemdLibs,
+  systemd,
   openssl,
   libglvnd,
 }:
@@ -93,7 +93,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   '';
 
   runtimeDependencies = [
-    systemdLibs
+    (lib.getLib systemd)
   ];
 
   meta = {

--- a/pkgs/by-name/gr/grafana-alloy/package.nix
+++ b/pkgs/by-name/gr/grafana-alloy/package.nix
@@ -107,9 +107,7 @@ buildGoModule (finalAttrs: rec {
   # Add to RUNPATH so it can be found.
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     patchelf \
-      --set-rpath "${
-        lib.makeLibraryPath [ (lib.getLib systemd) ]
-      }:$(patchelf --print-rpath $out/bin/alloy)" \
+      --set-rpath "${lib.makeLibraryPath [ systemd ]}:$(patchelf --print-rpath $out/bin/alloy)" \
       $out/bin/alloy
   '';
 

--- a/pkgs/by-name/ht/htop/package.nix
+++ b/pkgs/by-name/ht/htop/package.nix
@@ -10,8 +10,8 @@
   libnl,
   sensorsSupport ? stdenv.hostPlatform.isLinux,
   lm_sensors,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   withVimKeys ? false,
 }:
 
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     libnl
   ]
   ++ lib.optional sensorsSupport lm_sensors
-  ++ lib.optional systemdSupport systemdLibs;
+  ++ lib.optional systemdSupport systemd;
 
   configureFlags = [
     "--enable-unicode"
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
     in
     lib.optionalString (!stdenv.hostPlatform.isStatic) ''
       ${optionalPatch sensorsSupport "${lib.getLib lm_sensors}/lib/libsensors.so"}
-      ${optionalPatch systemdSupport "${systemdLibs}/lib/libsystemd.so"}
+      ${optionalPatch systemdSupport "${lib.getLib systemd}/lib/libsystemd.so"}
     '';
 
   meta = {

--- a/pkgs/by-name/hw/hwinfo/package.nix
+++ b/pkgs/by-name/hw/hwinfo/package.nix
@@ -7,7 +7,7 @@
   libx86emu,
   perl,
   kmod,
-  systemdMinimal,
+  systemd,
   testers,
   binutils,
   writeText,
@@ -61,8 +61,8 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/hd/hd_int.h \
       --replace-fail "/sbin/modprobe" "${kmod}/bin/modprobe" \
       --replace-fail "/sbin/rmmod" "${kmod}/bin/rmmod" \
-      --replace-fail "/usr/bin/udevinfo" "${systemdMinimal}/bin/udevinfo" \
-      --replace-fail "/usr/bin/udevadm" "${systemdMinimal}/bin/udevadm"
+      --replace-fail "/usr/bin/udevinfo" "${systemd}/bin/udevinfo" \
+      --replace-fail "/usr/bin/udevadm" "${systemd}/bin/udevadm"
 
     # Replace /usr/bin/perl
     patchShebangs src/ids/convert_hd
@@ -80,8 +80,8 @@ stdenv.mkDerivation (finalAttrs: {
     # since we don't have .git, we cannot run this.
     rm git2log
     pushd src/ids
-    cp ${systemdMinimal.src}/hwdb.d/pci.ids src/pci
-    cp ${systemdMinimal.src}/hwdb.d/usb.ids src/usb
+    cp ${systemd.src}/hwdb.d/pci.ids src/pci
+    cp ${systemd.src}/hwdb.d/usb.ids src/usb
     # taken from https://github.com/openSUSE/hwinfo/blob/c87f449f1d4882c71b0a1e6dc80638224a5baeed/src/ids/update_pci_usb
     perl -pi -e 'undef $_ if /^C\s/..1' src/usb
     perl ./convert_hd src/pci

--- a/pkgs/by-name/hy/hypridle/package.nix
+++ b/pkgs/by-name/hy/hypridle/package.nix
@@ -12,7 +12,7 @@
   hyprland-protocols,
   hyprwayland-scanner,
   sdbus-cpp_2,
-  systemdLibs,
+  systemd,
   nix-update-script,
 }:
 
@@ -40,7 +40,7 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     hyprlang
     hyprutils
     sdbus-cpp_2
-    systemdLibs
+    systemd
     wayland
     wayland-protocols
   ];

--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -12,7 +12,7 @@
   hyprwayland-scanner,
   pam,
   sdbus-cpp_2,
-  systemdLibs,
+  systemd,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -59,7 +59,7 @@ gcc15Stdenv.mkDerivation (finalAttrs: {
     pam
     pango
     sdbus-cpp_2
-    systemdLibs
+    systemd
     wayland
     wayland-protocols
   ];

--- a/pkgs/by-name/ir/irods/package.nix
+++ b/pkgs/by-name/ir/irods/package.nix
@@ -11,7 +11,7 @@
   unixODBC,
   jsoncons,
   curl,
-  systemdLibs,
+  systemd,
   openssl,
   boost183,
   nlohmann_json,
@@ -44,7 +44,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     unixODBC
     jsoncons
     curl
-    systemdLibs
+    systemd
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/ir/irqbalance/package.nix
+++ b/pkgs/by-name/ir/irqbalance/package.nix
@@ -7,8 +7,8 @@
   glib,
   ncurses,
   libcap_ng,
-  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
-  systemdMinimal,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   nixosTests,
 }:
 
@@ -32,9 +32,9 @@ stdenv.mkDerivation rec {
     ncurses
     libcap_ng
   ]
-  ++ (lib.optionals enableSystemd [
-    systemdMinimal
-  ]);
+  ++ lib.optionals enableSystemd [
+    systemd
+  ];
 
   configureFlags = lib.optionals enableSystemd [
     "--with-systemd"

--- a/pkgs/by-name/is/isolate/package.nix
+++ b/pkgs/by-name/is/isolate/package.nix
@@ -5,7 +5,7 @@
   asciidoc,
   libcap,
   pkg-config,
-  systemdLibs,
+  systemd,
   installShellFiles,
   nixosTests,
 }:
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libcap.dev
-    systemdLibs.dev
+    systemd.dev
   ];
 
   patches = [

--- a/pkgs/by-name/km/kmscon/package.nix
+++ b/pkgs/by-name/km/kmscon/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   meson,
   libtsm,
-  systemdLibs,
+  systemd,
   libxkbcommon,
   libdrm,
   libGLU,
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtsm
     libxkbcommon
     pango
-    systemdLibs
+    systemd
     libgbm
     check
     # Needed for autoPatchShebangs when strictDeps = true

--- a/pkgs/by-name/kn/knot-resolver_5/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_5/package.nix
@@ -16,7 +16,7 @@
   gnutls,
   lmdb,
   jemalloc,
-  systemdMinimal,
+  systemd,
   libcap_ng,
   dns-root-data,
   nghttp2, # optionals, in principle
@@ -106,7 +106,7 @@ let
     ## the rest are optional dependencies
     ++ optionals stdenv.hostPlatform.isLinux [
       # lib
-      systemdMinimal
+      systemd
       libcap_ng
     ]
     ++ [

--- a/pkgs/by-name/kn/knot-resolver_6/package.nix
+++ b/pkgs/by-name/kn/knot-resolver_6/package.nix
@@ -17,7 +17,7 @@
   lmdb,
   # optionals, in principle
   jemalloc,
-  systemdMinimal,
+  systemd,
   libcap_ng,
   dns-root-data,
   nghttp2,
@@ -88,7 +88,7 @@ let
     ## the rest are optional dependencies
     ++ optionals stdenv.hostPlatform.isLinux [
       # lib
-      systemdMinimal
+      systemd
       libcap_ng
     ]
     ++ [

--- a/pkgs/by-name/la/lact/package.nix
+++ b/pkgs/by-name/la/lact/package.nix
@@ -14,7 +14,7 @@
   vulkan-loader,
   vulkan-tools,
   coreutils,
-  systemdMinimal,
+  systemd,
   nix-update-script,
   nixosTests,
   hwdata,
@@ -71,7 +71,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace lact-daemon/src/server/handler.rs \
-      --replace-fail 'run_command("journalctl",'  'run_command("${systemdMinimal}/bin/journalctl",'
+      --replace-fail 'run_command("journalctl",'  'run_command("${systemd}/bin/journalctl",'
 
     substituteInPlace lact-daemon/src/server/handler.rs \
       --replace-fail 'Command::new("sh")' 'Command::new("${bashNonInteractive}/bin/bash")'

--- a/pkgs/by-name/le/lemurs/package.nix
+++ b/pkgs/by-name/le/lemurs/package.nix
@@ -4,7 +4,7 @@
   bash,
   linux-pam,
   rustPlatform,
-  systemdMinimal,
+  systemd,
   versionCheckHook,
   nixosTests,
 }:
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildInputs = [
     bash
     linux-pam
-    systemdMinimal
+    systemd
   ];
 
   doInstallCheck = true;

--- a/pkgs/by-name/li/libcanberra/package.nix
+++ b/pkgs/by-name/li/libcanberra/package.nix
@@ -12,8 +12,7 @@
   gst_all_1,
   libvorbis,
   libcap,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
-  systemd,
+  udev,
   withAlsa ? stdenv.hostPlatform.isLinux,
   alsa-lib,
 }:
@@ -38,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpulseaudio
     libvorbis
     libtool # in buildInputs rather than nativeBuildInputs since libltdl is used (not libtool itself)
+    udev
   ]
   ++ (with gst_all_1; [
     gstreamer
@@ -46,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional (gtkSupport == "gtk2") gtk2-x11
   ++ lib.optional (gtkSupport == "gtk3") gtk3-x11
   ++ lib.optional stdenv.hostPlatform.isLinux libcap
-  ++ lib.optional withSystemd systemd
   ++ lib.optional withAlsa alsa-lib;
 
   configureFlags = [

--- a/pkgs/by-name/li/libcgroup/package.nix
+++ b/pkgs/by-name/li/libcgroup/package.nix
@@ -5,8 +5,8 @@
   pam,
   bison,
   flex,
-  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   musl-fts,
   autoreconfHook,
 }:
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     pam
   ]
-  ++ lib.optional enableSystemd systemdLibs
+  ++ lib.optional enableSystemd systemd
   ++ lib.optional stdenv.hostPlatform.isMusl musl-fts;
 
   postPatch = ''

--- a/pkgs/by-name/li/libguestfs/package.nix
+++ b/pkgs/by-name/li/libguestfs/package.nix
@@ -19,7 +19,7 @@
   libcap,
   libcap_ng,
   libconfig,
-  systemdLibs,
+  systemd,
   fuse,
   yajl,
   libvirt,
@@ -88,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
     libcap
     libcap_ng
     libconfig
-    systemdLibs
+    systemd
     fuse
     yajl
     libvirt

--- a/pkgs/by-name/li/libusbsio/package.nix
+++ b/pkgs/by-name/li/libusbsio/package.nix
@@ -5,7 +5,7 @@
   pkg-config,
   fixDarwinDylibNames,
   libusb1,
-  systemdMinimal,
+  udev,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
 
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    systemdMinimal # libudev
+    udev
   ];
 
   installPhase = ''

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -15,7 +15,7 @@
   nixosTests,
   meson,
   pkg-config,
-  systemdLibs,
+  systemd,
   docbook5,
   libxslt,
   libxml2,
@@ -23,7 +23,7 @@
   findXMLCatalogs,
   docbook_xsl_ns,
   nix-update-script,
-  withLogind ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  withLogind ? lib.meta.availableOn stdenv.hostPlatform systemd,
   withAudit ?
     lib.meta.availableOn stdenv.hostPlatform audit
     # cross-compilation only works from platforms with linux headers
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     audit
   ]
   ++ lib.optionals withLogind [
-    systemdLibs
+    systemd
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/by-name/li/linyaps/package.nix
+++ b/pkgs/by-name/li/linyaps/package.nix
@@ -19,7 +19,7 @@
   nlohmann_json,
   openssl,
   ostree,
-  systemdLibs,
+  systemd,
   tl-expected,
   uncrustify,
   xz,
@@ -82,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     ostree
     qt6Packages.qtbase
-    systemdLibs
+    systemd
     tl-expected
     uncrustify
     xz

--- a/pkgs/by-name/ma/mako/package.nix
+++ b/pkgs/by-name/ma/mako/package.nix
@@ -6,7 +6,7 @@
   ninja,
   pkg-config,
   scdoc,
-  systemdMinimal,
+  systemd,
   pango,
   cairo,
   gdk-pixbuf,
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland-scanner
   ];
   buildInputs = [
-    systemdMinimal
+    systemd
     pango
     cairo
     gdk-pixbuf
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     gappsWrapperArgs+=(
       --prefix PATH : "${
         lib.makeBinPath [
-          systemdMinimal # for busctl
+          systemd # for busctl
           jq
           bash
         ]

--- a/pkgs/by-name/mi/miraclecast/package.nix
+++ b/pkgs/by-name/mi/miraclecast/package.nix
@@ -12,9 +12,8 @@
   pkg-config,
   readline,
   stdenv,
-  systemdLibs,
+  systemd,
   testers,
-  udev,
   wpa_supplicant,
   relyUdev ? true,
 }:
@@ -52,8 +51,7 @@ stdenv.mkDerivation {
     iproute2
     libtool
     readline
-    systemdLibs
-    udev
+    systemd
     wpa_supplicant
   ];
 

--- a/pkgs/by-name/mi/mission-center/package.nix
+++ b/pkgs/by-name/mi/mission-center/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fetchFromGitLab,
   rustPlatform,
-  systemdMinimal,
+  systemd,
   symlinkJoin,
 
   # nativeBuildInputs
@@ -116,7 +116,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Inject the absolute path to the udevadm binary in magpie's source code
     + ''
       substituteInPlace subprojects/magpie/platform-linux/src/memory.rs \
-        --replace-fail "udevadm" "${lib.getExe' systemdMinimal "udevadm"}"
+        --replace-fail "udevadm" "${lib.getExe' systemd "udevadm"}"
     '';
 
   cargoDeps = symlinkJoin {

--- a/pkgs/by-name/mu/musikcube/package.nix
+++ b/pkgs/by-name/mu/musikcube/package.nix
@@ -24,8 +24,8 @@
   pulseaudio,
   sndioSupport ? true,
   sndio,
-  systemdLibs,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemd,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 
 let
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     portaudio
     taglib
   ]
-  ++ lib.optionals systemdSupport [ systemdLibs ]
+  ++ lib.optionals systemdSupport [ systemd ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     alsa-lib
     pulseaudio

--- a/pkgs/by-name/ne/nemu/package.nix
+++ b/pkgs/by-name/ne/nemu/package.nix
@@ -21,8 +21,8 @@
   socat,
   sqlite,
   stdenv,
-  systemd,
   tigervnc,
+  udev,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -65,8 +65,8 @@ stdenv.mkDerivation (finalAttrs: {
     qemu
     socat
     sqlite
-    systemd # for libudev
     tigervnc
+    udev
   ];
 
   runtimeDependencies = [

--- a/pkgs/by-name/ni/nixos-facter/package.nix
+++ b/pkgs/by-name/ni/nixos-facter/package.nix
@@ -10,7 +10,7 @@
   makeWrapper,
   nixosTests,
   stdenv,
-  systemdMinimal,
+  systemd,
 }:
 let
   # We are waiting on some changes to be merged upstream: https://github.com/openSUSE/hwinfo/pulls
@@ -52,7 +52,7 @@ buildGoModule (finalAttrs: {
   # nixos-facter calls systemd-detect-virt
   postInstall = ''
     wrapProgram "$out/bin/nixos-facter" \
-        --prefix PATH : "${lib.makeBinPath [ systemdMinimal ]}"
+        --prefix PATH : "${lib.makeBinPath [ systemd ]}"
   '';
 
   ldflags = [

--- a/pkgs/by-name/oo/oo7-portal/package.nix
+++ b/pkgs/by-name/oo/oo7-portal/package.nix
@@ -7,7 +7,7 @@
   rustPlatform,
   rustc,
   stdenv,
-  systemdLibs,
+  systemd,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "oo7-portal";
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    systemdLibs
+    systemd
   ];
 
   meta = {

--- a/pkgs/by-name/oo/oo7-server/package.nix
+++ b/pkgs/by-name/oo/oo7-server/package.nix
@@ -7,7 +7,7 @@
   rustPlatform,
   rustc,
   stdenv,
-  systemdLibs,
+  systemd,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "oo7-server";
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    systemdLibs
+    systemd
   ];
 
   meta = {

--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -9,12 +9,12 @@
   libsodium,
   libtool,
   openssl,
-  systemdMinimal,
+  systemd,
   libxcrypt,
 
   # options
   withModules ? !stdenv.hostPlatform.isStatic,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 
   # passthru
   nixosTests,
@@ -67,7 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
     libsodium
   ]
   ++ lib.optionals withSystemd [
-    systemdMinimal
+    systemd
   ];
 
   preConfigure = lib.optionalString (lib.versionAtLeast stdenv.hostPlatform.darwinMinVersion "11") ''

--- a/pkgs/by-name/pc/pcsclite/package.nix
+++ b/pkgs/by-name/pc/pcsclite/package.nix
@@ -10,10 +10,10 @@
   python3,
   dbus,
   polkit,
-  systemdLibs,
+  systemd,
   udev,
   dbusSupport ? stdenv.hostPlatform.isLinux,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   udevSupport ? dbusSupport,
   libusb1,
   testers,
@@ -99,7 +99,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     python3
   ]
-  ++ lib.optionals systemdSupport [ systemdLibs ]
+  ++ lib.optionals systemdSupport [ systemd ]
   ++ lib.optionals (!systemdSupport && udevSupport) [ udev ]
   ++ lib.optionals dbusSupport [ dbus ]
   ++ lib.optionals polkitSupport [ polkit ]

--- a/pkgs/by-name/po/polkit/package.nix
+++ b/pkgs/by-name/po/polkit/package.nix
@@ -22,8 +22,8 @@
   docbook_xml_dtd_412,
   gtk-doc,
   coreutils,
-  useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
-  systemdMinimal,
+  useSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   elogind,
   buildPackages,
   withIntrospection ?
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     # On Linux, fall back to elogind when systemd support is off.
-    (if useSystemd then systemdMinimal else elogind)
+    (if useSystemd then systemd else elogind)
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/pp/ppp/package.nix
+++ b/pkgs/by-name/pp/ppp/package.nix
@@ -11,8 +11,8 @@
   openssl,
   pkg-config,
   stdenv,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
-  systemdMinimal,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
   ]
   ++ lib.optionals withSystemd [
-    systemdMinimal
+    systemd
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ra/rauc/package.nix
+++ b/pkgs/by-name/ra/rauc/package.nix
@@ -14,7 +14,7 @@
   ninja,
   util-linux,
   libnl,
-  systemdLibs,
+  systemd,
   nixosTests,
 }:
 
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     openssl
     util-linux
     libnl
-    systemdLibs
+    systemd
   ];
 
   mesonFlags = [

--- a/pkgs/by-name/re/realmd/package.nix
+++ b/pkgs/by-name/re/realmd/package.nix
@@ -10,7 +10,7 @@
   polkit,
   samba,
   stdenv,
-  systemdLibs,
+  systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     openldap
     polkit
     samba
-    systemdLibs
+    systemd
   ];
 
   configureFlags = [

--- a/pkgs/by-name/sd/sdl3/package.nix
+++ b/pkgs/by-name/sd/sdl3/package.nix
@@ -31,7 +31,7 @@
   nixosTests,
   pipewire,
   sndio,
-  systemdLibs,
+  systemd,
   testers,
   validatePkgConfig,
   vulkan-headers,
@@ -137,7 +137,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional jackSupport libjack2
     ++ lib.optional libdecorSupport libdecor
-    ++ lib.optional libudevSupport systemdLibs
+    ++ lib.optional libudevSupport systemd
     ++ lib.optional openglSupport libGL
     ++ lib.optional pipewireSupport pipewire
     ++ lib.optional pulseaudioSupport libpulseaudio

--- a/pkgs/by-name/se/sedutil/package.nix
+++ b/pkgs/by-name/se/sedutil/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
-  systemdLibs,
+  systemd,
   libnvme,
 }:
 
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ autoreconfHook ];
 
   buildInputs = [
-    systemdLibs
+    systemd
     libnvme
   ];
 

--- a/pkgs/by-name/sf/sftool-gui/package.nix
+++ b/pkgs/by-name/sf/sftool-gui/package.nix
@@ -6,7 +6,7 @@
   glib-networking,
   nodejs,
   libgudev,
-  systemdLibs,
+  systemd,
   fetchPnpmDeps,
   pnpmConfigHook,
   pnpm,
@@ -56,7 +56,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     glib-networking # Most Tauri apps need networking
     webkitgtk_4_1
     libgudev
-    systemdLibs
+    systemd
   ];
 
   # Set our Tauri source directory

--- a/pkgs/by-name/sf/sftool/package.nix
+++ b/pkgs/by-name/sf/sftool/package.nix
@@ -3,7 +3,7 @@
   pkg-config,
   rustPlatform,
   stdenv,
-  systemdLibs,
+  udev,
   fetchFromGitHub,
   nix-update-script,
 }:
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
-    systemdLibs # libudev-sys
+    udev
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/si/signal-desktop-bin/generic.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/generic.nix
@@ -46,7 +46,7 @@
   libgbm,
   libwebp,
   # Runtime dependencies:
-  systemdLibs,
+  systemd,
   libnotify,
   libdbusmenu,
   libpulseaudio,
@@ -187,13 +187,13 @@ stdenv.mkDerivation (finalAttrs: {
     nspr
     nss
     pango
-    systemdLibs
+    systemd
     libxcb
     libxshmfence
   ];
 
   runtimeDependencies = [
-    systemdLibs
+    (lib.getLib systemd)
     libappindicator-gtk3
     libnotify
     libdbusmenu

--- a/pkgs/by-name/si/sitespeed-io/package.nix
+++ b/pkgs/by-name/si/sitespeed-io/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   buildNpmPackage,
-  systemdLibs,
+  systemd,
   coreutils,
   ffmpeg-headless,
   imagemagick_light,
@@ -44,7 +44,7 @@ buildNpmPackage (finalAttrs: {
   };
 
   buildInputs = [
-    systemdLibs
+    systemd
   ];
 
   dontNpmBuild = true;

--- a/pkgs/by-name/sm/smartmontools/package.nix
+++ b/pkgs/by-name/sm/smartmontools/package.nix
@@ -7,7 +7,7 @@
   gnused,
   hostname,
   mailutils,
-  systemdLibs,
+  systemd,
   writeShellScript,
   nix-update,
 }:
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   nativeBuildInputs = [ autoreconfHook ];
-  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform systemdLibs) [ systemdLibs ];
+  buildInputs = lib.optionals (lib.meta.availableOn stdenv.hostPlatform systemd) [ systemd ];
   enableParallelBuilding = true;
 
   drivedb = fetchFromGitHub {

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -10,7 +10,7 @@
   itstool,
   libtool,
   texinfo,
-  systemdMinimal,
+  systemd,
   util-linux,
   autoreconfHook,
   glib,
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     python
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
-    systemdMinimal # libsystemd
+    systemd # libsystemd
   ]
   ++ lib.optionals withAlsa [
     alsa-lib

--- a/pkgs/by-name/sv/svp/package.nix
+++ b/pkgs/by-name/sv/svp/package.nix
@@ -15,7 +15,7 @@
   libusb1,
   vapoursynth,
   libx11,
-  systemdLibs,
+  systemd,
   openssl,
   p7zip,
 }:
@@ -54,7 +54,7 @@ let
     libusb1
     vapoursynth
     libx11
-    systemdLibs
+    (lib.getLib systemd)
     openssl
   ];
 

--- a/pkgs/by-name/sw/swayidle/package.nix
+++ b/pkgs/by-name/sw/swayidle/package.nix
@@ -10,8 +10,8 @@
   wayland,
   wayland-protocols,
   runtimeShell,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
   ]
-  ++ lib.optionals systemdSupport [ systemdLibs ];
+  ++ lib.optionals systemdSupport [ systemd ];
 
   mesonFlags = [
     "-Dman-pages=enabled"

--- a/pkgs/by-name/sy/systemd-netlogd/package.nix
+++ b/pkgs/by-name/sy/systemd-netlogd/package.nix
@@ -12,7 +12,6 @@
   pkgsCross,
   sphinx,
   systemd,
-  systemdLibs,
   testers,
   opensslSupport ? true,
 }:
@@ -58,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     libcap
-    systemdLibs
+    systemd
   ]
   ++ lib.optional opensslSupport openssl;
 

--- a/pkgs/by-name/tm/tmux/package.nix
+++ b/pkgs/by-name/tm/tmux/package.nix
@@ -8,8 +8,8 @@
   ncurses,
   pkg-config,
   runCommand,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   # broken on i686-linux https://github.com/tmux/tmux/issues/4597
   withUtf8proc ? !(stdenv.hostPlatform.is32bit),
   utf8proc, # gets Unicode updates faster than glibc
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
     libevent
   ]
-  ++ lib.optionals withSystemd [ systemdLibs ]
+  ++ lib.optionals withSystemd [ systemd ]
   ++ lib.optionals withUtf8proc [ utf8proc ]
   ++ lib.optionals withUtempter [ libutempter ];
 

--- a/pkgs/by-name/ud/udev-block-notify/package.nix
+++ b/pkgs/by-name/ud/udev-block-notify/package.nix
@@ -4,7 +4,7 @@
   multimarkdown,
   libnotify,
   udev,
-  systemdLibs,
+  systemd,
   glib,
   pkg-config,
   lib,
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     libnotify
     udev
-    systemdLibs
+    systemd
     glib
   ];
 

--- a/pkgs/by-name/um/umockdev/package.nix
+++ b/pkgs/by-name/um/umockdev/package.nix
@@ -14,7 +14,7 @@
   pkg-config,
   python3,
   replaceVars,
-  systemdMinimal,
+  systemd,
   usbutils,
   vala,
   which,
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
     # umockdev will just work without having to provide it in their test environment
     # $PATH.
     (replaceVars ./substitute-udevadm.patch {
-      udevadm = "${systemdMinimal}/bin/udevadm";
+      udevadm = "${systemd}/bin/udevadm";
     })
   ];
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     glib
-    systemdMinimal
+    systemd
     libpcap
   ];
 

--- a/pkgs/by-name/us/ustreamer/package.nix
+++ b/pkgs/by-name/us/ustreamer/package.nix
@@ -14,7 +14,7 @@
   jansson,
   libopus,
   nixosTests,
-  systemdLibs,
+  systemd,
   which,
   python3Packages,
   withSystemd ? true,
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   )
   ++ lib.optionals withSystemd [
-    systemdLibs
+    systemd
   ]
   ++ lib.optionals withJanus [
     janus-gateway

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -19,8 +19,8 @@
   ncurses,
   pamSupport ? lib.meta.availableOn stdenv.hostPlatform pam,
   pam,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
   sqlite,
   nlsSupport ? true,
   translateManpages ? true,
@@ -170,7 +170,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optionals pamSupport [ pam ]
   ++ lib.optionals capabilitiesSupport [ libcap_ng ]
   ++ lib.optionals ncursesSupport [ ncurses ]
-  ++ lib.optionals systemdSupport [ systemdLibs ];
+  ++ lib.optionals systemdSupport [ systemd ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/uu/uutils-procps/package.nix
+++ b/pkgs/by-name/uu/uutils-procps/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pkg-config,
   writableTmpDirAsHomeHook,
-  systemdLibs,
+  systemd,
   nix-update-script,
 }:
 
@@ -26,7 +26,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     writableTmpDirAsHomeHook
   ];
 
-  buildInputs = [ systemdLibs ];
+  buildInputs = [ systemd ];
 
   checkFlags = [
     # can't run on sandbox

--- a/pkgs/by-name/vi/viber/package.nix
+++ b/pkgs/by-name/vi/viber/package.nix
@@ -50,7 +50,7 @@
   openssl,
   snappy,
   speex,
-  systemdLibs,
+  systemd,
   tslib,
   twolame,
   wavpack,
@@ -146,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
     snappy
     speex
     stdenv.cc.cc
-    systemdLibs
+    systemd
     tslib
     twolame
     wavpack

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -75,7 +75,7 @@
   speex,
   srt,
   stdenv,
-  systemdLibs,
+  systemd,
   taglib_1,
   unzip,
   wayland,
@@ -191,7 +191,7 @@ stdenv.mkDerivation (finalAttrs: {
     schroedinger
     speex
     srt
-    systemdLibs
+    systemd
     taglib_1
     libxcb-keysyms
     zlib

--- a/pkgs/by-name/wa/waybar/package.nix
+++ b/pkgs/by-name/wa/waybar/package.nix
@@ -35,7 +35,7 @@
   scdoc,
   sndio,
   spdlog,
-  systemdMinimal,
+  systemd,
   udev,
   upower,
   versionCheckHook,
@@ -60,7 +60,7 @@
   rfkillSupport ? true,
   runTests ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
   sndioSupport ? true,
-  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
+  systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   traySupport ? true,
   udevSupport ? true,
   upowerSupport ? true,
@@ -145,9 +145,8 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional nlSupport libnl
   ++ lib.optional pulseSupport libpulseaudio
   ++ lib.optional sndioSupport sndio
-  ++ lib.optional systemdSupport systemdMinimal
   ++ lib.optional traySupport libdbusmenu-gtk3
-  ++ lib.optional udevSupport udev
+  ++ lib.optional (systemdSupport || udevSupport) udev
   ++ lib.optional upowerSupport upower
   ++ lib.optional wireplumberSupport wireplumber
   ++ lib.optional (cavaSupport || pipewireSupport) pipewire

--- a/pkgs/by-name/yp/ypbind-mt/package.nix
+++ b/pkgs/by-name/yp/ypbind-mt/package.nix
@@ -8,7 +8,7 @@
   libxcrypt,
   pkg-config,
   rpcbind,
-  systemdLibs,
+  systemd,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     libtirpc
     libxcrypt
     rpcbind
-    systemdLibs
+    systemd
   ];
 
   meta = {

--- a/pkgs/by-name/zi/zigbee2mqtt/package.nix
+++ b/pkgs/by-name/zi/zigbee2mqtt/package.nix
@@ -7,10 +7,10 @@
   pnpm_9,
   fetchPnpmDeps,
   pnpmConfigHook,
-  systemdMinimal,
+  systemd,
   nixosTests,
   nix-update-script,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "zigbee2mqtt";
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = lib.optionals withSystemd [
-    systemdMinimal
+    systemd
   ];
 
   buildPhase = ''

--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -25,7 +25,7 @@ let
       libargon2,
       libxml2,
       pcre2,
-      systemdLibs,
+      systemd,
       system-sendmail,
       valgrind,
       xcbuild,
@@ -61,7 +61,7 @@ let
       ipv6Support ? true,
       zendSignalsSupport ? true,
       zendMaxExecutionTimersSupport ? false,
-      systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
+      systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
       valgrindSupport ?
         !stdenv.hostPlatform.isDarwin && lib.meta.availableOn stdenv.hostPlatform valgrind,
       ztsSupport ? apxs2Support,
@@ -254,7 +254,7 @@ let
             # Misc deps
             ++ lib.optional apxs2Support apacheHttpd
             ++ lib.optional argon2Support libargon2
-            ++ lib.optional systemdSupport systemdLibs
+            ++ lib.optional systemdSupport systemd
             ++ lib.optional valgrindSupport valgrind;
 
           CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";

--- a/pkgs/development/libraries/sdbus-cpp/default.nix
+++ b/pkgs/development/libraries/sdbus-cpp/default.nix
@@ -5,7 +5,7 @@
   cmake,
   expat,
   pkg-config,
-  systemdLibs,
+  systemd,
 }:
 let
   generic =
@@ -31,7 +31,7 @@ let
 
       buildInputs = [
         expat
-        systemdLibs
+        systemd
       ];
 
       cmakeFlags = [

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -63,7 +63,7 @@
   bubblewrap,
   libseccomp,
   libbacktrace,
-  systemdLibs,
+  systemd,
   xdg-dbus-proxy,
   replaceVars,
   glib,
@@ -72,7 +72,7 @@
   enableGeoLocation ? true,
   enableExperimental ? false,
   withLibsecret ? true,
-  systemdSupport ? lib.meta.availableOn clangStdenv.hostPlatform systemdLibs,
+  systemdSupport ? lib.meta.availableOn clangStdenv.hostPlatform systemd,
   testers,
   fetchpatch,
 }:
@@ -189,7 +189,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     libx11
   ]
   ++ lib.optionals systemdSupport [
-    systemdLibs
+    systemd
   ]
   ++ lib.optionals enableGeoLocation [
     geoclue2

--- a/pkgs/development/libraries/xdg-desktop-portal/default.nix
+++ b/pkgs/development/libraries/xdg-desktop-portal/default.nix
@@ -5,7 +5,7 @@
   fuse3,
   bubblewrap,
   docutils,
-  systemdMinimal,
+  systemd,
   geoclue2,
   glib,
   gsettings-desktop-schemas,
@@ -102,7 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
     geoclue2
   ]
   ++ lib.optionals enableSystemd [
-    systemdMinimal # libsystemd
+    systemd
   ];
 
   nativeCheckInputs = [

--- a/pkgs/development/ocaml-modules/systemd/default.nix
+++ b/pkgs/development/ocaml-modules/systemd/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildDunePackage,
   fetchFromGitHub,
-  systemdLibs,
+  pkgs,
 }:
 buildDunePackage {
   pname = "systemd";
@@ -14,7 +14,7 @@ buildDunePackage {
     hash = "sha256-/FV+mFhuB3mEZv34XZrA4gO6+QIYssXqurnvkNBTJ2o=";
   };
   minimalOCamlVersion = "4.06";
-  propagatedBuildInputs = [ systemdLibs ];
+  propagatedBuildInputs = [ pkgs.systemd ];
   meta = {
     platforms = lib.platforms.linux;
     description = "OCaml module for native access to the systemd facilities";

--- a/pkgs/development/web/playwright/webkit.nix
+++ b/pkgs/development/web/playwright/webkit.nix
@@ -42,7 +42,7 @@
   libxslt,
   libgbm,
   sqlite,
-  systemdLibs,
+  systemd,
   wayland-scanner,
   woff2,
   zlib,
@@ -184,7 +184,7 @@ let
       libxslt
       libgbm
       sqlite
-      systemdLibs
+      systemd
       wayland-scanner
       woff2.lib
       libxkbcommon

--- a/pkgs/kde/gear/kpmcore/default.nix
+++ b/pkgs/kde/gear/kpmcore/default.nix
@@ -7,7 +7,7 @@
   lvm2,
   mdadm,
   smartmontools,
-  systemdMinimal,
+  systemd,
   util-linux,
   bcachefs-tools,
   btrfs-progs,
@@ -30,7 +30,7 @@ let
     lvm2
     mdadm
     smartmontools
-    systemdMinimal
+    systemd
     util-linux
 
     bcachefs-tools

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -51,7 +51,7 @@ rec {
     buildInputs = [ systemd ];
     tags = [ "withjournald" ];
     postFixup = ''
-      patchelf --set-rpath ${lib.makeLibraryPath [ (lib.getLib systemd) ]} "$out/bin/filebeat"
+      patchelf --set-rpath ${lib.makeLibraryPath [ systemd ]} "$out/bin/filebeat"
     '';
   };
   heartbeat7 = beat "heartbeat" {

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -9,8 +9,8 @@
 
   # `ps` with systemd support is able to properly report different
   # attributes like unit name, so we want to have it on linux.
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-  systemdLibs,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  systemd,
 
   # procps is mostly Linux-only. Most commands require a running Linux
   # system (or very similar like that found in Cygwin). The one
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Z76m+8OkKlNaAjDJ6JHl3ftNnTlCLUZWWimQ0azhUhY=";
   };
 
-  buildInputs = [ ncurses ] ++ lib.optionals withSystemd [ systemdLibs ];
+  buildInputs = [ ncurses ] ++ lib.optionals withSystemd [ systemd ];
   nativeBuildInputs = [
     pkg-config
     autoreconfHook

--- a/pkgs/os-specific/linux/systemd/0009-add-current-system-to-lookup-dir-paths.patch
+++ b/pkgs/os-specific/linux/systemd/0009-add-current-system-to-lookup-dir-paths.patch
@@ -1,12 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Andreas Rammhold <andreas@rammhold.de>
 Date: Thu, 9 May 2019 11:15:22 +0200
-Subject: [PATCH] add rootprefix to lookup dir paths
+Subject: [PATCH] add current-system to lookup dir paths
 
 systemd does not longer use the UDEVLIBEXEC directory as root for
-discovery default udev rules. By adding `$out/lib` to the lookup paths
-we should again be able to discover the udev rules amongst other default
-files that I might have missed.
+discovery default udev rules. By adding
+`/run/current-system/systemd/lib` to the lookup paths we should again be
+able to discover the udev rules amongst other default files that I might
+have missed.
 ---
  src/basic/constants.h | 6 ++++--
  1 file changed, 4 insertions(+), 2 deletions(-)
@@ -21,7 +22,7 @@ index a26cff4062..3800c37e1b 100644
          "/usr/local/lib/" n "\0"                \
 -        "/usr/lib/" n "\0"
 +        "/usr/lib/" n "\0"                      \
-+        PREFIX "/lib/" n "\0"
++        "/run/current-system/systemd/lib/" n "\0"
  
  #define CONF_PATHS(n)                           \
          "/etc/" n,                              \
@@ -29,7 +30,7 @@ index a26cff4062..3800c37e1b 100644
          "/usr/local/lib/" n,                    \
 -        "/usr/lib/" n
 +        "/usr/lib/" n,                          \
-+        PREFIX "/lib/" n
++        "/run/current-system/systemd/lib/" n
  
  #define CONF_PATHS_STRV(n)                      \
          STRV_MAKE(CONF_PATHS(n))

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -399,6 +399,7 @@ stdenv.mkDerivation (finalAttrs: {
       [
         "man"
       ]
+      ++ lib.optional withTimesyncd "timesyncd"
   );
   separateDebugInfo = true;
   __structuredAttrs = true;
@@ -925,7 +926,45 @@ stdenv.mkDerivation (finalAttrs: {
     ''
     + lib.optionalString (withSysusers && !buildLibsOnly) ''
       mv $out/lib/sysusers.d $out/example
-    '';
+    ''
+    + (
+      let
+        customOutputs = {
+          timesyncd = [
+            "example/systemd/system/systemd-timesyncd.service"
+            "example/sysusers.d/systemd-timesync.conf" # this file seems to be unused regardless of whether it is moved...
+            "lib/systemd/ntp-units.d"
+            "lib/systemd/systemd-timesyncd"
+            "share/dbus-1/system.d/org.freedesktop.timesync1.conf"
+            "share/dbus-1/system-services/org.freedesktop.timesync1.service"
+            "share/polkit-1/actions/org.freedesktop.timesync1.policy"
+          ];
+        };
+        filtered = lib.filterAttrs (name: _: builtins.elem name finalAttrs.outputs) customOutputs;
+      in
+      lib.optionalString (!buildLibsOnly && filtered != { }) ''
+        systemdMoveTo() {
+          local dst=$1 path dst_path
+          shift
+          for path; do
+            dst_path=''${path/#example/lib}
+            mkdir -p "$dst/$(dirname "$dst_path")"
+            mv "$out/$path" "$dst/$dst_path"
+          done
+          for path; do
+            dst_path=''${path/#example/lib}
+            case $path in
+              *.*) ;;
+              *) find "$dst" -type f -name '*.service' -exec sed -i "s#$out/$path#$dst/$dst_path#g" '{}' \; ;;
+            esac
+          done
+        }
+
+        ${lib.concatMapAttrsStringSep "\n" (
+          output: paths: "systemdMoveTo \"\$${output}\" ${lib.concatStringsSep " " paths}"
+        ) filtered}
+      ''
+    );
 
   doInstallCheck = true;
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -1,4 +1,4 @@
-{
+args@{
   stdenv,
   lib,
   nixosTests,
@@ -88,6 +88,9 @@
   # Needed to produce a ukify that works for cross compiling UKIs.
   targetPackages,
 
+  # If you are adding a build option to this list, consider also adding it to
+  # the set of overrides in libsOnly below.
+
   withAcl ? true,
   withAnalyze ? true,
   withApparmor ? true,
@@ -97,7 +100,7 @@
     withEfi
     # "Unknown 64-bit data model"
     && !stdenv.hostPlatform.isRiscV32,
-  # adds bzip2, lz4, xz and zstd
+  # adds bzip2, lz4, xz, zlib, and zstd
   withCompression ? true,
   withCoredump ? true,
   withCryptsetup ? true,
@@ -134,7 +137,7 @@
   withLogind ? true,
   withMachined ? true,
   withNetworkd ? true,
-  withNspawn ? !buildLibsOnly,
+  withNspawn ? true,
   withNss ? !stdenv.hostPlatform.isMusl,
   withOomd ? true,
   withOpenSSL ? true,
@@ -171,6 +174,8 @@
   withTests ? false,
   # build only libudev and libsystemd
   buildLibsOnly ? false,
+  # verify that the libsOnly overrides are harmless during postFixup
+  checkLibsystemdCorrectness ? true,
 
   # yes, pname is an argument here
   pname ? "systemd",
@@ -190,7 +195,7 @@ assert withHomed -> withOpenSSL;
 assert withFido2 -> withOpenSSL;
 assert withSysupdate -> withOpenSSL;
 assert withImportd -> (withGcrypt || withOpenSSL);
-assert withUkify -> (withEfi && withBootloader);
+assert withUkify -> withBootloader;
 assert withRepart -> withCryptsetup;
 assert withBootloader -> withEfi;
 
@@ -203,9 +208,101 @@ let
   #  $ curl -s https://api.github.com/repos/systemd/systemd/releases/latest | \
   #     jq '.created_at|strptime("%Y-%m-%dT%H:%M:%SZ")|mktime'
   releaseTimestamp = "1766012573";
+
+  # We somewhat awkwardly split this derivation into two: one containing
+  # libsystemd.so and libudev.so, the two public shared libraries in systemd;
+  # and one containing everything but those libraries. buildLibsOnly determines
+  # which of the two variants are being built. The libsOnly variant takes fewer
+  # dependencies, so that some external packages (libfido2, for example) can
+  # have a dependency on libsOnly but be dependencies of the main derivation.
+  # But to prevent a proliferation of systemd derivations in a closure, we try
+  # to build libsOnly with all of the relevant flags that the main derivation
+  # will use. The set of irrelevant flags is specified below — flags that only
+  # affect the contents of the main derivation, and which can safely be
+  # disabled in libsOnly without affecting any functionality. This way, the
+  # same libsOnly derivation can be used by dependencies of the main derivation
+  # and by the rest of the system closure. As a convenient hack, a passthru.lib
+  # property allows the libsOnly derivation to be consumed as if it was the lib
+  # output of the main derivation.
+  #
+  # (An alternate design, putting libsystemd.so and libudev.so into a true lib
+  # output, would not have broken the dependency cycle between systemd.lib ->
+  # libfido2 -> systemd.out without also putting a second copy of the systemd
+  # libs in the final closure.)
+
+  libsOnly =
+    assert lib.assertMsg (!buildLibsOnly) "libsOnly should not be used when buildLibsOnly is true";
+    import ./. (
+      args
+      // {
+        buildLibsOnly = true;
+
+        # Every flag that gets added to this set becomes one that can be
+        # overridden in systemd while sharing the same libsOnly derivation, so
+        # the more the merrier, as long as it wouldn't affect the libsOnly
+        # build. (systemdVerifyLibEquality verifies this.)
+        withAcl = false;
+        withAnalyze = false;
+        withApparmor = false;
+        withAudit = false;
+        withBootloader = false;
+        withCoredump = false;
+        withCryptsetup = false;
+        withDocumentation = false;
+        withEfi = false;
+        withFido2 = false;
+        withFirstboot = false;
+        withHomed = false;
+        withHostnamed = false;
+        withHwdb = false;
+        withImportd = false;
+        withKernelInstall = false;
+        withKexectools = false;
+        withKmod = false;
+        withLibarchive = false;
+        withLibseccomp = false;
+        withLibidn2 = false;
+        withLocaled = false;
+        withLogind = false;
+        withMachined = false;
+        withNetworkd = false;
+        withNspawn = false;
+        withNss = false;
+        withOomd = false;
+        withOpenSSL = false;
+        withPam = false;
+        withPasswordQuality = false;
+        withPCRE2 = false;
+        withPolkit = false;
+        withPortabled = false;
+        withQrencode = false;
+        withRemote = false;
+        withRepart = false;
+        withResolved = false;
+        withSelinux = false;
+        withShellCompletions = false;
+        withSysupdate = false;
+        withSysusers = false;
+        withTests = false;
+        withTimedated = false;
+        withTimesyncd = false;
+        withTpm2Tss = false;
+        withUkify = false;
+        withUserDb = false;
+        withUtmp = false;
+        withVConsole = false;
+        withVmspawn = false;
+      }
+    );
+
+  libsOnlyTargets = [
+    "devel"
+    "libsystemd"
+    "libudev"
+  ];
 in
 stdenv.mkDerivation (finalAttrs: {
-  inherit pname;
+  pname = if buildLibsOnly then "lib${pname}" else pname;
   version = "259";
 
   src = fetchFromGitHub {
@@ -232,7 +329,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0006-hostnamed-localed-timedated-disable-methods-that-cha.patch
     ./0007-Change-usr-share-zoneinfo-to-etc-zoneinfo.patch
     ./0008-localectl-use-etc-X11-xkb-for-list-x11.patch
-    ./0009-add-rootprefix-to-lookup-dir-paths.patch
+    ./0009-add-current-system-to-lookup-dir-paths.patch
     ./0010-systemd-shutdown-execute-scripts-in-etc-systemd-syst.patch
     ./0011-systemd-sleep-execute-scripts-in-etc-systemd-system-.patch
     ./0012-path-util.h-add-placeholder-for-DEFAULT_PATH_NORMAL.patch
@@ -254,7 +351,20 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   postPatch = ''
-    substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" "${placeholder "out"}/bin/"
+    substituteInPlace src/core/systemd.pc.in --replace-fail '{{PREFIX_NOSLASH}}' /run/current-system/systemd
+    substituteInPlace src/libsystemd/sd-path/{path-lookup,sd-path}.c \
+      --replace-fail SYSTEM_DATA_UNIT_DIR     '"/run/current-system/systemd/lib/systemd/system"' \
+      --replace-fail USER_DATA_UNIT_DIR       '"/run/current-system/systemd/lib/systemd/user"' \
+      --replace-fail SYSTEM_GENERATOR_DIR     '"/run/current-system/systemd/lib/systemd/system-generators"' \
+      --replace-fail USER_GENERATOR_DIR       '"/run/current-system/systemd/lib/systemd/user-generators"' \
+      --replace-fail SYSTEM_ENV_GENERATOR_DIR '"/run/current-system/systemd/lib/systemd/system-environment-generators"' \
+      --replace-fail USER_ENV_GENERATOR_DIR   '"/run/current-system/systemd/lib/systemd/user-environment-generators"'
+    substituteInPlace src/libsystemd/sd-path/sd-path.c \
+      --replace-fail LIBDIR                   '"/run/current-system/systemd/lib"' \
+      --replace-fail PREFIX_NOSLASH           '"/run/current-system/systemd"'
+    substituteInPlace src/libsystemd/sd-hwdb/hwdb-internal.h \
+      --replace-fail UDEVLIBEXECDIR           '"/run/current-system/systemd/lib/udev"'
+    substituteInPlace src/basic/path-util.h --replace "@defaultPathNormal@" /run/current-system/systemd/bin/
   ''
   + lib.optionalString withLibBPF ''
     substituteInPlace meson.build \
@@ -279,9 +389,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   outputs = [
     "out"
-    "dev"
   ]
-  ++ (lib.optional (!buildLibsOnly) "man");
+  ++ (
+    if buildLibsOnly then
+      [
+        "dev"
+      ]
+    else
+      [
+        "man"
+      ]
+  );
   separateDebugInfo = true;
   __structuredAttrs = true;
 
@@ -340,7 +458,7 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
     libgpg-error
   ]
-  ++ lib.optionals withOpenSSL [ openssl ]
+  ++ lib.optional withOpenSSL openssl
   ++ lib.optional withTests glib
   ++ lib.optional withAcl acl
   ++ lib.optional withApparmor libapparmor
@@ -354,7 +472,10 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
   ]
   ++ lib.optional withCoredump elfutils
-  ++ lib.optional withCryptsetup (lib.getDev cryptsetup.dev)
+  ++ lib.optionals withCryptsetup [
+    (lib.getDev cryptsetup)
+    p11-kit
+  ]
   ++ lib.optional withKexectools kexec-tools
   ++ lib.optional withKmod kmod
   ++ lib.optional withLibidn2 libidn2
@@ -366,14 +487,13 @@ stdenv.mkDerivation (finalAttrs: {
     libmicrohttpd
     gnutls
   ]
-  ++ lib.optionals (withHomed || withCryptsetup) [ p11-kit ]
-  ++ lib.optionals (withHomed || withCryptsetup) [ libfido2 ]
-  ++ lib.optionals withLibBPF [ libbpf ]
+  ++ lib.optional withFido2 libfido2
+  ++ lib.optional withLibBPF libbpf
   ++ lib.optional withTpm2Tss tpm2-tss
   ++ lib.optional withUkify (python3Packages.python.withPackages (ps: with ps; [ pefile ]))
-  ++ lib.optionals withPasswordQuality [ libpwquality ]
-  ++ lib.optionals withQrencode [ qrencode ]
-  ++ lib.optionals withLibarchive [ libarchive ]
+  ++ lib.optional withPasswordQuality libpwquality
+  ++ lib.optional withQrencode qrencode
+  ++ lib.optional withLibarchive libarchive
   ++ lib.optional (withBootloader && stdenv.targetPlatform.useLLVM or false) (
     llvmPackages.compiler-rt.override {
       doFakeLibgcc = true;
@@ -420,8 +540,12 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonOption "dbussystemservicedir" "${placeholder "out"}/share/dbus-1/system-services")
 
     # pkgconfig
-    (lib.mesonOption "pkgconfiglibdir" "${placeholder "dev"}/lib/pkgconfig")
-    (lib.mesonOption "pkgconfigdatadir" "${placeholder "dev"}/share/pkgconfig")
+    (lib.mesonOption "pkgconfiglibdir" (
+      if buildLibsOnly then "${placeholder "dev"}/lib/pkgconfig" else "no"
+    ))
+    (lib.mesonOption "pkgconfigdatadir" (
+      if buildLibsOnly then "${placeholder "dev"}/share/pkgconfig" else "no"
+    ))
 
     # SBAT
     (lib.mesonOption "sbat-distro" "nixos")
@@ -481,7 +605,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Cryptsetup
     (lib.mesonEnable "libcryptsetup" withCryptsetup)
     (lib.mesonEnable "libcryptsetup-plugins" withCryptsetup)
-    (lib.mesonEnable "p11kit" (withHomed || withCryptsetup))
+    (lib.mesonEnable "p11kit" withCryptsetup)
 
     # FIDO2
     (lib.mesonEnable "libfido2" withFido2)
@@ -619,7 +743,7 @@ stdenv.mkDerivation (finalAttrs: {
       ++ lib.optionals withNspawn [
         {
           # we only need to patch getent when nspawn will actually be built/installed
-          # as of systemd 257.x, nspawn will not be installed on systemdLibs, so we don't need to patch it
+          # as of systemd 257.x, nspawn will not be installed on libsOnly, so we don't need to patch it
           # patching getent unconditionally here introduces infinite recursion on musl
           search = "/usr/bin/getent";
           replacement = "${getent}/bin/getent";
@@ -707,7 +831,7 @@ stdenv.mkDerivation (finalAttrs: {
       ${lib.concatMapStringsSep "\n" mkEnsureSubstituted binaryReplacements}
 
       substituteInPlace src/libsystemd/sd-journal/catalog.c \
-        --replace /usr/lib/systemd/catalog/ $out/lib/systemd/catalog/
+        --replace /usr/lib/systemd/catalog/ /run/current-system/systemd/lib/systemd/catalog/
 
       substituteInPlace src/import/pull-tar.c \
         --replace 'wait_for_terminate_and_check("tar"' 'wait_for_terminate_and_check("${gnutar}/bin/tar"'
@@ -720,7 +844,25 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "POLKIT_AGENT_BINARY_PATH" "_POLKIT_AGENT_BINARY_PATH" \
       --replace "SYSTEMD_BINARY_PATH" "_SYSTEMD_BINARY_PATH" \
       --replace "SYSTEMD_CGROUP_AGENTS_PATH" "_SYSTEMD_CGROUP_AGENT_PATH"
-  '';
+  ''
+  # This is some silliness to make the systemdVerifyLibEquality check work.
+  # Meson generates a build file that links more libraries than are actually
+  # used by the public libraries, which results in a larger .dynstr section in
+  # the compiled binaries when more dependencies are enabled for the entire
+  # project. Filtering out these unused dependencies is harmless (if it
+  # weren't, the link would fail), if not marginally beneficial; and results in
+  # binaries that are near-identical (the remaining differences can be patched
+  # post-compilation).
+  + lib.optionalString (!buildLibsOnly) (
+    let
+      allowedPaths = lib.concatMapStringsSep "|" (
+        x: lib.escapeRegex (lib.getLib x).outPath
+      ) libsOnly.buildInputs;
+    in
+    ''
+      sed -Ei '/^build lib(systemd|udev)\.so/,+1s#( *(${allowedPaths})/lib/lib[^ .]*\.so)| */nix/store/[^ /]*/lib/lib[^ .]*\.so|( *[^ ]+)#\1\3#g' build.ninja
+    ''
+  );
 
   env.NIX_CFLAGS_COMPILE = toString [
     # Can't say ${polkit.bin}/bin/pkttyagent here because that would
@@ -738,6 +880,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSYSTEMD_BINARY_PATH=\"/run/current-system/systemd/lib/systemd/systemd\""
   ];
 
+  env.NIX_NO_SELF_RPATH = true;
+
   doCheck = false;
 
   # trigger the test -n "$DESTDIR" || mutate in upstreams build system
@@ -745,17 +889,17 @@ stdenv.mkDerivation (finalAttrs: {
     export DESTDIR=/
   '';
 
-  mesonInstallTags = lib.optionals buildLibsOnly [
-    "devel"
-    "libudev"
-    "libsystemd"
-  ];
+  ${if buildLibsOnly then "ninjaFlags" else null} = libsOnlyTargets;
+  ${if buildLibsOnly then "mesonInstallTags" else null} = libsOnlyTargets;
 
   postInstall =
     lib.optionalString (!buildLibsOnly) ''
       mkdir -p $out/example/systemd
       mv $out/lib/{binfmt.d,sysctl.d,tmpfiles.d} $out/example
       mv $out/lib/systemd/{system,user} $out/example/systemd
+
+      progs=$(ls -m -w0 $out/bin | sed 's/[$*.[\^@]/\\&/g;s/, /\\|/g')
+      find $out/example/systemd -type f -exec sed -e 's@^\(Exec\w*=[@:+!|-]*\)\('"$progs"'\)@\1'"$out"'/bin/\2@' -i '{}' \;
 
       rm -rf $out/etc/systemd/system
 
@@ -779,7 +923,7 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString (withKmod && !buildLibsOnly) ''
       mv $out/lib/modules-load.d $out/example
     ''
-    + lib.optionalString withSysusers ''
+    + lib.optionalString (withSysusers && !buildLibsOnly) ''
       mv $out/lib/sysusers.d $out/example
     '';
 
@@ -795,6 +939,45 @@ stdenv.mkDerivation (finalAttrs: {
     ) "$out/bin/udevadm verify --resolve-names=late --no-style $out/lib/udev/rules.d"}
 
     runHook postInstallCheck
+  '';
+
+  # Verify that the libraries built in the main derivation don't differ in any
+  # important ways from their libsOnly equivalents (before deleting them). This
+  # needs to happen after autoPatchelfHook, which acts in postFixup, and this
+  # logic belongs in postFixup itself. But setup hooks will run after their
+  # corresponding attributes in a derivation, so this verify-and-delete step
+  # has to be manually inserted into the hooks array after the setup hooks are
+  # sourced.
+  ${if buildLibsOnly then null else "preFixup"} = ''
+    getBuildIdPerl() {
+      readelf -n "$1" | sed -n 's/^ *Build ID: \(.*\)$/\1/;T;s/../\\x&/g;p'
+    }
+
+    systemdVerifyLibEquality() {
+      ${lib.optionalString checkLibsystemdCorrectness ''
+        for name in $(ls ${libsOnly}/lib); do
+          lib1=${libsOnly}/lib/$name
+          lib2=$out/lib/$name
+          if ! [ -L "$lib1" ]; then
+            perl -gpi -e "s/$(getBuildIdPerl "$lib2")/$(getBuildIdPerl "$lib1")/s" "$lib2"
+            if ! cmp -b "$lib1" "$lib2"; then
+              echo "The locally-built copy of '$name' doesn't match '$lib1'."
+              echo "Perhaps there is an overridden flag in libsOnly that shouldn't be there."
+              return 1
+            fi
+          fi
+        done
+      ''}
+      rm "$out"/lib/lib{systemd,udev}.so*
+      rm -rf "$out"/include
+      rm "$debug"/lib/debug/lib{systemd,udev}.so.*
+      while read -r -d $'\0' f; do
+        rm "''${f%.*}".*
+        rmdir --ignore-fail-on-non-empty "''${f%/*}"
+      done < <(find "$debug/lib/debug" -! -xtype f -a \( -lname '*/libsystemd.so.*' -o -lname '*/libudev.so.*' \) -print0)
+    }
+
+    postFixupHooks+=(systemdVerifyLibEquality)
   '';
 
   # Avoid *.EFI binary stripping.
@@ -962,6 +1145,14 @@ stdenv.mkDerivation (finalAttrs: {
 
         pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       };
+  }
+  // lib.optionalAttrs (!buildLibsOnly) {
+    # These are not real outputs of this derivation, but the names are chosen
+    # so that they masquerade as such, so that packages can include systemd in
+    # their buildInputs and get the corresponding libsOnly package
+    # automatically.
+    lib = libsOnly;
+    inherit (libsOnly) dev;
   };
 
   meta = {

--- a/pkgs/servers/dns/nsd/default.nix
+++ b/pkgs/servers/dns/nsd/default.nix
@@ -5,7 +5,7 @@
   libevent,
   openssl,
   pkg-config,
-  systemdMinimal,
+  systemd,
   nixosTests,
   bind8Stats ? false,
   checking ? false,
@@ -18,7 +18,7 @@
   rootServer ? false,
   rrtypes ? false,
   zoneStats ? false,
-  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemdMinimal,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   configFile ? "/etc/nsd/nsd.conf",
 }:
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     openssl
   ]
   ++ lib.optionals withSystemd [
-    systemdMinimal
+    systemd
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/postfix-exporter.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   makeWrapper,
   nixosTests,
-  systemdLibs,
+  systemd,
   withSystemdSupport ? true,
 }:
 
@@ -27,12 +27,12 @@ buildGoModule rec {
   ];
 
   nativeBuildInputs = lib.optionals withSystemdSupport [ makeWrapper ];
-  buildInputs = lib.optionals withSystemdSupport [ systemdLibs ];
+  buildInputs = lib.optionals withSystemdSupport [ systemd ];
   tags = lib.optionals (!withSystemdSupport) "nosystemd";
 
   postInstall = lib.optionals withSystemdSupport ''
     wrapProgram $out/bin/postfix_exporter \
-      --prefix LD_LIBRARY_PATH : "${lib.getLib systemdLibs}/lib"
+      --prefix LD_LIBRARY_PATH : "${lib.getLib systemd}/lib"
   '';
 
   passthru.tests = { inherit (nixosTests.prometheus-exporters) postfix; };

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -148,8 +148,8 @@ let
       libselinux,
 
       # Systemd
-      systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemdLibs,
-      systemdLibs,
+      systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
+      systemd,
 
       # Uring
       uringSupport ? lib.versionAtLeast version "18" && lib.meta.availableOn stdenv.hostPlatform liburing,
@@ -286,7 +286,7 @@ let
       ++ lib.optionals jitSupport [ llvmPackages.llvm ]
       ++ lib.optionals lz4Enabled [ lz4 ]
       ++ lib.optionals zstdEnabled [ zstd ]
-      ++ lib.optionals systemdSupport [ systemdLibs ]
+      ++ lib.optionals systemdSupport [ systemd ]
       ++ lib.optionals uringSupport [ liburing ]
       ++ lib.optionals curlSupport [ curl ]
       ++ lib.optionals numaSupport [ numactl ]

--- a/pkgs/tools/networking/dd-agent/datadog-agent.nix
+++ b/pkgs/tools/networking/dd-agent/datadog-agent.nix
@@ -114,7 +114,7 @@ buildGoModule rec {
       --set PYTHONPATH "$out/${python.sitePackages}"''
   + lib.optionalString withSystemd " --prefix LD_LIBRARY_PATH : ${
      lib.makeLibraryPath [
-       (lib.getLib systemd)
+       systemd
        rtloader
      ]
    }";

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1793,6 +1793,7 @@ mapAliases {
   syndicate_utils = throw "'syndicate_utils' has been removed due to a hostile upstream moving tags and breaking src FODs"; # Added 2025-09-01
   synth = throw "'synth' has been removed because it is unmaintained"; # Added 2025-11-15
   system = warnAlias "'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'" stdenv.hostPlatform.system; # Converted to warning 2025-10-28
+  systemdLibs = systemd.lib; # Added 2026-MM-DD
   t1lib = throw "'t1lib' has been removed as it was broken and unmaintained upstream."; # Added 2025-06-11
   tamgamp.lv2 = tamgamp-lv2; # Added 2025-09-27
   taplo-cli = throw "'taplo-cli' has been renamed to/replaced by 'taplo'"; # Converted to throw 2025-10-27

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9247,10 +9247,6 @@ with pkgs;
     withLibseccomp = false;
     withNspawn = false;
   };
-  systemdLibs = systemdMinimal.override {
-    pname = "systemd-minimal-libs";
-    buildLibsOnly = true;
-  };
   # We do not want to include ukify in the normal systemd attribute as it
   # relies on Python at runtime.
   systemdUkify = systemd.override {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9185,6 +9185,11 @@ with pkgs;
 
   libsysprof-capture = callPackage ../development/tools/profiling/sysprof/capture.nix { };
 
+  # Which Systemd Package Should I Take as a Dependency?
+  #
+  # * If you are a dependency of systemd, and you need to use systemd binaries: systemdMinimal
+  # * If all you need is libudev, and you want to use it on not-Linux: udev
+  # * Otherwise: systemd
   systemd = callPackage ../os-specific/linux/systemd {
     # break some cyclic dependencies
     util-linux = util-linuxMinimal;
@@ -9253,7 +9258,7 @@ with pkgs;
     withUkify = true;
   };
 
-  udev = if lib.meta.availableOn stdenv.hostPlatform systemdLibs then systemdLibs else libudev-zero;
+  udev = if lib.meta.availableOn stdenv.hostPlatform systemd then systemd.lib else libudev-zero;
 
   sysvtools = sysvinit.override {
     withoutInitTools = true;


### PR DESCRIPTION
This is another attempt at cleaving systemd into smaller outputs. (Prior art: #99382, #264163.)

There are two main thrusts here (they could go in separate PRs if needed, but bundling them is convenient given how much overhead there is for building a PR on staging):
  * Rationalize the systemd/systemdLibs/systemdMinimal situation, so that we can eliminate duplicate copies of systemd floating around in a closure. At present, systemdLibs is a systemdMinimal-configured build of just libsystemd.so and libudev.so, but then the main systemd derivation also contains copies of those libraries, and both derivations can be taken as dependencies of a closure; furthermore, the flags disabled in systemdMinimal may result in different behavior between the two copies of the libraries. In this new approach, the libraries remain a separate derivation, but it is exposed as if it were an output of the main systemd derivation, and the lib derivation is configured with the same flags as systemd when those flags would change the compiled result. The main systemd derivation verifies that, when it builds its copy of the libraries, the binaries match byte-for-byte with the previously-built libraries; and then the main systemd derivation deletes its copies to save a few kilobytes. The result is that almost all packages can simply take the one systemd package as a dependency, and the typical final system closure will have only one copy of the main systemd binaries and only one copy of libsystemd.so.
  * Separate leaf systemd features into their own (true) outputs. Since systemd is such a foundational package, it's expensive to have an overlay that reconfigures it without (e.g.) timesyncd. But the architecture of systemd is modular and many of these features can be isolated from the core, which promotes the feature from a package-level concern which causes downstream rebuilds to a system-level one which doesn't. I've only done timesyncd here, as a proof of concept (inspired by [a recent Discourse thread](https://discourse.nixos.org/t/why-are-we-using-systemd-timesyncd-by-default) proposing switching to chrony or something by default); if the general approach is green-lit, I plan on adding more.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
