### PR TITLE
drawio-headless: set pname and version

### DIFF
--- a/pkgs/build-support/trivial-builders/default.nix
+++ b/pkgs/build-support/trivial-builders/default.nix
@@ -117,7 +117,9 @@ rec {
       in
       finalAttrs:
       {
-        name,
+        pname ? null,
+        version ? null,
+        name ? "${pname}-${version}",
         text,
         executable ? false,
         destination ? "",
@@ -127,7 +129,7 @@ rec {
         allowSubstitutes ? false,
         preferLocalBuild ? true,
         derivationArgs ? { },
-        pos ? builtins.unsafeGetAttrPos "name" args,
+        pos ? builtins.unsafeGetAttrPos (if pname != null then "pname" else "name") args,
       }@args:
       {
         inherit
@@ -139,6 +141,10 @@ rec {
           allowSubstitutes
           preferLocalBuild
           ;
+
+        ${if pname != null then "pname" else null} = pname;
+        ${if version != null then "version" else null} = version;
+
         destination =
           assert
             (destination != "" -> (hasRootPrefix destination && destination != "/"))

--- a/pkgs/by-name/dr/drawio-headless/package.nix
+++ b/pkgs/by-name/dr/drawio-headless/package.nix
@@ -8,6 +8,7 @@
 
 writeTextFile {
   name = "${drawio.pname}-headless-${drawio.version}";
+  inherit (drawio) pname version;
 
   executable = true;
   destination = "/bin/drawio";


### PR DESCRIPTION
#485742
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
