### PR TITLE
python314Packages.pyporscheconnectapi: 0.2.5 -> 0.2.6

### DIFF
--- a/pkgs/development/python-modules/pyporscheconnectapi/default.nix
+++ b/pkgs/development/python-modules/pyporscheconnectapi/default.nix
@@ -8,7 +8,7 @@
   setuptools,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "pyporscheconnectapi";
   version = "0.2.6";
   pyproject = true;
@@ -16,7 +16,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "CJNE";
     repo = "pyporscheconnectapi";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-aiNCT1IYSXdlJfIoQsBnVn9FGHifkI8e35VCQGGAAZ0=";
   };
 
@@ -41,8 +41,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python client library for Porsche Connect API";
     homepage = "https://github.com/CJNE/pyporscheconnectapi";
-    changelog = "https://github.com/CJNE/pyporscheconnectapi/releases/tag/${src.tag}";
+    changelog = "https://github.com/CJNE/pyporscheconnectapi/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/development/python-modules/pyporscheconnectapi/default.nix
+++ b/pkgs/development/python-modules/pyporscheconnectapi/default.nix
@@ -10,14 +10,14 @@
 
 buildPythonPackage rec {
   pname = "pyporscheconnectapi";
-  version = "0.2.5";
+  version = "0.2.6";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "CJNE";
     repo = "pyporscheconnectapi";
     tag = version;
-    hash = "sha256-uB8dbAWoHUWuvWyUhPV1P2wPH/ZzVX22PJNEiDYoOA4=";
+    hash = "sha256-aiNCT1IYSXdlJfIoQsBnVn9FGHifkI8e35VCQGGAAZ0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/CJNE/pyporscheconnectapi/compare/0.2.5...0.2.6

Changelog: https://github.com/CJNE/pyporscheconnectapi/releases/tag/0.2.6


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
