### PR TITLE
[Backport release-25.11] noctalia-shell: init at 4.5.0

### DIFF
--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -13,15 +13,14 @@
   cava,
   cliphist,
   ddcutil,
-  matugen,
   wlsunset,
   wl-clipboard,
   imagemagick,
   wget,
   gpu-screen-recorder,
+  python3,
 
   # calendar support
-  python3,
   evolution-data-server,
   libical,
   glib,
@@ -33,27 +32,26 @@
   cavaSupport ? true,
   cliphistSupport ? true,
   ddcutilSupport ? true,
-  matugenSupport ? true,
   wlsunsetSupport ? true,
   wl-clipboardSupport ? true,
   imagemagickSupport ? true,
-  gpuScreenRecorderSupport ? stdenvNoCC.hostPlatform.system == "x86_64-linux",
   calendarSupport ? false,
+  # gpu-screen-recorder support was moved to an optional plugin in v4.0.0
+  gpuScreenRecorderSupport ? false,
 }:
 let
   runtimeDeps = [
     wget
+    (python3.withPackages (pp: lib.optional calendarSupport pp.pygobject3))
   ]
   ++ lib.optional brightnessctlSupport brightnessctl
   ++ lib.optional cavaSupport cava
   ++ lib.optional cliphistSupport cliphist
   ++ lib.optional ddcutilSupport ddcutil
-  ++ lib.optional matugenSupport matugen
   ++ lib.optional wlsunsetSupport wlsunset
   ++ lib.optional wl-clipboardSupport wl-clipboard
   ++ lib.optional imagemagickSupport imagemagick
-  ++ lib.optional gpuScreenRecorderSupport gpu-screen-recorder
-  ++ lib.optional calendarSupport (python3.withPackages (pp: [ pp.pygobject3 ]));
+  ++ lib.optional gpuScreenRecorderSupport gpu-screen-recorder;
 
   giTypelibPath = lib.makeSearchPath "lib/girepository-1.0" [
     evolution-data-server
@@ -66,13 +64,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.1.1";
+  version = "4.2.5";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/7yEiXC2Z/Yk/p7aNgChkAa7BgPRlV5/0z8+jZXH8e8=";
+    hash = "sha256-SHavMqGRv78sND/wQ53OhBBE2VBhgE3bSNRxxo5z7FE=";
   };
 
   nativeBuildInputs = [
@@ -91,11 +89,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ln -s ${quickshell}/bin/qs $out/bin/noctalia-shell
 
     cp -R \
-      Assets Bin Commons CREDITS.md Helpers Modules Services Shaders Widgets shell.qml \
+      Assets Commons CREDITS.md Helpers Modules Services Shaders Scripts Widgets shell.qml \
       $out/share/noctalia-shell
 
     rm -R $out/share/noctalia-shell/Assets/Screenshots
-    rm -R $out/share/noctalia-shell/Bin/dev
 
     runHook postInstall
   '';

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -64,13 +64,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.2.5";
+  version = "4.3.0";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SHavMqGRv78sND/wQ53OhBBE2VBhgE3bSNRxxo5z7FE=";
+    hash = "sha256-u+M2dCw9PznZTgn51DwHpX4VcU9ZC9Acub7qKhCpr3c=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -65,13 +65,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.4.1";
+  version = "4.4.3";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ozr4zO+T7o7FkPRTLpAymnb3K9+hc9OIN1lq0i5oWbs=";
+    hash = "sha256-5HqCE5qfW6ItA+ZeFGfTT7/+12QYp/1j93EPdn+nlK0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -1,0 +1,121 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  stdenvNoCC,
+
+  # build
+  qt6,
+  quickshell,
+
+  # runtime deps
+  brightnessctl,
+  cava,
+  cliphist,
+  ddcutil,
+  matugen,
+  wlsunset,
+  wl-clipboard,
+  imagemagick,
+  wget,
+  gpu-screen-recorder,
+
+  # calendar support
+  python3,
+  evolution-data-server,
+  libical,
+  glib,
+  libsoup_3,
+  json-glib,
+  gobject-introspection,
+
+  brightnessctlSupport ? true,
+  cavaSupport ? true,
+  cliphistSupport ? true,
+  ddcutilSupport ? true,
+  matugenSupport ? true,
+  wlsunsetSupport ? true,
+  wl-clipboardSupport ? true,
+  imagemagickSupport ? true,
+  gpuScreenRecorderSupport ? stdenvNoCC.hostPlatform.system == "x86_64-linux",
+  calendarSupport ? false,
+}:
+let
+  runtimeDeps = [
+    wget
+  ]
+  ++ lib.optional brightnessctlSupport brightnessctl
+  ++ lib.optional cavaSupport cava
+  ++ lib.optional cliphistSupport cliphist
+  ++ lib.optional ddcutilSupport ddcutil
+  ++ lib.optional matugenSupport matugen
+  ++ lib.optional wlsunsetSupport wlsunset
+  ++ lib.optional wl-clipboardSupport wl-clipboard
+  ++ lib.optional imagemagickSupport imagemagick
+  ++ lib.optional gpuScreenRecorderSupport gpu-screen-recorder
+  ++ lib.optional calendarSupport (python3.withPackages (pp: [ pp.pygobject3 ]));
+
+  giTypelibPath = lib.makeSearchPath "lib/girepository-1.0" [
+    evolution-data-server
+    libical
+    glib.out
+    libsoup_3
+    json-glib
+    gobject-introspection
+  ];
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "noctalia-shell";
+  version = "3.7.5";
+
+  src = fetchFromGitHub {
+    owner = "noctalia-dev";
+    repo = "noctalia-shell";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TBrsYS+n+8AsXRAP4wA3JNOdT604QmPo8yeSTT/p61I=";
+  };
+
+  nativeBuildInputs = [
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtmultimedia
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/noctalia-shell $out/bin
+    ln -s ${quickshell}/bin/qs $out/bin/noctalia-shell
+
+    cp -R \
+      Assets Bin Commons CREDITS.md Helpers Modules Services Shaders Widgets shell.qml \
+      $out/share/noctalia-shell
+
+    rm -R $out/share/noctalia-shell/Assets/Screenshots
+    rm -R $out/share/noctalia-shell/Bin/dev
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      --prefix PATH : ${lib.makeBinPath runtimeDeps}
+      --add-flags "-p $out/share/noctalia-shell"
+      ${lib.optionalString calendarSupport "--prefix GI_TYPELIB_PATH : ${giTypelibPath}"}
+    )
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Sleek and minimal desktop shell thoughtfully crafted for Wayland, built with Quickshell";
+    homepage = "https://github.com/noctalia-dev/noctalia-shell";
+    license = lib.licenses.mit;
+    mainProgram = "noctalia-shell";
+    maintainers = with lib.maintainers; [ spacedentist ];
+    platforms = quickshell.meta.platforms;
+  };
+})

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -66,13 +66,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "3.8.2";
+  version = "4.0.0";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ZjtdQbVPHJeWP8VHWZmSwPwD6fC7Dqmknx1KErzfDks=";
+    hash = "sha256-1ByxRYrivSkD4lIQQxv88r+I/mFo+JF3ebok6375+3Q=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -66,13 +66,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "3.7.5";
+  version = "3.8.0";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-TBrsYS+n+8AsXRAP4wA3JNOdT604QmPo8yeSTT/p61I=";
+    hash = "sha256-Bh4XcEyG6XRQugahL/2Vd42k/YeGK0f+yW3+Oc74Rp4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -66,13 +66,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.0.0";
+  version = "4.1.1";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-1ByxRYrivSkD4lIQQxv88r+I/mFo+JF3ebok6375+3Q=";
+    hash = "sha256-/7yEiXC2Z/Yk/p7aNgChkAa7BgPRlV5/0z8+jZXH8e8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -66,13 +66,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "3.8.0";
+  version = "3.8.2";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Bh4XcEyG6XRQugahL/2Vd42k/YeGK0f+yW3+Oc74Rp4=";
+    hash = "sha256-ZjtdQbVPHJeWP8VHWZmSwPwD6fC7Dqmknx1KErzfDks=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -9,6 +9,7 @@
   quickshell,
 
   # runtime deps
+  bluez,
   brightnessctl,
   cava,
   cliphist,
@@ -29,6 +30,7 @@
   json-glib,
   gobject-introspection,
 
+  bluetoothSupport ? true,
   brightnessctlSupport ? true,
   cavaSupport ? true,
   cliphistSupport ? true,
@@ -45,6 +47,7 @@ let
     wget
     (python3.withPackages (pp: lib.optional calendarSupport pp.pygobject3))
   ]
+  ++ lib.optional bluetoothSupport bluez
   ++ lib.optional brightnessctlSupport brightnessctl
   ++ lib.optional cavaSupport cava
   ++ lib.optional cliphistSupport cliphist
@@ -65,13 +68,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.4.3";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5HqCE5qfW6ItA+ZeFGfTT7/+12QYp/1j93EPdn+nlK0=";
+    hash = "sha256-Y5P0RYO9NKxa4UZBoGmmxtz3mEwJrBOfvdLJRGjV2Os=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -110,6 +110,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.updateScript = nix-update-script { };
 
   meta = {
+    changelog = "https://github.com/noctalia-dev/noctalia-shell/releases/tag/v${finalAttrs.version}";
     description = "Sleek and minimal desktop shell thoughtfully crafted for Wayland, built with Quickshell";
     homepage = "https://github.com/noctalia-dev/noctalia-shell";
     license = lib.licenses.mit;

--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -19,6 +19,7 @@
   wget,
   gpu-screen-recorder,
   python3,
+  wayland-scanner,
 
   # calendar support
   evolution-data-server,
@@ -64,13 +65,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.3.0";
+  version = "4.4.1";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-u+M2dCw9PznZTgn51DwHpX4VcU9ZC9Acub7qKhCpr3c=";
+    hash = "sha256-ozr4zO+T7o7FkPRTLpAymnb3K9+hc9OIN1lq0i5oWbs=";
   };
 
   nativeBuildInputs = [
@@ -100,6 +101,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   preFixup = ''
     qtWrapperArgs+=(
       --prefix PATH : ${lib.makeBinPath runtimeDeps}
+      --prefix XDG_DATA_DIRS : ${wayland-scanner}/share
       --add-flags "-p $out/share/noctalia-shell"
       ${lib.optionalString calendarSupport "--prefix GI_TYPELIB_PATH : ${giTypelibPath}"}
     )


### PR DESCRIPTION
Manual backport of noctalia-shell.
Cherry-picked all commits from init until 4.5.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
