### PR TITLE
opensmtpd: fix offline enqueueing

### DIFF
--- a/nixos/modules/services/mail/opensmtpd.nix
+++ b/nixos/modules/services/mail/opensmtpd.nix
@@ -105,12 +105,21 @@ in
       };
     };
 
-    security.wrappers.smtpctl = {
-      owner = "root";
-      group = "smtpq";
-      setuid = false;
-      setgid = true;
-      source = "${cfg.package}/bin/smtpctl";
+    security.wrappers = {
+      makemap = {
+        owner = "root";
+        group = "smtpq";
+        setuid = false;
+        setgid = true;
+        source = "${cfg.package}/bin/smtpctl";
+      };
+      smtpctl = {
+        owner = "root";
+        group = "smtpq";
+        setuid = false;
+        setgid = true;
+        source = "${cfg.package}/bin/smtpctl";
+      };
     };
 
     services.mail.sendmailSetuidWrapper = lib.mkIf cfg.setSendmail (

--- a/pkgs/by-name/op/opensmtpd/offline.patch
+++ b/pkgs/by-name/op/opensmtpd/offline.patch
@@ -1,0 +1,20 @@
+Commit ID: 0527fcb65d6af4271a33dbd425f30d457fc7ab4f
+Change ID: puqrnyuutmspqxqtkkqqrsmsxnyqvomm
+Author   : Ricardo Correia <someplaceguy@wizy.org> (2026-02-18 23:51:00)
+Committer: Ricardo Correia <someplaceguy@wizy.org> (2026-02-19 00:43:47)
+
+    (no description set)
+
+diff --git a/usr.sbin/smtpd/smtpd.c b/usr.sbin/smtpd/smtpd.c
+index 2365b1ee46..b9e40e1417 100644
+--- a/usr.sbin/smtpd/smtpd.c
++++ b/usr.sbin/smtpd/smtpd.c
+@@ -1806,7 +1806,7 @@
+ 		envp[1] = (char *)NULL;
+ 		environ = envp;
+ 
+-		execvp(PATH_SMTPCTL, args.list);
++		execvp(@@PATH_SENDMAIL@@, args.list);
+ 		_exit(1);
+ 	}
+ 


### PR DESCRIPTION
Note: for it to work correctly, it requires `services.opensmtpd.setSendmail` is set to true.

Fixes #255691

cc @vifino @obadz 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
