### PR TITLE
python3Packages.requests-hardened: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/pproxy/default.nix
+++ b/pkgs/development/python-modules/pproxy/default.nix
@@ -18,8 +18,8 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "qwj";
     repo = "python-proxy";
-    rev = "7fccf8dd62204f34b0aa3a70fc568fd6ddff7728";
-    sha256 = "sha256-bOqDdNiaZ5MRi/UeF0hJwMs+rfQBKRsTmXrZ6ieIguo=";
+    tag = version;
+    hash = "sha256-DWxbU2LtXzec1T175cMVJuWuhnxWYhe0FH67stMyOTM=";
   };
 
   nativeBuildInputs = [ setuptools ];
@@ -58,6 +58,6 @@ buildPythonPackage rec {
     mainProgram = "pproxy";
     homepage = "https://github.com/qwj/python-proxy";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.ryand56 ];
   };
 }

--- a/pkgs/development/python-modules/requests-hardened/default.nix
+++ b/pkgs/development/python-modules/requests-hardened/default.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  poetry-core,
+  requests,
+
+  pproxy,
+  pytest-socket,
+  pysocks,
+  trustme,
+  pytestCheckHook,
+}:
+buildPythonPackage rec {
+  pname = "requests-hardened";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "saleor";
+    repo = "requests-hardened";
+    tag = "v${version}";
+    hash = "sha256-J4xQY2W5upJQ3hrA2hjkw8voLpxNPpekNwmyMKKAVAo=";
+  };
+
+  build-system = [ poetry-core ];
+  dependencies = [ requests ];
+
+  nativeCheckInputs = [
+    pproxy
+    pytest-socket
+    pysocks
+    trustme
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "requests_hardened" ];
+
+  meta = {
+    description = "Library that adds hardened behavior to python requests";
+    homepage = "https://github.com/saleor/requests-hardened";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.ryand56 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16488,6 +16488,8 @@ self: super: with self; {
 
   requests-gssapi = callPackage ../development/python-modules/requests-gssapi { };
 
+  requests-hardened = callPackage ../development/python-modules/requests-hardened { };
+
   requests-hawk = callPackage ../development/python-modules/requests-hawk { };
 
   requests-http-message-signatures =


### PR DESCRIPTION
Needed for #485582

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
