### PR TITLE
weathr: init at 1.3.0

### DIFF
--- a/pkgs/by-name/we/weathr/package.nix
+++ b/pkgs/by-name/we/weathr/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  pkg-config,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "weathr";
+  version = "1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Veirt";
+    repo = "weathr";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JwI5a+O5Nu39Nr0st5yBLTM5kPLC8UIGAoBMqxnOOl4=";
+  };
+
+  cargoHash = "sha256-Yj1WxpOLL8GiVpCebPZQgdw+L9g+4CNY7n2z8PJQz4k=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  checkFlags = [
+    # network dependent tests
+    "--skip=weather_client_integration_test"
+    "--skip=test_cache_invalidation"
+    "--skip=test_weather_client_integration_realistic_weather_ranges"
+    "--skip=test_weather_client_integration_cache_behavior"
+    "--skip=test_weather_client_integration_cache_invalidation"
+  ];
+
+  meta = {
+    changelog = "https://github.com/Veirt/weathr/releases/tag/v${finalAttrs.version}";
+    description = "Terminal weather app with ASCII animations driven by real-time weather data";
+    homepage = "https://github.com/Veirt/weathr";
+    license = lib.licenses.mit;
+    mainProgram = "weathr";
+    maintainers = with lib.maintainers; [ phanirithvij ];
+  };
+})


### PR DESCRIPTION
closes #489687

Don't merge this until we hear from the above PR's author. (for a reasonable amount of time)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core"
        functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in
      `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and
      other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage
[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
