### PR TITLE
dovecot: add missing dependency libxcrypt, set strictDeps to true, fix broken test

### DIFF
--- a/nixos/tests/opensmtpd.nix
+++ b/nixos/tests/opensmtpd.nix
@@ -149,7 +149,7 @@ import ./make-test-python.nix {
     client.wait_for_unit("network-online.target")
     smtp1.wait_for_unit("opensmtpd")
     smtp2.wait_for_unit("opensmtpd")
-    smtp2.wait_for_unit("dovecot2")
+    smtp2.wait_for_unit("dovecot")
 
     # To prevent sporadic failures during daemon startup, make sure
     # services are listening on their ports before sending requests

--- a/pkgs/by-name/do/dovecot/package.nix
+++ b/pkgs/by-name/do/dovecot/package.nix
@@ -182,6 +182,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = !stdenv.hostPlatform.isDarwin;
 
+  strictDeps = true;
+
   meta = {
     homepage = "https://dovecot.org/";
     description = "Open source IMAP and POP3 email server written with security primarily in mind";

--- a/pkgs/by-name/do/dovecot/package.nix
+++ b/pkgs/by-name/do/dovecot/package.nix
@@ -21,6 +21,7 @@
   icu75,
   libexttextcat,
   libsodium,
+  libxcrypt,
   libstemmer,
   cyrus_sasl,
   nixosTests,
@@ -67,6 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
     icu75
     libexttextcat
     libsodium
+    libxcrypt
     libstemmer
     cyrus_sasl.dev
   ]


### PR DESCRIPTION
When cross compiling `dovecot` from `x86_64-linux` to `aarch64-linux`, `crypt` is not found and the build fails. I have added the dependency `libxcrypt` to fix this.

Closes #483259. See that issue for detailed build logs detailing the failure with a comparison with what happens on `hydra` for the native build.

Tested locally by cross compiling from `x86_64-linux` to `aarch64-linux` and running it in production.

To prevent this occurring in the future, `strictDeps` has been set to be `true`.

Additionally, this PR highlighted that the `opensmtpd` `NixOS` test was failing due to it having fallen out of synchronisation with the service name of `dovecot`. This has been fixed in this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
