### PR TITLE
[25.11] wordpressPackages.plugins.merge-minify-refresh: 2.12 -> 2.15

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -114,10 +114,10 @@
     "version": "5.10.1"
   },
   "merge-minify-refresh": {
-    "path": "merge-minify-refresh/trunk",
-    "rev": "3126978",
-    "sha256": "1xrr7ddriagd8hh6f0n9bkfqsc32rvzb9prbrh1r1k6qr84z0pi6",
-    "version": "2.12"
+    "path": "merge-minify-refresh/tags/2.15",
+    "rev": "3432380",
+    "sha256": "13p324apg3rpb3ssr8d1kmbm51i2bmpn4z6xzardsl10nw79yy1f",
+    "version": "2.15"
   },
   "opengraph": {
     "path": "opengraph/tags/2.0.2",


### PR DESCRIPTION
Fixes CVE-2026-24384

Closes #482975.

https://github.com/Launch-Interactive/Merge-Minify-Refresh/compare/2.13...2.15

Not-cherry-picked-because: upgrade on stable is bundled with other packages https://github.com/NixOS/nixpkgs/commit/afd2dc4ec4fea58a5137d9118e9b81d993b2e4fc


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
