### PR TITLE
nf-test: 0.9.3 -> 0.9.4

### DIFF
--- a/pkgs/by-name/nf/nf-test/package.nix
+++ b/pkgs/by-name/nf/nf-test/package.nix
@@ -4,18 +4,18 @@
   makeWrapper,
   nextflow,
   nf-test,
-  openjdk11,
+  openjdk17,
   stdenv,
   testers,
 }:
 stdenv.mkDerivation (finalAttrs: {
 
   pname = "nf-test";
-  version = "0.9.3";
+  version = "0.9.4";
 
   src = fetchurl {
     url = "https://github.com/askimed/nf-test/releases/download/v${finalAttrs.version}/nf-test-${finalAttrs.version}.tar.gz";
-    hash = "sha256-LLylgv34HiMXg+sjBbMdeLVPMV5+h+Z2xEWCiBqbNEY=";
+    hash = "sha256-A9k8HVIPqbfHZKqSY2wqOhgvZ9aSb3K4SdoLOypB2j8=";
   };
   sourceRoot = ".";
 
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm644 nf-test.jar $out/share/nf-test
 
     mkdir -p $out/bin
-    makeWrapper ${openjdk11}/bin/java $out/bin/nf-test \
+    makeWrapper ${openjdk17}/bin/java $out/bin/nf-test \
       --add-flags "-jar $out/share/nf-test/nf-test.jar" \
       --prefix PATH : ${lib.makeBinPath [ nextflow ]} \
 


### PR DESCRIPTION
This PR
Closes https://github.com/NixOS/nixpkgs/pull/489920.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
