### PR TITLE
python3Packages.kanidm: 1.2.0 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/kanidm/default.nix
+++ b/pkgs/development/python-modules/kanidm/default.nix
@@ -20,14 +20,14 @@
 
 buildPythonPackage rec {
   pname = "kanidm";
-  version = "1.2.0";
+  version = "1.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kanidm";
     repo = "kanidm";
-    rev = "1774f9428ccdc357d514652acbcae49f6b16687a";
-    hash = "sha256-SE3b9Ug0EZFygGf9lsmVsQzmop9qOMiCUsbO//1QWF8=";
+    rev = "d9a952b8816054b6f10be564dcd43a7202a2ef02";
+    hash = "sha256-JTo883Lq4CbzQ9G5y3XDgBC696r+Fyk5I3m9G9uYwVk=";
   };
 
   sourceRoot = "${src.name}/pykanidm";
@@ -56,6 +56,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/kanidm/kanidm/tree/master/pykanidm";
     license = lib.licenses.mpl20;
     maintainers = with lib.maintainers; [
+      adamcstephens
       arianvp
       hexa
     ];


### PR DESCRIPTION
no real release notes, here's what we have:
https://github.com/kanidm/kanidm/commit/d9a952b8816054b6f10be564dcd43a7202a2ef02 https://github.com/kanidm/kanidm/pull/4149


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
