### PR TITLE
sbclPackages.*: fix various build breaks from SBCL 2.6.0

### DIFF
--- a/pkgs/development/lisp-modules/patches/cl-ana-fix-type-error.patch
+++ b/pkgs/development/lisp-modules/patches/cl-ana-fix-type-error.patch
@@ -1,0 +1,21 @@
+Fix type error in fixed-mem-cache for SBCL 2.6.0
+
+cache starts as nil and may be emptied by the loop, so (last cache)
+can return nil. (setf (cdr nil) ...) is undefined behavior that
+SBCL 2.6.0 now catches as a type conflict during compilation,
+causing COMPILE-FILE-ERROR.
+
+Use nconc instead, which handles the nil case correctly.
+
+Upstream issue: https://github.com/ghollisjr/cl-ana/issues/48
+
+--- a/makeres/makeres.lisp
++++ b/makeres/makeres.lisp
+@@ -936,5 +936,5 @@
+                    do (unload-target (pop cache))))
+               (load-target id)
+-              (setf (cdr (last cache))
+-                    (list id)))))))))
++              (setf cache
++                    (nconc cache (list id))))))))))
+

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -191,6 +191,9 @@ let
           "iolib/pathnames"
         ];
       });
+      cl-ana_dot_makeres = super.cl-ana_dot_makeres.overrideLispAttrs (o: {
+        patches = (o.patches or [ ]) ++ [ ./patches/cl-ana-fix-type-error.patch ];
+      });
       cl-ana_dot_hdf-cffi = super.cl-ana_dot_hdf-cffi.overrideLispAttrs (o: {
         nativeBuildInputs = [ pkgs.hdf5 ];
         nativeLibs = [ pkgs.hdf5 ];

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -12,6 +12,15 @@ let
 
   overrides = (
     self: super: {
+      named-readtables = super.named-readtables.overrideLispAttrs (o: {
+        patches = (o.patches or [ ]) ++ [
+          (pkgs.fetchpatch {
+            name = "named-readtables-sbcl-fix.patch";
+            url = "https://github.com/melisgl/named-readtables/commit/6eea56674442b884a4fee6ede4c8aad63541aa5b.patch";
+            hash = "sha256-ZkmBz50tkJutCNhrgVTHyE+sxRjmL8y7YC7yewrmves=";
+          })
+        ];
+      });
       cl_plus_ssl = super.cl_plus_ssl.overrideLispAttrs (o: {
         nativeLibs = [ pkgs.openssl ];
       });

--- a/pkgs/development/lisp-modules/ql.nix
+++ b/pkgs/development/lisp-modules/ql.nix
@@ -196,6 +196,34 @@ let
         nativeLibs = [ pkgs.hdf5 ];
         NIX_LDFLAGS = [ "-lhdf5" ];
       });
+      # The antik source archive contains a broken documentation.pdf symlink
+      # pointing to documentation/build/latex/Antik.pdf which doesn't exist.
+      # All packages built from this archive need the symlink removed.
+      antik = super.antik.overrideLispAttrs (o: {
+        postInstall = (o.postInstall or "") + ''
+          rm -f $out/documentation.pdf
+        '';
+      });
+      antik-base = super.antik-base.overrideLispAttrs (o: {
+        postInstall = (o.postInstall or "") + ''
+          rm -f $out/documentation.pdf
+        '';
+      });
+      foreign-array = super.foreign-array.overrideLispAttrs (o: {
+        postInstall = (o.postInstall or "") + ''
+          rm -f $out/documentation.pdf
+        '';
+      });
+      physical-dimension = super.physical-dimension.overrideLispAttrs (o: {
+        postInstall = (o.postInstall or "") + ''
+          rm -f $out/documentation.pdf
+        '';
+      });
+      science-data = super.science-data.overrideLispAttrs (o: {
+        postInstall = (o.postInstall or "") + ''
+          rm -f $out/documentation.pdf
+        '';
+      });
       gsll = super.gsll.overrideLispAttrs (o: {
         nativeBuildInputs = [ pkgs.gsl ];
         nativeLibs = [ pkgs.gsl ];


### PR DESCRIPTION
See individual commits for specifics. Nothing major.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test