### PR TITLE
python3Packages.visionpluspython: init at 1.0.2

### DIFF
--- a/pkgs/development/python-modules/visionpluspython/default.nix
+++ b/pkgs/development/python-modules/visionpluspython/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  fetchPypi,
+  pyjwt,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "visionpluspython";
+  version = "1.0.2";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-9tHjRWMVxi1diPlKGPXLRgi5rkuAXskStUBIqfO0oh4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    pyjwt
+  ];
+
+  # no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "visionpluspython" ];
+
+  meta = {
+    description = "Python API wrapper for Watts Vision+ smart home system";
+    homepage = "https://github.com/Watts-Digital/visionpluspython";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jamiemagee ];
+  };
+}

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -6772,7 +6772,8 @@
         python-matter-server
         pyturbojpeg
         securetar
-      ]; # missing inputs: visionpluspython
+        visionpluspython
+      ];
     "watttime" =
       ps: with ps; [
         aiowatttime
@@ -8131,6 +8132,7 @@
     "water_heater"
     "waterfurnace"
     "watergate"
+    "watts"
     "watttime"
     "waze_travel_time"
     "weather"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20480,6 +20480,8 @@ self: super: with self; {
 
   viser = callPackage ../development/python-modules/viser { };
 
+  visionpluspython = callPackage ../development/python-modules/visionpluspython { };
+
   visions = callPackage ../development/python-modules/visions { };
 
   visitor = callPackage ../development/python-modules/visitor { };


### PR DESCRIPTION
- https://pypi.org/project/visionpluspython/
- https://github.com/Watts-Digital/visionpluspython
- https://www.home-assistant.io/integrations/watts/

Filed upstream:

- https://github.com/Watts-Digital/visionpluspython/issues/3
- https://github.com/Watts-Digital/visionpluspython/issues/4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
