### PR TITLE
treefmt.withConfig: define pname & propagate all files using symlinkJoin

### DIFF
--- a/pkgs/by-name/tr/treefmt/modules/wrapper.nix
+++ b/pkgs/by-name/tr/treefmt/modules/wrapper.nix
@@ -15,26 +15,23 @@
     internal = true;
   };
 
-  config.result =
-    pkgs.runCommand config.name
-      {
-        nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
-        env = {
-          inherit (config) configFile;
-          binPath = lib.makeBinPath config.runtimeInputs;
-        };
-        passthru = {
-          inherit (config) runtimeInputs;
-          inherit config options;
-        };
-        inherit (config.package) meta version;
-      }
-      ''
-        mkdir -p $out/bin
-        makeWrapper \
-          ${lib.getExe config.package} \
-          $out/bin/treefmt \
-          --prefix PATH : "$binPath" \
-          --add-flags "--config-file $configFile"
-      '';
+  config.result = pkgs.symlinkJoin {
+    pname = config.name;
+    inherit (config.package) meta version;
+    nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+    paths = [ config.package ];
+    env = {
+      inherit (config) configFile;
+      binPath = lib.makeBinPath config.runtimeInputs;
+    };
+    passthru = {
+      inherit (config) runtimeInputs;
+      inherit config options;
+    };
+    postBuild = ''
+      wrapProgram "$out/bin/treefmt" \
+        --prefix PATH : "$binPath" \
+        --add-flags "--config-file $configFile"
+    '';
+  };
 }


### PR DESCRIPTION
Fixes the underlying issue raised in #487791

Closes #487791

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
