### PR TITLE
python313Packages.stanza: modernize and remove dependencies

### DIFF
--- a/pkgs/development/python-modules/stanza/default.nix
+++ b/pkgs/development/python-modules/stanza/default.nix
@@ -1,47 +1,52 @@
 {
   lib,
   buildPythonPackage,
-  emoji,
   fetchFromGitHub,
+  # build-system
+  setuptools,
+  # dependencies
+  emoji,
   networkx,
   numpy,
   peft,
   protobuf,
   requests,
-  six,
-  toml,
   torch,
   tqdm,
   transformers,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "stanza";
   version = "1.11.0";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "stanfordnlp";
     repo = "stanza";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-zY2+8QuPJTX/HSkE/gKMCWpSanKpYSGZeeYgb4eFuuw=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     emoji
     networkx
     numpy
     peft
     protobuf
     requests
-    six
-    toml
     torch
     tqdm
     transformers
   ];
 
-  # Tests require network access
+  # Most tests require resources from the network (models). Many of the ones that do run are slow
+  # and some of them fail.
+  #
+  # Maintaining a list of "tests we can actually run in CI" isn't feasible, there are WAY too many
+  # exceptions and no useful pytest marks.
   doCheck = false;
 
   pythonImportsCheck = [ "stanza" ];
@@ -49,8 +54,8 @@ buildPythonPackage rec {
   meta = {
     description = "Official Stanford NLP Python Library for Many Human Languages";
     homepage = "https://github.com/stanfordnlp/stanza/";
-    changelog = "https://github.com/stanfordnlp/stanza/releases/tag/v${version}";
+    changelog = "https://github.com/stanfordnlp/stanza/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ riotbib ];
   };
-}
+})

--- a/pkgs/development/python-modules/stanza/default.nix
+++ b/pkgs/development/python-modules/stanza/default.nix
@@ -56,6 +56,9 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/stanfordnlp/stanza/";
     changelog = "https://github.com/stanfordnlp/stanza/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ riotbib ];
+    maintainers = with lib.maintainers; [
+      riotbib
+      Stebalien
+    ];
   };
 })


### PR DESCRIPTION
This PR switches to pyproject and uses `finalAttrs` instead of a recursive attribute set. I've also added myself as a co-maintainer at @riotbib's request.

Additionally, it removes the following dependencies:

- toml: [stanza will use tomllib](https://github.com/stanfordnlp/stanza/blob/156f86bff61fe673c3930af5fcf7a44d66b28dac/stanza/models/coref/model.py#L14) when available ([added in python 3.11](https://docs.python.org/3/library/tomllib.html#module-tomllib)), which
appears to be the minimum supported cpython in nix.
- six: [upstream no longer requires six](https://github.com/stanfordnlp/stanza/pull/1274).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test