### PR TITLE
nixos/nixseparatedebuginfod2: Relax too strict hardening

### DIFF
--- a/nixos/modules/services/development/nixseparatedebuginfod2.nix
+++ b/nixos/modules/services/development/nixseparatedebuginfod2.nix
@@ -87,7 +87,6 @@ in
         ProtectKernelLogs = true; # Prevent access to kernel logs
         ProtectClock = true; # Prevent setting the RTC
         ProtectProc = "noaccess";
-        ProcSubset = "pid";
 
         # Networking
         RestrictAddressFamilies = "AF_UNIX AF_INET AF_INET6";


### PR DESCRIPTION
All debuginfo downloads were failing because downloading uses "nix store --restore", which seems to need access to /proc. Blocking this access via ProcSubset is even [noted in systemd's documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#ProcSubset=) as "not suitable for most non-trivial programs".

Tested with:

```
nix shell nixpkgs#gnumake nixpkgs#elfutils
debuginfod-find -v debuginfo (which make)
```

Before:

    Server query failed: No such file or directory

After:

    /home/jakob/.cache/debuginfod_client/7af4822834c45cc8159b5fd3b0424edc340574ae/debuginfo

When switching between versions, be aware that there are two caches that both need to be cleaned:
```
sudo rm -rf /var/cache/private/nixseparatedebuginfod2
rm -rf ~/.cache/debuginfod_client/
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
