### PR TITLE
homebox: 0.22.3 -> 0.23.1

### DIFF
--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -6,31 +6,31 @@
   fetchPnpmDeps,
   pnpmConfigHook,
   nodejs,
-  go_1_24,
+  go_1_25,
   git,
   cacert,
   nixosTests,
 }:
 let
   pname = "homebox";
-  version = "0.22.3";
+  version = "0.23.1";
   src = fetchFromGitHub {
     owner = "sysadminsmedia";
     repo = "homebox";
     tag = "v${version}";
-    hash = "sha256-0/pf7jShuoME6it8GPXJ7ugoRLVfpEzu2uaUW0XFwJg=";
+    hash = "sha256-bKPlaiAJUwEQbHKBRnUvwuPB4sTlgltUm426LsSQ7yQ=";
   };
 in
 buildGoModule {
   inherit pname version src;
 
-  vendorHash = "sha256-pAMWPMZV5U7hIKNNFgRyyqZEH3wjUCplo7cQfKh1A6g=";
+  vendorHash = "sha256-bHrpZ/zrXl/zjDgn8aETDZZBUQAfVgi6WLDUxFUSmiQ=";
   modRoot = "backend";
   # the goModules derivation inherits our buildInputs and buildPhases
   # Since we do pnpm thing in those it fails if we don't explicitly remove them
   overrideModAttrs = _: {
     nativeBuildInputs = [
-      go_1_24
+      go_1_25
       git
       cacert
     ];
@@ -42,7 +42,7 @@ buildGoModule {
     src = "${src}/frontend";
     pnpm = pnpm_9;
     fetcherVersion = 1;
-    hash = "sha256-5AEwgI5rQzp/36USr+QEzjgllZkKhhIvlzl+9ZVfGM4=";
+    hash = "sha256-MG2IzSOjdGIjuKOtbDlI6UY+67+6/AAsnBscFvs2V4o=";
   };
   pnpmRoot = "../frontend";
 


### PR DESCRIPTION
https://github.com/sysadminsmedia/homebox/releases/tag/v0.23.1
https://github.com/sysadminsmedia/homebox/releases/tag/v0.23.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
