### PR TITLE
git-wt: 0.17.0 -> 0.21.1, add shell completions

### DIFF
--- a/pkgs/by-name/gi/git-wt/package.nix
+++ b/pkgs/by-name/gi/git-wt/package.nix
@@ -1,22 +1,25 @@
 {
   lib,
   fetchFromGitHub,
-  buildGoModule,
+  buildGo126Module,
+  installShellFiles,
   git,
 }:
 
-buildGoModule (finalAttrs: {
+buildGo126Module (finalAttrs: {
   pname = "git-wt";
-  version = "0.17.0";
+  version = "0.21.1";
 
   src = fetchFromGitHub {
     owner = "k1LoW";
     repo = "git-wt";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-gZO3SAIrOQ+wEKf1VAg+e5bLVDt2/s73INZougMXH4k=";
+    hash = "sha256-t4kN5Z+1zKcwK2s7So0OA+I5wKLZTjWffgtEbs/vXiQ=";
   };
 
-  vendorHash = "sha256-LkyH7czzBkiyAYGrKuPSeB4pNAZLmgwXgp6fmYBps6s=";
+  vendorHash = "sha256-O4vqouNxvA3GvrnpRO6GXDD8ysPfFCaaSJVFj2ufxwI=";
+
+  nativeBuildInputs = [ installShellFiles ];
 
   nativeCheckInputs = [ git ];
 
@@ -25,6 +28,13 @@ buildGoModule (finalAttrs: {
     "-w"
     "-X github.com/k1LoW/git-wt/version.Version=v${finalAttrs.version}"
   ];
+
+  postInstall = ''
+    installShellCompletion --cmd git-wt \
+      --bash <($out/bin/git-wt --init bash --nocd) \
+      --zsh <($out/bin/git-wt --init zsh --nocd) \
+      --fish <($out/bin/git-wt --init fish --nocd)
+  '';
 
   meta = {
     description = "Git subcommand that makes git worktree simple";


### PR DESCRIPTION
Update git-wt from 0.17.0 to 0.21.1 and add shell completions for bash, zsh, and fish.

Changes:
- Version bump: 0.17.0 -> 0.21.1
- Switch from `buildGoModule` to `buildGo126Module` as upstream now requires Go >= 1.25.7
- Add shell completions (bash, zsh, fish) using `git-wt --init <shell> --nocd`

Upstream changelog: https://github.com/k1LoW/git-wt/releases

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test