### PR TITLE
treewide: eliminate unnecessary `__curPos` usage in nixpkgs

### DIFF
--- a/nixos/modules/misc/documentation/modular-services.nix
+++ b/nixos/modules/misc/documentation/modular-services.nix
@@ -18,7 +18,6 @@ let
     };
 
   modularServicesModule = {
-    _file = "${__curPos.file}:${toString __curPos.line}";
     options = {
       "<imports = [ pkgs.ghostunnel.services.default ]>" = fakeSubmodule pkgs.ghostunnel.services.default;
       "<imports = [ pkgs.php.services.default ]>" = fakeSubmodule pkgs.php.services.default;

--- a/nixos/modules/profiles/nix-builder-vm.nix
+++ b/nixos/modules/profiles/nix-builder-vm.nix
@@ -218,27 +218,34 @@ in
           KEYS="$(${hostPkgs.nix}/bin/nix-store --add "$KEYS")" ${lib.getExe config.system.build.vm}
         '';
 
-        script = hostPkgs.writeShellScriptBin "create-builder" ''
+      in
+      hostPkgs.writeTextFile {
+        name = "create-builder";
+        executable = true;
+        destination = "/bin/create-builder";
+        text = ''
+          #!${hostPkgs.runtimeShell}
           set -euo pipefail
           export KEYS="''${KEYS:-./keys}"
           ${lib.getExe add-keys}
           ${lib.getExe run-builder}
         '';
-
-      in
-      script.overrideAttrs (old: {
-        pos = __curPos; # sets meta.position to point here; see script binding above for package definition
-        meta = (old.meta or { }) // {
+        checkPhase = ''
+          ${hostPkgs.stdenv.shellDryRun} "$target"
+        '';
+        meta = {
+          mainProgram = "create-builder";
+          description = "Create a Linux builder VM for macOS";
           platforms = lib.platforms.darwin;
         };
-        passthru = (old.passthru or { }) // {
+        passthru = {
           # Let users in the repl inspect the config
           nixosConfig = config;
           nixosOptions = options;
 
           inherit add-keys run-builder;
         };
-      });
+      };
 
     system = {
       # To prevent gratuitous rebuilds on each change to Nixpkgs

--- a/nixos/modules/system/service/portable/test.nix
+++ b/nixos/modules/system/service/portable/test.nix
@@ -22,7 +22,6 @@ let
     };
 
   exampleConfig = {
-    _file = "${__curPos.file}:${toString __curPos.line}";
     services = {
       service1 = {
         process = {

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -564,7 +564,6 @@ in
                           extraConfig =
                             { options, ... }:
                             {
-                              _file = "module at ${__curPos.file}:${toString __curPos.line}";
                               config = {
                                 nixpkgs =
                                   if options.nixpkgs ? hostPlatform then

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -112,7 +112,7 @@ let
         ((import ../lib/testing-python.nix { inherit system pkgs; }).evalTest {
           imports = [
             arg
-            readOnlyPkgs
+            ./read-only-pkgs.nix
           ];
         }).config.result;
       findTests =
@@ -139,24 +139,6 @@ let
     */
     runTestOn
     ;
-
-  # Using a single instance of nixpkgs makes test evaluation faster.
-  # To make sure we don't accidentally depend on a modified pkgs, we make the
-  # related options read-only. We need to test the right configuration.
-  #
-  # If your service depends on a nixpkgs setting, first try to avoid that, but
-  # otherwise, you can remove the readOnlyPkgs import and test your service as
-  # usual.
-  readOnlyPkgs =
-    # TODO: We currently accept this for nixosTests, so that the `pkgs` argument
-    #       is consistent with `pkgs` in `pkgs.nixosTests`. Can we reinitialize
-    #       it with `allowAliases = false`?
-    # warnIf pkgs.config.allowAliases "nixosTests: pkgs includes aliases."
-    {
-      _file = "${__curPos.file} readOnlyPkgs";
-      _class = "nixosTest";
-      node.pkgs = pkgs.pkgsLinux;
-    };
 
 in
 {

--- a/nixos/tests/read-only-pkgs.nix
+++ b/nixos/tests/read-only-pkgs.nix
@@ -1,0 +1,17 @@
+# Using a single instance of nixpkgs makes test evaluation faster.
+# To make sure we don't accidentally depend on a modified pkgs, we make the
+# related options read-only. We need to test the right configuration.
+#
+# If your service depends on a nixpkgs setting, first try to avoid that, but
+# otherwise, you can remove the readOnlyPkgs import and test your service as
+# usual.
+
+# TODO: We currently accept this for nixosTests, so that the `pkgs` argument
+#       is consistent with `pkgs` in `pkgs.nixosTests`. Can we reinitialize
+#       it with `allowAliases = false`?
+# warnIf pkgs.config.allowAliases "nixosTests: pkgs includes aliases."
+{ hostPkgs, ... }:
+{
+  _class = "nixosTest";
+  node.pkgs = hostPkgs.pkgsLinux;
+}

--- a/pkgs/applications/emulators/wine/sources.nix
+++ b/pkgs/applications/emulators/wine/sources.nix
@@ -61,7 +61,7 @@ let
         nix
       ]
     }
-    sources_file=${__curPos.file}
+    sources_file=./pkgs/applications/emulators/wine/sources.nix
     source ${./update-lib.sh}
   '';
 

--- a/pkgs/applications/networking/cluster/hadoop/default.nix
+++ b/pkgs/applications/networking/cluster/hadoop/default.nix
@@ -144,9 +144,7 @@ let
 
       passthru = { inherit tests; };
 
-      # The recursiveUpdate below breaks default meta.position, so manually override it.
-      pos = __curPos;
-      meta = lib.recursiveUpdate {
+      meta = {
         homepage = "https://hadoop.apache.org/";
         description = "Framework for distributed processing of large data sets across clusters of computers";
         license = lib.licenses.asl20;
@@ -165,7 +163,7 @@ let
         '';
         maintainers = with lib.maintainers; [ illustris ];
         platforms = lib.attrNames platformAttrs;
-      } (lib.attrByPath [ stdenv.system "meta" ] { } platformAttrs);
+      };
     });
 in
 {

--- a/pkgs/development/compilers/corretto/mk-corretto.nix
+++ b/pkgs/development/compilers/corretto/mk-corretto.nix
@@ -137,9 +137,6 @@ jdk.overrideAttrs (
         };
       };
 
-    # Some of the OpenJDK derivation set their `pos` by hand. We need to
-    # overwrite this in order to point to Corretto, not OpenJDK.
-    pos = __curPos;
     meta = oldAttrs.meta // {
       homepage = "https://aws.amazon.com/corretto";
       license = lib.licenses.gpl2Only;

--- a/pkgs/games/openra_2019/default.nix
+++ b/pkgs/games/openra_2019/default.nix
@@ -72,11 +72,9 @@ lib.recurseIntoAttrs rec {
     {
       name ? null,
       version,
-      description,
-      homepage,
+      meta,
       mods,
       src,
-      pos,
     }@engine:
     # Allow specifying the name at a later point if no name has been given.
     let
@@ -99,10 +97,8 @@ lib.recurseIntoAttrs rec {
       name ? null,
       version,
       title,
-      description,
-      homepage,
+      meta,
       src,
-      pos,
       engine,
       assetsError ? "",
     }@mod:

--- a/pkgs/games/openra_2019/engine.nix
+++ b/pkgs/games/openra_2019/engine.nix
@@ -17,10 +17,13 @@
   engine,
 }:
 
+let
+  version = "${engine.name}-${engine.version}";
+in
 stdenv.mkDerivation (
-  lib.recursiveUpdate packageAttrs rec {
+  {
     pname = "openra_2019";
-    version = "${engine.name}-${engine.version}";
+    inherit version;
 
     src = engine.src;
 
@@ -61,9 +64,7 @@ stdenv.mkDerivation (
       )}
     '';
 
-    inherit (engine) pos;
-    meta = {
-      inherit (engine) description homepage;
-    };
+    meta = packageAttrs.meta // engine.meta;
   }
+  // removeAttrs packageAttrs [ "meta" ]
 )

--- a/pkgs/games/openra_2019/engines.nix
+++ b/pkgs/games/openra_2019/engines.nix
@@ -14,8 +14,10 @@ let
     name:
     (buildOpenRAEngine {
       inherit version;
-      description = "Open-source re-implementation of Westwood Studios' 2D Command and Conquer games";
-      homepage = "https://www.openra.net/";
+      meta = {
+        description = "Open-source re-implementation of Westwood Studios' 2D Command and Conquer games";
+        homepage = "https://www.openra.net/";
+      };
       mods = [
         "cnc"
         "d2k"
@@ -27,7 +29,6 @@ let
         repo = "OpenRA";
         inherit rev sha256 postFetch;
       };
-      pos = __curPos;
     } name).overrideAttrs
       (origAttrs: {
         postInstall = ''

--- a/pkgs/games/openra_2019/mod.nix
+++ b/pkgs/games/openra_2019/mod.nix
@@ -23,10 +23,12 @@ let
 
 in
 # Based on: https://build.opensuse.org/package/show/home:fusion809/openra-ura
+let
+  pname = "openra_2019-${mod.name}";
+in
 stdenv.mkDerivation (
-  lib.recursiveUpdate packageAttrs rec {
-    name = "${pname}-${version}";
-    pname = "openra_2019-${mod.name}";
+  {
+    inherit pname;
     inherit (mod) version;
 
     srcs = [
@@ -47,7 +49,7 @@ stdenv.mkDerivation (
       exit 0
       EOF
 
-      sed -i 's/^VERSION.*/VERSION = ${version}/g' Makefile
+      sed -i 's/^VERSION.*/VERSION = ${mod.version}/g' Makefile
 
       dos2unix *.md
 
@@ -57,7 +59,7 @@ stdenv.mkDerivation (
     configurePhase = ''
       runHook preConfigure
 
-      make version VERSION=${lib.escapeShellArg version}
+      make version VERSION=${lib.escapeShellArg mod.version}
       make -C ${engineSourceName} version VERSION=${lib.escapeShellArg engine.version}
 
       runHook postConfigure
@@ -93,7 +95,7 @@ stdenv.mkDerivation (
       substitute ${./openra-mod.desktop} $(mkdirp $out/share/applications)/${pname}.desktop \
         --subst-var-by name ${lib.escapeShellArg mod.name} \
         --subst-var-by title ${lib.escapeShellArg mod.title} \
-        --subst-var-by description ${lib.escapeShellArg mod.description}
+        --subst-var-by description ${lib.escapeShellArg mod.meta.description}
 
       cp README.md $(mkdirp $out/share/doc/packages/${pname})/README.md
 
@@ -110,9 +112,7 @@ stdenv.mkDerivation (
       runHook postInstall
     '';
 
-    inherit (mod) pos;
-    meta = {
-      inherit (mod) description homepage;
-    };
+    meta = packageAttrs.meta // mod.meta;
   }
+  // removeAttrs packageAttrs [ "meta" ]
 )

--- a/pkgs/games/openra_2019/mods.nix
+++ b/pkgs/games/openra_2019/mods.nix
@@ -16,15 +16,14 @@ in
   ca = buildOpenRAMod {
     version = "96.git.fc3cf0b";
     title = "Combined Arms";
-    description = "A game that combines units from the official OpenRA Red Alert and Tiberian Dawn mods";
-    homepage = "https://github.com/Inq8/CAmod";
+    meta.description = "A game that combines units from the official OpenRA Red Alert and Tiberian Dawn mods";
+    meta.homepage = "https://github.com/Inq8/CAmod";
     src = fetchFromGitHub {
       owner = "Inq8";
       repo = "CAmod";
       rev = "fc3cf0baf2b827650eaae9e1d2335a3eed24bac9";
       sha256 = "15w91xs253gyrlzsgid6ixxjazx0fbzick6vlkiay0znb58n883m";
     };
-    pos = __curPos;
     engine = {
       version = "b8a7dd5";
       src = fetchFromGitHub {
@@ -41,15 +40,14 @@ in
   d2 = unsafeBuildOpenRAMod rec {
     version = "134.git.69a4aa7";
     title = "Dune II";
-    description = "A modernization of the original ${title} game";
-    homepage = "https://github.com/OpenRA/d2";
+    meta.description = "A modernization of the original ${title} game";
+    meta.homepage = "https://github.com/OpenRA/d2";
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "d2";
       rev = "69a4aa708e2c26376469c0048fac13592aa452ca";
       sha256 = "1mfch4s6c05slyqvxllklbxpqq8dqcbx3515n3gyylyq43gq481r";
     };
-    pos = __curPos;
     engine = rec {
       version = "release-20181215";
       mods = [
@@ -75,15 +73,14 @@ in
   dr = buildOpenRAMod rec {
     version = "324.git.ffcd6ba";
     title = "Dark Reign";
-    description = "A re-imagination of the original Command & Conquer: ${title} game";
-    homepage = "https://github.com/drogoganor/DarkReign";
+    meta.description = "A re-imagination of the original Command & Conquer: ${title} game";
+    meta.homepage = "https://github.com/drogoganor/DarkReign";
     src = fetchFromGitHub {
       owner = "drogoganor";
       repo = "DarkReign";
       rev = "ffcd6ba72979e5f77508136ed7b0efc13e4b100e";
       sha256 = "07g4qw909649s3i1yhw75613mpwfka05jana5mpp5smhnf0pkack";
     };
-    pos = __curPos;
     engine = {
       version = "DarkReign";
       src = fetchFromGitHub {
@@ -100,15 +97,14 @@ in
   gen = buildOpenRAMod {
     version = "1157.git.4f5e11d";
     title = "Generals Alpha";
-    description = "Re-imagination of the original Command & Conquer: Generals game";
-    homepage = "https://github.com/MustaphaTR/Generals-Alpha";
+    meta.description = "Re-imagination of the original Command & Conquer: Generals game";
+    meta.homepage = "https://github.com/MustaphaTR/Generals-Alpha";
     src = fetchFromGitHub {
       owner = "MustaphaTR";
       repo = "Generals-Alpha";
       rev = "4f5e11d916e4a03d8cf1c97eef484ce2d77d7df2";
       sha256 = "1wnl4qrlhynnlahgdlxwhgsdba5wgdg9yrv9f8hkgi69j60szypd";
     };
-    pos = __curPos;
     engine = rec {
       version = "gen-20190128_3";
       src = fetchFromGitHub {
@@ -130,15 +126,14 @@ in
     (buildOpenRAMod rec {
       inherit version;
       title = "Krush, Kill 'n' Destroy";
-      description = "Re-imagination of the original ${title} game";
-      homepage = "https://kknd-game.com/";
+      meta.description = "Re-imagination of the original ${title} game";
+      meta.homepage = "https://kknd-game.com/";
       src = fetchFromGitHub {
         owner = "IceReaper";
         repo = "KKnD";
         rev = "5530babcb05170e0959e4cf2b079161e9fedde4f";
         sha256 = "07jczrarmgm6zdk0myzwgq200x19yvpjyxrnhdac08mjgyz75zk1";
       };
-      pos = __curPos;
       engine = {
         version = "4e8eab4ca00d1910203c8a103dfd2c002714daa8";
         src = fetchFromGitHub {
@@ -162,15 +157,14 @@ in
   mw = buildOpenRAMod rec {
     version = "257.git.c9be8f2";
     title = "Medieval Warfare";
-    description = "A re-imagination of the original Command & Conquer: ${title} game";
-    homepage = "https://github.com/CombinE88/Medieval-Warfare";
+    meta.description = "A re-imagination of the original Command & Conquer: ${title} game";
+    meta.homepage = "https://github.com/CombinE88/Medieval-Warfare";
     src = fetchFromGitHub {
       owner = "CombinE88";
       repo = "Medieval-Warfare";
       rev = "c9be8f2a6f1dd710b1aedd9d5b00b4cf5020e2fe";
       sha256 = "09fp7k95jd6hjqdasbspbd43z5670wkyzbbgqkll9dfsrv0sky0v";
     };
-    pos = __curPos;
     engine = {
       version = "MedievalWarfareEngine";
       src = fetchFromGitHub {
@@ -187,15 +181,14 @@ in
   ra2 = buildOpenRAMod rec {
     version = "903.git.2f7c700";
     title = "Red Alert 2";
-    description = "Re-imagination of the original Command & Conquer: ${title} game";
-    homepage = "https://github.com/OpenRA/ra2";
+    meta.description = "Re-imagination of the original Command & Conquer: ${title} game";
+    meta.homepage = "https://github.com/OpenRA/ra2";
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "ra2";
       rev = "2f7c700d6d63c0625e7158ef3098221fa6741569";
       sha256 = "11vnzwczn47wjfrq6y7z9q234p27ihdrcl5p87i6h2xnrpwi8b6m";
     };
-    pos = __curPos;
     engine = rec {
       version = "release-20180923";
       src = fetchFromGitHub {
@@ -216,15 +209,14 @@ in
   raclassic = buildOpenRAMod {
     version = "183.git.c76c13e";
     title = "Red Alert Classic";
-    description = "A modernization of the original Command & Conquer: Red Alert game";
-    homepage = "https://github.com/OpenRA/raclassic";
+    meta.description = "A modernization of the original Command & Conquer: Red Alert game";
+    meta.homepage = "https://github.com/OpenRA/raclassic";
     src = fetchFromGitHub {
       owner = "OpenRA";
       repo = "raclassic";
       rev = "c76c13e9f0912a66ddebae8d05573632b19736b2";
       sha256 = "1cnr3ccvrkjlv8kkdcglcfh133yy0fkva9agwgvc7wlj9n5ydl4g";
     };
-    pos = __curPos;
     engine = rec {
       version = "release-20190314";
       src = fetchFromGitHub {
@@ -241,15 +233,14 @@ in
   rv = unsafeBuildOpenRAMod {
     version = "1330.git.9230e6f";
     title = "Romanov's Vengeance";
-    description = "Re-imagination of the original Command & Conquer: Red Alert 2 game";
-    homepage = "https://github.com/MustaphaTR/Romanovs-Vengeance";
+    meta.description = "Re-imagination of the original Command & Conquer: Red Alert 2 game";
+    meta.homepage = "https://github.com/MustaphaTR/Romanovs-Vengeance";
     src = fetchFromGitHub {
       owner = "MustaphaTR";
       repo = "Romanovs-Vengeance";
       rev = "9230e6f1dd9758467832aee4eda115e18f0e635f";
       sha256 = "0bwbmmlhp1kh8rgk2nx1ca9vqssj849amndacf318d61gksc1w9n";
     };
-    pos = __curPos;
     engine = {
       version = "f3873ae";
       mods = [ "as" ];
@@ -271,15 +262,14 @@ in
   sp = unsafeBuildOpenRAMod {
     version = "221.git.ac000cc";
     title = "Shattered Paradise";
-    description = "Re-imagination of the original Command & Conquer: Tiberian Sun game";
-    homepage = "https://github.com/ABrandau/OpenRAModSDK";
+    meta.description = "Re-imagination of the original Command & Conquer: Tiberian Sun game";
+    meta.homepage = "https://github.com/ABrandau/OpenRAModSDK";
     src = fetchFromGitHub {
       owner = "ABrandau";
       repo = "OpenRAModSDK";
       rev = "ac000cc15377cdf6d3c2b72c737d692aa0ed8bcd";
       sha256 = "16mzs5wcxj9nlpcyx2c87idsqpbm40lx0rznsccclnlb3hiwqas9";
     };
-    pos = __curPos;
     engine = {
       version = "SP-22-04-19";
       mods = [
@@ -300,15 +290,14 @@ in
   ss = buildOpenRAMod rec {
     version = "77.git.23e1f3e";
     title = "Sole Survivor";
-    description = "A re-imagination of the original Command & Conquer: ${title} game";
-    homepage = "https://github.com/MustaphaTR/sole-survivor";
+    meta.description = "A re-imagination of the original Command & Conquer: ${title} game";
+    meta.homepage = "https://github.com/MustaphaTR/sole-survivor";
     src = fetchFromGitHub {
       owner = "MustaphaTR";
       repo = "sole-survivor";
       rev = "23e1f3e5d8b98c936797b6680d95d56a69a9e2ab";
       sha256 = "104clmxphchs7r8y7hpmw103bychayz80bqj98bp89i64nv9d89x";
     };
-    pos = __curPos;
     engine = {
       version = "6de92de";
       src = fetchFromGitHub {
@@ -325,15 +314,14 @@ in
   ura = buildOpenRAMod {
     version = "431.git.128dc53";
     title = "Red Alert Unplugged";
-    description = "Re-imagination of the original Command & Conquer: Red Alert game";
-    homepage = "http://redalertunplugged.com/";
+    meta.description = "Re-imagination of the original Command & Conquer: Red Alert game";
+    meta.homepage = "http://redalertunplugged.com/";
     src = fetchFromGitHub {
       owner = "RAunplugged";
       repo = "uRA";
       rev = "128dc53741fae923f4af556f2293ceaa0cf571f0";
       sha256 = "1mhr8kyh313z52gdrqv31d6z7jvdldiajalca5mcr8gzg6mph66p";
     };
-    pos = __curPos;
     engine = rec {
       version = "unplugged-cd82382";
       src = fetchFromGitHub {
@@ -349,16 +337,15 @@ in
 
   yr = unsafeBuildOpenRAMod rec {
     version = "199.git.5b8b952";
-    homepage = "https://github.com/cookgreen/yr";
     title = "Yuri's Revenge";
-    description = "Re-imagination of the original Command & Conquer: ${title} game";
+    meta.description = "Re-imagination of the original Command & Conquer: ${title} game";
+    meta.homepage = "https://github.com/cookgreen/yr";
     src = fetchFromGitHub {
       owner = "cookgreen";
       repo = "yr";
       rev = "5b8b952dbe21f194a6d00485f20e215ce8362712";
       sha256 = "0hxzrqnz5d7qj1jjr20imiyih62x1cnmndf75nnil4c4sj82f9a6";
     };
-    pos = __curPos;
     engine = rec {
       version = "release-20190314";
       src = fetchFromGitHub {

--- a/pkgs/misc/logging/beats/7.x.nix
+++ b/pkgs/misc/logging/beats/7.x.nix
@@ -13,14 +13,15 @@ let
   beat =
     package: extraArgs:
     buildGoModule (
-      lib.attrsets.recursiveUpdate rec {
+      finalAttrs:
+      {
         pname = package;
         version = elk7Version;
 
         src = fetchFromGitHub {
           owner = "elastic";
           repo = "beats";
-          rev = "v${version}";
+          tag = "v${finalAttrs.version}";
           hash = "sha256-TzcKB1hIHe1LNZ59GcvR527yvYqPKNXPIhpWH2vyMTY=";
         };
 
@@ -36,17 +37,19 @@ let
             dfithian
           ];
           platforms = lib.platforms.linux;
-        };
-      } extraArgs
+        }
+        // (extraArgs.meta or { });
+      }
+      // removeAttrs extraArgs [
+        "meta"
+      ]
     );
 in
 rec {
   auditbeat7 = beat "auditbeat" {
-    pos = __curPos;
     meta.description = "Lightweight shipper for audit data";
   };
   filebeat7 = beat "filebeat" {
-    pos = __curPos;
     meta.description = "Lightweight shipper for logfiles";
     buildInputs = [ systemd ];
     tags = [ "withjournald" ];
@@ -55,11 +58,9 @@ rec {
     '';
   };
   heartbeat7 = beat "heartbeat" {
-    pos = __curPos;
     meta.description = "Lightweight shipper for uptime monitoring";
   };
   metricbeat7 = beat "metricbeat" {
-    pos = __curPos;
     meta.description = "Lightweight shipper for metrics";
     passthru.tests = lib.optionalAttrs config.allowUnfree (
       assert metricbeat7.drvPath == nixosTests.elk.unfree.ELK-7.elkPackages.metricbeat.drvPath;
@@ -70,7 +71,6 @@ rec {
   };
   packetbeat7 = beat "packetbeat" {
     buildInputs = [ libpcap ];
-    pos = __curPos;
     meta.description = "Network packet analyzer that ships data to Elasticsearch";
     meta.longDescription = ''
       Packetbeat is an open source network packet analyzer that ships the

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -272,7 +272,7 @@ stdenv.mkDerivation (
             # Have to double-wrap it...
             installPhase = oa.installPhase + ''
               wrapProgram $out/bin/update-source-version \
-                --add-flag '--file=${lib.strings.removeSuffix "/common.nix" __curPos.file}/default.nix'
+                --add-flag '--file=pkgs/servers/mir/default.nix'
             '';
           });
         in


### PR DESCRIPTION
`__curPos` is a Nix language builtin that returns `{ file, line, column }` for the source location where it appears. Most Nix users never encounter it. It's obscure and its presence in nixpkgs was almost always a workaround for something else.

The main culprit was `lib.recursiveUpdate`. When you use `recursiveUpdate` to merge attrsets, the result is a dynamically constructed attrset that loses source position metadata. Nix's `builtins.unsafeGetAttrPos` (which `mkDerivation` uses internally to figure out where a package was defined, powering `nix edit` and error messages) returns `null` for these dynamic attrsets. So package authors reached for `pos = __curPos` to manually re-inject the position that `recursiveUpdate` destroyed.

The fix is straightforward: replace `recursiveUpdate` with the `//` merge operator (which preserves source positions) plus explicit merging of nested attrsets like `meta` and `passthru`. This is what the `beats`, `hadoop`, and `openra_2019` changes do.

The remaining uses fell into a few other categories:

- **Corretto** had a stale `pos = __curPos` left over from when OpenJDK set `pos` explicitly; that was removed during OpenJDK's deduplication into `generic.nix`, making Corretto's workaround unnecessary.
- **nix-builder-vm** used `overrideAttrs` on a `writeShellScriptBin` output, which preserved `writeTextFile`'s explicit `pos` and prevented `mkDerivation`'s fallback from ever running. Rewriting to use `writeTextFile` directly eliminated both `overrideAttrs` and `__curPos`.
- **Wine and mir** used `__curPos.file` in update scripts to locate their own `.nix` file for `sed -i`. Other update scripts just hardcode the path (they already assume running from the nixpkgs root), so these were replaced with hardcoded paths.
- **NixOS modules** (`all-tests.nix`, `modular-services.nix`, `nixos-containers.nix`, `portable/test.nix`) used `__curPos` to set `_file` on inline module attrsets. Most NixOS modules don't do this — the module system has its own fallback. Where possible, we extracted the inline module to its own file (so `_file` is set automatically); where the closure dependencies made extraction impractical, we just dropped the `_file` line.

After this PR, the only remaining `__curPos` uses are 17 occurrences in 3 files under `lib/tests/modules/`. Here, I feel they're genuinely the right tool, since they're testing that the module system correctly tracks source positions and laziness.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test