### PR TITLE
backblaze-b2: 4.4.2 -> 4.5.1

### DIFF
--- a/pkgs/by-name/ba/backblaze-b2/0001-fix-error-with-pytest-4.0.patch
+++ b/pkgs/by-name/ba/backblaze-b2/0001-fix-error-with-pytest-4.0.patch
@@ -1,0 +1,40 @@
+From 898cfcc19af66f5a9273cd04b43cf76ae9ec6da9 Mon Sep 17 00:00:00 2001
+From: Michael Daniels <mdaniels5757@gmail.com>
+Date: Tue, 17 Feb 2026 21:17:33 -0500
+Subject: [PATCH] fix error with pytest 4.0
+
+https://docs.pytest.org/en/stable/deprecations.html#pytest-plugins-in-non-top-level-conftest-files
+---
+ test/conftest.py             | 1 +
+ test/integration/conftest.py | 3 ---
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/test/conftest.py b/test/conftest.py
+index 8f0629b..53f3e32 100644
+--- a/test/conftest.py
++++ b/test/conftest.py
+@@ -12,6 +12,7 @@ import sys
+ 
+ import pytest
+ 
++pytest_plugins = ['b2sdk.v3.testing']
+ 
+ @pytest.hookimpl
+ def pytest_configure(config):
+diff --git a/test/integration/conftest.py b/test/integration/conftest.py
+index 1a7226d..035a2be 100755
+--- a/test/integration/conftest.py
++++ b/test/integration/conftest.py
+@@ -47,9 +47,6 @@ ROOT_PATH = pathlib.Path(__file__).parent.parent.parent
+ GENERAL_BUCKET_NAME_PREFIX = 'clitst'
+ 
+ 
+-pytest_plugins = ['b2sdk.v3.testing']
+-
+-
+ @pytest.fixture(scope='session', autouse=True)
+ def summary_notes(request, worker_id):
+     capmanager = request.config.pluginmanager.getplugin('capturemanager')
+-- 
+2.51.2
+

--- a/pkgs/by-name/ba/backblaze-b2/package.nix
+++ b/pkgs/by-name/ba/backblaze-b2/package.nix
@@ -11,15 +11,17 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "backblaze-b2";
-  version = "4.4.2";
+  version = "4.5.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "B2_Command_Line_Tool";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ut1e/A36Tp4pgwZx+S8nYmjg3k/2CmRpdUfz3iOXTz0=";
+    hash = "sha256-0BF4+L47Cx7GNGeNm8nJkEfTLYb6jLxSH3WE+h9B6zA=";
   };
+
+  patches = [ ./0001-fix-error-with-pytest-4.0.patch ];
 
   nativeBuildInputs = with python3Packages; [
     installShellFiles


### PR DESCRIPTION
Changelog: https://github.com/Backblaze/B2_Command_Line_Tool/blob/v4.5.1/CHANGELOG.md

Fixes build failure on staging-next.

I made my own patch instead of using https://redirect.github.com/Backblaze/B2_Command_Line_Tool/pull/1133, as it has to be vendored anyways (paragraph just above https://github.com/NixOS/nixpkgs/blob/f88d09144286971d3568a77c40299b29a9961e60/pkgs/README.md#vendoring-patches), and there's no need for us to vendor the changelog.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
