### PR TITLE
ablog: 0.11.12 -> 0.11.13

### DIFF
--- a/pkgs/by-name/ab/ablog/package.nix
+++ b/pkgs/by-name/ab/ablog/package.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "0.11.12";
+  version = "0.11.13";
 in
 python3Packages.buildPythonApplication {
   pname = "ablog";
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication {
     owner = "sunpy";
     repo = "ablog";
     tag = "v${version}";
-    hash = "sha256-bPTaxkuIKeypfnZItG9cl51flHBIx/yg0qENuiqQgY4=";
+    hash = "sha256-P1eSN3wqlPNYbYW3Rkz2Y6yFcC379dt/qK8aVNwZRSs=";
   };
 
   build-system = with python3Packages; [
@@ -43,7 +43,6 @@ python3Packages.buildPythonApplication {
 
   pytestFlags = [
     "--rootdir=src/ablog"
-    "-Wignore::sphinx.deprecation.RemovedInSphinx90Warning" # Ignore ImportError
   ];
 
   disabledTests = [


### PR DESCRIPTION
Changelog: https://github.com/sunpy/ablog/releases/tag/v0.11.13

Don't ignore RemovedInSphinx90Warning, as with sphinx 9, it doesn't exist.

Fixes build failure on staging-next, where sphinx has been updated. (e.g. https://hydra.nixos.org/build/321274421)

Closes: #482184

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
