### PR TITLE
python3Packages.ibis-framework: 11.0.0 -> 12.0.0

### DIFF
--- a/pkgs/development/python-modules/ibis-framework/default.nix
+++ b/pkgs/development/python-modules/ibis-framework/default.nix
@@ -99,14 +99,14 @@ in
 
 buildPythonPackage (finalAttrs: {
   pname = "ibis-framework";
-  version = "11.0.0";
+  version = "12.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ibis-project";
     repo = "ibis";
     tag = finalAttrs.version;
-    hash = "sha256-hf5guWeX9WQbKaNrs7ALwwDxV1Rgeb5Z0PedTQ4P7S0=";
+    hash = "sha256-GqSbjjUr4EaWueMl4TrhaDvqn1iDd4CO3QcDnOXfSAk=";
   };
 
   build-system = [
@@ -185,6 +185,69 @@ buildPythonPackage (finalAttrs: {
 
     # assert 0 == 3 (tests edge case behavior of databases)
     "test_self_join_with_generated_keys"
+
+    # https://github.com/ibis-project/ibis/issues/11929
+    # AssertionError: value does not match the expected value
+    "ibasic_aggregation_with_join"
+    "itest_endswith"
+    "itest_multiple_limits"
+    "itest_simple_joins"
+    "test_aggregate_count_joined"
+    "test_anti_join"
+    "test_binop_parens"
+    "test_bool_bool"
+    "test_case_in_projection"
+    "test_column_distinct"
+    "test_column_expr_default_name"
+    "test_column_expr_retains_name"
+    "test_count_distinct"
+    "test_difference_project_column"
+    "test_fuse_projections"
+    "test_having_from_filter"
+    "test_intersect_project_column"
+    "test_join_between_joins"
+    "test_join_just_materialized"
+    "test_limit_with_self_join"
+    "test_lower_projection_sort_key"
+    "test_multiple_count_distinct"
+    "test_multiple_joins"
+    "test_no_cart_join"
+    "test_order_by_on_limit_yield_subquery"
+    "test_parse_sql_aggregation_with_multiple_joins"
+    "test_parse_sql_basic_aggregation"
+    "test_parse_sql_basic_join[inner]"
+    "test_parse_sql_basic_join[left]"
+    "test_parse_sql_basic_join[right]"
+    "test_parse_sql_basic_projection"
+    "test_parse_sql_in_clause"
+    "test_parse_sql_join_subquery"
+    "test_parse_sql_join_with_filter"
+    "test_parse_sql_limited_join"
+    "test_parse_sql_multiple_joins"
+    "test_parse_sql_scalar_subquery"
+    "test_parse_sql_simple_reduction"
+    "test_parse_sql_simple_select_count"
+    "test_parse_sql_table_alias"
+    "test_parse_sql_tpch"
+    "test_sample"
+    "test_select_sql"
+    "test_selects_with_impure_operations_not_merged"
+    "test_semi_join"
+    "test_startswith"
+    "test_subquery_in_union"
+    "test_subquery_where_location"
+    "test_table_difference"
+    "test_table_distinct"
+    "test_table_drop_with_filter"
+    "test_table_intersect"
+    "test_union_order_by"
+    "test_union_project_column"
+    "test_union"
+    "test_where_analyze_scalar_op"
+    "test_where_no_pushdown_possible"
+    "test_where_simple_comparisons"
+    "test_where_with_between"
+    "test_where_with_join"
   ]
   ++ lib.optionals (pythonAtLeast "3.14") [
     # ExceptionGroup: multiple unraisable exception warnings (4 sub-exceptions)


### PR DESCRIPTION
Version bump
Disabled broken formatting/snapshot tests and filed https://github.com/ibis-project/ibis/issues/11929

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
