### PR TITLE
libation: fix darwin build

### DIFF
--- a/pkgs/by-name/li/libation/package.nix
+++ b/pkgs/by-name/li/libation/package.nix
@@ -26,6 +26,8 @@ buildDotnetModule rec {
 
   sourceRoot = "${src.name}/Source";
 
+  env.AVALONIA_TELEMETRY_OPTOUT = "1";
+
   dotnet-sdk = dotnetCorePackages.sdk_10_0;
 
   dotnet-runtime = dotnetCorePackages.runtime_10_0;


### PR DESCRIPTION
```
/nix/var/nix/builds/nix-66216-1817390111/nuget.fPkgoh/fallback/avalonia.buildservices/11.3.2/buildTransitive/Avalonia.BuildServices.targets(9,9): error MSB4018: The "AvaloniaStatsTask" task failed unexpectedly. [/nix/var/nix/builds/nix-66216-1817390111/source/Source/LibationAvalonia/LibationAvalonia.csproj]
/nix/var/nix/builds/nix-66216-1817390111/nuget.fPkgoh/fallback/avalonia.buildservices/11.3.2/buildTransitive/Avalonia.BuildServices.targets(9,9): error MSB4018: System.UnauthorizedAccessException: Access to the path '/var/empty/Library' is denied. [/nix/var/nix/builds/nix-66216-1817390111/source/Source/LibationAvalonia/LibationAvalonia.csproj]
/nix/var/nix/builds/nix-66216-1817390111/nuget.fPkgoh/fallback/avalonia.buildservices/11.3.2/buildTransitive/Avalonia.BuildServices.targets(9,9): error MSB4018:  ---> System.IO.IOException: Operation not permitted [/nix/var/nix/builds/nix-66216-1817390111/source/Source/LibationAvalonia/LibationAvalonia.csproj]
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
