### PR TITLE
fluxer-bin: init at 0.0.8

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28789,6 +28789,11 @@
     githubId = 28888242;
     name = "WORLDofPEACE";
   };
+  WoutFontaine = {
+    name = "Wout Fontaine";
+    github = "WoutFontaine";
+    githubId = 123456;
+  };
   WoutSwinkels = {
     name = "Wout Swinkels";
     email = "nixpkgs@woutswinkels.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28792,7 +28792,7 @@
   WoutFontaine = {
     name = "Wout Fontaine";
     github = "WoutFontaine";
-    githubId = 123456;
+    githubId = 231103959;
   };
   WoutSwinkels = {
     name = "Wout Swinkels";

--- a/pkgs/by-name/fl/fluxer-bin/package.nix
+++ b/pkgs/by-name/fl/fluxer-bin/package.nix
@@ -23,6 +23,6 @@ appimageTools.wrapType2 {
     license = licenses.agpl3Only;
     platforms = platforms.linux;
     mainProgram = "fluxer-bin";
-    maintainers = with maintainers; [ ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/fl/fluxer-bin/package.nix
+++ b/pkgs/by-name/fl/fluxer-bin/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+}:
+
+let
+  pname = "fluxer-bin";
+  version = "0.0.8";
+
+  src = fetchurl {
+    url = "https://api.fluxer.app/dl/desktop/stable/linux/x64/fluxer-stable-${version}-x86_64.AppImage";
+    hash = "sha256-GdoBK+Z/d2quEIY8INM4IQy5tzzIBBM+3CgJXQn0qAw=";
+  };
+in
+
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  meta = with lib; {
+    description = "Fluxer desktop client";
+    homepage = "https://fluxer.app";
+    license = licenses.agpl3Only;
+    platforms = platforms.linux;
+    mainProgram = "fluxer-bin";
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/pkgs/by-name/fl/fluxer-bin/package.nix
+++ b/pkgs/by-name/fl/fluxer-bin/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchurl,
   appimageTools,
+  makeDesktopItem,
 }:
 
 let
@@ -12,17 +13,40 @@ let
     url = "https://api.fluxer.app/dl/desktop/stable/linux/x64/fluxer-stable-${version}-x86_64.AppImage";
     hash = "sha256-GdoBK+Z/d2quEIY8INM4IQy5tzzIBBM+3CgJXQn0qAw=";
   };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+
+  desktopItem = makeDesktopItem {
+    name = "fluxer";
+    desktopName = "Fluxer";
+    comment = "Fluxer desktop client";
+    exec = "fluxer-bin %U";
+    icon = "fluxer";
+    terminal = false;
+    categories = [ "InstantMessaging" ];
+  };
 in
 
 appimageTools.wrapType2 {
   inherit pname version src;
 
-  meta = with lib; {
+  extraInstallCommands = ''
+    install -Dm444 ${desktopItem}/share/applications/*.desktop \
+      $out/share/applications/fluxer.desktop
+
+    install -Dm444 \
+      ${appimageContents}/usr/share/icons/hicolor/256x256/apps/fluxer.png \
+      $out/share/icons/hicolor/256x256/apps/fluxer.png
+  '';
+
+  meta = {
     description = "Fluxer desktop client";
     homepage = "https://fluxer.app";
-    license = licenses.agpl3Only;
-    platforms = platforms.linux;
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
     mainProgram = "fluxer-bin";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ WoutFontaine ];
   };
 }


### PR DESCRIPTION
Adds `fluxer-bin` 0.0.8 (AppImage wrapped with `appimageTools.wrapType2`).

Tested: launched successfully on NixOS (Wayland).

Download source: https://fluxer.app/