### PR TITLE
treewide: move CARGO_* env vars into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/ca/cargo-lambda/package.nix
+++ b/pkgs/by-name/ca/cargo-lambda/package.nix
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     wrapProgram $out/bin/cargo-lambda --prefix PATH : ${lib.makeBinPath [ zig_0_13 ]}
   '';
 
-  CARGO_LAMBDA_BUILD_INFO = "(nixpkgs)";
+  env.CARGO_LAMBDA_BUILD_INFO = "(nixpkgs)";
 
   cargoBuildFlags = [ "--features=skip-build-banner" ];
   cargoCheckFlags = [ "--features=skip-build-banner" ];

--- a/pkgs/by-name/co/codebook/package.nix
+++ b/pkgs/by-name/co/codebook/package.nix
@@ -20,8 +20,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
   buildAndTestSubdir = "crates/codebook-lsp";
   cargoHash = "sha256-hxPgYGBq+KZfEyFiHQG31cNEN6A6hUgKRgZXIHOGalw=";
 
-  CARGO_PROFILE_RELEASE_LTO = "fat";
-  CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+  env = {
+    CARGO_PROFILE_RELEASE_LTO = "fat";
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+  };
 
   # Integration tests require internet access for dictionaries
   doCheck = false;

--- a/pkgs/by-name/ec/ecc/package.nix
+++ b/pkgs/by-name/ec/ecc/package.nix
@@ -78,7 +78,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     zlib
   ];
 
-  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "gcc";
+  env.CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER = "gcc";
 
   preBuild = ''
     # `SANDBOX` defined by upstream to disable build-time network access

--- a/pkgs/by-name/mh/mhost/package.nix
+++ b/pkgs/by-name/mh/mhost/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-08pvkBa2PD7/uko1OOBg6/dCcOM3z9Cp//8mylFCMcE=";
 
-  CARGO_CRATE_NAME = "mhost";
+  env.CARGO_CRATE_NAME = "mhost";
 
   doCheck = false;
 

--- a/pkgs/by-name/oh/oha/package.nix
+++ b/pkgs/by-name/oh/oha/package.nix
@@ -22,8 +22,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-v+OfQEfAwHxX+FfC0UK2F8/e2tJKaI3zQpg+3hk2hV4=";
 
-  CARGO_PROFILE_RELEASE_LTO = "fat";
-  CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+  env = {
+    CARGO_PROFILE_RELEASE_LTO = "fat";
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+  };
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     pkg-config

--- a/pkgs/by-name/ru/rutabaga_gfx/package.nix
+++ b/pkgs/by-name/ru/rutabaga_gfx/package.nix
@@ -58,8 +58,10 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "gfxstream" withGfxstream)
   ];
 
-  CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
-  "CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" = "${stdenv.cc.targetPrefix}cc";
+  env = {
+    CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;
+    "CARGO_TARGET_${stdenv.hostPlatform.rust.cargoEnvVarTarget}_LINKER" = "${stdenv.cc.targetPrefix}cc";
+  };
 
   preConfigure = ''
     cd rutabaga_gfx/ffi

--- a/pkgs/by-name/sc/scryer-prolog/package.nix
+++ b/pkgs/by-name/sc/scryer-prolog/package.nix
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   buildInputs = [ openssl ];
 
-  CARGO_FEATURE_USE_SYSTEM_LIBS = true;
+  env.CARGO_FEATURE_USE_SYSTEM_LIBS = true;
 
   meta = {
     description = "Modern Prolog implementation written mostly in Rust";

--- a/pkgs/by-name/ya/yara-x/package.nix
+++ b/pkgs/by-name/ya/yara-x/package.nix
@@ -22,8 +22,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-ihNFGlPhPLCIDvFnMqKA+flD/mv9wcKgQ1txO71xOp4=";
 
-  CARGO_PROFILE_RELEASE_LTO = "fat";
-  CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+  env = {
+    CARGO_PROFILE_RELEASE_LTO = "fat";
+    CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "1";
+  };
 
   nativeBuildInputs = [
     installShellFiles


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
