### PR TITLE
music-assistant: 2.7.6 -> 2.7.8

### DIFF
--- a/pkgs/by-name/mu/music-assistant/fix-webserver-tests-in-sandbox.patch
+++ b/pkgs/by-name/mu/music-assistant/fix-webserver-tests-in-sandbox.patch
@@ -1,11 +1,11 @@
 diff --git a/music_assistant/helpers/util.py b/music_assistant/helpers/util.py
-index bc14912b..d207b855 100644
+index 377c7221..aaf6460d 100644
 --- a/music_assistant/helpers/util.py
 +++ b/music_assistant/helpers/util.py
-@@ -274,7 +274,7 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
-                 if ip.is_IPv6 and not include_ipv6:
+@@ -305,7 +305,7 @@ async def get_ip_addresses(include_ipv6: bool = False) -> tuple[str, ...]:
                      continue
-                 ip_str = str(ip.ip)
+                 # ifaddr returns IPv6 addresses as (address, flowinfo, scope_id) tuples
+                 ip_str = ip.ip[0] if isinstance(ip.ip, tuple) else ip.ip
 -                if ip_str.startswith(("127", "169.254")):
 +                if ip_str.startswith(("127", "169.254")) and "PYTEST_VERSION" not in os.environ:
                      # filter out IPv4 loopback/APIPA address

--- a/pkgs/by-name/mu/music-assistant/frontend.nix
+++ b/pkgs/by-name/mu/music-assistant/frontend.nix
@@ -7,13 +7,13 @@
 
 buildPythonPackage rec {
   pname = "music-assistant-frontend";
-  version = "2.17.76";
+  version = "2.17.73";
   pyproject = true;
 
   src = fetchPypi {
     pname = "music_assistant_frontend";
     inherit version;
-    hash = "sha256-wQ+6xD1BDajMIpz7VVH0j/AIgCcIVjv1Y/k/kMYv96U=";
+    hash = "sha256-vmZa98pT5Cg22fa73/KTrMUqP4Axc1y4x710HCxBzIY=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -47,14 +47,14 @@ assert
 
 python.pkgs.buildPythonApplication rec {
   pname = "music-assistant";
-  version = "2.7.6";
+  version = "2.7.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "music-assistant";
     repo = "server";
     tag = version;
-    hash = "sha256-tAzCEU8jFWENOy0WaAchuhQGjmQl8BTW9TuGZPJByPw=";
+    hash = "sha256-o17H8cmMC8szh/hfgdq0JWCPh45TkrhuXOikr+DcBw8=";
   };
 
   patches = [
@@ -186,6 +186,7 @@ python.pkgs.buildPythonApplication rec {
     "tests/core/test_server_base.py::test_events"
     # provider is missing dependencies
     "tests/providers/nicovideo"
+    "tests/providers/apple_music"
   ];
 
   pythonImportsCheck = [ "music_assistant" ];

--- a/pkgs/by-name/mu/music-assistant/providers.nix
+++ b/pkgs/by-name/mu/music-assistant/providers.nix
@@ -1,7 +1,7 @@
 # Do not edit manually, run ./update-providers.py
 
 {
-  version = "2.7.6";
+  version = "2.7.8";
   providers = {
     airplay =
       ps: with ps; [


### PR DESCRIPTION
https://github.com/music-assistant/server/releases/tag/2.7.7

https://github.com/music-assistant/server/releases/tag/2.7.8

diff: https://github.com/music-assistant/server/compare/2.7.6...2.7.8

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
