### PR TITLE
mistral-vibe: 2.1.0 -> 2.2.0

### DIFF
--- a/pkgs/by-name/mi/mistral-vibe/package.nix
+++ b/pkgs/by-name/mi/mistral-vibe/package.nix
@@ -12,14 +12,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "mistral-vibe";
-  version = "2.1.0";
+  version = "2.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mistralai";
     repo = "mistral-vibe";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Xeb16Ravk60DXAjRs1OcCl8axCRwTf9yqXWnva9VQro=";
+    hash = "sha256-q79/xP+kaovkch5wXzXumQb9l4wSspXg2cl7mD0Q2f8=";
   };
 
   build-system = with python3Packages; [
@@ -32,9 +32,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     "agent-client-protocol"
     "gitpython"
     "mistralai"
-    "pydantic"
     "pydantic-settings"
-    "watchfiles"
     "zstandard"
   ];
   dependencies = with python3Packages; [
@@ -43,6 +41,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     cryptography
     gitpython
     giturlparse
+    google-auth
     httpx
     keyring
     mcp
@@ -54,12 +53,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
     pyperclip
     python-dotenv
     pyyaml
+    requests
     rich
     textual
     textual-speedups
     tomli-w
     tree-sitter
-    tree-sitter-grammars.tree-sitter-bash
+    tree-sitter-bash
     watchfiles
     zstandard
   ];

--- a/pkgs/development/python-modules/tree-sitter-bash/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-bash/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  tree-sitter,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "tree-sitter-bash";
+  version = "0.25.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "tree-sitter";
+    repo = "tree-sitter-bash";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ONQ1Ljk3aRWjElSWD2crCFZraZoRj3b3/VELz1789GE=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  optional-dependencies = {
+    core = [
+      tree-sitter
+    ];
+  };
+
+  pythonImportsCheck = [ "tree_sitter_bash" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    tree-sitter
+  ];
+
+  meta = {
+    description = "Bash grammar for tree-sitter";
+    homepage = "https://github.com/tree-sitter/tree-sitter-bash";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19353,6 +19353,8 @@ self: super: with self; {
 
   tree-sitter = callPackage ../development/python-modules/tree-sitter { };
 
+  tree-sitter-bash = callPackage ../development/python-modules/tree-sitter-bash { };
+
   tree-sitter-c-sharp = callPackage ../development/python-modules/tree-sitter-c-sharp { };
 
   tree-sitter-embedded-template =


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/mistralai/mistral-vibe/compare/v2.1.0...v2.2.0
Changelog: https://github.com/mistralai/mistral-vibe/blob/v2.2.0/CHANGELOG.md

cc @shikanime @mana-byte

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test