### PR TITLE
Fixed hyprpaper functionality for newer versions

### DIFF
--- a/pkgs/by-name/wa/waypaper/hypr-compat.patch
+++ b/pkgs/by-name/wa/waypaper/hypr-compat.patch
@@ -1,0 +1,24 @@
+--- a/waypaper/changer.py
++++ b/waypaper/changer.py
+@@ -218,7 +218,20 @@
+             try:
+                 subprocess.check_output(unload_command, encoding="utf-8").strip()
+                 subprocess.check_output(preload_command, encoding="utf-8").strip()
+-                result = subprocess.check_output(wallpaper_command, encoding="utf-8").strip()
++            except Exception:
++                pass
++                # Preloading images with Hyprpaper is currently unavailable due to https://github.com/hyprwm/hyprpaper/pull/288
++                # It has not yet been determined if this will be reimplemented - https://github.com/hyprwm/hyprpaper/issues/292
++            try:
++                wpresult = subprocess.run(
++                        wallpaper_command,
++                        encoding="utf-8",
++                        capture_output=True,
++                        text=True,
++                        check=True
++                )
++                if wpresult.returncode == 0 or wpresult.stdout.strip() == "ok":
++                    result = "ok"
+                 time.sleep(0.1)
+             except Exception:
+                 retry_counter += 1

--- a/pkgs/by-name/wa/waypaper/package.nix
+++ b/pkgs/by-name/wa/waypaper/package.nix
@@ -20,6 +20,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hash = "sha256-wtYF9H56IARkrFbChtuhWtOietA88khQJSOpfDtGQro=";
   };
 
+  patches = [
+    ./hypr-compat.patch
+  ];
+
   nativeBuildInputs = [
     gobject-introspection
     wrapGAppsHook3


### PR DESCRIPTION
A recent merge into the main branch of Hyprpaper removed its image preloading/unloading capabilities. This change simply moves those IPC requests to their own try/catch block so that the wallpaper will still be changed if they fail.

notify: @prince213 @totalchaos

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
