### PR TITLE
mcfm: migrate to by-name, modernize, fix cmake error

### DIFF
--- a/pkgs/by-name/mc/MCFM/package.nix
+++ b/pkgs/by-name/mc/MCFM/package.nix
@@ -1,12 +1,18 @@
 {
   lib,
-  stdenv,
   fetchurl,
   cmake,
   gfortran,
+  gccStdenv,
   lhapdf,
 }:
-
+let
+  stdenv = gccStdenv;
+  lhapdf' = lhapdf.override {
+    stdenv = gccStdenv;
+    python3 = null;
+  };
+in
 stdenv.mkDerivation rec {
   pname = "MCFM";
   version = "10.0.1";
@@ -18,15 +24,19 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace 'target_link_libraries(mcfm lhapdf_lib)' \
+      --replace-fail 'target_link_libraries(mcfm lhapdf_lib)' \
                 'target_link_libraries(mcfm ''${lhapdf_lib})'
+
+    substituteInPlace qcdloop-2.0.5/CMakeLists.txt \
+    --replace-fail 'cmake_minimum_required (VERSION 3.0.2)' \
+    'cmake_minimum_required (VERSION 3.15)'
   '';
 
   nativeBuildInputs = [
     cmake
     gfortran
   ];
-  buildInputs = [ lhapdf ];
+  buildInputs = [ lhapdf' ];
 
   cmakeFlags = [
     "-Duse_external_lhapdf=ON"

--- a/pkgs/by-name/mc/mcfm/package.nix
+++ b/pkgs/by-name/mc/mcfm/package.nix
@@ -13,13 +13,13 @@ let
     python3 = null;
   };
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "MCFM";
   version = "10.0.1";
 
   src = fetchurl {
-    url = "https://mcfm.fnal.gov/downloads/${pname}-${version}.tar.gz";
-    sha256 = "sha256-3Dg4KoILb0XhgGkzItDh/1opCtYrrIvtbuALYqPUvE8=";
+    url = "https://mcfm.fnal.gov/downloads/MCFM-${finalAttrs.version}.tar.gz";
+    hash = "sha256-3Dg4KoILb0XhgGkzItDh/1opCtYrrIvtbuALYqPUvE8=";
   };
 
   postPatch = ''
@@ -50,4 +50,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ veprbl ];
     platforms = lib.platforms.x86_64;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12069,14 +12069,6 @@ with pkgs;
 
   ### SCIENCE/PHYSICS
 
-  mcfm = callPackage ../applications/science/physics/MCFM {
-    stdenv = gccStdenv;
-    lhapdf = lhapdf.override {
-      stdenv = gccStdenv;
-      python3 = null;
-    };
-  };
-
   xflr5 = libsForQt5.callPackage ../applications/science/physics/xflr5 { };
 
   ### SCIENCE/LOGIC


### PR DESCRIPTION
This pull request refactors the packaging for the `mcfm` scientific software in Nixpkgs. The main change is moving and modernizing the package definition to the new `pkgs/by-name` directory, while also updating how dependencies and the build environment are handled.

**Packaging and Build Improvements:**

* Moved the `MCFM` package from `pkgs/applications/science/physics/MCFM/default.nix` to the new location `pkgs/by-name/mc/mcfm/package.nix` and updated it to use the new-style function argument pattern.
* Switched from using `stdenv` to `gccStdenv` for the build environment, ensuring better compatibility with Fortran and C/C++ code.
* Updated the handling of the `lhapdf` dependency to override its `stdenv` and disable Python support for a leaner build.
* Improved patching in the build phase by using `--replace-fail` in `substituteInPlace` and updating the required CMake version in a bundled dependency.

**Repository Maintenance:**

* Removed the old-style `mcfm` package definition from `pkgs/top-level/all-packages.nix` in favor of the new location and style.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
