### PR TITLE
man-pages: 6.16 -> 6.17, split outputs, add passthru test

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -106,6 +106,8 @@
 
 - `vicinae` has been updated to v0.17. Version 0.17 contains a complete overhaul of the configuration system. For update instructions, see the [release notes for v0.17.0](https://github.com/vicinaehq/vicinae/releases/tag/v0.17.0) and the [upstream configuration documentation](https://docs.vicinae.com/config).
 
+- The `man-pages` package's outputs have been split. The manual pages are installed into the `man` output, which is installed by default. Binaries (including `diffman-git`, `mansect`, `pdfman`, and `sortman`) are installed into the `out` output, which is not installed by default.
+
 - All Log4Shell vulnerability scanners were removed, as they were all unmaintained upstream and are no longer relevant given that the vulnerability has been fixed upstream for several years.
 
 - Plugins for the JetBrains IDEs have been removed from Nixpkgs.

--- a/nixos/tests/man.nix
+++ b/nixos/tests/man.nix
@@ -88,6 +88,8 @@ in
       ${machine}.succeed("man 3 libunwind > /dev/null")
       # NixOS configuration man page is installed
       ${machine}.succeed("man configuration.nix > /dev/null")
+      # Linux `man-pages` work
+      ${machine}.succeed("man 5 proc_vmstat > /dev/null")
 
     with subtest("Test generateCaches via man -k in ${machine}"):
       expected = [
@@ -97,6 +99,7 @@ in
         ("user", "userdel", 8),
         ("mem", "free", 3),
         ("mem", "free", 1),
+        ("statistics", "proc_vmstat", 5),
       ]
 
       for (keyword, page, section) in expected:

--- a/pkgs/by-name/ma/man-pages/package.nix
+++ b/pkgs/by-name/ma/man-pages/package.nix
@@ -6,6 +6,7 @@
   gawk,
   man,
   pcre2,
+  nixosTests,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -65,8 +66,11 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstallCheck
   '';
 
-  passthru.updateScript = directoryListingUpdater {
-    url = "https://www.kernel.org/pub/linux/docs/man-pages/";
+  passthru = {
+    tests = { inherit (nixosTests) man; };
+    updateScript = directoryListingUpdater {
+      url = "https://www.kernel.org/pub/linux/docs/man-pages/";
+    };
   };
 
   meta = {

--- a/pkgs/by-name/ma/man-pages/package.nix
+++ b/pkgs/by-name/ma/man-pages/package.nix
@@ -12,6 +12,15 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "man-pages";
   version = "6.17";
 
+  # `man` is first: most people installing `man-pages` want man pages.
+  # The binaries could be split to a seperate package (as upstream suggests),
+  # but storing in a seperate not-installed-by-default output is easier,
+  # and has a similar effect.
+  outputs = [
+    "man"
+    "out"
+  ];
+
   src = fetchurl {
     url = "mirror://kernel/linux/docs/man-pages/man-pages-${finalAttrs.version}.tar.xz";
     hash = "sha256-0Y8hpgKwl3ilqQlr8b6EQbdzPpmBUEdKzPcD0WX06/Q=";
@@ -31,6 +40,8 @@ stdenv.mkDerivation (finalAttrs: {
     "-R"
     "VERSION=${finalAttrs.version}"
     "prefix=${placeholder "out"}"
+    "bindir=${placeholder "out"}/bin"
+    "mandir=${placeholder "man"}/share/man"
   ];
 
   preConfigure = ''
@@ -48,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Check for a few well-known man pages
     for page in ldd write printf null hosts random ld.so; do
-      man -M "$out/share/man" -P cat "$page" >/dev/null
+      man -M "$man/share/man" -P cat "$page" >/dev/null
     done
 
     runHook postInstallCheck
@@ -60,10 +71,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = {
     description = "Linux development manual pages";
+    longDescription = ''
+      This package provides the manual pages in its "man" output,
+      and various utility programs in its "out" output.
+
+      Only the "man" output is installed by default.
+    '';
     homepage = "https://www.kernel.org/doc/man-pages/";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ mdaniels5757 ];
     platforms = lib.platforms.unix;
+    outputsToInstall = [ "man" ];
     priority = 30; # if a package comes with its own man page, prefer it
   };
 })

--- a/pkgs/by-name/ma/man-pages/package.nix
+++ b/pkgs/by-name/ma/man-pages/package.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "man-pages";
-  version = "6.16";
+  version = "6.17";
 
   src = fetchurl {
     url = "mirror://kernel/linux/docs/man-pages/man-pages-${finalAttrs.version}.tar.xz";
-    hash = "sha256-jiR6vXXNgICc/ghpbIG4xwaQWDsEV0lISyQvtDYx16M=";
+    hash = "sha256-0Y8hpgKwl3ilqQlr8b6EQbdzPpmBUEdKzPcD0WX06/Q=";
   };
 
   nativeInstallCheckInputs = [
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    # Check for a few well‐known man pages
+    # Check for a few well-known man pages
     for page in ldd write printf null hosts random ld.so; do
       man -M "$out/share/man" -P cat "$page" >/dev/null
     done


### PR DESCRIPTION
Changes: https://lore.kernel.org/linux-man/aYy41v6tYda2Qc_1@devuan/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
