### PR TITLE
torcs: comply with freedesktop icon specification

### DIFF
--- a/pkgs/by-name/to/torcs/package.nix
+++ b/pkgs/by-name/to/torcs/package.nix
@@ -1,4 +1,5 @@
 {
+  imagemagick,
   stdenv,
   symlinkJoin,
   torcs-without-data,
@@ -20,7 +21,11 @@ let
 
     installTargets = "export datainstall";
     postInstall = ''
-      install -D -m644 Ticon.png $out/share/pixmaps/torcs.png
+      mkdir -p $out/share/icons/hicolor/64x64/apps
+      ${imagemagick}/bin/magick Ticon.png -resize 64x64 $out/share/icons/hicolor/64x64/apps/torcs.png
+
+      substituteInPlace torcs.desktop \
+        --replace-fail "Icon=torcs.png" "Icon=torcs"
       install -D -m644 torcs.desktop $out/share/applications/torcs.desktop
     '';
 


### PR DESCRIPTION
Part of #428824

Not sure if this is the best approach, but it gets the job done. The `torcs.desktop` file has `Icon=torcs.png` which might not be complaint, so that might have to be changed too.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
