### PR TITLE
python3Packages.victron-ble{,-ha-parser}: init at 0.9.3 & 0.4.10

### DIFF
--- a/pkgs/development/python-modules/victron-ble-ha-parser/default.nix
+++ b/pkgs/development/python-modules/victron-ble-ha-parser/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  bluetooth-sensor-state-data,
+  buildPythonPackage,
+  fetchFromGitHub,
+  sensor-state-data,
+  setuptools,
+  victron-ble,
+}:
+
+buildPythonPackage rec {
+  pname = "victron-ble-ha-parser";
+  version = "0.4.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "rajlaud";
+    repo = "victron-ble-ha-parser";
+    tag = "v${version}";
+    hash = "sha256-mvQrY1f3Da621yMgTzxduZQ0pxCJN6j7+6pgFwgl4Rs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    bluetooth-sensor-state-data
+    sensor-state-data
+    victron-ble
+  ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "victron_ble_ha_parser" ];
+
+  meta = {
+    description = "Parser for Victron BLE messages suitable for use with Home Assistant";
+    homepage = "https://github.com/rajlaud/victron-ble-ha-parser";
+    changelog = "https://github.com/rajlaud/victron-ble-ha-parser/releases/tag/${src.tag}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/development/python-modules/victron-ble/default.nix
+++ b/pkgs/development/python-modules/victron-ble/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  bleak,
+  buildPythonPackage,
+  click,
+  fetchFromGitHub,
+  pycryptodome,
+  pytestCheckHook,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "victron-ble";
+  version = "0.9.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "keshavdv";
+    repo = "victron-ble";
+    tag = "v${version}";
+    hash = "sha256-ALdNM6U9bEX/KHcQu+7vM8Z42dEdxYtuxQRZMf10DyI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    bleak
+    click
+    pycryptodome
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "victron_ble" ];
+
+  meta = {
+    description = "Python library to parse Instant Readout advertisement data from Victron devices";
+    homepage = "https://github.com/keshavdv/victron-ble";
+    changelog = "https://github.com/keshavdv/victron-ble/releases/tag/${src.tag}";
+    license = lib.licenses.unlicense;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6682,8 +6682,9 @@
         pymicro-vad
         pyserial
         pyspeex-noise
+        victron-ble-ha-parser
         zeroconf
-      ]; # missing inputs: victron-ble-ha-parser
+      ];
     "victron_remote_monitoring" =
       ps: with ps; [
         victron-vrm
@@ -8139,6 +8140,7 @@
     "version"
     "vesync"
     "vicare"
+    "victron_ble"
     "victron_remote_monitoring"
     "vilfo"
     "vivotek"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20572,6 +20572,10 @@ self: super: with self; {
 
   viaggiatreno-ha = callPackage ../development/python-modules/viaggiatreno-ha { };
 
+  victron-ble = callPackage ../development/python-modules/victron-ble { };
+
+  victron-ble-ha-parser = callPackage ../development/python-modules/victron-ble-ha-parser { };
+
   victron-mqtt = callPackage ../development/python-modules/victron-mqtt { };
 
   victron-vrm = callPackage ../development/python-modules/victron-vrm { };


### PR DESCRIPTION
Add `victron-ble` (0.9.3) and `victron-ble-ha-parser` (0.4.10) to nixpkgs.

- https://github.com/keshavdv/victron-ble
- https://github.com/rajlaud/victron-ble-ha-parser

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
