### PR TITLE
vscode-extensions.dieghernan.selenized-theme: init at 0.2.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1326,6 +1326,23 @@ let
         };
       };
 
+      dieghernan.selenized-theme = buildVscodeMarketplaceExtension {
+        meta = {
+          changelog = "https://marketplace.visualstudio.com/items?itemName=dieghernan.selenized-theme/changelog";
+          description = "Dark and light syntax themes with green accents inspired by Selenized by Jan Warchoł";
+          downloadPage = "https://marketplace.visualstudio.com/items?itemName=dieghernan.selenized-theme";
+          homepage = "https://github.com/dieghernan/selenized-theme";
+          licenses = lib.licenses.mit;
+          maintainers = [ ];
+        };
+        mktplcRef = {
+          name = "selenized-theme";
+          publisher = "dieghernan";
+          version = "0.2.1";
+          hash = "sha256-s1EHGugQCQQSRL7nS2XLwEQnF9coJHW4PTbkyWGv/H0=";
+        };
+      };
+
       discloud.discloud = buildVscodeMarketplaceExtension {
         mktplcRef = {
           publisher = "discloud";


### PR DESCRIPTION
The Selenized black/dark/light/white theme family, easy on the eyes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [v] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [v] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
