### PR TITLE
xvfb: convert build to meson

### DIFF
--- a/pkgs/by-name/xv/xvfb/package.nix
+++ b/pkgs/by-name/xv/xvfb/package.nix
@@ -3,6 +3,8 @@
 {
   lib,
   stdenv,
+  meson,
+  ninja,
   pkg-config,
   xorg-server,
   dri-pkgconfig-stub,
@@ -29,6 +31,7 @@
   xkeyboard-config,
   xorgproto,
   xtrans,
+  font-util,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "xvfb";
@@ -37,10 +40,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
 
   buildInputs = [
     dri-pkgconfig-stub
+    font-util
     libdrm
     libGL
     libx11
@@ -64,16 +72,28 @@ stdenv.mkDerivation (finalAttrs: {
     xtrans
   ];
 
-  configureFlags = [
-    "--enable-xvfb"
-    "--disable-xorg"
-    "--disable-xquartz"
-    "--disable-xwayland"
-    "--with-xkb-bin-directory=${xkbcomp}/bin"
-    "--with-xkb-path=${xkeyboard-config}/share/X11/xkb"
-    "--with-xkb-output=$out/share/X11/xkb/compiled"
+  mesonFlags = [
+    "-Dxvfb=true"
+    "-Dxephyr=false"
+    "-Dxorg=false"
+    "-Dxnest=false"
+    "-Dsecure-rpc=false"
+    "-Dudev=false"
+    "-Dudev_kms=false"
+
+    "-Dlog_dir=/var/log"
+    "-Ddefault_font_path="
+
+    "-Dxkb_bin_dir=${xkbcomp}/bin"
+    "-Dxkb_dir=${xkeyboard-config}/share/X11/xkb"
+    "-Dxkb_output_dir=$out/share/X11/xkb/compiled"
   ]
-  ++ lib.optional stdenv.hostPlatform.isDarwin "--without-dtrace";
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    "-Dxcsecurity=true"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-Ddtrace=false"
+  ];
 
   meta = {
     description = "X virtual framebuffer";

--- a/pkgs/by-name/xv/xvfb/package.nix
+++ b/pkgs/by-name/xv/xvfb/package.nix
@@ -20,6 +20,7 @@
   libxkbfile,
   libxshmfence,
   mesa-gl-headers,
+  mesa,
   openssl,
   pixman,
   libxcb-util,
@@ -47,9 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    dri-pkgconfig-stub
     font-util
-    libdrm
     libGL
     libx11
     libxau
@@ -70,6 +69,13 @@ stdenv.mkDerivation (finalAttrs: {
     libxcb-wm
     xorgproto
     xtrans
+  ]
+  ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+    dri-pkgconfig-stub
+    libdrm
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    mesa
   ];
 
   mesonFlags = [


### PR DESCRIPTION
Update xvfb build to use meson, similar to how main xorg does it. This also prepares for future releases of xorg, since they have gotten rid of autotools build.

Putting this towards staging, since it triggers mass rebuild.

Adding dependencies meson, ninja, fontutil, udev and libtirpc shouldn't bloat the closure too much.

I don't have access to darwin, so please review carefully. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
