### PR TITLE
igf: init at 0.20.0-unstable-2026-02-10

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4440,6 +4440,12 @@
     githubId = 495429;
     name = "Claas Augner";
   };
+  caverav = {
+    email = "camilo@fvv.cl";
+    github = "caverav";
+    githubId = 66751764;
+    name = "Camilo Vera Vidales";
+  };
   cawilliamson = {
     email = "home@chrisaw.com";
     github = "cawilliamson";

--- a/pkgs/by-name/fr/frida-node-prebuilds/package.nix
+++ b/pkgs/by-name/fr/frida-node-prebuilds/package.nix
@@ -1,0 +1,83 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+  prebuilds =
+    {
+      aarch64-darwin = {
+        frida = {
+          url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-darwin-arm64.tar.gz";
+          hash = "sha256-47kQG90h/puHAr018ESk6dLgQPziWg7hheMQp2rL1MI=";
+        };
+        frida16 = {
+          url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-darwin-arm64.tar.gz";
+          hash = "sha256-KmDxDXGA6FxFhGY3SNvRriU/SJfXw6XkNOX6O0CtNpY=";
+        };
+      };
+      x86_64-darwin = {
+        frida = {
+          url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-darwin-x64.tar.gz";
+          hash = "sha256-JJkC1Pjzbp3TIUPr7Xytw2yd3qf9WVrZbm69WCbseTo=";
+        };
+        frida16 = {
+          url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-darwin-x64.tar.gz";
+          hash = "sha256-bnRd2BLK7XJFZvL1aJFNQ/2eI5QrMaKD4o++1/XrE6c=";
+        };
+      };
+      aarch64-linux = {
+        frida = {
+          url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-linux-arm64.tar.gz";
+          hash = "sha256-TChoxZGLDVhYQ05iZmP/WzP+SGVvrwQvBPYEkha/TrI=";
+        };
+        frida16 = {
+          url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-linux-arm64.tar.gz";
+          hash = "sha256-OImdJ/VGEkPi63TVf08T8N+qo/qxYCofdnatiocMDCc=";
+        };
+      };
+      x86_64-linux = {
+        frida = {
+          url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-linux-x64.tar.gz";
+          hash = "sha256-9rmXqwLGc+oIPh02ty4z8TytNUUAHvo5dVsRsxtAISI=";
+        };
+        frida16 = {
+          url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-linux-x64.tar.gz";
+          hash = "sha256-5+dDsi/3lnyoV4kdwp2r3+/AbdhdUE4HByTDY1tJgok=";
+        };
+      };
+    }
+    .${system} or (throw "Unsupported system: ${system}");
+in
+stdenvNoCC.mkDerivation {
+  pname = "frida-node-prebuilds";
+  version = "17.6.2-16.7.19";
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/frida" "$out/frida16"
+    tar -xzf ${fetchurl prebuilds.frida} -C "$out/frida"
+    tar -xzf ${fetchurl prebuilds.frida16} -C "$out/frida16"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Frida Node.js N-API prebuilt bindings (v17 and v16)";
+    homepage = "https://frida.re/";
+    changelog = "https://frida.re/news/";
+    license = lib.licenses.wxWindowsException31;
+    maintainers = with lib.maintainers; [ caverav ];
+    platforms = [
+      "aarch64-darwin"
+      "x86_64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+}

--- a/pkgs/by-name/ig/igf/package.nix
+++ b/pkgs/by-name/ig/igf/package.nix
@@ -106,10 +106,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     cp -r ${fridaNodePrebuilds}/frida16/build "$packageOut/node_modules/frida16/"
 
     mkdir -p "$out/bin"
-    cat > "$out/bin/igf" <<EOF
-#!${stdenvNoCC.shell}
-exec ${lib.getExe bun} "$packageOut/dist/index.mjs" "\$@"
-EOF
+    printf '%s\n' \
+      "#!${stdenvNoCC.shell}" \
+      "exec ${lib.getExe bun} \"$packageOut/dist/index.mjs\" \"\$@\"" \
+      > "$out/bin/igf"
     chmod +x "$out/bin/igf"
 
     runHook postInstall

--- a/pkgs/by-name/ig/igf/package.nix
+++ b/pkgs/by-name/ig/igf/package.nix
@@ -1,0 +1,130 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  fetchurl,
+  npm-lockfile-fix,
+  bun,
+  nodejs_22,
+  stdenv,
+}:
+
+let
+  fridaPrebuilds = {
+    aarch64-darwin = {
+      frida = {
+        url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-darwin-arm64.tar.gz";
+        hash = "sha256-47kQG90h/puHAr018ESk6dLgQPziWg7hheMQp2rL1MI=";
+      };
+      frida16 = {
+        url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-darwin-arm64.tar.gz";
+        hash = "sha256-KmDxDXGA6FxFhGY3SNvRriU/SJfXw6XkNOX6O0CtNpY=";
+      };
+    };
+    x86_64-darwin = {
+      frida = {
+        url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-darwin-x64.tar.gz";
+        hash = "sha256-JJkC1Pjzbp3TIUPr7Xytw2yd3qf9WVrZbm69WCbseTo=";
+      };
+      frida16 = {
+        url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-darwin-x64.tar.gz";
+        hash = "sha256-bnRd2BLK7XJFZvL1aJFNQ/2eI5QrMaKD4o++1/XrE6c=";
+      };
+    };
+    aarch64-linux = {
+      frida = {
+        url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-linux-arm64.tar.gz";
+        hash = "sha256-TChoxZGLDVhYQ05iZmP/WzP+SGVvrwQvBPYEkha/TrI=";
+      };
+      frida16 = {
+        url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-linux-arm64.tar.gz";
+        hash = "sha256-OImdJ/VGEkPi63TVf08T8N+qo/qxYCofdnatiocMDCc=";
+      };
+    };
+    x86_64-linux = {
+      frida = {
+        url = "https://github.com/frida/frida/releases/download/17.6.2/frida-v17.6.2-napi-v8-linux-x64.tar.gz";
+        hash = "sha256-9rmXqwLGc+oIPh02ty4z8TytNUUAHvo5dVsRsxtAISI=";
+      };
+      frida16 = {
+        url = "https://github.com/frida/frida/releases/download/16.7.19/frida-v16.7.19-napi-v8-linux-x64.tar.gz";
+        hash = "sha256-5+dDsi/3lnyoV4kdwp2r3+/AbdhdUE4HByTDY1tJgok=";
+      };
+    };
+  };
+
+  prebuildsForSystem =
+    fridaPrebuilds.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system ${stdenv.hostPlatform.system}");
+in
+buildNpmPackage {
+  pname = "igf";
+  version = "0.20.0-unstable-2026-02-10";
+
+  src = fetchFromGitHub {
+    owner = "ChiChou";
+    repo = "Grapefruit";
+    rev = "acc0506eb6f1b477564816eeef2781462fedb437";
+    hash = "sha256-5prjcojnz4NGh1CVtsihQfOm5emONnJufLWfFLtOqwg=";
+    postFetch = ''
+      ${lib.getExe npm-lockfile-fix} $out/package-lock.json
+    '';
+  };
+
+  npmDepsHash = "sha256-e4Lyet3zrvKOoXuzJ2AA0Xk94w1yKK/XixTwa6P6ZQ8=";
+
+  nodejs = nodejs_22;
+
+  npmBuildScript = "build:npm";
+  npmFlags = [ "--ignore-scripts" ];
+  dontNpmInstall = true;
+  dontNpmPrune = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    npm prune --omit=dev --no-save --ignore-scripts
+    find node_modules -maxdepth 1 -type d -empty -delete
+
+    packageOut="$out/lib/node_modules/igf"
+    mkdir -p "$packageOut"
+
+    cp -r dist "$packageOut/"
+    cp -r bin "$packageOut/"
+    cp -r drizzle "$packageOut/"
+    # dist/index.mjs resolves migrations from ../../drizzle
+    cp -r drizzle "$out/lib/node_modules/drizzle"
+    cp package.json "$packageOut/"
+    cp -r node_modules "$packageOut/"
+
+    tar -xzf ${fetchurl prebuildsForSystem.frida} -C "$packageOut/node_modules/frida"
+    tar -xzf ${fetchurl prebuildsForSystem.frida16} -C "$packageOut/node_modules/frida16"
+
+    mkdir -p "$out/bin"
+    cat > "$out/bin/igf" <<EOF
+    #!${stdenv.shell}
+    exec ${lib.getExe bun} "$packageOut/dist/index.mjs" "\$@"
+    EOF
+    chmod +x "$out/bin/igf"
+
+    nodejsInstallManuals "$packageOut/package.json"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/igf --help >/dev/null
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Runtime application instrumentation toolkit powered by Frida";
+    homepage = "https://github.com/ChiChou/Grapefruit";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ caverav ];
+    mainProgram = "igf";
+    platforms = builtins.attrNames fridaPrebuilds;
+  };
+}


### PR DESCRIPTION
Adds `igf`, a runtime application instrumentation toolkit powered by Frida.

Upstream/project:
- https://github.com/ChiChou/Grapefruit

Why this is needed:
- `igf` is not yet packaged in nixpkgs.
- The npm release is outdated relative to upstream, so this package is built from upstream `main` (`acc0506eb6f1b477564816eeef2781462fedb437`) and adapted for the current Bun-based build/runtime.
- Includes required runtime assets/migrations and platform Frida prebuild handling so the packaged CLI works correctly.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
