### PR TITLE
nixos/systemd/tpm2: add pcrphase services

### DIFF
--- a/nixos/modules/system/boot/systemd/tpm2.nix
+++ b/nixos/modules/system/boot/systemd/tpm2.nix
@@ -9,19 +9,8 @@
 
   imports = [
     (lib.mkRenamedOptionModule
-      [
-        "boot"
-        "initrd"
-        "systemd"
-        "enableTpm2"
-      ]
-      [
-        "boot"
-        "initrd"
-        "systemd"
-        "tpm2"
-        "enable"
-      ]
+      [ "boot" "initrd" "systemd" "enableTpm2" ]
+      [ "boot" "initrd" "systemd" "tpm2" "enable" ]
     )
   ];
 
@@ -31,13 +20,18 @@
       defaultText = "systemd.package.withTpm2Units";
     };
 
+    systemd.tpm2.pcrphases.enable = lib.mkEnableOption "systemd boot phase measurements";
+
     boot.initrd.systemd.tpm2.enable = lib.mkEnableOption "systemd initrd TPM2 support" // {
       default = config.boot.initrd.systemd.package.withTpm2Units;
       defaultText = "boot.initrd.systemd.package.withTpm2Units";
     };
+
+    boot.initrd.systemd.tpm2.pcrphases.enable =
+      lib.mkEnableOption "systemd initrd boot phase measurements";
   };
 
-  # TODO: pcrphase, pcrextend, pcrfs, pcrmachine
+  # TODO: pcrextend, pcrfs, pcrmachine
   config = lib.mkMerge [
     # Stage 2
     (
@@ -50,6 +44,19 @@
           "systemd-tpm2-setup-early.service"
           "systemd-tpm2-setup.service"
         ];
+      }
+    )
+    (
+      let
+        cfg = config.systemd;
+      in
+      lib.mkIf (cfg.tpm2.enable && cfg.tpm2.pcrphases.enable) {
+        systemd.additionalUpstreamSystemUnits = [
+          "systemd-pcrphase.service"
+          "systemd-pcrphase-sysinit.service"
+        ];
+        systemd.services.systemd-pcrphase.wantedBy = [ "sysinit.target" ];
+        systemd.services.systemd-pcrphase-sysinit.wantedBy = [ "sysinit.target" ];
       }
     )
 
@@ -75,6 +82,16 @@
           "${cfg.package}/lib/systemd/systemd-tpm2-setup"
           "${cfg.package}/lib/systemd/system-generators/systemd-tpm2-generator"
         ];
+      }
+    )
+    (
+      let
+        cfg = config.boot.initrd.systemd;
+      in
+      lib.mkIf (cfg.enable && cfg.tpm2.enable && cfg.tpm2.pcrphases.enable) {
+        boot.initrd.systemd.additionalUpstreamUnits = [ "systemd-pcrphase-initrd.service" ];
+        boot.initrd.systemd.services.systemd-pcrphase-initrd.wantedBy = [ "initrd.target" ];
+        boot.initrd.systemd.storePaths = [ "${cfg.package}/lib/systemd/systemd-pcrextend" ];
       }
     )
   ];


### PR DESCRIPTION
Tested this running `/run/current-system/sw/lib/systemd/systemd-pcrlock` with [lanzaboote](https://github.com/nix-community/lanzaboote) set up because the upstream systemd services use `ConditionSecurity=measured-uki`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
