### PR TITLE
various: add meta.identifier.cpeParts to a batch of packages

### DIFF
--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -175,5 +175,10 @@ stdenv.mkDerivation (finalAttrs: {
       "auparse"
     ];
     platforms = lib.platforms.linux;
+    identifiers.cpeParts =
+      lib.meta.cpeFullVersionWithVendor "linux_audit_project" finalAttrs.version
+      // {
+        product = "linux_audit";
+      };
   };
 })

--- a/pkgs/by-name/bo/boehmgc/package.nix
+++ b/pkgs/by-name/bo/boehmgc/package.nix
@@ -120,5 +120,10 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.boehmGC;
     maintainers = [ ];
     platforms = lib.platforms.all;
+    identifiers.cpeParts =
+      lib.meta.cpeFullVersionWithVendor "boehm-demers-weiser" finalAttrs.version
+      // {
+        product = "garbage_collector";
+      };
   };
 })

--- a/pkgs/by-name/ca/cacert/package.nix
+++ b/pkgs/by-name/ca/cacert/package.nix
@@ -34,6 +34,9 @@ let
       lukegb
     ];
     license = lib.licenses.mpl20;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "mozilla" version // {
+      product = "nss";
+    };
   };
   certdata = stdenv.mkDerivation {
     pname = "nss-cacert-certdata";

--- a/pkgs/by-name/li/libcap_ng/package.nix
+++ b/pkgs/by-name/li/libcap_ng/package.nix
@@ -61,5 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.linux;
     license = lib.licenses.lgpl21;
     maintainers = with lib.maintainers; [ grimmauld ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "libcap-ng_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/lo/logrotate/package.nix
+++ b/pkgs/by-name/lo/logrotate/package.nix
@@ -59,5 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = [ lib.maintainers.tobim ];
     platforms = lib.platforms.all;
     mainProgram = "logrotate";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "logrotate_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/op/openresolv/package.nix
+++ b/pkgs/by-name/op/openresolv/package.nix
@@ -44,5 +44,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd2;
     maintainers = [ ];
     platforms = lib.platforms.unix;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "openresolv_project" finalAttrs.version;
   };
 })

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -135,6 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ mdaniels5757 ];
     platforms = lib.platforms.linux;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "shadow_project" finalAttrs.version;
   };
 
   passthru = {

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -254,5 +254,7 @@ stdenv.mkDerivation (finalAttrs: {
       "uuid"
     ];
     priority = 6; # lower priority than coreutils ("kill") and shadow ("login" etc.) packages
+
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "kernel" finalAttrs.version;
   };
 })

--- a/pkgs/development/compilers/gcc/common/meta.nix
+++ b/pkgs/development/compilers/gcc/common/meta.nix
@@ -30,5 +30,5 @@ in
   teams = [ teams.gcc ];
   mainProgram = "${targetPrefix}gcc";
 
-  identifiers.cpeParts.vendor = "gnu";
+  identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version;
 }

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -594,6 +594,10 @@ stdenv.mkDerivation (
         widely used in academic research. Code in the LLVM project is licensed
         under the "Apache 2.0 License with LLVM exceptions".
       '';
+      identifiers.cpeParts = llvm_meta.identifiers.cpeParts // {
+        inherit version;
+        update = "*";
+      };
     };
   }
   // lib.optionalAttrs enableManpages {

--- a/pkgs/development/libraries/acl/default.nix
+++ b/pkgs/development/libraries/acl/default.nix
@@ -40,5 +40,6 @@ stdenv.mkDerivation rec {
     homepage = "https://savannah.nongnu.org/projects/acl";
     description = "Library and tools for manipulating access control lists";
     license = lib.licenses.gpl2Plus;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "acl_project" version;
   };
 }

--- a/pkgs/development/libraries/attr/default.nix
+++ b/pkgs/development/libraries/attr/default.nix
@@ -49,5 +49,6 @@ stdenv.mkDerivation rec {
     platforms = lib.platforms.linux;
     badPlatforms = lib.platforms.microblaze;
     license = lib.licenses.gpl2Plus;
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "attr_project" version;
   };
 }

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -216,5 +216,6 @@ in
 
     meta = (previousAttrs.meta or { }) // {
       description = "GNU C Library";
+      identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" previousAttrs.passthru.minorRelease;
     };
   })

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -198,5 +198,6 @@ stdenv.mkDerivation rec {
     ];
     platforms = lib.platforms.linux;
     priority = 15; # below systemd (halt, init, poweroff, reboot) and coreutils
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "busybox" version;
   };
 }

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -106,5 +106,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     mainProgram = "find";
     maintainers = [ lib.maintainers.mdaniels5757 ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" finalAttrs.version;
   };
 })

--- a/pkgs/tools/package-management/nix/modular/packaging/everything.nix
+++ b/pkgs/tools/package-management/nix/modular/packaging/everything.nix
@@ -252,6 +252,7 @@ stdenv.mkDerivation (finalAttrs: {
       "nix-util"
       "nix-util-c"
     ];
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "nixos" version;
   };
 
 })

--- a/pkgs/tools/text/gnugrep/default.nix
+++ b/pkgs/tools/text/gnugrep/default.nix
@@ -115,6 +115,9 @@ stdenv.mkDerivation {
     ];
     platforms = lib.platforms.all;
     mainProgram = "grep";
+    identifiers.cpeParts = lib.meta.cpeFullVersionWithVendor "gnu" version // {
+      product = "grep";
+    };
   };
 
   passthru = {


### PR DESCRIPTION
Following #484003, add CPE metadata to another batch of packages which are somewhat important.

Co-Authored-By: Silvan Mosberger <silvan.mosberger@tweag.io>

CC @0xf09f95b4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
