### PR TITLE
nix-post-build-hook-queue: init at 1.1.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -22,6 +22,8 @@
 
 - [mangowc](https://github.com/DreamMaoMao/mangowc), a lightweight and feature-rich Wayland compositor based on dwl. Available as [programs.mangowc](#opt-programs.mangowc.enable).
 
+- [nix-post-build-hook-queue](https://github.com/newAM/nix-post-build-hook-queue), a Nix post-build-hook queue to sign and upload store paths. Available as [services.nix-post-build-hook-queue](#opt-services.nix-post-build-hook-queue.enable).
+
 - [reaction](https://reaction.ppom.me/), a daemon that scans program outputs for repeated patterns, and takes action. A common usage is to scan ssh and webserver logs, and to ban hosts that cause multiple authentication errors. A modern alternative to fail2ban. Available as [services.reaction](#opt-services.reaction.enable).
 
 - [rqbit](https://github.com/ikatson/rqbit), a bittorrent client written in Rust. It has HTTP API and Web UI, and can be used as a library. Available as [services.rqbit](#opt-services.rqbit.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -609,6 +609,7 @@
   ./services/development/labgrid/coordinator.nix
   ./services/development/livebook.nix
   ./services/development/lorri.nix
+  ./services/development/nix-post-build-hook-queue.nix
   ./services/development/nixseparatedebuginfod2.nix
   ./services/development/rstudio-server/default.nix
   ./services/development/turborepo-remote-cache.nix

--- a/nixos/modules/services/development/nix-post-build-hook-queue.nix
+++ b/nixos/modules/services/development/nix-post-build-hook-queue.nix
@@ -1,0 +1,165 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.nix-post-build-hook-queue;
+in
+{
+  options.services.nix-post-build-hook-queue = with lib; {
+    enable = lib.mkEnableOption "nix-post-build-hook-queue";
+
+    signingPrivateKeyPath = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/nix-store-signing-priv-key";
+      description = ''
+        Path to the PEM encoded private key to sign store paths.
+
+        Paths will not be signed if null.
+      '';
+    };
+
+    uploadTo = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      example = "ssh://nix-ssh@nix-cache.example.com";
+      description = ''
+        Binary cache to upload store paths to after building.
+
+        Paths will not be uploaded if null.
+      '';
+    };
+
+    sshPrivateKeyPath = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/ssh-priv-key";
+      description = ''
+        Path to a private SSH key file.
+
+        This is only relevant if `services.nix-post-build-hook-queue.uploadTo`
+        is set to an SSH URL.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = !lib.isStorePath cfg.signingPrivateKeyPath;
+        message = ''
+          services.nix-post-build-hook-queue.signingPrivateKeyPath
+          points to a file in the Nix store.
+          You should use a quoted absolute path to prevent this.
+        '';
+      }
+      {
+        assertion = !lib.isStorePath cfg.sshPrivateKeyPath;
+        message = ''
+          services.nix-post-build-hook-queue.sshPrivateKeyPath
+          points to a file in the Nix store.
+          You should use a quoted absolute path to prevent this.
+        '';
+      }
+    ];
+
+    systemd.sockets.nix-post-build-hook-queue = {
+      listenDatagrams = [ "/run/nix-post-build-hook-queue.sock" ];
+      wantedBy = [ "sockets.target" ];
+      partOf = [ "nix-post-build-hook-queue.service" ];
+      socketConfig = {
+        SocketMode = "0600";
+        # start the service on incoming traffic
+        Service = "nix-post-build-hook-queue.service";
+      };
+    };
+
+    nix.settings.post-build-hook = lib.getExe' pkgs.nix-post-build-hook-queue "post-build-hook";
+
+    systemd.services.nix-post-build-hook-queue = {
+      after = lib.optionals (cfg.uploadTo != null) [ "network.target" ];
+      description = "nix-post-build-hook-queue";
+      path = [ config.nix.package ] ++ lib.optionals (cfg.uploadTo != null) [ pkgs.openssh ];
+      environment = {
+        NIX_SSHOPTS =
+          "-o IPQoS=throughput"
+          + lib.optionalString (cfg.sshPrivateKeyPath != null) " -i %d/sshPrivateKeyPath";
+      }
+      // lib.optionalAttrs (cfg.signingPrivateKeyPath != null) {
+        NPBHQ_SIGNING_PRIVATE_KEY_PATH = "%d/signingPrivateKeyPath";
+      }
+      // lib.optionalAttrs (cfg.uploadTo != null) {
+        NPBHQ_UPLOAD_TO = cfg.uploadTo;
+      };
+
+      serviceConfig = {
+        Type = "idle";
+        KillSignal = "SIGINT";
+        ExecStart = lib.getExe' pkgs.nix-post-build-hook-queue "post-build-hook-queue";
+        StandardInput = "socket";
+        RuntimeDirectory = "nix-post-build-hook-queue";
+        LoadCredential =
+          [ ]
+          ++ lib.optionals (cfg.signingPrivateKeyPath != null) [
+            "signingPrivateKeyPath:${cfg.signingPrivateKeyPath}"
+          ]
+          ++ lib.optionals (cfg.sshPrivateKeyPath != null) [
+            "sshPrivateKeyPath:${cfg.sshPrivateKeyPath}"
+          ];
+
+        # disable rate limiting
+        StartLimitBurst = 0;
+
+        # hardening
+        DynamicUser = true;
+        DevicePolicy = "closed";
+        CapabilityBoundingSet = "";
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+        ]
+        ++ lib.optionals (cfg.uploadTo != null) [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        DeviceAllow = [ ];
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        BindPaths = [ ];
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        RemoveIPC = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+        ProtectProc = "invisible";
+        ProtectHostname = true;
+        UMask = "0077";
+
+        # permissive to prevent GC warnings
+        # "GC Warning: Couldn't read /proc/stat"
+        ProcSubset = "all";
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ newam ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1116,6 +1116,7 @@ in
   nix-daemon-unprivileged = runTest ./nix-daemon-unprivileged.nix;
   nix-ld = runTest ./nix-ld.nix;
   nix-misc = handleTest ./nix/misc.nix { };
+  nix-post-build-hook-queue = runTest ./nix-post-build-hook-queue.nix;
   nix-required-mounts = runTest ./nix-required-mounts;
   nix-serve = runTest ./nix-serve.nix;
   nix-serve-ssh = runTest ./nix-serve-ssh.nix;

--- a/nixos/tests/nix-post-build-hook-queue.nix
+++ b/nixos/tests/nix-post-build-hook-queue.nix
@@ -1,0 +1,106 @@
+{
+  ...
+}:
+let
+  cacheDomain = "nix-cache.home.arpa";
+in
+{
+  name = "nix-post-build-hook-queue";
+
+  nodes = {
+    build =
+      {
+        lib,
+        nodes,
+        ...
+      }:
+      {
+        networking.hosts.${nodes.cache.networking.primaryIPAddress} = [ cacheDomain ];
+
+        virtualisation.writableStore = true;
+
+        nix.settings = {
+          # do not attempt to fetch from cache.nixos.org
+          substituters = lib.mkForce [ ];
+          experimental-features = "nix-command";
+        };
+
+        services.nix-post-build-hook-queue = {
+          enable = true;
+          sshPrivateKeyPath = ./initrd-network-ssh/id_ed25519;
+          uploadTo = "ssh://nix-ssh@${cacheDomain}";
+        };
+
+        programs.ssh.knownHosts.${cacheDomain} = {
+          hostNames = [ cacheDomain ];
+          publicKeyFile = ./initrd-network-ssh/ssh_host_ed25519_key.pub;
+        };
+      };
+
+    cache =
+      { ... }:
+      {
+        nix = {
+          sshServe = {
+            enable = true;
+            write = true;
+            keys = [
+              (builtins.readFile ./initrd-network-ssh/id_ed25519.pub)
+            ];
+          };
+          # required for writing without a valid signature
+          settings.trusted-users = [ "nix-ssh" ];
+        };
+
+        environment.etc = {
+          "ssh/ssh_host_ed25519_key" = {
+            source = ./initrd-network-ssh/ssh_host_ed25519_key;
+            mode = "0600";
+          };
+          "ssh/ssh_host_ed25519_key.pub" = {
+            source = ./initrd-network-ssh/ssh_host_ed25519_key.pub;
+            mode = "0644";
+          };
+        };
+
+        services.openssh = {
+          enable = true;
+          hostKeys = [
+            {
+              type = "ed25519";
+              path = "/etc/ssh/ssh_host_ed25519_key";
+            }
+          ];
+        };
+      };
+  };
+
+  testScript = ''
+    # from nixos/tests/qemu-vm-store.nix
+    build_derivation = """
+      nix-build --option substitute false -E 'derivation {{
+        name = "{name}";
+        builder = "/bin/sh";
+        args = ["-c" "echo something > $out"];
+        system = builtins.currentSystem;
+        preferLocalBuild = true;
+      }}'
+    """
+
+    start_all()
+
+    build.systemctl("start network-online.target")
+    cache.systemctl("start network-online.target")
+    build.wait_for_unit("network-online.target")
+    cache.wait_for_unit("network-online.target")
+
+    with subtest("Basic upload"):
+      for name in ("a", "b"):
+        store_path: str = build.succeed(build_derivation.format(name=name)).rsplit(" ", 1)[-1].strip()
+        print(f"{store_path=}")
+        cache.wait_until_succeeds(f"nix-store --verify-path {store_path}", timeout=3)
+
+    with subtest("Graceful exit"):
+      build.succeed("journalctl --grep 'nix-post-build-hook-queue.service: Deactivated successfully'")
+  '';
+}

--- a/pkgs/by-name/ni/nix-post-build-hook-queue/package.nix
+++ b/pkgs/by-name/ni/nix-post-build-hook-queue/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nixosTests,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "nix-post-build-hook-queue";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "newAM";
+    repo = "nix-post-build-hook-queue";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nD9x41meUh28JUdv0O0kBnXw1XtypINh1RRFMNorcqY=";
+  };
+
+  cargoHash = "sha256-Z1wGwvMJLAj6MP3RSX0D8ZAMq5iYEwkN9M9bJfZ+igk=";
+
+  passthru.tests = {
+    inherit (nixosTests) nix-post-build-hook-queue;
+  };
+
+  meta = {
+    description = "Nix post-build-hook queue";
+    homepage = "https://github.com/newAM/nix-post-build-hook-queue";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.newam ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [`nix-post-build-hook-queue`](https://github.com/newAM/nix-post-build-hook-queue), a Nix [`post-build-hook`](https://nix.dev/manual/nix/2.33/advanced-topics/post-build-hook.html#using-the-post-build-hook) queue to sign and upload store paths.

This is a project I have maintained for the last 4 years.
I recently had a request to upstream it to nixpkgs: https://github.com/newAM/nix-post-build-hook-queue/issues/115

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
