### PR TITLE
rustfetch: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14807,6 +14807,11 @@
     githubId = 736291;
     name = "Lee Machin";
   };
+  lefaucheur0769 = {
+    name = "LeFaucheur0769";
+    github = "LeFaucheur0769";
+    githubId = 90474269;
+  };
   legojames = {
     github = "jrobinson-uk";
     githubId = 4701504;

--- a/pkgs/by-name/ru/rustfetch/package.nix
+++ b/pkgs/by-name/ru/rustfetch/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+}:
+
+let
+  platformMap = {
+    x86_64-linux = "rustfetch-x86_64-unknown-linux-gnu.tar.gz";
+    aarch64-linux = "rustfetch-aarch64-unknown-linux-gnu.tar.gz";
+    x86_64-darwin = "rustfetch-x86_64-apple-darwin.tar.gz";
+    aarch64-darwin = "rustfetch-aarch64-apple-darwin.tar.gz";
+  };
+
+  filename =
+    platformMap.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  hashMap = {
+    x86_64-linux = "sha256-STjjBXKt34ws3m8y38wwNwwiW2mZSufSFf22rQ9ywX4=";
+    aarch64-linux = "sha256-G9v/hdoT2kPKB/AF4gSoSoaO/YLH6hxMxX0v4gohqzU=";
+    x86_64-darwin = "sha256-fM4xJv/qcNS1u4W0u2u0ukr4suA3tEsQe0K70xBGeHk=";
+    aarch64-darwin = "sha256-xMTHvro2YkciR99oTQElH+43dmbPfyYjK3Bw1SZigns=";
+  };
+
+  fileHash =
+    hashMap.${stdenv.hostPlatform.system}
+      or (throw "No hash defined for system: ${stdenv.hostPlatform.system}");
+in
+
+stdenv.mkDerivation rec {
+  pname = "rustfetch";
+  version = "0.2.0";
+
+  src = fetchzip {
+    url = "https://github.com/lemuray/rustfetch/releases/download/v${version}/${filename}";
+    hash = fileHash;
+  };
+
+  dontBuild = true;
+  dontConfigure = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp rustfetch $out/bin/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A CLI tool designed to fetch system information in the fastest and safest way possible";
+    homepage = "https://github.com/lemuray/rustfetch";
+    license = lib.licenses.mit;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ LeFaucheur0769 ];
+    mainProgram = "rustfetch";
+  };
+}


### PR DESCRIPTION
## Maintainers

Added myself as a maintainer 

## Rustfetch

Added Rustfetch which is an alternative to fastfetch or neofetch written in rust to nixpkgs

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x]  Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


