### PR TITLE
roblox: init at 0.717.0.7170982

### DIFF
--- a/pkgs/by-name/ro/roblox/package.nix
+++ b/pkgs/by-name/ro/roblox/package.nix
@@ -1,0 +1,55 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  makeWrapper,
+}:
+let
+  clientVersionUpload = "4a858a3a05c64f79";
+  hashes = {
+    aarch64-darwin = "sha256-s/HLY/uDeJFudamYr5DofoBpNE+vl3OcSQUpOMysLnE=";
+    x86_64-darwin = "sha256-B7Kzkjk8yA4AhYWQku1gc1eiMjFH6ySyxYcTSySoAV4=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "roblox";
+  version = "0.720.0.7201160";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchzip {
+    url = "https://setup.rbxcdn.com/mac${lib.optionalString stdenvNoCC.hostPlatform.isAarch64 "/arm64"}/version-${clientVersionUpload}-RobloxPlayer.zip";
+    stripRoot = false;
+    hash =
+      hashes.${stdenvNoCC.hostPlatform.system}
+        or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r $src/*.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Multiplayer game platform designed for playing games";
+    homepage = "https://www.roblox.com";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+    mainProgram = "RobloxPlayer.app";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/ro/roblox/package.nix
+++ b/pkgs/by-name/ro/roblox/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenvNoCC,
+  lib,
+  fetchzip,
+  makeWrapper,
+}:
+stdenvNoCC.mkDerivation {
+  pname = "roblox";
+  version = "0.724.0.7240735";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchzip {
+    url = "https://web.archive.org/web/20260604191635/http://setup.rbxcdn.com/mac/arm64/version-b6bc8a3f6c184e6f-RobloxPlayer.zip";
+    hash = "sha256-l2p7zSjV8bZvetQyVVjRdy693hVk7SrBHxeGgIv1GdE=";
+    stripRoot = false;
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r $src/*.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Multiplayer game platform designed for playing games";
+    homepage = "https://www.roblox.com";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ eveeifyeve ];
+    mainProgram = "RobloxPlayer.app";
+    platforms = lib.platforms.darwin;
+  };
+}

--- a/pkgs/by-name/ro/roblox/update.sh
+++ b/pkgs/by-name/ro/roblox/update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq nix
+
+set -euo pipefail
+
+RESPONSE="$(curl -fsSL "https://clientsettingscdn.roblox.com/v1/client-version/MacPlayer")"
+VERSION="$(echo "$RESPONSE" | jq -r '.version')"
+CLIENT_UPLOAD="$(echo "$RESPONSE" | jq -r '.clientVersionUpload' | sed 's/version-//')"
+NIX_FILE="$(dirname "$0")/package.nix"
+
+prefetch() {
+  nix-prefetch-url --unpack "$1" 2>/dev/null \
+    | xargs -I{} nix hash convert --hash-algo sha256 --to sri {}
+}
+
+ARM_HASH="$(prefetch "https://setup.rbxcdn.com/mac/arm64/version-${CLIENT_UPLOAD}-RobloxPlayer.zip")"
+X86_HASH="$(prefetch "https://setup.rbxcdn.com/mac/version-${CLIENT_UPLOAD}-RobloxPlayer.zip")"
+OLD_UPLOAD="$(grep -oE '[0-9a-f]{16}' "$NIX_FILE" | head -1)"
+
+sed -i \
+  -e "s/$OLD_UPLOAD/$CLIENT_UPLOAD/" \
+  -e "s|version = \"[^\"]*\"|version = \"$VERSION\"|" \
+  -e "s|aarch64-darwin = \"sha256-[^\"]*\"|aarch64-darwin = \"$ARM_HASH\"|" \
+  -e "s|x86_64-darwin = \"sha256-[^\"]*\"|x86_64-darwin = \"$X86_HASH\"|" \
+  "$NIX_FILE"

--- a/pkgs/by-name/ro/roblox/update.sh
+++ b/pkgs/by-name/ro/roblox/update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -I nixpkgs=./. -i bash -p curl jq gnused gnugrep common-updater-scripts
+
+set -euo pipefail
+nix_file="$(dirname "$0")/package.nix"
+
+update_macos() {
+  cdn_versions_response="$(curl -fsSL "https://clientsettingscdn.roblox.com/v1/client-version/MacPlayer")"
+  upstream_version="$(echo "$cdn_versions_response" | jq -r '.version')"
+  client_upload_version="$(echo "$cdn_versions_response" | jq -r '.clientVersionUpload')"
+  url="setup.rbxcdn.com/mac/arm64/$client_upload_version-RobloxPlayer.zip";
+
+  current_nix_version=$(
+    grep 'version\s*=' "$nix_file" \
+    | sed -Ene 's/.*"(.*)".*/\1/p'
+  )
+
+  if [[ "$current_nix_version" != "$upstream_version" ]]; then
+    archive_url="https://web.archive.org/save"
+    archived_url=$(curl -s -I -L -o /dev/null "$archive_url/$url" -w '%{url_effective}')
+
+    update-source-version "pkgsCross.aarch64-darwin.roblox" "$upstream_version" "" "$archived_url" \
+      --file=$nix_file \
+      --ignore-same-version
+  fi
+}
+
+update_macos


### PR DESCRIPTION
Packages [Roblox App](https://www.roblox.com) for darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the [automation/AI policy].

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[automation/AI policy]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#automationai-policy
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
