### PR TITLE
zotero: facilitate using mainProgram on darwin

### DIFF
--- a/pkgs/by-name/zo/zotero/package.nix
+++ b/pkgs/by-name/zo/zotero/package.nix
@@ -19,6 +19,7 @@
   wrapGAppsHook3,
   nix-update-script,
   xvfb-run,
+  makeBinaryWrapper,
   doCheck ? false,
 }:
 let
@@ -174,6 +175,11 @@ buildNpmPackage (finalAttrs: {
     gawk
     rsync
     copyDesktopItems
+  ]
+  ++ lib.optionals stdenv.targetPlatform.isDarwin [
+    makeBinaryWrapper
+  ]
+  ++ lib.optionals (!stdenv.targetPlatform.isDarwin) [
     wrapGAppsHook3
   ];
 
@@ -308,6 +314,11 @@ buildNpmPackage (finalAttrs: {
         pciutils
       ]
     })
+  '';
+
+  postFixup = lib.optionalString stdenv.targetPlatform.isDarwin ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/Zotero.app/Contents/MacOS/zotero $out/bin/zotero
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Wrap the binary to allow using mainProgram on darwin

Without this, `nix run nixpkgs#zotero` or `lib.getExe pkgs.zotero` fail on darwin

Fixes https://github.com/NixOS/nixpkgs/issues/491449
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
