### PR TITLE
librewolf-unwrapped: 147.0.3-2 -> 147.0.4-1

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/src.json
+++ b/pkgs/by-name/li/librewolf-unwrapped/src.json
@@ -1,11 +1,11 @@
 {
-  "packageVersion": "147.0.3-2",
+  "packageVersion": "147.0.4-1",
   "source": {
-    "rev": "147.0.3-2",
-    "hash": "sha256-Gnsk+dY0B0j/0npy//y/UItKvPrI9HELrH86x0QklBk="
+    "rev": "147.0.4-1",
+    "hash": "sha256-xdeYyD1zwhQ5BzHzbQNCb3oHr4DAfwHGzbtGr2E3MR0="
   },
   "firefox": {
-    "version": "147.0.3",
-    "hash": "sha512-N+OcR9aU7M3Ku32KCkz+GwKGCpf2BGU/Nkxg9OmHlv/H8carUSJrLlA0pLSAXMxuw5g/DYMMnzZpLfLsJhJz2Q=="
+    "version": "147.0.4",
+    "hash": "sha512-mBNokWWC4VZllKuOLAPKtHGq8EYT0sd6DU4GerFZu4G1kpqAG7rCDvBQbvBIzekbLi+JWY+o1OjWaoyAFrubMw=="
   }
 }


### PR DESCRIPTION
Diff: https://codeberg.org/librewolf/source/compare/147.0.3-2...147.0.4-1

Currently building the browser on `x86_64-linux`. I will mark this as ready for review once the build finishes successfully.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
