### PR TITLE
rustfetch: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14807,6 +14807,11 @@
     githubId = 736291;
     name = "Lee Machin";
   };
+  lefaucheur0769 = {
+    name = "LeFaucheur0769";
+    github = "LeFaucheur0769";
+    githubId = 90474269;
+  };
   legojames = {
     github = "jrobinson-uk";
     githubId = 4701504;

--- a/pkgs/by-name/ru/rustfetch/package.nix
+++ b/pkgs/by-name/ru/rustfetch/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rustfetch";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "lemuray";
+    repo = "rustfetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-iGcxDKl36kbEi+OiH4gB2+HxP37bpqAMZguIXDzq3Jw=";
+  };
+  cargoHash = "sha256-87wfFczmgCft4ke/RQKi54wvqFKGRJMtqhkwQgDCedg=";
+
+  meta = {
+    description = "CLI tool designed to fetch system information in the fastest and safest way possible";
+    homepage = "https://github.com/lemuray/rustfetch";
+    changelog = "https://github.com/lemuray/rustfetch/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ lefaucheur0769 ];
+    mainProgram = "rustfetch";
+  };
+})


### PR DESCRIPTION

## Things done

Added LeFaucheur0769 as a maintainer 

Added [rusfetch](https://github.com/lemuray/rustfetch), an alternative to fastfetch or neofetch written in rust and which is faster, to nixpkgs

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


