### PR TITLE
sacnview: init at v3.0.0-beta.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29697,6 +29697,11 @@
     githubId = 250877;
     name = "Elmar Athmer";
   };
+  zax71 = {
+    name = "Zax71";
+    github = "zax71";
+    githubId = 67716263;
+  };
   zazedd = {
     name = "Leonardo Santos";
     email = "leomendesantos@gmail.com";

--- a/pkgs/by-name/sa/sacnview/package.nix
+++ b/pkgs/by-name/sa/sacnview/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  makeDesktopItem,
+  cmake,
+  qt6,
+  libpcap,
+}:
+let
+  desktopItem = makeDesktopItem {
+    name = "sacnview";
+    desktopName = "sACNView";
+    icon = "sacnview";
+    comment = "A tool for monitoring and sending the Streaming ACN lighting control protocol used in theatres, TV studios and architectural systems.";
+    exec = "sACNView";
+    categories = [ "Network" ];
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "sacnview";
+  version = "v3.0.0-beta.2";
+
+  src = fetchFromGitHub {
+    owner = "docsteer";
+    repo = "sacnview";
+    rev = version;
+    hash = "sha256-ZHHfKtc30MA6d746bBTIAbdSudEEzSzNNNPe/eLDBjU=";
+    fetchSubmodules = true;
+    deepClone = true;
+  };
+
+  nativeBuildInputs = [
+    qt6.qtbase
+    cmake
+  ];
+
+  buildInputs = [
+    libpcap
+    qt6.qtmultimedia
+    qt6.qttools
+    qt6.wrapQtAppsHook
+  ];
+
+  # Copy binary, .desktop file and icon to $out
+  installPhase = ''
+    mkdir -p $out/bin
+    cp sACNView $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons/hicolor/128x128/apps/
+    cp ${desktopItem}/share/applications/sacnview.desktop $out/share/applications/sacnview.desktop
+    cp ${src}/res/Logo.png $out/share/icons/hicolor/128x128/apps/sacnview.png
+    runHook postInstall
+  '';
+
+  meta = src.meta // {
+    description = "A tool for monitoring and sending the Streaming ACN lighting control protocol used in theatres, TV studios and architectural systems.";
+    changelog = "https://github.com/docsteer/sacnview/releases/tag/${version}";
+    homepage = "https://sacnview.org/";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ zax71 ];
+    platforms = lib.platforms.linux;
+    mainProgram = "sacnview";
+  };
+}


### PR DESCRIPTION
Init SacnView @ v3.0.0-beta.2, it describes itself as "A tool for monitoring and sending the Streaming ACN lighting control protocol used in theatres, TV studios and architectural systems." I personally use it to monitor communication to BlenderDMX.

Homepage: https://sacnview.org/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
