### PR TITLE
nixos/jellyfin: add options for downmixing audio to stereo

### DIFF
--- a/nixos/modules/services/misc/jellyfin.nix
+++ b/nixos/modules/services/misc/jellyfin.nix
@@ -27,6 +27,7 @@ let
     enum
     ints
     nullOr
+    number
     path
     str
     submodule
@@ -58,6 +59,8 @@ let
       <AllowAv1Encoding>${boolToString cfg.transcoding.hardwareEncodingCodecs.av1}</AllowAv1Encoding>
       <EnableIntelLowPowerH264HwEncoder>${boolToString cfg.transcoding.enableIntelLowPowerEncoding}</EnableIntelLowPowerH264HwEncoder>
       <EnableIntelLowPowerHevcHwEncoder>${boolToString cfg.transcoding.enableIntelLowPowerEncoding}</EnableIntelLowPowerHevcHwEncoder>
+      <DownMixAudioBoost>${toString cfg.transcoding.downMixAudioBoost}</DownMixAudioBoost>
+      <DownMixStereoAlgorithm>${cfg.transcoding.downMixStereoAlgorithm}</DownMixStereoAlgorithm>
       <EnableDecodingColorDepth10HevcRext>${boolToString cfg.transcoding.hardwareDecodingCodecs.hevcRExt10bit}</EnableDecodingColorDepth10HevcRext>
       <EnableDecodingColorDepth12HevcRext>${boolToString cfg.transcoding.hardwareDecodingCodecs.hevcRExt12bit}</EnableDecodingColorDepth12HevcRext>
       <HardwareDecodingCodecs>
@@ -345,6 +348,35 @@ in
           description = ''
             Enable low-power encoding mode for Intel Quick Sync Video.
             Requires i915 HuC firmware to be configured.
+          '';
+        };
+
+        downMixAudioBoost = mkOption {
+          type = number;
+          default = 2;
+          description = ''
+            Audio volume boost applied when downmixing surround sound to stereo.
+            A value of 1 means no boost.
+          '';
+        };
+
+        downMixStereoAlgorithm = mkOption {
+          type = enum [
+            "None"
+            "Dave750"
+            "NightmodeDialogue"
+            "Rfc7845"
+            "Ac4"
+          ];
+          default = "None";
+          description = ''
+            Algorithm used for downmixing surround sound audio to stereo.
+
+            - `"None"`: No special algorithm, use ffmpeg's default.
+            - `"Dave750"`: Algorithm by Dave_750 for 5.1/7.1 to stereo.
+            - `"NightmodeDialogue"`: Nightmode algorithm that boosts dialogue clarity.
+            - `"Rfc7845"`: Algorithm defined in RFC 7845 Section 5.1.1.5 (Opus spec).
+            - `"Ac4"`: AC-4 standard algorithm defined in ETSI TS 103 190.
           '';
         };
       };

--- a/nixos/tests/jellyfin.nix
+++ b/nixos/tests/jellyfin.nix
@@ -41,6 +41,8 @@
             hevc = true;
             av1 = true;
           };
+          downMixAudioBoost = 2;
+          downMixStereoAlgorithm = "Dave750";
         };
       };
       environment.systemPackages = with pkgs; [ ffmpeg ];
@@ -177,6 +179,10 @@
           # HEVC RExt color depth verification
           assert config.get("EnableDecodingColorDepth10HevcRext") == True, f"HEVC RExt 10bit: expected True, got '{config.get('EnableDecodingColorDepth10HevcRext')}'"
           assert config.get("EnableDecodingColorDepth12HevcRext") == True, f"HEVC RExt 12bit: expected True, got '{config.get('EnableDecodingColorDepth12HevcRext')}'"
+
+          # Stereo downmixing verification
+          assert config.get("DownMixAudioBoost") == 2, f"DownMix audio boost: expected 2, got '{config.get('DownMixAudioBoost')}'"
+          assert config.get("DownMixStereoAlgorithm") == "Dave750", f"DownMix stereo algorithm: expected 'Dave750', got '{config.get('DownMixStereoAlgorithm')}'"
 
           # Hardware decoding codecs verification
           decoding_codecs = config.get("HardwareDecodingCodecs", [])


### PR DESCRIPTION
Adds more options in the transcoding category for downmixing transcoded audio to stereo.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [X] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
