### PR TITLE
haskellPackages: add missing dependencies on windows

### DIFF
--- a/pkgs/development/haskell-modules/configuration-windows.nix
+++ b/pkgs/development/haskell-modules/configuration-windows.nix
@@ -8,9 +8,17 @@ with haskellLib;
 
 (self: super: {
   # cabal2nix doesn't properly add dependencies conditional on os(windows)
+  digest = addBuildDepends [ self.zlib ] super.digest;
+  echo = addBuildDepends [ self.mintty ] super.echo;
   http-client = addBuildDepends [ self.safe ] super.http-client;
-
+  regex-posix = addBuildDepends [ self.regex-posix-clib ] super.regex-posix;
+  simple-sendfile =
+    with self;
+    addBuildDepends [ conduit conduit-extra resourcet ] super.simple-sendfile;
+  snap-core = addBuildDepends [ self.time-locale-compat ] super.snap-core;
+  tar-conduit = addBuildDepends [ self.unix-compat ] super.tar-conduit;
   unix-time = addBuildDepends [ pkgs.windows.pthreads ] super.unix-time;
+  warp = addBuildDepends [ self.unix-compat ] super.warp;
 
   network = lib.pipe super.network [
     (addBuildDepends [ self.temporary ])


### PR DESCRIPTION
Needs https://github.com/NixOS/nixpkgs/pull/490607/

```
nix-build -E 'with (import ./. {}).pkgsCross.ucrt64.haskell.packages.ghc912; [ digest echo http-client regex-posix simple-sendfile snap-core tar-conduit unix-time warp]'
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
