### PR TITLE
goconvey: fix build with Go 1.25+

### DIFF
--- a/pkgs/by-name/go/goconvey/package.nix
+++ b/pkgs/by-name/go/goconvey/package.nix
@@ -1,26 +1,36 @@
 {
   lib,
   fetchFromGitHub,
-  # Build fails with Go 1.25, with the following error:
-  # 'vendor/golang.org/x/tools/internal/tokeninternal/tokeninternal.go:64:9: invalid array length -delta * delta (constant -256 of type int64)'
-  # Wait for upstream to update their vendored dependencies before unpinning.
-  buildGo124Module,
+  fetchpatch,
+  applyPatches,
+  buildGoModule,
 }:
 
-buildGo124Module {
+buildGoModule {
   pname = "goconvey";
   version = "1.8.1-unstable-2024-03-06";
 
   excludedPackages = "web/server/watch/integration_testing";
 
-  src = fetchFromGitHub {
-    owner = "smartystreets";
-    repo = "goconvey";
-    rev = "a50310f1e3e53e63e2d23eb904f853aa388a5988";
-    hash = "sha256-w5eX/n6Wu2gYgCIhgtjqH3lNckWIDaN4r80cJW3JqFo=";
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "smartystreets";
+      repo = "goconvey";
+      rev = "a50310f1e3e53e63e2d23eb904f853aa388a5988";
+      hash = "sha256-w5eX/n6Wu2gYgCIhgtjqH3lNckWIDaN4r80cJW3JqFo=";
+    };
+    patches = [
+      # Update golang.org/x/tools to v0.42.0 for Go 1.25+ compatibility
+      # https://github.com/smartystreets/goconvey/pull/703
+      (fetchpatch {
+        url = "https://github.com/smartystreets/goconvey/commit/a8d73b2e5380902ab6caa6716ad69c324f390a2d.patch";
+        hash = "sha256-4JZs4/kxt3KP21q4U8mpBJkueVmRsCsKqST1Cn6ySN8=";
+      })
+    ];
   };
 
-  vendorHash = "sha256-P4J/CZY95ks08DC+gSqG+eanL3zoiaoz1d9/ZvBoc9Q=";
+  proxyVendor = true;
+  vendorHash = "sha256-0LQ5yxqy+WGc9TzmXiiHYyUNIIImoLsItkv5KcHjVGc=";
 
   ldflags = [
     "-s"


### PR DESCRIPTION
The vendored `golang.org/x/tools` v0.18.0 uses unsafe struct punching into `token.FileSet` internals with a compile-time size assertion that fails with Go 1.25+ due to `token.FileSet` layout changes:

```
vendor/golang.org/x/tools/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta * delta (constant -256 of type int64)
```

This replaces the unsafe `AddExistingFiles` implementation with the native `FileSet.AddExistingFiles` method available since Go 1.25, following the upstream x/tools fix: https://go-review.googlesource.com/c/tools/+/672618

- Unpin from `buildGo124Module` to `buildGoModule`
- Patch vendored `tokeninternal.go` via `overrideModAttrs`

Fixes goconvey breakage tracked in https://github.com/NixOS/nixpkgs/pull/490142#issuecomment-3902085217

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test