### PR TITLE
plasma-login-manager: init at 6.6.0

### DIFF
--- a/pkgs/by-name/pl/plasma-login-manager/package.nix
+++ b/pkgs/by-name/pl/plasma-login-manager/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  cmake,
+  pkg-config,
+
+  kdePackages,
+}:
+stdenv.mkDerivation rec {
+  pname = "plasma-login-manager";
+  version = "6.6.0";
+
+  src = fetchFromGitHub {
+    owner = "KDE";
+    repo = "plasma-login-manager";
+    tag = "v${version}";
+    hash = "sha256-yKdXqe9TnyBo0pjjaYSUJ1MxMqepTuMe3GfadMiKUoM=";
+  };
+
+  buildInputs = with kdePackages; [
+    extra-cmake-modules
+    qtbase
+    qtdeclarative
+    qttools
+    ki18n
+    kcmutils
+    kconfig
+    kdbusaddons
+    kio
+    kwindowsystem
+    kauth
+    kpackage
+    kscreen
+    layer-shell-qt
+    libxau
+
+    # systemd libs ?
+    # unclear if systemd itself is needed as well
+    systemdLibs
+
+    # LibKWorkspace ?
+    plasma-workspace
+
+    # LibKLookAndFeel ?
+    plasma-integration
+
+    # FIXME: need to find PlasmaQuick and probably pam
+  ];
+
+  nativeBuildInputs = [
+    kdePackages.wrapQtAppsHook
+    cmake
+    pkg-config
+  ];
+
+  meta = with lib; {
+    description = "KDE Plasma Login Manager";
+    homepage = "https://github.com/KDE/plasma-login-manager";
+    license = with licenses; [
+      gpl2
+      cc-by-30
+    ];
+    maintainers = [ maintainers.justdeeevin ];
+    # TODO: mainProgram
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds plasma-login-manager, KDE's new login manager for the plasma ecosystem added with plasma 6.6.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
