### PR TITLE
obs-studio-plugins.obs-media-controls: fix build

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/default.nix
@@ -52,7 +52,7 @@
 
   obs-markdown = callPackage ./obs-markdown.nix { };
 
-  obs-media-controls = qt6Packages.callPackage ./obs-media-controls.nix { };
+  obs-media-controls = qt6Packages.callPackage ./obs-media-controls { };
 
   obs-move-transition = callPackage ./obs-move-transition.nix { };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-media-controls/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-media-controls/default.nix
@@ -18,6 +18,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-CElK9e+wpnMiup6DwdQpQfVMm6atXvz+JYHsGnv3lFo=";
   };
 
+  patches = [
+    # Fix cmake build with qt 6.10
+    # Submitted upstream: https://github.com/exeldro/obs-media-controls/pull/28
+    ./fix-cmake.patch
+  ];
+
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     obs-studio

--- a/pkgs/applications/video/obs-studio/plugins/obs-media-controls/fix-cmake.patch
+++ b/pkgs/applications/video/obs-studio/plugins/obs-media-controls/fix-cmake.patch
@@ -1,0 +1,25 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 95172a0..3be0ec3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,7 +25,7 @@ else()
+   target_link_libraries(${PROJECT_NAME} PRIVATE OBS::frontend-api)
+ endif()
+ 
+-find_package(Qt6 COMPONENTS Widgets Core)
++find_package(Qt6 REQUIRED COMPONENTS Widgets Core)
+ if(BUILD_OUT_OF_TREE)
+   if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
+     find_package(Qt6 REQUIRED Gui)
+@@ -33,8 +33,9 @@ if(BUILD_OUT_OF_TREE)
+ endif()
+ target_link_libraries(${PROJECT_NAME} PRIVATE Qt::Core Qt::Widgets)
+ 
+-if((OS_LINUX OR OS_FREEBSD OR OS_OPENBSD) AND Qt_VERSION VERSION_LESS "6.9.0")
+-	target_link_libraries(${PROJECT_NAME} PRIVATE Qt::GuiPrivate)
++if((OS_LINUX OR OS_FREEBSD OR OS_OPENBSD) AND Qt6_VERSION VERSION_LESS "6.9.0")
++  find_package(Qt6 REQUIRED COMPONENTS GuiPrivate)
++  target_link_libraries(${PROJECT_NAME} PRIVATE Qt::GuiPrivate)
+ endif()
+ 
+ target_compile_options(


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix regression introduced in https://github.com/NixOS/nixpkgs/pull/445693:
```
-- Configuring done (2.5s)
CMake Error at CMakeLists.txt:37 (target_link_libraries):
  Target "media-controls" links to:

    Qt::GuiPrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



-- Generating done (0.0s)
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
