### PR TITLE
nixos/hardware.displaylink: fix unknown driver assertion

### DIFF
--- a/nixos/modules/hardware/video/displaylink.nix
+++ b/nixos/modules/hardware/video/displaylink.nix
@@ -23,6 +23,8 @@ in
     boot.extraModulePackages = [ evdi ];
     boot.kernelModules = [ "evdi" ];
 
+    services.xserver.externallyConfiguredDrivers = [ "displaylink" ];
+
     environment.etc."X11/xorg.conf.d/40-displaylink.conf".text = ''
       Section "OutputClass"
         Identifier  "DisplayLink"

--- a/nixos/modules/services/x11/xserver.nix
+++ b/nixos/modules/services/x11/xserver.nix
@@ -497,7 +497,25 @@ in
         internal = true;
         description = ''
           A list of attribute sets specifying drivers to be loaded by
-          the X11 server.
+          the X11 server. This module will create a Device section in
+          the Xorg config for every driver listed here, along with a
+          Screen section if the driver's {option}`display` attribute is
+          `true`. If such configuration sections should not be created,
+          use {options}`services.xserver.externallyConfiguredDrivers`
+          instead.
+
+          Users should not add drivers to this option but should instead
+          add drivers to {option}`services.xserver.videoDrivers`.
+        '';
+      };
+
+      externallyConfiguredDrivers = mkOption {
+        type = types.listOf types.str;
+        internal = true;
+        description = ''
+          A list of externally configured drivers (by name). Modules that
+          manually configure their drivers should add said drivers to this
+          list to let this module know that the driver has been configured.
         '';
       };
 
@@ -865,7 +883,9 @@ in
       }
     ]
     ++ map (driver: {
-      assertion = builtins.elem driver (builtins.catAttrs "name" cfg.drivers);
+      assertion = builtins.elem driver (
+        (builtins.catAttrs "name" cfg.drivers) ++ cfg.externallyConfiguredDrivers
+      );
       message = "Unknown X11 driver ‘${driver}’ specified in `services.xserver.videoDrivers`.";
     }) cfg.videoDrivers;
 


### PR DESCRIPTION
The `services.xserver` module asserts that all drivers listed in `services.xserver.videoDrivers` end up as drivers in `services.xserver.drivers`. Unfortunately, the DisplayLink module configures an OutputClass, not a single Device, so it can't simply add a driver to this list (as far as I can tell).

We solve this by:

1. Introducing a new (internal) `services.xserver.externallyConfiguredDrivers` option where drivers can be added to tell the xserver module that they have been configured and aren't simply "unknown".
2. Use this option in the displaylink module.

Fixes #491861

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test