### PR TITLE
git: fix build with osxkeychain

### DIFF
--- a/pkgs/by-name/gi/git/osxkeychain-link-rust_lib.patch
+++ b/pkgs/by-name/gi/git/osxkeychain-link-rust_lib.patch
@@ -1,0 +1,15 @@
+diff -ur a/Makefile b/Makefile
+--- a/Makefile	2026-02-14 15:58:16.624434564 -0500
++++ b/Makefile	2026-02-14 15:59:25.701016105 -0500
+@@ -4059,9 +4059,9 @@
+ contrib/libgit-sys/libgitpub.a: $(LIBGIT_HIDDEN_EXPORT)
+ 	$(AR) $(ARFLAGS) $@ $^
+ 
+-contrib/credential/osxkeychain/git-credential-osxkeychain: contrib/credential/osxkeychain/git-credential-osxkeychain.o $(LIB_FILE) GIT-LDFLAGS
++contrib/credential/osxkeychain/git-credential-osxkeychain: contrib/credential/osxkeychain/git-credential-osxkeychain.o $(LIB_FILE) $(RUST_LIB) GIT-LDFLAGS
+ 	$(QUIET_LINK)$(CC) $(ALL_CFLAGS) -o $@ $(ALL_LDFLAGS) \
+-		$(filter %.o,$^) $(LIB_FILE) $(EXTLIBS) -framework Security -framework CoreFoundation
++		$(filter %.o,$^) $(LIB_FILE) $(RUST_LIB) $(EXTLIBS) -framework Security -framework CoreFoundation
+ 
+ contrib/credential/osxkeychain/git-credential-osxkeychain.o: contrib/credential/osxkeychain/git-credential-osxkeychain.c GIT-CFLAGS
+ 	$(QUIET_LINK)$(CC) -o $@ -c $(dep_args) $(compdb_args) $(ALL_CFLAGS) $(EXTRA_CPPFLAGS) $<

--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -130,6 +130,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://lore.kernel.org/git/20251201031040.1120091-1-brianmlyles@gmail.com/raw";
       hash = "sha256-vvhbvg74OIMzfksHiErSnjOZ+W0M/T9J8GOQ4E4wKbU=";
     })
+  ]
+  ++ lib.optionals osxkeychainSupport [
     # Fix build failure on Darwin when building Keychain integration
     # See https://github.com/git/git/pull/2188 and https://github.com/Homebrew/homebrew-core/pull/266961
     (fetchurl {
@@ -138,7 +140,7 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-7jTiMM5XFRDj/srtVf8olW62T/mesqLcyRp3NZJcid8=";
     })
   ]
-  ++ lib.optionals rustSupport [
+  ++ lib.optionals (rustSupport && osxkeychainSupport) [
     # The above patch doesn’t work with Rust support enabled.
     ./osxkeychain-link-rust_lib.patch
   ]

--- a/pkgs/by-name/gi/git/package.nix
+++ b/pkgs/by-name/gi/git/package.nix
@@ -130,6 +130,17 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://lore.kernel.org/git/20251201031040.1120091-1-brianmlyles@gmail.com/raw";
       hash = "sha256-vvhbvg74OIMzfksHiErSnjOZ+W0M/T9J8GOQ4E4wKbU=";
     })
+    # Fix build failure on Darwin when building Keychain integration
+    # See https://github.com/git/git/pull/2188 and https://github.com/Homebrew/homebrew-core/pull/266961
+    (fetchurl {
+      name = "osxkeychain-define-build-targets-in-toplevel-Makefile.patch";
+      url = "https://lore.kernel.org/git/pull.2046.v2.git.1770775169908.gitgitgadget@gmail.com/raw";
+      hash = "sha256-7jTiMM5XFRDj/srtVf8olW62T/mesqLcyRp3NZJcid8=";
+    })
+  ]
+  ++ lib.optionals rustSupport [
+    # The above patch doesn’t work with Rust support enabled.
+    ./osxkeychain-link-rust_lib.patch
   ]
   ++ lib.optionals withSsh [
     # Hard-code the ssh executable to ${pkgs.openssh}/bin/ssh instead of
@@ -271,7 +282,7 @@ stdenv.mkDerivation (finalAttrs: {
     make -C contrib/diff-highlight "''${flagsArray[@]}"
   ''
   + lib.optionalString osxkeychainSupport ''
-    make -C contrib/credential/osxkeychain "''${flagsArray[@]}"
+    make -C contrib/credential/osxkeychain COMPUTE_HEADER_DEPENDENCIES=no "''${flagsArray[@]}"
   ''
   + lib.optionalString withLibsecret ''
     make -C contrib/credential/libsecret "''${flagsArray[@]}"


### PR DESCRIPTION
Cherry-pick a patch from Git next and make further adjustments to allow it to build in our environment.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
