### PR TITLE
godot*: move env variable to env for structuredAttrs

### DIFF
--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -373,14 +373,22 @@ let
         ++ lib.optional editor "man";
         separateDebugInfo = true;
 
-        # Set the build name which is part of the version. In official downloads, this
-        # is set to 'official'. When not specified explicitly, it is set to
-        # 'custom_build'. Other platforms packaging Godot (Gentoo, Arch, Flatpack
-        # etc.) usually set this to their name as well.
-        #
-        # See also 'methods.py' in the Godot repo and 'build' in
-        # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
-        BUILD_NAME = "nixpkgs";
+        env = {
+          # Set the build name which is part of the version. In official downloads, this
+          # is set to 'official'. When not specified explicitly, it is set to
+          # 'custom_build'. Other platforms packaging Godot (Gentoo, Arch, Flatpack
+          # etc.) usually set this to their name as well.
+          #
+          # See also 'methods.py' in the Godot repo and 'build' in
+          # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
+          BUILD_NAME = "nixpkgs";
+        }
+        // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+          NIX_CFLAGS_COMPILE = toString [
+            "-I${lib.getDev harfbuzz-icu}/include/harfbuzz"
+            "-I${lib.getDev recastnavigation}/include/recastnavigation"
+          ];
+        };
 
         preConfigure = lib.optionalString (editor && withMono) ''
           # TODO: avoid pulling in dependencies of windows-only project
@@ -551,13 +559,6 @@ let
           buildPackages.stdenv.cc
           pkg-config
         ];
-
-        env.NIX_CFLAGS_COMPILE = toString (
-          lib.optionals stdenv.hostPlatform.isDarwin [
-            "-I${lib.getDev harfbuzz-icu}/include/harfbuzz"
-            "-I${lib.getDev recastnavigation}/include/recastnavigation"
-          ]
-        );
 
         buildInputs =
           lib.optionals (!withBuiltins) (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
