### PR TITLE
dtk: init at 0-unstable-2020-05-28

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1773,6 +1773,12 @@
     githubId = 2085567;
     name = "Aneesh Agrawal";
   };
+  Aneurysm9 = {
+    email = "a9@aneurysm9.com";
+    github = "Aneurysm9";
+    githubId = 473616;
+    name = "Anthony Mirabella";
+  };
   angaz = {
     name = "Angus Dippenaar";
     github = "angaz";

--- a/pkgs/by-name/dt/dtk/package.nix
+++ b/pkgs/by-name/dt/dtk/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  makeWrapper,
+  perl,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "dtk";
+  version = "0-unstable-2020-05-28";
+
+  src = fetchFromGitHub {
+    owner = "synacor";
+    repo = "dtk";
+    rev = "8d0e8707762bf36181db506da383cf4b44fa074a";
+    hash = "sha256-pzYsz2oJRZMA+81h8j+poBkTmkTVVFanwLG3Ll0RcVQ=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    (perl.withPackages (ps: [ ps.TimeDate ]))
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dtk $out/bin/dtk
+
+    mkdir -p $out/libexec/dtk-modules/parse-formats
+    for f in modules/*; do
+      [ -f "$f" ] && install -m755 "$f" $out/libexec/dtk-modules/
+    done
+    for f in modules/parse-formats/*; do
+      [ -f "$f" ] && install -m755 "$f" $out/libexec/dtk-modules/parse-formats/
+    done
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/dtk \
+      --prefix DTK_MODPATH : $out/libexec/dtk-modules
+    for f in $out/libexec/dtk-modules/*; do
+      [ -f "$f" ] && wrapProgram "$f"
+    done
+    for f in $out/libexec/dtk-modules/parse-formats/*; do
+      [ -f "$f" ] && wrapProgram "$f"
+    done
+  '';
+
+  meta = {
+    description = "Suite of command-line tools for parsing, analyzing, and visualizing logs and datasets";
+    homepage = "https://github.com/synacor/dtk";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.unix;
+    mainProgram = "dtk";
+    maintainers = with lib.maintainers; [ Aneurysm9 ];
+  };
+}


### PR DESCRIPTION
new package `dtk`: https://github.com/synacor/dtk

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
