### PR TITLE
New VS Code extensions: jjk, packaging

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11111,6 +11111,12 @@
     githubId = 7481521;
     name = "Balázs Lengyel";
   };
+  ilai-deutel = {
+    github = "ilai-deutel";
+    githubId = 10098207;
+    name = "Ilaï Deutel";
+    keys = [ { fingerprint = "1025 8841 8FF7 E165 6964  90A2 06E8 A973 4948 08A2"; } ];
+  };
   ilarvne = {
     email = "ilarvne@proton.me";
     github = "ilarvne";

--- a/pkgs/applications/editors/vscode/extensions/claui.packaging/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/claui.packaging/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "packaging";
+    publisher = "claui";
+    version = "0.2.5";
+    hash = "sha256-WGs00Q1oa8Nz9dpKn3iZSjrhR0VKUwJWPGdm+wWtoxs=";
+  };
+  meta = {
+    changelog = "https://github.com/claui/vscode-packaging/releases";
+    description = "Visual Studio Code extension for PKGBUILDs in the Arch User Repository (AUR)";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=claui.packaging";
+    homepage = "https://github.com/claui/vscode-packaging";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ilai-deutel ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -989,6 +989,8 @@ let
         };
       };
 
+      claui.packaging = callPackage ./claui.packaging { };
+
       cmschuetz12.wal = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "wal";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -2516,6 +2516,8 @@ let
         };
       };
 
+      jjk.jjk = callPackage ./jjk.jjk { };
+
       jkillian.custom-local-formatters = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "jkillian";

--- a/pkgs/applications/editors/vscode/extensions/jjk.jjk/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/jjk.jjk/default.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  vscode-utils,
+}:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "jjk";
+    publisher = "jjk";
+    version = "0.8.1";
+    hash = "sha256-2JUn6wkWgZKZzhitQy6v9R/rCNLrt7DBtt59707hp6c=";
+  };
+  meta = {
+    changelog = "https://github.com/keanemind/jjk/releases";
+    description = "Visual Studio Code extension for the Jujutsu (jj) version control system";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=jjk.jjk";
+    homepage = "https://github.com/keanemind/jjk";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ilai-deutel ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Add 2 VSCode extensions:
  * [Jujutsu Kaizen](https://marketplace.visualstudio.com/items?itemName=jjk.jjk) for Jujutsu (VCS) support
  * [Packaging](https://marketplace.visualstudio.com/items?itemName=claui.packaging) for `PKGBUILD` support
* Add myself as a new maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [[CONTRIBUTING.md](http://contributing.md/)], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[[CONTRIBUTING.md](http://contributing.md/)]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test