### PR TITLE
meowlnir: 26.01 -> 26.05

### DIFF
--- a/pkgs/by-name/me/meowlnir/package.nix
+++ b/pkgs/by-name/me/meowlnir/package.nix
@@ -9,19 +9,19 @@
 
 buildGoModule rec {
   pname = "meowlnir";
-  version = "26.01";
-  tag = "v0.2601.0";
+  version = "26.02";
+  tag = "v0.2602.0";
 
   src = fetchFromGitHub {
     owner = "maunium";
     repo = "meowlnir";
     inherit tag;
-    hash = "sha256-vrj19+YuhCFwluR+f73WPOJ4bMVxzoG3WjWrN3QuhZ0=";
+    hash = "sha256-nrnVwI1P9EItmpjwX+6mo7e1Os3yWIxJ4CWU8j/Ycnw=";
   };
 
   buildInputs = [ olm ];
 
-  vendorHash = "sha256-l6H6NqAq3C0OBYaea3ed6g/wHdNmo5tVkgizx+vU09E=";
+  vendorHash = "sha256-KbdGerSdGvs+qgA3dUyTTnWN6oCUCN+p2iUQ4oRzKk4=";
 
   doCheck = true;
   doInstallCheck = true;

--- a/pkgs/by-name/me/meowlnir/package.nix
+++ b/pkgs/by-name/me/meowlnir/package.nix
@@ -9,19 +9,19 @@
 
 buildGoModule rec {
   pname = "meowlnir";
-  version = "26.02";
-  tag = "v0.2602.0";
+  version = "26.03";
+  tag = "v0.2603.0";
 
   src = fetchFromGitHub {
     owner = "maunium";
     repo = "meowlnir";
     inherit tag;
-    hash = "sha256-nrnVwI1P9EItmpjwX+6mo7e1Os3yWIxJ4CWU8j/Ycnw=";
+    hash = "sha256-wKUBZSanVLdHDVYdPTLQPFS0L5ribCde37nIqawnIlM=";
   };
 
   buildInputs = [ olm ];
 
-  vendorHash = "sha256-KbdGerSdGvs+qgA3dUyTTnWN6oCUCN+p2iUQ4oRzKk4=";
+  vendorHash = "sha256-mtB1s4Jfb9Ws2nok1vCaK9azotORS2nyqEpUdbDgz7I=";
 
   doCheck = true;
   doInstallCheck = true;

--- a/pkgs/by-name/me/meowlnir/package.nix
+++ b/pkgs/by-name/me/meowlnir/package.nix
@@ -9,19 +9,19 @@
 
 buildGoModule rec {
   pname = "meowlnir";
-  version = "26.03";
-  tag = "v0.2603.0";
+  version = "26.04";
+  tag = "v0.2604.0";
 
   src = fetchFromGitHub {
     owner = "maunium";
     repo = "meowlnir";
     inherit tag;
-    hash = "sha256-wKUBZSanVLdHDVYdPTLQPFS0L5ribCde37nIqawnIlM=";
+    hash = "sha256-zLPRsEbusci9FoI0Pwb4CsQo5GB4QlXdCH+oGQUdx8E=";
   };
 
   buildInputs = [ olm ];
 
-  vendorHash = "sha256-mtB1s4Jfb9Ws2nok1vCaK9azotORS2nyqEpUdbDgz7I=";
+  vendorHash = "sha256-ev0UjRuJpxruemz9DxHxi43SuLQ28a1NOSuM3td1s6Q=";
 
   doCheck = true;
   doInstallCheck = true;

--- a/pkgs/by-name/me/meowlnir/package.nix
+++ b/pkgs/by-name/me/meowlnir/package.nix
@@ -9,19 +9,19 @@
 
 buildGoModule rec {
   pname = "meowlnir";
-  version = "26.04";
-  tag = "v0.2604.0";
+  version = "26.05";
+  tag = "v0.2605.0";
 
   src = fetchFromGitHub {
     owner = "maunium";
     repo = "meowlnir";
     inherit tag;
-    hash = "sha256-zLPRsEbusci9FoI0Pwb4CsQo5GB4QlXdCH+oGQUdx8E=";
+    hash = "sha256-f2SgDFswjBDFQq9KvFo6A02vghMfYRkV26uWN8yxOz0=";
   };
 
   buildInputs = [ olm ];
 
-  vendorHash = "sha256-ev0UjRuJpxruemz9DxHxi43SuLQ28a1NOSuM3td1s6Q=";
+  vendorHash = "sha256-rHBGTOqBfbu9EN0rWCui03aW2Co6Y4yxOvpuznjQ4qc=";
 
   doCheck = true;
   doInstallCheck = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://mau.fi/blog/2026-02-mautrix-release/
https://github.com/maunium/meowlnir/releases/v0.2602.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
