### PR TITLE
surge-xt: install desktop files and icons

### DIFF
--- a/pkgs/by-name/su/surge-xt/package.nix
+++ b/pkgs/by-name/su/surge-xt/package.nix
@@ -85,6 +85,22 @@ stdenv.mkDerivation (finalAttrs: {
     "-lXrandr"
   ];
 
+  postInstall = lib.optionalString buildStandalone ''
+    install -Dm644 -t $out/share/applications \
+      $src/scripts/installer_linux/assets/applications/Surge-XT.desktop \
+      $src/scripts/installer_linux/assets/applications/Surge-XT-FX.desktop
+
+    substituteInPlace $out/share/applications/Surge-XT.desktop \
+      --replace-fail '"/usr/bin/Surge XT"' "\"$out/bin/Surge XT\""
+    substituteInPlace $out/share/applications/Surge-XT-FX.desktop \
+      --replace-fail '"/usr/bin/Surge XT Effects"' "\"$out/bin/Surge XT Effects\""
+
+    install -Dm644 $src/scripts/installer_linux/assets/icons/scalable/apps/surge-xt.svg \
+      $out/share/icons/hicolor/scalable/apps/surge-xt.svg
+    install -Dm644 $src/scripts/installer_linux/assets/icons/scalable/apps/surge-xt-fx.svg \
+      $out/share/icons/hicolor/scalable/apps/surge-xt-fx.svg
+  '';
+
   passthru = {
     rev-prefix = "release_xt_";
     updateScript = gitUpdater {


### PR DESCRIPTION
## Description

The upstream source tree ships `.desktop` files and SVG icons in `scripts/installer_linux/assets/` but they were never installed by the derivation. This means the standalone application doesn't appear in application launchers.

This adds a `postInstall` phase (gated on `buildStandalone`) that:
- Installs `Surge-XT.desktop` and `Surge-XT-FX.desktop` from the source tree
- Patches their `Exec` paths from `/usr/bin` to the nix store path
- Installs scalable SVG icons (`surge-xt.svg`, `surge-xt-fx.svg`) into the hicolor icon theme

## Things done

- [x] Built on my machine and tested
- [x] Tested with `buildStandalone = false` (postInstall is skipped)
- [x] Checked formatting with `nixfmt`
- [x] This is a non-breaking addition (no rebuild of dependent packages)

cc @magnetophon @mrtnvgr