### PR TITLE
python313Packages.argostranslate: modernize, update, and enable tests

### DIFF
--- a/pkgs/development/python-modules/argostranslate/default.nix
+++ b/pkgs/development/python-modules/argostranslate/default.nix
@@ -67,6 +67,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://www.argosopentech.com";
     changelog = "https://github.com/argosopentech/argos-translate/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ misuzu ];
+    maintainers = with lib.maintainers; [
+      misuzu
+      Stebalien
+    ];
   };
 })

--- a/pkgs/development/python-modules/argostranslate/default.nix
+++ b/pkgs/development/python-modules/argostranslate/default.nix
@@ -7,8 +7,10 @@
   # dependencies
   ctranslate2,
   ctranslate2-cpp,
+  minisbd,
   sacremoses,
   sentencepiece,
+  spacy,
   stanza,
   # tests
   pytestCheckHook,
@@ -25,22 +27,24 @@ let
 in
 buildPythonPackage (finalAttrs: {
   pname = "argostranslate";
-  version = "1.9.6";
+  version = "1.11.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "argosopentech";
     repo = "argos-translate";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OFF2DAcuRwEJxZebgRq5Ukb/TaNsP/rsO7BUAcD+lz8=";
+    hash = "sha256-8uzWS0YZEteeLTYAp9qpnnJhxyhxbWkKt1krqe/RF4M=";
   };
 
   build-system = [ setuptools ];
 
   dependencies = [
     ctranslate2OneDNN
+    minisbd
     sacremoses
     sentencepiece
+    spacy
     stanza
   ];
 
@@ -51,7 +55,6 @@ buildPythonPackage (finalAttrs: {
 
   pythonRelaxDeps = [
     "stanza"
-    "sentencepiece"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
1. Modernize per feedback received in #491271.
2. Enable all checks.
3. Update from 1.9.6 -> 1.11.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
