### PR TITLE
python3Packages.libvalkey: init at 4.0.1

### DIFF
--- a/pkgs/development/python-modules/libvalkey/default.nix
+++ b/pkgs/development/python-modules/libvalkey/default.nix
@@ -1,0 +1,42 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "libvalkey-py";
+  version = "4.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "valkey-io";
+    repo = "libvalkey-py";
+    tag = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-tOq4SC9xA1rXfclqIzseedu7lyQ+7ZcVy/4ELTAorJ4=";
+  };
+
+  build-system = [ setuptools ];
+
+  pythonImportsCheck = [ "libvalkey" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    # import from $out
+    rm -r libvalkey
+  '';
+
+  meta = {
+    changelog = "https://github.com/valkey-io/libvalkey-py/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    description = "Python wrapper for libvalkey";
+    homepage = "https://github.com/valkey-io/libvalkey-py";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.dotlambda ];
+  };
+})

--- a/pkgs/development/python-modules/valkey/default.nix
+++ b/pkgs/development/python-modules/valkey/default.nix
@@ -11,6 +11,7 @@
 
   # optional-dependencies
   cryptography,
+  libvalkey,
   pyopenssl,
   requests,
 
@@ -49,7 +50,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   optional-dependencies = {
-    # TODO: libvalkey = [ libvalkey ];
+    libvalkey = [ libvalkey ];
     ocsp = [
       cryptography
       pyopenssl

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8751,6 +8751,8 @@ self: super: with self; {
 
   libuuu = callPackage ../development/python-modules/libuuu { };
 
+  libvalkey = callPackage ../development/python-modules/libvalkey { };
+
   libversion = callPackage ../development/python-modules/libversion { inherit (pkgs) libversion; };
 
   libvirt = callPackage ../development/python-modules/libvirt { inherit (pkgs) libvirt; };


### PR DESCRIPTION
see https://github.com/NixOS/nixpkgs/pull/489152#issuecomment-3903545921
cc @trofi

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
