### PR TITLE
todoist-electron: comply with freedesktop icon specification

### DIFF
--- a/pkgs/by-name/to/todoist-electron/package.nix
+++ b/pkgs/by-name/to/todoist-electron/package.nix
@@ -37,7 +37,7 @@ appimageTools.wrapAppImage {
   # Add desktop convencience stuff
   extraInstallCommands = ''
     install -D --mode 0644 ${appimageContents}/todoist.desktop -t $out/share/applications
-    install -D --mode 0644 ${appimageContents}/todoist.png -t $out/share/pixmaps
+    install -D --mode 0644 ${appimageContents}/todoist.png -t $out/share/icons/hicolor/512x512/apps
     substituteInPlace $out/share/applications/todoist.desktop \
       --replace-fail "Exec=AppRun" "Exec=todoist-electron --" \
       --replace-fail "Exec=todoist" "Exec=todoist-electron --"


### PR DESCRIPTION
Part of #428824

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
