### PR TITLE
greptimedb, octelium, openspec, otel-ebpf-profiler: init at various versions

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7513,6 +7513,11 @@
     githubId = 1847524;
     name = "Evan Stoll";
   };
+  evanlhatch = {
+    github = "evanlhatch";
+    githubId = 44220750;
+    name = "Evan Hatch";
+  };
   evanrichter = {
     email = "evanjrichter@gmail.com";
     github = "evanrichter";

--- a/pkgs/by-name/gr/greptimedb/package.nix
+++ b/pkgs/by-name/gr/greptimedb/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  openssl,
+  zlib,
+  zstd,
+  ...
+}:
+stdenv.mkDerivation rec {
+  pname = "greptimedb";
+  version = "1.0.0-rc.1";
+
+  src = fetchurl {
+    url = "https://github.com/GreptimeTeam/greptimedb/releases/download/v${version}/greptime-linux-amd64-v${version}.tar.gz";
+    hash = "sha256-xitwxtDeWe/xSlOKVZPKaSe5hKTiFavjiyjFCwVvdTE=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+    zstd
+    stdenv.cc.cc.lib
+  ];
+
+  sourceRoot = "greptime-linux-amd64-v${version}";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m755 greptime $out/bin/greptime
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Cloud-native, unified observability database for metrics, logs and traces";
+    homepage = "https://greptime.com";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    mainProgram = "greptime";
+  };
+}

--- a/pkgs/by-name/oc/octelium/package.nix
+++ b/pkgs/by-name/oc/octelium/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+let
+  pname = "octelium";
+  version = "0.27.0";
+in
+buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "octelium";
+    repo = "octelium";
+    tag = "v${version}";
+    hash = "sha256-O2jgGKuE5Y0WcsreZrgTNkWw94CEK9EfOrND7pwjqBw=";
+  };
+
+  # Use proxyVendor for Go workspace support
+  proxyVendor = true;
+
+  vendorHash = "sha256-7CmpyH8I20AgUeRk8q1Z1HR43I0BTWgQEefDzZ6hgzk=";
+
+  # Build all three CLI tools
+  subPackages = [
+    "client/octelium"
+    "client/octeliumctl"
+    "client/octops"
+  ];
+
+  # Set ldflags to match the Makefile build flags
+  ldflags =
+    let
+      ldflags_path = "github.com/octelium/octelium/pkg/utils/ldflags";
+    in
+    [
+      "-X ${ldflags_path}.GitCommit=${version}"
+      "-X ${ldflags_path}.GitTag=v${version}"
+      "-X ${ldflags_path}.GitBranch=main"
+      "-X ${ldflags_path}.SemVer=v${version}"
+      "-X ${ldflags_path}.ImageRegistry=ghcr.io"
+      "-X ${ldflags_path}.ImageRegistryPrefix=octelium"
+    ];
+
+  meta = {
+    description = "Next-gen FOSS self-hosted unified zero trust secure access platform";
+    longDescription = ''
+      Octelium is a free and open source, self-hosted, unified zero trust secure
+      access platform that can operate as a modern zero-config remote access VPN,
+      a comprehensive Zero Trust Network Access (ZTNA)/BeyondCorp platform, an
+      ngrok/Cloudflare Tunnel alternative, an API gateway, an AI/LLM gateway, a
+      scalable infrastructure for MCP gateways and A2A architectures/meshes, a
+      PaaS-like platform, and a homelab infrastructure.
+
+      This package includes three CLI tools:
+      - octelium: Used by all Users to connect to the Cluster and access its Services
+      - octeliumctl: Used by Cluster managers to manage the Cluster's resources
+      - octops: Used to install, upgrade and uninstall Clusters
+    '';
+    homepage = "https://github.com/octelium/octelium";
+    changelog = "https://github.com/octelium/octelium/releases/tag/v${version}";
+    license = with lib.licenses; [
+      asl20 # Client components
+      agpl3Only # Cluster components (not built here)
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    mainProgram = "octelium";
+  };
+}

--- a/pkgs/by-name/op/openspec/package.nix
+++ b/pkgs/by-name/op/openspec/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nodejs_20,
+  pnpm_9,
+  npmHooks,
+  pnpmConfigHook,
+  fetchPnpmDeps,
+}:
+let
+  pname = "openspec";
+  version = "1.1.1";
+in
+stdenv.mkDerivation (finalAttrs: {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "Fission-AI";
+    repo = "OpenSpec";
+    rev = "v${version}";
+    hash = "sha256-XdE8WGXdBm9FQKZJIJtnPCqpD20ontpINlfmqFmts3U=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_9;
+    hash = "sha256-9s2kdvd7svK4hofnD66HkDc86WTQeayfF5y7L2dmjNg=";
+    fetcherVersion = 3;
+  };
+
+  nativeBuildInputs = [
+    nodejs_20
+    npmHooks.npmInstallHook
+    pnpmConfigHook
+    pnpm_9
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  dontNpmPrune = true;
+
+  meta = {
+    description = "AI-native system for spec-driven development";
+    homepage = "https://github.com/Fission-AI/OpenSpec";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "openspec";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ot/otel-ebpf-profiler/package.nix
+++ b/pkgs/by-name/ot/otel-ebpf-profiler/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  libbpf,
+  elfutils,
+  zlib,
+  pkg-config,
+  llvmPackages,
+}:
+buildGoModule (finalAttrs: {
+  pname = "otel-ebpf-profiler";
+  version = "0.0.202606";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-ebpf-profiler";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-G3mbz0DJhTOJ2EyPwu8jfoLTeAKrBxNtzgySfW7zTbU=";
+    fetchSubmodules = true;
+  };
+
+  vendorHash = "sha256-FsmprnK+RFdfUsUYwCRYwFnGqep+DVTUsQ92+44UV4Q=";
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    pkg-config
+    llvmPackages.clang
+  ];
+
+  buildInputs = [
+    libbpf
+    elfutils
+    zlib
+  ];
+
+  env = {
+    CGO_ENABLED = "1";
+    CC = "clang";
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Continuous profiling for OpenTelemetry using eBPF";
+    homepage = "https://github.com/open-telemetry/opentelemetry-ebpf-profiler";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ evanlhatch ];
+    mainProgram = "ebpf-profiler";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
# Description of changes

This PR adds four observability and infrastructure tools:

1. **greptimedb** - Cloud-native unified observability database for metrics, logs and traces
2. **octelium** - Self-hosted unified zero trust secure access platform
3. **openspec** - AI-native system for spec-driven development
4. **otel-ebpf-profiler** - Continuous profiling for OpenTelemetry using eBPF

All packages build successfully and have been tested locally.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested using sandboxing
- [x] Tested basic functionality of all binary files
- [x] Fits CONTRIBUTING.md
- [x] Package names follow naming conventions
- [x] Added myself as maintainer
- [x] Formatted with `nix fmt`

## Package Details

### greptimedb
- **Version**: 1.0.0-rc.1
- **License**: Apache-2.0
- **Platform**: Linux (x86_64)
- **Type**: Pre-built binary
- **Homepage**: https://greptime.com

### octelium
- **Version**: 0.27.0
- **License**: Apache-2.0 (client), AGPL-3.0 (cluster components, not included)
- **Platform**: Unix (Linux + macOS)
- **Type**: Go
- **Homepage**: https://github.com/octelium/octelium
- **Note**: Builds 3 CLI tools: octelium, octeliumctl, octops

### openspec
- **Version**: 1.1.1
- **License**: MIT
- **Platform**: All
- **Type**: Node.js + pnpm
- **Homepage**: https://github.com/Fission-AI/OpenSpec
- **Note**: Spec-driven development framework for AI coding assistants (24.4k+ stars)

### otel-ebpf-profiler
- **Version**: 0.0.202606
- **License**: Apache-2.0
- **Platform**: Linux only
- **Type**: Go + eBPF
- **Homepage**: https://github.com/open-telemetry/opentelemetry-ebpf-profiler
- **Note**: Official OpenTelemetry/CNCF project

## Build verification

All packages built successfully:

```bash
$ nix-build -A greptimedb
/nix/store/...-greptimedb-1.0.0-rc.1

$ nix-build -A octelium
/nix/store/...-octelium-0.27.0

$ nix-build -A openspec
/nix/store/...-openspec-1.1.1

$ nix-build -A otel-ebpf-profiler
/nix/store/...-otel-ebpf-profiler-0.0.202606
```

## Additional notes

- All packages have been formatted with `nix fmt`
- greptimedb uses pre-built binary (faster, but Linux x86_64 only)
- otel-ebpf-profiler and beyla (PR #491544) are complementary eBPF observability tools
- openspec is a popular tool (24.4k stars) for AI-assisted development
