### PR TITLE
knope: init at 0.22.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10779,6 +10779,11 @@
     email = "astrid@astrid.tech";
     name = "ifd3f";
   };
+  ifiokjr = {
+    name = "Ifiok Jr.";
+    github = "ifiokjr";
+    githubId = 1160934;
+  };
   iFreilicht = {
     github = "iFreilicht";
     githubId = 9742635;

--- a/pkgs/by-name/kn/knope/package.nix
+++ b/pkgs/by-name/kn/knope/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "knope";
+  version = "0.22.2";
+
+  src = fetchFromGitHub {
+    owner = "knope-dev";
+    repo = "knope";
+    tag = "knope/v${finalAttrs.version}";
+    hash = "sha256-8vR1kNx1UFwROCRm1LtrTcBmiZoKZ9sXP5MdAvYWLRI=";
+  };
+
+  cargoHash = "sha256-69x6tErSmH3QcQGIu9jc77JlWkm+Z+2Yae5CjzsfiQk=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  # Integration tests require git and network access
+  doCheck = false;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^knope/v(.*)$"
+    ];
+  };
+
+  meta = {
+    description = "A command line tool for automating common development tasks";
+    homepage = "https://knope.tech";
+    changelog = "https://github.com/knope-dev/knope/blob/knope/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ifiokjr ];
+    mainProgram = "knope";
+  };
+})


### PR DESCRIPTION
[knope](https://knope.tech) is a command line tool for automating common development tasks like versioning, changelogs, and GitHub/Gitea releases.

- Homepage: https://knope.tech
- License: MIT
- Changelog: https://github.com/knope-dev/knope/blob/knope/v0.22.2/CHANGELOG.md

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test