### PR TITLE
file-preview-daemon: init at 0.1.0

### DIFF
--- a/pkgs/by-name/fi/file-preview-daemon/package.nix
+++ b/pkgs/by-name/fi/file-preview-daemon/package.nix
@@ -1,0 +1,45 @@
+{ lib
+, rustPlatform
+, fetchFromGitHub
+, pkg-config
+, gtk4
+, gtk4-layer-shell
+, wl-clipboard
+, hyprland
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "file-preview-daemon";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "areofyl";
+    repo = "file-preview-daemon";
+    rev = "168aa36d9c4af7123d301ce6ee5b415f926c01e7";
+    sha256 = "sha256-6VvD36dJhhza6vR9V8dUj+calZsHHhNgbUhFxd/7A4k=";
+  };
+
+  cargoHash = "sha256-cZiWksVePRYe5fEv+FspMDmp02qVRg2EOCkDY4MedSA=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk4
+    gtk4-layer-shell
+  ];
+
+  propagatedBuildInputs = [
+    wl-clipboard
+    hyprland
+  ];
+
+  meta = with lib; {
+    description = "File preview daemon for Waybar — shows new files and lets you drag-and-drop them";
+    homepage = "https://github.com/areofyl/file-preview-daemon";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [ ];
+  };
+}


### PR DESCRIPTION
Adds [file-preview-daemon](https://github.com/areofyl/file-preview-daemon), a file preview daemon for Waybar that shows new files and lets you drag-and-drop them.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
