### PR TITLE
nixos/frigate: set LIBAVFORMAT_VERSION_MAJOR

### DIFF
--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -699,6 +699,17 @@ in
       environment = {
         CONFIG_FILE = "/run/frigate/frigate.yml";
         HOME = "/var/lib/frigate";
+        # Extract libavformat version in the same way Docker scripts in frigate directory do. This
+        # environment variable changes the flags given to `ffmpeg` improving compatibility.
+        LIBAVFORMAT_VERSION_MAJOR = lib.strings.trim (
+          builtins.readFile (
+            pkgs.runCommandLocal "libavformat-major-version" { } ''
+              ${cfg.settings.ffmpeg.path}/bin/ffmpeg -version 2>&1 \
+                | sed -n 's/.*libavformat[[:space:]]*\([0-9]*\).*/\1/p' \
+                | head -1 > $out
+            ''
+          )
+        );
         PYTHONPATH = cfg.package.pythonPath;
       }
       // optionalAttrs (cfg.vaapiDriver != null) {

--- a/nixos/modules/services/video/frigate.nix
+++ b/nixos/modules/services/video/frigate.nix
@@ -704,9 +704,7 @@ in
         LIBAVFORMAT_VERSION_MAJOR = lib.strings.trim (
           builtins.readFile (
             pkgs.runCommandLocal "libavformat-major-version" { } ''
-              ${cfg.settings.ffmpeg.path}/bin/ffmpeg -version 2>&1 \
-                | sed -n 's/.*libavformat[[:space:]]*\([0-9]*\).*/\1/p' \
-                | head -1 > $out
+              ${cfg.settings.ffmpeg.path}/bin/ffmpeg -version | grep -Po "libavformat\W+\K\d+" > $out
             ''
           )
         );


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Emulate setting LIBAVFORMAT_VERSION_MAJOR from the version printed by `ffmpeg`. This is the same logic used by Docker scripts in `frigate` upstream. This environment variable tells frigate to tailor the flags to a concrete ffmpeg version.

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
