### PR TITLE
factorio: make it possible to use `impureEnvVars` for username and token

### DIFF
--- a/pkgs/by-name/fa/factorio/package.nix
+++ b/pkgs/by-name/fa/factorio/package.nix
@@ -139,7 +139,12 @@ let
                 "token@token"
               ];
             })
-            (_: {
+            (prevAttrs: {
+              impureEnvVars = prevAttrs.impureEnvVars or [ ] ++ [
+                "NIX_FACTORIO_USERNAME"
+                "NIX_FACTORIO_TOKEN"
+              ];
+
               # This preHook hides the credentials from /proc
               preHook =
                 if username != "" && token != "" then
@@ -149,8 +154,12 @@ let
                   ''
                 else
                   ''
-                    # Deliberately failing since username/token was not provided, so we can't fetch.
-                    exit 1
+                    if [[ -z "''${NIX_FACTORIO_USERNAME}" || -z "''${NIX_FACTORIO_TOKEN}" ]]; then
+                      # Deliberately failing since username/token was not provided, so we can't fetch.
+                      exit 1
+                    fi
+                    echo -n "$NIX_FACTORIO_USERNAME" >username
+                    echo -n "$NIX_FACTORIO_TOKEN"    >token
                   '';
               failureHook = ''
                 cat <<EOF


### PR DESCRIPTION
This makes it possible to download Factorio without needing to use overrides or exposing the values in the store.

For testing, do one of the following (Token and Username can be found on https://www.factorio.com/profile) it may require a restart:

Create an env file with the following vars:
```env
NIX_FACTORIO_USERNAME=my_factorio_username
NIX_FACTORIO_TOKEN=my_factorio_token
```

And add this to your NixOS config.
```nix
{
  systemd.services."nix-daemon".serviceConfig.EnvironmentFile = "/path/to/env/file";`
  systemd.services."nix-daemon@".serviceConfig.EnvironmentFile = "/path/to/env/file";`
}
```

Or alternatively, just add this to your NixOS config, but expose secrets in your `nix-store` and NixOS config.

```nix
{
  nix.envVars = {
    NIX_FACTORIO_USERNAME = "my_factorio_username";
    NIX_FACTORIO_TOKEN = "my_factorio_token";
  };
}
```

Or if you have the experimental feature [`configurable-impure-env`](https://nix.dev/manual/nix/2.34/development/experimental-features.html#xp-feature-configurable-impure-env) enabled, add this line to your `nix.conf` (requires the user to be in [trusted-users](https://nix.dev/manual/nix/2.34/command-ref/conf-file.html?highlight=trusted-users#conf-trusted-users))
```conf
impure-env = NIX_FACTORIO_USERNAME=my_factorio_username NIX_FACTORIO_TOKEN=my_factorio_token
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
​