### PR TITLE
backrest: 1.10.1 -> 1.13.0

### DIFF
--- a/pkgs/by-name/ba/backrest/inlang-plugins.json
+++ b/pkgs/by-name/ba/backrest/inlang-plugins.json
@@ -1,0 +1,10 @@
+{
+  "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4/dist/index.js": {
+    "url": "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@4.4.0/dist/index.js",
+    "hash": "sha256-lIZViAHAjrsBgiPFHCBEtsPCP8KowOeJSleIKzT+tso="
+  },
+  "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2/dist/index.js": {
+    "url": "https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@2.2.9/dist/index.js",
+    "hash": "sha256-hYYvYwV5O1a/2a/lNosJbmP7Kuqzi3eZwFFRe+NJnAs="
+  }
+}

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -188,7 +188,10 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/garethgeorge/backrest";
     changelog = "https://github.com/garethgeorge/backrest/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ iedame ];
+    maintainers = with lib.maintainers; [
+      iedame
+      alexandru0-dev
+    ];
     mainProgram = "backrest";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -191,6 +191,7 @@ buildGoModule (finalAttrs: {
     maintainers = with lib.maintainers; [
       iedame
       alexandru0-dev
+      phanirithvij
     ];
     mainProgram = "backrest";
     platforms = lib.platforms.unix;

--- a/pkgs/by-name/ba/backrest/package.nix
+++ b/pkgs/by-name/ba/backrest/package.nix
@@ -2,46 +2,78 @@
   buildGoModule,
   fetchFromGitHub,
   gzip,
+  fetchurl,
   iana-etc,
   lib,
   libredirect,
   nodejs,
-  pnpm_9,
+  pnpm_11,
   fetchPnpmDeps,
   pnpmConfigHook,
   restic,
   stdenv,
   util-linux,
   makeBinaryWrapper,
+  versionCheckHook,
+  nix-update-script,
+  _experimental-update-script-combinators,
 }:
 let
+  pnpm = pnpm_11;
+
   pname = "backrest";
-  version = "1.10.1";
+  version = "1.13.0";
 
   src = fetchFromGitHub {
     owner = "garethgeorge";
     repo = "backrest";
     tag = "v${version}";
-    hash = "sha256-8WWs7XEVKAc/XmeL+dsw25azfLjUbHKp2MsB6Be14VE=";
+    hash = "sha256-JcrHQDjoaaK6BONEcn6XKsjhGlth4SaZKqfxa3cD0gY=";
+    leaveDotGit = true;
+    postFetch = ''
+      cd "$out"
+      git rev-parse HEAD > $out/COMMIT
+      find "$out" -name .git -print0 | xargs -0 rm -rf
+    '';
   };
 
+  # we need to pin the inlang plugins to specific versions because
+  # the remote ones are not pinned and we can't fetch them in the sandbox.
+  inlang-plugins = lib.mapAttrs (remote: info: fetchurl { inherit (info) url hash; }) (
+    lib.importJSON ./inlang-plugins.json
+  );
+
   frontend = stdenv.mkDerivation (finalAttrs: {
-    inherit version;
-    pname = "${pname}-webui";
-    src = "${src}/webui";
+    inherit version src;
+    pname = "backrest-webui";
+    sourceRoot = "${finalAttrs.src.name}/webui";
+
+    __structuredAttrs = true;
+    strictDeps = true;
 
     nativeBuildInputs = [
       nodejs
       pnpmConfigHook
-      pnpm_9
+      pnpm
     ];
 
     pnpmDeps = fetchPnpmDeps {
       inherit (finalAttrs) pname version src;
-      pnpm = pnpm_9;
-      fetcherVersion = 3;
-      hash = "sha256-9wzPNZxLE0l/AJ8SyE0SkhkBImiibhqJgsG3UrGj3aA=";
+      inherit pnpm;
+      sourceRoot = "${finalAttrs.src.name}/webui";
+      fetcherVersion = 4;
+      hash = "sha256-xPZg7kYRlqdO/EfZr+m+IVhDcyYegQ6v8ZAF2EjrKjU=";
     };
+
+    postPatch = ''
+      # Replace remote inlang plugins with local ones
+      ${lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (remote: local: ''
+          substituteInPlace project.inlang/settings.json \
+            --replace-fail "${remote}" "${local}"
+        '') inlang-plugins
+      )}
+    '';
 
     buildPhase = ''
       runHook preBuild
@@ -52,14 +84,20 @@ let
 
     installPhase = ''
       runHook preInstall
-      mkdir $out
-      cp -r dist/* $out
+      mv dist $out
       runHook postInstall
     '';
   });
 in
-buildGoModule {
-  inherit pname src version;
+buildGoModule (finalAttrs: {
+  inherit
+    pname
+    src
+    version
+    ;
+
+  __structuredAttrs = true;
+  strictDeps = true;
 
   postPatch = ''
     sed -i -e \
@@ -68,16 +106,26 @@ buildGoModule {
       internal/resticinstaller/resticinstaller.go
   '';
 
-  vendorHash = "sha256-cYqK/sddLI38K9bzCpnomcZOYbSRDBOEru4Y26rBLFw=";
+  proxyVendor = true;
+  vendorHash = "sha256-1PecXGXdSu4FzOKVZ15lTLLPy3VlLiGvGeTUDzqe9sc=";
+
+  subPackages = [ "cmd/backrest" ];
 
   nativeBuildInputs = [
     gzip
     makeBinaryWrapper
   ];
 
+  ldflags = [
+    "-s"
+    "-X main.version=${finalAttrs.version}"
+  ];
+
   preBuild = ''
+    ldflags+=" -X main.commit=$(cat COMMIT)"
+
     mkdir -p ./webui/dist
-    cp -r ${frontend}/* ./webui/dist
+    cp -r ${finalAttrs.passthru.frontend}/* ./webui/dist
 
     go generate -skip="npm" ./...
   '';
@@ -102,9 +150,9 @@ buildGoModule {
     in
     [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
 
+  # Use restic from nixpkgs, otherwise download fails in sandbox
   preCheck = ''
-    # Use restic from nixpkgs, otherwise download fails in sandbox
-    export BACKREST_RESTIC_COMMAND="${restic}/bin/restic"
+    export BACKREST_RESTIC_COMMAND="${lib.getExe restic}"
     export HOME=$(pwd)
   ''
   + lib.optionalString (stdenv.hostPlatform.isDarwin) ''
@@ -118,13 +166,30 @@ buildGoModule {
       --set-default BACKREST_RESTIC_COMMAND "${lib.getExe restic}"
   '';
 
+  doInstallCheck = true;
+  versionCheckProgramArg = "-version";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  passthru = {
+    inherit frontend inlang-plugins;
+    updateScript = _experimental-update-script-combinators.sequence [
+      (nix-update-script {
+        extraArgs = [
+          "--subpackage"
+          "frontend"
+        ];
+      })
+      ./update-inlang-plugins.sh
+    ];
+  };
+
   meta = {
     description = "Web UI and orchestrator for restic backup";
     homepage = "https://github.com/garethgeorge/backrest";
-    changelog = "https://github.com/garethgeorge/backrest/releases/tag/v${version}";
+    changelog = "https://github.com/garethgeorge/backrest/releases/tag/${finalAttrs.src.rev}";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ iedame ];
     mainProgram = "backrest";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ba/backrest/update-inlang-plugins.sh
+++ b/pkgs/by-name/ba/backrest/update-inlang-plugins.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p jq curl common-updater-scripts
+
+set -exuo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
+
+SETTINGS_FILE="$(nix-build -A "backrest.src")/webui/project.inlang/settings.json"
+
+MODULES=$(cat "$SETTINGS_FILE" | jq -r '.modules[]')
+
+# Initialize an empty JSON object
+PLUGINS_JSON="{}"
+
+for remote_url in $MODULES; do
+    echo "Processing $remote_url..." >&2
+
+    final_url="$remote_url"
+
+    # Matches: https://cdn.jsdelivr.net/npm/((@[^/]+/[^@/]+|[^@/]+)@([^/]+))(/.*)?$
+    #   Group 1: Full identifier (e.g. @scope/pkg@1)
+    #   Group 2: Package name (e.g. @scope/pkg or pkg)
+    #   Group 3: Version/Tag/Alias (e.g. 4 or latest)
+    #   Group 4: Sub-path (e.g. /dist/index.js)
+    if [[ $remote_url =~ ^https://cdn.jsdelivr.net/npm/((@[^/]+/[^@/]+|[^@/]+)@([^/]+))(/.*)?$ ]]; then
+        pkg_full="${BASH_REMATCH[1]}"
+        pkg_name="${BASH_REMATCH[2]}"
+        current_ver="${BASH_REMATCH[3]}"
+        path="${BASH_REMATCH[4]}"
+
+        # Construct package.json URL to find the exact version
+        PKG_JSON_URL="https://cdn.jsdelivr.net/npm/$pkg_name@$current_ver/package.json"
+        # echo "  Fetching package.json from $PKG_JSON_URL" >&2
+
+        RESOLVED_VERSION=$(curl -s "$PKG_JSON_URL" | jq -r .version || true)
+
+        if [[ -n "$RESOLVED_VERSION" && "$RESOLVED_VERSION" != "null" ]]; then
+            final_url="https://cdn.jsdelivr.net/npm/$pkg_name@$RESOLVED_VERSION$path"
+            echo "  Resolved version $RESOLVED_VERSION from package.json" >&2
+        fi
+    fi
+
+    echo "  Pinned to $final_url" >&2
+
+    hash=$(nix-prefetch-url "$final_url")
+    sri=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+
+    # Add to JSON object using jq
+    PLUGINS_JSON=$(echo "$PLUGINS_JSON" | jq --arg remote "$remote_url" --arg url "$final_url" --arg hash "$sri" \
+        '. + {($remote): {url: $url, hash: $hash}}')
+done
+
+echo "$PLUGINS_JSON" | jq . > "$SCRIPT_DIR/inlang-plugins.json"
+
+echo "Updated $SCRIPT_DIR/inlang-plugins.json"


### PR DESCRIPTION
Changes made:
- update backrest to 1.13.0 (this requires to pin some javascript contents from CDNs)
- include updateScripts (supersedes https://github.com/NixOS/nixpkgs/pull/453791)
- build only "cmd/backrest" (by default also builds docker-entrypoint)
- added myself and @phanirithvij  as a maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
