### PR TITLE
beyla: init at 2.8.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7513,6 +7513,12 @@
     githubId = 1847524;
     name = "Evan Stoll";
   };
+  evanlhatch = {
+    email = "evan@evanhatch.com";
+    github = "evanlhatch";
+    githubId = 44220750;
+    name = "Evan Hatch";
+  };
   evanrichter = {
     email = "evanjrichter@gmail.com";
     github = "evanrichter";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7514,7 +7514,6 @@
     name = "Evan Stoll";
   };
   evanlhatch = {
-    email = "evan@evanhatch.com";
     github = "evanlhatch";
     githubId = 44220750;
     name = "Evan Hatch";

--- a/pkgs/by-name/be/beyla/package.nix
+++ b/pkgs/by-name/be/beyla/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  libbpf,
+  elfutils,
+  zlib,
+  pkg-config,
+}:
+buildGoModule (finalAttrs: {
+  pname = "beyla";
+  version = "2.8.5";
+
+  src = fetchFromGitHub {
+    owner = "grafana";
+    repo = "beyla";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-JX2zUZHLZEdOyMDpPjWg66tjMQdC6lXWAQuifI0TTSY=";
+    fetchSubmodules = true;
+  };
+
+  vendorHash = null;
+
+  subPackages = ["cmd/beyla"];
+
+  nativeBuildInputs = [pkg-config];
+
+  buildInputs = [
+    libbpf
+    elfutils
+    zlib
+  ];
+
+  env.CGO_ENABLED = "1";
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  # Tests require kernel with eBPF enabled
+  doCheck = false;
+
+  meta = {
+    description = "eBPF-based auto-instrumentation for OpenTelemetry and Prometheus";
+    longDescription = ''
+      Beyla is a vendor agnostic, eBPF-based, OpenTelemetry/Prometheus application
+      auto-instrumentation tool. eBPF is used to automatically inspect application
+      executables and the OS networking layer, allowing capture of essential
+      application observability events for HTTP/S and gRPC services.
+    '';
+    homepage = "https://github.com/grafana/beyla";
+    changelog = "https://github.com/grafana/beyla/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [evanlhatch];
+    mainProgram = "beyla";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/be/beyla/package.nix
+++ b/pkgs/by-name/be/beyla/package.nix
@@ -51,7 +51,7 @@ buildGoModule (finalAttrs: {
       application observability events for HTTP/S and gRPC services.
     '';
     homepage = "https://github.com/grafana/beyla";
-    changelog = "https://github.com/grafana/beyla/releases/tag/v${finalAttrs.version}";
+    changelog = "https://github.com/grafana/beyla/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ evanlhatch ];
     mainProgram = "beyla";

--- a/pkgs/by-name/be/beyla/package.nix
+++ b/pkgs/by-name/be/beyla/package.nix
@@ -7,6 +7,7 @@
   zlib,
   pkg-config,
 }:
+
 buildGoModule (finalAttrs: {
   pname = "beyla";
   version = "2.8.5";
@@ -21,9 +22,9 @@ buildGoModule (finalAttrs: {
 
   vendorHash = null;
 
-  subPackages = ["cmd/beyla"];
+  subPackages = [ "cmd/beyla" ];
 
-  nativeBuildInputs = [pkg-config];
+  nativeBuildInputs = [ pkg-config ];
 
   buildInputs = [
     libbpf
@@ -52,7 +53,7 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/grafana/beyla";
     changelog = "https://github.com/grafana/beyla/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [evanlhatch];
+    maintainers = with lib.maintainers; [ evanlhatch ];
     mainProgram = "beyla";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
# Description of changes

This PR adds Beyla, an eBPF-based auto-instrumentation tool for OpenTelemetry and Prometheus metrics. Beyla allows for vendor-agnostic application observability without requiring code modifications.

**Key features:**
- Zero-code automatic instrumentation using eBPF
- Support for HTTP/HTTPS/HTTP2 and gRPC
- Generates OpenTelemetry traces and Prometheus metrics
- Works with multiple languages (Go, Java, .NET, Python, Ruby, Rust, etc.)

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested using sandboxing
- [x] Tested basic functionality of all binary files
  - `beyla --help` works
  - Binary runs and shows version info
- [x] Fits CONTRIBUTING.md
- [x] Package name follows naming conventions
- [x] Added myself as maintainer

## Upstream Information

- **Homepage**: https://github.com/grafana/beyla
- **Documentation**: https://grafana.com/docs/beyla/
- **License**: Apache-2.0
- **Platforms**: Linux only (requires eBPF kernel >= 5.8)
- **Latest version**: v2.8.5 (released Jan 13, 2026)

## Build verification

```bash
$ nix-build -A beyla
/nix/store/...-beyla-2.8.5

$ ./result/bin/beyla --help
Usage of ./result/bin/beyla:
  -config string
        path to the configuration file
```

## Additional notes

- Tests are disabled (`doCheck = false`) as they require a kernel with eBPF enabled
- Package requires Linux kernel >= 5.8 with BTF (BPF Type Format) enabled
- Uses CGO for eBPF integration with libbpf
- Fetches git submodules as required by upstream build process

---

**Related projects by Grafana in nixpkgs:**
- `grafana`
- `grafana-agent`
- `grafana-loki`
- `tempo`
- `mimir`
