### PR TITLE
flutter341: 3.41.0 -> 3.41.1

### DIFF
--- a/pkgs/development/compilers/flutter/versions/3_41/data.json
+++ b/pkgs/development/compilers/flutter/versions/3_41/data.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.41.0",
+  "version": "3.41.1",
   "engineVersion": "3452d735bd38224ef2db85ca763d862d6326b17f",
   "engineSwiftShaderHash": "sha256-qbtCl2nTpmtp9dnaoXc7rF3RqLnAZEmzw1BzPoCRWrc=",
   "engineSwiftShaderRev": "794b0cfce1d828d187637e6d932bae484fbe0976",
@@ -21,7 +21,7 @@
     "x86_64-darwin": "sha256-Wlwpx6g4EmkzKAEyaxHMrc8M/nMB7QGj8G6BdmvLjXQ=",
     "aarch64-darwin": "sha256-IjJFpC6rG4EeUC4VYluGcHX/4BLenrU3Skzd4u4IdTQ="
   },
-  "flutterHash": "sha256-/rgmV0BMOF3Mlw/9DVEQkptDUXzJCNEYmQX+BIXlyxY=",
+  "flutterHash": "sha256-qn0r6/JHPN+bFrsxkZ6NvVo3yLFgYnt70LwzsKXNRSk=",
   "artifactHashes": {
     "android": {
       "aarch64-darwin": "sha256-9bjCiMYvcwMMWU8lJdJB+f2P0WxZzzjfs/pUD4qr74g=",
@@ -896,31 +896,31 @@
         "dependency": "direct dev",
         "description": {
           "name": "test",
-          "sha256": "77cc98ea27006c84e71a7356cf3daf9ddbde2d91d84f77dbfe64cf0e4d9611ae",
+          "sha256": "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a",
           "url": "https://pub.dev"
         },
         "source": "hosted",
-        "version": "1.28.0"
+        "version": "1.29.0"
       },
       "test_api": {
         "dependency": "direct main",
         "description": {
           "name": "test_api",
-          "sha256": "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8",
+          "sha256": "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636",
           "url": "https://pub.dev"
         },
         "source": "hosted",
-        "version": "0.7.8"
+        "version": "0.7.9"
       },
       "test_core": {
         "dependency": "direct main",
         "description": {
           "name": "test_core",
-          "sha256": "f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4",
+          "sha256": "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943",
           "url": "https://pub.dev"
         },
         "source": "hosted",
-        "version": "0.6.14"
+        "version": "0.6.15"
       },
       "typed_data": {
         "dependency": "direct main",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/flutter/flutter/blob/3.41.1/CHANGELOG.md#3411
https://github.com/flutter/flutter/releases/tag/3.41.1
https://github.com/flutter/flutter/compare/3.41.0...3.41.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
