### PR TITLE
nixtamal: 1.1.1 → 1.1.2

### DIFF
--- a/pkgs/by-name/ni/nixtamal/package.nix
+++ b/pkgs/by-name/ni/nixtamal/package.nix
@@ -17,7 +17,7 @@
 
 ocamlPackages.buildDunePackage (finalAttrs: {
   pname = "nixtamal";
-  version = "1.1.1";
+  version = "1.1.2";
   release_year = 2026;
 
   minimalOCamlVersion = "5.3";
@@ -26,7 +26,7 @@ ocamlPackages.buildDunePackage (finalAttrs: {
     url = "https://darcs.toastal.in.th/nixtamal/stable/";
     mirrors = [ "https://smeder.ee/~toastal/nixtamal.darcs" ];
     rev = finalAttrs.version;
-    hash = "sha256-VYK6ZqEutlVA8ASegLfqnJhLSU5jc2dIL3YOrXrGT0I=";
+    hash = "sha256-Sgr3FGMjo/eETc6DA+rnBHKIQ3yUPkFKRRbf4O1Ns/o=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Cmdliner 2.x support

```console
$ nixtamal show
nixpkgs: (archive)
	fetch-time: build
	url: https://github.com/NixOS/nixpkgs/archive/500435a9e724c08bdda83899c522f9160fc1dc4f.tar.gz
	fresh-cmd: $ git ls-remote https://github.com/NixOS/nixpkgs.git --branches staging-next | cut -f1
	fresh-value: 500435a9e724c08bdda83899c522f9160fc1dc4f
	hash-algorithm: SHA-256
	hash-value: sha256-k8b3uNy8qgdgfxfjSW+WT3tDnAbdOL65+Ck3/PWzVgQ=
	frozen: false
$ nix repl --file nix/tamal/default.nix
Nix 2.31.3
Type :? for help.
Loading installable ''...
Added 2 variables.
dash-nix, nixpkgs
nix-repl> pkgs = import nixpkgs { }

nix-repl> :p pkgs.ocamlPackages.cmdliner.version
2.1.0
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

[^1]

[^1]: Please consider [giving up MS GitHub](https://sfconservancy.org/GiveUpGitHub/) or offering a non-proprietary, non-US-corporate-controlled mirror for this free software project. I wish to delete this Microsoft account in the future, but I need more projects like this to support alternative methods to send patches & contribute.