### PR TITLE
docker-color-output: 2.6.1 -> 3.0.1

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -131,6 +131,8 @@
   retained for packages that have not completed migration. `asio_1_10` has been removed as no packages depend on it anymore.
   `asio` also no longer propagates `boost` as it is used independent from `boost` in most cases.
 
+- `docker-color-output` has been updated from major version 2 to 3. One breaking change is, that they switched to [YAML-based configuration files](https://github.com/devemio/docker-color-output?tab=readme-ov-file#configuration).
+
 - `stalwart-mail` has been renamed to `stalwart`
 
 - Ethercalc and its associated module have been removed, as the package is unmaintained and cannot be installed from source with npm now.

--- a/pkgs/by-name/do/docker-color-output/package.nix
+++ b/pkgs/by-name/do/docker-color-output/package.nix
@@ -7,20 +7,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "docker-color-output";
-  version = "2.6.1";
+  version = "3.0.1";
 
   src = fetchFromGitHub {
     owner = "devemio";
     repo = "docker-color-output";
-    tag = finalAttrs.version;
-    hash = "sha256-r11HNRXnmTC1CJR871sX7xW9ts9KAu1+azwIwXH09qg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Rpym9YckgJ583zgPpC/mQW1IGgQUppemFhAecgy3M8A=";
   };
 
   postInstall = ''
     mv $out/bin/cli $out/bin/docker-color-output
   '';
 
-  vendorHash = null;
+  vendorHash = "sha256-g+yaVIx4jxpAQ/+WrGKxhVeliYx7nLQe/zsGpxV4Fn4=";
 
   passthru = {
     updateScript = nix-update-script { };


### PR DESCRIPTION
Update [docker-color-output](https://github.com/devemio/docker-color-output) from 2.6.1 to 3.0.1.

> [!NOTE]
> The maintainer uses inconsistent tag names (sometimes with the `v` prefix, sometimes not).

## Things done

Updated vendor hash to build with vendored Go modules, otherwise it would fail with the original `null` vendor hash.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
