### PR TITLE
weechat-matrix-rs: init at 0-unstable-2025-10-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -30096,6 +30096,12 @@
     githubId = 873857;
     name = "Zack Newman";
   };
+  zodman = {
+    github = "zodman";
+    githubId = 44167;
+    name = "Andres Vargas";
+    email = "zodman@gmail.com";
+  };
   zoedsoupe = {
     github = "zoedsoupe";
     githubId = 44469426;

--- a/pkgs/by-name/we/weechat-matrix-rs/package.nix
+++ b/pkgs/by-name/we/weechat-matrix-rs/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  weechat,
+  openssl,
+  sqlite,
+  runCommand,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "weechat-matrix-rs";
+  version = "0-unstable-2025-10-09";
+  src = fetchFromGitHub {
+    owner = "poljar";
+    repo = "weechat-matrix-rs";
+    rev = "4cc5777b630ba4d6a9c964248531f283178a4717";
+    hash = "sha256-CF4xDoRYey9F8/XSW/euNb8IjZXyP6k0Nj61shsmyEo=";
+  };
+  cargoHash = "sha256-jAlBCmLJfWWAUHd3ySB930iqAVXMh6ueba7xS///Rt0=";
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+  buildInputs = [
+    weechat
+    openssl
+    sqlite
+  ];
+  postInstall = ''
+    mkdir -p $out/lib/weechat/plugins
+    mv $out/lib/libmatrix${stdenv.hostPlatform.extensions.sharedLibrary} $out/lib/weechat/plugins/matrix${stdenv.hostPlatform.extensions.sharedLibrary}
+  '';
+  passthru.tests.load-plugin =
+    runCommand "${finalAttrs.pname}-test-load"
+      {
+        nativeBuildInputs = [ weechat ];
+      }
+      ''
+        weechat -t -d "$(mktemp -d)" \
+         --run-command "/plugin load ${finalAttrs.finalPackage}/lib/weechat/plugins/matrix${stdenv.hostPlatform.extensions.sharedLibrary} ; /quit" \
+         2>&1 | tee log
+        if grep -q 'Plugin "matrix" loaded' log; then
+          echo "Check passed: matrix plugin loaded into WeeChat."
+          touch $out
+        else
+          echo "Check failed: 'matrix' not found in WeeChat output."
+          exit 1
+        fi
+      '';
+  meta = {
+    description = "Rust plugin for WeeChat to communicate over Matrix";
+    homepage = "https://github.com/poljar/weechat-matrix-rs";
+    license = lib.licenses.isc;
+    maintainers = with lib.maintainers; [ zodman ];
+    platforms = lib.platforms.unix;
+  };
+
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

new package.

the old script weechat-matrix, it is deprecated, the new version weechat-matrix-rs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
