### PR TITLE
boomer: init at 0-unstable-2024-02-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -28875,6 +28875,12 @@
     github = "WoutSwinkels";
     githubId = 113464111;
   };
+  woynert = {
+    email = "woynertgamer@gmail.com";
+    github = "woynert";
+    githubId = 61242172;
+    name = "Woynert";
+  };
   wozeparrot = {
     email = "wozeparrot@gmail.com";
     github = "wozeparrot";

--- a/pkgs/by-name/bo/boomer/lock.json
+++ b/pkgs/by-name/bo/boomer/lock.json
@@ -1,0 +1,28 @@
+{
+  "depends": [
+    {
+      "method": "fetchzip",
+      "packages": [
+        "x11"
+      ],
+      "path": "/nix/store/8qaywzr8nzsiddjba77nhf75hzmxx0d9-source",
+      "ref": "1.2",
+      "rev": "29aca5e519ebf5d833f63a6a2769e62ec7bfb83a",
+      "sha256": "16npqgmi2qawjxaddj9ax15rfpdc7sqc37i2r5vg23lyr6znq4wc",
+      "srcDir": "",
+      "url": "https://github.com/nim-lang/x11/archive/29aca5e519ebf5d833f63a6a2769e62ec7bfb83a.tar.gz"
+    },
+    {
+      "method": "fetchzip",
+      "packages": [
+        "opengl"
+      ],
+      "path": "/nix/store/dvv6cgzl9xmax5rmjxnp5wrr08ibvjaw-source",
+      "ref": "1.2.9",
+      "rev": "8e2e098f82dc5eefd874488c37b5830233cd18f4",
+      "sha256": "01csz5bl4jiv7jx76k7izgknl7k73y2i9hd9s6brlhfqhq7cqxmz",
+      "srcDir": "src",
+      "url": "https://github.com/nim-lang/opengl/archive/8e2e098f82dc5eefd874488c37b5830233cd18f4.tar.gz"
+    }
+  ]
+}

--- a/pkgs/by-name/bo/boomer/package.nix
+++ b/pkgs/by-name/bo/boomer/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  buildNimPackage,
+  fetchFromGitHub,
+  libxrandr,
+  libGL,
+}:
+
+buildNimPackage (finalAttrs: {
+  name = "boomer";
+  pname = "boomer";
+  version = "0-unstable-2024-02-08";
+
+  src = fetchFromGitHub {
+    owner = "tsoding";
+    repo = "boomer";
+    rev = "dfd4e1f5514e2a9d7c7a6429c1c0642c2021e792";
+    hash = "sha256-o65/VVxttriA5Qqt35lLKkWIZYS7T4VBBuYdAIGUmx8=";
+  };
+
+  lockFile = ./lock.json;
+
+  postFixup = ''
+    existing=$(patchelf --print-rpath $out/bin/boomer)
+    patchelf --set-rpath "$existing:${
+      lib.makeLibraryPath [
+        libxrandr
+        libGL
+      ]
+    }" $out/bin/boomer
+  '';
+
+  meta = {
+    description = "Zooming tool for X11 desktop";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      woynert
+    ];
+    mainProgram = "boomer";
+    homepage = "https://github.com/tsoding/boomer";
+  };
+})


### PR DESCRIPTION
Boomer is a X11 tool for zooming in the screen, useful for graphics programmer to inspect pixels from close or as a general tool for accessibility to read small text.

Homepage: https://github.com/tsoding/boomer

Video:

https://github.com/user-attachments/assets/a140be75-832b-4763-a644-7f256f334a32



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
