### PR TITLE
python3Packages.viaggiatreno-ha: init at 0.2.4

### DIFF
--- a/pkgs/development/python-modules/viaggiatreno-ha/default.nix
+++ b/pkgs/development/python-modules/viaggiatreno-ha/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "viaggiatreno-ha";
+  version = "0.2.4";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "monga";
+    repo = "viaggiatreno_ha";
+    tag = "v${version}";
+    hash = "sha256-XmZVguuZK4pnAqINBWJbyAa5VesrQS6wP1jNPdWqhiQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ aiohttp ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  preCheck = ''
+    cd tests
+  '';
+
+  # Tests use aiohttp's AioHTTPTestCase which starts a local TCP server
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "viaggiatreno_ha" ];
+
+  meta = {
+    changelog = "https://github.com/monga/viaggiatreno_ha/releases/tag/${src.tag}";
+    description = "Viaggiatreno API wrapper to use with Home Assistant";
+    homepage = "https://github.com/monga/viaggiatreno_ha";
+    license = lib.licenses.gpl3Plus;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6639,7 +6639,8 @@
       ];
     "viaggiatreno" =
       ps: with ps; [
-      ]; # missing inputs: viaggiatreno_ha
+        viaggiatreno-ha
+      ];
     "vicare" =
       ps: with ps; [
         pyvicare

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20444,6 +20444,8 @@ self: super: with self; {
 
   vharfbuzz = callPackage ../development/python-modules/vharfbuzz { };
 
+  viaggiatreno-ha = callPackage ../development/python-modules/viaggiatreno-ha { };
+
   victron-vrm = callPackage ../development/python-modules/victron-vrm { };
 
   videocr = callPackage ../development/python-modules/videocr { };


### PR DESCRIPTION
Viaggiatreno API wrapper for querying Trenitalia ViaggiaTreno API, used by the Home Assistant viaggiatreno integration.

- https://github.com/monga/viaggiatreno_ha
- https://pypi.org/project/viaggiatreno-ha
- https://www.home-assistant.io/integrations/viaggiatreno/ 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
