### PR TITLE
maintainers: drop pleshevskiy

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21060,12 +21060,6 @@
     github = "plebhash";
     githubId = 147345153;
   };
-  pleshevskiy = {
-    email = "dmitriy@pleshevski.ru";
-    github = "pleshevskiy";
-    githubId = 7839004;
-    name = "Dmitriy Pleshevskiy";
-  };
   pluiedev = {
     email = "hi@pluie.me";
     github = "pluiedev";

--- a/pkgs/by-name/so/sonic-server/package.nix
+++ b/pkgs/by-name/so/sonic-server/package.nix
@@ -61,9 +61,6 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mpl20;
     platforms = lib.platforms.unix;
     mainProgram = "sonic";
-    maintainers = with lib.maintainers; [
-      pleshevskiy
-      anthonyroussel
-    ];
+    maintainers = with lib.maintainers; [ anthonyroussel ];
   };
 }


### PR DESCRIPTION
User is not active anymore on nixpkgs since 2022.

Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/tree/a7808b41c3cfd040fbe03e12a68654db3c02d5bc/maintainers#losing-maintainer-status)

@pleshevskiy: if you'd like to stay involved, please respond within a week and disable whatever is causing you to be unable to be requested for reviews. Even if you don't do so, you are welcome back at any time.

This PR was split from #490266, which also contains details about the CI that breaks as a result of being unable to request a maintainer for reviews.