### PR TITLE
apt-dater: 1.0.4-unstable-2024-10-04 -> 1.0.4-unstable-2026-02-15 (`g…

### DIFF
--- a/pkgs/by-name/ap/apt-dater/package.nix
+++ b/pkgs/by-name/ap/apt-dater/package.nix
@@ -12,17 +12,18 @@
   popt,
   libxslt,
   screen,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation {
   pname = "apt-dater";
-  version = "1.0.4-unstable-2024-10-04";
+  version = "1.0.4-unstable-2026-02-15";
 
   src = fetchFromGitHub {
     owner = "DE-IBH";
     repo = "apt-dater";
-    rev = "113ea9b72d318f316ea7cac8ddad5be004787a22";
-    hash = "sha256-/Ufa/pEbqD25kp+k0zm9MuLS1zG+xWqhpBkL7ng2+Bo=";
+    rev = "eb3df6923262051082df2e9377516553da9ba508";
+    hash = "sha256-I5TQ6sPIWD7jllelkvYjLa/7FI2IpWsGRS4FsxXQKGs=";
   };
 
   nativeBuildInputs = [
@@ -65,6 +66,12 @@ stdenv.mkDerivation {
   '';
 
   doCheck = true;
+
+  # Use unstable to pull in gcc-15 fixes:
+  #   https://github.com/DE-IBH/apt-dater/pull/187
+  passthru.updateScript = unstableGitUpdater {
+    tagPrefix = "v";
+  };
 
   meta = {
     homepage = "https://github.com/DE-IBH/apt-dater";


### PR DESCRIPTION
…cc-15` fix)

Without the change the build fails on `master` as
https://hydra.nixos.org/build/320776415:

```
sighandler.c: In function 'setSigHandler':
sighandler.c:68:18: error: passing argument 2 of 'signal' from incompatible pointer type [-Wincompatible-pointer-types]
   68 |  signal(SIGTERM, sigtermSigHandler);
      |                  ^~~~~~~~~~~~~~~~~
      |                  |
      |                  void (*)(void)
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
