### PR TITLE
regreet: fix detection of available sessions

### DIFF
--- a/nixos/modules/programs/regreet.nix
+++ b/nixos/modules/programs/regreet.nix
@@ -168,6 +168,10 @@ in
           settingsFormat.generate "regreet.toml" cfg.settings;
     };
 
+    # link related .desktop files from compositors so that the program uses it
+    # it's expected that regreet is compiled with correct SESSION_DIRS
+    environment.pathsToLink = ["/share/xsessions" "/share/wayland-sessions"];
+
     systemd.tmpfiles.settings."10-regreet" =
       let
         defaultConfig = {

--- a/pkgs/by-name/re/regreet/package.nix
+++ b/pkgs/by-name/re/regreet/package.nix
@@ -37,6 +37,14 @@ rustPlatform.buildRustPackage (finalAttrs: {
     librsvg
   ];
 
+  # default dirs doesn't exists on nixos, set dirs that will be created when using
+  # environment.pathsToLink = ["/share/xsessions" "/share/wayland-sessions"]
+  # default dirs is: /usr/share/xsessions:/usr/share/wayland-sessions
+  SESSION_DIRS = lib.strings.join ":" [
+    "/run/current-system/sw/share/xsessions"
+    "/run/current-system/sw/share/wayland-sessions"
+  ];
+
   passthru.updateScript = nix-update-script { };
 
   meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

regreet doesn't see available wayland sessions because it looks for directories that doesn't exists on nixos - /usr/share/xsessions and /usr/share/wayland-sessions

I'm not sure about implementation, it looks a bit hacky, I'm open to suggestions

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
