### PR TITLE
ha-mcp, home-assistant-custom-components.ha_mcp_tools: restrict update script to release versions

### DIFF
--- a/pkgs/by-name/ha/ha-mcp/package.nix
+++ b/pkgs/by-name/ha/ha-mcp/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
@@ -36,6 +37,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   # Tests require a running Home Assistant instance
   doCheck = false;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^v([0-9]+\\.[0-9]+\\.[0-9]+)$" ];
+  };
 
   pythonImportsCheck = [ "ha_mcp" ];
 

--- a/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/ha_mcp_tools/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildHomeAssistantComponent,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 buildHomeAssistantComponent rec {
@@ -14,6 +15,10 @@ buildHomeAssistantComponent rec {
     repo = "ha-mcp";
     tag = "v${version}";
     hash = "sha256-yAJbvfIH5ewRTip8whbOKxE479qAihESaiLFTnhpRkY=";
+  };
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=^v([0-9]+\\.[0-9]+\\.[0-9]+)$" ];
   };
 
   meta = {


### PR DESCRIPTION
The upstream [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) repo tags both releases (`v6.6.1`) and dev builds (`v6.6.1.dev211`). Without a version regex, the update bot picks up dev tags and opens PRs that shouldn't exist:

- https://github.com/NixOS/nixpkgs/pull/490377
- https://github.com/NixOS/nixpkgs/pull/490375

This adds `nix-update-script` with `--version-regex=^v([0-9]+\.[0-9]+\.[0-9]+)$` to both packages, so only three-segment release versions are matched.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test