### PR TITLE
octelium: init at 0.27.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7513,6 +7513,11 @@
     githubId = 1847524;
     name = "Evan Stoll";
   };
+  evanlhatch = {
+    github = "evanlhatch";
+    githubId = 44220750;
+    name = "Evan Hatch";
+  };
   evanrichter = {
     email = "evanjrichter@gmail.com";
     github = "evanrichter";

--- a/pkgs/by-name/oc/octelium/package.nix
+++ b/pkgs/by-name/oc/octelium/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+let
+  pname = "octelium";
+  version = "0.27.0";
+in
+buildGoModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "octelium";
+    repo = "octelium";
+    tag = "v${version}";
+    hash = "sha256-O2jgGKuE5Y0WcsreZrgTNkWw94CEK9EfOrND7pwjqBw=";
+  };
+
+  # Use proxyVendor for Go workspace support
+  proxyVendor = true;
+
+  vendorHash = "sha256-7CmpyH8I20AgUeRk8q1Z1HR43I0BTWgQEefDzZ6hgzk=";
+
+  # Build all three CLI tools
+  subPackages = [
+    "client/octelium"
+    "client/octeliumctl"
+    "client/octops"
+  ];
+
+  # Set ldflags to match the Makefile build flags
+  ldflags =
+    let
+      ldflags_path = "github.com/octelium/octelium/pkg/utils/ldflags";
+    in
+    [
+      "-X ${ldflags_path}.GitCommit=${version}"
+      "-X ${ldflags_path}.GitTag=v${version}"
+      "-X ${ldflags_path}.GitBranch=main"
+      "-X ${ldflags_path}.SemVer=v${version}"
+      "-X ${ldflags_path}.ImageRegistry=ghcr.io"
+      "-X ${ldflags_path}.ImageRegistryPrefix=octelium"
+    ];
+
+  meta = {
+    description = "Next-gen FOSS self-hosted unified zero trust secure access platform";
+    longDescription = ''
+      Octelium is a free and open source, self-hosted, unified zero trust secure
+      access platform that can operate as a modern zero-config remote access VPN,
+      a comprehensive Zero Trust Network Access (ZTNA)/BeyondCorp platform, an
+      ngrok/Cloudflare Tunnel alternative, an API gateway, an AI/LLM gateway, a
+      scalable infrastructure for MCP gateways and A2A architectures/meshes, a
+      PaaS-like platform, and a homelab infrastructure.
+
+      This package includes three CLI tools:
+      - octelium: Used by all Users to connect to the Cluster and access its Services
+      - octeliumctl: Used by Cluster managers to manage the Cluster's resources
+      - octops: Used to install, upgrade and uninstall Clusters
+    '';
+    homepage = "https://github.com/octelium/octelium";
+    changelog = "https://github.com/octelium/octelium/releases/tag/v${version}";
+    license = with lib.licenses; [
+      asl20 # Client components
+      agpl3Only # Cluster components (not built here)
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+    mainProgram = "octelium";
+  };
+}


### PR DESCRIPTION
# Description of changes

This PR adds `octelium`, a self-hosted unified zero trust secure access platform.

## About

Octelium is a free and open source platform that can operate as a modern VPN, Zero Trust Network Access (ZTNA) platform, API gateway, and more.

This package includes three CLI tools:
- `octelium`: Used by users to connect to clusters and access services
- `octeliumctl`: Used by cluster managers to manage resources
- `octops`: Used to install, upgrade and uninstall clusters

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested using sandboxing
- [x] Tested basic functionality
- [x] Fits CONTRIBUTING.md
- [x] Package name follows naming conventions
- [x] Added myself as maintainer
- [x] Formatted with `nix fmt`

## Package Information

- **Version**: 0.27.0
- **License**: Apache-2.0 (client components), AGPL-3.0 (cluster components, not built here)
- **Platform**: Unix (Linux + macOS)
- **Type**: Go
- **Homepage**: https://github.com/octelium/octelium

## Build verification

```bash
$ nix-build -A octelium
/nix/store/...-octelium-0.27.0

$ ./result/bin/octelium --version
$ ./result/bin/octeliumctl --version
$ ./result/bin/octops --version
# All three binaries work as expected
```

## Additional notes

- Builds only the client components (Apache-2.0 licensed)
- Cluster components (AGPL-3.0) are not included
- Cross-platform (works on Linux and macOS)
