### PR TITLE
presenterm: Drop Sixel dependency

### DIFF
--- a/pkgs/by-name/pr/presenterm/package.nix
+++ b/pkgs/by-name/pr/presenterm/package.nix
@@ -5,7 +5,6 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   lld,
-  libsixel,
   versionCheckHook,
   nix-update-script,
 }:
@@ -31,10 +30,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
       lld
     ];
 
-  buildInputs = [
-    libsixel
-  ];
-
   cargoHash = "sha256-OlZXf8Wg32mXGDGbavLVf1ELoqqSmc8z9DNpvGOfAJ8=";
 
   env = lib.optionalAttrs (isDarwin && isx86_64) {
@@ -45,12 +40,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     # failed to load .tmpEeeeaQ: No such file or directory (os error 2)
     "--skip=external_snippet"
   ];
-
-  # sixel-sys is dynamically linked to libsixel
-  postInstall = lib.optionalString isDarwin ''
-    wrapProgram $out/bin/presenterm \
-      --prefix DYLD_LIBRARY_PATH : "${lib.makeLibraryPath [ libsixel ]}"
-  '';
 
   nativeInstallCheckInputs = [
     versionCheckHook


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
presenterm: 0.15.1 -> 0.16.0

Diff: https://github.com/mfontanini/presenterm/compare/refs/tags/v0.15.1...refs/tags/v0.16.0
Changelog: https://github.com/mfontanini/presenterm/releases/tag/v0.16.0

Sixel is no longer a separate build feature, but integrated into presenterm by default, see https://github.com/mfontanini/presenterm/pull/828

First MR here, hope this is kind of fine :)

cc @MikaelFangel

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
