### PR TITLE
apk-tools: 3.0.3 -> 3.0.4; switch to meson build system 

### DIFF
--- a/pkgs/by-name/ap/apk-tools/package.nix
+++ b/pkgs/by-name/ap/apk-tools/package.nix
@@ -3,6 +3,10 @@
   stdenv,
   fetchFromGitLab,
   pkg-config,
+  meson,
+  ninja,
+  python3,
+  cmocka,
   scdoc,
   openssl,
   zlib,
@@ -11,7 +15,7 @@
   lua5_3,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "apk-tools";
   version = "3.0.3";
 
@@ -19,41 +23,35 @@ stdenv.mkDerivation rec {
     domain = "gitlab.alpinelinux.org";
     owner = "alpine";
     repo = "apk-tools";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-ydqJiLkz80TQGyf9m/l8HSXfoTAvi0av7LHETk1c0GI=";
   };
 
   nativeBuildInputs = [
+    meson
+    ninja
     pkg-config
-    scdoc
+    python3
   ]
   ++ lib.optionals luaSupport [
     lua5_3
     lua5_3.pkgs.lua-zlib
   ];
+
   buildInputs = [
     openssl
     zlib
     zstd
+    scdoc
+    cmocka
   ]
   ++ lib.optional luaSupport lua5_3;
+
   strictDeps = true;
 
-  makeFlags = [
-    "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-    "SBINDIR=$(out)/bin"
-    "LIBDIR=$(out)/lib"
-    "LUA=${if luaSupport then "lua" else "no"}"
-    "LUA_LIBDIR=$(out)/lib/lua/${lib.versions.majorMinor lua5_3.version}"
-    "MANDIR=$(out)/share/man"
-    "DOCDIR=$(out)/share/doc/apk"
-    "INCLUDEDIR=$(out)/include"
-    "PKGCONFIGDIR=$(out)/lib/pkgconfig"
-  ];
-
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=unused-result"
-    "-Wno-error=deprecated-declarations"
+  mesonFlags = [
+    (lib.mesonEnable "lua" luaSupport)
+    (lib.mesonOption "lua_bin" "lua")
   ];
 
   enableParallelBuilding = true;
@@ -63,7 +61,6 @@ stdenv.mkDerivation rec {
     description = "Alpine Package Keeper";
     maintainers = [ ];
     license = lib.licenses.gpl2Only;
-    platforms = lib.platforms.linux;
     mainProgram = "apk";
   };
-}
+})

--- a/pkgs/by-name/ap/apk-tools/package.nix
+++ b/pkgs/by-name/ap/apk-tools/package.nix
@@ -17,14 +17,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "apk-tools";
-  version = "3.0.3";
+  version = "3.0.4";
 
   src = fetchFromGitLab {
     domain = "gitlab.alpinelinux.org";
     owner = "alpine";
     repo = "apk-tools";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-ydqJiLkz80TQGyf9m/l8HSXfoTAvi0av7LHETk1c0GI=";
+    sha256 = "sha256-51lBWcUSILCJZNP6LaOGyERCosNWTuEne/+xX8xHLf0=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
