### PR TITLE
pokefinder: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/po/pokefinder/package.nix
+++ b/pkgs/by-name/po/pokefinder/package.nix
@@ -7,7 +7,7 @@
   cmake,
   python3,
   qt6,
-  imagemagick,
+  iconConvTools,
   gitUpdater,
 }:
 
@@ -40,8 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
   ''
   + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
     install -D Source/PokeFinder $out/bin/PokeFinder
-    mkdir -p $out/share/pixmaps
-    convert "$src/Source/Form/Images/pokefinder.ico[-1]" $out/share/pixmaps/pokefinder.png
+    icoFileToHiColorTheme $src/Source/Form/Images/pokefinder.ico pokefinder $out
   ''
   + ''
     runHook postInstall
@@ -54,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     copyDesktopItems
-    imagemagick
+    iconConvTools
   ];
 
   desktopItems = [


### PR DESCRIPTION
Part of #428824 
also a strict improvement over the original icon install because it properly installs all sizes 
there is also #481448 bumping this package but it has conflicts. 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
