### PR TITLE
qsstv: move icon to spec-compliant location

### DIFF
--- a/pkgs/applications/radio/qsstv/default.nix
+++ b/pkgs/applications/radio/qsstv/default.nix
@@ -13,14 +13,15 @@
   hamlib,
   libv4l,
   fftwFloat,
+  imagemagick,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   version = "9.5.8";
   pname = "qsstv";
 
   src = fetchurl {
-    url = "https://www.qsl.net/o/on4qz/qsstv/downloads/qsstv_${version}.tar.gz";
+    url = "https://www.qsl.net/o/on4qz/qsstv/downloads/qsstv_${finalAttrs.version}.tar.gz";
     sha256 = "0s3sivc0xan6amibdiwfnknrl3248wzgy98w6gyxikl0qsjpygy0";
   };
 
@@ -28,6 +29,7 @@ stdenv.mkDerivation rec {
     qmake
     pkg-config
     wrapQtAppsHook
+    imagemagick
   ];
 
   buildInputs = [
@@ -43,7 +45,8 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     # Install desktop icon
-    install -D icons/qsstv.png $out/share/pixmaps/qsstv.png
+    mkdir -p $out/share/icons/hicolor/32x32/apps
+    magick icons/qsstv.png -resize 32x32 $out/share/icons/hicolor/32x32/apps/qsstv.png
     install -D qsstv.desktop $out/share/applications/qsstv.desktop
   '';
 
@@ -55,4 +58,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ hax404 ];
   };
-}
+})


### PR DESCRIPTION
Part of #428824 
Also resized to a standard 32x32 size for better support
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
