### PR TITLE
pkgsMusl.nix: fix build

### DIFF
--- a/pkgs/tools/package-management/nix/modular/src/libexpr/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libexpr/package.nix
@@ -37,6 +37,10 @@ mkMesonLibrary (finalAttrs: {
 
   workDir = ./.;
 
+  hardeningDisable = lib.optionals stdenv.hostPlatform.isMusl [
+    "fortify"
+  ];
+
   nativeBuildInputs = [
     bison
     flex


### PR DESCRIPTION
fixes:
- `nix-build -A pkgsMusl.nix`
- `nix-build -A pkgsStatic.nix`
- `nix-build -A {pkgsMusl,pkgsStatic}.nixVersions.nixComponents_{2_30,2_31,2_32,2_33,git}.nix-expr`

original build failure:
```
/nix/store/maa6d7kbflymf5ha1gs3553kvjwkwadn-fortify-headers-1.1alpine3/include/stdio.h: In function ‘__to_xstring.constprop’:
/nix/store/maa6d7kbflymf5ha1gs3553kvjwkwadn-fortify-headers-1.1alpine3/include/stdio.h:80:28: error: inlining failed in call to ‘always_inline’ ‘vsnprintf’: function body can be overwritten at link time
   80 | _FORTIFY_FN(vsnprintf) int vsnprintf(char * _FORTIFY_POS0 __s, size_t __n,
      |                            ^
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
