### PR TITLE
python3Packages.tcia-utils: init at 3.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -24237,6 +24237,12 @@
     githubId = 75371;
     name = "Stig Palmquist";
   };
+  sgomezsal = {
+    email = "contact@sgomezsal.com";
+    github = "sgomezsal";
+    githubId = 79657820;
+    name = "Santiago Gomez";
+  };
   sgraf = {
     email = "sgraf1337@gmail.com";
     github = "sgraf812";

--- a/pkgs/development/python-modules/tcia-utils/default.nix
+++ b/pkgs/development/python-modules/tcia-utils/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  beautifulsoup4,
+  ipython,
+  pandas,
+  plotly,
+  requests,
+  tqdm,
+  unidecode,
+  hatchling,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "tcia-utils";
+  version = "3.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kirbyju";
+    repo = "tcia_utils";
+    rev = "9ff8a409df9daaa3f9bc28f0a951d7f6fcb90160"; # Corresponds to v3.2.1
+    hash = "sha256-IW6rxlmRj7RW3hM7aZR+BuqboDzp+2R2ObGwAhOxMPM=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    beautifulsoup4
+    ipython
+    pandas
+    plotly
+    requests
+    tqdm
+    unidecode
+  ];
+
+  pythonRemoveDeps = [ "bs4" ];
+
+  # Tests require network access to TCIA API and specific credentials
+  doCheck = false;
+
+  pythonImportsCheck = [ "tcia_utils" ];
+
+  meta = {
+    description = "Python utilities for interacting with The Cancer Imaging Archive (TCIA)";
+    homepage = "https://github.com/kirbyju/tcia_utils";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ sgomezsal ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18697,6 +18697,8 @@ self: super: with self; {
 
   tccbox = callPackage ../development/python-modules/tccbox { };
 
+  tcia-utils = callPackage ../development/python-modules/tcia-utils { };
+
   tcolorpy = callPackage ../development/python-modules/tcolorpy { };
 
   tcxfile = callPackage ../development/python-modules/tcxfile { };


### PR DESCRIPTION
## Description

Adds the Python package `tcia-utils`, a collection of utilities for interacting
with The Cancer Imaging Archive (TCIA) from Python and Jupyter notebooks.

The package builds and imports successfully.

## Motivation and Context

This library simplifies access to TCIA datasets and metadata.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
  - [x] Ran `nixpkgs-review` on this PR.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md.
