### PR TITLE
python3Packages.pyaes: raise on default IV

### DIFF
--- a/pkgs/development/python-modules/pyaes/default-iv.patch
+++ b/pkgs/development/python-modules/pyaes/default-iv.patch
@@ -1,0 +1,51 @@
+From 034c7eea63a155582109233d2fc1de8e14121908 Mon Sep 17 00:00:00 2001
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Mon, 2 Mar 2026 12:55:44 +0100
+Subject: [PATCH] Raise on default IV
+
+This disables the static default IV for CBC, CFB and OFB by raising when
+not IV gets passed. We make sure not to break the API contract this way,
+so that existing consumers who rely on the default IV get a useful
+exception message instead of an API break, which could be done in a
+future version.
+
+In CBC mode an IV cannot be predictable or it breaks IND-CPA, this is
+also described as CWE-329.
+
+In CFB and OFB mode an IV still requires to be unique, which does not
+really hold when initializing it statically.
+---
+ pyaes/aes.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/pyaes/aes.py b/pyaes/aes.py
+index c6e8bc0..fd25547 100644
+--- a/pyaes/aes.py
++++ b/pyaes/aes.py
+@@ -376,7 +376,7 @@ class AESModeOfOperationCBC(AESBlockModeOfOperation):
+ 
+     def __init__(self, key, iv = None):
+         if iv is None:
+-            self._last_cipherblock = [ 0 ] * 16
++            raise ValueError("Missing IV parameter. This is a security problem, see https://github.com/ricmoo/pyaes/issues/56.")
+         elif len(iv) != 16:
+             raise ValueError('initialization vector must be 16 bytes')
+         else:
+@@ -423,7 +423,7 @@ def __init__(self, key, iv, segment_size = 1):
+         if segment_size == 0: segment_size = 1
+ 
+         if iv is None:
+-            self._shift_register = [ 0 ] * 16
++            raise ValueError("Missing IV parameter. This is a security problem, see https://github.com/ricmoo/pyaes/issues/56.")
+         elif len(iv) != 16:
+             raise ValueError('initialization vector must be 16 bytes')
+         else:
+@@ -495,7 +495,7 @@ class AESModeOfOperationOFB(AESStreamModeOfOperation):
+ 
+     def __init__(self, key, iv = None):
+         if iv is None:
+-            self._last_precipherblock = [ 0 ] * 16
++            raise ValueError("Missing IV parameter. This is a security problem, see https://github.com/ricmoo/pyaes/issues/56.")
+         elif len(iv) != 16:
+             raise ValueError('initialization vector must be 16 bytes')
+         else:

--- a/pkgs/development/python-modules/pyaes/default.nix
+++ b/pkgs/development/python-modules/pyaes/default.nix
@@ -14,6 +14,12 @@ buildPythonPackage rec {
     sha256 = "02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f";
   };
 
+  patches = [
+    # https://github.com/ricmoo/pyaes/issues/56
+    # https://blog.trailofbits.com/2026/02/18/carelessness-versus-craftsmanship-in-cryptography/
+    ./default-iv.patch
+  ];
+
   meta = {
     description = "Pure-Python AES";
     license = lib.licenses.mit;


### PR DESCRIPTION
https://github.com/ricmoo/pyaes/issues/56
https://blog.trailofbits.com/2026/02/18/carelessness-versus-craftsmanship-in-cryptography/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
