### PR TITLE
vortex: init at 2.4.0

### DIFF
--- a/pkgs/by-name/vo/vortex/package.nix
+++ b/pkgs/by-name/vo/vortex/package.nix
@@ -1,0 +1,368 @@
+{
+  lib,
+  stdenv,
+  autoPatchelfHook,
+  copyDesktopItems,
+  dotnetCorePackages,
+  electron_43,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  fetchpatch,
+  fetchurl,
+  fontconfig,
+  gitMinimal,
+  makeDesktopItem,
+  makeWrapper,
+  node-gyp,
+  nodejs_24,
+  pnpm_11,
+  pnpmConfigHook,
+  pkg-config,
+  python3,
+  steam-run-free,
+  writeShellScript,
+}:
+
+let
+  pnpm = pnpm_11.override { nodejs-slim = nodejs_24; };
+  electron = electron_43;
+
+  levelPivot = fetchurl {
+    url = "https://nexus-mods.github.io/duckdb-level-pivot/current_release/v1.5.1/linux_amd64/level_pivot.duckdb_extension.gz";
+    hash = "sha256-+CKjeCbhl1VXrv+7MPwaea1KEEi0VaQpugtr8DEBMGU=";
+  };
+
+  # FIXME: Upstream's pnpm-lock currently contains multiple Nexus-Mods/7z-bin pins.
+  # Most are handled correctly by pnpm-github-dependencies, however this one is not:
+  #
+  # TODO: Replace all `Nexus-Mods/7z-bin` dependencies with a Nix-provided compatibility
+  # package that exports the path to pkgs._7zz (or pkgs._7zz-rar if targeting `unfree`).
+  # See https://github.com/Nexus-Mods/7z-bin/blob/master/index.js
+  legacy7zDependency = fetchurl {
+    name = "7z-bin-legacy.tar.gz";
+    url = "https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/025786f01319526b56400b0410af6268adc1125c";
+    hash = "sha256-Tf84krgoWQSh/1yH0DO5Fik83fTq1iYkguZVQwxKAXw=";
+    meta = gitDependencyMetaOverrides."Nexus-Mods/7z-bin";
+  };
+
+  dotnetProbe = writeShellScript "dotnetprobe" ''
+    requiredMajor="''${1:-9}"
+    version=""
+    while read -r runtime candidate _; do
+      if [[ "$runtime" == "Microsoft.NETCore.App" ]]; then
+        version="$candidate"
+      fi
+    done < <(${dotnetCorePackages.runtime_9_0}/bin/dotnet --list-runtimes)
+    if [[ -z "$version" ]]; then
+      echo "Error: Could not find the .NET runtime" >&2
+      exit 1
+    fi
+    actualMajor="''${version%%.*}"
+    if (( actualMajor < requiredMajor )); then
+      echo "Error: Requires .NET $requiredMajor or higher but found .NET $version" >&2
+      exit 1
+    fi
+    echo "Success: Found .NET $version"
+  '';
+
+  gitDependencyMetaOverrides = {
+    "Nexus-Mods/7z-bin" = {
+      license = with lib.licenses; [
+        lgpl2Plus
+        bsd3
+        unfreeRedistributable
+      ];
+    };
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vortex";
+  version = "2.4.0";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Nexus-Mods";
+    repo = "Vortex";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-d27HT1w5NlQ4eS5OcotlNmimGbhDV3kCz34J/qHxUD8=";
+  };
+
+  patches = [
+    # Backport the upstream fix that makes API type generation reproducible.
+    (fetchpatch {
+      url = "https://github.com/Nexus-Mods/Vortex/commit/012a3ca7ddc50607aff8df38e092255ee577d949.patch";
+      hash = "sha256-MGOCJyYEV/PRu4D12QuuVW9JQPYndKEITd87QRn7raQ=";
+    })
+  ];
+
+  pnpmDeps = fetchPnpmDeps {
+    pname = "${finalAttrs.pname}-pnpm-deps";
+    inherit (finalAttrs) version src;
+    inherit pnpm;
+    fetcherVersion = 4;
+    hash = "sha256-iTeMC/DnMwKN3DhWMikywKcrExmmAcYl6tzmCPt7noY=";
+  };
+
+  # pnpm's deploy command needs the original archives for Git-hosted
+  # dependencies. fetchPnpmDeps installs their contents but does not retain
+  # those archives in the form deploy expects.
+  gitDependencies = lib.forEach (lib.importJSON ./pnpm-github-dependencies.json) (dep: {
+    inherit (dep) repository revision;
+    archive = fetchurl {
+      inherit (dep) url hash;
+      name = "${lib.replaceString "/" "-" dep.repository}.tar.gz";
+      meta = gitDependencyMetaOverrides.${dep.repository} or { };
+    };
+  });
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    copyDesktopItems
+    gitMinimal
+    makeWrapper
+    node-gyp
+    nodejs_24
+    pnpm
+    pnpmConfigHook
+    pkg-config
+    (python3.withPackages (ps: [ ps.setuptools ]))
+  ];
+
+  buildInputs = [
+    fontconfig
+    (lib.getLib stdenv.cc.cc)
+  ];
+
+  env = {
+    CI = "1";
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    NO_PARALLEL = "1";
+    NX_DAEMON = "false";
+    NX_TASKS_RUNNER_DYNAMIC_OUTPUT = "false";
+    PNPM_CONFIG_REPORTER = "append-only";
+    VORTEX_SKIP_SUBMODULES = "1";
+    VORTEX_VERSION = finalAttrs.version;
+    npm_config_runtime = "electron";
+    npm_config_target = electron.version;
+    npm_config_nodedir = electron.headers;
+  };
+
+  postPatch = ''
+    pinGitDependency() {
+      local repository="$1"
+      local revision="$2"
+      local archive="$3"
+
+      substituteInPlace pnpm-workspace.yaml \
+        --replace-fail \
+          "github:$repository#$revision" \
+          "file:$archive"
+      substituteInPlace pnpm-lock.yaml \
+        --replace-fail \
+          "github:$repository#$revision" \
+          "file:$archive" \
+        --replace-fail \
+          "https://codeload.github.com/$repository/tar.gz/$revision" \
+          "file:$archive"
+    }
+
+    ${lib.concatMapStringsSep "\n" (
+      dep:
+      lib.escapeShellArgs [
+        "pinGitDependency"
+        dep.repository
+        dep.revision
+        dep.archive
+      ]
+    ) finalAttrs.gitDependencies}
+
+    # Special case for 7zip:
+    substituteInPlace pnpm-lock.yaml \
+      --replace-fail \
+        "https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/025786f01319526b56400b0410af6268adc1125c" \
+        "file:${legacy7zDependency}"
+
+    substituteInPlace src/main/package.json \
+      --replace-fail '"version": "1.0.0"' '"version": "${finalAttrs.version}"'
+
+    # Generic Linux Proton binaries need NixOS' FHS runner.
+    substituteInPlace src/renderer/src/util/linux/proton.ts \
+      --replace-fail \
+        'executable: path.join(protonPath, "proton"),' \
+        'executable: process.env.VORTEX_PROTON_WRAPPER || path.join(protonPath, "proton"),' \
+      --replace-fail \
+        'args: ["run", exePath, ...args],' \
+        'args: process.env.VORTEX_PROTON_WRAPPER ? [path.join(protonPath, "proton"), "run", exePath, ...args] : ["run", exePath, ...args],'
+
+    # Only prepare the extension used by the Linux build.
+    substituteInPlace src/main/duckdb-extensions.json \
+      --replace-fail \
+        '"platforms": ["windows_amd64", "linux_amd64"]' \
+        '"platforms": ["linux_amd64"]'
+
+    mkdir -p src/main/build/duckdb-extensions/v1.5.1/linux_amd64
+    gzip -dc ${levelPivot} > src/main/build/duckdb-extensions/v1.5.1/linux_amd64/level_pivot.duckdb_extension
+
+    # This is equivalent to upstream's small, network-built .NET version probe.
+    mkdir -p tools/dotnetprobe/dist
+    cp ${dotnetProbe} tools/dotnetprobe/dist/dotnetprobe
+    substituteInPlace tools/dotnetprobe/project.json \
+      --replace-fail \
+        '"command": "pnpm exec node ./build.mjs"' \
+        '"command": "test -x ./dist/dotnetprobe"'
+
+    # These optional integrations fetch unversioned Windows executables during
+    # their builds. Do not perform those downloads in the Nix sandbox.
+    substituteInPlace extensions/mtframework-arc-support/package.json \
+      --replace-fail \
+        '"build": "node build.mjs && node download_arctool.js && pnpm extractInfo"' \
+        '"build": "node build.mjs && pnpm extractInfo"'
+    substituteInPlace extensions/quickbms-support/package.json \
+      --replace-fail \
+        '"build": "node build.mjs && node download_dependencies.js && pnpm extractInfo"' \
+        '"build": "node build.mjs && pnpm extractInfo"'
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    node-gyp rebuild \
+      --directory extensions/theme-switcher/node_modules/font-scanner
+
+    pnpm cross-env NODE_ENV=production \
+      pnpm nx run @vortex/main:build --output-style=stream --parallel=1
+
+    # Do not bundle plugins that cannot be built reproducibly on Linux.
+    rm -rf \
+      src/main/build/bundledPlugins/gamebryo-archive-check \
+      src/main/build/bundledPlugins/gamebryo-plugin-indexlock \
+      src/main/build/bundledPlugins/mtframework-arc-support \
+      src/main/build/bundledPlugins/quickbms-support
+
+    pushd src/main
+    pnpm cross-env \
+      pnpm_config_inject_workspace_packages=true \
+      pnpm_config_ignore_scripts=true \
+      pnpm_config_node_linker=hoisted \
+      pnpm_config_offline=true \
+      pnpm -F @vortex/main deploy ./dist
+    node dist/prepare-dist-package.mjs
+
+    pushd dist
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    ../node_modules/.bin/electron-builder \
+      --config ./electron-builder.config.json \
+      --publish never \
+      --linux dir \
+      --x64 \
+      -c.electronDist=electron-dist \
+      -c.electronVersion=${electron.version} \
+      -c.compression=store
+    popd
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/vortex"
+    cp -r dist/linux-unpacked/resources "$out/share/vortex/"
+    find "$out/share/vortex" -type f -name '*.musl.node' -delete
+    install -Dm755 ${dotnetProbe} \
+      "$out/share/vortex/resources/app.asar.unpacked/assets/dotnetprobe"
+
+    makeWrapper ${lib.getExe electron} "$out/bin/vortex" \
+      --add-flags "$out/share/vortex/resources/app.asar" \
+      --unset ELECTRON_RUN_AS_NODE \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          (lib.getLib stdenv.cc.cc)
+          stdenv.cc.cc.libgcc
+        ]
+      } \
+      --set DOTNET_ROOT ${dotnetCorePackages.runtime_9_0}/share/dotnet \
+      --set ELECTRON_TRASH gio \
+      --set IGNORE_UPDATES yes \
+      --set VORTEX_PROTON_WRAPPER ${lib.getExe steam-run-free} \
+      --inherit-argv0
+
+    makeWrapper "$out/bin/vortex" "$out/bin/vortex-nxm" \
+      --add-flags --download
+
+    install -Dm644 assets/images/vortex.png \
+      "$out/share/icons/hicolor/256x256/apps/vortex.png"
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    restoreDuckDbExtension() {
+      # DuckDB verifies a signed metadata footer. patchelf changes the file and
+      # invalidates that footer, so restore it after autoPatchelf has run.
+      gzip -dc ${levelPivot} > \
+        "$out/share/vortex/resources/app.asar.unpacked/duckdb-extensions/v1.5.1/linux_amd64/level_pivot.duckdb_extension"
+    }
+    postFixupHooks+=(restoreDuckDbExtension)
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vortex";
+      desktopName = "Vortex";
+      genericName = "Mod Manager";
+      comment = "Mod manager for PC games from Nexus Mods";
+      exec = "vortex";
+      icon = "vortex";
+      categories = [
+        "Game"
+      ];
+      startupWMClass = "Vortex";
+      keywords = [
+        "mod"
+        "mods"
+        "modding"
+        "nexus"
+        "games"
+      ];
+    })
+    (makeDesktopItem {
+      name = "vortex-nxm";
+      desktopName = "Vortex NXM Handler";
+      noDisplay = true;
+      exec = "vortex-nxm %u";
+      mimeTypes = [ "x-scheme-handler/nxm" ];
+    })
+  ];
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Open-source mod manager from Nexus Mods";
+    homepage = "https://github.com/Nexus-Mods/Vortex";
+    changelog = "https://github.com/Nexus-Mods/Vortex/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "vortex";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+    maintainers = with lib.maintainers; [
+      caniko
+      MattSturgeon
+    ];
+    longDescription = ''
+      Vortex's native Linux build is pre-alpha software. It lacks some of the
+      features available in the Windows build, including complete Wine/Proton
+      integration and portal-backed file pickers. The ArcTool and QuickBMS
+      integrations are omitted because upstream does not provide versioned
+      artifacts for their bundled Windows executables.
+    '';
+  };
+})

--- a/pkgs/by-name/vo/vortex/package.nix
+++ b/pkgs/by-name/vo/vortex/package.nix
@@ -187,6 +187,12 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace src/main/package.json \
       --replace-fail '"version": "1.0.0"' '"version": "${finalAttrs.version}"'
 
+    # Packaged NXM handler is vortex-nxm.desktop; do not write a user-local one.
+    substituteInPlace src/renderer/src/util/protocolRegistration/linux/nxm.ts \
+      --replace-fail \
+        'return process.defaultApp === true || process.env.NODE_ENV === "development";' \
+        'return false;'
+
     # Generic Linux Proton binaries need NixOS' FHS runner.
     substituteInPlace src/renderer/src/util/linux/proton.ts \
       --replace-fail \
@@ -346,7 +352,10 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Open-source mod manager from Nexus Mods";
     homepage = "https://github.com/Nexus-Mods/Vortex";
     changelog = "https://github.com/Nexus-Mods/Vortex/releases/tag/v${finalAttrs.version}";
-    license = lib.licenses.gpl3Only;
+    license = with lib.licenses; [
+      gpl3Only
+      unfreeRedistributable
+    ];
     mainProgram = "vortex";
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [

--- a/pkgs/by-name/vo/vortex/pnpm-github-dependencies.json
+++ b/pkgs/by-name/vo/vortex/pnpm-github-dependencies.json
@@ -1,0 +1,104 @@
+[
+  {
+    "repository": "Nexus-Mods/7z-bin",
+    "revision": "3298c42e69e3220dc39694bc2f610c077c3e213a",
+    "url": "https://codeload.github.com/Nexus-Mods/7z-bin/tar.gz/3298c42e69e3220dc39694bc2f610c077c3e213a",
+    "hash": "sha256-HuodRQNR/gk2fLwpR2jCUyZ04Vphyyqu9eGrjCURb1Q="
+  },
+  {
+    "repository": "Nexus-Mods/modmeta-db",
+    "revision": "daa8935b6e38e255ec192c908adfce35d47c0336",
+    "url": "https://codeload.github.com/Nexus-Mods/modmeta-db/tar.gz/daa8935b6e38e255ec192c908adfce35d47c0336",
+    "hash": "sha256-c5cdf4NjVjS80YPy3PgOL3bGx3o1zq4002FbzDUmg6w="
+  },
+  {
+    "repository": "Nexus-Mods/node-7z",
+    "revision": "b75def8d0d7d81a03f4526c52b8ada9a34a06479",
+    "url": "https://codeload.github.com/Nexus-Mods/node-7z/tar.gz/b75def8d0d7d81a03f4526c52b8ada9a34a06479",
+    "hash": "sha256-FuW4hYtlikimOenyfGQTH+SJGiZHz4Jqo9lvRW17vjo="
+  },
+  {
+    "repository": "Nexus-Mods/node-bsatk",
+    "revision": "5a3d15fae2177bfb0a42b794d3afb21eda563c59",
+    "url": "https://codeload.github.com/Nexus-Mods/node-bsatk/tar.gz/5a3d15fae2177bfb0a42b794d3afb21eda563c59",
+    "hash": "sha256-4P+1q4VzlZjYp7kZAap7dNWD5uYJZDdXVE5oPJ9Glv4="
+  },
+  {
+    "repository": "Nexus-Mods/node-loot",
+    "revision": "7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d",
+    "url": "https://codeload.github.com/Nexus-Mods/node-loot/tar.gz/7b6028fb2caeb3a2af6a0c3d68630c033cc01e8d",
+    "hash": "sha256-urVFBjm5XqTZwK6INn0se5sLYWHX92HkSQoloOlzSk4="
+  },
+  {
+    "repository": "Nexus-Mods/node-nexus-api",
+    "revision": "97ad222d2d7aca05e581390eb85be9af22833fba",
+    "url": "https://codeload.github.com/Nexus-Mods/node-nexus-api/tar.gz/97ad222d2d7aca05e581390eb85be9af22833fba",
+    "hash": "sha256-kPj+n6aWLV3JSxiO9aY98UJ+QWeaj6Ft41yCfrvsQVE="
+  },
+  {
+    "repository": "Nexus-Mods/node-permissions",
+    "revision": "7c1b6f1d6437f2238be51316de823b0fbd63e4c0",
+    "url": "https://codeload.github.com/Nexus-Mods/node-permissions/tar.gz/7c1b6f1d6437f2238be51316de823b0fbd63e4c0",
+    "hash": "sha256-/nn4Oqyjb44Xcrn9aXP7nzWqbOJFBLajr43uvgDNZMY="
+  },
+  {
+    "repository": "Nexus-Mods/node-turbowalk",
+    "revision": "3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f",
+    "url": "https://codeload.github.com/Nexus-Mods/node-turbowalk/tar.gz/3502f6ffc3f9eb55fe1c9c097b4e4772edce0c0f",
+    "hash": "sha256-WGBjYDSPSWCXumCLEucsSkP1KDlpyfWSbZLHCRQ5rlg="
+  },
+  {
+    "repository": "Nexus-Mods/node-wholocks",
+    "revision": "28da3bcf312312e577d7c636799a59011998b4af",
+    "url": "https://codeload.github.com/Nexus-Mods/node-wholocks/tar.gz/28da3bcf312312e577d7c636799a59011998b4af",
+    "hash": "sha256-91HdT9u4HFPfMQ4XIFIdLwwpqX1/w5RP+PS2Fn0TnNo="
+  },
+  {
+    "repository": "Nexus-Mods/node-winapi-bindings",
+    "revision": "faa92afe3320731e98abc15b3f5f19c60896d7c1",
+    "url": "https://codeload.github.com/Nexus-Mods/node-winapi-bindings/tar.gz/faa92afe3320731e98abc15b3f5f19c60896d7c1",
+    "hash": "sha256-WlxKvxhD4AnyIXBLFI+a0jSQfixZcd9LfMIAqhkaXFQ="
+  },
+  {
+    "repository": "Nexus-Mods/vdf-parser",
+    "revision": "df279ff89cb480597544d3029e12f90cb8c79464",
+    "url": "https://codeload.github.com/Nexus-Mods/vdf-parser/tar.gz/df279ff89cb480597544d3029e12f90cb8c79464",
+    "hash": "sha256-5sqqSD31iyw4Bszja60rBgu9GRy3jqzwLYmxxdRHFQs="
+  },
+  {
+    "repository": "Nexus-Mods/vortex-parse-ini",
+    "revision": "2425af99d1cff2331ccf3aacfa892c314e99e18d",
+    "url": "https://codeload.github.com/Nexus-Mods/vortex-parse-ini/tar.gz/2425af99d1cff2331ccf3aacfa892c314e99e18d",
+    "hash": "sha256-UiHVe8JABfoFHS55dpa/bczKeRhJA3w53oPQSCzDIqM="
+  },
+  {
+    "repository": "TanninOne/bbcode-to-react",
+    "revision": "c67356006470e5066ea447e04a3968dca367339d",
+    "url": "https://codeload.github.com/TanninOne/bbcode-to-react/tar.gz/c67356006470e5066ea447e04a3968dca367339d",
+    "hash": "sha256-O2Ci2XoOEeKIfdhx3xwT8/N0Pvj5GoodLlUzyLJYDyk="
+  },
+  {
+    "repository": "TanninOne/drivelist",
+    "revision": "720d1890db11482ec05fc0f6aa176cfa6e6844dd",
+    "url": "https://codeload.github.com/TanninOne/drivelist/tar.gz/720d1890db11482ec05fc0f6aa176cfa6e6844dd",
+    "hash": "sha256-AqIpcybiGYo9MZT/VRah0YqB2cslp5elgyLWisEBTUQ="
+  },
+  {
+    "repository": "TanninOne/electron-redux",
+    "revision": "66bbd9d389579806e8c4ebd87bd513a668cc64a8",
+    "url": "https://codeload.github.com/TanninOne/electron-redux/tar.gz/66bbd9d389579806e8c4ebd87bd513a668cc64a8",
+    "hash": "sha256-2aSewOSJbBw/JiJ0rlbVkZlGioJaQoDssCnrz3oyYzY="
+  },
+  {
+    "repository": "TanninOne/rimraf",
+    "revision": "7b8b70d4e8783cd233fca3283cf1f930af4e39c2",
+    "url": "https://codeload.github.com/TanninOne/rimraf/tar.gz/7b8b70d4e8783cd233fca3283cf1f930af4e39c2",
+    "hash": "sha256-G2qc0YFw/zBg5lFD/bWCtVu+KU49JvWSIQFRtako7U8="
+  },
+  {
+    "repository": "foi/node-json-socket",
+    "revision": "d56c8e2938fa4284c4001b815d9b6e4a92b5c07b",
+    "url": "https://codeload.github.com/foi/node-json-socket/tar.gz/d56c8e2938fa4284c4001b815d9b6e4a92b5c07b",
+    "hash": "sha256-4UVoPGNh1lH2FVa5yFhkgdjzUhWcejWYfhYfBCrlY8s="
+  }
+]

--- a/pkgs/by-name/vo/vortex/pnpm-github-lock.py
+++ b/pkgs/by-name/vo/vortex/pnpm-github-lock.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i python3 -p nix python3 python3Packages.pyyaml cacert
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+GITHUB_SPECIFIER = re.compile(r"^github:(?P<repository>[^#]+)#(?P<revision>[0-9a-f]+)$")
+
+
+@dataclass(frozen=True, order=True)
+class GitDependency:
+    repository: str
+    revision: str
+
+    @property
+    def url(self) -> str:
+        return f"https://codeload.github.com/{self.repository}/tar.gz/{self.revision}"
+
+
+@dataclass(frozen=True, order=True)
+class LockedGitDependency:
+    repository: str
+    revision: str
+    url: str
+    hash: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--lockfile",
+        type=Path,
+        help="Existing pnpm-lock.yaml (skips nix-build)",
+    )
+
+    parser.add_argument(
+        "--attr",
+        default=os.getenv("UPDATE_NIX_ATTR_PATH", "vortex") + ".src",
+        help="Nix attribute built for 'src'",
+    )
+
+    parser.add_argument(
+        "--nixpkgs",
+        type=Path,
+        default=Path(__file__).parents[4],
+        help="Nixpkgs to evaluate for --attr",
+    )
+
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path(__file__).with_name("pnpm-github-dependencies.json"),
+        help="Output JSON lockfile",
+    )
+
+    return parser.parse_args()
+
+
+def iter_objects(node: Any):
+    stack = [node]
+
+    while stack:
+        node = stack.pop()
+
+        if isinstance(node, Mapping):
+            yield node
+            stack.extend(reversed(tuple(node.values())))
+        elif isinstance(node, (list, tuple)):
+            stack.extend(reversed(list(node)))
+
+
+def iter_git_dependencies(document: Any):
+    seen: set[GitDependency] = set()
+
+    for obj in iter_objects(document):
+        if not isinstance(specifier := obj.get("specifier"), str):
+            continue
+
+        if (match := GITHUB_SPECIFIER.fullmatch(specifier)) is None:
+            continue
+
+        dep = GitDependency(
+            repository=match["repository"],
+            revision=match["revision"],
+        )
+
+        if dep in seen:
+            continue
+
+        seen.add(dep)
+        yield dep
+
+
+def resolve_lockfile(nixpkgs: Path, attr: str) -> Path:
+    src = subprocess.run(
+        [
+            "nix-build",
+            nixpkgs,
+            "--no-out-link",
+            "--attr",
+            attr,
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout.strip()
+
+    return Path(src) / "pnpm-lock.yaml"
+
+
+def prefetch(dep: GitDependency) -> LockedGitDependency:
+    result = subprocess.run(
+        [
+            "nix",
+            "store",
+            "prefetch-file",
+            "--json",
+            dep.url,
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    ).stdout
+
+    return LockedGitDependency(
+        repository=dep.repository,
+        revision=dep.revision,
+        url=dep.url,
+        hash=json.loads(result)["hash"],
+    )
+
+
+def generate_lockfile(lockfile: Path) -> list[LockedGitDependency]:
+    with lockfile.open() as f:
+        deps = (
+            dep
+            for document in yaml.safe_load_all(f)
+            for dep in iter_git_dependencies(document)
+        )
+
+        with ThreadPoolExecutor() as executor:
+            return sorted(executor.map(prefetch, deps))
+
+
+def write_lockfile(entries, output: Path) -> None:
+    with output.open("w") as f:
+        json.dump(
+            [asdict(entry) for entry in entries],
+            f,
+            indent=2,
+        )
+        f.write("\n")
+
+
+def main() -> int:
+    args = parse_args()
+
+    lockfile = args.lockfile or resolve_lockfile(args.nixpkgs, args.attr)
+    entries = generate_lockfile(lockfile)
+    write_lockfile(entries, args.output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/by-name/vo/vortex/update.sh
+++ b/pkgs/by-name/vo/vortex/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p nix-update
+
+set -eu -o pipefail
+
+scriptDir=$(cd "${BASH_SOURCE[0]%/*}" && pwd)
+nixpkgs=$(realpath "$scriptDir"/../../../..)
+cd "$nixpkgs"
+
+# Normalize update variables, usually provided by the update shell
+export UPDATE_NIX_ATTR_PATH="${UPDATE_NIX_ATTR_PATH:-vortex}"
+if [ -z "${UPDATE_NIX_OLD_VERSION:-}" ]; then
+  UPDATE_NIX_OLD_VERSION=$(nix-instantiate --raw --eval -A "$UPDATE_NIX_ATTR_PATH.version")
+fi
+if [ -z "${UPDATE_NIX_PNAME:-}" ]; then
+  UPDATE_NIX_PNAME=$(nix-instantiate --raw --eval -A "$UPDATE_NIX_ATTR_PATH.pname")
+fi
+if [ -z "${UPDATE_NIX_NAME:-}" ]; then
+  UPDATE_NIX_NAME=$(nix-instantiate --raw --eval -A "$UPDATE_NIX_ATTR_PATH.name")
+fi
+export UPDATE_NIX_ATTR_PATH UPDATE_NIX_OLD_VERSION UPDATE_NIX_PNAME UPDATE_NIX_NAME
+
+# Do the actual update
+nix-update
+"$scriptDir/pnpm-github-lock.py"


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in `nixos/tests`.
  - [ ] Package tests at `passthru.tests`.
  - [ ] Tests in `lib/tests` or `pkgs/test`.
- [x] Ran `nixpkgs-review` on this PR.
- [x] Verified the `vortex` and `vortex-nxm` launchers, `app.asar`, and both desktop entries.
- [x] Fits `CONTRIBUTING.md`, `pkgs/README.md`, `maintainers/README.md`, and other READMEs.

This is a package-only addition; it does not add a NixOS module.

Vortex is built from source with pinned pnpm 11 dependencies. The package backports upstream's checked-in Nexus API OpenAPI schema so API type generation runs offline and reproducibly in the Nix build.

Vortex's native Linux build is pre-alpha software. It lacks some features available in the Windows build, including complete Wine/Proton integration and portal-backed file pickers. The ArcTool and QuickBMS integrations are omitted because upstream does not provide versioned artifacts for their bundled Windows executables.

### Resolves

#147228
