### PR TITLE
nixos-rebuild-ng: pass --preserve-env to sudo calls

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -143,7 +143,17 @@ def run_wrapper(
             env = os.environ | extra_env
         if sudo:
             sudo_args = shlex.split(os.getenv("NIX_SUDOOPTS", ""))
-            run_args = ["sudo", *sudo_args, *run_args]
+            # Using --preserve-env is less than ideal since it will cause
+            # the following warn during usage:
+            # > warning: $HOME ('/home/<user>') is not owned by you,
+            # > falling back to the one defined in the 'passwd' file ('/root')
+            # However, right now it is the only way to guarantee the semantics
+            # expected for the commands, e.g. activation with systemd-run
+            # expects access to environment variables like LOCALE_ARCHIVE,
+            # NIXOS_NO_CHECK.
+            # For now, for anyone that the above warn bothers you, please
+            # use `sudo nixos-rebuild` instead of `--sudo` flag.
+            run_args = ["sudo", "--preserve-env", *sudo_args, *run_args]
 
     logger.debug(
         "calling run with args=%r, kwargs=%r, extra_env=%r",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -487,6 +487,7 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
             call(
                 [
                     "sudo",
+                    "--preserve-env",
                     "nix-env",
                     "-p",
                     Path("/nix/var/nix/profiles/system"),
@@ -504,6 +505,7 @@ def test_execute_nix_switch_flake(mock_run: Mock, tmp_path: Path) -> None:
             call(
                 [
                     "sudo",
+                    "--preserve-env",
                     *nr.nix.SWITCH_TO_CONFIGURATION_CMD_PREFIX,
                     config_path / "bin/switch-to-configuration",
                     "switch",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -27,7 +27,7 @@ def test_run(mock_run: Any) -> None:
             extra_env={"FOO": "bar"},
         )
     mock_run.assert_called_with(
-        ["sudo", "test", "--with", "flags"],
+        ["sudo", "--preserve-env", "test", "--with", "flags"],
         check=False,
         text=True,
         errors="surrogateescape",
@@ -164,14 +164,14 @@ def test_ssh_host() -> None:
 
 @patch("subprocess.run", autospec=True)
 def test_custom_sudo_args(mock_run: Any) -> None:
-    with patch.dict(p.os.environ, {"NIX_SUDOOPTS": "--custom sudo --args"}):
+    with patch.dict(p.os.environ, {"NIX_SUDOOPTS": "--custom foo --args"}):
         p.run_wrapper(
             ["test"],
             check=False,
             sudo=True,
         )
     mock_run.assert_called_with(
-        ["sudo", "--custom", "sudo", "--args", "test"],
+        ["sudo", "--preserve-env", "--custom", "foo", "--args", "test"],
         check=False,
         env=None,
         input=None,


### PR DESCRIPTION
Fix #491557.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
