### PR TITLE
nixos-install-tools: handle spaces in mount paths

### DIFF
--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -24,8 +24,7 @@ sub uniq {
 }
 
 sub runCommand {
-    my ($cmd) = @_;
-    open FILE, "$cmd 2>&1 |" or die "Failed to execute: $cmd\n";
+    open FILE, "-|", @_ or die "Failed to execute: @_\n";
     my @ret = <FILE>;
     close FILE;
     return ($?, @ret);
@@ -459,7 +458,7 @@ EOF
 
     # Is this a btrfs filesystem?
     if ($fsType eq "btrfs") {
-        my ($status, @info) = runCommand("@btrfs@ subvol show $rootDir$mountPoint");
+        my ($status, @info) = runCommand("@btrfs@", "subvol", "show", "$rootDir$mountPoint");
         if ($status != 0 || join("", @info) =~ /ERROR:/) {
             die "Failed to retrieve subvolume info for $mountPoint\n";
         }
@@ -506,7 +505,7 @@ EOF
     # This should work for single and multi-device systems.
     # still needs subvolume support
     if ($fsType eq "bcachefs") {
-        my ($status, @info) = runCommand("bcachefs fs usage $rootDir$mountPoint");
+        my ($status, @info) = runCommand("bcachefs", "fs", "usage", "$rootDir$mountPoint");
         my $UUID = $info[0];
 
         if ($status == 0 && $UUID =~ /^Filesystem:[ \t\n]*([0-9a-z-]+)/) {

--- a/nixos/modules/installer/tools/nixos-generate-config.pl
+++ b/nixos/modules/installer/tools/nixos-generate-config.pl
@@ -24,8 +24,7 @@ sub uniq {
 }
 
 sub runCommand {
-    my ($cmd) = @_;
-    open FILE, "$cmd 2>&1 |" or die "Failed to execute: $cmd\n";
+    open FILE, "-|", @_ or die "Failed to execute: @_\n";
     my @ret = <FILE>;
     close FILE;
     return ($?, @ret);
@@ -458,7 +457,7 @@ EOF
 
     # Is this a btrfs filesystem?
     if ($fsType eq "btrfs") {
-        my ($status, @info) = runCommand("@btrfs@ subvol show $rootDir$mountPoint");
+        my ($status, @info) = runCommand("@btrfs@", "subvol", "show", "$rootDir$mountPoint");
         if ($status != 0 || join("", @info) =~ /ERROR:/) {
             die "Failed to retrieve subvolume info for $mountPoint\n";
         }
@@ -505,7 +504,7 @@ EOF
     # This should work for single and multi-device systems.
     # still needs subvolume support
     if ($fsType eq "bcachefs") {
-        my ($status, @info) = runCommand("@bcachefs@ fs usage $rootDir$mountPoint");
+        my ($status, @info) = runCommand("@bcachefs@", "fs", "usage", "$rootDir$mountPoint");
         my $UUID = $info[0];
 
         if ($status == 0 && $UUID =~ /^Filesystem:[ \t\n]*([0-9a-z-]+)/) {


### PR DESCRIPTION
If a btrfs or bcachefs mountpoint has a space or some other special characters, these will mangle the command that nixos-generate-config runs to get information about the mount.  Avoid this by switching from the "magic" form of calling the `open` function to the "three-argument" form, where each command argument is specified separately.

https://perldoc.perl.org/functions/open#Whitespace-and-special-characters-in-the-filename-argument

Fixes #491738


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
