### PR TITLE
python3Packages.mastodon-py: patch to use graphemeu

### DIFF
--- a/pkgs/development/python-modules/mastodon-py/default.nix
+++ b/pkgs/development/python-modules/mastodon-py/default.nix
@@ -5,6 +5,7 @@
   blurhash,
   cryptography,
   decorator,
+  fetchpatch,
   graphemeu,
   http-ece,
   python-dateutil,
@@ -29,6 +30,14 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-i3HMT8cabSl664UK3eopJQ9bDBpGCgbHTvBJkgeoxd8=";
   };
+
+  patches = [
+    # Switch dependency from unmaintained `grapheme` to `graphemeu`
+    (fetchpatch {
+      url = "https://github.com/halcy/Mastodon.py/commit/939c7508414e950922c518260a9ba5a5853aeef2.patch";
+      hash = "sha256-XBiAFxYUBNyynld++UwPGIIg9j+3/EF2jGqiysVqYRM=";
+    })
+  ];
 
   build-system = [ setuptools ];
 


### PR DESCRIPTION
Properly patch python3Packages.mastodon-py package with upstream commit https://github.com/halcy/Mastodon.py/commit/939c7508414e950922c518260a9ba5a5853aeef2 to use graphemeu instead of grapheme in pyproject.toml

~~`python3Packages.mastodon-py` 2.1.4 still officially depends on [`grapheme`](https://github.com/halcy/Mastodon.py/blob/v2.1.4/pyproject.toml#L41), so we cannot use `graphemeu` until upstream release a new version.~~

~~This reverts the `grapheme` package removal and restores the `grapheme` dependency in `mastodon-py` package.~~

See https://github.com/NixOS/nixpkgs/pull/473415#discussion_r2810365677

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
