### PR TITLE
lgpio: use --replace-fail in substitution

### DIFF
--- a/pkgs/by-name/lg/lgpio/package.nix
+++ b/pkgs/by-name/lg/lgpio/package.nix
@@ -44,7 +44,7 @@ mkDerivation (finalAttrs: {
   # Emulate ldconfig when building the C API
   postConfigure = lib.optionalString (pyProject == "") ''
     substituteInPlace Makefile \
-      --replace ldconfig 'echo ldconfig'
+      --replace-fail ldconfig 'echo ldconfig'
   '';
 
   preBuild = lib.optionalString (pyProject == "PY_LGPIO") ''

--- a/pkgs/by-name/lg/lgpio/package.nix
+++ b/pkgs/by-name/lg/lgpio/package.nix
@@ -20,7 +20,7 @@
 let
   mkDerivation = if pyProject == "" then stdenv.mkDerivation else buildPythonPackage;
 in
-mkDerivation rec {
+mkDerivation (finalAttrs: {
   pname = "lgpio";
   version = "0.2.2";
   format = if pyProject == "" then null else "setuptools";
@@ -28,7 +28,7 @@ mkDerivation rec {
   src = fetchFromGitHub {
     owner = "joan2937";
     repo = "lg";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-92lLV+EMuJj4Ul89KIFHkpPxVMr/VvKGEocYSW2tFiE=";
   };
 
@@ -67,4 +67,4 @@ mkDerivation rec {
     maintainers = with lib.maintainers; [ doronbehar ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
## Things done

CC @robertjakub 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test