### PR TITLE
arrow-cpp: enable structuredAttrs; python3Packages.pyarrow: fix references to env vars

### DIFF
--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -322,6 +322,8 @@ stdenv.mkDerivation (finalAttrs: {
       runHook postInstallCheck
     '';
 
+  __structuredAttrs = true;
+
   meta = {
     description = "Cross-language development platform for in-memory data";
     homepage = "https://arrow.apache.org/docs/cpp/";

--- a/pkgs/development/python-modules/pyarrow/default.nix
+++ b/pkgs/development/python-modules/pyarrow/default.nix
@@ -60,23 +60,30 @@ buildPythonPackage rec {
     pytest-lazy-fixture
   ];
 
-  PYARROW_BUILD_TYPE = "release";
+  env = {
+    PYARROW_BUILD_TYPE = "release";
 
-  PYARROW_WITH_DATASET = zero_or_one true;
-  PYARROW_WITH_FLIGHT = zero_or_one arrow-cpp.enableFlight;
-  PYARROW_WITH_HDFS = zero_or_one true;
-  PYARROW_WITH_PARQUET = zero_or_one true;
-  PYARROW_WITH_PARQUET_ENCRYPTION = zero_or_one true;
-  PYARROW_WITH_S3 = zero_or_one arrow-cpp.enableS3;
-  PYARROW_WITH_GCS = zero_or_one arrow-cpp.enableGcs;
-  PYARROW_BUNDLE_ARROW_CPP_HEADERS = zero_or_one false;
+    PYARROW_WITH_DATASET = zero_or_one true;
+    PYARROW_WITH_FLIGHT = zero_or_one arrow-cpp.enableFlight;
+    PYARROW_WITH_HDFS = zero_or_one true;
+    PYARROW_WITH_PARQUET = zero_or_one true;
+    PYARROW_WITH_PARQUET_ENCRYPTION = zero_or_one true;
+    PYARROW_WITH_S3 = zero_or_one arrow-cpp.enableS3;
+    PYARROW_WITH_GCS = zero_or_one arrow-cpp.enableGcs;
+    PYARROW_BUNDLE_ARROW_CPP_HEADERS = zero_or_one false;
 
-  PYARROW_CMAKE_OPTIONS = [ "-DCMAKE_INSTALL_RPATH=${ARROW_HOME}/lib" ];
+    PYARROW_CMAKE_OPTIONS = toString [
+      "-DCMAKE_INSTALL_RPATH=${arrow-cpp}/lib"
+    ];
 
-  ARROW_HOME = arrow-cpp;
-  PARQUET_HOME = arrow-cpp;
+    ARROW_HOME = arrow-cpp;
+    PARQUET_HOME = arrow-cpp;
 
-  ARROW_TEST_DATA = lib.optionalString doCheck arrow-cpp.ARROW_TEST_DATA;
+  }
+  // lib.optionalAttrs doCheck {
+    ARROW_TEST_DATA = arrow-cpp.env.ARROW_TEST_DATA;
+  };
+
   doCheck = true;
 
   dontUseCmakeConfigure = true;
@@ -150,7 +157,7 @@ buildPythonPackage rec {
   disabledTests = [ "GcsFileSystem" ];
 
   preCheck = ''
-    export PARQUET_TEST_DATA="${arrow-cpp.PARQUET_TEST_DATA}"
+    export PARQUET_TEST_DATA="${arrow-cpp.env.PARQUET_TEST_DATA}"
     shopt -s extglob
     rm -r pyarrow/!(conftest.py|tests)
     mv pyarrow/conftest.py pyarrow/tests/parent_conftest.py


### PR DESCRIPTION
Possible followup to eval errors encountered in https://github.com/NixOS/nixpkgs/pull/489960#issuecomment-3903739208 .

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
