### PR TITLE
tclPackages.mkTclDerivation: fix clobbering of env

### DIFF
--- a/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
+++ b/pkgs/development/interpreters/tcl/mk-tcl-derivation.nix
@@ -57,7 +57,10 @@ let
         ];
         propagatedBuildInputs = propagatedBuildInputs ++ [ tcl ];
 
-        env.TCLSH = "${getBin tcl}/bin/tclsh";
+        env = {
+          TCLSH = "${getBin tcl}/bin/tclsh";
+        }
+        // (attrs.env or { });
 
         # Run tests after install, at which point we've done all TCLLIBPATH setup
         doCheck = false;


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/pull/488683

Is it preferred to have `TCLSH` "overridable" (as this PR is set up now), or "forced" by swapping the arguments to `//`?

@trofi Do you see any other issues?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
