### PR TITLE
cri-o: move env variable into env, use finalAttrs

### DIFF
--- a/pkgs/applications/virtualization/cri-o/default.nix
+++ b/pkgs/applications/virtualization/cri-o/default.nix
@@ -15,14 +15,14 @@
   go-md2man,
 }:
 
-buildGoModule rec {
+buildGoModule (finalAttrs: {
   pname = "cri-o";
   version = "1.35.0";
 
   src = fetchFromGitHub {
     owner = "cri-o";
     repo = "cri-o";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-aP3qhD2d1x+VPDifkg9lXgVD38UcongyN6vHkn8oYos=";
   };
   vendorHash = null;
@@ -52,7 +52,14 @@ buildGoModule rec {
     glibc.static
   ];
 
-  BUILDTAGS = "apparmor seccomp selinux containers_image_openpgp containers_image_ostree_stub";
+  env.BUILDTAGS = toString [
+    "apparmor"
+    "seccomp"
+    "selinux"
+    "containers_image_openpgp"
+    "containers_image_ostree_stub"
+  ];
+
   buildPhase = ''
     runHook preBuild
     sed -i 's;\thack/;\tbash ./hack/;g' Makefile
@@ -87,4 +94,4 @@ buildGoModule rec {
     teams = [ lib.teams.podman ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
