### PR TITLE
xs: init at 0.11.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23797,6 +23797,12 @@
     githubId = 70169773;
     name = "Tarun Chinmai Sekar";
   };
+  schlich = {
+    email = "ty.schlich@gmail.com";
+    github = "schlich";
+    githubId = 21191435;
+    name = "Tyler Schlichenmeyer";
+  };
   schmitthenner = {
     email = "development@schmitthenner.eu";
     github = "fkz";

--- a/pkgs/by-name/xs/xs/package.nix
+++ b/pkgs/by-name/xs/xs/package.nix
@@ -1,0 +1,50 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenvNoCC,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "xs";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "cablehead";
+    repo = "xs";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-M6HDYwKmrQEzDVhgZkDh8PDABa7UOU+9Z/dQH8kCR5Q=";
+  };
+
+  cargoHash = "sha256-eK0VFbtI8ETfK7lJLaIUNTFuF4La9zVVGzki7DTgU4I=";
+
+  # Darwin needs bindgenHook for libproc
+  nativeBuildInputs = lib.optionals stdenvNoCC.hostPlatform.isDarwin [
+    rustPlatform.bindgenHook
+  ];
+  checkFlags = [
+    # call to ping probably blocked in nix-build sandbox
+    "--skip=ping"
+    "--skip=network"
+  ];
+  dontUseCargoParallelTests = true;
+  __darwinAllowLocalNetworking = true;
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Local-first event streaming for building reactive workflows and automation";
+    homepage = "https://github.com/cablehead/xs";
+    changelog = "https://github.com/cablehead/xs/blob/v${finalAttrs.version}/changes/v${finalAttrs.version}.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      schlich
+    ];
+    mainProgram = "xs";
+  };
+})


### PR DESCRIPTION
New package: `xs`
Description: Local-first event streaming for building reactive workflows and automation
Repo: https://github.com/cablehead/xs


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
