### PR TITLE
gtree: 1.13.3 -> 1.13.5, adopt

### DIFF
--- a/pkgs/by-name/gt/gtree/package.nix
+++ b/pkgs/by-name/gt/gtree/package.nix
@@ -1,23 +1,26 @@
 {
   lib,
-  buildGoModule,
+  buildGo126Module,
   fetchFromGitHub,
-  testers,
   gtree,
+  nix-update-script,
+  testers,
 }:
-
-buildGoModule (finalAttrs: {
+# buildGoModule currently builds with go 1.25.0. This package requires
+# version 1.26.0 theirfor needing to be pinned to buildGo126Module until
+# it's updated.
+buildGo126Module (finalAttrs: {
   pname = "gtree";
-  version = "1.13.3";
+  version = "1.13.5";
 
   src = fetchFromGitHub {
     owner = "ddddddO";
     repo = "gtree";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-K7LFnMCx28Abj4U9glFtQWJDHPHPRrGPsP0TiCr5NKc=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2OhXb6ivje7Li/sUO+YHfZPRBKoQnUhNbhbFtqlyjyM=";
   };
 
-  vendorHash = "sha256-A/O8w56RsiS8VHzq4NpIn8dAt12sNpfl/Jf9KziZ12I=";
+  vendorHash = "sha256-UTJQvoiqdF1q4VRUfAx7a7V5UyH+zjwDM5YU7cqVDKE=";
 
   subPackages = [
     "cmd/gtree"
@@ -27,20 +30,23 @@ buildGoModule (finalAttrs: {
     "-s"
     "-w"
     "-X=main.Version=${finalAttrs.version}"
-    "-X=main.Revision=${finalAttrs.src.rev}"
+    "-X=main.Revision=${finalAttrs.src.tag}"
   ];
 
-  passthru.tests = {
-    version = testers.testVersion {
-      package = gtree;
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = gtree;
+      };
     };
+    updateScript = nix-update-script { };
   };
 
   meta = {
     description = "Generate directory trees and directories using Markdown or programmatically";
     mainProgram = "gtree";
     homepage = "https://github.com/ddddddO/gtree";
-    changelog = "https://github.com/ddddddO/gtree/releases/tag/${finalAttrs.src.rev}";
+    changelog = "https://github.com/ddddddO/gtree/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
     maintainers = [ ];
   };

--- a/pkgs/by-name/gt/gtree/package.nix
+++ b/pkgs/by-name/gt/gtree/package.nix
@@ -48,6 +48,6 @@ buildGo126Module (finalAttrs: {
     homepage = "https://github.com/ddddddO/gtree";
     changelog = "https://github.com/ddddddO/gtree/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hythera ];
   };
 })


### PR DESCRIPTION
Part of #458096

Diff: https://github.com/ddddddO/gtree/compare/v1.13.3...v1.13.5
Changelogs:
- https://github.com/ddddddO/gtree/releases/tag/v1.13.4
- https://github.com/ddddddO/gtree/releases/tag/v1.13.5

Currently `buildGoModule` builds with go `1.25.0` but the package requires go `1.26.0`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
