### PR TITLE
go_1_26: init at 1.26.0

### DIFF
--- a/pkgs/development/compilers/go/1.26.nix
+++ b/pkgs/development/compilers/go/1.26.nix
@@ -1,0 +1,204 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  tzdata,
+  replaceVars,
+  iana-etc,
+  mailcap,
+  buildPackages,
+  pkgsBuildTarget,
+  targetPackages,
+  # for testing
+  buildGo126Module,
+  callPackage,
+}:
+
+let
+  goBootstrap = buildPackages.callPackage ./bootstrap124.nix { };
+
+  # We need a target compiler which is still runnable at build time,
+  # to handle the cross-building case where build != host == target
+  targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
+
+  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "go";
+  version = "1.26rc1";
+
+  src = fetchurl {
+    url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
+    hash = "sha256-ZeM0BQb0uhJaV5nsx4etSdTJ9NJX4sLBXT4pXlACtoQ=";
+  };
+
+  strictDeps = true;
+  buildInputs =
+    [ ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.libc.out ]
+    ++ lib.optionals (stdenv.hostPlatform.libc == "glibc") [ stdenv.cc.libc.static ];
+
+  depsBuildTarget = lib.optional isCross targetCC;
+
+  depsTargetTarget = lib.optional stdenv.targetPlatform.isMinGW targetPackages.threads.package;
+
+  postPatch = ''
+    patchShebangs .
+  '';
+
+  patches = [
+    (replaceVars ./iana-etc-1.25.patch {
+      iana = iana-etc;
+    })
+    # Patch the mimetype database location which is missing on NixOS.
+    # but also allow static binaries built with NixOS to run outside nix
+    (replaceVars ./mailcap-1.17.patch {
+      inherit mailcap;
+    })
+    # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
+    # that run outside a nix server
+    (replaceVars ./tzdata-1.19.patch {
+      inherit tzdata;
+    })
+    ./remove-tools-1.11.patch
+    ./go_no_vendor_checks-1.26.patch
+    ./go-env-go_ldso.patch
+  ];
+
+  env = {
+    inherit (stdenv.targetPlatform.go) GOOS GOARCH GOARM;
+    # GOHOSTOS/GOHOSTARCH must match the building system, not the host system.
+    # Go will nevertheless build a for host system that we will copy over in
+    # the install phase.
+    GOHOSTOS = stdenv.buildPlatform.go.GOOS;
+    GOHOSTARCH = stdenv.buildPlatform.go.GOARCH;
+
+    GO386 = "softfloat"; # from Arch: don't assume sse2 on i686
+    # Wasi does not support CGO
+    # ppc64/linux CGO is incomplete/borked, and will likely not receive any further improvements
+    # https://github.com/golang/go/issues/8912
+    # https://github.com/golang/go/issues/13192
+    CGO_ENABLED =
+      if
+        (
+          stdenv.targetPlatform.isWasi
+          || (stdenv.targetPlatform.isPower64 && stdenv.targetPlatform.isBigEndian)
+        )
+      then
+        0
+      else
+        1;
+
+    GOROOT_BOOTSTRAP = "${goBootstrap}/share/go";
+  }
+  // lib.optionalAttrs isCross {
+    # {CC,CXX}_FOR_TARGET must be only set for cross compilation case as go expect those
+    # to be different from CC/CXX
+    CC_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}cc";
+    CXX_FOR_TARGET = "${targetCC}/bin/${targetCC.targetPrefix}c++";
+  };
+
+  buildPhase = ''
+    runHook preBuild
+    export GOCACHE=$TMPDIR/go-cache
+    if [ -f "$NIX_CC/nix-support/dynamic-linker" ]; then
+      export GO_LDSO=$(cat $NIX_CC/nix-support/dynamic-linker)
+    fi
+
+    export PATH=$(pwd)/bin:$PATH
+
+    ${lib.optionalString isCross ''
+      # Independent from host/target, CC should produce code for the building system.
+      # We only set it when cross-compiling.
+      export CC=${buildPackages.stdenv.cc}/bin/cc
+      # Prefer external linker for cross when CGO is supported, since
+      # we haven't taught go's internal linker to pick the correct ELF
+      # interpreter for cross
+      # When CGO is not supported we rely on static binaries being built
+      # since they don't need an ELF interpreter
+      export GO_EXTLINK_ENABLED=${toString finalAttrs.env.CGO_ENABLED}
+    ''}
+    ulimit -a
+
+    pushd src
+    ./make.bash
+    popd
+    runHook postBuild
+  '';
+
+  preInstall = ''
+    # Contains the wrong perl shebang when cross compiling,
+    # since it is not used for anything we can deleted as well.
+    rm src/regexp/syntax/make_perl_groups.pl
+  ''
+  + (
+    if (stdenv.buildPlatform.system != stdenv.hostPlatform.system) then
+      ''
+        mv bin/*_*/* bin
+        rmdir bin/*_*
+        ${lib.optionalString
+          (
+            !(
+              finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS
+            )
+          )
+          ''
+            rm -rf pkg/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH} pkg/tool/${finalAttrs.env.GOHOSTOS}_${finalAttrs.env.GOHOSTARCH}
+          ''
+        }
+      ''
+    else
+      lib.optionalString (stdenv.hostPlatform.system != stdenv.targetPlatform.system) ''
+        rm -rf bin/*_*
+        ${lib.optionalString
+          (
+            !(
+              finalAttrs.env.GOHOSTARCH == finalAttrs.env.GOARCH && finalAttrs.env.GOOS == finalAttrs.env.GOHOSTOS
+            )
+          )
+          ''
+            rm -rf pkg/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH} pkg/tool/${finalAttrs.env.GOOS}_${finalAttrs.env.GOARCH}
+          ''
+        }
+      ''
+  );
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/go
+    cp -a bin pkg src lib misc api doc go.env VERSION $out/share/go
+    mkdir -p $out/bin
+    ln -s $out/share/go/bin/* $out/bin
+    runHook postInstall
+  '';
+
+  disallowedReferences = [ goBootstrap ];
+
+  passthru = {
+    inherit goBootstrap;
+    tests = callPackage ./tests.nix {
+      go = finalAttrs.finalPackage;
+      buildGoModule = buildGo126Module;
+    };
+  };
+
+  __structuredAttrs = true;
+
+  meta = {
+    changelog = "https://go.dev/doc/devel/release#go${lib.versions.majorMinor finalAttrs.version}";
+    description = "Go Programming language";
+    homepage = "https://go.dev/";
+    license = lib.licenses.bsd3;
+    teams = [ lib.teams.golang ];
+    platforms =
+      lib.platforms.darwin ++ lib.platforms.linux ++ lib.platforms.wasi ++ lib.platforms.freebsd;
+    badPlatforms = [
+      # Support for big-endian POWER < 8 was dropped in 1.9, but POWER8 users have less of a reason to run in big-endian mode than pre-POWER8 ones
+      # So non-LE ppc64 is effectively unsupported, and Go SIGILLs on affordable ppc64 hardware
+      # https://github.com/golang/go/issues/19074 - Dropped support for big-endian POWER < 8, with community pushback
+      # https://github.com/golang/go/issues/73349 - upstream will not accept submissions to fix this
+      "powerpc64-linux"
+    ];
+    mainProgram = "go";
+  };
+})

--- a/pkgs/development/compilers/go/1.26.nix
+++ b/pkgs/development/compilers/go/1.26.nix
@@ -25,11 +25,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.26rc3";
+  version = "1.26.0";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-t32nB+A4hWXdgUcCPE1cRsTAA6bh9xNQ9jfPXYCtLps=";
+    hash = "sha256-yRMqih9r0qpKrR10uCMdlSdJUEg6SVBlfubFbm6Bd5A=";
   };
 
   strictDeps = true;

--- a/pkgs/development/compilers/go/1.26.nix
+++ b/pkgs/development/compilers/go/1.26.nix
@@ -25,11 +25,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.26rc2";
+  version = "1.26rc3";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-4lzIxf/hJBpdhxmSCSQ9cMJIRyYPsep7FjqVtTfeZaw=";
+    hash = "sha256-t32nB+A4hWXdgUcCPE1cRsTAA6bh9xNQ9jfPXYCtLps=";
   };
 
   strictDeps = true;

--- a/pkgs/development/compilers/go/1.26.nix
+++ b/pkgs/development/compilers/go/1.26.nix
@@ -25,11 +25,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.26rc1";
+  version = "1.26rc2";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-ZeM0BQb0uhJaV5nsx4etSdTJ9NJX4sLBXT4pXlACtoQ=";
+    hash = "sha256-4lzIxf/hJBpdhxmSCSQ9cMJIRyYPsep7FjqVtTfeZaw=";
   };
 
   strictDeps = true;

--- a/pkgs/development/compilers/go/bootstrap124.nix
+++ b/pkgs/development/compilers/go/bootstrap124.nix
@@ -1,0 +1,27 @@
+{ callPackage }:
+callPackage ./binary.nix {
+  version = "1.24.11";
+  hashes = {
+    # Use `print-hashes.sh ${version}` to generate the list below
+    darwin-amd64 = "c45566cf265e2083cd0324e88648a9c28d0edede7b5fd12f8dc6932155a344c5";
+    darwin-arm64 = "a9c90c786e75d5d1da0547de2d1199034df6a4b163af2fa91b9168c65f229c12";
+    freebsd-386 = "99229da13fd74d5cdcb81fae844bf48574c64eae0d2821137f45c848f1453771";
+    freebsd-amd64 = "de6fdd4eefa06dbb2531ed601ef5f2b88e73f49f89c10bc1078f51a96a7ae88f";
+    freebsd-arm = "fd7a01515c09ad190c969bd9cd277803c05acfaa7b03c496d3a9d1b8cad72d03";
+    freebsd-arm64 = "eead4408b88557228fe4b30ee90aa33062d338fa5647c046a5aaca4237839f5a";
+    freebsd-riscv64 = "3c192d96d57c6330e6a92d70235a4e938345c9b3a50d37cfce60c92dd7240d04";
+    linux-386 = "bb702d0b67759724dccee1825828e8bae0b5199e3295cac5a98a81f3098fa64a";
+    linux-amd64 = "bceca00afaac856bc48b4cc33db7cd9eb383c81811379faed3bdbc80edb0af65";
+    linux-arm64 = "beaf0f51cbe0bd71b8289b2b6fa96c0b11cd86aa58672691ef2f1de88eb621de";
+    linux-armv6l = "24d712a7e8ea2f429c05bc67287249e0291f2fe0ea6d6ff268f11b7343ad0f47";
+    linux-loong64 = "45c3cbec9e30071ea1f3323fc30fb1b8497007c992f00ba48fcdcb729f06467c";
+    linux-mips = "c006942d74a348af080aac3930c3772148761cf1de5d97c3879c30d17b72ccf5";
+    linux-mips64 = "d054e2fb0873ac1d5502c4a860090bfff130b8fabdeeea311adda658fbc45ac5";
+    linux-mips64le = "c0274255613b85e2ba45e210e8f07995d51a048f11c7f0b9128dc177472692b3";
+    linux-mipsle = "5c787fc3ac04c4ebeaa0a6602c8a69eae557fe15d033a07cf22ac44e2489285f";
+    linux-ppc64 = "3fceb9492469f2155134a834c12b4bf9c1126fbb3cbf5a5ae660648897b8076d";
+    linux-ppc64le = "f770d0c5d7e7e2edb030133ac7854d9204f4e954e79a176e81362ffedf6ea34c";
+    linux-riscv64 = "9db9ba8e6b60f3662f55ed78b128175edbe8b9480e657126a5b8f5043ee1e38c";
+    linux-s390x = "5955ddda3445b2cbfd81b8772044084911f55d0baeb32414da0411f6a377a2d4";
+  };
+}

--- a/pkgs/development/compilers/go/go_no_vendor_checks-1.26.patch
+++ b/pkgs/development/compilers/go/go_no_vendor_checks-1.26.patch
@@ -1,0 +1,26 @@
+diff --git a/src/cmd/go/internal/modload/import.go b/src/cmd/go/internal/modload/import.go
+index 04e95b7a8d..1ab4431d95 100644
+--- a/src/cmd/go/internal/modload/import.go
++++ b/src/cmd/go/internal/modload/import.go
+@@ -350,7 +350,7 @@ func importFromModules(loaderstate *State, ctx context.Context, path string, rs
+ 				// vendor/modules.txt does not exist or the user manually added directories to the vendor directory.
+ 				// Go 1.23 and later require vendored packages to be present in modules.txt to be imported.
+ 				_, ok := vendorPkgModule[path]
+-				if ok || (gover.Compare(loaderstate.MainModules.GoVersion(loaderstate), gover.ExplicitModulesTxtImportVersion) < 0) {
++				if ok || (gover.Compare(loaderstate.MainModules.GoVersion(loaderstate), gover.ExplicitModulesTxtImportVersion) < 0) || os.Getenv("GO_NO_VENDOR_CHECKS") == "1" {
+ 					mods = append(mods, vendorPkgModule[path])
+ 					dirs = append(dirs, dir)
+ 					roots = append(roots, vendorDir)
+diff --git a/src/cmd/go/internal/modload/vendor.go b/src/cmd/go/internal/modload/vendor.go
+index 9956bcdb12..5247daabfa 100644
+--- a/src/cmd/go/internal/modload/vendor.go
++++ b/src/cmd/go/internal/modload/vendor.go
+@@ -159,7 +159,7 @@ func checkVendorConsistency(loaderstate *State, indexes []*modFileIndex, modFile
+ 			panic(fmt.Errorf("not in workspace mode but number of indexes is %v, not 1", len(indexes)))
+ 		}
+ 		index := indexes[0]
+-		if gover.Compare(index.goVersion, "1.14") < 0 {
++		if gover.Compare(index.goVersion, "1.14") < 0 || (os.Getenv("GO_NO_VENDOR_CHECKS") == "1" && len(vendorMeta) == 0) {
+ 			// Go versions before 1.14 did not include enough information in
+ 			// vendor/modules.txt to check for consistency.
+ 			// If we know that we're on an earlier version, relax the consistency check.

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8856,6 +8856,11 @@ with pkgs;
     go = buildPackages.go_1_25;
   };
 
+  go_1_26 = callPackage ../development/compilers/go/1.26.nix { };
+  buildGo126Module = callPackage ../build-support/go/module.nix {
+    go = buildPackages.go_1_26;
+  };
+
   ### DEVELOPMENT / HARE
 
   hareHook = callPackage ../by-name/ha/hare/hook.nix { };


### PR DESCRIPTION
Backport 1.26 to release-25.11.

ref #489224

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
