### PR TITLE
tokstat: init at 0.5.0

### DIFF
--- a/pkgs/by-name/to/tokstat/package.nix
+++ b/pkgs/by-name/to/tokstat/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  installShellFiles,
+  openssl,
+  dbus,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tokstat";
+  version = "0.5.0";
+
+  src = fetchFromGitHub {
+    owner = "pbek";
+    repo = "tokstat";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-J144les0gxAFt34+r2hcikIyLKm+A1p8zNg+FljZ41o=";
+  };
+
+  cargoHash = "sha256-llS2UrJ9B+JSNkBUYioEEbe36lGgIr3ifjBXgPhTRnE=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    dbus
+  ];
+
+  # For keyring support
+  PKG_CONFIG_PATH = lib.optionalString stdenv.hostPlatform.isLinux "${dbus.dev}/lib/pkgconfig";
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # Generate shell completions
+    installShellCompletion --cmd tokstat \
+      --bash <($out/bin/tokstat --generate bash 2>/dev/null) \
+      --fish <($out/bin/tokstat --generate fish 2>/dev/null) \
+      --zsh <($out/bin/tokstat --generate zsh 2>/dev/null)
+  '';
+
+  meta = {
+    description = "CLI application to monitor token quotas across multiple AI providers";
+    homepage = "https://github.com/pbek/tokstat";
+    changelog = "https://github.com/pbek/tokstat/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ pbek ];
+    mainProgram = "tokstat";
+  };
+})


### PR DESCRIPTION
Added a package for [tokstat](https://github.com/pbek/tokstat), a CLI application, to monitor token quotas across multiple AI providers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
