### PR TITLE
qemu_ga: init -> Alias to qemu:ga, dropping ~1700 requisites for QEMU guest agent

### DIFF
--- a/nixos/modules/virtualisation/qemu-guest-agent.nix
+++ b/nixos/modules/virtualisation/qemu-guest-agent.nix
@@ -18,7 +18,7 @@ in
       default = false;
       description = "Whether to enable the qemu guest agent.";
     };
-    package = mkPackageOption pkgs [ "qemu_kvm" "ga" ] { };
+    package = mkPackageOption pkgs [ "qemu_ga" "ga" ] { };
   };
 
   config = mkIf cfg.enable (mkMerge [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9077,6 +9077,12 @@ with pkgs;
     else
       unixtools.procps;
 
+  qemu_ga = lowPrio (
+    qemu.override {
+      minimal = true;
+      guestAgentSupport = true;
+    }
+  );
   qemu_kvm = lowPrio (qemu.override { hostCpuOnly = true; });
   qemu_full = lowPrio (
     qemu.override {


### PR DESCRIPTION
Reduces the number of dependencies for any user of `services.qemuGuest` by ~1715 requisites, including x265, SDL, ...etc. on headless systems.

More details (including how that number was calculated) can be found in each commit. Top level summary:

- Add a `pkg.qemu_ga` target that builds the QEMU guest agent only as a minimal qemu build.- This makes it easier to reason with, apply overlays, or investigate the potential attack surface of this package. 
- Update the `services.qemuGuest` module to point to the new dedicated pkg 
- Added a release note that `services.qemuGuest` will no longer build documentation. That means anyone who uses `services.qemuGuest` will need to manually re-enable documentation afterwards or use the full `qemu_kvm` package like before.

## Things done

- Validated the new `qemu_ga` target builds
- Switched a Linux x86-64 qemu-kvm machine between the two module definitions, which happened without interruption
- Rebooted the VM to validate QEMU continues reporting, which it did

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.  

(Tried to, but first PR to this repo, so let me know if I've missed anything)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
