### PR TITLE
autosuspend: 9.0.1 -> 10.0.0

### DIFF
--- a/nixos/modules/services/misc/autosuspend.nix
+++ b/nixos/modules/services/misc/autosuspend.nix
@@ -37,6 +37,7 @@ let
 
   # Dependencies needed by specific checks
   dependenciesForChecks = {
+    "Ping" = [ pkgs.iputils ];
     "Smb" = pkgs.samba;
     "XIdleTime" = [
       pkgs.xprintidle

--- a/nixos/modules/services/misc/autosuspend.nix
+++ b/nixos/modules/services/misc/autosuspend.nix
@@ -235,16 +235,6 @@ in
         ExecStart = "${autosuspend}/bin/autosuspend -l ${autosuspend}/etc/autosuspend-logging.conf -c ${autosuspend-conf} daemon";
       };
     };
-
-    systemd.services.autosuspend-detect-suspend = {
-      description = "Notifies autosuspend about suspension";
-      documentation = [ "https://autosuspend.readthedocs.io/en/latest/systemd_integration.html" ];
-      wantedBy = [ "sleep.target" ];
-      after = [ "sleep.target" ];
-      serviceConfig = {
-        ExecStart = "${autosuspend}/bin/autosuspend -l ${autosuspend}/etc/autosuspend-logging.conf -c ${autosuspend-conf} presuspend";
-      };
-    };
   };
 
   meta = {

--- a/nixos/modules/services/misc/autosuspend.nix
+++ b/nixos/modules/services/misc/autosuspend.nix
@@ -226,6 +226,13 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.checks != { };
+        message = "`services.autosuspend.checks` must contain at least one activity check.";
+      }
+    ];
+
     systemd.services.autosuspend = {
       description = "A daemon to suspend your server in case of inactivity";
       documentation = [ "https://autosuspend.readthedocs.io/en/latest/systemd_integration.html" ];

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -257,6 +257,7 @@ in
   authelia = runTest ./authelia.nix;
   auto-cpufreq = runTest ./auto-cpufreq.nix;
   autobrr = runTest ./autobrr.nix;
+  autosuspend = runTest ./autosuspend.nix;
   avahi = runTest {
     imports = [ ./avahi.nix ];
     _module.args.networkd = false;

--- a/nixos/tests/autosuspend.nix
+++ b/nixos/tests/autosuspend.nix
@@ -1,0 +1,30 @@
+{ lib, pkgs, ... }:
+
+{
+  name = "autosuspend";
+  meta.maintainers = [ lib.maintainers.anthonyroussel ];
+
+  nodes = {
+    machine = {
+      services.autosuspend = {
+        enable = true;
+
+        settings = {
+          interval = 5;
+          idle_time = 5;
+          suspend_cmd = "${pkgs.coreutils}/bin/touch /tmp/suspended";
+        };
+
+        # Return exit code 1 to trigger suspend
+        checks.ExternalCommand.command = "exit 1";
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("autosuspend.service")
+    machine.wait_for_file("/tmp/suspended")
+  '';
+}

--- a/pkgs/by-name/au/autosuspend/package.nix
+++ b/pkgs/by-name/au/autosuspend/package.nix
@@ -7,14 +7,14 @@
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "autosuspend";
-  version = "9.0.1";
+  version = "10.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "languitar";
     repo = "autosuspend";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PVxsdCPGu+bhjfAF5Hu4Xa3lETARitbBUKuy7ursAUE=";
+    hash = "sha256-o9Jpb4i2/SJ3s3h5sclNjpaN/UFk1YbpPf7b3rGXLRg=";
   };
 
   build-system = with python3.pkgs; [
@@ -27,8 +27,8 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     jsonpath-ng
     lxml
     mpd2
-    portalocker
     psutil
+    pygobject3
     python-dateutil
     requests
     requests-file

--- a/pkgs/by-name/au/autosuspend/package.nix
+++ b/pkgs/by-name/au/autosuspend/package.nix
@@ -2,6 +2,7 @@
   lib,
   dbus,
   fetchFromGitHub,
+  nixosTests,
   python3,
   sphinxHook,
   withDocs ? true,
@@ -86,6 +87,10 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "test_smoke"
     "test_multiple_sessions"
   ];
+
+  passthru.tests = {
+    inherit (nixosTests) autosuspend;
+  };
 
   meta = {
     description = "Daemon to automatically suspend and wake up a system";


### PR DESCRIPTION
* Upgrade autosuspend to 10.0.0
  * Notable upstream change: presuspend SystemD unit has been removed
  * Diff: https://github.com/languitar/autosuspend/compare/v9.0.1...v10.0.0
  * Changelog: https://github.com/languitar/autosuspend/releases/tag/v10.0.0
* Generate doc and manpages
* Add autosuspend NixOS test
* NixOS module: Add missing iputils dependency with Ping check
* NixOS module: Assert at least one check has been configured

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
