### PR TITLE
python3Packages.cadquery-ocp: init at 7.9.3.1

### DIFF
--- a/pkgs/development/python-modules/cadquery-ocp/cmake-implicit-include-darwin.patch
+++ b/pkgs/development/python-modules/cadquery-ocp/cmake-implicit-include-darwin.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 12fef27a..39ff1974 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -58,12 +58,8 @@ list(GET VTK_INCLUDE_DIR 0 VTK_INCLUDE_DIR)
+ message( STATUS "Include dirs: ${VTK_INCLUDE_DIR}")
+ message( STATUS "Include dirs: ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES}")
+ 
+-# OSX
+-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+-    list( APPEND CXX_INCLUDES -i /opt/usr/local/include/c++/v1/ -i /opt/usr/local/include/ )
+-
+-# Linux-like
+-elseif(NOT PLATFORM STREQUAL "Windows")
++# Unix-like
++if(NOT PLATFORM STREQUAL "Windows")
+     foreach( inc IN LISTS CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES)
+         list( APPEND CXX_INCLUDES -i ${inc}/ )
+     endforeach()

--- a/pkgs/development/python-modules/cadquery-ocp/default.nix
+++ b/pkgs/development/python-modules/cadquery-ocp/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  python,
+  callPackage,
+  buildPythonPackage,
+  cmake,
+  pybind11,
+  mkPythonMetaPackage,
+  vtk,
+}:
+let
+  ocp-source = callPackage ./ocp-source.nix { };
+in
+buildPythonPackage (finalAttrs: {
+  pname = "cadquery-ocp";
+  inherit (ocp-source) version;
+  pyproject = false;
+
+  src = ocp-source;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [ pybind11 ] ++ ocp-source.buildInputs;
+
+  dependencies = [
+    (mkPythonMetaPackage {
+      inherit (finalAttrs) pname version meta;
+      dependencies = [ vtk ];
+    })
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "PYTHON_SP_DIR" "${placeholder "out"}/${python.sitePackages}")
+  ];
+
+  pythonImportsCheck = [
+    "OCP"
+    "OCP.gp"
+  ];
+
+  passthru = {
+    inherit ocp-source;
+  };
+
+  meta = {
+    description = "Python wrapper for OCCT generated using pywrap";
+    homepage = "https://github.com/CadQuery/OCP";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      # tnytown
+      qbisi
+    ];
+  };
+})

--- a/pkgs/development/python-modules/cadquery-ocp/inhert-python-path.patch
+++ b/pkgs/development/python-modules/cadquery-ocp/inhert-python-path.patch
@@ -1,0 +1,19 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 12fef27a..1914680b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -104,12 +104,12 @@ else()
+     endif()
+ endif()
+ 
+-set(ENV{PYTHONPATH} ${CMAKE_SOURCE_DIR}/pywrap )
++set(ENV{PYTHONPATH} ${CMAKE_SOURCE_DIR}/pywrap:$ENV{PYTHONPATH} )
+ 
+ add_custom_command(
+     OUTPUT ${CMAKE_BINARY_DIR}/OCP/CMakeLists.txt
+     COMMAND
+-        ${CMAKE_COMMAND} -E env "PYTHONPATH=${CMAKE_SOURCE_DIR}/pywrap"
++        ${CMAKE_COMMAND} -E env "PYTHONPATH=$ENV{PYTHONPATH}"
+         ${Python_EXECUTABLE}
+         -m bindgen
+         -n ${N_PROC}

--- a/pkgs/development/python-modules/cadquery-ocp/ocp-source.nix
+++ b/pkgs/development/python-modules/cadquery-ocp/ocp-source.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  llvmPackages,
+  fetchFromGitHub,
+  lief,
+  click,
+  path,
+  libclang,
+  toml,
+  pandas,
+  joblib,
+  tqdm,
+  jinja2,
+  toposort,
+  logzero,
+  pyparsing,
+  pybind11,
+  schema,
+  cmake,
+  fmt,
+  rapidjson,
+  libGL,
+  vtk,
+  opencascade-occt,
+}:
+let
+  opencascade-occt' = (
+    opencascade-occt.override {
+      inherit vtk;
+      withVtk = true;
+    }
+  );
+in
+llvmPackages.libcxxStdenv.mkDerivation (finalAttrs: {
+  pname = "ocp-source";
+  version = "7.9.3.1";
+
+  src = fetchFromGitHub {
+    owner = "CadQuery";
+    repo = "OCP";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-TKvJ03WHVuUAMTHLr2KWjKU1rBoSOfpAIxjjpYKN2nQ=";
+  };
+
+  patches = [
+    ./cmake-implicit-include-darwin.patch
+    ./inhert-python-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt --replace-fail \
+      ''\'''${CLANG_INSTALL_PREFIX}/lib/clang/''${LLVM_VERSION_MAJOR}/include/' \
+      '${lib.getLib llvmPackages.libclang}/lib/clang/''${LLVM_VERSION_MAJOR}/include/'
+  '';
+
+  nativeBuildInputs = [
+    lief
+    click
+    path
+    libclang
+    toml
+    pandas
+    joblib
+    tqdm
+    jinja2
+    toposort
+    logzero
+    pyparsing
+    pybind11
+    schema
+    cmake
+  ];
+
+  buildInputs = [
+    fmt
+    rapidjson
+    libGL
+    vtk
+    llvmPackages.libclang
+    llvmPackages.llvm
+    llvmPackages.openmp
+    opencascade-occt'
+  ];
+
+  dontUseCmakeBuildDir = true;
+
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      "-DN_PROC=$NIX_BUILD_CORES"
+    )
+  '';
+
+  installPhase = ''
+    mkdir $out
+    cp OCP/* $out
+  '';
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2393,6 +2393,8 @@ self: super: with self; {
 
   cachy = callPackage ../development/python-modules/cachy { };
 
+  cadquery-ocp = callPackage ../development/python-modules/cadquery-ocp { };
+
   cadwyn = callPackage ../development/python-modules/cadwyn { };
 
   caffe = toPythonModule (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
