### PR TITLE
ugdb: init at 0.1.12

### DIFF
--- a/pkgs/by-name/ug/ugdb/package.nix
+++ b/pkgs/by-name/ug/ugdb/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+
+  pkg-config,
+
+  oniguruma,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "ugdb";
+  version = "0.1.12";
+
+  src = fetchFromGitHub {
+    owner = "ftilde";
+    repo = "ugdb";
+    tag = finalAttrs.version;
+    hash = "sha256-6mlvr/2hqwu5Zoo9E2EfOmyg0yEGBi4jk3BsRZ+zkN8=";
+  };
+
+  buildInputs = [ oniguruma ];
+  nativeBuildInputs = [ pkg-config ];
+
+  cargoHash = "sha256-+J4gwjQXB905yk4b2GwpamXO/bHpwqMxw6GsnusbJKU=";
+
+  RUSTONIG_SYSTEM_LIBONIG = 1;
+
+  # Upstream has a failing test :<
+  doCheck = false;
+
+  meta = with lib; {
+    description = "Alternative TUI for gdb";
+    homepage = "https://github.com/ftilde/ugdb";
+    changelog = "https://github.com/ftilde/ugdb/blob/master/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = [ maintainers.justdeeevin ];
+    mainProgram = "ugdb";
+    platforms = platforms.unix;
+  };
+})


### PR DESCRIPTION
UGDB is a rust-based TUI for debugging with GDB, meant to be a bit nicer than GDB's built-in TUI.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
