### PR TITLE
steamfetch: init at 0.5.6

### DIFF
--- a/pkgs/by-name/st/steamfetch/package.nix
+++ b/pkgs/by-name/st/steamfetch/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  pkg-config,
+  openssl,
+
+  stdenvNoCC,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "steamfetch";
+  version = "0.5.5";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "unhappychoice";
+    repo = "steamfetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Gi037/wqUfpohLK2FsFt7HqoJYa41wUDbbqnbuZwX0I=";
+  };
+
+  cargoHash = "sha256-RJdcVJ4CxKl/7xBzemRsQPhpxcXInyB4tS/EtYKRj4s=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  postInstall = ''
+    mkdir -p $out/bin
+    install -Dm644 -t $out/bin ./target/${stdenvNoCC.hostPlatform.rust.cargoShortTarget}/release/libsteam_api${stdenvNoCC.hostPlatform.extensions.sharedLibrary}
+  '';
+
+  meta = {
+    description = "Neofetch-like Steam stats grabber - display your profile in style";
+    homepage = "https://github.com/unhappychoice/steamfetch";
+    changelog = "https://github.com/unhappychoice/steamfetch/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.ryand56 ];
+    mainProgram = "steamfetch";
+  };
+})

--- a/pkgs/by-name/st/steamfetch/package.nix
+++ b/pkgs/by-name/st/steamfetch/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+
+  pkg-config,
+  openssl,
+
+  cacert,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "steamfetch";
+  version = "0.5.6";
+
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "unhappychoice";
+    repo = "steamfetch";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-V4lMSmf7mnSt7yNEwjy277XuzT2eUZoEemNXlhVi1as=";
+  };
+
+  cargoHash = "sha256-c+TeAJARsFmnXOISLEmR1XR0FAdn6ttfLbbOIr5yn6c=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  nativeCheckInputs = [ openssl ];
+  env.SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+
+  meta = {
+    description = "Neofetch-like Steam stats grabber - display your profile in style";
+    homepage = "https://github.com/unhappychoice/steamfetch";
+    changelog = "https://github.com/unhappychoice/steamfetch/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.ryand56 ];
+    mainProgram = "steamfetch";
+  };
+})


### PR DESCRIPTION
Adds [steamfetch](https://github.com/unhappychoice/steamfetch), a Neofetch-like tool that displays your Steam stats.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
