### PR TITLE
coredns: fix externalPlugins

### DIFF
--- a/pkgs/by-name/co/coredns/package.nix
+++ b/pkgs/by-name/co/coredns/package.nix
@@ -32,60 +32,61 @@ buildGoModule (finalAttrs: {
     "man"
   ];
 
-  # Override the go-modules fetcher derivation to fetch plugins
-  modBuildPhase = ''
-    cp plugin.cfg plugin.cfg.orig
-    ${
-      (lib.concatMapStringsSep "\n" (
-        plugin:
-        let
-          position = plugin.position or "end-of-file";
-          formatPlugin = { name, repo, ... }: "${name}:${repo}";
-        in
-        if position == "end-of-file" then
-          "echo '${formatPlugin plugin}' >> plugin.cfg"
-        else if position == "start-of-file" then
-          "sed -i '1i ${formatPlugin plugin}' plugin.cfg"
-        else if lib.hasAttrByPath [ "before" ] position then
-          ''
-            if ! grep -q '^${position.before}:' plugin.cfg; then
-              echo 'Failed to insert ${plugin.name} before ${position.before} in plugin.cfg: ${position.before} is not in plugin.cfg'
-              exit 1
-            fi
-            sed -i '/^${position.before}:/i ${formatPlugin plugin}' plugin.cfg
-          ''
-        else if lib.hasAttrByPath [ "after" ] position then
-          ''
-            if ! grep -q '^${position.after}:' plugin.cfg; then
-              echo 'Failed to insert ${plugin.name} after ${position.after} in plugin.cfg: ${position.after} is not in plugin.cfg'
-              exit 1
-            fi
-            sed -i '/^${position.after}:/a ${formatPlugin plugin}' plugin.cfg
-          ''
-        else
-          throw ''
-            Unsupported position value in externalPlugin:
-              ${builtins.toJSON plugin}.
-            Valid values for position attr are:
-              - position = "end-of-file" (the default)
-              - position = "start-of-file"
-              - position.before = "{other plugin}"
-              - position.after = "{other plugin}"
-          ''
-      ) externalPlugins)
-    }
-    diff -u plugin.cfg.orig plugin.cfg || true
-    for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
-    go mod vendor
-    CC= GOOS= GOARCH= go generate
-    go mod vendor
-    go mod tidy
-  '';
+  overrideModAttrs = {
+    # Add plugins before vendoring the modules.
+    preBuild = ''
+      cp plugin.cfg plugin.cfg.orig
+      ${
+        (lib.concatMapStringsSep "\n" (
+          plugin:
+          let
+            position = plugin.position or "end-of-file";
+            formatPlugin = { name, repo, ... }: "${name}:${repo}";
+          in
+          if position == "end-of-file" then
+            "echo '${formatPlugin plugin}' >> plugin.cfg"
+          else if position == "start-of-file" then
+            "sed -i '1i ${formatPlugin plugin}' plugin.cfg"
+          else if lib.hasAttrByPath [ "before" ] position then
+            ''
+              if ! grep -q '^${position.before}:' plugin.cfg; then
+                echo 'Failed to insert ${plugin.name} before ${position.before} in plugin.cfg: ${position.before} is not in plugin.cfg'
+                exit 1
+              fi
+              sed -i '/^${position.before}:/i ${formatPlugin plugin}' plugin.cfg
+            ''
+          else if lib.hasAttrByPath [ "after" ] position then
+            ''
+              if ! grep -q '^${position.after}:' plugin.cfg; then
+                echo 'Failed to insert ${plugin.name} after ${position.after} in plugin.cfg: ${position.after} is not in plugin.cfg'
+                exit 1
+              fi
+              sed -i '/^${position.after}:/a ${formatPlugin plugin}' plugin.cfg
+            ''
+          else
+            throw ''
+              Unsupported position value in externalPlugin:
+                ${builtins.toJSON plugin}.
+              Valid values for position attr are:
+                - position = "end-of-file" (the default)
+                - position = "start-of-file"
+                - position.before = "{other plugin}"
+                - position.after = "{other plugin}"
+            ''
+        ) externalPlugins)
+      }
+      diff -u plugin.cfg.orig plugin.cfg || true
+      for src in ${toString (attrsToSources externalPlugins)}; do go get $src; done
+      GOFLAGS=''${GOFLAGS//-mod=vendor/} CC= GOOS= GOARCH= go generate
+      go mod tidy
+    '';
 
-  modInstallPhase = ''
-    mv -t vendor go.mod go.sum plugin.cfg
-    cp -r --reflink=auto vendor "$out"
-  '';
+    # Move the modified `go.mod`, `go.sum`, and `plugin.cfg` files into the
+    # vendor directory so we can retrieve them later in the `preBuild` hook.
+    postBuild = ''
+      mv -t vendor go.mod go.sum plugin.cfg
+    '';
+  };
 
   preBuild = ''
     chmod -R u+w vendor


### PR DESCRIPTION
Fixes the `externalPlugins` system in the coredns package. This is done by using `preBuild` and `postBuild` hooks for the Go modules derivation instead of overriding the whole build phase, and removing the `-mod=vendor` flag for the `go generate` call to stop it from throwing errors.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
