### PR TITLE
fmodstudio: init at 2.03.14

### DIFF
--- a/pkgs/by-name/fm/fmodstudio/deepbind-shim-hook.nix
+++ b/pkgs/by-name/fm/fmodstudio/deepbind-shim-hook.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  makeSetupHook,
+}:
+
+makeSetupHook {
+  name = "deepbind-shim-hook";
+  substitutions = {
+    shimTemplate = ./deepbind-shim.c.in;
+  };
+  meta = {
+    description = "Compile and inject a shim that adds RTLD_DEEPBIND to dlopen() calls for specified libraries using LD_PRELOAD";
+    longDescription = ''
+      Solves symbol interposition crashes when a proprietary shared library
+      (e.g. libfsbvorbis) statically bundles a common library (e.g. libvorbis)
+      but exports the same symbols. If another copy of that library is loaded
+      in the same process (e.g. via qtwebengine -> ffmpeg -> libvorbis), the
+      dynamic linker resolves the bundled library's internal calls to the
+      system copy, causing ABI mismatches and segfaults.
+
+      Usage:
+        nativeBuildInputs = [ deepbindShimHook ];
+        deepbindLibraries = [ "libfsbvorbis" ];
+
+      The hook compiles a small C shim during preFixup and automatically
+      injects it into the active wrapping mechanism (wrapQtAppsHook,
+      wrapGAppsHook, or makeWrapper).
+
+      RTLD_DEEPBIND has no ELF DT_FLAGS_1 equivalent. It can only be applied at
+      dlopen() time, which is why a shim is necessary.
+    '';
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ ilkecan ];
+  };
+} ./deepbind-shim-hook.sh

--- a/pkgs/by-name/fm/fmodstudio/deepbind-shim-hook.sh
+++ b/pkgs/by-name/fm/fmodstudio/deepbind-shim-hook.sh
@@ -1,0 +1,58 @@
+# Compile and inject a shim that adds RTLD_DEEPBIND to dlopen() calls for
+# specified libraries using LD_PRELOAD.
+
+deepbindShimHook() {
+    echo "Executing deepbindShimHook"
+    # Validate that deepbindShimLibraries is set and non-empty.
+    if [[ -z "${deepbindShimLibraries:-}" ]]; then
+        echo "Error: 'deepbindShimLibraries' must be set when using deepbindShimHook."
+        return 1
+    fi
+
+    # Build the C condition expression from the space-separated library list.
+    local checks=""
+    for lib in $deepbindShimLibraries; do
+        if [[ -n "$checks" ]]; then
+            checks+=" || "
+        fi
+        checks+="strstr(filename, \"$lib\")"
+    done
+
+    # Generate and compile the shim.
+    local shimSrc
+    shimSrc=$(mktemp "${TMPDIR:-/tmp}/deepbind-shim-XXXXXX.c")
+    sed "s|@DEEPBIND_CHECKS@|$checks|" @shimTemplate@ > "$shimSrc"
+
+    mkdir -p "$out/lib"
+    local shimPath="$out/lib/deepbind-shim.so"
+    $CC -shared -fPIC -o "$shimPath" "$shimSrc"
+    rm -f "$shimSrc"
+
+    # Auto-inject LD_PRELOAD into the first available wrapping mechanism.
+    #
+    # Detection order (highest to lowest priority):
+    #   1. wrapQtAppsHook -> qtWrapperArgs    (registered via fixupOutputHooks)
+    #   2. wrapGAppsHook  -> gappsWrapperArgs (registered via fixupOutputHooks)
+    #   3. makeWrapper    -> makeWrapperArgs  (fallback; user must call wrapProgram)
+    #
+    # wrapQtAppsHook and wrapGAppsHook both register functions that run during
+    # fixupOutputHooks, which executes after preFixupHooks. So any args we
+    # append here will be picked up when wrapping actually happens.
+    if declare -p qtWrapperArgs &>/dev/null; then
+        qtWrapperArgs+=(--prefix LD_PRELOAD : "$shimPath")
+        echo "injected LD_PRELOAD into qtWrapperArgs"
+    elif declare -p gappsWrapperArgs &>/dev/null; then
+        gappsWrapperArgs+=(--prefix LD_PRELOAD : "$shimPath")
+        echo "injected LD_PRELOAD into gappsWrapperArgs"
+    elif declare -p makeWrapperArgs &>/dev/null; then
+        makeWrapperArgs+=(--prefix LD_PRELOAD : "$shimPath")
+        echo "injected LD_PRELOAD into makeWrapperArgs"
+    else
+        echo "Error: no wrapping mechanism detected to inject the shim."
+        echo "  Add wrapQtAppsHook, wrapGAppsHook, or makeWrapper to nativeBuildInputs"
+        return 1
+    fi
+    echo "Finished deepbindShimHook"
+}
+
+preFixupHooks+=(deepbindShimHook)

--- a/pkgs/by-name/fm/fmodstudio/deepbind-shim.c.in
+++ b/pkgs/by-name/fm/fmodstudio/deepbind-shim.c.in
@@ -1,0 +1,12 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <string.h>
+
+void *dlopen(const char *filename, int flags) {
+    static void *(*real_dlopen)(const char *, int) = NULL;
+    if (!real_dlopen)
+        real_dlopen = dlsym(RTLD_NEXT, "dlopen");
+    if (filename && (@DEEPBIND_CHECKS@))
+        flags |= RTLD_DEEPBIND;
+    return real_dlopen(filename, flags);
+}

--- a/pkgs/by-name/fm/fmodstudio/package.nix
+++ b/pkgs/by-name/fm/fmodstudio/package.nix
@@ -1,0 +1,94 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  autoPatchelfHook,
+  dpkg,
+  kdePackages,
+  libgcc,
+  qt6,
+  wrapGAppsHook3,
+  requireFile,
+  icu56,
+}:
+
+let
+  debSystem =
+    {
+      x86_64-linux = "linux64";
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system ${stdenv.hostPlatform.system}");
+
+  deepbindShimHook = callPackage ./deepbind-shim-hook.nix { };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fmodstudio";
+  version = "2.03.14";
+
+  src = requireFile {
+    url = "https://www.fmod.com/download#fmodstudio";
+    name = "fmodstudio${lib.replaceString "." "" finalAttrs.version}${debSystem}-installer.deb";
+    hash = "sha256-nmqJMxQj0/ups9bGWpGDYYoXIo2MRw//t3jm1QKcTTw=";
+  };
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    deepbindShimHook
+    dpkg
+    qt6.wrapQtAppsHook
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    kdePackages.qtbase
+    kdePackages.qtwebengine
+    libgcc.lib
+    icu56
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    for exe in fmodstudio fmodstudiocl; do
+      install -Dm755 opt/fmodstudio/$exe $out/share/fmodstudio/$exe
+      ln -s $out/share/fmodstudio/$exe $out/bin/$exe
+    done
+
+    install -Dm755 -t $out/lib opt/fmodstudio/lib/{libstudio.so,libfsbvorbis.so}
+
+    cp -r -t $out/share/fmodstudio opt/fmodstudio/{Plugins,Scripts,documentation,examples,extras}
+
+    cp -r -t $out/share usr/share/*
+    substituteInPlace $out/share/applications/fmodstudio.desktop \
+      --replace-fail /opt/fmodstudio/ $out/bin/
+
+    runHook postInstall
+  '';
+
+  dontWrapGApps = true;
+  deepbindShimLibraries = [
+    "libfsbvorbis"
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(
+      "''${gappsWrapperArgs[@]}"
+      --prefix LD_LIBRARY_PATH : "$out/lib"
+    )
+  '';
+
+  meta = {
+    description = "Desktop application for creation of adaptive audio";
+    homepage = "https://www.fmod.com";
+    changelog = "https://www.fmod.com/docs/${lib.versions.majorMinor finalAttrs.version}/studio/welcome-to-fmod-studio-revision-history.html";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "fmodstudio";
+    maintainers = with lib.maintainers; [ ilkecan ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/development/libraries/icu/default.nix
+++ b/pkgs/development/libraries/icu/default.nix
@@ -87,4 +87,13 @@ in
     version = "60.2";
     hash = "sha256-8HPqjzW5JtcLsz5ld1CKpkKosxaoA/Eb4grzhIEdtBg=";
   };
+  icu56 =
+    (make-icu {
+      version = "56.1";
+      hash = "sha256-OmTpEFxzTc9jHAs+1gQEUxvObA9aZL/hpkAqTMIxSBY=";
+    }).overrideAttrs
+      {
+        __structuredAttrs = true;
+        strictDeps = true;
+      };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5900,6 +5900,7 @@ with pkgs;
 
   icu-versions = callPackages ../development/libraries/icu { };
   inherit (icu-versions)
+    icu56
     icu60
     icu63
     icu64


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

resolves: #437153

There is already an open [PR](https://github.com/NixOS/nixpkgs/pull/413330) for this package, but my reasons for creating a new one are:
- It was last updated 8 months ago and packages an older version (`2.03.08`)
- The packaged `fmodstudio` does not run on Wayland
- It copies all the shared objects from the .deb file's lib/ directory, rather than using library derivations already available in nixpkgs

This PR reuses nixpkgs libraries wherever possible and only copies the proprietary ones (`libstudio.so` and `libfsbvorbis.so`), reducing the total closure size from 380MB to 116MB.

---
## `deepbindShimHook`
One problem I encountered was `libfsbvorbis.so`, one of the proprietary libraries, statically bundles a custom vorbis encoder but exports symbols with the same names as the system `libvorbis.so.0` (e.g. `vorbis_book_encode`, `floor1_encode`, `vorbis_analysis`). Because this PR replaces the bundled Qt/ffmpeg stack with nixpkgs equivalents, `libvorbis.so.0` is now loaded into the process via `qtwebengine` -> `ffmpeg`.

When `libfsbvorbis.so` is `dlopen()`'d at bank build time, its internal calls to bundled vorbis functions are resolved through the ELF dynamic linker's global scope. The linker finds the system `libvorbis.so.0` definitions first (loaded earlier by qtwebengine) and this ABI mismatch causes a segmentation fault.

I tried:
- `patchelf --rename-dynamic-symbols` (requires `patchelfUnstable`): Renaming conflicting symbols breaks `libstudio.so`, which uses `dlsym()` to look up the encoder's entry points by name at runtime, not just via ELF `DT_NEEDED` references. Since the `dlsym()` lookups are embedded in the proprietary binary, we can't know all the symbol names it expects.
- ELF `DT_FLAGS_1` patching: `RTLD_DEEPBIND` has no corresponding bit in `DT_FLAGS_1`. There is no way to achieve deepbind behavior through ELF metadata alone; it can only be applied at `dlopen()` time.
- Copying all bundled libraries: This works but defeats the purpose of using nixpkgs dependencies (inflates closure size by ~3x and loses security updates).

The solution: `deepbindShimHook`
The fix is an `LD_PRELOAD` shim that intercepts `dlopen()` and adds the `RTLD_DEEPBIND` flag when the specified libraries (only `libfsbvorbis.so` in this case) are loaded. `RTLD_DEEPBIND` tells the dynamic linker to search the loaded library's own symbols before the global scope, preventing interposition.

Since this is a general problem that can affect any proprietary package bundling common libraries (e.g. libvorbis, libpng, zlib) while also depending on nixpkgs libraries that pull in system copies of the same, I've implemented the shim as a reusable setup hook: `deepbindShimHook`.

Usage:
```nix
{
  nativeBuildInputs = [ deepbindShimHook ];
  deepbindHookLibraries = [ "libfsbvorbis" ];
}
```

The hook:
1. Compiles a small C shim during `preFixup` that adds `RTLD_DEEPBIND` to `dlopen()` calls matching the specified library names
2. Auto-detects the active wrapping mechanism (`wrapQtAppsHook` / `wrapGAppsHook` / `makeWrapper`) and injects the shim via `LD_PRELOAD`

While the hook does not depend on `fmodstudio`, I currently put it under `pkgs/by-name/fm/fmodstudio/` because I am not sure whether it will ever be needed for a different package[^1] or is this a generally good approach.

[^1]: the fact that this was not needed until now makes me believe this might be a very unique situation or that I might be missing something.

---

I am not an audio engineer, but I confirmed these (on Wayland):
- example project builds
- quick start tutorial works and builds
- built-in scripts works
- built-in user manual works

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
