### PR TITLE
cfspeedtest: 2.0.3 -> 2.2.0

### DIFF
--- a/pkgs/by-name/cf/cfspeedtest/package.nix
+++ b/pkgs/by-name/cf/cfspeedtest/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cfspeedtest";
-  version = "2.0.3";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "code-inflation";
     repo = "cfspeedtest";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-KeJ/p9kXfI3OuAyNUx2C6DKpmtL3239uHpWAf4mDr4Q=";
+    hash = "sha256-EVZFmTjv2j7kax4MC5HTkVa7/IiDNZcIOgsntSGfzG4=";
   };
 
-  cargoHash = "sha256-mXSbbY3nuhEw+QUk6gt71HIh2gKNBO6C0trZbyzbpnM=";
+  cargoHash = "sha256-cA+eRVZiZL+bbPc+Vr7nkwMLbQBKOO3uU0XzrxVajqg=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -27,6 +27,18 @@ rustPlatform.buildRustPackage (finalAttrs: {
       --fish <($out/bin/cfspeedtest --generate-completion fish) \
       --zsh <($out/bin/cfspeedtest --generate-completion zsh)
   '';
+
+  # require internet access
+  checkFlags = map (t: "--skip=${t}") [
+    "speedtest::tests::test_fetch_metadata_integration"
+    "speedtest::tests::test_run_tests_does_not_retry_non_retryable_4xx"
+    "speedtest::tests::test_run_tests_retries_429_and_records_success"
+    "speedtest::tests::test_run_tests_retry_delay_resets_after_success"
+    "speedtest::tests::test_run_tests_retry_delay_uses_retry_streak_not_total_attempts"
+    "speedtest::tests::test_run_tests_stops_after_max_attempts_on_retryable_failures"
+    "speedtest::tests::test_upload_duration_excludes_delayed_response_body"
+    "speedtest::tests::test_upload_retryable_failure_parses_retry_after_without_drain_skew"
+  ];
 
   meta = {
     description = "Unofficial CLI for speed.cloudflare.com";


### PR DESCRIPTION
Diff: https://github.com/code-inflation/cfspeedtest/compare/v2.0.3...v2.2.0

Changelog: https://github.com/code-inflation/cfspeedtest/releases/tag/v2.2.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
