### PR TITLE
python313Packages.minisbd: init at 0.9.3

### DIFF
--- a/pkgs/development/python-modules/minisbd/default.nix
+++ b/pkgs/development/python-modules/minisbd/default.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  # build-system
+  hatchling,
+  # dependencies
+  filelock,
+  numpy,
+  onnxruntime,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "minisbd";
+  version = "0.9.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "LibreTranslate";
+    repo = "MiniSBD";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-QAIuggOxoFeod4CaTDXDQj6UGwRpy4N1Pw0pTXHs7/A=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    filelock
+    numpy
+    onnxruntime
+  ];
+
+  pythonImportsCheck = [
+    "minisbd"
+  ];
+
+  meta = {
+    description = "Free and open source library for fast sentence boundary detection";
+    homepage = finalAttrs.src.meta.homepage;
+    changelog = "https://github.com/LibreTranslate/MiniSBD/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ Stebalien ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9760,6 +9760,8 @@ self: super: with self; {
 
   minio = callPackage ../development/python-modules/minio { };
 
+  minisbd = callPackage ../development/python-modules/minisbd { };
+
   miniupnpc = callPackage ../development/python-modules/miniupnpc { };
 
   mip = callPackage ../development/python-modules/mip { };


### PR DESCRIPTION
This PR adds minisbd, a dependency of argostranslate 1.11.0. See https://github.com/NixOS/nixpkgs/pull/491472.

Project Homepage: https://github.com/LibreTranslate/MiniSBD

This is a part of the LibreTranslate project, the main consumer of argo-stranslate (from what I can tell).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
