### PR TITLE
Revert "tree-sitter: 0.25.10 → 0.26.3"

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -103,17 +103,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tree-sitter";
-  version = "0.26.5";
+  version = "0.25.10";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
     repo = "tree-sitter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tnZ8VllRRYPL8UhNmrda7IjKSeFmmOnW/2/VqgJFLgU=";
+    hash = "sha256-aHszbvLCLqCwAS4F4UmM3wbSb81QuG9FM7BDHTu1ZvM=";
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-EU8kdG2NT3NvrZ1AqvaJPLpDQQwUhYG3Gj5TAjPYRsY=";
+  cargoHash = "sha256-4R5Y9yancbg/w3PhACtsWq0+gieUd2j8YnmEj/5eqkg=";
 
   buildInputs = [
     installShellFiles
@@ -122,7 +122,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     openssl
   ];
   nativeBuildInputs = [
-    rustPlatform.bindgenHook
     which
   ]
   ++ lib.optionals webUISupport [

--- a/pkgs/development/tools/parsing/tree-sitter/remove-web-interface.patch
+++ b/pkgs/development/tools/parsing/tree-sitter/remove-web-interface.patch
@@ -1,39 +1,9 @@
-diff --git a/crates/cli/src/main.rs b/crates/cli/src/main.rs
-index 937e54b4..4d16b739 100644
---- a/crates/cli/src/main.rs
-+++ b/crates/cli/src/main.rs
-@@ -24,7 +24,6 @@ use tree_sitter_cli::{
-     input::{get_input, get_tmp_source_file, CliInput},
-     logger,
-     parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
--    playground,
-     query::{self, QueryFileOptions},
-     tags::{self, TagsOptions},
-     test::{self, TestOptions, TestStats, TestSummary},
-@@ -1904,16 +1903,8 @@ impl Tags {
- 
- impl Playground {
-     fn run(self, current_dir: &Path) -> Result<()> {
--        let grammar_path = self.grammar_path.as_deref().map_or(current_dir, Path::new);
--
--        if let Some(export_path) = self.export {
--            playground::export(grammar_path, &export_path)?;
--        } else {
--            let open_in_browser = !self.quiet;
--            playground::serve(grammar_path, open_in_browser)?;
--        }
--
--        Ok(())
-+        println!("ERROR: web-ui is not available in this nixpkgs build; enable the webUISupport");
-+        std::process::exit(1);
-     }
- }
- 
-diff --git a/crates/cli/src/tree_sitter_cli.rs b/crates/cli/src/tree_sitter_cli.rs
-index 3960d961..55f8e2e4 100644
---- a/crates/cli/src/tree_sitter_cli.rs
-+++ b/crates/cli/src/tree_sitter_cli.rs
-@@ -6,7 +6,6 @@ pub mod init;
+diff --git a/cli/src/lib.rs b/cli/src/lib.rs
+index 4a00747e..e17d253b 100644
+--- a/cli/src/lib.rs
++++ b/cli/src/lib.rs
+@@ -6,7 +6,6 @@ pub mod highlight;
+ pub mod init;
  pub mod input;
  pub mod logger;
  pub mod parse;
@@ -41,3 +11,29 @@ index 3960d961..55f8e2e4 100644
  pub mod query;
  pub mod query_testing;
  pub mod tags;
+diff --git a/cli/src/main.rs b/cli/src/main.rs
+index 1758fada..4bc56cc2 100644
+--- a/cli/src/main.rs
++++ b/cli/src/main.rs
+@@ -23,7 +23,7 @@ use tree_sitter_cli::{
+     input::{get_input, get_tmp_source_file, CliInput},
+     logger,
+     parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
+-    playground, query,
++    query,
+     tags::{self, TagsOptions},
+     test::{self, TestOptions, TestStats},
+     test_highlight, test_tags, util, version, wasm,
+@@ -1614,10 +1614,8 @@ impl Tags {
+ 
+ impl Playground {
+     fn run(self, current_dir: &Path) -> Result<()> {
+-        let open_in_browser = !self.quiet;
+-        let grammar_path = self.grammar_path.as_deref().map_or(current_dir, Path::new);
+-        playground::serve(grammar_path, open_in_browser)?;
+-        Ok(())
++        println!("ERROR: web-ui is not available in this nixpkgs build; enable the webUISupport");
++        std::process::exit(1);
+     }
+ }
+ 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#482787

We need to stick to 0.25.x until we get neovim 0.12 (or introduce multiple versions of treesitter).

See https://github.com/neovim/neovim/issues/36914

CC: @trofi