### PR TITLE
untangle: init at 0.2.0

### DIFF
--- a/pkgs/by-name/un/untangle/package.nix
+++ b/pkgs/by-name/un/untangle/package.nix
@@ -1,0 +1,68 @@
+# This file goes in nixpkgs at: pkgs/by-name/un/untangle/package.nix
+#
+# To get the real cargoHash, set it to lib.fakeHash, run `nix-build -A untangle`,
+# and the error output will contain the correct hash.
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  openssl,
+  libgit2,
+  zlib,
+  testers,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "untangle";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "jonochang";
+    repo = "untangle";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qjwglo9YNBelLq6wM0QOSspi63qoUyz128Xh1fVRJ50=";
+  };
+
+  cargoHash = "sha256-+7gsk5YigKZ7KEtkrzFaaelAmiABAkc8DYwBnaZwqD0=";
+
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
+
+  buildInputs = [
+    openssl
+    libgit2
+    zlib
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = "1";
+    LIBGIT2_NO_VENDOR = "1";
+  };
+
+  # Integration tests require git repos and filesystem fixtures
+  checkFlags = [
+    "--skip=integration"
+  ];
+
+  passthru.tests.version = testers.testVersion {
+    package = finalAttrs.finalPackage;
+    command = "untangle --version";
+  };
+
+  meta = {
+    description = "Module-level dependency graph analyzer for Go, Python, Ruby, and Rust";
+    homepage = "https://github.com/jonochang/untangle";
+    changelog = "https://github.com/jonochang/untangle/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with lib.maintainers; [ jonochang ];
+    mainProgram = "untangle";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
Add [untangle](https://github.com/jonochang/untangle), a module-level dependency graph analyzer for Go, Python, Ruby, and Rust codebases.

 It uses tree-sitter to parse source files and builds a dependency graph, computing metrics like fan-out, fan-in, Shannon entropy, and strongly connected components. It can diff graphs between git revisions for CI gating.

  ## Things done
  - [x] `passthru.tests.version` verifies `untangle --version`
  - [x] Integration tests skipped in sandbox (require git repos and filesystem fixtures)
  
  
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
