### PR TITLE
noctalia-shell: 4.4.3 -> 4.5.0

### DIFF
--- a/pkgs/by-name/no/noctalia-shell/package.nix
+++ b/pkgs/by-name/no/noctalia-shell/package.nix
@@ -9,6 +9,7 @@
   quickshell,
 
   # runtime deps
+  bluez,
   brightnessctl,
   cava,
   cliphist,
@@ -29,6 +30,7 @@
   json-glib,
   gobject-introspection,
 
+  bluetoothSupport ? true,
   brightnessctlSupport ? true,
   cavaSupport ? true,
   cliphistSupport ? true,
@@ -45,6 +47,7 @@ let
     wget
     (python3.withPackages (pp: lib.optional calendarSupport pp.pygobject3))
   ]
+  ++ lib.optional bluetoothSupport bluez
   ++ lib.optional brightnessctlSupport brightnessctl
   ++ lib.optional cavaSupport cava
   ++ lib.optional cliphistSupport cliphist
@@ -65,13 +68,13 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "noctalia-shell";
-  version = "4.4.3";
+  version = "4.5.0";
 
   src = fetchFromGitHub {
     owner = "noctalia-dev";
     repo = "noctalia-shell";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-5HqCE5qfW6ItA+ZeFGfTT7/+12QYp/1j93EPdn+nlK0=";
+    hash = "sha256-Y5P0RYO9NKxa4UZBoGmmxtz3mEwJrBOfvdLJRGjV2Os=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/noctalia-dev/noctalia-shell/releases/tag/v4.5.0
https://github.com/noctalia-dev/noctalia-shell/compare/v4.4.3..v4.5.0

I have tested it on my own PC.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
