### PR TITLE
radicle-concourse-adaptor: init at v0.6.6

### DIFF
--- a/pkgs/by-name/ra/radicle-concourse-adaptor/package.nix
+++ b/pkgs/by-name/ra/radicle-concourse-adaptor/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildGoModule,
+  fetchgit,
+  gitMinimal,
+  writableTmpDirAsHomeHook,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "radicle-concourse-adapter";
+  version = "0.6.6";
+
+  src = fetchgit {
+    url = "https://seed.radicle.garden/z2woyw9Get9Q21VJzdbVz33b47xDb.git";
+    rev = "525e19167448f07fb87d9720c07b832a38332f5a";
+    hash = "sha256-sEMIKOC+/iXpxJspgH85pVGcfwyTVhZUioy2pgaeSuw=";
+  };
+
+  vendorHash = "sha256-IJzYLR9FVU/+00WbRSVIBUhGVAuNtkEIA3cjW7CGex8=";
+
+  subPackages = [ "cmd/concourse-adapter" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X radicle-concourse-adapter/pkg/version.Version=${finalAttrs.version}"
+    "-X radicle-concourse-adapter/pkg/version.BuildTime=1970-01-01"
+  ];
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+    gitMinimal
+  ];
+
+  postInstall = ''
+    mv $out/bin/concourse-adapter $out/bin/radicle-concourse-adapter
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = [ "--version" ];
+
+  meta = {
+    description = "A Concourse CI adapter for Radicle Broker";
+    homepage = "https://app.radicle.xyz/nodes/seed.radicle.garden/rad:z2woyw9Get9Q21VJzdbVz33b47xDb";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ philocalyst ];
+    mainProgram = "radicle-concourse-adapter";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
