### PR TITLE
set default zonedir to match fhs

### DIFF
--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -208,7 +208,12 @@ stdenv.mkDerivation (
 
     makeFlags =
       (args.makeFlags or [ ])
-      ++ [ "OBJCOPY=${stdenv.cc.targetPrefix}objcopy" ]
+      ++ [
+        "OBJCOPY=${stdenv.cc.targetPrefix}objcopy"
+        # zonedir does nothing on NixOS but is important for non-NixOS.
+        # See https://github.com/NixOS/nixpkgs/pull/491193
+        "zonedir=/usr/share/zoneinfo"
+      ]
       ++ lib.optionals (stdenv.cc.libc != null) [
         "BUILD_LDFLAGS=-Wl,-rpath,${stdenv.cc.libc}/lib"
         "OBJDUMP=${stdenv.cc.bintools.bintools}/bin/objdump"


### PR DESCRIPTION
On NixOS, `TZDIR` is set to `/etc/zoneinfo` such that glibc depends on a configurable source of timezone information, presumably to avoid having to rebuild all software whenever tzdata is updated. Some packages are patched to support this because they do their own timezone handling and don't support `TZDIR` (eg [`plasma-desktop`](https://github.com/NixOS/nixpkgs/blob/5851afd2442c2c1000d7984a9a1b0cc81804acb7/pkgs/kde/plasma/plasma-desktop/tzdir.patch#L10)).

Because of the way nixpkgs builds glibc, the default zonedir location gets set to a non-existent location inside the glibc package in the Nix store. This doesn't matter on NixOS, because we want to use the files from `/etc/zoneinfo`, and we accomplish that by ensuring that `TZDIR` is always set. But on non-NixOS, `/etc/zoneinfo` does not normally exist, `TZDIR` is usually unset, and the non-existent location inside the glibc package is still guaranteed by Nix to not exist. This leads to compatibility problems when not running on non-NixOS systems.

I originally [proposed this on Discourse](https://discourse.nixos.org/t/tzdata-glibc-and-fhs/75121) and I was told that this makes things worse and would cause problems on non-NixOS, but when I looked into it I found that non-NixOS is already broken and I don't know how better to fix it. This fixes #65415 and is related to #279893.

## Alternative 1: Set `TZDIR` on non-NixOS

Rather than making nixpkgs glibc compatible with non-NixOS Linux, make non-NixOS Linux more like NixOS.

The easiest way would be to modify environment variables during the Nix install scripts, but I think this would cause users unexpected problems. If `TZDIR` is set to a location managed by Nix, it impacts all software on the system, not just software installed using Nix, and then the hosting distro's normal mechanism for timezone database updates no longer works and the user is only getting timezone database updates if they are updating their Nix environment. If `TZDIR` is set to `/usr/share/zoneinfo`, it's much less risky, but it seems kind of weird for the Nix installer to modify the user's environment in this way. If it's just for the installing user's profile or just for nix-shell, then software installed by Nix would be subtly broken when used in different contexts, eg if spawned by systemd.

## Alternative 2: Include a copy of tzdata in glibc

Instead of having the default location when `TZDIR` is unset point to a location outside the Nix store, ensure that the location inside the store exists and contains appropriate files.

If this is the latest tzdata, every change to tzdata would require rebuilding all software dependent on glibc. If it's a slightly old version of tzdata, software will have subtle differences when running on non-NixOS without `TZDIR` set when compared to running on NixOS where it is set.

Nix software and non-Nix software running in the same environment may disagree about local time representations of the same UTC time because they use different timezone databases. This problem of multiple timezone databases on the same system isn't completely unheard of (eg when running containerized software).

This behavior would be inconsistent even across different Nix software, because only nixpkgs glibc will be falling back to looking for tzdata within nixpkgs glibc. For example, `plasma-desktop` is being [patched to consider `TZDIR` instead of `/usr/share/zoneinfo` if `TZDIR` is set](https://github.com/NixOS/nixpkgs/blob/5851afd2442c2c1000d7984a9a1b0cc81804acb7/pkgs/kde/plasma/plasma-desktop/tzdir.patch#L10), but not being patched to look in `${glibc}/share/zoneinfo` when `TZDIR` is not set.

This alternative was previously rejected in #2447, and [this comment](https://github.com/NixOS/nixpkgs/pull/2447#issuecomment-43999516) also suggests that glibc should be using `/usr/share/zoneinfo` like I am proposing.

## Alternative 3: Create a `/nix/var/tzdata` or similar

Instead of having the default location when `TZDIR` is unset point to a location unmanaged by Nix, create a new Nix-managed location for holding a copy of tzdata.

This gets rid of the alternative 2 problem of having to rebuild everything every time tzdata changes, without getting rid of the other problems. All software built by nixpkgs that is currently being patched to check `TZDIR`, as well as all software that natively supports `TZDIR`, would need to be patched by nixpkgs to fall back to `/nix/var/tzdata`, only for the benefit of non-NixOS systems.

This was also rejected in the #2447 discussion.

## Reservations

It's kind of weird that this patch explicitly de-Nixes glibc in a way, but on NixOS neither location exists so it doesn't seem like a big deal.

This `zonedir` parameter to the makefile is only mentioned in the code and in the changelog. It's been around for a while, but undocumented interfaces may unexpectedly change, and I don't know how to ensure that the package build fails if it does unexpectedly change.

Are there other non-NixOS systems that aren't FHS, don't store their timezone database at /usr/share/zoneinfo, and still use this glibc package? A quick search online says Darwin uses /usr/share/zoneinfo so it shouldn't cause problems there.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

I've built the package, and I can see the expected path inside the library with strings. It shouldn't cause any issues because this patch is just changing a build variable from one location that doesn't exist ever to a location that only exists on most non-NixOS systems, but I haven't done all the compilation to do anything meaningful using this this modified package.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
