### PR TITLE
switch-to-configuration-ng: handle mount/automount changes more robustly

### DIFF
--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -841,6 +841,14 @@ in
           assert_lacks(out, "\nrestarting the following units:")
           assert_lacks(out, "\nstarting the following units:")
           assert_contains(out, "the following new units were started: test.mount\n")
+          # we can start inactive mounts
+          machine.succeed("systemctl stop test.mount")
+          out = switch_to_specialisation("${machine}", "addedMount")
+          assert_lacks(out, "stopping the following units:")
+          assert_lacks(out, "NOT restarting the following changed units:")
+          assert_lacks(out, "\nrestarting the following units:")
+          assert_lacks(out, "\nstarting the following units:")
+          assert_contains(out, "the following new units were started: local-fs.target, test.mount\n")
           # modify the mountpoint's options
           out = switch_to_specialisation("${machine}", "addedMountOptsModified")
           assert_lacks(out, "stopping the following units:")
@@ -1444,6 +1452,15 @@ in
           switch_to_specialisation("${machine}", "mount")
           out = machine.succeed("mount | grep 'on /testmount'")
           assert_contains(out, "size=1024k")
+          # We can start inactive mounts
+          machine.succeed("systemctl stop testmount.mount")
+          out = switch_to_specialisation("${machine}", "mount")
+          assert_lacks(out, "stopping the following units:")
+          assert_lacks(out, "NOT restarting the following changed units:")
+          assert_lacks(out, "reloading the following units")
+          assert_lacks(out, "restarting the following units:")
+          assert_lacks(out, "starting the following units:")
+          assert_contains(out, "the following new units were started: testmount.mount\n")
           # Changing options reloads the unit
           out = switch_to_specialisation("${machine}", "mountOptionsModified")
           assert_lacks(out, "stopping the following units:")


### PR DESCRIPTION
Mount options changing for the same mountpoint means we perform a unit reload as opposed to a unit restart. If a mount unit is not active (for example, with a mount unit that is failing), then we need to start the unit instead. Since we do some of the work that the fstab generator already does, we parse /etc/fstab and derive mount unit names that we should start ourselves. We cannot expect those units to be present in /etc/systemd/system, however, which we currently do in order to determine whether we should _not_ start the inactive unit.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
