### PR TITLE
ncps: 0.8.4 -> 0.8.5

### DIFF
--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -13,6 +13,7 @@
   python3,
   redis,
   writeShellScriptBin,
+  nix-update-script,
 }:
 
 let
@@ -93,6 +94,10 @@ let
       source $src/nix/packages/ncps/pre-check-postgres.sh
       source $src/nix/packages/ncps/pre-check-redis.sh
     '';
+
+    passthru = {
+      updateScript = nix-update-script { };
+    };
 
     meta = {
       description = "Nix binary cache proxy service";

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -34,13 +34,13 @@ let
 
   finalAttrs = {
     pname = "ncps";
-    version = "0.8.4";
+    version = "0.8.5";
 
     src = fetchFromGitHub {
       owner = "kalbasit";
       repo = "ncps";
       tag = "v${finalAttrs.version}";
-      hash = "sha256-GJnWVhn8SZY5IJbBSuq1j8qV06/kdHhcVu6QhnTsk0Y=";
+      hash = "sha256-0kQ2DTnBil7eSP/eSwLVqw/UyIwBMFtmKAeLCi64Fr8=";
     };
 
     vendorHash = "sha256-AcgC+zTS3eVsbcs0jim4zDBGc3lIjwPbdVT7/KQ9Lkc=";

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -13,6 +13,7 @@
   python3,
   redis,
   writeShellScriptBin,
+  nixosTests,
   nix-update-script,
 }:
 
@@ -94,6 +95,16 @@ buildGoModule (finalAttrs: {
       vendorHash = null;
 
       subPackages = [ "." ];
+    };
+
+    tests = {
+      inherit (nixosTests)
+        ncps
+        ncps-custom-sqlite-directory
+        ncps-custom-storage-local
+        ncps-ha-pg
+        ncps-ha-pg-redis
+        ;
     };
 
     updateScript = nix-update-script { };

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -21,17 +21,6 @@ let
     exec ${dbmate}/bin/dbmate "$@"
   '';
 
-  dbmate-wrapper = buildGoModule {
-    pname = "ncps-dbmate-wrapper";
-    inherit (finalAttrs) version;
-
-    src = "${finalAttrs.src}/nix/dbmate-wrapper/src";
-
-    vendorHash = null;
-
-    subPackages = [ "." ];
-  };
-
   finalAttrs = {
     pname = "ncps";
     version = "0.8.5";
@@ -68,7 +57,7 @@ let
       mkdir -p $out/share/ncps
       cp -r db $out/share/ncps/db
 
-      makeWrapper ${dbmate-wrapper}/bin/dbmate-wrapper \
+      makeWrapper ${finalAttrs.passthru.dbmate-wrapper}/bin/dbmate-wrapper \
         $out/bin/dbmate-ncps \
         --prefix PATH : ${dbmate-real}/bin \
         --set NCPS_DB_MIGRATIONS_DIR $out/share/ncps/db/migrations
@@ -96,6 +85,17 @@ let
     '';
 
     passthru = {
+      dbmate-wrapper = buildGoModule {
+        pname = "ncps-dbmate-wrapper";
+        inherit (finalAttrs) version;
+
+        src = "${finalAttrs.src}/nix/dbmate-wrapper/src";
+
+        vendorHash = null;
+
+        subPackages = [ "." ];
+      };
+
       updateScript = nix-update-script { };
     };
 

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -20,95 +20,93 @@ let
   dbmate-real = writeShellScriptBin "dbmate.real" ''
     exec ${dbmate}/bin/dbmate "$@"
   '';
-
-  finalAttrs = {
-    pname = "ncps";
-    version = "0.8.5";
-
-    src = fetchFromGitHub {
-      owner = "kalbasit";
-      repo = "ncps";
-      tag = "v${finalAttrs.version}";
-      hash = "sha256-0kQ2DTnBil7eSP/eSwLVqw/UyIwBMFtmKAeLCi64Fr8=";
-    };
-
-    vendorHash = "sha256-AcgC+zTS3eVsbcs0jim4zDBGc3lIjwPbdVT7/KQ9Lkc=";
-
-    ldflags = [
-      "-X github.com/kalbasit/ncps/pkg/ncps.Version=v${finalAttrs.version}"
-    ];
-
-    subPackages = [ "." ];
-
-    nativeBuildInputs = [
-      curl # used for checking MinIO health check
-      dbmate # used for testing
-      jq # used for testing by the init-minio
-      mariadb # MySQL/MariaDB for integration tests
-      minio # S3-compatible storage for integration tests
-      minio-client # mc CLI for MinIO setup
-      postgresql # PostgreSQL for integration tests
-      python3 # used for generating the ports
-      redis # Redis for distributed locking integration tests
-      makeWrapper # For wrapping dbmate.
-    ];
-
-    postInstall = ''
-      mkdir -p $out/share/ncps
-      cp -r db $out/share/ncps/db
-
-      makeWrapper ${finalAttrs.passthru.dbmate-wrapper}/bin/dbmate-wrapper \
-        $out/bin/dbmate-ncps \
-        --prefix PATH : ${dbmate-real}/bin \
-        --set NCPS_DB_MIGRATIONS_DIR $out/share/ncps/db/migrations
-    '';
-
-    doCheck = true;
-
-    checkFlags = [ "-race" ];
-
-    # pre and post checks
-    preCheck = ''
-      # Set up cleanup trap to ensure background processes are killed even if tests fail
-      cleanup() {
-        source $src/nix/packages/ncps/post-check-minio.sh
-        source $src/nix/packages/ncps/post-check-mysql.sh
-        source $src/nix/packages/ncps/post-check-postgres.sh
-        source $src/nix/packages/ncps/post-check-redis.sh
-      }
-      trap cleanup EXIT
-
-      source $src/nix/packages/ncps/pre-check-minio.sh
-      source $src/nix/packages/ncps/pre-check-mysql.sh
-      source $src/nix/packages/ncps/pre-check-postgres.sh
-      source $src/nix/packages/ncps/pre-check-redis.sh
-    '';
-
-    passthru = {
-      dbmate-wrapper = buildGoModule {
-        pname = "ncps-dbmate-wrapper";
-        inherit (finalAttrs) version;
-
-        src = "${finalAttrs.src}/nix/dbmate-wrapper/src";
-
-        vendorHash = null;
-
-        subPackages = [ "." ];
-      };
-
-      updateScript = nix-update-script { };
-    };
-
-    meta = {
-      description = "Nix binary cache proxy service";
-      homepage = "https://github.com/kalbasit/ncps";
-      license = lib.licenses.mit;
-      mainProgram = "ncps";
-      maintainers = with lib.maintainers; [
-        kalbasit
-        aciceri
-      ];
-    };
-  };
 in
-buildGoModule finalAttrs
+buildGoModule (finalAttrs: {
+  pname = "ncps";
+  version = "0.8.5";
+
+  src = fetchFromGitHub {
+    owner = "kalbasit";
+    repo = "ncps";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-0kQ2DTnBil7eSP/eSwLVqw/UyIwBMFtmKAeLCi64Fr8=";
+  };
+
+  vendorHash = "sha256-AcgC+zTS3eVsbcs0jim4zDBGc3lIjwPbdVT7/KQ9Lkc=";
+
+  ldflags = [
+    "-X github.com/kalbasit/ncps/pkg/ncps.Version=v${finalAttrs.version}"
+  ];
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    curl # used for checking MinIO health check
+    dbmate # used for testing
+    jq # used for testing by the init-minio
+    mariadb # MySQL/MariaDB for integration tests
+    minio # S3-compatible storage for integration tests
+    minio-client # mc CLI for MinIO setup
+    postgresql # PostgreSQL for integration tests
+    python3 # used for generating the ports
+    redis # Redis for distributed locking integration tests
+    makeWrapper # For wrapping dbmate.
+  ];
+
+  postInstall = ''
+    mkdir -p $out/share/ncps
+    cp -r db $out/share/ncps/db
+
+    makeWrapper ${finalAttrs.passthru.dbmate-wrapper}/bin/dbmate-wrapper \
+      $out/bin/dbmate-ncps \
+      --prefix PATH : ${dbmate-real}/bin \
+      --set NCPS_DB_MIGRATIONS_DIR $out/share/ncps/db/migrations
+  '';
+
+  doCheck = true;
+
+  checkFlags = [ "-race" ];
+
+  # pre and post checks
+  preCheck = ''
+    # Set up cleanup trap to ensure background processes are killed even if tests fail
+    cleanup() {
+      source $src/nix/packages/ncps/post-check-minio.sh
+      source $src/nix/packages/ncps/post-check-mysql.sh
+      source $src/nix/packages/ncps/post-check-postgres.sh
+      source $src/nix/packages/ncps/post-check-redis.sh
+    }
+    trap cleanup EXIT
+
+    source $src/nix/packages/ncps/pre-check-minio.sh
+    source $src/nix/packages/ncps/pre-check-mysql.sh
+    source $src/nix/packages/ncps/pre-check-postgres.sh
+    source $src/nix/packages/ncps/pre-check-redis.sh
+  '';
+
+  passthru = {
+    dbmate-wrapper = buildGoModule {
+      pname = "ncps-dbmate-wrapper";
+      inherit (finalAttrs) version;
+
+      src = "${finalAttrs.src}/nix/dbmate-wrapper/src";
+
+      vendorHash = null;
+
+      subPackages = [ "." ];
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Nix binary cache proxy service";
+    homepage = "https://github.com/kalbasit/ncps";
+    license = lib.licenses.mit;
+    mainProgram = "ncps";
+    maintainers = with lib.maintainers; [
+      kalbasit
+      aciceri
+    ];
+  };
+})


### PR DESCRIPTION
Release: https://github.com/kalbasit/ncps/releases/tag/v0.8.5

When the package was added, `buildGoModules` didn't support `finalAttrs`, but now it does. I refactored it to actually use this pattern, which resulted in a bigger diff due to whitespaces changes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
