### PR TITLE
cursor-clip: init at unstable-2026-02-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23560,6 +23560,12 @@
     githubId = 78461130;
     keys = [ { fingerprint = "CA52 EE7B E681 720E 32B6  6792 FE52 FD65 B76E 4751"; } ];
   };
+  salvogiarracca = {
+    name = "Salvatore Giarracca";
+    email = "salvogiarracca07@gmail.com";
+    github = "Salvogiarracca";
+    githubId = 39529770;
+  };
   samalws = {
     email = "sam@samalws.com";
     name = "Sam Alws";

--- a/pkgs/by-name/cu/cursor-clip/package.nix
+++ b/pkgs/by-name/cu/cursor-clip/package.nix
@@ -8,7 +8,7 @@
   gtk4-layer-shell,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage {
   pname = "cursor-clip";
   version = "unstable-2026-02-17";
 

--- a/pkgs/by-name/cu/cursor-clip/package.nix
+++ b/pkgs/by-name/cu/cursor-clip/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  gtk4,
+  libadwaita,
+  gtk4-layer-shell,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cursor-clip";
+  version = "unstable-2026-02-17";
+
+  src = fetchFromGitHub {
+    owner = "Sirulex";
+    repo = "cursor-clip";
+    rev = "e8015f48782ff91c02cf9d624b8602f10ad5fdaf";
+    hash = "sha256-d/7w0yuOsKc41h5z8H9NQ/iOW0fW5E6w8ffcPBt0FuM=";
+  };
+
+  cargoHash = "sha256-nIbrapOUcTsHSn1nxEZtzSdDzPzIVuslri7Va94slOE=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    gtk4-layer-shell
+  ];
+
+  meta = {
+    description = "GTK4 clipboard manager with dynamic cursor positioning for Wayland";
+    longDescription = ''
+      A Wayland clipboard manager built with Rust, GTK4, Libadwaita, and
+      Wayland Layer Shell. Features a Windows 11-style clipboard history
+      interface that appears at the current mouse cursor position.
+    '';
+    homepage = "https://github.com/Sirulex/cursor-clip";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ salvogiarracca ];
+    mainProgram = "cursor-clip";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
# Description

`cursor-clip` is a GTK4 Wayland clipboard manager with dynamic cursor positioning. It features a Windows 11-style clipboard history interface that appears at the current mouse cursor position, built with Rust, GTK4, Libadwaita, and Wayland Layer Shell.

Upstream: https://github.com/Sirulex/cursor-clip
License: GPL-3.0

# Checklist

- [x] package builds on x86_64-linux
- [x] tested the binary works (daemon starts, overlay appears, clipboard history functional)
- [ ] package builds on aarch64-linux (not tested)

# Notes

- No upstream releases yet, packaging at latest commit
- Wayland-only; requires zwlr_layer_shell_v1 and zwlr_data_control_manager_v1
- GNOME Shell is explicitly not supported upstream (missing required protocols)