### PR TITLE
kluctl: cleanup, use python3 instead of python310

### DIFF
--- a/pkgs/by-name/kl/kluctl/package.nix
+++ b/pkgs/by-name/kl/kluctl/package.nix
@@ -5,9 +5,9 @@
   buildPackages,
   fetchFromGitHub,
   installShellFiles,
-  testers,
   makeWrapper,
   python310,
+  versionCheckHook,
 }:
 
 buildGoModule (finalAttrs: {
@@ -27,22 +27,16 @@ buildGoModule (finalAttrs: {
 
   ldflags = [
     "-s"
-    "-w"
     "-X main.version=v${finalAttrs.version}"
   ];
-
-  # Depends on docker
-  doCheck = false;
 
   nativeBuildInputs = [
     installShellFiles
     makeWrapper
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = finalAttrs.finalPackage;
-    version = "v${finalAttrs.version}";
-  };
+  # Depends on docker
+  doCheck = false;
 
   postInstall =
     let
@@ -58,6 +52,11 @@ buildGoModule (finalAttrs: {
         --fish <(${emulator} $out/bin/kluctl completion fish) \
         --zsh  <(${emulator} $out/bin/kluctl completion zsh)
     '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
 
   meta = {
     description = "Missing glue to put together large Kubernetes deployments";

--- a/pkgs/by-name/kl/kluctl/package.nix
+++ b/pkgs/by-name/kl/kluctl/package.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   installShellFiles,
   makeWrapper,
-  python310,
+  python3,
   versionCheckHook,
 }:
 
@@ -46,7 +46,7 @@ buildGoModule (finalAttrs: {
       mv $out/bin/{cmd,kluctl}
       wrapProgram $out/bin/kluctl \
         --set KLUCTL_USE_SYSTEM_PYTHON 1 \
-        --prefix PATH : '${lib.makeBinPath [ python310 ]}'
+        --prefix PATH : '${lib.makeBinPath [ python3 ]}'
       installShellCompletion --cmd kluctl \
         --bash <(${emulator} $out/bin/kluctl completion bash) \
         --fish <(${emulator} $out/bin/kluctl completion fish) \


### PR DESCRIPTION
## Things done

- **kluctl: cleanup**
- **kluctl: use python3 instead of python310**
  Context: https://github.com/NixOS/nixpkgs/issues/488818

cc @sikmir @netthier

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
