### PR TITLE
goaway: init at 0.63.7

### DIFF
--- a/pkgs/by-name/go/goaway/package.nix
+++ b/pkgs/by-name/go/goaway/package.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  buildGo126Module,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  net-tools,
+  nodejs,
+  pnpm,
+  pnpmConfigHook,
+  stdenvNoCC,
+}:
+
+let
+  version = "0.63.7";
+
+  src = fetchFromGitHub {
+    owner = "pommee";
+    repo = "goaway";
+    tag = "v${version}";
+    hash = "sha256-XNjp9fSMu5AdLnFNsh7Lrf1J06sPZPjvlNFkDa1QDJQ=";
+  };
+
+  goaway-web = stdenvNoCC.mkDerivation (finalAttrs: {
+    pname = "goaway-web";
+    inherit version src;
+
+    pnpmDeps = fetchPnpmDeps {
+      inherit (finalAttrs) pname version src;
+      sourceRoot = "${finalAttrs.src.name}/client";
+      fetcherVersion = 1;
+      hash = "sha256-cJLJMJNDPr73w5IiB1/zIloIdsUhqI+o/JqoKNwNweI=";
+    };
+
+    pnpmRoot = "client";
+
+    nativeBuildInputs = [
+      nodejs
+      pnpmConfigHook
+      pnpm
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+
+      pnpm -C client build
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r client/dist $out
+
+      runHook postInstall
+    '';
+
+  });
+in
+buildGo126Module (finalAttrs: {
+  pname = "goaway";
+  inherit
+    version
+    src
+    goaway-web
+    ;
+
+  vendorHash = "sha256-QgacBw+kpGdv8fAPQyndrHTxY1JrxFRf2qCS7etjNfw=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${finalAttrs.src.tag}"
+    "-X=main.commit=${finalAttrs.src.tag}"
+    "-X=main.date=1970-01-01T00:00:00Z"
+  ];
+
+  preBuild = ''
+    rm -rf client/dist
+    cp -r ${goaway-web} client/dist
+  '';
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  postInstall = ''
+    wrapProgram $out/bin/goaway \
+     --prefix PATH : $out/bin:${lib.makeBinPath [ net-tools ]}
+  '';
+
+  meta = {
+    description = "Lightweight DNS sinkhole written in Go with a modern dashboard client";
+    homepage = "https://github.com/pommee/goaway";
+    changelog = "https://github.com/pommee/goaway/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "goaway";
+  };
+})


### PR DESCRIPTION
Lightweight DNS sinkhole written in Go with a modern dashboard client

https://github.com/pommee/goaway


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
