### PR TITLE
python313Packages.osc-lib: convert hack to patch

### DIFF
--- a/pkgs/development/python-modules/osc-lib/default.nix
+++ b/pkgs/development/python-modules/osc-lib/default.nix
@@ -15,7 +15,6 @@
   stdenv,
   stestr,
   stevedore,
-  writeText,
 }:
 
 buildPythonPackage rec {
@@ -30,11 +29,9 @@ buildPythonPackage rec {
     hash = "sha256-1mMON/aVJon7t/zfYVhFpuB78b+DmOEVhvIFaTBRqfo=";
   };
 
-  postPatch = ''
-    # TODO: somehow bring this to upstreams attention
-    substituteInPlace pyproject.toml \
-      --replace-fail '"osc_lib"' '"osc_lib", "osc_lib.api", "osc_lib.cli", "osc_lib.command", "osc_lib.test", "osc_lib.tests", "osc_lib.tests.api", "osc_lib.tests.cli", "osc_lib.tests.command", "osc_lib.tests.utils", "osc_lib.utils"'
-  '';
+  patches = [
+    ./fix-pyproject.diff
+  ];
 
   env.PBR_VERSION = version;
 
@@ -79,7 +76,19 @@ buildPythonPackage rec {
       runHook postCheck
     '';
 
-  pythonImportsCheck = [ "osc_lib" ];
+  pythonImportsCheck = [
+    "osc_lib"
+    "osc_lib.api"
+    "osc_lib.cli"
+    "osc_lib.command"
+    "osc_lib.test"
+    "osc_lib.tests"
+    "osc_lib.tests.api"
+    "osc_lib.tests.cli"
+    "osc_lib.tests.command"
+    "osc_lib.tests.utils"
+    "osc_lib.utils"
+  ];
 
   meta = {
     description = "OpenStackClient Library";

--- a/pkgs/development/python-modules/osc-lib/fix-pyproject.diff
+++ b/pkgs/development/python-modules/osc-lib/fix-pyproject.diff
@@ -1,0 +1,18 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 34680b2..95f573c 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -37,10 +37,9 @@ test = [
+     "testtools>=2.2.0",  # MIT
+ ]
+ 
+-[tool.setuptools]
+-packages = [
+-    "osc_lib"
+-]
++[tool.setuptools.packages.find]
++where = ["."]
++include = ["osc_lib*"]
+ 
+ [tool.mypy]
+ show_column_numbers = true


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
