### PR TITLE
[25.11] phpExtensions.xdebug: 3.4.7 -> 3.5.1

### DIFF
--- a/pkgs/development/php-packages/xdebug/default.nix
+++ b/pkgs/development/php-packages/xdebug/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "3.4.7";
+  version = "3.5.0";
 in
 buildPecl {
   inherit version;
@@ -16,7 +16,7 @@ buildPecl {
     owner = "xdebug";
     repo = "xdebug";
     rev = version;
-    hash = "sha256-TxwEyXyUGq3rUWyLExyDopJZ29eAoh9QG1TC2+hImmc=";
+    hash = "sha256-RrT79o0eFKwGFq3gIfBWCUy5gFy6odj2AWfsfcGN2R4=";
   };
 
   doCheck = true;

--- a/pkgs/development/php-packages/xdebug/default.nix
+++ b/pkgs/development/php-packages/xdebug/default.nix
@@ -5,7 +5,7 @@
 }:
 
 let
-  version = "3.5.0";
+  version = "3.5.1";
 in
 buildPecl {
   inherit version;
@@ -16,7 +16,7 @@ buildPecl {
     owner = "xdebug";
     repo = "xdebug";
     rev = version;
-    hash = "sha256-RrT79o0eFKwGFq3gIfBWCUy5gFy6odj2AWfsfcGN2R4=";
+    hash = "sha256-GOlWCKDLwptsHV9SvOOlR4uScvcw8V/DjwXIpfWjSkM=";
   };
 
   doCheck = true;


### PR DESCRIPTION
Backport of #469818 and #487970 to release-25.11.

Updates `phpExtensions.xdebug` from 3.4.7 to 3.5.1.

- [xdebug 3.5.0 changelog](https://github.com/xdebug/xdebug/releases/tag/3.5.0)
- [xdebug 3.5.1 changelog](https://github.com/xdebug/xdebug/releases/tag/3.5.1)

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable
- [ ] Ran `nixpkgs-review` on this PR
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md)