### PR TITLE
filezilla: 3.69.5 -> 3.69.6, libfilezilla: 0.52.0 -> 0.54.1

### DIFF
--- a/pkgs/by-name/fi/filezilla/package.nix
+++ b/pkgs/by-name/fi/filezilla/package.nix
@@ -22,12 +22,12 @@
 
 stdenv.mkDerivation {
   pname = "filezilla";
-  version = "3.69.5";
+  version = "3.69.6";
 
   src = fetchsvn {
     url = "https://svn.filezilla-project.org/svn/FileZilla3/trunk";
-    rev = "11338";
-    hash = "sha256-OQZFwowkmiOcIjWoHkIFwsm6nuyMGSaBSn8zwVpCMAs=";
+    rev = "11365";
+    hash = "sha256-KJI+UxKiwmZfVG0CiS3lDnjz+YNjTy7IoTcOmlGkluk=";
   };
 
   configureFlags = [

--- a/pkgs/by-name/li/libfilezilla/package.nix
+++ b/pkgs/by-name/li/libfilezilla/package.nix
@@ -13,12 +13,12 @@
 
 stdenv.mkDerivation {
   pname = "libfilezilla";
-  version = "0.52.0";
+  version = "0.54.1";
 
   src = fetchsvn {
     url = "https://svn.filezilla-project.org/svn/libfilezilla/trunk";
-    rev = "11335";
-    hash = "sha256-BjHqPC43UtwlYeKbgIaGU8jmWbg5UUiTN8vl1m2mZpo=";
+    rev = "11363";
+    hash = "sha256-m4CfnovtZPvwwjlyWKx/L1OkjiIlKfR7tqg+xB+nqzw=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changes: https://svn.filezilla-project.org/filezilla/FileZilla3/trunk/NEWS

This PR updates both libfilezilla and filezilla to their latest versions.

I updated both simultaneously because libfilezilla is a direct dependency required by the filezilla package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
