### PR TITLE
docify: 1.1.0 -> 1.2.1

### DIFF
--- a/pkgs/by-name/do/docify/package.nix
+++ b/pkgs/by-name/do/docify/package.nix
@@ -6,18 +6,18 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "docify";
-  version = "1.1.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
-    owner = "AThePeanut4";
+    owner = "atoerien";
     repo = "docify";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pENahqprTf6weP6qi9CyeQPdNOqr9c/q7j6GO9Lq3N4=";
+    hash = "sha256-xp8VsDv2Wf8g2mUMPmBgWoyWpJna/r1xPgqO3SUqcR0=";
   };
 
   build-system = with python3Packages; [
-    pdm-backend
+    hatchling
   ];
 
   dependencies = with python3Packages; [
@@ -31,9 +31,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
   doCheck = false;
 
   meta = {
-    changelog = "https://github.com/AThePeanut4/docify/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/atoerien/docify/releases/tag/v${finalAttrs.version}";
     description = "Script to add docstrings to Python type stubs using reflection";
-    homepage = "https://github.com/AThePeanut4/docify";
+    homepage = "https://github.com/atoerien/docify";
     license = lib.licenses.mit;
     mainProgram = "docify";
     maintainers = with lib.maintainers; [ dotlambda ];


### PR DESCRIPTION
Diff: https://github.com/atoerien/docify/compare/v1.1.0...v1.2.1

Changelog:
https://github.com/atoerien/docify/releases/tag/v1.2.0
https://github.com/atoerien/docify/releases/tag/v1.2.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
