### PR TITLE
home-assistant-custom-components.waste_collection_schedule: jumomind fix encoding

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/waste_collection_schedule/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildHomeAssistantComponent,
+  fetchpatch,
   fetchFromGitHub,
   beautifulsoup4,
   cloudscraper,
@@ -9,8 +10,15 @@
   lxml,
   pycryptodome,
   pypdf,
+  pymupdf,
 }:
 
+let
+  fixEncodingPatch = fetchpatch {
+    url = "https://github.com/mampfes/hacs_waste_collection_schedule/commit/f5eb6f44ab40a1a14280ceb903f68195afb367d4.patch";
+    hash = "sha256-PmUb5MJpz6TttgUKeMZUmsD6ZQMO8+MVNI5pjQQYOQI=";
+  };
+in
 buildHomeAssistantComponent rec {
   owner = "mampfes";
   domain = "waste_collection_schedule";
@@ -23,6 +31,8 @@ buildHomeAssistantComponent rec {
     hash = "sha256-+yt6kjUV+fqbOa7jj603XdGX7XtI8mXnCnmUjYFNA7c=";
   };
 
+  patches = [ fixEncodingPatch ];
+
   dependencies = [
     beautifulsoup4
     cloudscraper
@@ -31,6 +41,7 @@ buildHomeAssistantComponent rec {
     lxml
     pycryptodome
     pypdf
+    pymupdf
   ];
 
   meta = {


### PR DESCRIPTION
apply patch to disable encoding to workaround encoding bug in urllib3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
