### PR TITLE
python313Packages.azure-storage-file-datalake: 12.17.0 -> 12.21.0

### DIFF
--- a/pkgs/development/python-modules/azure-storage-file-datalake/default.nix
+++ b/pkgs/development/python-modules/azure-storage-file-datalake/default.nix
@@ -1,27 +1,24 @@
 {
   lib,
-  buildPythonPackage,
-  fetchFromGitHub,
-  setuptools,
   azure-core,
   azure-storage-blob,
+  buildPythonPackage,
+  fetchPypi,
   isodate,
+  setuptools,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "azure-storage-file-datalake";
-  version = "12.17.0";
+  version = "12.21.0";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "Azure";
-    repo = "azure-sdk-for-python";
-    tag = "azure-storage-file-datalake_${version}";
-    hash = "sha256-FT51a7yuSMLJSnMFK9N09Rc8p/uaoYCcj9WliSvY6UA=";
+  src = fetchPypi {
+    pname = "azure_storage_file_datalake";
+    inherit version;
+    hash = "sha256-tJzSFW6jJfb0So9mdNc8WUnprEjWSA+vkBspOYVfzdM=";
   };
-
-  sourceRoot = "${src.name}/sdk/storage/azure-storage-file-datalake";
 
   build-system = [ setuptools ];
 
@@ -38,15 +35,13 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "azure.storage.filedatalake" ];
 
-  # require devtools_testutils which is a internal package for azure-sdk
+  # Tests are only available in mono repo
   doCheck = false;
-
-  # multiple packages in a singel repo, and the updater picks the wrong tag
-  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Microsoft Azure File DataLake Storage Client Library for Python";
     homepage = "https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-file-datalake";
+    changelog = "https://github.com/Azure/azure-sdk-for-python/blob/azure-storage-file-datalake_${version}/sdk/storage/azure-storage-file-datalake/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
   };


### PR DESCRIPTION
Changelog: https://github.com/Azure/azure-sdk-for-python/blob/azure-storage-file-datalake_12.21.0/sdk/storage/azure-storage-file-datalake/CHANGELOG.md

Split from #433349.

Because the first commit in that PR is redundant to 26978a401dde87f2d09ed1cb87997c2a2c4cc83a (and 30bcf10203adf1d72faaefd2a62d61508bb8aa43), this also closes #433349.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
