### PR TITLE
greptimedb: init at 1.0.0-rc.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7513,6 +7513,11 @@
     githubId = 1847524;
     name = "Evan Stoll";
   };
+  evanlhatch = {
+    github = "evanlhatch";
+    githubId = 44220750;
+    name = "Evan Hatch";
+  };
   evanrichter = {
     email = "evanjrichter@gmail.com";
     github = "evanrichter";

--- a/pkgs/by-name/gr/greptimedb/package.nix
+++ b/pkgs/by-name/gr/greptimedb/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  openssl,
+  zlib,
+  zstd,
+  ...
+}:
+stdenv.mkDerivation rec {
+  pname = "greptimedb";
+  version = "1.0.0-rc.1";
+
+  src = fetchurl {
+    url = "https://github.com/GreptimeTeam/greptimedb/releases/download/v${version}/greptime-linux-amd64-v${version}.tar.gz";
+    hash = "sha256-xitwxtDeWe/xSlOKVZPKaSe5hKTiFavjiyjFCwVvdTE=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+    zstd
+    stdenv.cc.cc.lib
+  ];
+
+  sourceRoot = "greptime-linux-amd64-v${version}";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    install -m755 greptime $out/bin/greptime
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Cloud-native, unified observability database for metrics, logs and traces";
+    homepage = "https://greptime.com";
+    license = licenses.asl20;
+    platforms = platforms.linux;
+    mainProgram = "greptime";
+  };
+}


### PR DESCRIPTION
# Description of changes

This PR adds `greptimedb`, a cloud-native unified observability database for metrics, logs, and traces.

## About

GreptimeDB is a time-series database designed for cloud-native observability, supporting metrics, logs, and traces in a single unified database.

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested using sandboxing
- [x] Tested basic functionality
- [x] Fits CONTRIBUTING.md
- [x] Package name follows naming conventions
- [x] Added myself as maintainer
- [x] Formatted with `nix fmt`

## Package Information

- **Version**: 1.0.0-rc.1
- **License**: Apache-2.0
- **Platform**: Linux x86_64
- **Type**: Pre-built binary
- **Homepage**: https://greptime.com
- **Upstream**: https://github.com/GreptimeTeam/greptimedb

## Build verification

```bash
$ nix-build -A greptimedb
/nix/store/...-greptimedb-1.0.0-rc.1

$ ./result/bin/greptime --version
# Works as expected
```

## Additional notes

- Uses pre-built binary from upstream releases
- Currently Linux x86_64 only (can add other platforms later)
- RC version - stable 1.0 should be released soon
