### PR TITLE
nodePackages.coc-{go,tsserver}: drop

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -67,6 +67,8 @@
 
 - `spoof` has been removed, as there are many issues upstream with it working on modern OS versions, and it appears to be unmaintained.
 
+- `nodePackages.coc-go` and `nodePackages.coc-tsserver`, along with their vim plugins, have been removed from nixpkgs due to being unmaintained.
+
 - `nodePackages.wavedrom-cli` has been removed, as it was unmaintained within nixpkgs.
 
 - `arti` has been updated to major version 2, which removed the long-deprecated `proxy.socks_port` and `proxy.dns_port` and the legacy syntax for specifying directory authorities. For more information, see the [changelog for 2.0.0](https://gitlab.torproject.org/tpo/core/arti/-/blob/arti-v2.0.0/CHANGELOG.md).

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -104,6 +104,7 @@ mapAliases {
   inherit (pkgs) coc-explorer; # added 2025-10-01
   inherit (pkgs) coc-flutter; # Added 2025-11-05
   inherit (pkgs) coc-git; # added 2025-10-01
+  coc-go = throw "coc-go has been removed because it was unmaintained in nixpkgs"; # Added 2026-02-14
   inherit (pkgs) coc-haxe; # Added 2025-11-05
   inherit (pkgs) coc-highlight; # Added 2025-11-05
   inherit (pkgs) coc-html; # Added 2025-11-05

--- a/pkgs/development/node-packages/aliases.nix
+++ b/pkgs/development/node-packages/aliases.nix
@@ -136,6 +136,7 @@ mapAliases {
   inherit (pkgs) coc-toml;
   coc-tslint = throw "coc-tslint was removed because it was deprecated upstream; coc-eslint offers comparable features for eslint, which replaced tslint"; # Added 2024-10-18
   coc-tslint-plugin = throw "coc-tslint-plugin was removed because it was deprecated upstream; coc-eslint offers comparable features for eslint, which replaced tslint"; # Added 2024-10-18
+  coc-tsserver = throw "coc-tsserver has been removed because it was unmaintained in nixpkgs"; # Added 2026-02-14
   coc-ultisnips = throw "'coc-ultisnips' has been removed because it was unmaintained upstream"; # Added 2025-11-14
   coc-vetur = throw "coc-vetur was removed because vetur was deprecated by Vue in favor of volar. Use coc-volar instead, which supports Vue 3"; # added 2025-10-01
   inherit (pkgs) coc-vimlsp; # Added 2025-11-05

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -4,7 +4,6 @@
 , "@tailwindcss/line-clamp"
 , "@tailwindcss/typography"
 , "browserify"
-, "coc-go"
 , "coc-tsserver"
 , "node2nix"
 , "sass"

--- a/pkgs/development/node-packages/node-packages.json
+++ b/pkgs/development/node-packages/node-packages.json
@@ -4,7 +4,6 @@
 , "@tailwindcss/line-clamp"
 , "@tailwindcss/typography"
 , "browserify"
-, "coc-tsserver"
 , "node2nix"
 , "sass"
 , "semver"

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -4944,15 +4944,6 @@ let
         sha512 = "vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==";
       };
     };
-    "typescript-5.8.2" = {
-      name = "typescript";
-      packageName = "typescript";
-      version = "5.8.2";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz";
-        sha512 = "aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==";
-      };
-    };
     "uid-number-0.0.5" = {
       name = "uid-number";
       packageName = "uid-number";
@@ -5644,27 +5635,6 @@ in
     meta = {
       description = "browser-side require() the node way";
       homepage = "https://github.com/browserify/browserify#readme";
-      license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
-  coc-tsserver = nodeEnv.buildNodePackage {
-    name = "coc-tsserver";
-    packageName = "coc-tsserver";
-    version = "2.2.3";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/coc-tsserver/-/coc-tsserver-2.2.3.tgz";
-      sha512 = "XYMekSGU+2jJ4U53FXUPmcv8WayME0eXUYruVL6PDYyVUUij86UQetliWHt1ai42VLTh3riIIZlcMdQkLot1sQ==";
-    };
-    dependencies = [
-      sources."typescript-5.8.2"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "javascript and typescript language features extension of coc.nvim";
-      homepage = "https://github.com/neoclide/coc-tsserver#readme";
       license = "MIT";
     };
     production = true;

--- a/pkgs/development/node-packages/node-packages.nix
+++ b/pkgs/development/node-packages/node-packages.nix
@@ -2694,15 +2694,6 @@ let
         sha512 = "VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==";
       };
     };
-    "isexe-3.1.1" = {
-      name = "isexe";
-      packageName = "isexe";
-      version = "3.1.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz";
-        sha512 = "LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==";
-      };
-    };
     "isomorphic-ws-4.0.1" = {
       name = "isomorphic-ws";
       packageName = "isomorphic-ws";
@@ -4872,15 +4863,6 @@ let
         sha512 = "ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==";
       };
     };
-    "tslib-2.8.1" = {
-      name = "tslib";
-      packageName = "tslib";
-      version = "2.8.1";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz";
-        sha512 = "oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==";
-      };
-    };
     "tsx-4.19.3" = {
       name = "tsx";
       packageName = "tsx";
@@ -5187,15 +5169,6 @@ let
         sha512 = "X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==";
       };
     };
-    "vscode-languageserver-textdocument-1.0.12" = {
-      name = "vscode-languageserver-textdocument";
-      packageName = "vscode-languageserver-textdocument";
-      version = "1.0.12";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz";
-        sha512 = "cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==";
-      };
-    };
     "vscode-languageserver-types-3.16.0" = {
       name = "vscode-languageserver-types";
       packageName = "vscode-languageserver-types";
@@ -5232,15 +5205,6 @@ let
         sha512 = "RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==";
       };
     };
-    "vscode-uri-3.1.0" = {
-      name = "vscode-uri";
-      packageName = "vscode-uri";
-      version = "3.1.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz";
-        sha512 = "/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==";
-      };
-    };
     "walk-2.3.15" = {
       name = "walk";
       packageName = "walk";
@@ -5248,15 +5212,6 @@ let
       src = fetchurl {
         url = "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz";
         sha512 = "4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==";
-      };
-    };
-    "which-5.0.0" = {
-      name = "which";
-      packageName = "which";
-      version = "5.0.0";
-      src = fetchurl {
-        url = "https://registry.npmjs.org/which/-/which-5.0.0.tgz";
-        sha512 = "JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==";
       };
     };
     "which-typed-array-1.1.19" = {
@@ -5689,31 +5644,6 @@ in
     meta = {
       description = "browser-side require() the node way";
       homepage = "https://github.com/browserify/browserify#readme";
-      license = "MIT";
-    };
-    production = true;
-    bypassCache = true;
-    reconstructLock = true;
-  };
-  coc-go = nodeEnv.buildNodePackage {
-    name = "coc-go";
-    packageName = "coc-go";
-    version = "1.3.35";
-    src = fetchurl {
-      url = "https://registry.npmjs.org/coc-go/-/coc-go-1.3.35.tgz";
-      sha512 = "1XHfCsUe8Xcb8EJb0kCXIuCFc7EfNFM4qziZhk/1LcKS9oMWrUCxQqPpYSdpd1XAatTad1KeuRFigPv6aaijiQ==";
-    };
-    dependencies = [
-      sources."isexe-3.1.1"
-      sources."tslib-2.8.1"
-      sources."vscode-languageserver-textdocument-1.0.12"
-      sources."vscode-uri-3.1.0"
-      sources."which-5.0.0"
-    ];
-    buildInputs = globalBuildInputs;
-    meta = {
-      description = "gopls extension for coc";
-      homepage = "https://github.com/josa42/coc-go#readme";
       license = "MIT";
     };
     production = true;


### PR DESCRIPTION
Basically the 2nd part of #489984, actually dropping these from the `nodePackages` set.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
