### PR TITLE
typescript-go: sync buildGoModule in updateScript, 0-unstable-2026-02-11 -> 0-unstable-2026-04-08

### DIFF
--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -2,7 +2,12 @@
   lib,
   buildGo125Module,
   fetchFromGitHub,
+  _experimental-update-script-combinators,
   nix-update-script,
+  writeShellApplication,
+  nix,
+  gnugrep,
+  gnused,
 }:
 
 let
@@ -44,9 +49,33 @@ buildGoModule {
   '';
 
   passthru = {
-    updateScript = nix-update-script {
-      extraArgs = [ "--version=branch" ];
-    };
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script {
+        extraArgs = [
+          "--version=branch"
+          "--src-only"
+        ];
+      })
+
+      (lib.getExe (writeShellApplication {
+        name = "typescript-go-go-version-updater";
+        runtimeInputs = [
+          nix
+          gnugrep
+          gnused
+        ];
+        text = ''
+          new_src="$(nix-build --attr 'pkgs.typescript-go.src' --no-out-link)"
+          new_go_major_minor="$(grep --only-matching --perl-regexp '^go \K([0-9]+\.[0-9]+)' "$new_src/go.mod")"
+          sed -i -E "s/buildGo[0-9]+Module/buildGo''${new_go_major_minor//./}Module/g" '${toString ./package.nix}'
+        '';
+      }))
+
+      # Update vendorHash
+      (nix-update-script {
+        extraArgs = [ "--version=skip" ];
+      })
+    ];
   };
 
   meta = {

--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  buildGo125Module,
+  buildGo126Module,
   fetchFromGitHub,
   _experimental-update-script-combinators,
   nix-update-script,
@@ -11,17 +11,17 @@
 }:
 
 let
-  buildGoModule = buildGo125Module;
+  buildGoModule = buildGo126Module;
 in
 buildGoModule {
   pname = "typescript-go";
-  version = "0-unstable-2026-02-11";
+  version = "0-unstable-2026-02-15";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "typescript-go";
-    rev = "08cb84c68ae83b9def5e0132e05362e5061342ab";
-    hash = "sha256-IvR7zHSl7kUmamQkGGrzdKJrdypnQe2a0X1YUyRYYTU=";
+    rev = "4b301b2d3a6c626d0c932b6db182c63d9a98505e";
+    hash = "sha256-IhK12tLjm2eTDcqsrX37lGssSieZgPNGao0w1DfduZ4=";
     fetchSubmodules = false;
   };
 

--- a/pkgs/by-name/ty/typescript-go/package.nix
+++ b/pkgs/by-name/ty/typescript-go/package.nix
@@ -15,17 +15,17 @@ let
 in
 buildGoModule {
   pname = "typescript-go";
-  version = "0-unstable-2026-02-15";
+  version = "0-unstable-2026-04-08";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "typescript-go";
-    rev = "4b301b2d3a6c626d0c932b6db182c63d9a98505e";
-    hash = "sha256-IhK12tLjm2eTDcqsrX37lGssSieZgPNGao0w1DfduZ4=";
+    rev = "2a5e1cf9fe2261f2ad56871a6d2ed12d6ac34083";
+    hash = "sha256-vG53leoltVF7jXnf7AJRUIkbytqsqheoKG7bt7oB/h4=";
     fetchSubmodules = false;
   };
 
-  vendorHash = "sha256-QNKXJ9HA8WlLlTxflLt0a/Y2Lt8NG1AnNmBOESYFyRI=";
+  vendorHash = "sha256-YmKVn9fc7dKMBiXnutI15mg/BFCyvyXntr7QaxJ7qU8=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

* Diff: https://github.com/microsoft/typescript-go/compare/08cb84c68ae83b9def5e0132e05362e5061342ab...4b301b2d3a6c626d0c932b6db182c63d9a98505e
* Required go version has been updated in: https://github.com/microsoft/typescript-go/commit/cbceeeca5b7e348f43369309f9f03a2e99669d0e

`buildGoModule` takes some time to use the latest Go version on the master branch. Upstream Go updates quickly, so `nixpkgs-update` PRs are a couple of weeks late with the following error:

```
go: go.mod requires go >= 1.26 (running go 1.25.5; GOTOOLCHAIN=local)
```


This PR adds an updater for `buildGo${MajorMinor}Module`. I think we don't need `buildGoLatestModule` because the upstream updates the Go version only in major updates.

* https://github.com/NixOS/nixpkgs/blob/948ef70f04c4bea6cb3e66d9b93170267bb6fffc/pkgs/build-support/go/README.md?plain=1#L21-L24
* https://github.com/NixOS/nixpkgs/pull/437484
* https://github.com/NixOS/nixpkgs/pull/490142
* https://nixpkgs-update-logs.nix-community.org/typescript-go/2026-02-19.log: `go: go.mod requires go >= 1.26 (running go 1.25.5; GOTOOLCHAIN=local)`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
