### PR TITLE
kotlin-lsp, vscode-extensions.jetbrains.kotlin: init at 261.13587.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11273,6 +11273,12 @@
     githubId = 49095435;
     name = "imsuck";
   };
+  imsugeno = {
+    email = "g.tokyo.kazusa@gmail.com";
+    github = "imsugeno";
+    githubId = 52691115;
+    name = "Kazusa Sugeno";
+  };
   imuli = {
     email = "i@imu.li";
     github = "imuli";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2499,6 +2499,8 @@ let
         };
       };
 
+      jetbrains.kotlin = callPackage ./jetbrains.kotlin { };
+
       jetmartin.bats = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "bats";

--- a/pkgs/applications/editors/vscode/extensions/jetbrains.kotlin/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jetbrains.kotlin/default.nix
@@ -62,6 +62,8 @@ vscode-utils.buildVscodeExtension {
     rm -rf server/jre
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Official Kotlin Language Server extension for VSCode from JetBrains";
     homepage = "https://github.com/Kotlin/kotlin-lsp";

--- a/pkgs/applications/editors/vscode/extensions/jetbrains.kotlin/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jetbrains.kotlin/default.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  vscode-utils,
+  jq,
+  moreutils,
+  openjdk21,
+}:
+
+let
+  version = "261.13587.0";
+
+  sources = {
+    "x86_64-linux" = {
+      platform = "linux-x64";
+      hash = "sha256-awQsgq1njVvdaF4RX4tEMa+LXi4MRd3MWlc424ePX7w=";
+    };
+    "aarch64-linux" = {
+      platform = "linux-aarch64";
+      hash = "sha256-3b1ewCH3rCkAH2hqJKwcUgJ3VPQzoVBNKl9Br6PiChA=";
+    };
+    "x86_64-darwin" = {
+      platform = "mac-x64";
+      hash = "sha256-Ziwu7roFZmWMXIJX5fGP4eMsRYhJ6AnchCZZ/zpZaPY=";
+    };
+    "aarch64-darwin" = {
+      platform = "mac-aarch64";
+      hash = "sha256-PheDfIJ9Eya5BQck84x43VDImi7yRleW84Eebcsfma0=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+vscode-utils.buildVscodeExtension {
+  pname = "kotlin";
+  inherit version;
+  src = fetchurl {
+    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${version}/kotlin-lsp-${version}-${source.platform}.vsix";
+    inherit (source) hash;
+  };
+  vscodeExtPublisher = "JetBrains";
+  vscodeExtName = "kotlin";
+  vscodeExtUniqueId = "JetBrains.kotlin";
+
+  nativeBuildInputs = [
+    jq
+    moreutils
+  ];
+
+  postInstall = ''
+    cd "$out/$installPrefix"
+    jq '.contributes.configuration |= map(
+      if .properties."kotlinLSP.jrePathToRunLsp" then
+        .properties."kotlinLSP.jrePathToRunLsp".default = "${openjdk21}"
+      else . end
+    )' package.json | sponge package.json
+
+    # Remove bundled JRE (using nixpkgs openjdk21 instead)
+    rm -rf server/jre
+  '';
+
+  meta = {
+    description = "Official Kotlin Language Server extension for VSCode from JetBrains";
+    homepage = "https://github.com/Kotlin/kotlin-lsp";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    platforms = builtins.attrNames sources;
+    maintainers = with lib.maintainers; [ imsugeno ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/jetbrains.kotlin/update.sh
+++ b/pkgs/applications/editors/vscode/extensions/jetbrains.kotlin/update.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix curl coreutils jq common-updater-scripts
+
+set -eou pipefail
+
+latestVersion=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL \
+  https://api.github.com/repos/Kotlin/kotlin-lsp/releases/latest \
+  | jq -r '.tag_name | ltrimstr("kotlin-lsp/v")')
+currentVersion=$(nix-instantiate --eval -E \
+  "with import ./. {}; vscode-extensions.jetbrains.kotlin.version" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+update-source-version vscode-extensions.jetbrains.kotlin "$latestVersion" || true
+
+for system in x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin; do
+    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 \
+      $(nix-prefetch-url $(nix-instantiate --eval -E \
+        "with import ./. {}; vscode-extensions.jetbrains.kotlin.src.url" \
+        --system "$system" | tr -d '"')))
+    update-source-version vscode-extensions.jetbrains.kotlin "$latestVersion" "$hash" \
+      --system="$system" --ignore-same-version
+done

--- a/pkgs/by-name/ko/kotlin-lsp/package.nix
+++ b/pkgs/by-name/ko/kotlin-lsp/package.nix
@@ -122,6 +122,8 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Official Kotlin Language Server from JetBrains (pre-alpha)";
     homepage = "https://github.com/Kotlin/kotlin-lsp";

--- a/pkgs/by-name/ko/kotlin-lsp/package.nix
+++ b/pkgs/by-name/ko/kotlin-lsp/package.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  openjdk21,
+  makeWrapper,
+  autoPatchelfHook,
+}:
+
+let
+  version = "261.13587.0";
+
+  sources = {
+    "x86_64-linux" = {
+      platform = "linux-x64";
+      hash = "sha256-EweSqy30NJuxvlJup78O+e+JOkzvUdb6DshqAy1j9jE=";
+    };
+    "aarch64-linux" = {
+      platform = "linux-aarch64";
+      hash = "sha256-MhHEYHBctaDH9JVkN/guDCG1if9Bip1aP3n+JkvHCvA=";
+    };
+    "x86_64-darwin" = {
+      platform = "mac-x64";
+      hash = "sha256-zMuUcahT1IiCT1NTrMCIzUNM0U6U3zaBkJtbGrzF7I8=";
+    };
+    "aarch64-darwin" = {
+      platform = "mac-aarch64";
+      hash = "sha256-zwlzVt3KYN0OXKr6sI9XSijXSbTImomSTGRGa+3zCK8=";
+    };
+  };
+
+  source =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
+stdenv.mkDerivation {
+  pname = "kotlin-lsp";
+  inherit version;
+
+  src = fetchzip {
+    url = "https://download-cdn.jetbrains.com/kotlin-lsp/${version}/kotlin-lsp-${version}-${source.platform}.zip";
+    inherit (source) hash;
+    stripRoot = false;
+  };
+
+  dontBuild = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/kotlin-lsp
+    cp -r lib/* $out/lib/kotlin-lsp/
+    cp -r native $out/lib/kotlin-lsp/
+
+    mkdir -p $out/bin
+    makeWrapper ${openjdk21}/bin/java $out/bin/kotlin-lsp \
+      --add-flags "--add-opens java.base/java.io=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.lang=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.lang.ref=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.lang.reflect=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.net=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.nio=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.nio.charset=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.text=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.time=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.util=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.util.concurrent=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/java.util.concurrent.locks=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/jdk.internal.vm=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/sun.net.dns=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/sun.nio.ch=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/sun.nio.fs=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/sun.security.ssl=ALL-UNNAMED" \
+      --add-flags "--add-opens java.base/sun.security.util=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/com.apple.eawt=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/com.apple.eawt.event=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/com.apple.laf=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/com.sun.java.swing=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/java.awt=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/java.awt.dnd.peer=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/java.awt.event=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/java.awt.font=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/java.awt.image=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/java.awt.peer=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/javax.swing=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/javax.swing.text=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/javax.swing.text.html=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.awt=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.awt.X11=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.awt.datatransfer=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.awt.image=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.awt.windows=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.font=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.java2d=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.lwawt=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.lwawt.macosx=ALL-UNNAMED" \
+      --add-flags "--add-opens java.desktop/sun.swing=ALL-UNNAMED" \
+      --add-flags "--add-opens java.management/sun.management=ALL-UNNAMED" \
+      --add-flags "--add-opens jdk.attach/sun.tools.attach=ALL-UNNAMED" \
+      --add-flags "--add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED" \
+      --add-flags "--add-opens jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED" \
+      --add-flags "--add-opens jdk.jdi/com.sun.tools.jdi=ALL-UNNAMED" \
+      --add-flags "--enable-native-access=ALL-UNNAMED" \
+      --add-flags "-Djdk.lang.Process.launchMechanism=FORK" \
+      --add-flags "-Djava.awt.headless=true" \
+      --add-flags "-Djava.library.path='$out/lib/kotlin-lsp/native'" \
+      --add-flags "-cp '$out/lib/kotlin-lsp/*'" \
+      --add-flags "com.jetbrains.ls.kotlinLsp.KotlinLspServerKt"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Official Kotlin Language Server from JetBrains (pre-alpha)";
+    homepage = "https://github.com/Kotlin/kotlin-lsp";
+    license = lib.licenses.asl20;
+    mainProgram = "kotlin-lsp";
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+      binaryNativeCode
+    ];
+    platforms = builtins.attrNames sources;
+    maintainers = with lib.maintainers; [ imsugeno ];
+  };
+}

--- a/pkgs/by-name/ko/kotlin-lsp/update.sh
+++ b/pkgs/by-name/ko/kotlin-lsp/update.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p bash nix curl coreutils jq common-updater-scripts
+
+set -eou pipefail
+
+latestVersion=$(curl ${GITHUB_TOKEN:+-u ":$GITHUB_TOKEN"} -sL \
+  https://api.github.com/repos/Kotlin/kotlin-lsp/releases/latest \
+  | jq -r '.tag_name | ltrimstr("kotlin-lsp/v")')
+currentVersion=$(nix-instantiate --eval -E "with import ./. {}; kotlin-lsp.version" | tr -d '"')
+
+echo "latest  version: $latestVersion"
+echo "current version: $currentVersion"
+
+if [[ "$latestVersion" == "$currentVersion" ]]; then
+    echo "package is up-to-date"
+    exit 0
+fi
+
+update-source-version kotlin-lsp "$latestVersion" || true
+
+for system in x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin; do
+    hash=$(nix --extra-experimental-features nix-command hash convert --to sri --hash-algo sha256 \
+      $(nix-prefetch-url --unpack $(nix-instantiate --eval -E \
+        "with import ./. {}; kotlin-lsp.src.url" --system "$system" | tr -d '"')))
+    update-source-version kotlin-lsp "$latestVersion" "$hash" \
+      --system="$system" --ignore-same-version
+done


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
