### PR TITLE
yabridge: disable bitbridge support

### DIFF
--- a/pkgs/by-name/ya/yabridge/hardcode-dependencies.patch
+++ b/pkgs/by-name/ya/yabridge/hardcode-dependencies.patch
@@ -1,16 +1,3 @@
-diff --git a/meson.build b/meson.build
-index 9e69128d..8c53ac88 100644
---- a/meson.build
-+++ b/meson.build
-@@ -226,7 +226,7 @@ if is_64bit_system
-   xcb_64bit_dep = dependency('xcb')
- endif
- if with_bitbridge
--  xcb_32bit_dep = winegcc.find_library('xcb')
-+  xcb_32bit_dep = winegcc.find_library('xcb', dirs: ['@libxcb32@/lib'])
- endif
- 
- # These are all headers-only libraries, and thus won't require separate 32-bit
 diff --git a/src/common/notifications.cpp b/src/common/notifications.cpp
 index 654b6c83..78ba2fe7 100644
 --- a/src/common/notifications.cpp

--- a/pkgs/by-name/ya/yabridge/package.nix
+++ b/pkgs/by-name/ya/yabridge/package.nix
@@ -1,9 +1,8 @@
 {
   lib,
-  multiStdenv,
+  stdenv,
   fetchFromGitHub,
   replaceVars,
-  pkgsi686Linux,
   dbus,
   meson,
   ninja,
@@ -73,7 +72,7 @@ let
     hash = "sha256-LsPHPoAL21XOKmF1Wl/tvLJGzjaCLjaDAcUtDvXdXSU=";
   };
 in
-multiStdenv.mkDerivation (finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "yabridge";
   version = "5.1.1";
 
@@ -105,7 +104,6 @@ multiStdenv.mkDerivation (finalAttrs: {
     # Hard code bitbridge & runtime dependencies
     (replaceVars ./hardcode-dependencies.patch {
       libdbus = dbus.lib;
-      libxcb32 = pkgsi686Linux.libxcb;
       inherit wine;
     })
 
@@ -140,7 +138,7 @@ multiStdenv.mkDerivation (finalAttrs: {
   mesonFlags = [
     "--cross-file"
     "cross-wine.conf"
-    "-Dbitbridge=true"
+    "-Dbitbridge=false"
 
     # Requires CMake and is unnecessary
     "-Dtomlplusplus:generate_cmake_config=false"
@@ -149,7 +147,7 @@ multiStdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
     mkdir -p "$out/bin" "$out/lib"
-    cp yabridge-host{,-32}.exe{,.so} "$out/bin"
+    cp yabridge-host.exe{,.so} "$out/bin"
     cp libyabridge{,-chainloader}-{vst2,vst3,clap}.so "$out/lib"
     runHook postInstall
   '';


### PR DESCRIPTION
Fixes build failure with Wine WoW64 mode which no longer supports 32-bit Winelib applications.

Fixes #490049

!NOTE: The proposed changes will make it impossible to use 32-bit VSTs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
