### PR TITLE
llr: init at 4.0.7b3

### DIFF
--- a/pkgs/by-name/ll/llr/package.nix
+++ b/pkgs/by-name/ll/llr/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchzip,
+  lib,
+  stdenv,
+  gmp,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "llr";
+  version = "4.0.7b3";
+
+  src = fetchzip {
+    url = "http://jpenne.free.fr/llr4/llr${
+      builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }src.zip";
+    hash = "sha256-U6Mjpcq5Kdkx2f6tVQNBldsN4JiKXZqbil1Lg3Q5Asw=";
+  };
+
+  enableParallelBuilding = true;
+
+  env.NIX_CFLAGS_COMPILE = "-std=gnu11";
+
+  # Disable _chdir in lprime.c to prevent segmentation fault when fopen returns NULL
+  postPatch = ''
+    substituteInPlace lprime.c \
+      --replace-fail "_chdir (buf)" "0/* _chdir (buf) */"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -f make64
+
+    cd linux64llr
+
+    make llr64 \
+      LFLAGS="-L${gmp}/lib -lgmp -lm -lpthread"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 llr64 $out/bin/llr
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Primality proving program for numbers of the form N = k*b^n +/- 1, (k < b^n)";
+    homepage = "http://jpenne.free.fr/index2.html";
+    maintainers = with lib.maintainers; [ dstremur ];
+    license = lib.licenses.unfree;
+    # LLR links against gwnum.a which is part of the proprietary gwnum library,
+    # making the resulting binary unfree even though the LLR source code itself
+    # may have different licensing terms.
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "llr";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding the llr package for primality testing numbers of the form N = k*b^n +/- 1.
It implements a Lucas-Lehmer-Riesel test.
Since it links against `gwnum`, it needs to be classified as unfree, see `mprime` package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
