### PR TITLE
sidfactory2: init at 20231002

### DIFF
--- a/pkgs/by-name/si/sidfactory2/package.nix
+++ b/pkgs/by-name/si/sidfactory2/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  SDL2,
+}:
+
+stdenv.mkDerivation {
+  pname = "sidfactory2";
+  version = "20231002";
+
+  src = fetchFromGitHub {
+    owner = "Chordian";
+    repo = "sidfactory2";
+    rev = "e06dce7a113d52a5dcc2469ed1dcc4144cba6045";
+    hash = "sha256-Kg+LbWXcUIW/WUnRwCQSEhEs78u1aMpVsR8b2Y0as4E=";
+  };
+
+  buildInputs = [
+    SDL2
+  ];
+
+  buildPhase = ''
+    make dist
+  '';
+
+  installPhase = ''
+
+    ARTIFACT_DIR=$(find artifacts -type d -name "SIDFactoryII_*" | head -n 1)
+
+    cd "$ARTIFACT_DIR" || {
+      echo "Error: Could not find build artifacts directory 'SIDFactoryII_*' inside 'artifacts/'"
+      exit 1
+    }
+
+    install -D -m 555 SIDFactoryII $out/bin/sidfactory2
+    install -d $out/bin/overlay
+    find drivers -type f -exec install -m 444 -D {} $out/bin/{} \;
+
+  '';
+
+  meta = with lib; {
+    description = "SID Factory II - A cross-platform tracker for Commodore 64 music";
+    homepage = "https://blog.chordian.net/sf2/";
+    license = licenses.gpl2;
+    maintainers = with maintainers; [ kmogged ];
+    platforms = platforms.linux;
+    mainProgram = "sidfactory2";
+  };
+}


### PR DESCRIPTION
Adds initial package for the cross-platform tracker for Commodore 64 music (https://blog.chordian.net/sf2/)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
