### PR TITLE
matrix-continuwuity: 0.5.4 -> 0.5.5

### DIFF
--- a/nixos/tests/matrix/continuwuity.nix
+++ b/nixos/tests/matrix/continuwuity.nix
@@ -1,6 +1,8 @@
 { lib, ... }:
 let
   name = "continuwuity";
+  user = "alice";
+  pass = "my-secret-password";
 in
 {
   inherit name;
@@ -12,8 +14,7 @@ in
         settings.global = {
           server_name = name;
           address = [ "0.0.0.0" ];
-          allow_registration = true;
-          yes_i_am_very_very_sure_i_want_an_open_registration_server_prone_to_abuse = true;
+          admin_execute = [ "users create ${user} ${pass}" ];
         };
         extraEnvironment.RUST_BACKTRACE = "yes";
       };
@@ -30,13 +31,10 @@ in
 
             async def main() -> None:
                 # Connect to continuwuity
-                client = nio.AsyncClient("http://continuwuity:6167", "alice")
-
-                # Register as user alice
-                response = await client.register("alice", "my-secret-password")
+                client = nio.AsyncClient("http://continuwuity:6167", "${user}")
 
                 # Log in as user alice
-                response = await client.login("my-secret-password")
+                response = await client.login("${pass}")
 
                 # Create a new room
                 response = await client.room_create(federate=False)

--- a/pkgs/by-name/ma/matrix-continuwuity/package.nix
+++ b/pkgs/by-name/ma/matrix-continuwuity/package.nix
@@ -72,17 +72,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "matrix-continuwuity";
-  version = "0.5.4";
+  version = "0.5.5";
 
   src = fetchFromGitea {
     domain = "forgejo.ellis.link";
     owner = "continuwuation";
     repo = "continuwuity";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-E2BJh0ynzUm3gHJXM0qKIgTyEEMD02PG+uPPdr/MKaQ=";
+    hash = "sha256-mEdhnyzuW2fTP/dBpJE6EnvTH2fbQXOOwZgjJ1trQmU=";
   };
 
-  cargoHash = "sha256-yPQxEZwMQv7HqlQzQxwGrUzZOL21cfNymkNdkOA4GIk=";
+  cargoHash = "sha256-giG4SZNh7uV7PIeHv0npfkgYi6lWn55YktKHOF7HGyM=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Changelog: https://forgejo.ellis.link/continuwuation/continuwuity/releases/tag/v0.5.5
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  (x86_64-linux only)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
