### PR TITLE
yarn-zpm: 6.0.0-rc.13 -> 6.0.0-rc.15

### DIFF
--- a/pkgs/by-name/ya/yarn-zpm/package.nix
+++ b/pkgs/by-name/ya/yarn-zpm/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "yarn-zpm";
-  version = "6.0.0-rc.13";
+  version = "6.0.0-rc.15";
 
   src = fetchFromGitHub {
     owner = "yarnpkg";
     repo = "zpm";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Mfzy2dmnQWD8B3bYhMnqAic7rv4JS6pzuqGKrrCqCY0=";
+    hash = "sha256-2HIEZR8gfze1Xf0LIQiMxjXAjs2NfZrs0mf/l/uku4U=";
   };
 
-  cargoHash = "sha256-k5lOVe9Ju6BjHswaN7WrzpHgyuOcHTCOEH+ExzUC5lc=";
+  cargoHash = "sha256-gDgJ2u0Rm8pOB/XILy69qQCFSB5DbqbQI/LcVf/97Ng=";
 
   cargoBuildFlags = [ "--package=zpm" ];
   cargoTestFlags = [ "--package=zpm" ];


### PR DESCRIPTION
## Things done

Update https://github.com/yarnpkg/zpm/releases/tag/v6.0.0-rc.15

```console
$ nix-build -A yarn-zpm
/nix/store/zpcn4ax0v4wa108g9b6xlqn2y5kx28nj-yarn-zpm-6.0.0-rc.15
$ cd /tmp
$ mkdir test-package
$ cd test-package
$ /nix/store/zpcn4ax0v4wa108g9b6xlqn2y5kx28nj-yarn-zpm-6.0.0-rc.15/bin/yarn -v
6.0.0-rc.15.local
$ /nix/store/zpcn4ax0v4wa108g9b6xlqn2y5kx28nj-yarn-zpm-6.0.0-rc.15/bin/yarn init
➤ · Yarn 6.0.0-rc.15.local
➤ ┌ Installing packages
➤ └ Completed in 1ms
➤ ┌ Linking the project
➤ └ Completed in 3ms
$ /nix/store/zpcn4ax0v4wa108g9b6xlqn2y5kx28nj-yarn-zpm-6.0.0-rc.15/bin/yarn add express
➤ · Yarn 6.0.0-rc.15.local
➤ ┌ Installing packages
➤ │ Resolved 82 packages, fetched 1 package (302.48 KiB)
➤ └ Completed in 878ms
➤ ┌ Linking the project
➤ └ Completed in 4ms
$ nix shell nixpkgs#nodejs --command /nix/store/zpcn4ax0v4wa108g9b6xlqn2y5kx28nj-yarn-zpm-6.0.0-rc.15/bin/yarn node -p "require('express/package.json').version"
5.2.1
$ cat package.json 
{
  "dependencies": {
    "express": "^5.2.1"
  },
  "name": "test-package"
}
$ mv yarn.lock yarn-lock.json
$ nix shell nixpkgs#nodejs --command /nix/store/zpcn4ax0v4wa108g9b6xlqn2y5kx28nj-yarn-zpm-6.0.0-rc.15/bin/yarn node -p "require('./yarn-lock.json').__metadata"
{ version: 9 }
$ nix shell nixpkgs#nodejs --command /nix/store/zpcn4ax0v4wa108g9b6xlqn2y5kx28nj-yarn-zpm-6.0.0-rc.15/bin/yarn node -p "Object.keys(require('./yarn-lock.json').entries).find(i => i.includes('express'))"
express@npm:^5.2.1
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
