### PR TITLE
tlaplus18: add tla+ community contrib libraries

### DIFF
--- a/pkgs/by-name/tl/tlaplus18/package.nix
+++ b/pkgs/by-name/tl/tlaplus18/package.nix
@@ -9,10 +9,15 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "tlaplus";
   version = "1.8.0";
+  version-contrib = "202601200755";
 
   src = fetchurl {
     url = "https://github.com/tlaplus/tlaplus/releases/download/v${finalAttrs.version}/tla2tools.jar";
-    sha256 = "sha256-OXgpd1xuyvhveunlybBi/N6jnxtp/J8Kmp8PYX3eSZ4=";
+    sha256 = "sha256-I4G9fTqK8pbh9gEtBJ/xPYUAa9FnDm9bFVX0u1v3nL8=";
+  };
+  src-contrib = fetchurl {
+    url = "https://github.com/tlaplus/CommunityModules/releases/download/${finalAttrs.version-contrib}/CommunityModules-deps.jar";
+    sha256 = "sha256-W3u22U6hzP3SYRcWuBQwII9wm0k657Tzn6fLhqYCky4=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -21,6 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     mkdir -p $out/share/java $out/bin
     cp $src $out/share/java/tla2tools.jar
+    cp ${finalAttrs.src-contrib} $out/share/java/CommunityModules-deps.jar
 
     makeWrapper ${jre}/bin/java $out/bin/tlc \
       --add-flags "-XX:+UseParallelGC -cp $out/share/java/tla2tools.jar tlc2.TLC"


### PR DESCRIPTION
This should be backward compatible.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
