### PR TITLE
nixos/security.acme: add settings to enable external account binding

### DIFF
--- a/nixos/modules/security/acme/default.nix
+++ b/nixos/modules/security/acme/default.nix
@@ -252,6 +252,13 @@ let
             "--http.port"
             data.listenHTTP
           ]
+        else if data.eabKeyId != null then
+          [
+            "--eab"
+            "--kid"
+            data.eabKeyId
+            "--tls"
+          ]
         else
           [
             "--http"
@@ -751,6 +758,15 @@ let
           '';
         };
 
+        eabKeyId = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            External Account Binding (EAB) key ID for challenge-free certificates.
+            The MAC key of the external CA needs to be provided via `credentialFiles` as "LEGO_EAB_HMAC_FILE".
+          '';
+        };
+
         environmentFile = lib.mkOption {
           type = lib.types.nullOr lib.types.path;
           inherit (defaultAndText "environmentFile" null) default defaultText;
@@ -768,9 +784,10 @@ let
           inherit (defaultAndText "credentialFiles" { }) default defaultText;
           description = ''
             Environment variables suffixed by "_FILE" to set for the cert's service
-            for your selected dnsProvider.
+            for your selected dnsProvider or eabKeyId.
             To find out what values you need to set, consult the documentation at
-            <https://go-acme.github.io/lego/dns/> for the corresponding dnsProvider.
+            <https://go-acme.github.io/lego/dns/> for the corresponding dnsProvider or set
+            `LEGO_EAB_HMAC_FILE` for the EAB key.
             This allows to securely pass credential files to lego by leveraging systemd
             credentials.
           '';
@@ -1110,6 +1127,13 @@ in
                 and remove the wildcard from the path.
               '';
             }
+            {
+              assertion = data.eabKeyId != null -> builtins.hasAttr "LEGO_EAB_HMAC_FILE" data.credentialFiles;
+              message = ''
+                If `eabKeyId` is set and external account binding is requested,
+                the secret key must be provided as `security.acme.certs.${cert}.credentialFiles.LEGO_EAB_HMAC_FILE`.
+              '';
+            }
             (
               let
                 exclusiveAttrs = {
@@ -1118,6 +1142,7 @@ in
                     webroot
                     listenHTTP
                     s3Bucket
+                    eabKeyId
                     ;
                 };
               in
@@ -1129,6 +1154,7 @@ in
                   `security.acme.certs.${cert}.webroot`,
                   `security.acme.certs.${cert}.listenHTTP` and
                   `security.acme.certs.${cert}.s3Bucket`
+                  `security.acme.certs.${cert}.eabKeyId`
                   is required.
                   Current values: ${(lib.generators.toPretty { } exclusiveAttrs)}.
                 '';


### PR DESCRIPTION
This adds the option to allow usage of external account binding (EAB) in `security.acme`, thus not requiring a DNS, HTTP or S3 challenge. LEGO's EAB options are documented here <https://go-acme.github.io/lego/usage/cli/options/> . This is useful, for example, for obtaining certificates from Harica in the European research networks <https://doku.tid.dfn.de/de:dfnpki:tcs:2025:acme> . 

Tested implementation in our compute centre and confirmed to work so far.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
