### PR TITLE
nixos/uwsm: add desktop entries to displayManager again

### DIFF
--- a/nixos/modules/programs/wayland/uwsm.nix
+++ b/nixos/modules/programs/wayland/uwsm.nix
@@ -24,6 +24,19 @@ let
         passthru.providedSessions = [ "${opts.name}-uwsm" ];
       };
     });
+
+  desktopEntries = lib.mapAttrsToList (
+    name: value:
+    mk_uwsm_desktop_entry {
+      inherit name;
+      inherit (value)
+        prettyName
+        comment
+        binPath
+        extraArgs
+        ;
+    }
+  ) cfg.waylandCompositors;
 in
 {
   options.programs.uwsm = {
@@ -126,18 +139,8 @@ in
       }
 
       (lib.mkIf (cfg.waylandCompositors != { }) {
-        environment.systemPackages = lib.mapAttrsToList (
-          name: value:
-          mk_uwsm_desktop_entry {
-            inherit name;
-            inherit (value)
-              prettyName
-              comment
-              binPath
-              extraArgs
-              ;
-          }
-        ) cfg.waylandCompositors;
+        environment.systemPackages = desktopEntries;
+        services.displayManager.sessionPackages = desktopEntries;
       })
     ]
   );


### PR DESCRIPTION
Follow up to: https://github.com/NixOS/nixpkgs/pull/489812

Removing desktop files generated by the UWSM module from `services.displayManager.sessionPackages` broke functionality for people who were using valid display managers with UWSM

This PR simply restores setting `services.displayManager.sessionPackages`, while maintaining the fix from https://github.com/NixOS/nixpkgs/pull/489812

I have not tested the changes here, as I do not use a display manager - if @DADA30000 & @jazzpi could test, that would be amazing! As such, I've marked this as a draft
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
