### PR TITLE
treewide: move CXXFLAGS into env for structuredAttrs

### DIFF
--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation rec {
   # Find FLTK without requiring an OpenGL library in buildInputs
   ++ lib.optional (guiModule == "fltk") "-DFLTK_SKIP_OPENGL=ON";
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     # GCC 13: error: 'uint8_t' does not name a type
     "-include cstdint"
   ];

--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
     zeromq
   ];
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     "-I${lib.getDev utf8cpp}/include/utf8cpp"
     "-I${lib.getDev cxx-rs}/include"
   ];

--- a/pkgs/applications/science/machine-learning/shogun/default.nix
+++ b/pkgs/applications/science/machine-learning/shogun/default.nix
@@ -191,7 +191,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "USE_SVMLIGHT" withSvmLight)
     ];
 
-  CXXFLAGS = "-faligned-new";
+  env.CXXFLAGS = "-faligned-new";
 
   doCheck = true;
 

--- a/pkgs/applications/version-management/monotone/default.nix
+++ b/pkgs/applications/version-management/monotone/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
       {} +
   '';
 
-  CXXFLAGS = " --std=c++11 ";
+  env.CXXFLAGS = " --std=c++11 ";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/cl/clfft/package.nix
+++ b/pkgs/by-name/cl/clfft/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # https://github.com/clMathLibraries/clFFT/issues/237
-  CXXFLAGS = "-std=c++98";
+  env.CXXFLAGS = "-std=c++98";
 
   meta = {
     description = "Library containing FFT functions written in OpenCL";

--- a/pkgs/by-name/cr/cryptopp/package.nix
+++ b/pkgs/by-name/cr/cryptopp/package.nix
@@ -42,7 +42,10 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
   hardeningDisable = [ "fortify" ];
-  CXXFLAGS = lib.optionals withOpenMP [ "-fopenmp" ];
+
+  env = lib.optionalAttrs withOpenMP {
+    CXXFLAGS = "-fopenmp";
+  };
 
   doCheck = true;
 

--- a/pkgs/by-name/cs/csmith/package.nix
+++ b/pkgs/by-name/cs/csmith/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     SysCPU
   ]);
 
-  CXXFLAGS = "-std=c++98";
+  env.CXXFLAGS = "-std=c++98";
 
   postInstall = ''
     substituteInPlace $out/bin/compiler_test.pl \

--- a/pkgs/by-name/da/darling-dmg/package.nix
+++ b/pkgs/by-name/da/darling-dmg/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     "-DCOMPILE_WITH_LZFSE=1"
     "-llzfse"
   ];

--- a/pkgs/by-name/dr/draco/package.nix
+++ b/pkgs/by-name/dr/draco/package.nix
@@ -61,9 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-DDRACO_TINYGLTF_PATH=${tinygltf}"
   ];
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     # error: expected ')' before 'value' in 'explicit GltfValue(uint8_t value)'
-    "-include cstdint"
+    "-include"
+    "cstdint"
   ];
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/ec/ecasound/package.nix
+++ b/pkgs/by-name/ec/ecasound/package.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  CXXFLAGS = "-std=c++11";
+  env.CXXFLAGS = "-std=c++11";
   configureFlags = [
     "--enable-liblilv"
     "--with-extra-cppflags=-Dnullptr=0"

--- a/pkgs/by-name/ek/ekho/package.nix
+++ b/pkgs/by-name/ek/ekho/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./autogen.sh
   '';
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     "-O0"
     "-I${lib.getDev utf8cpp}/include/utf8cpp"
   ];

--- a/pkgs/by-name/en/ente-auth/package.nix
+++ b/pkgs/by-name/en/ente-auth/package.nix
@@ -61,7 +61,7 @@ flutter332.buildFlutterApplication rec {
   ];
 
   # https://github.com/juliansteenbakker/flutter_secure_storage/issues/965
-  CXXFLAGS = [ "-Wno-deprecated-literal-operator" ];
+  env.CXXFLAGS = toString [ "-Wno-deprecated-literal-operator" ];
 
   # Based on https://github.com/ente-io/ente/blob/main/auth/linux/packaging/rpm/make_config.yaml
   # and https://github.com/ente-io/ente/blob/main/auth/linux/packaging/enteauth.appdata.xml

--- a/pkgs/by-name/et/eternal-terminal/package.nix
+++ b/pkgs/by-name/et/eternal-terminal/package.nix
@@ -45,9 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
     "-DDISABLE_CRASH_LOG=TRUE"
   ];
 
-  CXXFLAGS = lib.optionals stdenv.cc.isClang [
-    "-std=c++17"
-  ];
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    CXXFLAGS = toString [ "-std=c++17" ];
+  };
 
   doCheck = true;
 

--- a/pkgs/by-name/fr/freeswitch/package.nix
+++ b/pkgs/by-name/fr/freeswitch/package.nix
@@ -159,17 +159,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error"
-    # https://github.com/signalwire/freeswitch/issues/2495
-    "-Wno-incompatible-pointer-types"
-  ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-Wno-error"
+      # https://github.com/signalwire/freeswitch/issues/2495
+      "-Wno-incompatible-pointer-types"
+    ];
 
-  # Using c++14 because of build error
-  # gsm_at.h:94:32: error: ISO C++17 does not allow dynamic exception specifications
-  CXXFLAGS = "-std=c++14";
+    # Using c++14 because of build error
+    # gsm_at.h:94:32: error: ISO C++17 does not allow dynamic exception specifications
+    CXXFLAGS = "-std=c++14";
 
-  CFLAGS = "-D_ANSI_SOURCE";
+    CFLAGS = "-D_ANSI_SOURCE";
+  };
 
   hardeningDisable = [ "format" ];
 

--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Without the std explicitly set, we may run into abseil-cpp
   # compilation errors.
-  CXXFLAGS = "-std=gnu++23";
+  env.CXXFLAGS = "-std=gnu++23";
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/by-name/gi/git-crypt/package.nix
+++ b/pkgs/by-name/gi/git-crypt/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # https://github.com/AGWA/git-crypt/issues/232
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     "-DOPENSSL_API_COMPAT=0x30000000L"
   ];
 

--- a/pkgs/by-name/gp/gpuvis/package.nix
+++ b/pkgs/by-name/gp/gpuvis/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
     freetype
   ];
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     # GCC 13: error: 'uint32_t' has not been declared
     "-include cstdint"
   ];

--- a/pkgs/by-name/ha/hackedbox/package.nix
+++ b/pkgs/by-name/ha/hackedbox/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
   ];
 
-  CXXFLAGS = "-std=c++98";
+  env.CXXFLAGS = "-std=c++98";
 
   buildInputs = [
     freetype

--- a/pkgs/by-name/he/helm/package.nix
+++ b/pkgs/by-name/he/helm/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   nativeBuildInputs = [ pkg-config ];
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     "-DHAVE_LROUND"
     "-fpermissive"
   ];

--- a/pkgs/by-name/hy/hyperrogue/package.nix
+++ b/pkgs/by-name/hy/hyperrogue/package.nix
@@ -32,13 +32,13 @@ stdenv.mkDerivation (finalAttrs: {
     HYPERROGUE_USE_GLEW = 1;
     HYPERROGUE_USE_PNG = 1;
     HYPERROGUE_USE_ROGUEVIZ = 1;
-  };
 
-  CXXFLAGS = [
-    "-I${lib.getDev SDL}/include/SDL"
-    "-DHYPERPATH='\"${placeholder "out"}/share/hyperrogue/\"'"
-    "-DRESOURCEDESTDIR=HYPERPATH"
-  ];
+    CXXFLAGS = toString [
+      "-I${lib.getDev SDL}/include/SDL"
+      "-DHYPERPATH='\"${placeholder "out"}/share/hyperrogue/\"'"
+      "-DRESOURCEDESTDIR=HYPERPATH"
+    ];
+  };
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/ig/igprof/package.nix
+++ b/pkgs/by-name/ig/igprof/package.nix
@@ -32,7 +32,8 @@ stdenv.mkDerivation (finalAttrs: {
     pcre
   ];
   nativeBuildInputs = [ cmake ];
-  CXXFLAGS = [
+
+  env.CXXFLAGS = toString [
     "-fPIC"
     "-O2"
     "-w"

--- a/pkgs/by-name/li/libe57format/package.nix
+++ b/pkgs/by-name/li/libe57format/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-JARpxp6Z2VioBfY0pZSyQU2mG/EllbaF3qteSFM9u8o=";
   };
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     # GCC 13: error: 'int16_t' has not been declared in 'std'
     "-include cstdint"
   ];

--- a/pkgs/by-name/li/libfolia/package.nix
+++ b/pkgs/by-name/li/libfolia/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # compat with icu61+ https://github.com/unicode-org/icu/blob/release-64-2/icu4c/readme.html#L554
-  CXXFLAGS = [ "-DU_USING_ICU_NAMESPACE=1" ];
+  env.CXXFLAGS = toString [ "-DU_USING_ICU_NAMESPACE=1" ];
 
   passthru = {
     updateScript = gitUpdater { rev-prefix = "v"; };

--- a/pkgs/by-name/li/libpar2/package.nix
+++ b/pkgs/by-name/li/libpar2/package.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [ ./libpar2-0.4-external-verification.patch ];
 
-  CXXFLAGS = lib.optionalString stdenv.cc.isClang "-std=c++11";
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    CXXFLAGS = "-std=c++11";
+  };
 
   meta = {
     homepage = "https://parchive.sourceforge.net/";

--- a/pkgs/by-name/li/libretrack/package.nix
+++ b/pkgs/by-name/li/libretrack/package.nix
@@ -32,7 +32,7 @@ flutter329.buildFlutterApplication rec {
   ];
 
   # https://github.com/juliansteenbakker/flutter_secure_storage/issues/965
-  CXXFLAGS = [ "-Wno-deprecated-literal-operator" ];
+  env.CXXFLAGS = toString [ "-Wno-deprecated-literal-operator" ];
 
   postInstall = ''
     substituteInPlace snap/gui/org.proninyaroslav.libretrack.desktop \

--- a/pkgs/by-name/li/libthreadar/package.nix
+++ b/pkgs/by-name/li/libthreadar/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ gcc-unwrapped ];
 
-  CXXFLAGS = [ "-std=c++14" ];
+  env.CXXFLAGS = toString [ "-std=c++14" ];
 
   configureFlags = [
     "--disable-build-html"

--- a/pkgs/by-name/lo/log4shib/package.nix
+++ b/pkgs/by-name/lo/log4shib/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  CXXFLAGS = "-std=c++11";
+  env.CXXFLAGS = "-std=c++11";
 
   meta = {
     description = "Forked version of log4cpp that has been created for the Shibboleth project";

--- a/pkgs/by-name/ma/mainsail/package.nix
+++ b/pkgs/by-name/ma/mainsail/package.nix
@@ -21,7 +21,7 @@ buildNpmPackage rec {
   nodejs = nodejs_20;
 
   # Prevent Cypress binary download.
-  CYPRESS_INSTALL_BINARY = 0;
+  env.CYPRESS_INSTALL_BINARY = 0;
 
   preConfigure = ''
     # Make the build.zip target do nothing, since we will just copy these files later.

--- a/pkgs/by-name/mh/mhabit/package.nix
+++ b/pkgs/by-name/mh/mhabit/package.nix
@@ -35,7 +35,7 @@ flutter338.buildFlutterApplication {
   ];
 
   # https://github.com/juliansteenbakker/flutter_secure_storage/issues/965
-  CXXFLAGS = [ "-Wno-deprecated-literal-operator" ];
+  env.CXXFLAGS = toString [ "-Wno-deprecated-literal-operator" ];
 
   postInstall = ''
     install -Dm644 flatpak/io.github.friesi23.mhabit.desktop --target-directory=$out/share/applications

--- a/pkgs/by-name/mp/mpd/package.nix
+++ b/pkgs/by-name/mp/mpd/package.nix
@@ -257,9 +257,11 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional (builtins.elem "documentation" features_) "man";
 
-  CXXFLAGS = lib.optionals stdenv.hostPlatform.isDarwin [
-    "-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0"
-  ];
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CXXFLAGS = toString [
+      "-D__ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=0"
+    ];
+  };
 
   mesonFlags = [
     (lib.mesonBool "test" true)

--- a/pkgs/by-name/ns/ns-3/package.nix
+++ b/pkgs/by-name/ns/ns-3/package.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
     "build" + lib.optionalString enableDoxygen " doxygen" + lib.optionalString withManual "sphinx";
 
   # to prevent fatal error: 'backward_warning.h' file not found
-  CXXFLAGS = "-D_GLIBCXX_PERMIT_BACKWARD_HASH";
+  env.CXXFLAGS = "-D_GLIBCXX_PERMIT_BACKWARD_HASH";
 
   # Make generated python bindings discoverable in customized python environment
   passthru = {

--- a/pkgs/by-name/pd/pdfslicer/package.nix
+++ b/pkgs/by-name/pd/pdfslicer/package.nix
@@ -56,9 +56,10 @@ stdenv.mkDerivation (finalAttrs: {
     qpdf
   ];
 
-  CXXFLAGS =
+  env = lib.optionalAttrs (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "13") {
     # Pending upstream compatibility with GCC 13
-    lib.optional (stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "13") "-Wno-changes-meaning";
+    CXXFLAGS = "-Wno-changes-meaning";
+  };
 
   meta = {
     description = "Simple application to extract, merge, rotate and reorder pages of PDF documents";

--- a/pkgs/by-name/pr/proj/package.nix
+++ b/pkgs/by-name/pr/proj/package.nix
@@ -59,9 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
     "-DNLOHMANN_JSON_ORIGIN=external"
     "-DEXE_SQLITE3=${buildPackages.sqlite}/bin/sqlite3"
   ];
-  CXXFLAGS = [
+
+  env.CXXFLAGS = toString [
     # GCC 13: error: 'int64_t' in namespace 'std' does not name a type
-    "-include cstdint"
+    "-include"
+    "cstdint"
   ];
 
   preCheck =

--- a/pkgs/by-name/ra/rapidfuzz-cpp/package.nix
+++ b/pkgs/by-name/ra/rapidfuzz-cpp/package.nix
@@ -26,10 +26,13 @@ stdenv.mkDerivation (finalAttrs: {
     "-DRAPIDFUZZ_BUILD_TESTING=ON"
   ];
 
-  CXXFLAGS = lib.optionals stdenv.cc.isClang [
-    # error: no member named 'fill' in namespace 'std'
-    "-include algorithm"
-  ];
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    CXXFLAGS = toString [
+      # error: no member named 'fill' in namespace 'std'
+      "-include"
+      "algorithm"
+    ];
+  };
 
   nativeCheckInputs = [
     catch2_3

--- a/pkgs/by-name/sc/scite/package.nix
+++ b/pkgs/by-name/sc/scite/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     "prefix=${placeholder "out"}"
   ];
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     # GCC 13: error: 'intptr_t' does not name a type
     "-include cstdint"
     "-include system_error"

--- a/pkgs/by-name/se/server-box/package.nix
+++ b/pkgs/by-name/se/server-box/package.nix
@@ -36,7 +36,7 @@ flutter338.buildFlutterApplication {
   ];
 
   # https://github.com/juliansteenbakker/flutter_secure_storage/issues/965
-  CXXFLAGS = [ "-Wno-deprecated-literal-operator" ];
+  env.CXXFLAGS = toString [ "-Wno-deprecated-literal-operator" ];
 
   desktopItems = [
     (makeDesktopItem {

--- a/pkgs/by-name/si/sirius/package.nix
+++ b/pkgs/by-name/si/sirius/package.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   );
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     # GCC 13: error: 'uintptr_t' in namespace 'std' does not name a type
     "-include cstdint"
   ];

--- a/pkgs/by-name/sp/sphinxsearch/package.nix
+++ b/pkgs/by-name/sp/sphinxsearch/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       expat
     ];
 
-  CXXFLAGS = "-std=c++98";
+  env.CXXFLAGS = "-std=c++98";
 
   meta = {
     description = "Open source full text search server";

--- a/pkgs/by-name/su/superTuxKart/package.nix
+++ b/pkgs/by-name/su/superTuxKart/package.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DOpenGL_GL_PREFERENCE=GLVND"
   ];
 
-  CXXFLAGS = [
+  env.CXXFLAGS = toString [
     # GCC 13: error: 'snprintf' was not declared in this scope
     "-include cstdio"
     # GCC 13: error: 'runtime_error' is not a member of 'std'

--- a/pkgs/by-name/uc/ucommon/package.nix
+++ b/pkgs/by-name/uc/ucommon/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ pkg-config ];
 
   # use C++14 Standard until error handling code gets updated upstream
-  CXXFLAGS = [ "-std=c++14" ];
+  env.CXXFLAGS = toString [ "-std=c++14" ];
 
   # disable flaky networking test
   postPatch = ''

--- a/pkgs/by-name/zp/zpaq/package.nix
+++ b/pkgs/by-name/zp/zpaq/package.nix
@@ -20,14 +20,20 @@ stdenv.mkDerivation (finalAttrs: {
     perl # for pod2man
   ];
 
-  CPPFLAGS = [
-    "-Dunix"
-  ]
-  ++ lib.optional (!stdenv.hostPlatform.isi686 && !stdenv.hostPlatform.isx86_64) "-DNOJIT";
-  CXXFLAGS = [
-    "-O3"
-    "-DNDEBUG"
-  ];
+  env = {
+    CPPFLAGS = toString (
+      [
+        "-Dunix"
+      ]
+      ++ lib.optionals (!stdenv.hostPlatform.isi686 && !stdenv.hostPlatform.isx86_64) [
+        "-DNOJIT"
+      ]
+    );
+    CXXFLAGS = toString [
+      "-O3"
+      "-DNDEBUG"
+    ];
+  };
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/libraries/opencolorio/default.nix
+++ b/pkgs/development/libraries/opencolorio/default.nix
@@ -68,7 +68,7 @@ stdenv.mkDerivation rec {
 
   # Gcc blindly tries to optimize all float operations instead of just marked ones.
   # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=122304
-  CXXFLAGS = "-ffp-contract=on";
+  env.CXXFLAGS = "-ffp-contract=on";
   cmakeFlags = [
     "-DOCIO_INSTALL_EXT_PACKAGES=NONE"
     "-DOCIO_USE_SSE2NEON=OFF"

--- a/pkgs/development/tools/parsing/antlr/2.7.7.nix
+++ b/pkgs/development/tools/parsing/antlr/2.7.7.nix
@@ -15,7 +15,9 @@ stdenv.mkDerivation rec {
   patches = [ ./2.7.7-fixes.patch ];
   buildInputs = [ jdk ];
 
-  CXXFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CXXFLAGS = "-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION";
+  };
 
   meta = {
     description = "Powerful parser generator";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
