### PR TITLE
k3s: update `k3s_1_32`, `k3s_1_33` and `k3s_1_34`

### DIFF
--- a/nixos/tests/rancher/multi-node.nix
+++ b/nixos/tests/rancher/multi-node.nix
@@ -218,11 +218,6 @@ in
       # wait for the agent to show up
       server.wait_until_succeeds("kubectl get node agent")
 
-      ${lib.optionalString (rancherDistro == "k3s") ''
-        for m in machines:
-            m.succeed("k3s check-config")
-      ''}
-
       server.succeed("kubectl cluster-info")
       # Also wait for our service account to show up; it takes a sec
       server.wait_until_succeeds("kubectl get serviceaccount default")

--- a/nixos/tests/rancher/single-node.nix
+++ b/nixos/tests/rancher/single-node.nix
@@ -84,9 +84,6 @@ in
       machine.wait_for_unit("${serviceName}")
       machine.succeed("kubectl cluster-info")
       machine.fail("sudo -u noprivs kubectl cluster-info")
-      ${lib.optionalString (rancherDistro == "k3s") ''
-        machine.succeed("k3s check-config")
-      ''}
 
       # Also wait for our service account to show up; it takes a sec
       machine.wait_until_succeeds("kubectl get serviceaccount default")

--- a/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "572f512cc0bdf89213d2c532e6182d4a291663bb38a51beb57197bf3fb67dd47"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.12%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "3f45abe980b2a6ba9ba8037d9b5a96ab199ce5ddf53c496e99087422d20f0383"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "a65a1ed1cf081285d4c32ed3989d95cb0a4d90209e99a8765b65d41b02ea059d"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.12%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "924ecfe275f8e9e6c03ab52d78901cf7aa32bf5abd1c4294ac8c41d7860865b6"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm.tar.gz",
-    "sha256": "ffaee35854e9bfa6f34fae0a7a2ff81e8909cfb2d5a5bd65df89c03a1ceb1b3a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.12%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "fc310a93b1477a9e0e5ad21bc2e1a28dbadd7578923dff594bccc8cf90eb265b"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm.tar.zst",
-    "sha256": "b92568a2fa8683a5abd29c151d12f2737bf7ac961dfa615a2fa891a66f2d23cf"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.12%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "dcef1d1edf592dce46a6a039576c3169d0caf4eec165c6cbcf1dfbe019b1535d"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "cc99b0211110b8dc14c47cde0fe9b93b7e36c2ead64286412a896f6aa8a722cf"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.12%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "a5d645989991207bae3cee1597c8c581908291af912766132d99fae3b103918b"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.11%2Bk3s3/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "a7ab99f7e2a6cf6ecc833c8ba67ba154b3ff186c58d574fa4bbda2e70dcb55f7"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.12%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "53e747b44505ddcc239c3d175dfa9f23b925c5018e3f878b0be87af876c4c41b"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_32/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.32.11+k3s3";
-  k3sCommit = "c9aa1d2889a003715698542826c2af94160ac2e5";
-  k3sRepoSha256 = "0fi634dnsghjwnp07h6jhknccqlr9n5g3l34sipc41vvfmn4b0k8";
-  k3sVendorHash = "sha256-qbmqzsd8oMQSFCh7HvjDiYds5gLEIGjjcv4EJbgxfJI=";
+  k3sVersion = "1.32.12+k3s1";
+  k3sCommit = "0dc662e80238b7b70d24ad9025a6b64292d14955";
+  k3sRepoSha256 = "1pmdbzxp968hxya590qhf4sz3gx6yzpwhcg24hkfsxbm9bclrr0g";
+  k3sVendorHash = "sha256-T5GGzudpTTMb2SBC6+spCo7Q/IOr6LfiWb/oWOcCOv8=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
@@ -17,5 +17,5 @@
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s2.32";
-  helmJobVersion = "v0.9.12-build20251215";
+  helmJobVersion = "v0.9.14-build20260210";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_33/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "130a3b3e51947b7a0beffca422b85c2d3fbe78b1163a0fc069871877021123d3"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.8%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "e4c4437580f6a2379963ed78d3a58212932fd4c917fc33c0664ce2a8b89fe389"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "b0d7062008fa7fcad9ad7c6b60f74ae1c561927dbb5a4105433f5afbd091361b"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.8%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "1760ed5f74a27f4ac5ccac4f8cdf88f2cb5c3bc85ec23674bd499ae3efd93617"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm.tar.gz",
-    "sha256": "6451f4bd29b4ab76dcbfa520d907425976a04e9d5044b969e81fa2dfdc085c20"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.8%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "6f1ff82e1845d00692f89ad12cf0b0921ae451bae18e8479334a6200312dd746"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm.tar.zst",
-    "sha256": "03a165ad40d022616281fbf329bcfa546b9245a9f431d1c362b86faff72d83dd"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.8%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "9ae9184211aa4b729cb3c2c659e6442c55bedc7a13720f923898b284b48b87b0"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "6243a503de28c17f4b1b16018237a5008bc99983dc3b3b87ed2a1fe790d9e211"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.8%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "a1a00a92559e9a966e882e871163dae7278fea5f20194a37d00cd81fae5dff84"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.7%2Bk3s3/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "74713adf726f6b407330b93e252b7a8e0a85204137c8a6f61b66f681b5761c42"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.33.8%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "df4695448bd8a783cb0e6c91e40aa1abed36b921a121dd1b7f87ff3973faec27"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_33/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.33.7+k3s3";
-  k3sCommit = "1288e778af2a8ae295c47c213a3d13abd2969cde";
-  k3sRepoSha256 = "07274x0d0q7cn6x5g8d0zbyf67axrmchhngsjsp3plskyr313hcy";
-  k3sVendorHash = "sha256-XlZFYEGqoDGFlLJYRJDDoRPWuptFYkZT6axergChFN4=";
+  k3sVersion = "1.33.8+k3s1";
+  k3sCommit = "3552cfc26032474faad53ee617fde32ac0c1a222";
+  k3sRepoSha256 = "00dmd3rfghwi8mq33ksiga1nwpk1swqfdwalgspliy5vhfvwgma8";
+  k3sVendorHash = "sha256-89C0jv8IUweToIAGyZkaK9o9owm9e8qD4BhJuJw0XVs=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
@@ -17,5 +17,5 @@
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s2";
-  helmJobVersion = "v0.9.12-build20251215";
+  helmJobVersion = "v0.9.14-build20260210";
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_34/images-versions.json
@@ -1,26 +1,26 @@
 {
   "airgap-images-amd64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-amd64.tar.gz",
-    "sha256": "696c2e10f511295f5e0e6281a2f22eec60b33962d45bc9117703db1ac887e981"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.4%2Bk3s1/k3s-airgap-images-amd64.tar.gz",
+    "sha256": "ab5da5904db9b41df478fd59e526b5802902650e83a85674c6b19c51ad38b4a4"
   },
   "airgap-images-amd64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "4805a6c4bfdfd20d3ad42bc14c79e00662739aca275e6a37cd8f3a406fae0f0a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.4%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
+    "sha256": "924ecfe275f8e9e6c03ab52d78901cf7aa32bf5abd1c4294ac8c41d7860865b6"
   },
   "airgap-images-arm-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm.tar.gz",
-    "sha256": "a4bc850fcf9b73bf0f45d4a1f50bd612e52d77daa5de5020589e7f99e5d1a3e6"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.4%2Bk3s1/k3s-airgap-images-arm.tar.gz",
+    "sha256": "2018507533f3aa8c33be81358940d33ec98836f6fbcc463d1c2cfb7f20efb36c"
   },
   "airgap-images-arm-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm.tar.zst",
-    "sha256": "a1b0ac3a00f409fa51e196ea9db5f2282efff00a282ab797bf49b29453bb1379"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.4%2Bk3s1/k3s-airgap-images-arm.tar.zst",
+    "sha256": "2a93722994fb58faa36fa6293a7e454fa1c621eaa0a82e08e996f767e61c0c88"
   },
   "airgap-images-arm64-tar-gz": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm64.tar.gz",
-    "sha256": "ceea4427499fb39be0bff18f840cf80a091f63e88421bc89fdfceb8017aab59b"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.4%2Bk3s1/k3s-airgap-images-arm64.tar.gz",
+    "sha256": "61a8587016aabce6f1d701c679e1d3050adaa7029c3c6dc309940b5764fb9c38"
   },
   "airgap-images-arm64-tar-zst": {
-    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.3%2Bk3s3/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "e0cec00a1c19c8c6f7fde7005e325d285f23ff43752cce9ce0796ccb10e9582a"
+    "url": "https://github.com/k3s-io/k3s/releases/download/v1.34.4%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
+    "sha256": "df4695448bd8a783cb0e6c91e40aa1abed36b921a121dd1b7f87ff3973faec27"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/k3s/1_34/versions.nix
@@ -1,8 +1,8 @@
 {
-  k3sVersion = "1.34.3+k3s3";
-  k3sCommit = "2975fb0973ca47f54b1aa2a8c3a976a779f52349";
-  k3sRepoSha256 = "0bvccp573xihzbnkd3n6xldcxpnlwiz9b5p0fw6sxv69m7jaac2f";
-  k3sVendorHash = "sha256-R8QXwXmTKsONsbWaedFNDPdYZ82jaQ/T8S9sllqKPjk=";
+  k3sVersion = "1.34.4+k3s1";
+  k3sCommit = "c6017918a65c824ce8d321db15267c8a317cd39d";
+  k3sRepoSha256 = "0b19c1jpkndr6859m745xms1j3hn6bjffdgmv3yl05y6finaqgzq";
+  k3sVendorHash = "sha256-ZTRcv28rgKslrDRr5y8SnQJpo2ErbURa22l1nv+4QHw=";
   chartVersions = import ./chart-versions.nix;
   imagesVersions = builtins.fromJSON (builtins.readFile ./images-versions.json);
   k3sRootVersion = "0.15.0";
@@ -17,5 +17,5 @@
   flannelPluginVersion = "v1.9.0-flannel1";
   kubeRouterVersion = "v2.6.3-k3s1";
   criDockerdVersion = "v0.3.19-k3s3";
-  helmJobVersion = "v0.9.12-build20251215";
+  helmJobVersion = "v0.9.14-build20260210";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update of k3s packages:

- `k3s_1-32`: https://github.com/k3s-io/k3s/releases/tag/v1.32.12%2Bk3s1
- `k3s_1_33`: https://github.com/k3s-io/k3s/releases/tag/v1.33.8%2Bk3s1
- `k3s_1_34`: https://github.com/k3s-io/k3s/releases/tag/v1.34.4%2Bk3s1

`k3s_1_35` requires go >= 1.25.6, which is only available in staging for now.

The tests ~~**FAIL**~~ because we use Linux 6.18 by default and the `k3s check-config` command requires (I think) legacy config: `CONFIG_IP_NF_FILTER`, `CONFIG_IP_NF_TARGET_MASQUERADE` and `CONFIG_IP_NF_NAT`. Without the check, all tests pass. If the tests use `linux_6_12`, all tests pass as well.

 I opened an issue upstream: https://github.com/k3s-io/k3s/issues/13658

Does anyone know if the failing check is something to really worry about? To me it seems like the [script](https://github.com/k3s-io/k3s/blob/e96330febe5340ccb2c3bb65c12bc6848c7de712/contrib/util/check-config.sh) expects config that is legacy in 6.18, but everything else works.

@NixOS/k3s 

Edit: The first commit removes the `k3s check-config` command from the tests. If upstream adapts the test script, we can add it again. All tests pass locally. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
