### PR TITLE
voxtype,voxtype-{vulkan,onnx}: init at 0.6.3

### DIFF
--- a/pkgs/by-name/vo/voxtype/package.nix
+++ b/pkgs/by-name/vo/voxtype/package.nix
@@ -1,0 +1,178 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  versionCheckHook,
+
+  clang,
+  cmake,
+  gitMinimal,
+  installShellFiles,
+  libclang,
+  makeBinaryWrapper,
+  pkg-config,
+
+  alsa-lib,
+  dotool,
+  libnotify,
+  openssl,
+  pciutils,
+  wl-clipboard,
+  wtype,
+  xclip,
+  xdotool,
+
+  installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+  installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform,
+
+  vulkanSupport ? false,
+  shaderc,
+  vulkan-headers,
+  vulkan-loader,
+
+  onnxSupport ? false,
+  onnxruntime,
+
+  waylandSupport ? stdenv.hostPlatform.isLinux,
+  waylandRuntimePackages ? [
+    dotool
+    wl-clipboard
+    wtype
+  ],
+
+  x11Support ? stdenv.hostPlatform.isLinux,
+  x11RuntimePackages ? [
+    xclip
+    xdotool
+  ],
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "voxtype";
+  version = "0.6.3";
+
+  src = fetchFromGitHub {
+    owner = "peteonrails";
+    repo = "voxtype";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2YYHwiTJVD8kDccMvZe0wsKfWw+C2B0qSDAqT3ze8Mg=";
+  };
+
+  cargoHash = "sha256-l0GibrwJfDfJmoPFggeTJbDyW2Bg3XLzG7eX3BbHVUs=";
+
+  buildFeatures =
+    [ ]
+    ++ lib.optionals vulkanSupport [ "gpu-vulkan" ]
+    ++ lib.optionals onnxSupport [
+      "parakeet-load-dynamic"
+      "moonshine"
+      "sensevoice"
+      "paraformer"
+      "dolphin"
+      "omnilingual"
+    ];
+
+  nativeBuildInputs = [
+    cmake
+    clang
+    gitMinimal # Required by whisper.cpp cmake
+    installShellFiles
+    makeBinaryWrapper
+    pkg-config
+  ]
+  ++ lib.optional vulkanSupport [
+    shaderc
+    vulkan-headers
+    vulkan-loader
+  ];
+
+  buildInputs = [
+    alsa-lib
+    openssl
+  ]
+  ++ lib.optionals vulkanSupport [
+    vulkan-headers
+    vulkan-loader
+  ]
+  ++ lib.optionals onnxSupport [
+    onnxruntime
+  ];
+
+  env = {
+    # NOTE: set LIBCLANG_PATH so bindgen can locate libclang
+    LIBCLANG_PATH = "${lib.getLib libclang}/lib";
+
+    # NOTE: Ensure reproducible builds targeting AVX2-capable CPUs (x86-64-v3)
+    # This matches the portable AVX2 binaries we ship for other distros
+    RUSTFLAGS = lib.optionalString (
+      stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64
+    ) "-C target-cpu=x86-64-v3";
+  };
+
+  preBuild = ''
+    # NOTE: whisper.cpp cmake needs some help in sandbox
+    export CMAKE_BUILD_PARALLEL_LEVEL=$NIX_BUILD_CORES
+  ''
+  + lib.optionalString vulkanSupport ''
+    export VULKAN_SDK="${shaderc.bin}"
+  ''
+  + lib.optionalString onnxSupport ''
+    export ORT_LIB_LOCATION="${lib.getLib onnxruntime}/lib"
+  '';
+
+  postInstall = ''
+    install -Dm644 config/default.toml \
+      $out/share/voxtype/default-config.toml
+
+    wrapProgram $out/bin/voxtype \
+      --prefix PATH : ${
+        (lib.makeBinPath (
+          [
+            libnotify
+          ]
+          ++ lib.optionals vulkanSupport [
+            pciutils
+          ]
+          ++ lib.optionals waylandSupport waylandRuntimePackages
+          ++ lib.optionals x11Support x11RuntimePackages
+        ))
+        + lib.optionalString onnxSupport " \\"
+      }
+      ${lib.optionalString onnxSupport ''
+        --set ORT_DYLIB_PATH "${lib.getLib onnxruntime}/lib/libonnxruntime.so" \
+        --prefix LD_LIBRARY_PATH : "${lib.getLib onnxruntime}/lib"
+      ''}
+  ''
+  + lib.optionalString installManPages ''
+    installManPage target/debug/build/voxtype-*/out/man/*
+  ''
+  + lib.optionalString installShellCompletions ''
+    installShellCompletion packaging/completions/voxtype.{bash,zsh,fish}
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+
+  passthru.update-script = nix-update-script { };
+
+  meta = {
+    description = "Voice-to-text with push-to-talk for Wayland compositors";
+    longDescription = ''
+      Voxtype is a push-to-talk voice-to-text daemon for Linux.
+      Hold a hotkey while speaking, release to transcribe and output
+      text at your cursor position. Supports Whisper, Parakeet,
+      SenseVoice, Moonshine, Paraformer, Dolphin, and Omnilingual engines.
+    '';
+    homepage = "https://voxtype.io";
+    downloadPage = "https://voxtype.io/download/";
+    changelog = "https://github.com/peteonrails/voxtype/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ DuskyElf ];
+    platforms = lib.platforms.linux;
+    mainProgram = "voxtype";
+  };
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3579,6 +3579,9 @@ with pkgs;
     vkbasalt32 = pkgsi686Linux.vkbasalt;
   };
 
+  voxtype-vulkan = callPackage ../by-name/vo/voxtype/package.nix { vulkanSupport = true; };
+  voxtype-onnx = callPackage ../by-name/vo/voxtype/package.nix { onnxSupport = true; };
+
   vpn-slice = python3Packages.callPackage ../tools/networking/vpn-slice { };
 
   vpWithSixel = vp.override {


### PR DESCRIPTION
https://voxtype.io : Voice-to-text with push-to-talk, integrates nicely with Wayland compositors  
repo: https://github.com/peteonrails/voxtype

### Added 3 packages
- voxtype
- voxtype-vulkan
- voxtype-onnx

CUDA and ROCm packages could be added later (I don't have a way to test them yet).

### References used
- https://github.com/peteonrails/voxtype/blob/d0315072a89918cbfed6c88d237882334da85466/flake.nix
- https://github.com/NixOS/nixpkgs/blob/84ee066b513e8dd67c354ebbcf27d4a78ac18c56/pkgs/by-name/ol/ollama/package.nix
- https://github.com/NixOS/nixpkgs/pull/492111

The current release of the upstream doesn't support MacOS
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
