### PR TITLE
animeko: 5.2.0 -> 5.3.2

### DIFF
--- a/pkgs/by-name/an/animeko/0001-no-update-checker.patch
+++ b/pkgs/by-name/an/animeko/0001-no-update-checker.patch
@@ -1,0 +1,29 @@
+--- a/app/shared/ui-settings/src/commonMain/kotlin/ui/update/UpdateChecker.kt
++++ b/app/shared/ui-settings/src/commonMain/kotlin/ui/update/UpdateChecker.kt
+@@ -40,25 +40,7 @@
+             expectSuccess = true
+         }.use { client ->
+             withExceptionCollector {
+-                return kotlin.runCatching {
+-                    client.getVersionFromAniServer("https://danmaku-global.myani.org/", currentVersion, releaseClass)
+-                        .also {
+-                            logger.info { "Got latest version from global server: ${it?.name}" }
+-                        }
+-                }.recoverCatching { exception ->
+-                    collect(exception)
+-                    client.getVersionFromAniServer("https://danmaku-cn.myani.org/", currentVersion, releaseClass).also {
+-                        logger.info { "Got latest version from CN server: ${it?.name}" }
+-                    }
+-                }.onFailure { exception ->
+-                    collect(exception)
+-                    if (exception is CancellationException || exception is IOException) {
+-                        throwLast()
+-                    }
+-                    val finalException = getLast()!!
+-                    logger.error(finalException) { "Failed to get latest version" }
+-                    throw finalException
+-                }.getOrThrow()// should not throw, because of `onFailure`   
++                return null
+             }
+         }
+     }

--- a/pkgs/by-name/an/animeko/deps.json
+++ b/pkgs/by-name/an/animeko/deps.json
@@ -53,10 +53,6 @@
    "module": "sha256-KsL3EG4S8mNCW0pN/ICYlEf7iVZ1/pAthnWap0/RK30=",
    "pom": "sha256-/leyKEF/TXxneQPcYftKfPmT1gNJneJtjYET5HfMTxs="
   },
-  "androidx/annotation#annotation-iosarm64/1.7.0": {
-   "module": "sha256-AC0rtA4C7N7Y533F1nTe4s5f538pUxgcl+vVDSRlAY0=",
-   "pom": "sha256-ehf34KZP5hR8zaxQyF0Qo7AY/PHd/ip3e6YAA8pa3FY="
-  },
   "androidx/annotation#annotation-iosarm64/1.9.0": {
    "module": "sha256-6DJvdch3vV6HpxGXejlvW+xtpU1QTP3BBdQH6tTdXtc=",
    "pom": "sha256-r5RTiIOEj6z73kf5Xg2fNWerA2l/Nc6e7NnkS/y4JQc="
@@ -64,10 +60,6 @@
   "androidx/annotation#annotation-iosarm64/1.9.1": {
    "module": "sha256-gWifMc5Ndyzq5Nm4EKEPjSJlSrdSk/9EbJwgEfi6MjE=",
    "pom": "sha256-JTmoAKO24c6Fefs5T7n0Yi81sDPGYvSj9Zc9+O+IilI="
-  },
-  "androidx/annotation#annotation-iossimulatorarm64/1.7.0": {
-   "module": "sha256-OikdRa70npj492Pcc+iJJnOSmeiUyqGrKZhWZp7hjRI=",
-   "pom": "sha256-5+KpIB5thn7QIZaNGTjoBHdboYieIemh6IMcSL4iOYk="
   },
   "androidx/annotation#annotation-iossimulatorarm64/1.9.0": {
    "module": "sha256-b8ECz4xqGmk7qL083JGilvz/Ag6SMrz+MAS1VRXMhpI=",
@@ -80,11 +72,6 @@
   "androidx/annotation#annotation-jvm/1.6.0": {
    "module": "sha256-P1qPqhneZn5j3KlzD/jvDkeOS6+1/uuCWOXAhiRtyQw=",
    "pom": "sha256-K+ZlunzbBGtBtAnHmj3gxtnhJVJCwIf2uUssdJO+CPQ="
-  },
-  "androidx/annotation#annotation-jvm/1.7.0": {
-   "jar": "sha256-42uOS4OTpK3HTj1KsirVo2OW8M6i5AtXNOrhSTff0iQ=",
-   "module": "sha256-B85gw3erlOR8jJAlibl3YDAGT9Gn5NWgGjjXAONeXbQ=",
-   "pom": "sha256-LT/MEucHiGmSA5JmI39FEUDKqPlMHmLn/E1gLeNFsNc="
   },
   "androidx/annotation#annotation-jvm/1.8.1": {
    "module": "sha256-yVnjsM3HXBXv4BYF+laqefAz45I44VBji4+r3mqhIaA=",
@@ -501,10 +488,6 @@
   "androidx/compose/runtime#runtime-saveable/1.7.5": {
    "module": "sha256-EPd9GdGF6KLN1LDa+ymy2hgM61G1PuwstFu40CeVSpg=",
    "pom": "sha256-4itFFcGCYOqcksHaHQsJqkb+gnCr1mg4oveFn/JzJds="
-  },
-  "androidx/compose/runtime#runtime-saveable/1.8.2": {
-   "module": "sha256-bvgfp/FklhULLb9r4gHEEt7T80PKH5Xt5EIYdR7WbHI=",
-   "pom": "sha256-zkIRKN1Z/3cq3hv5T61DdKbcxe64Az4xQPawbvbZlCw="
   },
   "androidx/compose/runtime#runtime-saveable/1.9.0": {
    "module": "sha256-dWS0MU7dgdDxwPp2MH9HPDl7Y0hWIdPO4KKRiwUvJS4=",
@@ -3005,9 +2988,17 @@
    "module": "sha256-/Pqut7oYe99qycvB0HNJiWSbCn/8bfteU5TBcJYfaLI=",
    "pom": "sha256-sid4YljDlKaO0ntiFyaB+JdOQoJHeTBU0XxAxlDEEfI="
   },
+  "co/touchlab#stately-strict-iosarm64/2.0.6": {
+   "module": "sha256-qOtTajAaiWcZulLhdrLMOxgzg3PlRL85DjGApJNMAVg=",
+   "pom": "sha256-oY8yBrVtGjDoAR2dMt0GaPATdyKBGvmyiLd0NE/Z5ZU="
+  },
   "co/touchlab#stately-strict-iosarm64/2.1.0": {
    "module": "sha256-8UOjj43DzTJcUh82aMb3UuxN99vKlf/A4kJWhNubHN4=",
    "pom": "sha256-80CheYAdvDwZ0/xiJNOnySnM+3NmfP2EujE5jtZDafY="
+  },
+  "co/touchlab#stately-strict-iossimulatorarm64/2.0.6": {
+   "module": "sha256-uXuBPQgr1k5sLpnPY7KcFPKQaLaEw5jDf+pPy0OOeFg=",
+   "pom": "sha256-pvmqkz0ylUVaeLu1XRfqVFIYBybxlIr72XjkPJgFin4="
   },
   "co/touchlab#stately-strict-iossimulatorarm64/2.1.0": {
    "module": "sha256-HvYz59tOHPEu88DkMv3YAiaIBbb+M+0PSE1by2jplTw=",
@@ -5515,10 +5506,6 @@
    "module": "sha256-RWBz1hMzkqxpnWLPsN64wCvaKATJ0DowDPUiSpH/LIg=",
    "pom": "sha256-7woPdZv6dxVHNjyRKaa2PTUFds7PW4OZFTkQIcZoOgA="
   },
-  "org/jetbrains/compose/runtime#runtime-saveable-uikitarm64/1.8.2": {
-   "module": "sha256-O942iQhum9QIocX9wOQx+NVAaLPAlHHSI1AoWonTdmw=",
-   "pom": "sha256-fPWcnAL/lQ0yt1nF7TCzyp/bAHRX1v0fywMEw2e/E6g="
-  },
   "org/jetbrains/compose/runtime#runtime-saveable-uikitarm64/1.9.0": {
    "module": "sha256-uNVM3vXgpbeDXLM4iBM0iSz7qz+SN3/lmBeiXXU+kbg=",
    "pom": "sha256-HanDoPdPzxJ0SRyrHm7PfZ2C2iZnYCPoCQCldo+0uHs="
@@ -5530,10 +5517,6 @@
   "org/jetbrains/compose/runtime#runtime-saveable-uikitsimarm64/1.7.1": {
    "module": "sha256-OgEVWV6hCpJxUIVrUuPNsS4zRtVDcAd/+HKII0t043Q=",
    "pom": "sha256-idSq3GUxiPxdCKVpbmH8HGq/IkpFNZUZ1MSNZDWG5n4="
-  },
-  "org/jetbrains/compose/runtime#runtime-saveable-uikitsimarm64/1.8.2": {
-   "module": "sha256-hkmLu/22k8LUHFfk9wYTdE+1oDbT08zxzBB8zV1KwGY=",
-   "pom": "sha256-wqhTeOdhVYu27PHODBBZBkAcH97ai3FDQmThhayWKQU="
   },
   "org/jetbrains/compose/runtime#runtime-saveable-uikitsimarm64/1.9.0": {
    "module": "sha256-NgHdc32iO0hYHHvq25xG7bNLyR0HITAb2J5heheFy30=",
@@ -6202,6 +6185,9 @@
   "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.10": {
    "jar": "sha256-z5XszGzHhN/0ed7guINPNYS5MpLMXZGXLoL117nhPjs=",
    "pom": "sha256-vklJB+DhnHi7ghFUr6F3bVrXoFi0qzAJD3Q1Sw4TON4="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.0": {
+   "pom": "sha256-K7bHVRuXx7oCn5hmWC56oZ1jq/1M1T2j/AxGLzq1/CY="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk8/1.8.21": {
    "jar": "sha256-PbdSowB08G7mxXmEqm8n2kT00rvH9UQmUfaYjxyyt9c=",
@@ -6885,95 +6871,95 @@
    "module": "sha256-s+NvC4F8sW43udNc2Sf7pqQYPTpy6WYcDaEZtGe1U5Y=",
    "pom": "sha256-EN0WnADat5JXw6z/58I2vqwkgfngp2xT620S9Mp1q2c="
   },
-  "org/openani/mediamp#catalog/0.0.29": {
-   "module": "sha256-s6r4l6CUxAxXNrk0x4papHn7CT9Agn+VGhA5gde45/8=",
-   "pom": "sha256-E5GiqnTrK4imwFM7QBmAAhhxDKijBAIi/mwyH3FUuk4="
+  "org/openani/mediamp#catalog/0.0.30": {
+   "module": "sha256-2OPa47tUPbb2VrTHEOwV8lGquOHf0NP7ic+M1D2GCHM=",
+   "pom": "sha256-A2o2vXqHPKNgWU1tVkeQMvwwjDfb6Z1u116yd1RJch0="
   },
-  "org/openani/mediamp#mediamp-api-android-debug/0.0.29": {
-   "module": "sha256-jU1JEH7gsdNZqGDewGzwxm9RVbT/0cL0T4SsT1m/v/w=",
-   "pom": "sha256-ZRgAVnFvMsp3tirT+pxdzLl/UgaKwWLiJwix9zmo5hU="
+  "org/openani/mediamp#mediamp-api-android-debug/0.0.30": {
+   "module": "sha256-i05AWijPx24uS1h09c4mswpBwJKRgd9ey3mQPOXudsM=",
+   "pom": "sha256-WbTPILNxF14itRm7/VcMlWTusP8MJdaIzt0UduzodAs="
   },
-  "org/openani/mediamp#mediamp-api-android/0.0.29": {
-   "module": "sha256-A7Kf2AqX+9bds8WYtQnt7oRkoLXjXnk/3RnMiLcSCkw=",
-   "pom": "sha256-pyflDsXfp2uPi32gudBjcjjVfPjbwz2cV7Wnvclz7ME="
+  "org/openani/mediamp#mediamp-api-android/0.0.30": {
+   "module": "sha256-1R6MW6Hod8WqccN3hSjQL61q/SOAUgXOmUutKvB1ZAk=",
+   "pom": "sha256-VmpuVDAwn3sa5SVacHYYIV6/AMD8cHA9ccJbzsSHLg8="
   },
-  "org/openani/mediamp#mediamp-api-desktop/0.0.29": {
-   "jar": "sha256-k4Qsb20oECKLw2ZQ+QH7rCuKl9W3kM9nfJRWF0cTAlE=",
-   "module": "sha256-InxhvamLA6cAcu7JPORsd+NoK+eeTjlmg+kXHgUL8J8=",
-   "pom": "sha256-4yVSYeA9sIcF7x0W9IOSNEtURY10iC9gvsC00JZ6GmU="
+  "org/openani/mediamp#mediamp-api-desktop/0.0.30": {
+   "jar": "sha256-cjmXO7AT1WxxAnqjAVqm1W5rGWBzgQg72/FMDH4cBgk=",
+   "module": "sha256-qk9kYkERTe27Ae63/HtReT9rpYtxIQM6oV00VI15Jok=",
+   "pom": "sha256-4y32EbVgTpToWtNFgVIEtIBrwzsLkQefMg+ml/0thRw="
   },
-  "org/openani/mediamp#mediamp-api-iosarm64/0.0.29": {
-   "module": "sha256-pi4zPVts8iYT+Id6q3xRa5R9W9LQrCdYL3pKlLqVjV4=",
-   "pom": "sha256-FEuhDtbkSE07U1E8Q87TIB/v4YLFpLrOqZnpPchKilQ="
+  "org/openani/mediamp#mediamp-api-iosarm64/0.0.30": {
+   "module": "sha256-DWqiR1l7S++nrZxcFXJrLtw3XIjqj3kqwR2vd4m6fZw=",
+   "pom": "sha256-4bG2sVVe3LlKtenq/gUmWh3N2+l5FSh8EgYMYDoXyUk="
   },
-  "org/openani/mediamp#mediamp-api-iossimulatorarm64/0.0.29": {
-   "module": "sha256-vX2BCljeCqNtJiV7jXlH8iQJDFiX5J7EaaCnaK9u1GQ=",
-   "pom": "sha256-a+yj2/YHppcgKiQ/pK5lEM5ndC2GoLxN/RfHloDC6nU="
+  "org/openani/mediamp#mediamp-api-iossimulatorarm64/0.0.30": {
+   "module": "sha256-PMH1SJn/7HHzFVq+PIIrYtfLHCy1wqTJwRdsDuD11+U=",
+   "pom": "sha256-kwJMwkxnwD+Chp9ip+Cmgy/Fq39mcuUbTbeD4xyEpzE="
   },
-  "org/openani/mediamp#mediamp-api/0.0.29": {
-   "module": "sha256-5BiLU2hqMh9twBjyMkZymeltSP5Lvhqm+Ebram4FJxk=",
-   "pom": "sha256-bxPAiiGEC3XucMnl+KwnQfP1Q96RlQBpHw459rTU9os="
+  "org/openani/mediamp#mediamp-api/0.0.30": {
+   "module": "sha256-qpHZ8PUMNf0qUY7pImlp0BeOiLXccgCPfNR+jzXnTGo=",
+   "pom": "sha256-7mmAoDq1Js3QGlIlBpHvUN1WD1vWY6Vv3zjAejs3PTU="
   },
-  "org/openani/mediamp#mediamp-avkit-iosarm64/0.0.29": {
-   "module": "sha256-69NJ47GtvieicRl2jQwncgKUOdAg04krEMUkFanTD9E=",
-   "pom": "sha256-2ulgh0zZuf2Y3VB8HPEoeOoly57ZiuphZCxLt+O03PU="
+  "org/openani/mediamp#mediamp-avkit-iosarm64/0.0.30": {
+   "module": "sha256-zBn6Tz4aGOYy0nMEBFLKtp5mRFzgcHjovmTSLKPKetU=",
+   "pom": "sha256-OSqAIdGS1juME6tgpo3PYaf6F9gYq86ze155k8SUNfc="
   },
-  "org/openani/mediamp#mediamp-avkit-iossimulatorarm64/0.0.29": {
-   "module": "sha256-NqOkI5Z9iakDOzLu9J/VdLA8s4k+RpyMHRUtpCsGQrw=",
-   "pom": "sha256-IPEcwTRk7xoDOwRIjOXcQ/xWneSRyfavPFoRQkKeYak="
+  "org/openani/mediamp#mediamp-avkit-iossimulatorarm64/0.0.30": {
+   "module": "sha256-GkPl9oCYipnLq5AvhJSXfSmEN7CXDidf1jbveejZOgY=",
+   "pom": "sha256-sqk1pwBCNE3FVbYXPIvq9Wc1ZYC0t1HG8jRQiVGwKIs="
   },
-  "org/openani/mediamp#mediamp-avkit/0.0.29": {
-   "module": "sha256-3mZlCh9V5OHi74ETW/Z/7ElP12/rOxgDlHtfbcSmI5U=",
-   "pom": "sha256-BCn3TBi/kYcTE7qXYYJhAl+W7eXi5MPN6yodYYUi/18="
+  "org/openani/mediamp#mediamp-avkit/0.0.30": {
+   "module": "sha256-qPTctSZF3yZ7eWeGd3whSLpe1VqhTKvghX9gt1x9ROc=",
+   "pom": "sha256-qxNi8q1t4QvUvisiKZZkS35jBER/QO/q9RQ7BDdxN3w="
   },
-  "org/openani/mediamp#mediamp-exoplayer/0.0.29": {
-   "module": "sha256-q3w8QTM4lgFZCCcKSH4/O8VASBVN/SxA7Kr6WBBjIpM=",
-   "pom": "sha256-aoJSOzxoqYK5oJThfGXanf6/kkRoji8PtCuBwui6vfE="
+  "org/openani/mediamp#mediamp-exoplayer/0.0.30": {
+   "module": "sha256-vW+B6TZGu/PE96JqZVjTg4uhcLAO9XeN55Pfvm5Oz6M=",
+   "pom": "sha256-b9jem2r2BXE4BaMpCzchhh9bcKKRNPJvk2VA+50fbKM="
   },
-  "org/openani/mediamp#mediamp-internal-utils-iosarm64/0.0.29": {
-   "module": "sha256-dM6tWX17zmoxefcPBq5k+cj/YVlU5AG3ItIN+G4uOZ8=",
-   "pom": "sha256-UVczUfnaJ0ap5maZ7b1KNPrEZksna+QfhHVFLbAbAeg="
+  "org/openani/mediamp#mediamp-internal-utils-iosarm64/0.0.30": {
+   "module": "sha256-oc5QOdK5ZYxNsVD5suYvlCMbzGonBapKmz42Nf9fYHg=",
+   "pom": "sha256-5TZ7j3EaRSQruC/8PTXXzLLKoq0/xedJ++30j32GkBc="
   },
-  "org/openani/mediamp#mediamp-internal-utils-iossimulatorarm64/0.0.29": {
-   "module": "sha256-imh0Vg3ZZcWinZeWPcN8ShBhgot2EJ4ZZrYdHrMlu/M=",
-   "pom": "sha256-q6DVnhuXEHqiLfk5X11RzePudY63ga1PhhiZg3fncWo="
+  "org/openani/mediamp#mediamp-internal-utils-iossimulatorarm64/0.0.30": {
+   "module": "sha256-xL+LHQEp0IgT5QbkW7hhuQtsN4fCC0fPpjh51qNwMfM=",
+   "pom": "sha256-BTWno5jqBWiotMVy0BNLyKV35S5ZAFkVAg8zb0JPMrU="
   },
-  "org/openani/mediamp#mediamp-internal-utils/0.0.29": {
-   "module": "sha256-sIGzzI9XNlRUYlXqou8iLMNqvgi+v6XIUYnjfA+pbeo=",
-   "pom": "sha256-s5DI6wAi4qSMP8bAPz4K/gOCLLDBSwNKk6m2CKsdtIY="
+  "org/openani/mediamp#mediamp-internal-utils/0.0.30": {
+   "module": "sha256-Db89LZagBZhIODpzWh/yxf3ND6Ipikk1KsQr+PqbZtk=",
+   "pom": "sha256-SRXlD3PGaI3qk5R0uGvd48K79iPI2W+D0QyBegkWGm8="
   },
-  "org/openani/mediamp#mediamp-source-ktxio-android-debug/0.0.29": {
-   "module": "sha256-sUm1P7HhQUhOwDUR1uVAPvHfZO5xhgiWX7ePLYgKDDs=",
-   "pom": "sha256-/BJ4n949a/0FK/f8vMJ4LMyWDFYvb5PDL67YYZOzrMs="
+  "org/openani/mediamp#mediamp-source-ktxio-android-debug/0.0.30": {
+   "module": "sha256-nixitOGFxyv6HcDGdAKM1E8g9tBA96KD0x96SGkBzT0=",
+   "pom": "sha256-esmapPkeonUbs6tfhS35fbPdvtuh9hj6sPTwKesa4/o="
   },
-  "org/openani/mediamp#mediamp-source-ktxio-android/0.0.29": {
-   "module": "sha256-Qc/0FDWUS04Ss5F0BcpNAS5XJ6rTqVPhkHVXzaoFiRM=",
-   "pom": "sha256-tzinK8zk1fGrql2WXhwc7YgzDV6MnbnjIyT5KVzOqxw="
+  "org/openani/mediamp#mediamp-source-ktxio-android/0.0.30": {
+   "module": "sha256-OVhaDjRoRqpyMICPyqcNTYdjb8KjXNCDiYn4ZcgubSI=",
+   "pom": "sha256-AdM6u0OvP2RRt6IkQ3lwRKpUef9R/cuDSGvsulHHR0w="
   },
-  "org/openani/mediamp#mediamp-source-ktxio-desktop/0.0.29": {
+  "org/openani/mediamp#mediamp-source-ktxio-desktop/0.0.30": {
    "jar": "sha256-CmvsMdXJcrr1UcbNQVI8OyPqwxo9pLKYoa1ye5k0764=",
-   "module": "sha256-3ZMls4s+OGQgPoXLFBqB7WbyE1Qn2f84XoXw0pOdtUQ=",
-   "pom": "sha256-nN9HUn/RfKtPCOSNiD2URA+IBpkSwWWt0HZO8CZjtEE="
+   "module": "sha256-1u3N8N8Yg9A+5OThl+tqsqyEtns5RMiC8NdY1oB1M7k=",
+   "pom": "sha256-9duiRN3Hwp4p49AeyS6jLpoTjr0oTd8Akup3Yp+65As="
   },
-  "org/openani/mediamp#mediamp-source-ktxio-iosarm64/0.0.29": {
-   "module": "sha256-s848sz/BVAOAd5ORpSuZ5Mngsco2qJdoVX/IVhPUU6Q=",
-   "pom": "sha256-M+BJJRgYRKhY02cEqQbeqOUC4HQpkrIaoGqfpfMf1G0="
+  "org/openani/mediamp#mediamp-source-ktxio-iosarm64/0.0.30": {
+   "module": "sha256-AlnPAvx7IWWitGp6PpJgZoIrJ28DIoxXg5yDV/mgl2k=",
+   "pom": "sha256-DcyGFMKTaYnvniNAZq1db2g0ED4XO6TdLOGa5sjJpDs="
   },
-  "org/openani/mediamp#mediamp-source-ktxio-iossimulatorarm64/0.0.29": {
-   "module": "sha256-KodoKoQh4lb9t799R3O2ZhuX1fg57ULxCJ/xSL956hk=",
-   "pom": "sha256-RT9U7NnYMDnVCTWKnkvU4ZHtFVGM2+PON2JdB4hPwCs="
+  "org/openani/mediamp#mediamp-source-ktxio-iossimulatorarm64/0.0.30": {
+   "module": "sha256-T+2KAQm+6/pB5fbNurEukrK4OlOt5o5sjQxaO/23qjM=",
+   "pom": "sha256-IfCCH0sXk+TNXF0EXlafqihrONqUR49tVkwRp2f1RO4="
   },
-  "org/openani/mediamp#mediamp-source-ktxio/0.0.29": {
-   "module": "sha256-As/GVZGSN4hAfby3KRxBzyMMUpuNmy24wVPlSQ4ABww=",
-   "pom": "sha256-Zd+xibJweb9/tUsvBKtkQm8REPIRs9JI/q6D4uGBDag="
+  "org/openani/mediamp#mediamp-source-ktxio/0.0.30": {
+   "module": "sha256-cUirc+cdT2fXVcuTYofTsmRv6mDruHt2u9BBiDbzUoI=",
+   "pom": "sha256-nXoS8U+BvG/r6i9jCGOLV2Ha7RbyMS6dhS6mNo2qlWA="
   },
-  "org/openani/mediamp#mediamp-vlc/0.0.29": {
-   "jar": "sha256-IipT5VaRSsRsF0+DOLb4ZEAVSVIVuSVMbydWzTgjN6I=",
-   "module": "sha256-3iXzV+GUgG26i6JGs+KuifxMAqw6n91hvFBnY4PhGH0=",
-   "pom": "sha256-hyzw9+4O0IBKsOBpmMYXFbYOFfhxlAXtvx5Zb2I2bU4="
+  "org/openani/mediamp#mediamp-vlc/0.0.30": {
+   "jar": "sha256-DxMTtFdwUM76Vxs5a8EaohRI39mSLjhBtSnqPVj1IlQ=",
+   "module": "sha256-qT2ALGzzOSJamxUCRPOM91abwHZ4igwJqvPhB08G32U=",
+   "pom": "sha256-IaarXJ6GI1unhIJUDIN5j4RE1FVRbOCr9HYG5BIMOTo="
   },
-  "org/openani/mediamp/catalog/0.0.29/catalog-0.0.29": {
-   "toml": "sha256-wNPEmb14ugDo4NPEcf8lY0hRcCOGDFmsDGcHJqUSq5E="
+  "org/openani/mediamp/catalog/0.0.30/catalog-0.0.30": {
+   "toml": "sha256-NMqiEq/q+rgs2uiUsFJBROfMY9sSjCdpurSWrRjM2c0="
   },
   "org/ow2#ow2/1.5.1": {
    "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="

--- a/pkgs/by-name/an/animeko/package.nix
+++ b/pkgs/by-name/an/animeko/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   gradle,
   autoPatchelfHook,
-  jetbrains, # Requird by upstream due to JCEF dependency
+  jetbrains, # Required by upstream due to JCEF dependency
   fontconfig,
   libxinerama,
   libxrandr,
@@ -113,23 +113,20 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "animeko";
-  version = "5.2.0";
+  version = "5.3.2";
 
   src = fetchFromGitHub {
     owner = "open-ani";
     repo = "animeko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-eP1v/o9qUk8qG+n1cJRmlgu2l06hFZLeUN/X06qAVpY=";
+    hash = "sha256-mDUl1RpTIFBHdYst6R16iVljiUNOYh6mNUtOLBSuOE0=";
     fetchSubmodules = true;
   };
 
-  # CefLog.init(jcefConfig.cefSettings) is being comment out due to compile error
   postPatch = ''
     echo "kotlin.native.ignoreDisabledTargets=true" >> local.properties
     sed -i "s/^version.name=.*/version.name=${finalAttrs.version}/" gradle.properties
     sed -i "s/^package.version=.*/package.version=${finalAttrs.version}/" gradle.properties
-    substituteInPlace app/shared/app-platform/src/desktopMain/kotlin/platform/AniCefApp.kt \
-      --replace-fail 'CefLog.init(jcefConfig.cefSettings)' '//CefLog.init(jcefConfig.cefSettings)'
   '';
 
   gradleBuildTask = "createReleaseDistributable";
@@ -232,6 +229,11 @@ stdenv.mkDerivation (finalAttrs: {
     libGL
     libx11
     libxdamage
+  ];
+
+  patches = [
+    # Builtin updater will never work on NixOS, so we made a patch to disable updater
+    ./0001-no-update-checker.patch
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
- Update `animeko` to `5.3.2`
- Remove `CefLog` workaround as it is no longer needed
- Disable built-in updater as it will never work on NixOS
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
