### PR TITLE
php: prevent emitting warnings when including an extension that is enabled by default

### DIFF
--- a/pkgs/development/interpreters/php/generic.nix
+++ b/pkgs/development/interpreters/php/generic.nix
@@ -116,7 +116,7 @@ let
               let
                 deps = lib.concatMap (ext: (ext.internalDeps or [ ]) ++ (ext.peclDeps or [ ])) extensions;
               in
-              if !(deps == [ ]) then deps ++ (getDepsRecursively deps) else deps;
+              if deps == [ ] then [ ] else (deps ++ (getDepsRecursively deps));
 
             # Generate extension load configuration snippets from the
             # extension parameter. This is an attrset suitable for use
@@ -139,11 +139,14 @@ let
               ) (enabledExtensions ++ (getDepsRecursively enabledExtensions))
             );
 
-            extNames = map getExtName enabledExtensions;
-            extraInit = writeText "php-extra-init-${version}.ini" ''
-              ${lib.concatStringsSep "\n" (lib.textClosureList extensionTexts extNames)}
-              ${extraConfig}
-            '';
+            extraInit =
+              let
+                extNames = map getExtName (builtins.filter (ext: (ext.configureFlags != [ ])) enabledExtensions);
+              in
+              writeText "php-extra-init-${version}.ini" ''
+                ${lib.concatStringsSep "\n" (lib.textClosureList extensionTexts extNames)}
+                ${extraConfig}
+              '';
 
             phpWithExtensions = symlinkJoin {
               pname = "php-with-extensions";

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -730,9 +730,10 @@ lib.makeScope pkgs.newScope (
             {
               name = "xml";
               buildInputs = [ libxml2 ];
-              configureFlags = [
-                "--enable-xml"
-              ];
+              # Set this to an empty list because this extension is enabled by
+              # default. Also, there's no need to add the `xml.so` in the final
+              # PHP ini or else it will emit a warning at each php call.
+              configureFlags = [ ];
               doCheck = false;
             }
             {


### PR DESCRIPTION
This fix #491388

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
