### PR TITLE
sonar/radarr: fix darwin sandbox build

### DIFF
--- a/pkgs/by-name/ra/radarr/package.nix
+++ b/pkgs/by-name/ra/radarr/package.nix
@@ -100,6 +100,8 @@ buildDotnetModule {
   doCheck = true;
 
   __darwinAllowLocalNetworking = true; # for tests
+  # vstest.console process failed to connect to testhost process after 90 seconds
+  sandboxProfile = ''(allow network* (remote ip "*:*"))'';
 
   __structuredAttrs = true; # for Copyright property that contains spaces
 

--- a/pkgs/by-name/so/sonarr/package.nix
+++ b/pkgs/by-name/so/sonarr/package.nix
@@ -109,6 +109,8 @@ buildDotnetModule {
   doCheck = true;
 
   __darwinAllowLocalNetworking = true; # for tests
+  # vstest.console process failed to connect to testhost process after 90 seconds
+  sandboxProfile = ''(allow network* (remote ip "*:*"))'';
 
   __structuredAttrs = true; # for Copyright property that contains spaces
 


### PR DESCRIPTION
Ideally this wouldn't use `*:*`, but I only have non-admin access to the darwin community builder, so I can't use sandbox logging.  `localhost:*` is not sufficient, but I'm not sure if it's actually trying to use another interface.  The code (vstest) has "127.0.0.1:0" hardcoded.

This seems to be a problem with any packages that use vstest, for example `marksman`, which I will fix separately.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
