### PR TITLE
kubectl: avoid overriding env

### DIFF
--- a/pkgs/by-name/ku/kubectl/package.nix
+++ b/pkgs/by-name/ku/kubectl/package.nix
@@ -1,17 +1,19 @@
 { lib, kubernetes }:
-
-kubernetes.overrideAttrs (_: {
+let
+  kubernetes' = kubernetes.override {
+    components = [
+      "cmd/kubectl"
+      "cmd/kubectl-convert"
+    ];
+  };
+in
+kubernetes'.overrideAttrs (_: {
   pname = "kubectl";
 
   outputs = [
     "out"
     "man"
     "convert"
-  ];
-
-  env.WHAT = toString [
-    "cmd/kubectl"
-    "cmd/kubectl-convert"
   ];
 
   installPhase = ''


### PR DESCRIPTION
Followup to https://github.com/NixOS/nixpkgs/pull/488526#issuecomment-3919281300 .

@K900 Since you didn't like your own suggestion: this implementation avoids touching the `env` entirely. Seems cleaner to use the function argument that already exists?

The package wasn't broken (for me on `x86_64-linux`) to begin with, so are you doing some overriding of your own somewhere?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
