### PR TITLE
virtualbox: Wayland dependencies

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -28,6 +28,7 @@
   libopus,
   libtpms,
   qt6,
+  wayland,
   pkg-config,
   which,
   docbook_xsl,
@@ -103,6 +104,13 @@ let
     qtscxml
     wrapQtAppsHook
     ;
+
+  patchelfWayland = binPath: ''
+    patchelf ${binPath} \
+      --add-needed libwayland-client.so.0 \
+      --add-rpath ${lib.makeLibraryPath [ wayland ]}
+  '';
+
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "virtualbox";
@@ -386,11 +394,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   preFixup =
     optionalString (!headless) ''
+      ${patchelfWayland "$out/bin/VirtualBox"}
       wrapQtApp $out/bin/VirtualBox
     ''
     # If hardening is disabled, wrap the VirtualBoxVM binary instead of patching
     # the source code (see postPatch).
     + optionalString (!headless && !enableHardening) ''
+      ${patchelfWayland "$out/libexec/virtualbox/VirtualBoxVM"}
       wrapQtApp $out/libexec/virtualbox/VirtualBoxVM
     '';
 

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -171,6 +171,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ optionals (!headless) [
     qtbase
     qttools
+    qtwayland
     qtscxml
     libxinerama
     SDL2


### PR DESCRIPTION
VirtualBox slowly gains support for Wayland. However, on systems without `X11` (or when started with `DISPLAY=`) the GUI does not start.
There seem to be 2 issues:
1) With QT6, `qtwayland` has to be an explicit build input, see https://github.com/NixOS/nixpkgs/issues/219724
2) The runtime dependency `libwayland-client.so.0` is not found.

First issue is easy enough to fix.
For 2) I have used `patchelf`, I am not sure if that is the right thing to do.

@FriedrichAltheide @blitz 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
