### PR TITLE
guitarix: fix cross compilation

### DIFF
--- a/pkgs/applications/audio/guitarix/default.nix
+++ b/pkgs/applications/audio/guitarix/default.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/trunk";
 
+  strictDeps = true;
+
   nativeBuildInputs = [
     gettext
     hicolor-icon-theme
@@ -64,6 +66,8 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     wafHook
     wrapGAppsHook3
+    faust
+    sassc
   ];
 
   buildInputs = [
@@ -72,7 +76,6 @@ stdenv.mkDerivation (finalAttrs: {
     boost
     curl
     eigen
-    faust
     fftw
     glib
     glib-networking.out
@@ -87,7 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     lilv
     lrdf
     lv2
-    sassc
     serd
     sord
     sratom
@@ -102,6 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-nls"
     "--install-roboto-font"
   ]
+  ++ optional (!stdenv.hostPlatform.isx86) "--disable-sse"
   ++ optional optimizationSupport "--optimization";
 
   env.NIX_CFLAGS_COMPILE = toString [ "-fpermissive" ];


### PR DESCRIPTION
`faust` and `sassc` are only required during the build phase to generate and compile resources. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
