### PR TITLE
pvz-portable{,-unwrapped}: init at 0.1.19

### DIFF
--- a/pkgs/by-name/pv/pvz-portable-unwrapped/package.nix
+++ b/pkgs/by-name/pv/pvz-portable-unwrapped/package.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  desktopToDarwinBundle,
+  cmake,
+  ninja,
+  libogg,
+  libjpeg,
+  libopenmpt,
+  libpng,
+  libvorbis,
+  libmpg123,
+  SDL2,
+  python3,
+  imagemagick,
+  libicns,
+  nix-update-script,
+  pvzDebug ? false, # cheat keys and other debug features
+  limboPage ? true, # access to limbo page with hidden minigame levels
+  doFixBugs ? false, # fix bugs (which are usually considered features)
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pvz-portable-unwrapped";
+  version = "0.1.19";
+
+  src = fetchFromGitHub {
+    owner = "wszqkzqk";
+    repo = "PvZ-Portable";
+    tag = finalAttrs.version;
+    hash = "sha256-G+otMVg/RYpRSEGSvMYocMyN27ixJW9w+bNXCU9Otl0=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    imagemagick
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin desktopToDarwinBundle;
+
+  buildInputs = [
+    libogg
+    libjpeg
+    libopenmpt
+    libpng
+    libvorbis
+    libmpg123
+    SDL2
+    (python3.withPackages (ps: [ ps.pyyaml ]))
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "PVZ_DEBUG" pvzDebug)
+    (lib.cmakeBool "LIMBO_PAGE" limboPage)
+    (lib.cmakeBool "DO_FIX_BUGS" doFixBugs)
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 pvz-portable $out/bin/pvz-portable
+
+    cd .. # exit cmake build dir
+
+    install -Dm755 scripts/pvzp-v4-converter.py $out/bin/pvzp-v4-converter
+    install -Dm644 LICENSE $out/share/licenses/pvz-portable/LICENSE
+    install -Dm644 COPYING $out/share/licenses/pvz-portable/COPYING
+
+    install -Dm664 archlinux/io.github.wszqkzqk.pvz-portable.desktop $out/share/applications/io.github.wszqkzqk.pvz-portable.desktop
+    substituteInPlace $out/share/applications/io.github.wszqkzqk.pvz-portable.desktop --replace-fail /usr/bin/ ""
+    install -Dm644 icon.png $out/share/icons/hicolor/512x512/apps/io.github.wszqkzqk.pvz-portable.png
+    for size in 16 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/''${size}x$size/apps
+      magick icon.png -resize ''${size}x$size $out/share/icons/hicolor/''${size}x$size/apps/io.github.wszqkzqk.pvz-portable.png
+    done
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cross-platform community-driven reimplementation of Plants vs. Zombies GOTY";
+    homepage = "https://github.com/wszqkzqk/PvZ-Portable";
+    changelog = "https://github.com/wszqkzqk/PvZ-Portable/releases";
+    downloadPage = "https://github.com/wszqkzqk/PvZ-Portable/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [
+      lgpl3Plus
+      free # PopCap Games Framework License: redistribution with or without modifications allowed
+    ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = lib.platforms.all;
+    mainProgram = "pvz-portable";
+  };
+})

--- a/pkgs/by-name/pv/pvz-portable/package.nix
+++ b/pkgs/by-name/pv/pvz-portable/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+  symlinkJoin,
+  makeWrapper,
+  p7zip,
+  pvz-portable-unwrapped,
+  # set it to a dir or a zip containing main.pak and properties; can be a path or a derivation
+  # example: ./Plants_vs._Zombies_1.2.0.1073_EN.zip
+  # https://github.com/wszqkzqk/PvZ-Portable/blob/main/archlinux/README.md#prepare-game-assets
+  gameAssets ? fetchurl {
+    url = "https://web.archive.org/web/20220717170711/http://static-www.ec.popcap.com/binaries/popcap_downloads/PlantsVsZombiesSetup.exe";
+    hash = "sha256-S0u00Z+2OeVpiYPjnXrQYcdme87BkFZWBTLHrQ1n0OQ=";
+    meta.license = lib.licenses.unfree;
+  },
+  pvzDebug ? false,
+  limboPage ? true,
+  doFixBugs ? false,
+}:
+
+let
+  unwrapped = pvz-portable-unwrapped.override { inherit pvzDebug limboPage doFixBugs; };
+
+  assets = stdenvNoCC.mkDerivation {
+    name = "pvz-portable-assets";
+
+    src = gameAssets;
+
+    nativeBuildInputs = [ p7zip ];
+
+    unpackCmd = ''
+      [[ -d $curSrc ]] && cp -ar $curSrc source || 7z x $curSrc -osource -ba -bd
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      dir="$(find -type f -name main.pak -printf %h -execdir test -d properties \; | head -n 1)"
+      if [[ -z "$dir" ]]; then
+        echo "main.pak and properties not found in $src"
+        exit 1
+      fi
+
+      mkdir -p $out/share/pvz-portable
+      cp -ar "$dir"/{main.pak,properties} $out/share/pvz-portable
+
+      runHook postInstall
+    '';
+  };
+
+in
+symlinkJoin (finalAttrs: {
+  pname = "pvz-portable";
+  inherit (finalAttrs.passthru.unwrapped) version meta;
+
+  paths = [
+    finalAttrs.passthru.unwrapped
+    finalAttrs.passthru.assets
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+  postBuild = ''
+    wrapProgram $out/bin/pvz-portable --add-flags -resdir=$out/share/pvz-portable
+  '';
+
+  passthru = { inherit unwrapped assets; };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
