### PR TITLE
peon-ping: init at 1.8.1

### DIFF
--- a/pkgs/by-name/pe/peon-ping/package.nix
+++ b/pkgs/by-name/pe/peon-ping/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  bash,
+  makeWrapper,
+  installShellFiles,
+  python3,
+  curl,
+  coreutils,
+  libnotify,
+  nix-update-script,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peon-ping";
+  version = "1.8.1";
+
+  src = fetchFromGitHub {
+    owner = "PeonPing";
+    repo = "peon-ping";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-vndfP+fMS7FnDDQBS0UV6ZNg46Rno9E48DbYhoktYrw=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
+  buildInputs = [ bash ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 peon.sh $out/lib/peon-ping/peon.sh
+    install -Dm644 config.json $out/lib/peon-ping/config.json
+
+    makeWrapper $out/lib/peon-ping/peon.sh $out/bin/peon \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          curl
+          libnotify
+          python3
+        ]
+      }
+
+    installShellCompletion --cmd peon \
+      --bash completions.bash \
+      --fish completions.fish
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Notification sound player for AI coding agents";
+    longDescription = ''
+      peon-ping plays game character voice lines when AI coding agents
+      (Claude Code, Cursor, Codex, etc.) need your attention. It supports
+      desktop and mobile notifications, multiple sound packs, and integrates
+      as hooks in IDE configurations.
+
+      Sound packs must be installed separately into
+      ~/.claude/hooks/peon-ping/packs/ — see the project README for details.
+    '';
+    homepage = "https://github.com/PeonPing/peon-ping";
+    changelog = "https://github.com/PeonPing/peon-ping/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ workflow ];
+    platforms = lib.platforms.linux;
+    mainProgram = "peon";
+  };
+})


### PR DESCRIPTION
## Summary

Add [peon-ping](https://github.com/PeonPing/peon-ping), a notification sound player for AI coding agents (Claude Code, Cursor, Codex, etc.). It plays game character voice lines and sends desktop/mobile notifications when agents need your attention.

The package installs the core `peon` CLI with its shell completions (bash, fish). Sound packs are not bundled and must be installed separately by the user — see the project README for details.

## Things I am not sure about / things to discuss

- Sound packs are deliberately excluded. They contain audio from gaming franchises (Warcraft, StarCraft, etc.) with unclear redistribution licensing, and are better managed at runtime (e.g. via a home-manager module or the built-in `peon update` command).

## Checklist

- [x] Built on `x86_64-linux`
- [x] Tested binary execution (`peon status` works)
- [x] Formatted with `nix fmt`
- [x] Shell completions (bash, fish) included