### PR TITLE
lychee: 0.22.0 -> 0.23.0

### DIFF
--- a/pkgs/build-support/testers/lychee.nix
+++ b/pkgs/build-support/testers/lychee.nix
@@ -1,4 +1,5 @@
 deps@{
+  cacert,
   formats,
   lib,
   lychee,
@@ -40,7 +41,10 @@ let
     stdenv.mkDerivation (finalAttrs: {
       name = "lychee-link-check";
       inherit site;
-      nativeBuildInputs = [ finalAttrs.passthru.lychee ];
+      nativeBuildInputs = [
+        finalAttrs.passthru.lychee
+        cacert
+      ];
       configFile = (formats.toml { }).generate "lychee.toml" finalAttrs.passthru.config;
 
       # These can be overridden with overrideAttrs if needed.

--- a/pkgs/by-name/ly/lychee/package.nix
+++ b/pkgs/by-name/ly/lychee/package.nix
@@ -6,9 +6,8 @@
   fetchFromGitHub,
   rustPlatform,
   installShellFiles,
-  pkg-config,
-  openssl,
   testers,
+  cacert,
 }:
 
 let
@@ -17,13 +16,12 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lychee";
-  version = "0.22.0-unstable-2025-12-05";
+  version = "0.23.0";
 
   src = fetchFromGitHub {
     owner = "lycheeverse";
     repo = "lychee";
-    # tag = "lychee-v${finalAttrs.version}"; # use again with next release
-    rev = "db0f8a842f594e0a879563caf7d183266c02ca95"; # one revision after 0.22.0
+    tag = "lychee-v${finalAttrs.version}";
     leaveDotGit = true;
     postFetch = ''
       GIT_DATE=$(git -C $out/.git show -s --format=%cs)
@@ -33,17 +31,16 @@ rustPlatform.buildRustPackage (finalAttrs: {
           '("cargo:rustc-env=GIT_DATE={}", "'$GIT_DATE'")'
       rm -rf $out/.git
     '';
-    hash = "sha256-l8/llYq8rwt+UQMLnsva4/2m53cwqaJXD/XvgEfxXg4=";
+    hash = "sha256-Rfdys16a4N6B3NsmPsB3OpKjLGElFYvd4UtiRipy8iQ=";
   };
 
-  cargoHash = "sha256-03eahQ6GvOPxnvC82lfT1J/XfOg9V7gOZeOEBJx8IYY=";
+  cargoHash = "sha256-5KL/PmBSU8xkOE9/w7uUBkJSOBPsj3Z4o/2VmzA/f3Q=";
 
   nativeBuildInputs = [
-    pkg-config
     installShellFiles
   ];
 
-  buildInputs = [ openssl ];
+  nativeCheckInputs = [ cacert ];
 
   postFixup = lib.optionalString canRun ''
     ${lychee} --generate man > lychee.1


### PR DESCRIPTION
As we fully switched from OpenSSL to Rustls we now need `cacert` and set `SSL_CERT_FILE`. In turn we can remove `pkg-config` and `openssl`.

Not setting `SSL_CERT_FILE` will make the tests fail:

```
       > thread 'commands::check::tests::test_invalid_url' (10895) panicked at lychee-bin/src/commands/check.rs:343:64:
       > called `Result::unwrap()` on an `Err` value: BuildRequestClient(reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") })
       > note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
