### PR TITLE
sview: 20_08 -> 26_02

### DIFF
--- a/pkgs/by-name/sv/sview/package.nix
+++ b/pkgs/by-name/sv/sview/package.nix
@@ -1,30 +1,36 @@
 {
+  cmake,
   fetchFromGitHub,
   fetchurl,
-  ffmpeg_4,
+  ffmpeg,
   fontconfig,
-  gtk2,
+  freetype,
   lib,
   libconfig,
   libGL,
+  libx11,
+  libxext,
   libxpm,
+  libxrandr,
   makeFontsConf,
   makeWrapper,
   nanum,
   openal,
+  openvr,
   pkg-config,
   stdenv,
+  zenity,
 }:
 
 stdenv.mkDerivation rec {
   pname = "sview";
-  version = "20_08";
+  version = "26_02";
 
   src = fetchFromGitHub {
     owner = "gkv311";
     repo = "sview";
     tag = version;
-    hash = "sha256-mbEacdBQchziXoZ5vJUiEpa/iHeXeaozte2aXs50/Fo=";
+    hash = "sha256-UIA8bDGYVN8Zw23PkKprYrvcMubHzoquaSArLShu+aw=";
   };
 
   droidSansFallback = fetchurl {
@@ -33,17 +39,31 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    cmake
     makeWrapper
     pkg-config
   ];
 
+  cmakeFlags = [
+    "-DUSE_UPDATER=OFF"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DCMAKE_INSTALL_LIBDIR=/lib"
+    "-DCMAKE_INSTALL_BINDIR=/bin"
+    "-DCMAKE_INSTALL_DATAROOTDIR=/share"
+  ];
+
   buildInputs = [
-    ffmpeg_4
-    gtk2
+    freetype
+    ffmpeg
+    fontconfig
     libconfig
     libGL
+    libx11
+    libxext
     libxpm
+    libxrandr
     openal
+    openvr
   ];
 
   fontsConf = makeFontsConf {
@@ -55,7 +75,7 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
-    make install APP_PREFIX=$out DISABLE_UPDATER=1
+    make & make install
     mkdir -p $out/share/sView/fonts
     cp ${droidSansFallback} $out/share/sView/fonts/DroidSansFallbackFull.ttf
     cp '${fontsConf}' $out/share/sView/fonts/fonts.conf
@@ -66,7 +86,7 @@ stdenv.mkDerivation rec {
     substituteInPlace $out/share/sView/fonts/fonts.conf \
       --replace-warn "placeholder" "$out/share/sView/fonts/";
     wrapProgram $out/bin/sView \
-      --set StShare $out/share/sView \
+      --prefix PATH : "${zenity}/bin" \
       --set FONTCONFIG_FILE $out/share/sView/fonts/fonts.conf
   '';
 


### PR DESCRIPTION
Update to latest release.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
