### PR TITLE
zrepl: 0.6.1 -> 0.7.0

### DIFF
--- a/pkgs/by-name/zr/zrepl/package.nix
+++ b/pkgs/by-name/zr/zrepl/package.nix
@@ -8,16 +8,16 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "zrepl";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromGitHub {
     owner = "zrepl";
     repo = "zrepl";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-sFSWcJ0aBMay+ngUqnr0PKBMOfCcKHgBjff6KRpPZrg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-D2ADK1mX6Aq0I2fBeNLZeJ0GdxWxi2ApiZqT4b72yf4=";
   };
 
-  vendorHash = "sha256-75fGejR7eiECsm1j3yIU1lAWaW9GrorrVnv8JEzkAtU=";
+  vendorHash = "sha256-yu/bKkcWhHJSQPU2F4C58RC7geVTVEcXHlV0DRn/sUs=";
 
   subPackages = [ "." ];
 
@@ -46,6 +46,7 @@ buildGoModule (finalAttrs: {
 
   meta = {
     homepage = "https://zrepl.github.io/";
+    changelog = "https://github.com/zrepl/zrepl/releases/tag/${finalAttrs.src.tag}";
     description = "One-stop, integrated solution for ZFS replication";
     platforms = lib.platforms.linux;
     license = lib.licenses.mit;


### PR DESCRIPTION
Diff: https://github.com/zrepl/zrepl/compare/v0.6.1...v0.7.0

Changelog: https://github.com/zrepl/zrepl/releases/tag/v0.7.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
