### PR TITLE
google-guest-oslogin: 20250821.00 -> 20260214.00

### DIFF
--- a/pkgs/by-name/go/google-guest-oslogin/package.nix
+++ b/pkgs/by-name/go/google-guest-oslogin/package.nix
@@ -10,13 +10,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "google-guest-oslogin";
-  version = "20250821.00";
+  version = "20260214.00";
 
   src = fetchFromGitHub {
     owner = "GoogleCloudPlatform";
     repo = "guest-oslogin";
     rev = finalAttrs.version;
-    sha256 = "sha256-dvLr3rOzHs5gRbllxqmnkLlHUFYv9Hm2vz6AkwZoZy4=";
+    hash = "sha256-xMelRZ3OGQwZLOC03TjpUcXWqsViVWffIZcSVLz58S4=";
   };
 
   postPatch = ''
@@ -40,6 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     "MANDIR=$(out)/share/man"
     "SYSTEMDDIR=$(out)/etc/systemd/system"
     "PRESETDIR=$(out)/etc/systemd/system-preset"
+    "GOOGLEUSERSDIR=$(out)/google-users.d" # A readme is installed to this directory
   ];
 
   postInstall = ''


### PR DESCRIPTION
Bumped the version of the google-guest-oslogin package
- In particular, this update includes a fix to the systemd unit adding a dependency on the network being up (see https://github.com/GoogleCloudPlatform/guest-oslogin/pull/169).
- Added another makefile flag to prevent the installer from trying to create /var/google-users.d (see https://github.com/GoogleCloudPlatform/guest-oslogin/pull/177)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
