### PR TITLE
python3Packages.fastcluster: init at 1.3.0

### DIFF
--- a/pkgs/development/python-modules/fastcluster/default.nix
+++ b/pkgs/development/python-modules/fastcluster/default.nix
@@ -1,0 +1,43 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  lib,
+  setuptools,
+  pytestCheckHook,
+  numpy,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "fastcluster";
+  version = "1.3.0";
+
+  src = fetchPypi {
+    inherit version pname;
+    hash = "sha256-1SM666XD+qlJx/pqOTRaCfcWzOu9dIVB5XNchmaW3wI=";
+  };
+
+  pyproject = true;
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    scipy
+  ];
+
+  meta = {
+    description = "Fast hierarchical clustering routines for Python";
+    homepage = "https://danifold.net/fastcluster.html";
+    downloadPage = "https://pypi.org/project/fastcluster/";
+    changelog = "https://github.com/fastcluster/fastcluster/blob/v${version}/NEWS.txt";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ erooke ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5304,6 +5304,8 @@ self: super: with self; {
 
   fastcan = callPackage ../development/python-modules/fastcan { };
 
+  fastcluster = callPackage ../development/python-modules/fastcluster { };
+
   fastcore = callPackage ../development/python-modules/fastcore { };
 
   fastcrc = callPackage ../development/python-modules/fastcrc { };


### PR DESCRIPTION
Adds the python module [fastcluster](https://pypi.org/project/fastcluster/) which is an efficient implementation of hierarchical clustering.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
