### PR TITLE
fx-cast-bridge: patch mdns dependency to fix crashes on newer nodejs 

### DIFF
--- a/pkgs/by-name/fx/fx-cast-bridge/package.nix
+++ b/pkgs/by-name/fx/fx-cast-bridge/package.nix
@@ -39,6 +39,14 @@ buildNpmPackage rec {
       --replace-fail "../../../" "../../"
   '';
 
+  # to support later versions of nodejs
+  # node_mdns is unmaintained so this is the best we can do
+  postConfigure = ''
+    substituteInPlace node_modules/mdns/lib/resolver_sequence_tasks.js --replace-fail \
+      'cares.getaddrinfo(req, host, family, 0, false)' \
+      'cares.getaddrinfo(req, host, family, 0, 0)'
+  '';
+
   dontNpmInstall = true;
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
Without this patch, we run into https://github.com/agnat/node_mdns/issues/266

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
