### PR TITLE
linux-manual: fix for Linux 6.19

### DIFF
--- a/pkgs/by-name/li/linux-manual/package.nix
+++ b/pkgs/by-name/li/linux-manual/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   linuxPackages_latest,
-  perl,
   python3,
   man,
 }:
@@ -11,39 +10,35 @@ stdenv.mkDerivation {
   pname = "linux-manual";
   inherit (linuxPackages_latest.kernel) version src;
 
-  nativeBuildInputs = [
-    perl
-    python3
-  ];
+  nativeBuildInputs = [ python3 ];
   nativeInstallCheckInputs = [ man ];
 
   dontConfigure = true;
-  dontBuild = true;
   doInstallCheck = true;
 
   postPatch = ''
-    # Use scripts/kernel-doc.py here, not scripts/kernel-doc because
-    # patchShebangs skips symlinks
-
+    # Releases up to including 6.19.3 still use scripts/kernel-doc.py, but it
+    # has been moved to tools/docs with 7.0-rc1.
     patchShebangs --build \
-      scripts/kernel-doc.py \
-      scripts/split-man.pl
+      tools/docs \
+      scripts/kernel-doc.py
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # avoid Makefile because it checks for unnecessary Python dependencies
+    KBUILD_BUILD_TIMESTAMP="$(date -u -d "@$SOURCE_DATE_EPOCH")" \
+    tools/docs/sphinx-build-wrapper mandocs
+
+    runHook postBuild
   '';
 
   installPhase = ''
     runHook preInstall
 
-    export mandir="$out/share/man/man9"
-    mkdir -p "$mandir"
-
-    KBUILD_BUILD_TIMESTAMP="$(date -u -d "@$SOURCE_DATE_EPOCH")" \
-    grep -F -l -Z \
-      --exclude-dir Documentation \
-      --exclude-dir tools \
-      -R '/**' \
-      | xargs -0 -n 256 -P "$NIX_BUILD_CORES" \
-        "$SHELL" -c '{ scripts/kernel-doc -man "$@" || :; } \
-          | scripts/split-man.pl "$mandir"' kernel-doc
+    mkdir -p "$out/share/man"
+    cp -r output/man "$out/share/man/man9"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Linux 6.19 removed `scripts/split-man.pl` and instead made the man pages available through the `mandocs` target of `tools/docs/sphinx-build-wrapper`.

While it can be invoked indirectly through the `mandocs` make target, this results in unnecessary checks for Python dependencies for Sphinx.

Closes #489956.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
