### PR TITLE
authentik,authentik-outposts: 2025.10.1 -> 2025.12.4

### DIFF
--- a/pkgs/by-name/au/authentik/client-go-config.patch
+++ b/pkgs/by-name/au/authentik/client-go-config.patch
@@ -1,0 +1,9 @@
+diff --git a/config.yaml b/config.yaml
+index 2f07ea7..0f90432 100644
+--- a/config.yaml
++++ b/config.yaml
+@@ -4,3 +4,4 @@ additionalProperties:
+   packageName: api
+   enumClassPrefix: true
+   useOneOfDiscriminatorLookup: true
++  disallowAdditionalPropertiesIfNotPresent: false

--- a/pkgs/by-name/au/authentik/ldap.nix
+++ b/pkgs/by-name/au/authentik/ldap.nix
@@ -1,6 +1,7 @@
 {
   buildGoModule,
   authentik,
+  apiGoVendorHook,
   vendorHash,
 }:
 
@@ -8,6 +9,8 @@ buildGoModule {
   pname = "authentik-ldap-outpost";
   inherit (authentik) version src;
   inherit vendorHash;
+
+  nativeBuildInputs = [ apiGoVendorHook ];
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/au/authentik/outposts.nix
+++ b/pkgs/by-name/au/authentik/outposts.nix
@@ -1,10 +1,11 @@
 {
   callPackage,
   authentik,
+  apiGoVendorHook ? authentik.apiGoVendorHook,
   vendorHash ? authentik.proxy.vendorHash,
 }:
 {
-  ldap = callPackage ./ldap.nix { inherit vendorHash; };
-  proxy = callPackage ./proxy.nix { inherit vendorHash; };
-  radius = callPackage ./radius.nix { inherit vendorHash; };
+  ldap = callPackage ./ldap.nix { inherit apiGoVendorHook vendorHash; };
+  proxy = callPackage ./proxy.nix { inherit apiGoVendorHook vendorHash; };
+  radius = callPackage ./radius.nix { inherit apiGoVendorHook vendorHash; };
 }

--- a/pkgs/by-name/au/authentik/proxy.nix
+++ b/pkgs/by-name/au/authentik/proxy.nix
@@ -1,6 +1,7 @@
 {
   buildGoModule,
   authentik,
+  apiGoVendorHook,
   vendorHash,
 }:
 
@@ -8,6 +9,8 @@ buildGoModule {
   pname = "authentik-proxy-outpost";
   inherit (authentik) version src;
   inherit vendorHash;
+
+  nativeBuildInputs = [ apiGoVendorHook ];
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/au/authentik/radius.nix
+++ b/pkgs/by-name/au/authentik/radius.nix
@@ -1,6 +1,7 @@
 {
   buildGoModule,
   authentik,
+  apiGoVendorHook,
   vendorHash,
 }:
 
@@ -8,6 +9,8 @@ buildGoModule {
   pname = "authentik-radius-outpost";
   inherit (authentik) version src;
   inherit vendorHash;
+
+  nativeBuildInputs = [ apiGoVendorHook ];
 
   env.CGO_ENABLED = 0;
 


### PR DESCRIPTION
Because the shipped `schema.yml` might not match the released API Go/TypeScript bindings (see https://github.com/goauthentik/authentik/issues/19878#issuecomment-3836884640), we now build the bindings our self.

The TypeScript bindings (`client-ts`) are only used internally, so they are just copied into the build process. 

Because the Go bindings are also used in the outposts builds, I added a `apiGoVendorHook` hook, which patches the vendor folder with newly build bindings. The bindings aren't added to the `goModules` of `proxy`, because we can't guarantee the output of `client-go` doesn't change, which would invalidate the hash. This could happen for example, when the `openapi-generator-cli` version changes.

I also added a small patch, which removes the "only allow upload if the data directory is a mountpoint" check. This check is fine when the program is running in a Docker container, but prohibits uploads if run as a Systemd service.

With version `2025.12`, the default media storage location has changed (https://docs.goauthentik.io/releases/2025.12/#storage-mount-changes). This path was previously patched to be `/var/lib/authentik/media` in the default configuration. We could patch the new data location to `/var/lib/authentik`, which would be compatible with the previous behavior, but we would need to patch this in three location at the moment and locations could change with any update. It's probably best to remove this patch (as others also noted in #485210) and keep the upstream default of `./data`. This will be a breaking change for users who, but it only affects image loading and nothing functional (the same effect as the upstream update).

If users want to keep using the `/var/lib/authentik/media` directory, the would need to set
`AUTHENTIK_STORAGE__MEDIA__FILE__PATH = "/var/lib/authentik";` (because `<basedir>/media` is the base for media files).

Superseeds #485210

## Things done

- Tested service startup with `nix run git+https://gist.github.com/615c73b304b0a20c91deeba22445e778.git`
- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
