### PR TITLE
lmstudio: fix for Darwin

### DIFF
--- a/pkgs/by-name/lm/lmstudio/darwin.nix
+++ b/pkgs/by-name/lm/lmstudio/darwin.nix
@@ -2,6 +2,7 @@
   stdenv,
   fetchurl,
   undmg,
+  darwin,
   meta,
   pname,
   version,
@@ -16,7 +17,10 @@ stdenv.mkDerivation {
     inherit url hash;
   };
 
-  nativeBuildInputs = [ undmg ];
+  nativeBuildInputs = [
+    undmg
+    darwin.sigtool
+  ];
 
   sourceRoot = ".";
 
@@ -24,6 +28,19 @@ stdenv.mkDerivation {
     runHook preInstall
     mkdir -p $out/Applications
     cp -r *.app $out/Applications
+
+    # Bypass the /Applications path check in the main index.js
+    # LM Studio verifies the app is running from /Applications and shows an
+    # error dialog + refuses to auto-update if not. Replace the '/Applications'
+    # string literal with '/' so that any absolute path (e.g. /nix/store/...)
+    # passes the startsWith check. This works across obfuscated versions because
+    # the literal string '/Applications' is stable even when variable names change.
+    local indexJs="$out/Applications/LM Studio.app/Contents/Resources/app/.webpack/main/index.js"
+    substituteInPlace "$indexJs" --replace-quiet "'/Applications'" "'/'"
+
+    # Re-sign the app bundle after patching, otherwise macOS reports it as damaged
+    codesign --force --deep --sign - "$out/Applications/LM Studio.app"
+
     runHook postInstall
   '';
 

--- a/pkgs/by-name/lm/lmstudio/package.nix
+++ b/pkgs/by-name/lm/lmstudio/package.nix
@@ -23,7 +23,6 @@ let
       "aarch64-darwin"
     ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    broken = stdenv.hostPlatform.isDarwin; # Upstream issue: https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/347
   };
 in
 if stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
Patching workaround for https://github.com/lmstudio-ai/lmstudio-bug-tracker/issues/347

Replaces path check starting with `/Applications` with `/` and then re-signs the application bundle.

@crertel

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
