### PR TITLE
lessc: 4.2.2 -> 4.6.3

### DIFF
--- a/pkgs/by-name/le/lessc/package.nix
+++ b/pkgs/by-name/le/lessc/package.nix
@@ -1,7 +1,11 @@
 {
   lib,
-  buildNpmPackage,
+  stdenv,
   fetchFromGitHub,
+  fetchPnpmDeps,
+  nodejs,
+  pnpm_9,
+  pnpmConfigHook,
   callPackage,
   testers,
   runCommand,
@@ -10,27 +14,59 @@
   lessc,
 }:
 
-buildNpmPackage rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lessc";
-  version = "4.2.2";
+  version = "4.6.3";
 
   src = fetchFromGitHub {
     owner = "less";
     repo = "less.js";
-    rev = "v${version}";
-    hash = "sha256-vO/1laFb1yC+OESXTx9KuGdwSNC9Iv49F3V7kfXnyJU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-udfqfjdIhQ6UGAeXCT5FbI+iXNqfkbQMqZnnIDUrQaQ=";
   };
-  sourceRoot = "${src.name}/packages/less";
 
-  npmDepsHash = "sha256-3GlngmaxcUGXSv+ZwN2aovwEqcek6FJ1ZaL5KpjwNn4=";
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    pnpm = pnpm_9;
+    fetcherVersion = 3;
+    hash = "sha256-ZdADm6WKPP48DK+ezk/jdzXVEBX161SqgYgU5fsCW2k=";
+  };
 
-  postPatch = ''
-    sed -i ./package.json \
-      -e '/@less\/test-data/d' \
-      -e '/@less\/test-import-module/d'
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm_9
+    nodejs
+  ];
+
+  buildInputs = [ nodejs ];
+
+  pnpmWorkspaces = [ "less..." ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter "less" run build
+
+    runHook postBuild
   '';
 
-  env.PUPPETEER_SKIP_DOWNLOAD = 1;
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/lessc}
+    cp -r {packages,node_modules} $out/lib/lessc
+    chmod +x $out/lib/lessc/packages/less/bin/lessc
+    ln -s $out/lib/lessc/packages/less/bin/lessc $out/bin/lessc
+
+    runHook postInstall
+  '';
 
   passthru = {
     updateScript = nix-update-script { };
@@ -69,9 +105,10 @@ buildNpmPackage rec {
 
   meta = {
     homepage = "https://github.com/less/less.js";
+    changelog = "https://github.com/less/less.js/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Dynamic stylesheet language";
     mainProgram = "lessc";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ lelgenio ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Since 4.3.0, less.js uses pnpm as its package manager.

Could not find an appropriate build and install hook to use, so it's a manual implementation based on other packages.

nix-update is also fixed now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 490440`
Commit: `4447a8eb1dc7360255213a5e005e6d831abe0056`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>lessc</li>
    <li>styx</li>
    <li>styx.lib</li>
    <li>styx.themes</li>
  </ul>
</details>
