### PR TITLE
python3Packages.wagtail: 7.2.1 -> 7.2.2

### DIFF
--- a/pkgs/development/python-modules/wagtail/default.nix
+++ b/pkgs/development/python-modules/wagtail/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "wagtail";
-  version = "7.2.1";
+  version = "7.2.2";
   pyproject = true;
 
   # The GitHub source requires some assets to be compiled, which in turn
@@ -40,7 +40,7 @@ buildPythonPackage rec {
   # until https://github.com/wagtail/wagtail/pull/13136 gets merged.
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-OIu0LEgYwIGk3fNub0Upv7xU7SYqkbZbDl+VFHbyz3Q=";
+    hash = "sha256-v2rao6zZDZ7nc0dW3XAxsJAe7bgKSqTlGIqx5IHOML4=";
   };
 
   build-system = [


### PR DESCRIPTION
Fixes CVE-2026-25517.
Fixes #487266.

https://github.com/wagtail/wagtail/releases/tag/v7.2.2


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 491522`
Commit: `783705810b7990801da23a00555fdf49d2a24214`

---
### `x86_64-linux`
<details>
  <summary>:x: 8 packages failed to build:</summary>
  <ul>
    <li>python314Packages.wagtail</li>
    <li>python314Packages.wagtail-factories</li>
    <li>python314Packages.wagtail-factories.dist</li>
    <li>python314Packages.wagtail-localize</li>
    <li>python314Packages.wagtail-localize.dist</li>
    <li>python314Packages.wagtail-modeladmin</li>
    <li>python314Packages.wagtail-modeladmin.dist</li>
    <li>python314Packages.wagtail.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>python313Packages.wagtail</li>
    <li>python313Packages.wagtail-factories</li>
    <li>python313Packages.wagtail-factories.dist</li>
    <li>python313Packages.wagtail-localize</li>
    <li>python313Packages.wagtail-localize.dist</li>
    <li>python313Packages.wagtail-modeladmin</li>
    <li>python313Packages.wagtail-modeladmin.dist</li>
    <li>python313Packages.wagtail.dist</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
