### PR TITLE
nixos/home-assistant: migrate lovelace config to dashboards format

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -162,6 +162,8 @@
 
 - `systemd.coredump.extraConfig` has been removed in favor of the structured [](#opt-systemd.coredump.settings.Coredump) option. Use `systemd.coredump.settings.Coredump` to set any `coredump.conf(5)` option directly. For example, replace `systemd.coredump.extraConfig = "Storage=journal";` with `systemd.coredump.settings.Coredump.Storage = "journal";`.
 
+- `services.home-assistant.config.lovelace.mode` has been renamed to `lovelace.dashboards` and `lovelace.resource_mode` to match the [configuration format](https://www.home-assistant.io/dashboards/dashboards/) required by Home Assistant 2026.8. Users who explicitly set `lovelace.mode` should remove it; the module generates the correct entries automatically.
+
 - `opentrack`, `slushload`, `synthesia`, `vtfedit`, `winbox`, `wineasio`, and `yabridge` use wineWow64Packages instead of wineWowPackages as wine versions >= 11.0 have deprecated wineWowPackages. As such, the prefixes for these packages are NOT backwards compatible and need to be regenerated with potential for data loss.
 
 - []{#sec-release-26.05-incompatibilities-profiles-hardened-removed} `profiles/hardened` has been removed, because:

--- a/nixos/modules/services/home-automation/home-assistant.nix
+++ b/nixos/modules/services/home-automation/home-assistant.nix
@@ -30,6 +30,7 @@ let
     mapAttrsToList
     mergeAttrsList
     mkEnableOption
+    mkDefault
     mkIf
     mkMerge
     mkOption
@@ -319,7 +320,8 @@ in
         Available cards can be found below `pkgs.home-assistant-custom-lovelace-modules`.
 
         ::: {.note}
-        Automatic loading only works with lovelace in `yaml` mode.
+        When non-empty, `lovelace.resource_mode` is automatically set to `"yaml"`
+        so that resources are loaded from the YAML configuration.
         :::
       '';
     };
@@ -428,21 +430,57 @@ in
 
             lovelace = {
               # https://www.home-assistant.io/lovelace/dashboards/
-              mode = mkOption {
-                type = types.enum [
-                  "yaml"
-                  "storage"
-                ];
+              dashboards.nixos-lovelace = mkOption {
+                type = types.nullOr format.type;
                 default =
-                  if (cfg.lovelaceConfig != null || cfg.lovelaceConfigFile != null) then "yaml" else "storage";
+                  if cfg.lovelaceConfig != null || cfg.lovelaceConfigFile != null then
+                    {
+                      mode = "yaml";
+                      filename = "ui-lovelace.yaml";
+                      title = "Overview";
+                      icon = "mdi:view-dashboard";
+                      show_in_sidebar = true;
+                    }
+                  else
+                    null;
                 defaultText = literalExpression ''
-                  if (cfg.lovelaceConfig != null || cfg.lovelaceConfigFile != null)
-                    then "yaml"
-                  else "storage";
+                  if cfg.lovelaceConfig != null || cfg.lovelaceConfigFile != null then {
+                    mode = "yaml";
+                    filename = "ui-lovelace.yaml";
+                    title = "Overview";
+                    icon = "mdi:view-dashboard";
+                    show_in_sidebar = true;
+                  } else null
                 '';
-                example = "yaml";
                 description = ''
-                  In what mode should the main Lovelace panel be, `yaml` or `storage` (UI managed).
+                  Default NixOS-managed Lovelace dashboard. Automatically populated
+                  when {option}`lovelaceConfig` or {option}`lovelaceConfigFile` is set.
+
+                  Additional dashboards can be defined under
+                  `config.lovelace.dashboards.<name>`.
+
+                  See <https://www.home-assistant.io/lovelace/dashboards/> for details.
+                '';
+              };
+
+              resource_mode = mkOption {
+                type = types.nullOr (
+                  types.enum [
+                    "yaml"
+                    "storage"
+                  ]
+                );
+                default = if cfg.customLovelaceModules != [ ] then "yaml" else null;
+                defaultText = literalExpression ''
+                  if cfg.customLovelaceModules != [ ] then "yaml" else null
+                '';
+                description = ''
+                  Set to `"yaml"` to load Lovelace resources from YAML configuration,
+                  or `"storage"` to manage them through the UI. See
+                  <https://www.home-assistant.io/dashboards/dashboards/#resource_mode>.
+
+                  Automatically set to `"yaml"` when {option}`customLovelaceModules`
+                  is non-empty.
                 '';
               };
             };
@@ -510,7 +548,7 @@ in
       '';
       description = ''
         Your {file}`ui-lovelace.yaml` as a Nix attribute set.
-        Setting this option will automatically set `lovelace.mode` to `yaml`.
+        Setting this option will automatically configure a Lovelace dashboard in YAML mode.
 
         Beware that setting this option will delete your previous {file}`ui-lovelace.yaml`
       '';
@@ -521,8 +559,8 @@ in
       type = types.nullOr types.path;
       example = "/path/to/ui-lovelace.yaml";
       description = ''
-        Your {file}`ui-lovelace.yaml` managed as configuraton file.
-        Setting this option will automatically set `lovelace.mode` to `yaml`.
+        Your {file}`ui-lovelace.yaml` managed as configuration file.
+        Setting this option will automatically configure a Lovelace dashboard in YAML mode.
       '';
     };
 
@@ -619,6 +657,19 @@ in
   };
 
   config = mkIf cfg.enable {
+    warnings = optionals (cfg.config ? lovelace.mode) [
+      ''
+        services.home-assistant.config.lovelace.mode is deprecated.
+        Home Assistant 2026.8 renames the legacy top-level `lovelace.mode`
+        setting in favour of per-dashboard configuration.
+
+        Use `services.home-assistant.config.lovelace.dashboards` and
+        `services.home-assistant.config.lovelace.resource_mode` instead.
+
+        See https://www.home-assistant.io/dashboards/dashboards/ for details.
+      ''
+    ];
+
     assertions = [
       {
         assertion = cfg.openFirewall -> cfg.config != null;


### PR DESCRIPTION
Home Assistant 2026.8 drops the top-level `lovelace: mode: yaml`. Replace it with `lovelace.dashboards` and `lovelace.resource_mode` per https://www.home-assistant.io/dashboards/dashboards/

Also adds a deprecation warning for explicit `lovelace.mode` usage and a 26.05 release notes entry.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
