### PR TITLE
uutils-{hostname, login, tar, procps, acl, util-linux}: use workspace

### DIFF
--- a/pkgs/by-name/uu/uutils-acl/package.nix
+++ b/pkgs/by-name/uu/uutils-acl/package.nix
@@ -18,6 +18,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-p0JDeNLKkjmGsZ9fF/9Xm+0pc00pzY8pgWb4B82D6vE=";
 
+  cargoBuildFlags = [ "--workspace" ];
+
   checkFlags = [
     # Operation not supported
     "--skip=common::util::tests::test_compare_xattrs"

--- a/pkgs/by-name/uu/uutils-hostname/package.nix
+++ b/pkgs/by-name/uu/uutils-hostname/package.nix
@@ -18,6 +18,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-gt1cC06Viu0trXL1+0/EToybSAJwFL3KVSltqUtpGj0=";
 
+  cargoBuildFlags = [ "--package uu_hostname" ];
+
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];
   };

--- a/pkgs/by-name/uu/uutils-login/package.nix
+++ b/pkgs/by-name/uu/uutils-login/package.nix
@@ -18,6 +18,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-iCS3n7nd5qVjTcMoTubQFl15ZY2cf0w91OBqtckNb44=";
 
+  cargoBuildFlags = [ "--workspace" ];
+
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];
   };

--- a/pkgs/by-name/uu/uutils-procps/package.nix
+++ b/pkgs/by-name/uu/uutils-procps/package.nix
@@ -21,6 +21,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-QWz6Hr3nuE4ZIMM81pR4K2bjefWV5mlnu/HYcHDwToE=";
 
+  cargoBuildFlags = [ "--workspace" ];
+
   nativeBuildInputs = [
     pkg-config
     writableTmpDirAsHomeHook

--- a/pkgs/by-name/uu/uutils-tar/package.nix
+++ b/pkgs/by-name/uu/uutils-tar/package.nix
@@ -18,6 +18,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   cargoHash = "sha256-s8BHAfc6L0RyK8xX8C2exjjOUAULt1xnrSkt4T/qruE=";
 
+  cargoBuildFlags = [ "--workspace" ];
+
   passthru.updateScript = nix-update-script {
     extraArgs = [ "--version=branch" ];
   };

--- a/pkgs/by-name/uu/uutils-util-linux/package.nix
+++ b/pkgs/by-name/uu/uutils-util-linux/package.nix
@@ -42,6 +42,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     export NIX_LDFLAGS="$NIX_LDFLAGS -lsmartcols -lmount"
   '';
 
+  cargoBuildFlags = [ "--workspace" ];
+
   checkFlags = [
     # Operation not supported
     "--skip=common::util::tests::test_compare_xattrs"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
add cargoBuildFlags to enable the compilation of subpackage binaries

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
