### PR TITLE
socalabs-papu: comply with freedesktop icon specification

### DIFF
--- a/pkgs/by-name/so/socalabs-papu/package.nix
+++ b/pkgs/by-name/so/socalabs-papu/package.nix
@@ -7,6 +7,7 @@
   alsa-lib,
   copyDesktopItems,
   makeDesktopItem,
+  imagemagick,
   libx11,
   libxcomposite,
   libxcursor,
@@ -60,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
     copyDesktopItems
+    imagemagick
     ninja
   ];
 
@@ -113,7 +115,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     install -Dm555 PAPU_artefacts/Release/Standalone/PAPU $out/bin
 
-    install -Dm444 $src/plugin/Resources/icon.png $out/share/pixmaps/PAPU.png
+    mkdir -p $out/share/icons/hicolor/256x256/apps
+    magick $src/plugin/Resources/icon.png -resize 256x256 $out/share/icons/hicolor/256x256/apps/PAPU.png
 
     runHook postInstall
   '';


### PR DESCRIPTION
Part of #428824

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
