### PR TITLE
python313Packages.sacremoses: 0.0.35 -> 0.1.1

### DIFF
--- a/pkgs/development/python-modules/sacremoses/default.nix
+++ b/pkgs/development/python-modules/sacremoses/default.nix
@@ -3,29 +3,29 @@
   lib,
   fetchFromGitHub,
   click,
-  six,
-  tqdm,
   joblib,
+  tqdm,
+  regex,
   pytest,
 }:
 
 buildPythonPackage rec {
   pname = "sacremoses";
-  version = "0.0.35";
+  version = "0.1.1";
   format = "setuptools";
 
   src = fetchFromGitHub {
-    owner = "alvations";
+    owner = "hplt-project";
     repo = "sacremoses";
     rev = version;
-    sha256 = "1gzr56w8yx82mn08wax5m0xyg15ym4ri5l80gmagp8r53443j770";
+    sha256 = "sha256-ked6/8oaGJwVW1jvpjrWtJYfr0GKUHdJyaEuzid/S3M=";
   };
 
   propagatedBuildInputs = [
     click
-    six
-    tqdm
     joblib
+    tqdm
+    regex
   ];
 
   nativeCheckInputs = [ pytest ];

--- a/pkgs/development/python-modules/sacremoses/default.nix
+++ b/pkgs/development/python-modules/sacremoses/default.nix
@@ -1,38 +1,44 @@
 {
-  buildPythonPackage,
   lib,
+  buildPythonPackage,
   fetchFromGitHub,
+  # build-system
+  setuptools,
+  # dependencies
   click,
   joblib,
-  tqdm,
   regex,
-  pytest,
+  tqdm,
+  # tests
+  pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "sacremoses";
   version = "0.1.1";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hplt-project";
     repo = "sacremoses";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-ked6/8oaGJwVW1jvpjrWtJYfr0GKUHdJyaEuzid/S3M=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     click
     joblib
-    tqdm
     regex
+    tqdm
   ];
 
-  nativeCheckInputs = [ pytest ];
+  nativeCheckInputs = [ pytestCheckHook ];
   # ignore tests which call to remote host
-  checkPhase = ''
-    pytest -k 'not truecase'
-  '';
+  disabledTestPaths = [
+    "sacremoses/test/test_truecaser.py::TestTruecaser"
+  ];
 
   meta = {
     homepage = "https://github.com/alvations/sacremoses";
@@ -42,4 +48,4 @@ buildPythonPackage rec {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ pashashocky ];
   };
-}
+})


### PR DESCRIPTION
In addition to bumping the version, this commit:

1. Removes `six` and adds `regex` as a dependency per upstream's [requirements.txt](https://github.com/hplt-project/sacremoses/blob/master/requirements.txt).

2. Changes upstream from `alvations` to `hplt-project` based on the homepage link in https://pypi.org/project/sacremoses/.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test