### PR TITLE
mimosa: init at v1.0.0

### DIFF
--- a/pkgs/by-name/mi/mimosa/package.nix
+++ b/pkgs/by-name/mi/mimosa/package.nix
@@ -1,0 +1,100 @@
+{
+  buildFeatures ? [ ],
+  buildNoDefaultFeatures ? false,
+  buildPackages,
+  dbus,
+  fetchFromGitHub,
+  installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellFiles,
+  lib,
+  pkg-config,
+  rustPlatform,
+  stdenv,
+}:
+
+let
+  version = "1.0.0";
+  hash = "sha256-8Re4Jy80K3g69yrx+FcWUrzf6lhPFOdVPo0x5/IXHDo=";
+  cargoHash = "sha256-UXPK5fBah0DkwX3UnGUYbTpoArvDGD7anBcNK89whOk=";
+
+  inherit (stdenv.hostPlatform)
+    isLinux
+    isWindows
+    isAarch64
+    ;
+
+  emulator = stdenv.hostPlatform.emulator buildPackages;
+  exe = stdenv.hostPlatform.extensions.executable;
+
+  # dbus-secret-service feature is part of default cargo features
+  hasDbusSecretService = !buildNoDefaultFeatures || builtins.elem "dbus-secret-service" buildFeatures;
+
+  dbus' = dbus.overrideAttrs (old: {
+    env = (old.env or { }) // {
+      NIX_CFLAGS_COMPILE =
+        (old.env.NIX_CFLAGS_COMPILE or "")
+        # required for D-Bus on Linux AArch64
+        + lib.optionalString (isLinux && isAarch64) " -mno-outline-atomics";
+    };
+  });
+
+in
+rustPlatform.buildRustPackage {
+  inherit cargoHash version buildNoDefaultFeatures;
+
+  pname = "mimosa";
+
+  src = fetchFromGitHub {
+    inherit hash;
+    owner = "pimalaya";
+    repo = "mimosa";
+    rev = "v${version}";
+  };
+
+  nativeBuildInputs =
+    [ ]
+    ++ lib.optional hasDbusSecretService pkg-config
+    ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
+
+  buildInputs =
+    [ ]
+    # D-Bus is provided by vendors on Windows
+    ++ lib.optional (hasDbusSecretService && !isWindows) dbus';
+
+  buildFeatures =
+    buildFeatures
+    # D-Bus is provided by vendors on Windows
+    ++ lib.optional (hasDbusSecretService && isWindows) "vendored";
+
+  doCheck = false;
+
+  postInstall =
+    lib.optionalString (lib.hasInfix "wine" emulator) ''
+      export WINEPREFIX="''${WINEPREFIX:-$(mktemp -d)}"
+      mkdir -p $WINEPREFIX
+    ''
+    + ''
+      mkdir -p $out/share/{completions,man}
+      ${emulator} "$out"/bin/mimosa${exe} manuals "$out"/share/man
+      ${emulator} "$out"/bin/mimosa${exe} completions -d "$out"/share/completions bash elvish fish powershell zsh
+    ''
+    + lib.optionalString installManPages ''
+      installManPage "$out"/share/man/*
+    ''
+    + lib.optionalString installShellCompletions ''
+      installShellCompletion --cmd mimosa \
+        --bash "$out"/share/completions/mimosa.bash \
+        --fish "$out"/share/completions/mimosa.fish \
+        --zsh "$out"/share/completions/_mimosa
+    '';
+
+  meta = {
+    description = "CLI to manage passwords";
+    mainProgram = "mimosa";
+    homepage = "https://github.com/pimalaya/mimosa";
+    changelog = "https://github.com/pimalaya/mimosa/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ soywod ];
+  };
+}


### PR DESCRIPTION
Mimosa CLI is a CLI to manage passwords.

https://github.com/pimalaya/mimosa

https://github.com/pimalaya/mimosa/releases/tag/v1.0.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
