### PR TITLE
dmtcp: unstable-2022-02-28 -> 4.1.0

### DIFF
--- a/pkgs/by-name/dm/dmtcp/package.nix
+++ b/pkgs/by-name/dm/dmtcp/package.nix
@@ -7,18 +7,24 @@
   python3,
 }:
 
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dmtcp";
-  version = "unstable-2022-02-28";
+  version = "4.1.0";
 
   src = fetchFromGitHub {
     owner = "dmtcp";
     repo = "dmtcp";
-    rev = "133687764c6742906006a1d247e3b83cd860fa1d";
-    hash = "sha256-9Vr8IhoeATCfyt7Lp7kYe/7e87mFX9KMNGTqxJgIztE=";
+    tag = finalAttrs.version;
+    hash = "sha256-5laifZ/8oYJrNO5JOggCbPKmA9XiHEC79C/hk+0TdeQ=";
   };
 
   dontDisableStatic = true;
+
+  nativeCheckInputs = [
+    perl
+    python3
+  ];
+  env.HAS_PYTHON3 = "yes";
 
   patches = [ ./ld-linux-so-buffer-size.patch ];
 
@@ -26,18 +32,18 @@ stdenv.mkDerivation {
     patchShebangs .
 
     substituteInPlace configure \
-      --replace '#define ELF_INTERPRETER "$interp"' \
-                "#define ELF_INTERPRETER \"$(cat $NIX_CC/nix-support/dynamic-linker)\""
+      --replace-fail '#define ELF_INTERPRETER \"$interp\"' \
+                "#define ELF_INTERPRETER \\\"$(cat $NIX_CC/nix-support/dynamic-linker)\\\""
     substituteInPlace src/restartscript.cpp \
-      --replace /bin/bash ${stdenv.shell}
+      --replace-fail /bin/bash ${stdenv.shell}
     substituteInPlace util/dmtcp_restart_wrapper.sh \
-      --replace /bin/bash ${stdenv.shell}
+      --replace-fail /bin/bash ${stdenv.shell}
     substituteInPlace test/autotest.py \
-      --replace /bin/bash ${bash}/bin/bash \
-      --replace /usr/bin/perl ${perl}/bin/perl \
-      --replace /usr/bin/python ${python3.interpreter} \
-      --replace "os.environ['USER']" "\"nixbld1\"" \
-      --replace "os.getenv('USER')" "\"nixbld1\""
+      --replace-fail /bin/bash ${bash}/bin/bash \
+      --replace-fail /usr/bin/perl ${perl}/bin/perl \
+      --replace-fail '/usr/bin/env python3' ${python3.interpreter} \
+      --replace-fail "os.environ['USER']" "\"nixbld1\"" \
+      --replace-fail "os.getenv('USER')" "\"nixbld1\""
   '';
 
   meta = {
@@ -48,8 +54,10 @@ stdenv.mkDerivation {
       programs spread across many machines and connected by sockets. It does
       not modify the user's program or the operating system.
     '';
-    homepage = "http://dmtcp.sourceforge.net/";
+    homepage = "http://dmtcp.github.io/";
     license = lib.licenses.lgpl3Plus; # most files seem this or LGPL-2.1+
-    platforms = lib.intersectLists lib.platforms.linux lib.platforms.x86; # broken on ARM and Darwin
+    platforms = lib.intersectLists lib.platforms.linux (
+      lib.platforms.x86 ++ lib.platforms.aarch ++ lib.platforms.riscv
+    );
   };
-}
+})


### PR DESCRIPTION
Many releases have happened since 2022-02-28. See https://github.com/dmtcp/dmtcp/releases

Substitutions had to be updated a bit. Also switched to use `--replace-fail` instead of `--replace`.

Dependencies for tests were added, they aren't actually run though. They're currently broken in several ways: a build failure that's fixed on master but not in a tagged release yet, and the python tests all fail, though they fail on my host system as well.

Homepage updated.

Platform list updated. It seems linux x86, arm and riscv (both 32-bit and 64-bit) are all supported (though it's a little unclear? Release notes for 3.1.0 mention 32-bit arm but readme does not), and darwin is not.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
