### PR TITLE
[Backport release-25.11] various package adoptions

### DIFF
--- a/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/nvim-treesitter/overrides.nix
@@ -172,6 +172,6 @@ in
 
     (super.nvim-treesitter.meta or { }) // {
       license = lib.licenses.asl20;
-      maintainers = [ ];
+      maintainers = with lib.maintainers; [ figsoda ];
     };
 }

--- a/pkgs/by-name/ca/cadical/package.nix
+++ b/pkgs/by-name/ca/cadical/package.nix
@@ -96,7 +96,10 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Simplified Satisfiability Solver";
-    maintainers = with lib.maintainers; [ shnarazk ];
+    maintainers = with lib.maintainers; [
+      shnarazk
+      chrjabs
+    ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
     homepage = "https://fmv.jku.at/cadical/";

--- a/pkgs/by-name/ca/cargo-deny/package.nix
+++ b/pkgs/by-name/ca/cargo-deny/package.nix
@@ -46,6 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     maintainers = with lib.maintainers; [
       matthiasbeyer
       jk
+      chrjabs
     ];
   };
 })

--- a/pkgs/by-name/ca/cargo-insta/package.nix
+++ b/pkgs/by-name/ca/cargo-insta/package.nix
@@ -37,6 +37,7 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       oxalica
       matthiasbeyer
+      figsoda
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -91,6 +91,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       wucke13
       matthiasbeyer
       CobaltCause
+      chrjabs
     ];
 
     # The profiler runtime is (currently) disabled on non-Linux platforms

--- a/pkgs/by-name/ca/cargo-machete/package.nix
+++ b/pkgs/by-name/ca/cargo-machete/package.nix
@@ -28,6 +28,7 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       matthiasbeyer
+      chrjabs
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-nextest/package.nix
+++ b/pkgs/by-name/ca/cargo-nextest/package.nix
@@ -47,6 +47,7 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       ekleog
       matthiasbeyer
+      chrjabs
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-nextest/package.nix
+++ b/pkgs/by-name/ca/cargo-nextest/package.nix
@@ -48,6 +48,7 @@ rustPlatform.buildRustPackage rec {
       ekleog
       matthiasbeyer
       chrjabs
+      figsoda
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-rdme/package.nix
+++ b/pkgs/by-name/ca/cargo-rdme/package.nix
@@ -21,6 +21,9 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/orium/cargo-rdme";
     changelog = "https://github.com/orium/cargo-rdme/blob/v${version}/release-notes.md";
     license = with lib.licenses; [ mpl20 ];
-    maintainers = with lib.maintainers; [ GoldsteinE ];
+    maintainers = with lib.maintainers; [
+      GoldsteinE
+      chrjabs
+    ];
   };
 }

--- a/pkgs/by-name/ca/cargo-semver-checks/package.nix
+++ b/pkgs/by-name/ca/cargo-semver-checks/package.nix
@@ -67,6 +67,7 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       matthiasbeyer
+      chrjabs
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-show-asm/package.nix
+++ b/pkgs/by-name/ca/cargo-show-asm/package.nix
@@ -48,6 +48,7 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       oxalica
       matthiasbeyer
+      chrjabs
     ];
     mainProgram = "cargo-asm";
   };

--- a/pkgs/by-name/ca/cargo-spellcheck/package.nix
+++ b/pkgs/by-name/ca/cargo-spellcheck/package.nix
@@ -39,6 +39,7 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       newam
       matthiasbeyer
+      chrjabs
     ];
   };
 }

--- a/pkgs/by-name/ca/cargo-udeps/package.nix
+++ b/pkgs/by-name/ca/cargo-udeps/package.nix
@@ -41,6 +41,7 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       b4dm4n
       matthiasbeyer
+      chrjabs
     ];
     mainProgram = "cargo-udeps";
   };

--- a/pkgs/by-name/ca/cargo-valgrind/package.nix
+++ b/pkgs/by-name/ca/cargo-valgrind/package.nix
@@ -49,6 +49,7 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [
       otavio
       matthiasbeyer
+      chrjabs
     ];
   };
 }

--- a/pkgs/by-name/fa/faketty/package.nix
+++ b/pkgs/by-name/fa/faketty/package.nix
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage rec {
       asl20 # or
       mit
     ];
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "faketty";
   };
 }

--- a/pkgs/by-name/in/inlyne/package.nix
+++ b/pkgs/by-name/in/inlyne/package.nix
@@ -76,7 +76,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/Inlyne-Project/inlyne";
     changelog = "https://github.com/Inlyne-Project/inlyne/releases/tag/${src.rev}";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "inlyne";
   };
 }

--- a/pkgs/by-name/ki/kissat/package.nix
+++ b/pkgs/by-name/ki/kissat/package.nix
@@ -17,7 +17,10 @@ let
       It is a port of CaDiCaL back to C with improved data structures,
       better scheduling of inprocessing and optimized algorithms and implementation.
     '';
-    maintainers = with lib.maintainers; [ shnarazk ];
+    maintainers = with lib.maintainers; [
+      shnarazk
+      chrjabs
+    ];
     platforms = lib.platforms.unix;
     license = lib.licenses.mit;
     homepage = "https://fmv.jku.at/kissat";

--- a/pkgs/by-name/mm/mmtc/package.nix
+++ b/pkgs/by-name/mm/mmtc/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/figsoda/mmtc";
     changelog = "https://github.com/figsoda/mmtc/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "mmtc";
   };
 }

--- a/pkgs/by-name/na/namaka/package.nix
+++ b/pkgs/by-name/na/namaka/package.nix
@@ -45,6 +45,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/namaka";
     changelog = "https://github.com/nix-community/namaka/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/ni/nix-melt/package.nix
+++ b/pkgs/by-name/ni/nix-melt/package.nix
@@ -37,6 +37,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/nix-melt";
     changelog = "https://github.com/nix-community/nix-melt/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.matthiasbeyer ];
   };
 }

--- a/pkgs/by-name/ni/nix-melt/package.nix
+++ b/pkgs/by-name/ni/nix-melt/package.nix
@@ -37,6 +37,9 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/nix-melt";
     changelog = "https://github.com/nix-community/nix-melt/blob/${src.rev}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ lib.maintainers.matthiasbeyer ];
+    maintainers = with lib.maintainers; [
+      figsoda
+      matthiasbeyer
+    ];
   };
 }

--- a/pkgs/by-name/ni/nix-update/package.nix
+++ b/pkgs/by-name/ni/nix-update/package.nix
@@ -52,6 +52,7 @@ python3Packages.buildPythonApplication rec {
     changelog = "https://github.com/Mic92/nix-update/releases/tag/${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      figsoda
       mdaniels5757
       mic92
     ];

--- a/pkgs/by-name/ni/nixpkgs-review/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-review/package.nix
@@ -86,6 +86,7 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.mit;
     mainProgram = "nixpkgs-review";
     maintainers = with lib.maintainers; [
+      figsoda
       mdaniels5757
       mic92
     ];

--- a/pkgs/by-name/pa/patsh/package.nix
+++ b/pkgs/by-name/pa/patsh/package.nix
@@ -48,6 +48,6 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nix-community/patsh";
     changelog = "https://github.com/nix-community/patsh/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ figsoda ];
   };
 }

--- a/pkgs/by-name/re/release-plz/package.nix
+++ b/pkgs/by-name/re/release-plz/package.nix
@@ -50,7 +50,10 @@ rustPlatform.buildRustPackage rec {
       asl20
       mit
     ];
-    maintainers = with lib.maintainers; [ dannixon ];
+    maintainers = with lib.maintainers; [
+      dannixon
+      chrjabs
+    ];
     mainProgram = "release-plz";
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/sa/sagoin/package.nix
+++ b/pkgs/by-name/sa/sagoin/package.nix
@@ -32,7 +32,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/figsoda/sagoin";
     changelog = "https://github.com/figsoda/sagoin/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.agpl3Plus;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "sagoin";
   };
 }

--- a/pkgs/by-name/st/stylua/package.nix
+++ b/pkgs/by-name/st/stylua/package.nix
@@ -42,7 +42,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/johnnymorganz/stylua";
     changelog = "https://github.com/johnnymorganz/stylua/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mpl20;
-    maintainers = [ lib.maintainers.LunNova ];
+    maintainers = with lib.maintainers; [
+      LunNova
+      figsoda
+    ];
     mainProgram = "stylua";
   };
 })

--- a/pkgs/by-name/ty/typos/package.nix
+++ b/pkgs/by-name/ty/typos/package.nix
@@ -44,6 +44,7 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [
       mgttlinger
+      chrjabs
     ];
   };
 }

--- a/pkgs/shells/fish/plugins/async-prompt.nix
+++ b/pkgs/shells/fish/plugins/async-prompt.nix
@@ -19,6 +19,6 @@ buildFishPlugin rec {
     description = "Make your prompt asynchronous to improve the reactivity";
     homepage = "https://github.com/acomagu/fish-async-prompt";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.samasaur ];
   };
 }

--- a/pkgs/shells/fish/plugins/async-prompt.nix
+++ b/pkgs/shells/fish/plugins/async-prompt.nix
@@ -19,6 +19,9 @@ buildFishPlugin rec {
     description = "Make your prompt asynchronous to improve the reactivity";
     homepage = "https://github.com/acomagu/fish-async-prompt";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.samasaur ];
+    maintainers = with lib.maintainers; [
+      figsoda
+      samasaur
+    ];
   };
 }

--- a/pkgs/shells/fish/plugins/autopair.nix
+++ b/pkgs/shells/fish/plugins/autopair.nix
@@ -20,6 +20,7 @@ buildFishPlugin rec {
     homepage = "https://github.com/jorgebucaran/autopair.fish";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
+      figsoda
       kidonng
       pyrox0
     ];


### PR DESCRIPTION
Manual backport of #483464, #474084, #480315, #489217 to `release-25.11`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] 0 rebuilds
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
