### PR TITLE
wifi-manager: init at 0-unstable-2026-02-16

### DIFF
--- a/pkgs/by-name/wi/wifi-manager/package.nix
+++ b/pkgs/by-name/wi/wifi-manager/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  wrapGAppsHook4,
+  gtk4,
+  gtk4-layer-shell,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "wifi-manager";
+  version = "0-unstable-2026-02-16";
+
+  src = fetchFromGitHub {
+    owner = "Vijay-papanaboina";
+    repo = "wifi-manager";
+    rev = "80f09c6cdc4aa2dc5bc05cd80bc37aca30e5c5a7";
+    hash = "sha256-3L9kQJL8hnWNf6B2QmM/n7awvm0e6RtiCOIakDP3bpo=";
+  };
+
+  cargoHash = "sha256-CawPC9tkUy1npLmvCL71PzEf0fcJwMsOsIVAHsHwTUk=";
+
+  nativeBuildInputs = [
+    pkg-config
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    gtk4
+    gtk4-layer-shell
+  ];
+
+  meta = {
+    description = "Lightweight native WiFi manager for Wayland compositors";
+    homepage = "https://github.com/Vijay-papanaboina/wifi-manager";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ imalison ];
+    mainProgram = "wifi-manager";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
## Summary
- add a new package: `wifi-manager`
- package latest upstream commit from 2026-02-16 (`80f09c6cdc4aa2dc5bc05cd80bc37aca30e5c5a7`)
- wrap GTK application via `wrapGAppsHook4` and include GTK/layer-shell runtime dependencies

## Testing
- [x] `nix-build -A wifi-manager`
- [x] runtime smoke test: `./result/bin/wifi-manager --help`
- [x] runtime smoke test: `./result/bin/wifi-manager --toggle` (returns "No running instance found" without an active daemon)
- [x] runtime smoke test: `timeout 8s ./result/bin/wifi-manager` (process starts and remains running until timeout)
