### PR TITLE
relay-server: init at 0.9.3; nixos/relay-server: init module; nixosTests.relay-server: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -54,6 +54,8 @@
 
 - [Ente Auth](https://ente.io/auth/), an open source 2FA authenticator, with end-to-end encrypted backups. Available as [programs.ente-auth](#opt-programs.ente-auth.enable).
 
+- [relay-server](https://github.com/No-Instructions/Relay), the server component of the Relay obsidian plugin. Available as [services.relay-server](#opt-services.relay-server.enable).
+
 - [Dawarich](https://dawarich.app/), a self-hostable location history tracker. Available as [services.dawarich](#opt-services.dawarich.enable).
 
 - [Howdy](https://github.com/boltgolt/howdy), a Windows Hello™ style facial authentication program for Linux.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1351,6 +1351,7 @@
   ./services/networking/rdnssd.nix
   ./services/networking/realm.nix
   ./services/networking/redsocks.nix
+  ./services/networking/relay-server.nix
   ./services/networking/resilio.nix
   ./services/networking/robustirc-bridge.nix
   ./services/networking/rosenpass.nix

--- a/nixos/modules/services/networking/relay-server.nix
+++ b/nixos/modules/services/networking/relay-server.nix
@@ -146,13 +146,26 @@ in
         CapabilityBoundingSet = "";
         DevicePolicy = "closed";
         LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
         ProtectClock = true;
         ProtectControlGroups = true;
-        ProtectHostUserNamespaces = true;
+        ProtectHome = true;
+        ProtectHostname = true;
         ProtectKernelLogs = true;
         ProtectKernelModules = true;
         ProtectKernelTunables = true;
         ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;

--- a/nixos/modules/services/networking/relay-server.nix
+++ b/nixos/modules/services/networking/relay-server.nix
@@ -1,0 +1,168 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.relay-server;
+  format = pkgs.formats.toml { };
+
+  configFile = format.generate "relay.toml" cfg.settings;
+in
+{
+  meta.maintainers = with lib.maintainers; [ sweenu ];
+
+  options.services.relay-server = {
+    enable = lib.mkEnableOption "Relay Server, a self-hosted collaboration server for Relay.md";
+
+    package = lib.mkPackageOption pkgs "relay-server" { };
+
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = format.type;
+
+        options = {
+          server = {
+            url = lib.mkOption {
+              type = lib.types.str;
+              example = "http://relay-server.my-network.internal:8080";
+              default = "http://localhost:${builtins.toString cfg.settings.server.port}";
+              defaultText = "http://localhost:8080";
+              description = ''
+                The external URL where the relay server is accessible.
+                This should match the URL you configure in the Relay Obsidian plugin.
+              '';
+            };
+
+            host = lib.mkOption {
+              type = lib.types.str;
+              default = "0.0.0.0";
+              description = "Address to bind to.";
+            };
+
+            port = lib.mkOption {
+              type = lib.types.port;
+              default = 8080;
+              description = "Port to listen on.";
+            };
+          };
+
+          store = lib.mkOption {
+            type = lib.types.attrsOf lib.types.anything;
+            default = {
+              type = "filesystem";
+              path = "/var/lib/relay-server/data";
+            };
+            example = lib.literalExpression ''
+              {
+                type = "aws";
+                bucket = "my-bucket";
+                region = "us-east-1";
+              }
+            '';
+            description = ''
+              Storage backend configuration.
+              Supports `filesystem`, `aws` (S3), `cloudflare` (R2), and other S3-compatible stores.
+            '';
+          };
+
+          auth = lib.mkOption {
+            type = lib.types.listOf (
+              lib.types.submodule {
+                options = {
+                  key_id = lib.mkOption {
+                    type = lib.types.str;
+                    description = "The key identifier.";
+                  };
+                  public_key = lib.mkOption {
+                    type = lib.types.str;
+                    description = "The base64-encoded public key.";
+                  };
+                };
+              }
+            );
+            default = [
+              {
+                key_id = "relay_2025_10_22";
+                public_key = "/6OgBTHaRdWLogewMdyE+7AxnI0/HP3WGqRs/bYBlFg=";
+              }
+              {
+                key_id = "relay_2025_10_23";
+                public_key = "fbm9JLHrwPpST5HAYORTQR/i1VbZ1kdp2ZEy0XpMbf0=";
+              }
+            ];
+            description = ''
+              Authentication keys for the Relay.md control plane.
+              The default keys are the official Relay.md public keys.
+            '';
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Configuration for relay-server in TOML format.
+        See <https://github.com/No-Instructions/relay-server/blob/main/crates/relay.toml.example> for available options.
+      '';
+    };
+
+    environment = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
+      default = { };
+      description = ''
+        Environment variables to set for the relay-server service.
+        Note: Do not use this for secrets; use {option}`environmentFile` instead.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        Path to an environment file containing secrets.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.relay-server = {
+      description = "Relay Server for Relay.md";
+      documentation = [ "https://github.com/No-Instructions/relay-server" ];
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+
+      inherit (cfg) environment;
+
+      serviceConfig = {
+        ExecStart = "${lib.getExe cfg.package} serve --config ${configFile}";
+        StateDirectory = "relay-server";
+        DynamicUser = true;
+        Restart = "on-failure";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) cfg.environmentFile;
+
+        # Hardening
+        AmbientCapabilities = [ "" ];
+        CapabilityBoundingSet = "";
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHostUserNamespaces = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1399,6 +1399,7 @@ in
   redlib = runTest ./redlib.nix;
   redmine = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./redmine.nix { };
   refind = runTest ./refind.nix;
+  relay-server = runTest ./relay-server.nix;
   remark42 = runTest ./remark42.nix;
   renovate = runTest ./renovate.nix;
   repath-studio = runTest ./repath-studio.nix;

--- a/nixos/tests/relay-server.nix
+++ b/nixos/tests/relay-server.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+
+{
+  name = "relay-server";
+  meta.maintainers = with lib.maintainers; [ sweenu ];
+
+  nodes.machine = {
+    services.relay-server = {
+      enable = true;
+    };
+  };
+
+  testScript =
+    let
+      port = 8080;
+    in
+    ''
+      machine.wait_for_unit("relay-server.service")
+      machine.wait_for_open_port(${builtins.toString port})
+      machine.succeed("curl --fail http://localhost:${builtins.toString port}/ready")
+    '';
+}

--- a/pkgs/by-name/re/relay-server/package.nix
+++ b/pkgs/by-name/re/relay-server/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "relay-server";
+  version = "0.9.3";
+
+  src = fetchFromGitHub {
+    owner = "No-Instructions";
+    repo = "relay-server";
+    rev = finalAttrs.version;
+    hash = "sha256-9UhyRJ10JthiZM1ipXNp5UrzXXmUwfMkEYE3ecddgM8=";
+  };
+
+  sourceRoot = "${finalAttrs.src.name}/crates";
+
+  cargoHash = "sha256-r69vyDokrexfaZ655J6kTWJfZRl1BiV/1LmkzVgLirY=";
+
+  cargoBuildFlags = [
+    "--package"
+    "relay"
+  ];
+
+  cargoTestFlags = [
+    "--package"
+    "relay"
+  ];
+
+  # Sets the value of the "relay-server-version" HTTP response header
+  env.GIT_VERSION = finalAttrs.version;
+
+  meta = {
+    description = "Self-hosted document collaboration server for Relay.md";
+    homepage = "https://github.com/No-Instructions/relay-server";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sweenu ];
+    mainProgram = "relay";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/re/relay-server/package.nix
+++ b/pkgs/by-name/re/relay-server/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
@@ -31,6 +32,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   # Sets the value of the "relay-server-version" HTTP response header
   env.GIT_VERSION = finalAttrs.version;
+
+  passthru.tests.nixos = nixosTests.relay-server;
 
   meta = {
     description = "Self-hosted document collaboration server for Relay.md";


### PR DESCRIPTION
This is the server component of https://relay.md/ to self-host your own relay.

Questions for reviewers:
- I put the service in `networking`, I'm not sure if it's the best place as it is specific to obsidian. But I think it should go in the same place we would put https://github.com/jamsocket/y-sweet in if we were to create a module for it, as it is based on that.
- relay-server is the right name, but it's quite generic for something specific to obsidian. What do you think?
- I put 8080 as the default port, but I wonder if it should be 80 instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
