### PR TITLE
yarn-berry: fix fetcher with latest zlib-ng

### DIFF
--- a/pkgs/by-name/ya/yarn-berry/fetcher/default.nix
+++ b/pkgs/by-name/ya/yarn-berry/fetcher/default.nix
@@ -8,6 +8,7 @@
   zlib-ng,
   makeScopeWithSplicing',
   generateSplicesForMkScope,
+  fetchpatch,
 }:
 
 let
@@ -46,9 +47,22 @@ let
       libzip =
         (libzip.override {
           # Known good version: 2.2.4
-          zlib = zlib-ng.override {
-            withZlibCompat = true;
-          };
+          zlib =
+            (zlib-ng.overrideAttrs (old: {
+              patches = old.patches or [ ] ++ [
+                # Yarn hashes the output of libzip(untar(tarball)), so the output of libzip
+                # needs to be an exact match across versions, and this commit changes the
+                # exact output. This is ridiculous, but such is life.
+                (fetchpatch {
+                  url = "https://github.com/zlib-ng/zlib-ng/commit/be819413be8a284b1827437006c0859644d0c367.patch";
+                  revert = true;
+                  hash = "sha256-rwRcNKpA2dMWkC6WRATDOCYCDDqqPvFJkQ6DLDohQd8=";
+                })
+              ];
+            })).override
+              {
+                withZlibCompat = true;
+              };
         }).overrideAttrs
           (old: {
             patches = (old.patches or [ ]) ++ [


### PR DESCRIPTION
This sucks. This SUCKS. I have no better fix.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
