### PR TITLE
reef: init at 0.2.0

### DIFF
--- a/pkgs/by-name/re/reef/package.nix
+++ b/pkgs/by-name/re/reef/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "reef";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "ZStud";
+    repo = "reef";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-FP7cnqYIICb4JCYk9ytvSp4yxW+xW2SUVqhELdTGLZQ=";
+  };
+
+  cargoHash = "sha256-UmazwJqsWXQK3bniDLyNCLXHrgrF3iHRPugOAkRzhv8=";
+
+  postInstall = ''
+    install -Dm644 fish/functions/*.fish -t $out/share/fish/vendor_functions.d/
+    install -Dm644 fish/conf.d/reef.fish -t $out/share/fish/vendor_conf.d/
+  '';
+
+  nativeCheckInputs = [ versionCheckHook ];
+  doCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bash compatibility layer for fish shell";
+    homepage = "https://github.com/ZStud/reef";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ nadir-ishiguro ];
+    mainProgram = "reef";
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
From the [readme](https://github.com/ZStud/reef):

> Bash compatibility for fish shell. Just works.
> 
> Reef makes bash syntax work seamlessly inside [fish](https://fishshell.com/). No prefix commands, no mode switching, no learning curve. You type bash — fish runs it.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
