### PR TITLE
nextflow: fix trace+docker failure by reverting trace_cmd bash path

### DIFF
--- a/nixos/tests/nextflow.nix
+++ b/nixos/tests/nextflow.nix
@@ -1,5 +1,7 @@
 { pkgs, ... }:
 let
+  # This is the default image used by Nextflow if docker.enabled=true and no
+  # process.container is defined.
   bash = pkgs.dockerTools.pullImage {
     imageName = "quay.io/nextflow/bash";
     imageDigest = "sha256:bea0e244b7c5367b2b0de687e7d28f692013aa18970941c7dd184450125163ac";
@@ -21,13 +23,17 @@ let
   };
   run-nextflow-pipeline = pkgs.writeShellApplication {
     name = "run-nextflow-pipeline";
-    runtimeInputs = [ pkgs.nextflow ];
     text = ''
       export NXF_OFFLINE=true
-      for b in false true; do
-        echo "docker.enabled = $b" > nextflow.config
-        cat nextflow.config
-        nextflow run -ansi-log false ${hello}
+      for d in true false; do
+        for t in true false; do
+          rm -f nextflow.config; touch nextflow.config
+          echo "docker.enabled = $d" >> nextflow.config
+          echo "trace.enabled = $t" >> nextflow.config
+          echo "Testing docker=$d trace=$t"
+          nextflow run -ansi-log false ${hello}
+          echo "PASSED docker=$d trace=$t"
+        done
       done
     '';
   };


### PR DESCRIPTION
Fix #350183 

## Things done

- add docker+trace combination test
- patch `trace_cmd` for revert (`/bin/bash` <-> `pkgs.bash`)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
