### PR TITLE
maintainers: drop david-r-cox

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6059,13 +6059,6 @@
     github = "David-Kopczynski";
     githubId = 53194670;
   };
-  david-r-cox = {
-    email = "david@integrated-reasoning.com";
-    github = "david-r-cox";
-    githubId = 4259949;
-    name = "David Cox";
-    keys = [ { fingerprint = "0056 A3F6 9918 1E0D 8FF0  BCDE 65BB 07FA A4D9 4634"; } ];
-  };
   david-sawatzke = {
     email = "d-nix@sawatzke.dev";
     github = "david-sawatzke";

--- a/pkgs/by-name/ca/cargo-typify/package.nix
+++ b/pkgs/by-name/ca/cargo-typify/package.nix
@@ -53,6 +53,6 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mainProgram = "cargo-typify";
     homepage = "https://github.com/oxidecomputer/typify";
     license = with lib.licenses; [ asl20 ];
-    maintainers = with lib.maintainers; [ david-r-cox ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/pa/papilo/package.nix
+++ b/pkgs/by-name/pa/papilo/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Parallel Presolve for Integer and Linear Optimization";
     license = with lib.licenses; [ lgpl3Plus ];
     mainProgram = "papilo";
-    maintainers = with lib.maintainers; [ david-r-cox ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/so/soplex/package.nix
+++ b/pkgs/by-name/so/soplex/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Sequential object-oriented simPlex";
     license = with lib.licenses; [ asl20 ];
     mainProgram = "soplex";
-    maintainers = with lib.maintainers; [ david-r-cox ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Adavid-r-cox) since February 2025 despite 12 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2025-03-01+user-review-requested%3Adavid-r-cox+). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@david-r-cox if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
