### PR TITLE
otel-ebpf-profiler: init at 0.0.202606

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7513,6 +7513,11 @@
     githubId = 1847524;
     name = "Evan Stoll";
   };
+  evanlhatch = {
+    github = "evanlhatch";
+    githubId = 44220750;
+    name = "Evan Hatch";
+  };
   evanrichter = {
     email = "evanjrichter@gmail.com";
     github = "evanrichter";

--- a/pkgs/by-name/ot/otel-ebpf-profiler/package.nix
+++ b/pkgs/by-name/ot/otel-ebpf-profiler/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  libbpf,
+  elfutils,
+  zlib,
+  pkg-config,
+  llvmPackages,
+}:
+buildGoModule (finalAttrs: {
+  pname = "otel-ebpf-profiler";
+  version = "0.0.202606";
+
+  src = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-ebpf-profiler";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-G3mbz0DJhTOJ2EyPwu8jfoLTeAKrBxNtzgySfW7zTbU=";
+    fetchSubmodules = true;
+  };
+
+  vendorHash = "sha256-FsmprnK+RFdfUsUYwCRYwFnGqep+DVTUsQ92+44UV4Q=";
+
+  subPackages = [ "." ];
+
+  nativeBuildInputs = [
+    pkg-config
+    llvmPackages.clang
+  ];
+
+  buildInputs = [
+    libbpf
+    elfutils
+    zlib
+  ];
+
+  env = {
+    CGO_ENABLED = "1";
+    CC = "clang";
+  };
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "Continuous profiling for OpenTelemetry using eBPF";
+    homepage = "https://github.com/open-telemetry/opentelemetry-ebpf-profiler";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ evanlhatch ];
+    mainProgram = "ebpf-profiler";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
# Description of changes

This PR adds `otel-ebpf-profiler`, the official OpenTelemetry continuous profiling tool using eBPF.

## About

otel-ebpf-profiler is a CNCF/OpenTelemetry project that provides continuous profiling for applications using eBPF, with zero code changes required.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested using sandboxing
- [x] Tested basic functionality
- [x] Fits CONTRIBUTING.md
- [x] Package name follows naming conventions
- [x] Added myself as maintainer
- [x] Formatted with `nix fmt`

## Package Information

- **Version**: 0.0.202606
- **License**: Apache-2.0
- **Platform**: Linux only (eBPF)
- **Type**: Go + eBPF
- **Homepage**: https://github.com/open-telemetry/opentelemetry-ebpf-profiler
- **Upstream**: Official OpenTelemetry/CNCF project

## Build verification

```bash
$ nix-build -A otel-ebpf-profiler
/nix/store/...-otel-ebpf-profiler-0.0.202606

$ ./result/bin/ebpf-profiler --version
# Works as expected
```

## Additional notes

- Official OpenTelemetry project (CNCF)
- Requires Linux kernel with eBPF support
- Complementary to beyla (PR #491544) - both are eBPF observability tools
