### PR TITLE
morse-linux: init at 2.6

### DIFF
--- a/pkgs/by-name/mo/morse-linux/package.nix
+++ b/pkgs/by-name/mo/morse-linux/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  alsa-lib,
+  pulseaudio,
+  pkg-config,
+  xmlto,
+  docbook_xsl,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "morse";
+  version = "2.6";
+
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "morse-classic";
+    tag = finalAttrs.version;
+    hash = "sha256-wk/Jcp2YWUlecV3OMELD6IWrlj3IC8kh0U4geMxG4fw=";
+  };
+
+  buildInputs = [
+    alsa-lib
+    pulseaudio
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    xmlto
+    docbook_xsl
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile --replace-fail "xmlto" "xmlto --skip-validation"
+  '';
+
+  env.NIX_CFLAGS_COMPILE = "-std=gnu99";
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 morse -t "$out/bin/"
+    install -Dm755 QSO -t "$out/bin/"
+    install -Dm644 morse.1 -t "$out/share/man/man1/"
+    install -Dm644 QSO.1 -t "$out/share/man/man1/"
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Training program about morse-code for aspiring radio hams";
+    homepage = "https://gitlab.com/esr/morse-classic";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [
+      matthewcroughan
+      sarcasticadmin
+    ];
+    platforms = lib.platforms.linux;
+    mainProgram = "morse";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A nice CLI program for training and playing back morse code that couldn't believe wasn't already packaged. It has a really nice man page too.

https://code.tools/man/1/morseLinux/

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
