### PR TITLE
cargo-guppy: unstable-2023-10-04 -> 0.17.25, adopt

### DIFF
--- a/pkgs/by-name/ca/cargo-guppy/package.nix
+++ b/pkgs/by-name/ca/cargo-guppy/package.nix
@@ -1,23 +1,24 @@
 {
-  lib,
-  rustPlatform,
   fetchFromGitHub,
-  pkg-config,
+  lib,
+  nix-update-script,
   openssl,
+  pkg-config,
+  rustPlatform,
 }:
 
-rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-guppy";
-  version = "unstable-2023-10-04";
+  version = "0.17.25";
 
   src = fetchFromGitHub {
     owner = "guppy-rs";
     repo = "guppy";
-    rev = "837d0ae762b9ae79cc8ca5d629842e5ca34293b4";
-    sha256 = "sha256-LWU1yAD/f9w5m522vcKP9D2JusGkwzvfGSGstvFGUpk=";
+    tag = "guppy-${finalAttrs.version}";
+    hash = "sha256-wH14RCNjqbuJsyJdV3Vthulyd5GbLdfpoojK3F2muwM=";
   };
 
-  cargoHash = "sha256-nNbCQ/++gm2S+xFbE5t9U9gQR8E2fVWE4kh73wgbAwQ=";
+  cargoHash = "sha256-fNbuVXFCqrQPT0q00VkOVXm1H7/7HjuK9JYZ0TRxMJk=";
 
   nativeBuildInputs = [ pkg-config ];
 
@@ -27,19 +28,25 @@ rustPlatform.buildRustPackage {
     "-p"
     "cargo-guppy"
   ];
+
   cargoTestFlags = [
     "-p"
     "cargo-guppy"
   ];
 
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version-regex=guppy-(.*)" ];
+  };
+
   meta = {
+    changelog = "https://github.com/guppy-rs/guppy/releases/tag/${finalAttrs.src.tag}";
     description = "Command-line frontend for guppy";
-    mainProgram = "cargo-guppy";
     homepage = "https://github.com/guppy-rs/guppy/tree/main/cargo-guppy";
     license = with lib.licenses; [
       mit # or
       asl20
     ];
+    mainProgram = "cargo-guppy";
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-guppy/package.nix
+++ b/pkgs/by-name/ca/cargo-guppy/package.nix
@@ -47,6 +47,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       asl20
     ];
     mainProgram = "cargo-guppy";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })


### PR DESCRIPTION
Part of #458096

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
