### PR TITLE
python3Packages.whisperx: 3.7.6 -> 3.8.1

### DIFF
--- a/pkgs/development/python-modules/whisperx/default.nix
+++ b/pkgs/development/python-modules/whisperx/default.nix
@@ -37,7 +37,7 @@ let
     };
   };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "whisperx";
   version = "3.8.1";
   pyproject = true;
@@ -45,7 +45,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "m-bain";
     repo = "whisperX";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2HjQtb8k3px0kqXowKtCXkiG2GuKLCuCtDOPYYa/tbc=";
   };
 
@@ -90,8 +90,8 @@ buildPythonPackage rec {
     mainProgram = "whisperx";
     description = "Automatic Speech Recognition with Word-level Timestamps (& Diarization)";
     homepage = "https://github.com/m-bain/whisperX";
-    changelog = "https://github.com/m-bain/whisperX/releases/tag/${src.tag}";
+    changelog = "https://github.com/m-bain/whisperX/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.bengsparks ];
   };
-}
+})

--- a/pkgs/development/python-modules/whisperx/default.nix
+++ b/pkgs/development/python-modules/whisperx/default.nix
@@ -13,6 +13,7 @@
   huggingface-hub,
   nltk,
   numpy,
+  omegaconf,
   pandas,
   pyannote-audio,
   torch,
@@ -38,14 +39,14 @@ let
 in
 buildPythonPackage rec {
   pname = "whisperx";
-  version = "3.7.6";
+  version = "3.8.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "m-bain";
     repo = "whisperX";
     tag = "v${version}";
-    hash = "sha256-ZHPGQP5HIuFafHGS6ykiSNtHY6QHh0o8DUE2lV41lUI=";
+    hash = "sha256-2HjQtb8k3px0kqXowKtCXkiG2GuKLCuCtDOPYYa/tbc=";
   };
 
   # As `makeWrapperArgs` does not apply to the module, and whisperx depends on `ffmpeg`,
@@ -60,9 +61,6 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   pythonRelaxDeps = [
-    "numpy"
-    "pandas"
-    "pyannote-audio"
     "torch"
     "torchaudio"
   ];
@@ -72,6 +70,7 @@ buildPythonPackage rec {
     huggingface-hub
     nltk
     numpy
+    omegaconf
     pandas
     pyannote-audio
     torch
@@ -85,6 +84,8 @@ buildPythonPackage rec {
   # No tests in repository
   doCheck = false;
 
+  pythonImportsCheck = [ "whisperx" ];
+
   meta = {
     mainProgram = "whisperx";
     description = "Automatic Speech Recognition with Word-level Timestamps (& Diarization)";
@@ -92,14 +93,5 @@ buildPythonPackage rec {
     changelog = "https://github.com/m-bain/whisperX/releases/tag/${src.tag}";
     license = lib.licenses.bsd2;
     maintainers = [ lib.maintainers.bengsparks ];
-
-    # nixpkgs has `pyannote-audio` >= 4.0.0, but `whisperx`'s `pyproject.toml` specifies <4.0.0.
-    #
-    # See https://github.com/m-bain/whisperX/issues/1240 for a serious discussion,
-    # and a potential upgrade in https://github.com/m-bain/whisperX/pull/1243.
-    # Alternatively read https://github.com/m-bain/whisperX/issues/1336 if you prefer a more humorous perspective.
-    #
-    # Failure was first documented in nixpkgs under https://github.com/NixOS/nixpkgs/issues/460172.
-    broken = true;
   };
 }


### PR DESCRIPTION
Closes #460172

Very importantly, whisperx migrated away from pyannote-audio <4 to >= 4 in v3.8.0!

Changelog: https://github.com/m-bain/whisperX/releases/tag/v3.7.7
Changelog: https://github.com/m-bain/whisperX/releases/tag/v3.8.0
Changelog: https://github.com/m-bain/whisperX/releases/tag/v3.8.1

Diff: https://github.com/m-bain/whisperX/compare/v3.7.6...v3.8.1

I don't think these changes can be backported, as the README shows:
`diarize_model = DiarizationPipeline(use_auth_token=YOUR_HF_TOKEN, device=device)`
to 
`diarize_model = DiarizationPipeline(token=YOUR_HF_TOKEN, device=device)`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
