### PR TITLE
Implement services.lprint (MVP)

### DIFF
--- a/nixos/modules/services/misc/lprint.nix
+++ b/nixos/modules/services/misc/lprint.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  options.services.lprint = {
+    enable = lib.mkOption {
+      default = false;
+      example = true;
+      description = ''
+        Enable support for label printers using LPrint server.
+      '';
+      type = lib.types.bool;
+    };
+  };
+
+  config = lib.mkIf config.services.lprint.enable {
+    systemd.services.lprint = {
+      description = "LPrint Service";
+      after = [ "network.target" "nss-lookup.target" ];
+      requires = [ "avahi-daemon.socket" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.lprint}/bin/lprint server -o log-file=- -o log-level=info";
+        Restart = "on-failure";
+      };
+    };
+    services.avahi.enable = lib.mkDefault true;
+    services.avahi.publish.enable = lib.mkDefault true;
+    services.avahi.publish.userServices = lib.mkDefault true;
+  };
+}


### PR DESCRIPTION
There's been package `lprint` for a while, but that software is requires a running daemon to function.

## Things done

Written NixOS service from `lprint.service` of software repository.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
