### PR TITLE
mbrola-voices: set pname and version

### DIFF
--- a/pkgs/by-name/mb/mbrola-voices/package.nix
+++ b/pkgs/by-name/mb/mbrola-voices/package.nix
@@ -12,8 +12,11 @@ let
     repo = "MBROLA-voices";
     rev = "fe05a0ccef6a941207fd6aaad0b31294a1f93a51";
     hash = "sha256-QBUggnde5iNeCESzxE0btVVTDOxc3Kdk483mdGUXHvA=";
+    inherit pname version meta;
   };
 
+  pname = "mbrola-voices";
+  version = "0-unstable-2020-03-30";
   meta = {
     description = "Speech synthesizer based on the concatenation of diphones (voice files)";
     homepage = "https://github.com/numediart/MBROLA-voices";
@@ -22,12 +25,9 @@ let
 in
 
 if (languages == [ ]) then
-  src // { inherit meta; }
+  src
 else
   stdenv.mkDerivation {
-    pname = "mbrola-voices";
-    version = "0-unstable-2020-03-30";
-
     inherit src;
 
     postPatch = ''
@@ -46,5 +46,5 @@ else
       runHook postInstall
     '';
 
-    inherit meta;
+    inherit pname version meta;
   }


### PR DESCRIPTION
#485742
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
