### PR TITLE
fatrop: 0.0.4 -> 1.1.0

### DIFF
--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -1,41 +1,39 @@
 {
-  blasfeo,
-  cmake,
-  fetchFromGitHub,
   lib,
-  llvmPackages,
-  python3Packages,
-  pythonSupport ? false,
   stdenv,
+
+  fetchFromGitHub,
+
+  cmake,
+  blasfeo,
+  llvmPackages,
+  gtest,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fatrop";
-  version = "0.0.4";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "meco-group";
     repo = "fatrop";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-XVOS9L2vQeFkPXZieX1ZJiVagR0f2BtiRmSDPB9LQeI=";
+    hash = "sha256-iPYNbDN/rqx33y4zPD49WpGG3CP78cPwRlWnfVRktKc=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     blasfeo
   ]
-  ++ lib.optionals pythonSupport [ python3Packages.pybind11 ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
 
   cmakeFlags = [
-    (lib.cmakeBool "BUILD_DOCS" true)
-    (lib.cmakeBool "ENABLE_MULTITHREADING" true)
     (lib.cmakeBool "BUILD_WITH_BLASFEO" false)
-    (lib.cmakeBool "WITH_PYTHON" pythonSupport)
-    (lib.cmakeBool "WITH_SPECTOOL" false) # this depends on casadi
   ];
 
   doCheck = true;
+
+  checkInputs = [ gtest ];
 
   meta = {
     description = "Nonlinear optimal control problem solver that aims to be fast, support a broad class of optimal control problems and achieve a high numerical robustness";

--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fatrop";
-  version = "1.0.0";
+  version = "1.0.1.mod";
 
   src = fetchFromGitHub {
     owner = "meco-group";
     repo = "fatrop";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-iPYNbDN/rqx33y4zPD49WpGG3CP78cPwRlWnfVRktKc=";
+    hash = "sha256-2exJa9pKISDnq1MFLDV5My09BYEEN09slCTPtogd/f8=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "fatrop";
-  version = "1.0.1.mod";
+  version = "1.1.0";
 
   src = fetchFromGitHub {
     owner = "meco-group";
     repo = "fatrop";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-2exJa9pKISDnq1MFLDV5My09BYEEN09slCTPtogd/f8=";
+    hash = "sha256-WiIryO2bMtupJ2tvMY24Smrf86wgCNNxZbQJMn6ey/A=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -8,6 +8,7 @@
   blasfeo,
   llvmPackages,
   gtest,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -33,7 +34,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
+  nativeCheckInputs = [ ctestCheckHook ];
   checkInputs = [ gtest ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    "LUFactorizationTest.transposedLUFactorization"
+  ];
 
   meta = {
     description = "Nonlinear optimal control problem solver that aims to be fast, support a broad class of optimal control problems and achieve a high numerical robustness";

--- a/pkgs/by-name/fa/fatrop/package.nix
+++ b/pkgs/by-name/fa/fatrop/package.nix
@@ -44,7 +44,10 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Nonlinear optimal control problem solver that aims to be fast, support a broad class of optimal control problems and achieve a high numerical robustness";
     homepage = "https://github.com/meco-group/fatrop";
-    license = lib.licenses.lgpl3Only;
+    license = with lib.licenses; [
+      bsd2
+      epl20
+    ];
     maintainers = with lib.maintainers; [ nim65s ];
   };
 })

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5359,13 +5359,6 @@ self: super: with self; {
 
   fastuuid = callPackage ../development/python-modules/fastuuid { };
 
-  fatrop = toPythonModule (
-    pkgs.fatrop.override {
-      pythonSupport = true;
-      python3Packages = self;
-    }
-  );
-
   faust-cchardet = callPackage ../development/python-modules/faust-cchardet { };
 
   fava = callPackage ../development/python-modules/fava { };


### PR DESCRIPTION
fatropy vanished, but this does not look to be a big issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
