### PR TITLE
libmodplug: use the configured includedir in pc file

### DIFF
--- a/pkgs/by-name/li/libmodplug/package.nix
+++ b/pkgs/by-name/li/libmodplug/package.nix
@@ -14,10 +14,15 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1pnri98a603xk47smnxr551svbmgbzcw018mq1k6srbrq6kaaz25";
   };
 
-  # Unfortunately, upstream appears inactive and the patches from the fork don’t apply cleanly.
-  # Modify `src/fastmix.cpp` to remove usage of the register storage class, which is
-  # not allowed in C++17 and is an error in clang 16.
-  prePatch = "substituteInPlace src/fastmix.cpp --replace 'register ' ''";
+  postPatch = ''
+    # Unfortunately, upstream appears inactive and the patches from the fork don’t apply cleanly.
+    # Modify `src/fastmix.cpp` to remove usage of the register storage class, which is
+    # not allowed in C++17 and is an error in clang 16.
+    substituteInPlace src/fastmix.cpp --replace-fail 'register ' ""
+
+    substituteInPlace libmodplug.pc.in \
+      --replace-fail 'includedir=''${prefix}/include' 'includedir=@includedir@'
+  '';
 
   outputs = [
     "out"


### PR DESCRIPTION
This should make no difference at the moment because pc file is patched in the fixup phase by the global hook which I'm intending to remove.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
