### PR TITLE
[staging-next] python3Packages.{py-multiaddr: 0.0.10 -> 0.0.11;, py-cid:} fix build

### DIFF
--- a/pkgs/development/python-modules/py-cid/default.nix
+++ b/pkgs/development/python-modules/py-cid/default.nix
@@ -9,12 +9,14 @@
   morphys,
   py-multihash,
   hypothesis,
+  pytest-cov-stub,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "py-cid";
   version = "0.4.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ipld";
@@ -23,14 +25,11 @@ buildPythonPackage rec {
     hash = "sha256-IYjk7sajHFWgsOMxwk1tWvKtTfPN8vHoNeENQed7MiU=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace "base58>=1.0.2,<2.0" "base58>=1.0.2" \
-      --replace "py-multihash>=0.2.0,<1.0.0" "py-multihash>=0.2.0" \
-      --replace "'pytest-runner'," ""
-  '';
+  pythonRelaxDeps = [ "base58" ];
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     base58
     py-multibase
     py-multicodec
@@ -40,6 +39,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
+    pytest-cov-stub
     hypothesis
   ];
 
@@ -48,6 +48,7 @@ buildPythonPackage rec {
   meta = {
     description = "Self-describing content-addressed identifiers for distributed systems implementation in Python";
     homepage = "https://github.com/ipld/py-cid";
+    changelog = "https://github.com/ipld/py-cid/blob/${src.tag}/HISTORY.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ Luflosi ];
   };

--- a/pkgs/development/python-modules/py-multiaddr/default.nix
+++ b/pkgs/development/python-modules/py-multiaddr/default.nix
@@ -1,38 +1,45 @@
 {
   lib,
+  base58,
   buildPythonPackage,
   fetchFromGitHub,
-  varint,
-  base58,
-  netaddr,
   idna,
+  netaddr,
   py-cid,
   py-multicodec,
+  trio,
   pytestCheckHook,
+  setuptools,
+  psutil,
+  varint,
+  dnspython,
+  trio-typing,
 }:
 
 buildPythonPackage rec {
   pname = "py-multiaddr";
-  version = "0.0.10";
-  format = "setuptools";
+  version = "0.0.11";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "multiformats";
     repo = "py-multiaddr";
     tag = "v${version}";
-    hash = "sha256-N46D2H3RG6rtdBrSyDjh8UxD+Ph/FXEa4FcEI2uz4y8=";
+    hash = "sha256-mlHcuLVtczp3APXJFkWbjeY7xU39eFERa8hhiOEwBSU=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py --replace "'pytest-runner'," ""
-  '';
+  build-system = [ setuptools ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     varint
     base58
     netaddr
+    dnspython
+    trio-typing
+    trio
     idna
     py-cid
+    psutil
     py-multicodec
   ];
 
@@ -40,9 +47,22 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "multiaddr" ];
 
+  disabledTests = [
+    # Test is outdated
+    "test_resolve_cancellation_with_error"
+    # AssertionError
+    "test_ipv4_wildcard"
+  ];
+
+  disabledTestPaths = [
+    # Tests require network access
+    "tests/test_resolvers.py"
+  ];
+
   meta = {
     description = "Composable and future-proof network addresses";
     homepage = "https://github.com/multiformats/py-multiaddr";
+    changelog = "https://github.com/multiformats/py-multiaddr/releases/tag/${src.tag}";
     license = with lib.licenses; [
       mit
       asl20


### PR DESCRIPTION
Modified from @fabaff's PR #446766.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
