### PR TITLE
systemd: add assertion preventing DynamicUser and user at the same time

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -559,15 +559,24 @@ in
             assertion = false;
             inherit message;
           })
-          (concatLists [
-            (optional
-              (
-                (builtins.elem "network-interfaces.target" service.after)
-                || (builtins.elem "network-interfaces.target" service.wants)
+          (
+            let
+              dynamicUser = service.serviceConfig.DynamicUser or false;
+              user = service.serviceConfig.User or "";
+            in
+            concatLists [
+              (optional
+                (
+                  (builtins.elem "network-interfaces.target" service.after)
+                  || (builtins.elem "network-interfaces.target" service.wants)
+                )
+                "Service '${name}.service' is using the deprecated target network-interfaces.target, which no longer exists. Using network.target is recommended instead."
               )
-              "Service '${name}.service' is using the deprecated target network-interfaces.target, which no longer exists. Using network.target is recommended instead."
-            )
-          ])
+              (optional (dynamicUser == true && user != "" && builtins.hasAttr user config.users.users)
+                "Service '${name}.service' has 'DynamicUser=true' but 'User' is set to '${user}', which is defined in 'users.users'. DynamicUser is for ephemeral auto-allocated users and must not be combined with pre-existing users — it poisons systemd's userdb and breaks $HOME resolution. Either remove 'DynamicUser=true' or don't set 'User' to an existing system user."
+              )
+            ]
+          )
       ) cfg.services
     );
 


### PR DESCRIPTION
This PR adds a new assertion to systemd, which prevents services from being configured incorrectly.
Specifically, it prevents setting `DynamicUser=true` when `User=somename` is also used.

**How to reproduce bug?** On NixOS:

```nix
services.prometheus.exporters.smartctl = {
  enable = true;
  user = "root";
  group = "root";
};
```

this builds correctly and generally works well, but it silently causes issues with the root shell:
```
Service with DynamicUser=yes + User=root
   → systemd registers "root" in io.systemd.DynamicUser
   → userdb returns { homeDirectory: "/" } for "root"
   → pam_systemd (or nss-systemd in the login path) picks up this record
   → HOME=/ is set in the PAM/session environment
   → OpenSSH merges PAM environment, overwriting its own correct HOME=/root
   → user gets HOME=/
```

the fix is to avoid setting DynamicUser for the service, like so:

```
# DynamicUser=yes (exporter default) + User=root poisons systemd's userdb,
# causing root's HOME to resolve as "/" via io.systemd.DynamicUser.
systemd.services.prometheus-smartctl-exporter.serviceConfig.DynamicUser = lib.mkForce false;
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [x] ran manual tests listed below
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

### How to test this PR
I decided to not add new tests file, and instead test manually. 

Case that's expected to cause issues:
```
❯    nix-instantiate --eval -E '
   let
     eval = import ./nixos/lib/eval-config.nix {
       modules = [
         {
           boot.loader.grub.device = "nodev";
           fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
           systemd.services.test-bad = {
             serviceConfig.DynamicUser = true;
             serviceConfig.User = "root";
             serviceConfig.ExecStart = "/bin/true";
           };
         }
       ];
     };
     failed = builtins.filter (a: !a.assertion) eval.config.assertions;
     msgs = map (a: a.message) failed;
   in
     builtins.filter (m: builtins.match ".*DynamicUser.*" m != null) msgs
   ' 2>&1

trace: evaluation warning: system.stateVersion is not set, defaulting to 26.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
[ "Service 'test-bad.service' has 'DynamicUser=true' but 'User' is set to 'root', which is defined in 'users.users'. DynamicUser is for ephemeral auto-allocated users and must not be combined with pre-existing users — it poisons systemd's userdb and breaks $HOME resolution. Either remove 'DynamicUser=true' or don't set 'User' to an existing system user." ]
```

Test case 2: DynamicUser=true without User should be fine
```
❯ nix-instantiate --eval -E '
   let
     eval = import ./nixos/lib/eval-config.nix {
       modules = [
         {
           boot.loader.grub.device = "nodev";
           fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
           systemd.services.test-ok-dynamic = {
             serviceConfig.DynamicUser = true;
             serviceConfig.ExecStart = "/bin/true";
           };
         }
       ];
     };
     failed = builtins.filter (a: !a.assertion) eval.config.assertions;
     msgs = map (a: a.message) failed;
   in
     builtins.filter (m: builtins.match ".*DynamicUser.*" m != null) msgs
   ' 2>&1
trace: evaluation warning: system.stateVersion is not set, defaulting to 26.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
[ ]
```

Test case 3: User=root without DynamicUser should be fine
```
❯ nix-instantiate --eval -E '
   let
     eval = import ./nixos/lib/eval-config.nix {
       modules = [
         {
           boot.loader.grub.device = "nodev";
           fileSystems."/" = { device = "/dev/sda1"; fsType = "ext4"; };
           systemd.services.test-ok-root = {
             serviceConfig.User = "root";
             serviceConfig.ExecStart = "/bin/true";
           };
         }
       ];
     };
     failed = builtins.filter (a: !a.assertion) eval.config.assertions;
     msgs = map (a: a.message) failed;
   in
     builtins.filter (m: builtins.match ".*DynamicUser.*" m != null) msgs
   ' 2>&1
trace: evaluation warning: system.stateVersion is not set, defaulting to 26.05. Read why this matters on https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion.
[ ]
```