### PR TITLE
lazyworktree: 1.28.0 -> 1.38.1

### DIFF
--- a/pkgs/by-name/la/lazyworktree/package.nix
+++ b/pkgs/by-name/la/lazyworktree/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   buildGoModule,
   fetchFromGitHub,
   installShellFiles,
@@ -9,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "lazyworktree";
-  version = "1.28.0";
+  version = "1.38.1";
 
   src = fetchFromGitHub {
     owner = "chmouel";
     repo = "lazyworktree";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-syfhjNsqRz9Gte514NcuP/J8NMGLEdsJrvnuqBHAnCc=";
+    hash = "sha256-rNTzmvfVAToPzOvP+3wnL+zyQzL2mXQCnRY0cLKuQ6c=";
   };
 
-  vendorHash = "sha256-BfQWSogSoD0c71CPMqhfK7F+TzZQt6+wNIzPlFQ2zPU=";
+  vendorHash = "sha256-Y4TZZ7Fhn1YSxG6YH0l0y0iWxgml93gOwKyTXWkjpqg=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -32,8 +33,14 @@ buildGoModule (finalAttrs: {
   ];
 
   postInstall = ''
-    install -Dm444 shell/functions.shell -t $out/share/lazyworktree
+    install -Dm444 shell/functions.{bash,fish,zsh} -t $out/share/lazyworktree
     installManPage lazyworktree.1
+  ''
+  + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd lazyworktree \
+      --bash <($out/bin/lazyworktree completion bash --code) \
+      --zsh <($out/bin/lazyworktree completion zsh --code) \
+      --fish <($out/bin/lazyworktree completion fish --code)
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
Update lazyworktree from 1.28.0 to 1.38.1.

- Fix postInstall: upstream replaced `shell/functions.shell` with separate
  `shell/functions.{bash,fish,zsh}` files after version 1.28.0. This was
  causing r-ryantm auto-update attempts to fail with
  `install: cannot stat 'shell/functions.shell': No such file or directory`.
- Add shell completions for bash, zsh, and fish (supersedes #484000).

[Changelog](https://github.com/chmouel/lazyworktree/releases/tag/v1.38.0)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test