### PR TITLE
bruno{,-cli}: 3.0.2 -> 3.1.1

### DIFF
--- a/pkgs/by-name/br/bruno/package.nix
+++ b/pkgs/by-name/br/bruno/package.nix
@@ -21,13 +21,13 @@
 
 buildNpmPackage rec {
   pname = "bruno";
-  version = "3.0.2";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "usebruno";
     repo = "bruno";
     tag = "v${version}";
-    hash = "sha256-lvv1SJuUxNwukg/yi6mhgvVs8M/Eyf2H36NJN+6XKSE=";
+    hash = "sha256-XoGD8lDc6QGka17KTvVX3gEj1fo+4NWpUM8mLA5F+i4=";
 
     postFetch = ''
       ${lib.getExe npm-lockfile-fix} $out/package-lock.json
@@ -36,7 +36,7 @@ buildNpmPackage rec {
 
   nodejs = nodejs_22;
 
-  npmDepsHash = "sha256-zb0oP4/L7449z83tpcT6W/6sXS4Urph3ELN9kUC32dA=";
+  npmDepsHash = "sha256-XJsQFyi448yoRM8pUvaNpGDIZ41q0vpwYTgJufBBu1g=";
   npmFlags = [ "--legacy-peer-deps" ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Releases

- v3.1.0: https://github.com/usebruno/bruno/releases/tag/v3.1.0
- v3.1.1: https://github.com/usebruno/bruno/releases/tag/v3.1.1

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
