### PR TITLE
libcanberra: use a local copy of the `GdkDisplay` patch

### DIFF
--- a/pkgs/by-name/li/libcanberra/0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch
+++ b/pkgs/by-name/li/libcanberra/0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch
@@ -1,0 +1,52 @@
+--- a/src/canberra-gtk-module.c
++++ b/src/canberra-gtk-module.c
+@@ -307,6 +307,11 @@
+         guchar *data = NULL;
+         gint ret = -1;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return 0;
++#endif
++
+         if (XGetWindowProperty(GDK_DISPLAY_XDISPLAY(d), GDK_WINDOW_XID(w),
+                                gdk_x11_get_xatom_by_name_for_display(d, "_NET_WM_DESKTOP"),
+                                0, G_MAXLONG, False, XA_CARDINAL, &type_return,
+@@ -335,6 +340,11 @@
+         guchar *data = NULL;
+         gint ret = -1;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return 0;
++#endif
++
+         if (XGetWindowProperty(GDK_DISPLAY_XDISPLAY(d), DefaultRootWindow(GDK_DISPLAY_XDISPLAY(d)),
+                                gdk_x11_get_xatom_by_name_for_display(d, "_NET_CURRENT_DESKTOP"),
+                                0, G_MAXLONG, False, XA_CARDINAL, &type_return,
+@@ -365,6 +375,11 @@
+         gboolean ret = FALSE;
+         Atom xembed;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return FALSE;
++#endif
++
+         /* Gnome Panel applets are XEMBED windows. We need to make sure we
+          * ignore them */
+ 
+--- a/src/canberra-gtk.c
++++ b/src/canberra-gtk.c
+@@ -185,6 +185,11 @@
+         guchar *data = NULL;
+         gint ret = -1;
+ 
++#ifdef GDK_IS_X11_DISPLAY
++        if (!GDK_IS_X11_DISPLAY(d))
++                return 0;
++#endif
++
+         if (XGetWindowProperty(GDK_DISPLAY_XDISPLAY(d), GDK_WINDOW_XID(w),
+                                gdk_x11_get_xatom_by_name_for_display(d, "_NET_WM_DESKTOP"),
+                                0, G_MAXLONG, False, XA_CARDINAL, &type_return,

--- a/pkgs/by-name/li/libcanberra/package.nix
+++ b/pkgs/by-name/li/libcanberra/package.nix
@@ -55,11 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.hostPlatform.isLinux "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system";
 
   patches = [
-    (fetchpatch {
-      name = "0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch";
-      url = "http://git.0pointer.net/libcanberra.git/patch/?id=c0620e432650e81062c1967cc669829dbd29b310";
-      sha256 = "0rc7zwn39yxzxp37qh329g7375r5ywcqcaak8ryd0dgvg8m5hcx9";
-    })
+    ./0001-gtk-Don-t-assume-all-GdkDisplays-are-GdkX11Displays-.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     (fetchpatch {


### PR DESCRIPTION
The patch is no longer available from git.0pointer.net.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
