### PR TITLE
github-copilot-cli: refactor to use prebuilt binaries

### DIFF
--- a/pkgs/by-name/gi/github-copilot-cli/package.nix
+++ b/pkgs/by-name/gi/github-copilot-cli/package.nix
@@ -1,51 +1,56 @@
 {
   lib,
   stdenv,
-  fetchzip,
-  nodejs,
-  makeBinaryWrapper,
+  autoPatchelfHook,
+  fetchurl,
   versionCheckHook,
-  nix-update-script,
 }:
 
+let
+  sources = lib.importJSON ./sources.json;
+  srcConfig =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "github-copilot-cli";
-  version = "0.0.406";
+  inherit (sources) version;
 
-  src = fetchzip {
-    url = "https://registry.npmjs.org/@github/copilot/-/copilot-${finalAttrs.version}.tgz";
-    hash = "sha256-APjQW8YDoIO+Q2D5SkH0KI4u+w5mAF3VfEk/Yda2/54=";
+  src = fetchurl {
+    url = "https://github.com/github/copilot-cli/releases/download/v${finalAttrs.version}/${srcConfig.name}.tar.gz";
+    inherit (srcConfig) hash;
   };
 
-  nativeBuildInputs = [ makeBinaryWrapper ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [ stdenv.cc.cc.lib ];
+  sourceRoot = ".";
+  dontStrip = true;
 
   installPhase = ''
     runHook preInstall
-
-    mkdir -p $out/lib/node_modules/@github/copilot
-    cp -r . $out/lib/node_modules/@github/copilot
-
-    mkdir -p $out/bin
-    makeBinaryWrapper ${nodejs}/bin/node $out/bin/copilot \
-      --add-flags "$out/lib/node_modules/@github/copilot/index.js"
-
+    install -Dm755 copilot $out/bin/copilot
     runHook postInstall
   '';
 
   nativeInstallCheckInputs = [ versionCheckHook ];
   doInstallCheck = true;
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal";
     homepage = "https://github.com/github/copilot-cli";
     changelog = "https://github.com/github/copilot-cli/releases/tag/v${finalAttrs.version}";
-    downloadPage = "https://www.npmjs.com/package/@github/copilot";
     license = lib.licenses.unfree;
     maintainers = with lib.maintainers; [
       dbreyfogle
     ];
     mainProgram = "copilot";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 })

--- a/pkgs/by-name/gi/github-copilot-cli/sources.json
+++ b/pkgs/by-name/gi/github-copilot-cli/sources.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.0.410",
+  "x86_64-linux": {
+    "name": "copilot-linux-x64",
+    "hash": "sha256-JSO6ksh9jSzdgfnw+ZVHlLwWm8QqlJafu4f8fp9GGwk="
+  },
+  "aarch64-linux": {
+    "name": "copilot-linux-arm64",
+    "hash": "sha256-d9NGwnW059FLaDolYM01RciolbXacwc354lbJr2JOdo="
+  },
+  "x86_64-darwin": {
+    "name": "copilot-darwin-x64",
+    "hash": "sha256-mm3wQZgIJfx9TywWkqC1FLpxyaE/GO8FP2ev109Pk4o="
+  },
+  "aarch64-darwin": {
+    "name": "copilot-darwin-arm64",
+    "hash": "sha256-gbsjC8hIzk1kBJq9STxemKOM4b423LNfdyI6/eIuhf4="
+  }
+}

--- a/pkgs/by-name/gi/github-copilot-cli/update.sh
+++ b/pkgs/by-name/gi/github-copilot-cli/update.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq nix
+
+set -euo pipefail
+
+ROOT="$(dirname "$(readlink -f "$0")")"
+SOURCES_FILE="$ROOT/sources.json"
+
+LATEST_TAG=$(curl -s https://api.github.com/repos/github/copilot-cli/releases/latest | jq -r .tag_name)
+
+if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" = "null" ]; then
+  echo "Failed to fetch latest release from GitHub API"
+  exit 1
+fi
+
+VERSION="${LATEST_TAG#v}"
+
+echo "Updating to version $VERSION"
+
+# Create a temporary file for the JSON content
+TMP_FILE=$(mktemp)
+
+jq -n --arg v "$VERSION" '{version: $v}' > "$TMP_FILE"
+
+process_platform() {
+  local system="$1"
+  local name="$2"
+  local url="https://github.com/github/copilot-cli/releases/download/v${VERSION}/${name}.tar.gz"
+
+  echo "Processing $system..."
+
+  hash=$(nix-prefetch-url --type sha256 "$url")
+  sri_hash=$(nix hash convert --to sri --hash-algo sha256 "$hash")
+
+  jq --arg sys "$system" --arg n "$name" --arg h "$sri_hash" '. + {($sys): {name: $n, hash: $h}}' \
+    "$TMP_FILE" > "${TMP_FILE}.tmp" && mv "${TMP_FILE}.tmp" "$TMP_FILE"
+}
+
+process_platform "x86_64-linux" "copilot-linux-x64"
+process_platform "aarch64-linux" "copilot-linux-arm64"
+process_platform "x86_64-darwin" "copilot-darwin-x64"
+process_platform "aarch64-darwin" "copilot-darwin-arm64"
+
+mv "$TMP_FILE" "$SOURCES_FILE"
+
+echo "Updated sources.json successfully."


### PR DESCRIPTION
Refactor to use prebuilt binaries from GitHub releases instead of the npm package. This eliminates a few warning messages observed when launching the program compared to the previous npm-based build.

Key changes:
- Fetches architecture-specific binaries for the supported platforms.
- Adds `sources.json` and a custom `update.sh` script to handle hash updates.
- Uses `autoPatchelfHook` and `dontStrip = true` to ensure the binary runs correctly.                                                                                         

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
