### PR TITLE
expr: 1.17.7 -> 1.17.8, adopt

### DIFF
--- a/pkgs/by-name/ex/expr/package.nix
+++ b/pkgs/by-name/ex/expr/package.nix
@@ -6,18 +6,18 @@
 
 buildGoModule (finalAttrs: {
   pname = "expr";
-  version = "1.17.7";
+  version = "1.17.8";
 
   src = fetchFromGitHub {
     owner = "expr-lang";
     repo = "expr";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-OKKbEgJgQWL5jP+E8ZuxdVjZ89QjLy6AAPRepe4jWsk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-MJM7ezZtSdDaUewNGACOKvWc+ZOPVScTuW+d6n1K5jo=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/repl";
 
-  vendorHash = "sha256-NIcHf9P2/1Me+LuWA3BEjA2mOgdSzXFQJPrhAT7uPoo=";
+  vendorHash = "sha256-GH7rn0q/YuGBx0rrfHa2EMCsynQ3Pgtz1yDsD/NIKsU=";
 
   ldflags = [
     "-s"
@@ -31,7 +31,7 @@ buildGoModule (finalAttrs: {
   meta = {
     description = "Expression language and expression evaluation for Go";
     homepage = "https://github.com/expr-lang/expr";
-    changelog = "https://github.com/expr-lang/expr/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/expr-lang/expr/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "expr";

--- a/pkgs/by-name/ex/expr/package.nix
+++ b/pkgs/by-name/ex/expr/package.nix
@@ -33,7 +33,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/expr-lang/expr";
     changelog = "https://github.com/expr-lang/expr/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
     mainProgram = "expr";
   };
 })


### PR DESCRIPTION
Changelog: https://github.com/expr-lang/expr/releases/tag/v1.17.8
Diff: https://github.com/expr-lang/expr/compare/v1.17.7...v1.17.8
Also part of #458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
