### PR TITLE
treewide: replace `lib.trivial.version` with `lib.trivial.release`

### DIFF
--- a/doc/doc-support/package.nix
+++ b/doc/doc-support/package.nix
@@ -54,7 +54,7 @@ stdenvNoCC.mkDerivation (
     };
   in
   {
-    inherit (lib.trivial) version;
+    version = lib.trivial.release;
     pname = "nixpkgs-manual";
 
     nativeBuildInputs = [ nixos-render-docs ];

--- a/pkgs/build-support/dlang/dub-to-nix/default.nix
+++ b/pkgs/build-support/dlang/dub-to-nix/default.nix
@@ -16,7 +16,7 @@ in
 runCommand "dub-to-nix"
   {
     pname = "dub-to-nix";
-    version = lib.trivial.version;
+    version = lib.trivial.release;
     nativeBuildInputs = [ makeWrapper ];
     buildInputs = [ python3 ];
   }

--- a/pkgs/build-support/node/fetch-yarn-deps/default.nix
+++ b/pkgs/build-support/node/fetch-yarn-deps/default.nix
@@ -31,7 +31,7 @@ in
 {
   prefetch-yarn-deps = stdenv.mkDerivation {
     pname = "prefetch-yarn-deps";
-    inherit (lib.trivial) version;
+    version = lib.trivial.release;
 
     dontUnpack = true;
     dontBuild = true;
@@ -68,7 +68,7 @@ in
 
   fixup-yarn-lock = stdenv.mkDerivation {
     pname = "fixup-yarn-lock";
-    inherit (lib.trivial) version;
+    version = lib.trivial.release;
 
     dontUnpack = true;
     dontBuild = true;

--- a/pkgs/by-name/he/hello-cpp/package.nix
+++ b/pkgs/by-name/he/hello-cpp/package.nix
@@ -7,7 +7,7 @@
 
 stdenv.mkDerivation {
   pname = "hello-cpp";
-  version = lib.trivial.version;
+  version = lib.trivial.release;
   src = ./src;
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/xk/xkbvalidate/package.nix
+++ b/pkgs/by-name/xk/xkbvalidate/package.nix
@@ -7,7 +7,7 @@
 runCommandCC "xkbvalidate"
   {
     pname = "xkbvalidate";
-    inherit (lib.trivial) version;
+    version = lib.trivial.release;
 
     buildInputs = [ libxkbcommon ];
     meta = {

--- a/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
+++ b/pkgs/tools/package-management/nix-prefetch-scripts/default.nix
@@ -26,7 +26,7 @@ let
   mkPrefetchScript =
     tool: src: deps:
     stdenv.mkDerivation {
-      inherit (lib.trivial) version;
+      version = lib.trivial.release;
       pname = "nix-prefetch-${tool}";
 
       strictDeps = true;


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/NixOS/nixpkgs/issues/485742#issuecomment-3899809802

`lib.trivial.version` includes the Git hash when distributed over channels or flakes, making binary caches from builds by hydra not work. So let's make use of lib.trivial.release` which does not suffer from this issue.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
​