### PR TITLE
extism-js: 1.5.1 -> 1.6.0

### DIFF
--- a/pkgs/by-name/ex/extism-js/package.nix
+++ b/pkgs/by-name/ex/extism-js/package.nix
@@ -12,14 +12,14 @@
 }:
 
 let
-  version = "1.5.1";
+  version = "1.6.0";
   tag = "v${version}";
   system = lib.replaceStrings [ "darwin" ] [ "macos" ] stdenvNoCC.hostPlatform.system;
   hashes = {
-    aarch64-darwin = "sha256-BHld8Dwwd6fexc05oHOIawa5PtGZAI61wQGWE8T+iMs=";
-    aarch64-linux = "sha256-KM3/y31OdLmEAcc48TSLmXei2GD6FhOHYlD7W/ErP+I=";
-    x86_64-darwin = "sha256-cE0JJK92pTJyGnHEZ7wA6+dpMvVOTMzFM2Mkwfy5kbQ=";
-    x86_64-linux = "sha256-9qSjqPFmUaUnpGQ/ldIpyFSgTWbUYozcckpYxpm5PJU=";
+    aarch64-darwin = "sha256-VI4lvaOXGgfDLXiiSRNc+Mt7Pu3hAeh44G5T4BrC4M4=";
+    aarch64-linux = "sha256-FaGGJQ5o1r/07IOf/yddRakOODppIJ3MEjnrnjrubhs=";
+    x86_64-darwin = "sha256-2FqHXCoHHwwp/lcnZMUsOkmfFXq3+e+siTmkNkOQ4ps=";
+    x86_64-linux = "sha256-Te0nHM9GUDHM0Nw156FA4TTX8wchZxzEqOH/gF1KrWg=";
   };
 in
 stdenvNoCC.mkDerivation {
@@ -60,6 +60,11 @@ stdenvNoCC.mkDerivation {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
+
+  # https://github.com/extism/js-pdk/pull/154
+  preInstallCheck = ''
+    version=1.5.1
+  '';
 
   meta = {
     changelog = "https://github.com/extism/js-pdk/releases/tag/${tag}";


### PR DESCRIPTION
Diff: https://github.com/extism/js-pdk/compare/v1.5.1...v1.6.0

Changelog: https://github.com/extism/js-pdk/releases/tag/v1.6.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
