### PR TITLE
Rustfetch : init at 0.2.0

### DIFF
--- a/pkgs/by-name/ru/rustfetch/package.nix
+++ b/pkgs/by-name/ru/rustfetch/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "rustfetch";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "lemuray";
+    repo = "rustfetch";
+    rev = "v${version}";
+    hash = "sha256-iGcxDKl36kbEi+OiH4gB2+HxP37bpqAMZguIXDzq3Jw=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  dontBuild = true;
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+
+    # The source contains the binary already (from the GitHub release)
+    # Find and install the binary
+    find . -name "${pname}" -type f -executable -exec cp {} $out/bin/ \;
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Rustfetch is a CLI tool designed to fetch system information in the fastest and safest way possible while still keeping it visually appealing, inspired by neofetch and fastfetch.";
+    homepage = "https://github.com/lemuray/rustfetch";
+    license = lib.licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = with lib.maintainers; [
+      LeFaucheur0769
+    ];
+    mainProgram = "rustfetch";
+  };
+}


### PR DESCRIPTION
# Rustfetch

Added the package [rustfetch](https://github.com/lemuray/rustfetch) which is an alternative to fastfetch or neofetch written in rust. It's faster while still being in early development 

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

