### PR TITLE
wineasio: fix build with wine in new wow64 mode, add thunze to maintainers

### DIFF
--- a/pkgs/by-name/wi/wineasio/package.nix
+++ b/pkgs/by-name/wi/wineasio/package.nix
@@ -10,24 +10,24 @@
   qt6,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "wineasio";
   version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "wineasio";
     repo = "wineasio";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Yw07XBzllbZ7l1XZcCvEaxZieaHLVxM5cmBM+HAjtQ4=";
     fetchSubmodules = true;
   };
 
   wineasio-settings = python3Packages.buildPythonApplication {
-    inherit src version;
+    inherit (finalAttrs) src version;
     pname = "wineasio-settings";
     pyproject = false;
 
-    sourceRoot = "${src.name}/gui";
+    sourceRoot = "${finalAttrs.src.name}/gui";
 
     postPatch = ''
       patchShebangs wineasio-settings
@@ -76,14 +76,14 @@ stdenv.mkDerivation rec {
     install -D build64/wineasio64.dll.so $out/lib/wine/x86_64-unix/wineasio64.dll.so
 
     mkdir -p $out/bin
-    ln -s ${wineasio-settings}/bin/wineasio-settings $out/bin/wineasio-settings
+    ln -s ${finalAttrs.wineasio-settings}/bin/wineasio-settings $out/bin/wineasio-settings
 
     runHook postInstall
   '';
 
   meta = {
     homepage = "https://github.com/wineasio/wineasio";
-    changelog = "https://github.com/wineasio/wineasio/releases/tag/${src.tag}";
+    changelog = "https://github.com/wineasio/wineasio/releases/tag/${finalAttrs.src.tag}";
     description = "ASIO to JACK driver for WINE";
     license = with lib.licenses; [
       gpl2
@@ -92,4 +92,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ lovesegfault ];
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/wi/wineasio/package.nix
+++ b/pkgs/by-name/wi/wineasio/package.nix
@@ -89,7 +89,10 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2
       lgpl21
     ];
-    maintainers = with lib.maintainers; [ lovesegfault ];
+    maintainers = with lib.maintainers; [
+      lovesegfault
+      thunze
+    ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/by-name/wi/wineasio/package.nix
+++ b/pkgs/by-name/wi/wineasio/package.nix
@@ -1,17 +1,16 @@
 {
-  multiStdenv,
+  stdenv,
   lib,
   fetchFromGitHub,
   libjack2,
   pkg-config,
   wineWow64Packages,
-  pkgsi686Linux,
   python3,
   python3Packages,
   qt6,
 }:
 
-multiStdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "wineasio";
   version = "1.3.0";
 
@@ -57,7 +56,6 @@ multiStdenv.mkDerivation rec {
   ];
 
   buildInputs = [
-    pkgsi686Linux.libjack2
     libjack2
   ];
 
@@ -67,7 +65,6 @@ multiStdenv.mkDerivation rec {
 
   buildPhase = ''
     runHook preBuild
-    make "''${makeFlags[@]}" 32
     make "''${makeFlags[@]}" 64
     runHook postBuild
   '';
@@ -75,8 +72,6 @@ multiStdenv.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -D build32/wineasio32.dll    $out/lib/wine/i386-windows/wineasio32.dll
-    install -D build32/wineasio32.dll.so $out/lib/wine/i386-unix/wineasio32.dll.so
     install -D build64/wineasio64.dll    $out/lib/wine/x86_64-windows/wineasio64.dll
     install -D build64/wineasio64.dll.so $out/lib/wine/x86_64-unix/wineasio64.dll.so
 
@@ -95,6 +90,6 @@ multiStdenv.mkDerivation rec {
       lgpl21
     ];
     maintainers = with lib.maintainers; [ lovesegfault ];
-    platforms = lib.platforms.linux;
+    platforms = [ "x86_64-linux" ];
   };
 }


### PR DESCRIPTION
`wineWowPackages` was deprecated in favor of `wineWow64Packages` (new WoW64 mode, see https://github.com/NixOS/nixpkgs/pull/484145).

In the new WoW64 mode, it's [not possible to build 32-bit Unix libraries anymore](https://bugs.winehq.org/show_bug.cgi?id=58377).

Hydra: https://hydra.nixos.org/build/321722603/nixlog/2
Fixes #490101

Further changes:
- Add myself to maintainers
- Use `finalAttrs`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
