### PR TITLE
python3Packages.lorarf: init at 1.4.0

### DIFF
--- a/pkgs/development/python-modules/lorarf/default.nix
+++ b/pkgs/development/python-modules/lorarf/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  spidev,
+  rpi-lgpio,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "LoRaRF";
+  version = "1.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "chandrawi";
+    repo = "LoRaRF-Python";
+    rev = finalAttrs.version;
+    hash = "sha256-BdUpq0vwrhmg79sjTOEHen8hQRpcw34WlblXrlK3RWs=";
+  };
+
+  preBuild = ''
+    rm -rf dist/
+    substituteInPlace setup.cfg --replace-fail RPi.GPIO rpi-lgpio
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    spidev
+    rpi-lgpio
+  ];
+
+  # Tests do a platform check which requires running on a Raspberry Pi
+  doCheck = false;
+
+  meta = {
+    description = "Python library used for basic transmitting and receiving data using LoRa modem";
+    homepage = "https://github.com/chandrawi/LoRaRF-Python";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      robertjakub
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9174,6 +9174,8 @@ self: super: with self; {
 
   loqedapi = callPackage ../development/python-modules/loqedapi { };
 
+  lorarf = callPackage ../development/python-modules/lorarf { };
+
   loro = callPackage ../development/python-modules/loro { };
 
   losant-rest = callPackage ../development/python-modules/losant-rest { };


### PR DESCRIPTION
LoRa-RF Python is a library for basic transmitting and receiving data using LoRa module with Semtech SX126x series or LLCC68. The library works by interfacing SPI port and some GPIO pins under linux kernel.

homepage: https://github.com/chandrawi/LoRaRF-Python
documentation: https://github.com/chandrawi/LoRaRF-Python/wiki

note: requires python3Packages.rpi-lgpio - PR #490783 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
