### PR TITLE
scotch: 7.0.10 -> 7.0.11; doCheck

### DIFF
--- a/pkgs/by-name/sc/scotch/package.nix
+++ b/pkgs/by-name/sc/scotch/package.nix
@@ -10,6 +10,7 @@
   xz,
   zlib,
   mpi,
+  mpiCheckPhaseHook,
   withPtScotch ? false,
   testers,
   pkgsMusl ? { }, # default to empty set to avoid CI fails with allowVariants = false
@@ -18,14 +19,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "scotch";
-  version = "7.0.10";
+  version = "7.0.11";
 
   src = fetchFromGitLab {
     domain = "gitlab.inria.fr";
     owner = "scotch";
     repo = "scotch";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-qeMgTkoM/RDsZa0T6hmrDLbLuSeR8WNxllyHSlkMVzA=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ljz4Xu3ztxhx8c+gRYABG85T9SuauQc4UsVHPmREvkk=";
   };
 
   outputs = [
@@ -39,8 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "BUILD_PTSCOTCH" withPtScotch)
     # Prefix Scotch version of MeTiS routines
     (lib.cmakeBool "SCOTCH_METIS_PREFIX" true)
-    # building tests is broken with SCOTCH_METIS_PREFIX enabled, at least since 7.0.9
-    (lib.cmakeBool "ENABLE_TESTS" false)
+    (lib.cmakeBool "ENABLE_TESTS" finalAttrs.finalPackage.doCheck)
   ];
 
   nativeBuildInputs = [
@@ -59,6 +59,14 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs = lib.optionals withPtScotch [
     mpi
   ];
+
+  nativeCheckInputs = lib.optionals withPtScotch [
+    mpiCheckPhaseHook
+  ];
+
+  __darwinAllowLocalNetworking = withPtScotch;
+
+  doCheck = true;
 
   # SCOTCH provide compatibility with Metis/Parmetis interface.
   # We install the metis compatible headers to subdirectory to


### PR DESCRIPTION
Diff: https://gitlab.inria.fr/scotch/scotch/-/compare/v7.0.10...v7.0.11
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
