### PR TITLE
fix: fish docs building

### DIFF
--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -298,6 +298,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     rustc
     rustPlatform.cargoSetupHook
+    sphinx
     # Avoid warnings when building the manpages about HOME not being writable
     writableTmpDirAsHomeHook
   ];
@@ -350,7 +351,6 @@ stdenv.mkDerivation (finalAttrs: {
     glibcLocales
     (python3.withPackages (ps: [ ps.pexpect ]))
     procps
-    sphinx
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # For the getconf command, used in default-setup-path.fish


### PR DESCRIPTION
This commit adds `python3Packages.sphinx` to the build inputs for `fish`, as that package is used to generate the man / help pages for fish builtins.

Before this, the fish build did not actually build documentation, since the `sphinx` package is a required dependency for that.

There's been a bit of a back and forth about man-page building in the fish repo, so I don't really follow why it's broken for Nix builds. From what I can tell, there's been some changes to Sphinx in 4.2.0 that prompted a (temporary) fix in 4.2.1 fix (fish-shell/fish-shell@b9af3eca9f73297e0faab88c7587a08ac0ced64cto) to add them back to the release tarball, before being completely removed in 4.3.0 (fish-shell/fish-shell#12088). The temporary fix in 4.2.1 might not actually fix the problem fully (?) since the Nix release of 4.2.1 is broken as well.

I haven't tested 4.2.0 to see check whether that has man pages.

Either way, `fish` *needs* `sphinx` to generate the documentation, and we only add it to the `nativeCheckInputs`, not the `nativeBuildInputs`.

I was able to fix this in my flake
(tommyknows/nixfiles@3896633989e8b36f547f5706d1215a5c14e328d6) by adding an overlay that adds `python3Packages.sphinx` to the `nativeBuildInputs`. 

So this commit implements the same fix by moving `sphinx` from a `nativeCheckInput` to a `nativeBuildInput`.

This can be verified with the following command:
```
$ # current version 
$ nix run github:NixOS/nixpkgs/28b0c9a726c808030179c680756f9840172dc9d7#fish -- -c "set --help"
What manual page do you want?
For example, try 'man man'.
$ # fixed version
$ nix run github:tommyknows/nixpkgs/887352f919a79f1930a9f2a09d428663196ecc29#fish -- -c "set --help"
<opens man page>
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
