### PR TITLE
llrCUDA: init at 4.0.0

### DIFF
--- a/pkgs/by-name/ll/llrCUDA/package.nix
+++ b/pkgs/by-name/ll/llrCUDA/package.nix
@@ -1,0 +1,78 @@
+{
+  fetchzip,
+  lib,
+  gmp,
+  cudaPackages,
+  autoPatchelfHook,
+}:
+let
+  inherit (cudaPackages) backendStdenv;
+in
+backendStdenv.mkDerivation (finalAttrs: {
+  pname = "llrCUDA";
+  version = "4.0.0";
+
+  src = fetchzip {
+    url = "http://jpenne.free.fr/llr4/llrcuda${
+      builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version
+    }srcgpu12.zip";
+    hash = "sha256-/v89jsTKCpkmCMKp9nUf7VAnSobE8pDdwLw5n3Hz9dw=";
+  };
+
+  enableParallelBuilding = true;
+
+  # Disable _chdir in lprime.cu to prevent segmentation fault when fopen returns NULL
+  postPatch = ''
+    substituteInPlace lprime.cu \
+      --replace-fail "_chdir (buf)" "0/* _chdir (buf) */"
+
+    substituteInPlace Makefile \
+      --replace-fail "/usr/local/cuda" "${cudaPackages.cuda_nvcc}"
+  '';
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    cudaPackages.cuda_nvcc
+  ];
+
+  buildInputs = [
+    gmp
+    cudaPackages.cuda_cudart
+    cudaPackages.libcufft
+    cudaPackages.cuda_cccl
+  ];
+
+  env = {
+    NIX_LDFLAGS = lib.concatStringsSep " " [
+      "-L${lib.getLib gmp}/lib"
+      "-L${lib.getLib cudaPackages.cuda_cudart}/lib"
+    ];
+  };
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 dllrCUDA $out/bin/llrCUDA
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "GPU version of the LLR program";
+    longDescription = ''
+      Primality proving program for numbers of the form N = k*b^n +/- 1, (k < b^n),
+      or numbers which can be rewritten in this form, like
+      Gaussian-Mersenne norms or b^n-b^m +/- 1 with n>m (new feature).
+      The identity Phi(3,-X) = X^2-X+1 is now used with X=b^n to search for
+      Generalized Unique Primes.
+    '';
+    homepage = "http://jpenne.free.fr/index2.html";
+    maintainers = with lib.maintainers; [ dstremur ];
+    license = lib.licenses.unfree;
+    # Restricted by GWNUM terms and CUDA dependencies.
+    # Its CUDA code is based on GWNUM.
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "llrCUDA";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding the llrCUDA package, which is CUDA version of the llr program for primality testing.
http://jpenne.free.fr/index2.html

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
