### PR TITLE
python313Packages.colcon-cmake: init at 0.2.29

### DIFF
--- a/pkgs/development/python-modules/colcon-cmake/default.nix
+++ b/pkgs/development/python-modules/colcon-cmake/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  setuptools,
+  # dependencies
+  colcon,
+  colcon-devtools,
+  packaging,
+  colcon-library-path,
+  colcon-test-result,
+  # tests
+  pytestCheckHook,
+  pytest-cov-stub,
+  scspell,
+  writableTmpDirAsHomeHook,
+}:
+
+buildPythonPackage rec {
+  pname = "colcon-cmake";
+  version = "0.2.29";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "colcon";
+    repo = "colcon-cmake";
+    tag = version;
+    hash = "sha256-v91UREVifYnwbMcM819B5CsXl8FbAH61Ydzu0vXBPX8=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    colcon
+    colcon-devtools
+    packaging
+    colcon-library-path
+  ];
+
+  nativeCheckInputs = [
+    colcon-test-result
+    pytestCheckHook
+    pytest-cov-stub
+    scspell
+    writableTmpDirAsHomeHook
+  ];
+
+  disabledTestPaths = [
+    # Skip the linter tests that require additional dependencies
+    "test/test_flake8.py"
+  ];
+
+  pythonImportsCheck = [ "colcon_devtools" ];
+
+  pythonRemoveDeps = [
+    # We use pytest-cov-stub instead (and it is not a runtime dependency anyways)
+    "pytest-cov"
+  ];
+
+  meta = {
+    description = "Extension for colcon to support CMake packages";
+    homepage = "https://colcon.readthedocs.io/en/released/";
+    downloadPage = "https://github.com/colcon/colcon-cmake";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ guelakais ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2936,6 +2936,8 @@ self: super: with self; {
 
   colcon-cd = callPackage ../development/python-modules/colcon-cd { };
 
+  colcon-cmake = callPackage ../development/python-modules/colcon-cmake { };
+
   colcon-coveragepy-result = callPackage ../development/python-modules/colcon-coveragepy-result { };
 
   colcon-defaults = callPackage ../development/python-modules/colcon-defaults { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
