### PR TITLE
maintainers: drop codyopel

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5194,12 +5194,6 @@
     githubId = 27779510;
     keys = [ { fingerprint = "FDF5 EF67 8CC1 FE22 1845  6A22 CF7B BB5B C756 1BD3"; } ];
   };
-  codyopel = {
-    email = "codyopel@gmail.com";
-    github = "codyopel";
-    githubId = 5561189;
-    name = "Cody Opel";
-  };
   coffeeispower = {
     email = "tiagodinis33@proton.me";
     github = "coffeeispower";

--- a/pkgs/by-name/cu/cuetools/package.nix
+++ b/pkgs/by-name/cu/cuetools/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/svend/cuetools";
     license = lib.licenses.gpl2Only;
     maintainers = with lib.maintainers; [
-      codyopel
       jcumming
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/fa/faac/package.nix
+++ b/pkgs/by-name/fa/faac/package.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open source MPEG-4 and MPEG-2 AAC encoder";
     homepage = "https://github.com/knik0/faac";
     license = lib.licenses.unfreeRedistributable;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/fa/faad2/package.nix
+++ b/pkgs/by-name/fa/faad2/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open source MPEG-4 and MPEG-2 AAC decoder";
     homepage = "https://sourceforge.net/projects/faac/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     mainProgram = "faad";
     platforms = lib.platforms.all;
   };

--- a/pkgs/by-name/fd/fdk_aac/package.nix
+++ b/pkgs/by-name/fd/fdk_aac/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "High-quality implementation of the AAC codec from Android";
     homepage = "https://sourceforge.net/projects/opencore-amr/";
     license = lib.licenses.fraunhofer-fdk;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/gs/gsm/package.nix
+++ b/pkgs/by-name/gs/gsm/package.nix
@@ -63,7 +63,6 @@ stdenv.mkDerivation rec {
     homepage = "https://www.quut.com/gsm/";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [
-      codyopel
       raskin
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/la/lame/package.nix
+++ b/pkgs/by-name/la/lame/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "High quality MPEG Audio Layer III (MP3) encoder";
     homepage = "http://lame.sourceforge.net";
     license = lib.licenses.lgpl2;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "lame";
   };

--- a/pkgs/by-name/li/libass/package.nix
+++ b/pkgs/by-name/li/libass/package.nix
@@ -54,6 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/libass/libass";
     license = lib.licenses.isc;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/li/libsass/package.nix
+++ b/pkgs/by-name/li/libsass/package.nix
@@ -44,8 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C/C++ implementation of a Sass compiler";
     homepage = "https://github.com/sass/libsass";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [
-      codyopel
+    maintainers = [
     ];
     pkgConfigModules = [ "libsass" ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/li/libtorrent-rakshasa/package.nix
+++ b/pkgs/by-name/li/libtorrent-rakshasa/package.nix
@@ -47,7 +47,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/rakshasa/libtorrent";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      codyopel
       thiagokokada
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/li/libvpx/package.nix
+++ b/pkgs/by-name/li/libvpx/package.nix
@@ -267,7 +267,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.webmproject.org/";
     changelog = "https://github.com/webmproject/libvpx/raw/v${finalAttrs.version}/CHANGELOG";
     license = lib.licenses.bsd3;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/mk/mkvtoolnix/package.nix
+++ b/pkgs/by-name/mk/mkvtoolnix/package.nix
@@ -142,7 +142,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Only;
     mainProgram = if withGUI then "mkvtoolnix-gui" else "mkvtoolnix";
     maintainers = with lib.maintainers; [
-      codyopel
       rnhmjoj
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/op/openjpeg/package.nix
+++ b/pkgs/by-name/op/openjpeg/package.nix
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
     description = "Open-source JPEG 2000 codec written in C language";
     homepage = "https://www.openjpeg.org/";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     changelog = "https://github.com/uclouvain/openjpeg/blob/v${version}/CHANGELOG.md";
   };

--- a/pkgs/by-name/rt/rtmpdump/package.nix
+++ b/pkgs/by-name/rt/rtmpdump/package.nix
@@ -56,6 +56,6 @@ stdenv.mkDerivation {
     homepage = "https://rtmpdump.mplayerhq.hu/";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/rt/rtorrent/package.nix
+++ b/pkgs/by-name/rt/rtorrent/package.nix
@@ -81,7 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl2Plus;
     mainProgram = "rtorrent";
     maintainers = with lib.maintainers; [
-      codyopel
       thiagokokada
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/sa/sakura/package.nix
+++ b/pkgs/by-name/sa/sakura/package.nix
@@ -67,8 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
       options. No more no less.
     '';
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [
-      codyopel
+    maintainers = [
     ];
     platforms = lib.platforms.linux;
     mainProgram = "sakura";

--- a/pkgs/by-name/sa/sassc/package.nix
+++ b/pkgs/by-name/sa/sassc/package.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     mainProgram = "sassc";
     maintainers = with lib.maintainers; [
-      codyopel
       pjones
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/v4/v4l-utils/package.nix
+++ b/pkgs/by-name/v4/v4l-utils/package.nix
@@ -129,7 +129,6 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
     ];
     maintainers = with lib.maintainers; [
-      codyopel
       yarny
     ];
     platforms = lib.platforms.linux;

--- a/pkgs/by-name/wa/wavpack/package.nix
+++ b/pkgs/by-name/wa/wavpack/package.nix
@@ -41,6 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/dbry/WavPack/releases/tag/${finalAttrs.version}";
     license = lib.licenses.bsd3;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/x2/x265/package.nix
+++ b/pkgs/by-name/x2/x265/package.nix
@@ -209,7 +209,7 @@ stdenv.mkDerivation (finalAttrs: {
       lib.strings.replaceStrings [ "." ] [ "-" ] finalAttrs.version
     }";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/xa/xavs/package.nix
+++ b/pkgs/by-name/xa/xavs/package.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://xavs.sourceforge.net/";
     license = lib.licenses.lgpl2;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/xv/xvidcore/package.nix
+++ b/pkgs/by-name/xv/xvidcore/package.nix
@@ -74,7 +74,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.xvid.com/";
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [
-      codyopel
       lovek323
     ];
     platforms = lib.platforms.all;

--- a/pkgs/development/libraries/celt/generic.nix
+++ b/pkgs/development/libraries/celt/generic.nix
@@ -33,7 +33,6 @@ stdenv.mkDerivation {
     homepage = "https://gitlab.xiph.org/xiph/celt"; # http://www.celt-codec.org/ is gone
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [
-      codyopel
       raskin
     ];
     platforms = lib.platforms.unix;

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -153,7 +153,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.freedesktop.org/wiki/Software/libinput/";
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     teams = [ lib.teams.freedesktop ];
     changelog = "https://gitlab.freedesktop.org/libinput/libinput/-/releases/${version}";
     badPlatforms = [

--- a/pkgs/development/libraries/vid-stab/default.nix
+++ b/pkgs/development/libraries/vid-stab/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     description = "Video stabilization library";
     homepage = "http://public.hronopik.de/vid.stab/";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -110,7 +110,6 @@ stdenv.mkDerivation (finalAttrs: {
     # requires more work: https://gitlab.freedesktop.org/wayland/wayland/-/merge_requests/481
     badPlatforms = lib.platforms.darwin;
     maintainers = with lib.maintainers; [
-      codyopel
       qyliss
     ];
     pkgConfigModules = [

--- a/pkgs/os-specific/linux/v86d/default.nix
+++ b/pkgs/os-specific/linux/v86d/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation {
     mainProgram = "v86d";
     homepage = "https://github.com/mjanusz/v86d";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ codyopel ];
+    maintainers = [ ];
     platforms = [
       "i686-linux"
       "x86_64-linux"


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Acodyopel) since 2021 despite >250 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2022-01-01+user-review-requested%3Acodyopel+). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@codyopel if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
