### PR TITLE
python313Packages.pyqwikswitch: 0.94 -> 1.0.2

### DIFF
--- a/pkgs/development/python-modules/pyqwikswitch/default.nix
+++ b/pkgs/development/python-modules/pyqwikswitch/default.nix
@@ -11,7 +11,7 @@
   uv-build,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyqwikswitch";
   version = "1.0.2";
   pyproject = true;
@@ -19,7 +19,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "kellerza";
     repo = "pyqwikswitch";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-yx3rCPVuhsemAtFuEhPvFPHOFm2UWrXmWF3d/ZtPGo8=";
   };
 
@@ -47,8 +47,8 @@ buildPythonPackage rec {
   meta = {
     description = "QwikSwitch USB Modem API binding for Python";
     homepage = "https://github.com/kellerza/pyqwikswitch";
-    changelog = "https://github.com/kellerza/pyqwikswitch/blob/v${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/kellerza/pyqwikswitch/blob/v${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     teams = [ lib.teams.home-assistant ];
   };
-}
+})

--- a/pkgs/development/python-modules/pyqwikswitch/default.nix
+++ b/pkgs/development/python-modules/pyqwikswitch/default.nix
@@ -1,49 +1,53 @@
 {
   lib,
-  buildPythonPackage,
-  fetchpatch,
-  fetchPypi,
+  aiohttp,
+  aioresponses,
   attrs,
-  requests,
-  setuptools,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytest-asyncio,
+  pytest-cov-stub,
+  pytestCheckHook,
+  uv-build,
 }:
 
 buildPythonPackage rec {
   pname = "pyqwikswitch";
-  version = "0.94";
+  version = "1.0.2";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-IpyWz+3EMr0I+xULBJJhBgdnQHNPJIM1SqKFLpszhQc=";
+  src = fetchFromGitHub {
+    owner = "kellerza";
+    repo = "pyqwikswitch";
+    tag = "v${version}";
+    hash = "sha256-yx3rCPVuhsemAtFuEhPvFPHOFm2UWrXmWF3d/ZtPGo8=";
   };
 
-  patches = [
-    # https://github.com/kellerza/pyqwikswitch/pull/7
-    (fetchpatch {
-      name = "replace-async-timeout-with-asyncio.timeout.patch";
-      url = "https://github.com/kellerza/pyqwikswitch/commit/7b3f2211962b30bb6beea9a4fe17cd04cdf8e27f.patch";
-      hash = "sha256-sdO5jzIgKdneNY5dTngIzUFtyRg7HBGaZA1BBeAJxu4=";
-    })
-  ];
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "uv-build>=0.8.20,<0.9" "uv_build"
+  '';
 
-  build-system = [ setuptools ];
+  build-system = [ uv-build ];
 
   dependencies = [
+    aiohttp
     attrs
-    requests
   ];
 
-  pythonImportsCheck = [
-    "pyqwikswitch"
-    "pyqwikswitch.threaded"
+  nativeCheckInputs = [
+    aioresponses
+    pytest-asyncio
+    pytest-cov-stub
+    pytestCheckHook
   ];
 
-  doCheck = false; # no tests in sdist
+  pythonImportsCheck = [ "pyqwikswitch" ];
 
   meta = {
     description = "QwikSwitch USB Modem API binding for Python";
     homepage = "https://github.com/kellerza/pyqwikswitch";
+    changelog = "https://github.com/kellerza/pyqwikswitch/blob/v${src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     teams = [ lib.teams.home-assistant ];
   };


### PR DESCRIPTION
Changelog: https://github.com/kellerza/pyqwikswitch/blob/vv1.0.2/CHANGELOG.md

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
