### PR TITLE
chromium,chromedriver: 145.0.7632.75 -> 145.0.7632.109

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,10 +1,10 @@
 {
   "chromium": {
-    "version": "145.0.7632.75",
+    "version": "145.0.7632.109",
     "chromedriver": {
-      "version": "145.0.7632.76",
-      "hash_darwin": "sha256-7bZgvz6yD8qO1G82KTlAuPxLPelZ5TfIlLvyugDJUjM=",
-      "hash_darwin_aarch64": "sha256-fwtLzGyT810JoTKI52jXPGBu2EnrD+ROG1L2kGMfFfk="
+      "version": "145.0.7632.110",
+      "hash_darwin": "sha256-wa8s3PwS5G1TopGYheyLD7wlxxTZWPYwU90TLFpBMZw=",
+      "hash_darwin_aarch64": "sha256-/J4A4DrERlHdlI0Pv9hHCnBGoeUIB6G43fS0Y8taLFs="
     },
     "deps": {
       "depot_tools": {
@@ -21,8 +21,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "ab0b95409566de9da1ed76e690022f774aec7793",
-        "hash": "sha256-VvHDqNTXOFeV+QY3K2O9fTFxDzrkz6qKl9hP8nVDMAw=",
+        "rev": "61eff07de4f37ac1c6969c91034a447ef6cd394d",
+        "hash": "sha256-b498JyyvsN/+0Gqjdrq+eT1HW54/ayEENRHa1Sw69Xw=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -132,8 +132,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "0cf07977de12e7056ab3cbcbf584411e88a1f734",
-        "hash": "sha256-2OgNRRkpUlkyXAQDSOL4279JAi1C0QbH4MEfNW7WieQ="
+        "rev": "d9f5a980bb5a4baeb7d9c1fef89a39789a6cd9fb",
+        "hash": "sha256-DaNsRQm9bR2lfbiP6vWr2R7KD8mYWOaJ72VJyrUkJvI="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -257,8 +257,8 @@
       },
       "src/third_party/devtools-frontend/src": {
         "url": "https://chromium.googlesource.com/devtools/devtools-frontend",
-        "rev": "cc75f545bcb65238f74fd291833112305ce6915a",
-        "hash": "sha256-tOE96dcLmUaAVvOo4oGoUrEFpGSH2yxIBtvXSAVzbK0="
+        "rev": "8eb35b80efbc72ffb3aff36c3c1106fe9269df88",
+        "hash": "sha256-fzcXSU0kaIZVTQx1L5A0Xmn3HEzUE35mzfsU0YEaxw0="
       },
       "src/third_party/dom_distiller_js/dist": {
         "url": "https://chromium.googlesource.com/chromium/dom-distiller/dist.git",
@@ -602,8 +602,8 @@
       },
       "src/third_party/pdfium": {
         "url": "https://pdfium.googlesource.com/pdfium.git",
-        "rev": "3c679253a9e17c10be696d345c63636b18b7f925",
-        "hash": "sha256-OW39m1TVJnSdbeVeTCgSxePTqFTOwWqZIrU/5SEioCc="
+        "rev": "004b47619573a582c076679764e07725ace3e497",
+        "hash": "sha256-PHu3v/ZeEa11/CTGJh8aJjV/lTIVSJ6W7uH2njsHj1w="
       },
       "src/third_party/perfetto": {
         "url": "https://chromium.googlesource.com/external/github.com/google/perfetto.git",
@@ -817,8 +817,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "fffd2bdc35a900b4312833885d9d30803580670e",
-        "hash": "sha256-WqSGzOCvLw6k3t1oNgZV17KY8TVl6j4lJr0NZSVbm4o="
+        "rev": "a8b42c8fae7c7f1ce4e32b08ee61c22775185c01",
+        "hash": "sha256-HZ4JbSoMNVqUrCWoxk0/AxzlcpMgKhe/HJ7DGeTeE9M="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop_18.html

This update includes 3 security fixes.

CVEs:
CVE-2026-2648 CVE-2026-2649 CVE-2026-2650

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
