### PR TITLE
kazv: 0.5.0 -> 0.6.0 (and dependencies)

### DIFF
--- a/pkgs/by-name/ka/kazv/package.nix
+++ b/pkgs/by-name/ka/kazv/package.nix
@@ -1,18 +1,16 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchgit,
   boost,
   cmake,
   cmark,
   cryptopp,
-  extra-cmake-modules,
   immer,
   kdePackages,
   lager,
   libkazv,
   nlohmann_json,
-  olm,
   pkg-config,
   qt6,
   zug,
@@ -20,14 +18,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kazv";
-  version = "0.5.0";
+  version = "0.6.0";
 
-  src = fetchFromGitLab {
-    domain = "lily-is.land";
-    owner = "kazv";
-    repo = "kazv";
+  # Heavily mirrored. Click "Clone" at https://iron.lily-is.land/diffusion/K/ to see all mirrors
+  src = fetchgit {
+    url = "https://iron.lily-is.land/diffusion/K/kazv.git";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-WBS7TJJw0t57V4+NxsG8V8q4UKQXB8kRpWocvNy1Eto=";
+    hash = "sha256-7o6xUt/cryOg71/R33VBGpubskqlm9eYGSTyoGderDA=";
   };
 
   nativeBuildInputs = [
@@ -49,7 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     lager
     libkazv
     nlohmann_json
-    olm
     qt6.qtbase
     qt6.qtimageformats
     qt6.qtmultimedia

--- a/pkgs/by-name/li/libkazv/package.nix
+++ b/pkgs/by-name/li/libkazv/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitLab,
+  fetchgit,
   boost,
   catch2_3,
   cmake,
@@ -12,21 +12,20 @@
   libhttpserver,
   libmicrohttpd,
   nlohmann_json,
-  olm,
+  vodozemac-bindings-cpp,
   pkg-config,
   zug,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libkazv";
-  version = "0.7.0";
+  version = "0.8.0";
 
-  src = fetchFromGitLab {
-    domain = "lily-is.land";
-    owner = "kazv";
-    repo = "libkazv";
+  # Heavily mirrored. Click "Clone" at https://iron.lily-is.land/diffusion/L/ to see all mirrors
+  src = fetchgit {
+    url = "https://iron.lily-is.land/diffusion/L/libkazv.git";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-bKujiuAR5otF7nc/BdVWVaEW9fSxdh2bcAgsQ5UO1Aw=";
+    hash = "sha256-rXQLbYPmD9UH0iXXqrAQSPF3KgIvjEyZ/97Q+/tl9Ec=";
   };
 
   nativeBuildInputs = [
@@ -42,8 +41,8 @@ stdenv.mkDerivation (finalAttrs: {
     libcpr_1_10_5
     libhttpserver
     libmicrohttpd
-    olm
     nlohmann_json
+    vodozemac-bindings-cpp
     zug
   ];
 

--- a/pkgs/by-name/vo/vodozemac-bindings-cpp/package.nix
+++ b/pkgs/by-name/vo/vodozemac-bindings-cpp/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cargo,
+  perl,
+  rustPlatform,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vodozemac-bindings-cpp";
+  version = "0.2.1";
+
+  src = fetchgit {
+    url = "https://iron.lily-is.land/diffusion/VB/vodozemac-bindings.git";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-j6s+O3s6xSIZ+6aWI3itVwL4OU4qhoXos1R2NMBrJdo=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-RyZGR6VxWH98ujydPFbuzKZil+1pxk4qD6EuaCnN1Y8=";
+  };
+
+  makeFlags = [
+    "-C"
+    "cpp"
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  nativeBuildInputs = [
+    cargo
+    perl
+    rustPlatform.cargoSetupHook
+  ];
+
+  meta = {
+    description = "C++ bindings for the vodozemac cryptographic library.";
+    homepage = "https://iron.lily-is.land/diffusion/VB/";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ fgaz ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
Replaces the `olm` dependency that is marked insecure

Closes #422739

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
