### PR TITLE
mlucas: init at 21.0.2

### DIFF
--- a/pkgs/by-name/ml/mlucas/package.nix
+++ b/pkgs/by-name/ml/mlucas/package.nix
@@ -1,0 +1,76 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  gmp,
+  versionCheckHook,
+}:
+let
+
+  platform = if stdenv.hostPlatform.system == "aarch64-linux" then "asimd" else "avx2";
+
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mlucas";
+  # A specific git commit is used because there are no official GitHub releases.
+  version = "21.0.2";
+
+  src = fetchFromGitHub {
+    owner = "primesearch";
+    repo = "Mlucas";
+    rev = "d082c2a00b42410d6d87605212c68be25f9f4d7d";
+    hash = "sha256-YD2Kt8SD5sxZH8Em8jDZ1qSfIhgLUklOdkORmVR588o=";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    gmp
+  ];
+
+  postPatch = ''
+    chmod +x makemake.sh
+    patchShebangs makemake.sh
+  '';
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
+  buildPhase = ''
+    runHook preBuild
+
+    ./makemake.sh ${platform}
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 obj_${platform}/Mlucas $out/bin/mlucas
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Open-source program for primality testing of Mersenne numbers";
+    longDescription = ''
+      This program may be used to test any suitable number as you wish, but it is preferable that you do so in a coordinated fashion,
+      as part of the Great Internet Mersenne Prime Search (GIMPS). Note that on x86 processors Mlucas is not as efficient
+      as the main GIMPS client, George Woltman's Prime95 program (a.k.a. mprime for the linux version),
+      but that program is not 100% open-source. Prime95 is also only available for platforms based on the
+      x86 processor architecture. The help.txt file in the Github repo includes a variety of usage information
+      not covered in the original README.
+    '';
+    homepage = "https://github.com/primesearch/Mlucas";
+    maintainers = with lib.maintainers; [ dstremur ];
+    license = lib.licenses.gpl3Only;
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    mainProgram = "mlucas";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding the mlucas program for primality testing of Mersenne numbers. 
In contrast to the mprime package it is under a free license.
https://github.com/primesearch/Mlucas
I am looking for a reliable method to detect AVX-512 support on the host system to optimize builds. 
Any ideas are greatly appreciated.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
