### PR TITLE
mlton: Add version 20241230 binary release

### DIFF
--- a/pkgs/development/compilers/mlton/20241230-binary.nix
+++ b/pkgs/development/compilers/mlton/20241230-binary.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchpatch,
+  fetchurl,
+  patchelf,
+  bash,
+  gmp,
+}:
+let
+  dynamic-linker = stdenv.cc.bintools.dynamicLinker;
+  pname = "mlton";
+  version = "20241230";
+in
+stdenv.mkDerivation {
+  inherit pname version;
+  src =
+    if stdenv.hostPlatform.system == "x86_64-linux" then
+      (fetchurl {
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-linux.ubuntu-24.04_static.tgz";
+        sha256 = "sha256-dhcnfy0Mq6iA31cvarfxHfMRBDnCpNq53Rui4efNTOY=";
+      })
+    else if stdenv.hostPlatform.system == "x86_64-darwin" then
+      (fetchurl {
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.amd64-darwin.macos-13_gmp-static.tgz";
+        sha256 = "sha256-fW0hqjrWUcy+PIN8WHb1r4EYgfuwF9Zz3q7f2ZtxOi0=";
+      })
+    else if stdenv.hostPlatform.system == "aarch64-darwin" then
+      (fetchurl {
+        url = "https://github.com/MLton/mlton/releases/download/on-${version}-release/${pname}-${version}-1.arm64-darwin.macos-15_gmp-static.tgz";
+        sha256 = "sha256-xhFP2plFjP/mbLz1CNtlZzkm0Kx6twfD/Dmn79Vj908=";
+      })
+    else
+      throw "Architecture not supported";
+
+  buildInputs = [
+    bash
+    gmp
+  ];
+  strictDeps = true;
+
+  buildPhase = ''
+    make update \
+      CC="$(type -p cc)" \
+      WITH_GMP_INC_DIR="${gmp.dev}/include" \
+      WITH_GMP_LIB_DIR="${gmp}/lib"
+  '';
+
+  installPhase = ''
+    make install PREFIX=$out
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    install_name_tool -change \
+      /opt/local/lib/libgmp.10.dylib \
+      ${gmp}/lib/libgmp.10.dylib \
+      $out/lib/mlton/mlton-compile
+
+    for e in mllex mlnlffigen mlprof mlyacc; do
+      install_name_tool -change \
+        /opt/local/lib/libgmp.10.dylib \
+        ${gmp}/lib/libgmp.10.dylib \
+        $out/bin/$e
+    done
+  '';
+
+  meta = import ./meta.nix { inherit lib; };
+}

--- a/pkgs/development/compilers/mlton/default.nix
+++ b/pkgs/development/compilers/mlton/default.nix
@@ -21,8 +21,10 @@ rec {
     sha256 = "sha256-rqL8lnzVVR+5Hc7sWXK8dCXN92dU76qSoii3/4StODM=";
   };
 
+  mlton20241230Binary = callPackage ./20241230-binary.nix { };
+
   mlton20241230 = callPackage ./from-git-source.nix {
-    mltonBootstrap = mlton20210117Binary;
+    mltonBootstrap = mlton20241230Binary;
     version = "20241230";
     rev = "on-20241230-release";
     sha256 = "sha256-gJUzav2xH8C4Vy5FuqN73Z6lPMSPQgJApF8LgsJXRWo=";
@@ -31,7 +33,7 @@ rec {
   };
 
   mltonHEAD = callPackage ./from-git-source.nix {
-    mltonBootstrap = mlton20210117Binary;
+    mltonBootstrap = mlton20241230Binary;
     version = "HEAD";
     rev = "61baac7108fbd91413f0537b7a42d9a1023455f4";
     sha256 = "sha256-nWR7ZaXfKxeXfZ9IHipAQ39ASVtva4BeDHP3Zq8mqPo=";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4609,7 +4609,9 @@ with pkgs;
     mlton20130715
     mlton20180207Binary
     mlton20180207
+    mlton20210117Binary
     mlton20210117
+    mlton20241230Binary
     mlton20241230
     mltonHEAD
     ;


### PR DESCRIPTION
This PR adds the MLton 20241230 binary release to match the 20210117 binary release.
It also updates the 20241230 and HEAD builds to use this more recent compiler version.

I am unable to test the x86 darwin target, as I do not have an amd64 Mac.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
