### PR TITLE
folly: fix aarch64-linux build

### DIFF
--- a/pkgs/by-name/fo/folly/memset-memcpy-aarch64.patch
+++ b/pkgs/by-name/fo/folly/memset-memcpy-aarch64.patch
@@ -1,0 +1,57 @@
+From 9acd1ec8e6890c7f5d86a0dd6941ae3b8692ac9c Mon Sep 17 00:00:00 2001
+From: Lukas Krenz <lkrenz@nvidia.com>
+Date: Tue, 20 Jan 2026 05:59:00 -0800
+Subject: [PATCH] Fix memset/memcpy linkage on aarch64
+
+Otherwise memcpy and memset benchmarks won't compile
+---
+ folly/CMakeLists.txt | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/folly/CMakeLists.txt b/folly/CMakeLists.txt
+index a1bcbdd6e92..51280821a24 100644
+--- a/folly/CMakeLists.txt
++++ b/folly/CMakeLists.txt
+@@ -879,6 +879,9 @@ folly_add_library(
+   NAME memset-impl
+   SRCS
+     FollyMemset.cpp
++    $<$<BOOL:${IS_AARCH64_ARCH}>:memset_select_aarch64.cpp>
++  DEPS
++    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memset_aarch64>
+ )
+ 
+ folly_add_library(
+@@ -894,12 +897,20 @@ folly_add_library(
+   EXCLUDE_FROM_MONOLITH
+   SRCS
+     FollyMemset.cpp
++    $<$<BOOL:${IS_AARCH64_ARCH}>:memset_select_aarch64.cpp>
++  DEPS
++    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memset_aarch64-use>
++  COMPILE_OPTIONS
++    $<$<BOOL:${IS_AARCH64_ARCH}>:-DFOLLY_MEMSET_IS_MEMSET>
+ )
+ 
+ folly_add_library(
+   NAME memcpy-impl
+   SRCS
+     FollyMemcpy.cpp
++    $<$<BOOL:${IS_AARCH64_ARCH}>:memcpy_select_aarch64.cpp>
++  DEPS
++    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memcpy_aarch64>
+ )
+ 
+ folly_add_library(
+@@ -915,6 +926,11 @@ folly_add_library(
+   EXCLUDE_FROM_MONOLITH
+   SRCS
+     FollyMemcpy.cpp
++    $<$<BOOL:${IS_AARCH64_ARCH}>:memcpy_select_aarch64.cpp>
++  DEPS
++    $<$<BOOL:${IS_AARCH64_ARCH}>:folly_external_aor_memcpy_aarch64-use>
++  COMPILE_OPTIONS
++    $<$<BOOL:${IS_AARCH64_ARCH}>:-DFOLLY_MEMCPY_IS_MEMCPY>
+ )
+ 
+ # x86 assembly memcpy implementation (not supported on MSVC)

--- a/pkgs/by-name/fo/folly/package.nix
+++ b/pkgs/by-name/fo/folly/package.nix
@@ -139,6 +139,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     # <https://github.com/facebook/folly/issues/2171>
     ./folly-fix-glog-0.7.patch
+
+    # https://github.com/facebook/folly/pull/2561
+    ./memset-memcpy-aarch64.patch
   ];
 
   # https://github.com/NixOS/nixpkgs/issues/144170


### PR DESCRIPTION
Backports a patch that fixes memset/memcpy linking on aarch64-linux.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin broken in a different way https://hydra.nixos.org/build/321272916
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
