### PR TITLE
nixos/pangolin: make use of dataDir for gerbil-wg0-fix-script instead…

### DIFF
--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -23,12 +23,12 @@ let
     # will not work if the interface is renamed
     # https://github.com/fosrl/newt/issues/37#issuecomment-3193385911
     text = ''
-      if [ ! -f /var/lib/pangolin/config/wg0 ]; then
+      if [ ! -f ${cfg.dataDir}/config/wg0 ]; then
           until ip l d wg0
           do
             sleep 2
           done
-          touch /var/lib/pangolin/config/wg0
+          touch ${cfg.dataDir}/config/wg0
           systemctl restart gerbil --no-block
       fi
     '';

--- a/nixos/modules/services/networking/pangolin.nix
+++ b/nixos/modules/services/networking/pangolin.nix
@@ -474,60 +474,64 @@ in
       dynamicConfigOptions = {
         http = {
           middlewares.redirect-to-https.redirectScheme.scheme = "https";
-          routers = {
-            # HTTP to HTTPS redirect router
-            main-app-router-redirect = {
-              rule = "Host(`${cfg.dashboardDomain}`)";
-              service = "next-service";
-              entryPoints = [ "web" ];
-              middlewares = [ "redirect-to-https" ];
-            };
-            # Next.js router (handles everything except API and WebSocket paths)
-            next-router = {
-              rule = "Host(`${cfg.dashboardDomain}`) && !PathPrefix(`/api/v1`)";
-              service = "next-service";
-              entryPoints = [ "websecure" ];
-              tls =
-                lib.optionalAttrs (finalSettings.domains.domain1.prefer_wildcard_cert) {
-                  domains = [
-                    { main = cfg.baseDomain; }
-                    { sans = "*.${cfg.baseDomain}"; }
-                  ];
-                }
-                //
-                # common
-                {
-                  certResolver = "letsencrypt";
-                };
-            };
-            # API router (handles /api/v1 paths)
-            api-router = {
-              rule = "Host(`${cfg.dashboardDomain}`) && PathPrefix(`/api/v1`)";
-              service = "api-service";
-              entryPoints = [ "websecure" ];
-              tls.certResolver = "letsencrypt";
-            };
-            # WebSocket router
-            ws-router = {
-              rule = "Host(`${cfg.dashboardDomain}`)";
-              service = "api-service";
-              entryPoints = [ "websecure" ];
-              tls.certResolver = "letsencrypt";
-            };
-            # Integration API router
-            int-api-router-redirect = {
-              rule = "Host(`api.${cfg.baseDomain}`)";
-              service = "int-api-service";
-              entryPoints = [ "web" ];
-              middlewares = [ "redirect-to-https" ];
-            };
-            int-api-router = {
-              rule = "Host(`api.${cfg.baseDomain}`)";
-              service = "int-api-service";
-              entryPoints = [ "websecure" ];
-              tls.certResolver = "letsencrypt";
-            };
-          };
+          routers = lib.mkMerge [
+            {
+              # HTTP to HTTPS redirect router
+              main-app-router-redirect = {
+                rule = "Host(`${cfg.dashboardDomain}`)";
+                service = "next-service";
+                entryPoints = [ "web" ];
+                middlewares = [ "redirect-to-https" ];
+              };
+              # Next.js router (handles everything except API and WebSocket paths)
+              next-router = {
+                rule = "Host(`${cfg.dashboardDomain}`) && !PathPrefix(`/api/v1`)";
+                service = "next-service";
+                entryPoints = [ "websecure" ];
+                tls =
+                  lib.optionalAttrs (finalSettings.domains.domain1.prefer_wildcard_cert) {
+                    domains = [
+                      { main = cfg.baseDomain; }
+                      { sans = "*.${cfg.baseDomain}"; }
+                    ];
+                  }
+                  //
+                  # common
+                  {
+                    certResolver = "letsencrypt";
+                  };
+              };
+              # API router (handles /api/v1 paths)
+              api-router = {
+                rule = "Host(`${cfg.dashboardDomain}`) && PathPrefix(`/api/v1`)";
+                service = "api-service";
+                entryPoints = [ "websecure" ];
+                tls.certResolver = "letsencrypt";
+              };
+              # WebSocket router
+              ws-router = {
+                rule = "Host(`${cfg.dashboardDomain}`)";
+                service = "api-service";
+                entryPoints = [ "websecure" ];
+                tls.certResolver = "letsencrypt";
+              };
+            }
+            (lib.mkIf (finalSettings.flags.enable_integration_api) {
+              # Integration API router
+              int-api-router-redirect = {
+                rule = "Host(`api.${cfg.dashboardDomain}`)";
+                service = "int-api-service";
+                entryPoints = [ "web" ];
+                middlewares = [ "redirect-to-https" ];
+              };
+              int-api-router = {
+                rule = "Host(`api.${cfg.dashboardDomain}`)";
+                service = "int-api-service";
+                entryPoints = [ "websecure" ];
+                tls.certResolver = "letsencrypt";
+              };
+            })
+          ];
           # needs to be a mkMerge otherwise will give error about standalone element
           services = lib.mkMerge [
             {

--- a/pkgs/by-name/fo/fosrl-pangolin/package.nix
+++ b/pkgs/by-name/fo/fosrl-pangolin/package.nix
@@ -29,32 +29,42 @@ in
 
 buildNpmPackage (finalAttrs: {
   pname = "pangolin";
-  version = "1.15.3";
+  version = "1.16.2";
 
   src = fetchFromGitHub {
     owner = "fosrl";
     repo = "pangolin";
-    tag = finalAttrs.version;
-    hash = "sha256-UGfwbFbuQ0ljipCjnPxZ/Is2hh1vjZJb97Lo/43sWeg=";
+    rev = finalAttrs.version;
+    hash = "sha256-pWD2VinfkCiSSP6/einXgduKQ8lzWdHlrj2eqUU/x6Y=";
   };
 
-  npmDepsHash = "sha256-kfgwU5QusUNWVcRXlYCS3ES1Av/phCHG8nFBj0yjz2Q=";
+  npmDepsHash = "sha256-CwS26eRAIuxJ2fekRRapDWYAOHXPV0mIX/by4uW2ZOM=";
+
+  npmFlags = [
+    "--legacy-peer-deps"
+  ];
 
   nativeBuildInputs = [
     esbuild
     makeWrapper
   ];
 
-  # Replace the googleapis.com Inter font with a local copy from Nixpkgs.
-  # Based on pkgs.nextjs-ollama-llm-ui.
   postPatch = ''
+    # 1.16.2 release has wrong version set to 1.16.0 so patch it
+    # TODO remove this for the 1.17.0 update
+    substituteInPlace server/lib/consts.ts --replace-fail \
+      'export const APP_VERSION = "1.16.0";' \
+      'export const APP_VERSION = "1.16.2";'
+
+    # Replace the googleapis.com Inter font with a local copy from Nixpkgs.
+    # Based on pkgs.nextjs-ollama-llm-ui.
     substituteInPlace src/app/layout.tsx --replace-fail \
-      "{ Geist, Inter, Manrope, Open_Sans } from \"next/font/google\"" \
+      "{ Inter } from \"next/font/google\"" \
       "localFont from \"next/font/local\""
 
     substituteInPlace src/app/layout.tsx --replace-fail \
-      "const font = Inter({${"\n"}    subsets: [\"latin\"]${"\n"}});" \
-      "const font = localFont({ src: './Inter.ttf' });"
+      "const inter = Inter({${"\n"}    subsets: [\"latin\"]${"\n"}});" \
+      "const inter = localFont({ src: './Inter.ttf' });"
 
     cp "${inter}/share/fonts/truetype/InterVariable.ttf" src/app/Inter.ttf
   '';
@@ -62,7 +72,7 @@ buildNpmPackage (finalAttrs: {
   preBuild = ''
     npm run set:${db false}
     npm run set:oss
-    npm run db:${db false}:generate
+    npm run db:generate
   '';
 
   buildPhase = ''
@@ -84,6 +94,7 @@ buildNpmPackage (finalAttrs: {
     cp -r .next/static $out/share/pangolin/.next/static
     cp -r dist $out/share/pangolin/dist
     cp -r server/migrations $out/share/pangolin/dist/init
+
     cp package.json $out/share/pangolin/package.json
 
     cp server/db/names.json $out/share/pangolin/dist/names.json
@@ -121,7 +132,9 @@ buildNpmPackage (finalAttrs: {
                dir:
                "test -f ${dir}/.nix_skip_setup || { rm -${lib.optionalString (dir == ".next") "r"}f ${dir} && ${
                  if (dir == ".next") then "cp -rd" else "ln -s"
-               } ${placeholder "out"}/share/pangolin/${dir} .; }"
+               } ${placeholder "out"}/share/pangolin/${dir} .; ${
+                 lib.optionalString (dir == ".next") "chmod -R 755 .next;"
+               } }"
              )
              [
                ".next"


### PR DESCRIPTION
… of hardcoded /var/lib/pangolin

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Use `dataDir` instead of hardcoded `/var/lib/pandolin` in *gerbil-wg0-fix-script* which was previously preventing the gerbil systemd service from starting.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
