### PR TITLE
lib.systems: expose makeMuslParsedPlatform

### DIFF
--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -974,6 +974,41 @@ rec {
     in
     "${cpuName}-${vendor.name}-${kernelName kernel}${optExecFormat}${optAbi}";
 
+  # This is a function from parsed platforms (like stdenv.hostPlatform.parsed)
+  # to parsed platforms.
+  makeMuslParsedPlatform =
+    parsed:
+    # The following line guarantees that the output of this function
+    # is a well-formed platform with no missing fields.
+    (
+      x:
+      lib.trivial.pipe x [
+        (x: removeAttrs x [ "_type" ])
+        mkSystem
+      ]
+    )
+      (
+        parsed
+        // {
+          abi =
+            {
+              gnu = abis.musl;
+              gnueabi = abis.musleabi;
+              gnueabihf = abis.musleabihf;
+              gnuabin32 = abis.muslabin32;
+              gnuabi64 = abis.muslabi64;
+              gnuabielfv2 = abis.musl;
+              gnuabielfv1 = abis.musl;
+              # The following entries ensure that this function is idempotent.
+              musleabi = abis.musleabi;
+              musleabihf = abis.musleabihf;
+              muslabin32 = abis.muslabin32;
+              muslabi64 = abis.muslabi64;
+            }
+            .${parsed.abi.name} or abis.musl;
+        }
+      );
+
   ################################################################################
 
 }

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -85,36 +85,6 @@ in
 }@args:
 
 let
-  # This is a function from parsed platforms (like
-  # stdenv.hostPlatform.parsed) to parsed platforms.
-  makeMuslParsedPlatform =
-    parsed:
-    # The following line guarantees that the output of this function
-    # is a well-formed platform with no missing fields.  It will be
-    # uncommented in a separate PR, in case it breaks the build.
-    #(x: lib.trivial.pipe x [ (x: removeAttrs x [ "_type" ]) lib.systems.parse.mkSystem ])
-    (
-      parsed
-      // {
-        abi =
-          {
-            gnu = lib.systems.parse.abis.musl;
-            gnueabi = lib.systems.parse.abis.musleabi;
-            gnueabihf = lib.systems.parse.abis.musleabihf;
-            gnuabin32 = lib.systems.parse.abis.muslabin32;
-            gnuabi64 = lib.systems.parse.abis.muslabi64;
-            gnuabielfv2 = lib.systems.parse.abis.musl;
-            gnuabielfv1 = lib.systems.parse.abis.musl;
-            # The following two entries ensure that this function is idempotent.
-            musleabi = lib.systems.parse.abis.musleabi;
-            musleabihf = lib.systems.parse.abis.musleabihf;
-            muslabin32 = lib.systems.parse.abis.muslabin32;
-            muslabi64 = lib.systems.parse.abis.muslabi64;
-          }
-          .${parsed.abi.name} or lib.systems.parse.abis.musl;
-      }
-    );
-
   stdenvAdapters =
     self: super:
     let
@@ -199,7 +169,6 @@ let
           nixpkgsFun
           stdenv
           overlays
-          makeMuslParsedPlatform
           ;
       } self super
     );
@@ -319,7 +288,7 @@ let
         isStatic = true;
         config = lib.systems.parse.tripleFromSystem (
           if stdenv.hostPlatform.isLinux then
-            makeMuslParsedPlatform stdenv.hostPlatform.parsed
+            lib.systems.parse.makeMuslParsedPlatform stdenv.hostPlatform.parsed
           else
             stdenv.hostPlatform.parsed
         );

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -10,7 +10,6 @@
   stdenv,
   nixpkgsFun,
   overlays,
-  makeMuslParsedPlatform,
 }:
 let
   makeLLVMParsedPlatform =
@@ -84,7 +83,9 @@ self: super: {
         ]
         ++ overlays;
         ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
-          config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
+          config = lib.systems.parse.tripleFromSystem (
+            lib.systems.parse.makeMuslParsedPlatform stdenv.hostPlatform.parsed
+          );
         };
       }
     else


### PR DESCRIPTION
Moving this helper from pkgs/stdenv/stage.nix so it can be used for alternative variations of pkgsMusl and pkgsStatic.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
