### PR TITLE
avogadro2: 1.102.1 -> 1.103.0

### DIFF
--- a/pkgs/applications/science/chemistry/avogadro2/default.nix
+++ b/pkgs/applications/science/chemistry/avogadro2/default.nix
@@ -5,12 +5,10 @@
   cmake,
   eigen,
   avogadrolibs,
-  molequeue,
   hdf5,
   jkqtplotter,
   openbabel,
-  qttools,
-  wrapQtAppsHook,
+  qt6,
   mesa,
 }:
 
@@ -18,20 +16,20 @@ let
   avogadroI18N = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadro-i18n";
-    tag = "1.102.1";
-    hash = "sha256-doY+AWJ0GiE6VsTolgmFIRcRVl52lTgwNJLpXgVQ57c=";
+    tag = "1.103.0";
+    hash = "sha256-gdr0Ed0UWjQB0LQq+6RvlAb8ZNFQAjV9mrgFLePG+CM=";
   };
 
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "avogadro2";
-  version = "1.102.1";
+  version = "1.103.0";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadroapp";
     rev = finalAttrs.version;
-    hash = "sha256-nBkOiw6JO/cG1Ob9gw7Tt/076OoRaRRmDc/a9YAfZCA=";
+    hash = "sha256-nmvK3R966Xv2Xs5wXDh/8itIZLIRqbXHFe8dffFiI+s=";
   };
 
   postUnpack = ''
@@ -40,16 +38,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
     avogadrolibs
-    molequeue
     eigen
     hdf5
     jkqtplotter
-    qttools
+    qt6.qttools
   ];
 
   propagatedBuildInputs = [ openbabel ];

--- a/pkgs/development/libraries/jkqtplotter/default.nix
+++ b/pkgs/development/libraries/jkqtplotter/default.nix
@@ -4,28 +4,27 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
-  qttools,
-  wrapQtAppsHook,
+  qt6,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "jkqtplotter";
-  version = "5.0.0-unstable-2025-10-13";
+  version = "5.0.0-unstable-2025-12-26";
 
   src = fetchFromGitHub {
     owner = "jkriege2";
     repo = "JKQtPlotter";
-    rev = "d243218119b1632987df26baea0d4bc6ccdee533";
-    hash = "sha256-fLkZGl4LYr9zdGjxxhcU6IZkpXV/Sex4TC9DFPyw43M=";
+    rev = "ff89c53057ab15ac6dd7b9ebfd6713cef0ce9676";
+    hash = "sha256-rx1TWDAXHFo+LgylfkPqWIiHAJ9FKsQ4s9QSFHiBHC8=";
   };
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
-    qttools
+    qt6.qttools
   ];
 
   meta = {

--- a/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
+++ b/pkgs/development/libraries/science/chemistry/avogadrolibs/default.nix
@@ -13,8 +13,7 @@
   libarchive,
   libmsym,
   jkqtplotter,
-  qttools,
-  wrapQtAppsHook,
+  qt6,
 }:
 
 let
@@ -29,32 +28,32 @@ let
   moleculesRepo = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "molecules";
-    tag = "1.102.1";
+    tag = "1.103.0";
     hash = "sha256-hMLf0gYYnQpjSGKcPy4tihNbmpRR7UxnXF/hyhforgI=";
   };
   crystalsRepo = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "crystals";
-    tag = "1.102.1";
+    tag = "1.103.0";
     hash = "sha256-WhzFldaOt/wJy1kk+ypOkw1OYFT3hqD7j5qGdq9g+IY=";
   };
   fragmentsRepo = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "fragments";
-    tag = "1.102.1";
-    hash = "sha256-x10jGl3lAEfm8OxUZJnjXRJCQg8RLQZTstjwnt5B2bw=";
+    tag = "1.103.0";
+    hash = "sha256-jH8k+qPlyU3Tset63uxrDlMFLdcWh8JhJoe5sl1pJ2E=";
   };
 
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "avogadrolibs";
-  version = "1.102.1";
+  version = "1.103.0";
 
   src = fetchFromGitHub {
     owner = "OpenChemistry";
     repo = "avogadrolibs";
     tag = finalAttrs.version;
-    hash = "sha256-RmGRdCy1ubwAkEJlfldscR84NLOMBx33OdHdcq1R1gg=";
+    hash = "sha256-2SuSNaZnY3LXcUuGboc8ZRCCeoClENoYtWmNNahdor4=";
   };
 
   postUnpack = ''
@@ -65,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
     pythonWP
   ];
 
@@ -79,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     libarchive
     libmsym
     jkqtplotter
-    qttools
+    qt6.qttools
   ];
 
   # Fix the broken CMake files to use the correct paths

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2693,7 +2693,7 @@ with pkgs;
 
   jl = haskellPackages.jl;
 
-  jkqtplotter = libsForQt5.callPackage ../development/libraries/jkqtplotter { };
+  jkqtplotter = callPackage ../development/libraries/jkqtplotter { };
 
   jpylyzer = with python3Packages; toPythonApplication jpylyzer;
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11856,7 +11856,7 @@ with pkgs;
 
   molequeue = libsForQt5.callPackage ../development/libraries/science/chemistry/molequeue { };
 
-  avogadro2 = libsForQt5.callPackage ../applications/science/chemistry/avogadro2 { };
+  avogadro2 = callPackage ../applications/science/chemistry/avogadro2 { };
 
   libxc_7 = pkgs.libxc.override { version = "7.0.0"; };
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11852,7 +11852,7 @@ with pkgs;
 
   ### SCIENCE/CHEMISTY
 
-  avogadrolibs = libsForQt5.callPackage ../development/libraries/science/chemistry/avogadrolibs { };
+  avogadrolibs = callPackage ../development/libraries/science/chemistry/avogadrolibs { };
 
   molequeue = libsForQt5.callPackage ../development/libraries/science/chemistry/molequeue { };
 


### PR DESCRIPTION
Updates Avogadro2 and its dependencies to the latest versions.

AvogadroLibs Changelog: <https://github.com/OpenChemistry/avogadrolibs/releases/tag/1.103.0>
AvogadroApp Changelog: <https://github.com/OpenChemistry/avogadroapp/releases/tag/1.103.0>

As Avogadro dropped support for Qt5, these packages are now built using Qt6.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
