### PR TITLE
aligator: 0.16.0 -> 0.18.0

### DIFF
--- a/pkgs/by-name/al/aligator/package.nix
+++ b/pkgs/by-name/al/aligator/package.nix
@@ -14,6 +14,7 @@
 
   # buildInputs
   fmt,
+  mimalloc,
 
   # propagatedBuildInputs
   suitesparse,
@@ -27,13 +28,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "aligator";
-  version = "0.16.0";
+  version = "0.18.0";
 
   src = fetchFromGitHub {
     owner = "Simple-Robotics";
     repo = "aligator";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-OyCJa2iTkCxVLooSKdVgBd0y7rHObo4vFcc56t48TSY=";
+    hash = "sha256-qdXZo7IvgcUFEJARwxpSaHJVRlZ6HdgRADPOiY3oCpk=";
   };
 
   outputs = [
@@ -52,6 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     fmt
+    mimalloc
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     llvmPackages.openmp

--- a/pkgs/by-name/al/aligator/package.nix
+++ b/pkgs/by-name/al/aligator/package.nix
@@ -17,7 +17,6 @@
   mimalloc,
 
   # propagatedBuildInputs
-  suitesparse,
   crocoddyl,
   pinocchio,
 
@@ -62,7 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = [
     crocoddyl
     pinocchio
-    suitesparse
   ];
 
   checkInputs = [


### PR DESCRIPTION
Diff: https://github.com/Simple-Robotics/aligator/compare/v0.16.0...v0.18.0

Changelog: https://github.com/Simple-Robotics/aligator/blob/v0.18.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
