### PR TITLE
netdata: 2.8.4 -> 2.9.0

### DIFF
--- a/pkgs/tools/system/netdata/use-local-corrosion.patch
+++ b/pkgs/tools/system/netdata/use-local-corrosion.patch
@@ -1,11 +1,11 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 414a3c54b..cf1fcb7b4 100644
+index 3fa051e07..7dffb90aa 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -230,13 +230,8 @@ cmake_dependent_option(ENABLE_NETDATA_JOURNAL_FILE_READER "Enable netdata's jour
+@@ -195,13 +195,7 @@ cmake_dependent_option(ENABLE_NETDATA_JOURNAL_FILE_READER "Enable netdata's jour
 
  # Setup Rust/Corrosion for plugins that need it
- if(ENABLE_NETDATA_JOURNAL_FILE_READER OR ENABLE_PLUGIN_OTEL)
+ if(ENABLE_NETDATA_JOURNAL_FILE_READER OR ENABLE_PLUGIN_OTEL OR ENABLE_PLUGIN_OTEL_SIGNAL_VIEWER)
 -    include(FetchContent)
 -    FetchContent_Declare(
 -        Corrosion
@@ -14,7 +14,6 @@ index 414a3c54b..cf1fcb7b4 100644
 -    )
 -    FetchContent_MakeAvailable(Corrosion)
 +    find_package(Corrosion REQUIRED)
-+
-     corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml
-                            CRATES journal_reader_ffi otel-plugin)
- endif()
+
+     if(ENABLE_NETDATA_JOURNAL_FILE_READER)
+         corrosion_import_crate(MANIFEST_PATH src/crates/jf/Cargo.toml


### PR DESCRIPTION
Not sure why root [cargo.toml](https://github.com/netdata/netdata/blob/v2.9.0/src/crates/Cargo.toml#L3) excludes `jf`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
