### PR TITLE
nixmate: 0.7.2 -> 0.7.3, add maintainer

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5991,6 +5991,12 @@
     githubId = 7589338;
     name = "Daniel Șerbănescu";
   };
+  daskladas = {
+    email = "xvzrsm@tutanota.de";
+    github = "daskladas";
+    githubId = 155686186;
+    name = "Eric Heinemann";
+  };
   daspk04 = {
     email = "dpratyush.k@gmail.com";
     github = "daspk04";

--- a/pkgs/by-name/ni/nixmate/package.nix
+++ b/pkgs/by-name/ni/nixmate/package.nix
@@ -7,16 +7,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nixmate";
-  version = "0.7.2";
+  version = "0.7.3";
 
   src = fetchFromGitHub {
     owner = "daskladas";
     repo = "nixmate";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Buabxhaq9P1u2zqRMGnFnCZczrxENa/Ux//F5wHkb1U=";
+    hash = "sha256-w9qE5zZ8mEHPbR84OuJoFWFvmMuKpvq/ANwyDUEvbPo=";
   };
 
-  cargoHash = "sha256-c11NRt6qBNhj6JQeI7/80aYzuCY36ApsUWVnbRH7rRU=";
+  cargoHash = "sha256-87Q64EURBJJjW49sTB/qQB8dCZDq1PGyqI4fKYwR8yI=";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/ni/nixmate/package.nix
+++ b/pkgs/by-name/ni/nixmate/package.nix
@@ -28,7 +28,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     homepage = "https://github.com/daskladas/nixmate";
     changelog = "https://github.com/daskladas/nixmate/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ GaetanLepage ];
+    maintainers = with lib.maintainers; [
+      GaetanLepage
+      daskladas
+    ];
     mainProgram = "nixmate";
   };
 })


### PR DESCRIPTION
Update nixmate from 0.7.2 to 0.7.3 and add myself as maintainer.

Changes in 0.7.3:
- Fix rebuild timer not stopping after build completion
- Cap rebuild history at 100 entries
- Add flake update toggle in Rebuild Dashboard
- Add custom NixOS config path setting

Changelog: https://github.com/daskladas/nixmate/blob/main/CHANGELOG.md

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests
  - [ ] Package tests
  - [ ] Tests in lib/tests or pkgs/test
- [ ] Ran nixpkgs-review on this PR.
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [ ] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.