### PR TITLE
pev: adopt + 0-unstable-2020-05-23 -> 0.85.1 + rename to readpe

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17861,6 +17861,12 @@
     name = "Marcin Mikuła";
     keys = [ { fingerprint = "5547 2A56 AC30 69C9 15C8  B98D 997F 71FA 1D74 6E37"; } ];
   };
+  mildsunrise = {
+    email = "me@alba.sh";
+    github = "mildsunrise";
+    githubId = 1177304;
+    name = "Alba Mendez";
+  };
   milesbreslin = {
     email = "milesbreslin@gmail.com";
     github = "MilesBreslin";

--- a/pkgs/by-name/pe/pev/package.nix
+++ b/pkgs/by-name/pe/pev/package.nix
@@ -5,16 +5,15 @@
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "pev";
-  version = "0-unstable-2020-05-23";
+  version = "0.85.1";
 
   src = fetchFromGitHub {
-    owner = "merces";
-    repo = "pev";
-    rev = "beec2b4f09585fea919ed41ce466dee06be0b6bf";
-    hash = "sha256-HrMbk9YbuqkoBBM7+rfXpqVEnd1rDl2rMePdcfU1WDg=";
-    fetchSubmodules = true;
+    owner = "mentebinaria";
+    repo = "readpe";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e9omL/HSlzBkJSUnjw271hmXGhasZlWw9X8P8ohoRi0=";
   };
 
   buildInputs = [ openssl ];
@@ -27,9 +26,10 @@ stdenv.mkDerivation {
 
   meta = {
     description = "Full-featured, open source, multiplatform command line toolkit to work with PE (Portable Executables) binaries";
-    homepage = "https://pev.sourceforge.net/";
+    homepage = "https://pev.sourceforge.io/";
     license = lib.licenses.gpl2;
+    mainProgram = "readpe";
     maintainers = with lib.maintainers; [ jeschli ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/re/readpe/package.nix
+++ b/pkgs/by-name/re/readpe/package.nix
@@ -6,7 +6,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "pev";
+  pname = "readpe";
   version = "0.85.1";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/re/readpe/package.nix
+++ b/pkgs/by-name/re/readpe/package.nix
@@ -29,7 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://pev.sourceforge.io/";
     license = lib.licenses.gpl2;
     mainProgram = "readpe";
-    maintainers = with lib.maintainers; [ jeschli ];
+    maintainers = with lib.maintainers; [
+      jeschli
+      mildsunrise
+    ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/re/readpe/package.nix
+++ b/pkgs/by-name/re/readpe/package.nix
@@ -16,6 +16,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-e9omL/HSlzBkJSUnjw271hmXGhasZlWw9X8P8ohoRi0=";
   };
 
+  strictDeps = true;
+  __structuredAttrs = true;
+
   buildInputs = [ openssl ];
 
   enableParallelBuilding = true;

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1596,6 +1596,7 @@ mapAliases {
   percona-xtrabackup_lts = throw "'percona-xtrabackup_lts' has been renamed to/replaced by 'percona-xtrabackup'"; # Converted to throw 2025-10-27
   peruse = throw "'peruse' has been removed as it depends on KDE Gear 5, which has reached EOL"; # Added 2025-08-20
   petrifoo = throw "'petrifoo' was remove due to lack of maintenance and relying on gtk2"; # Added 2025-12-02
+  pev = warnAlias "'pev' has been renamed to 'readpe' in both upstream and Nixpkgs" readpe; # Added 2026-02-15
   pfstools = throw "'pfstools' was removed because it was broken and depends on an old version of ImageMagick"; # added 2026-02-26
   pg_cron = throw "'pg_cron' has been removed. Use 'postgresqlPackages.pg_cron' instead."; # Added 2025-07-19
   pg_hll = throw "'pg_hll' has been removed. Use 'postgresqlPackages.pg_hll' instead."; # Added 2025-07-19


### PR DESCRIPTION
upstream renamed the repository to 'readpe' and placed it under a GitHub org, so I suggest renaming the package here too, as other distros have done already.

old changelog: https://github.com/mentebinaria/readpe/wiki/Changelog
new changelog is in GH releases: https://github.com/mentebinaria/readpe/releases

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test