### PR TITLE
prpll: init at 0.15

### DIFF
--- a/pkgs/by-name/pr/prpll/package.nix
+++ b/pkgs/by-name/pr/prpll/package.nix
@@ -1,0 +1,60 @@
+{
+  fetchFromGitHub,
+  lib,
+  ocl-icd,
+  opencl-headers,
+  stdenv,
+  installShellFiles,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "prpll";
+  version = "0.15";
+
+  src = fetchFromGitHub {
+    owner = "preda";
+    repo = "gpuowl";
+    tag = "v/prpll/${finalAttrs.version}";
+    hash = "sha256-uARWaY48IdqWqiX4Z1ZZdhCNGqqVKbyFKOiILSln7ao=";
+  };
+
+  enableParallelBuilding = true;
+
+  buildInputs = [
+    ocl-icd
+    opencl-headers
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Fix stricter compilation rules on aarch64
+  postPatch = ''
+    substituteInPlace src/common.h \
+      --replace-fail "__float128" "_Float128"
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin build-release/prpll
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Probable Prime and Lucas-Lehmer mersenne categorizer";
+    longDescription = ''
+      PRPLL implements two primality tests for Mersenne numbers: PRP ("PRobable Prime") and LL ("Lucas-Lehmer") as
+      the name suggests.
+      PRPLL is an OpenCL (GPU) program for primality testing Mersenne numbers.
+    '';
+    homepage = "https://github.com/preda/gpuowl";
+    maintainers = with lib.maintainers; [ dstremur ];
+    license = lib.licenses.gpl3Only;
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    mainProgram = "prpll";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adding the prpll package for testing mersenne primes on GPU using OpenCL.
https://github.com/preda/gpuowl

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
