### PR TITLE
[25.11] suricata: 7.0.10 -> 7.0.14

### DIFF
--- a/pkgs/by-name/su/suricata/package.nix
+++ b/pkgs/by-name/su/suricata/package.nix
@@ -39,11 +39,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "suricata";
-  version = "7.0.10";
+  version = "7.0.14";
 
   src = fetchurl {
     url = "https://www.openinfosecfoundation.org/download/${pname}-${version}.tar.gz";
-    hash = "sha256-GX+SXqcBvctKFaygJLBlRrACZ0zZWLWJWPKaW7IU11k=";
+    hash = "sha256-qQoUFAfHy/uFiTIxRqTwfi3vuaxy9ChGBFy+PfwazhM=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes:
* CVE-2026-22264 / https://github.com/NixOS/nixpkgs/issues/488124
* CVE-2026-22258 / https://github.com/NixOS/nixpkgs/issues/488120
* CVE-2026-22262 / https://github.com/NixOS/nixpkgs/issues/488122
* CVE-2026-22261 / https://github.com/NixOS/nixpkgs/issues/488118

Changes:
https://forum.suricata.io/t/suricata-8-0-3-and-7-0-14-released/
https://forum.suricata.io/t/suricata-8-0-2-and-7-0-13-released/
https://forum.suricata.io/t/suricata-8-0-1-and-7-0-12-released/
https://forum.suricata.io/t/suricata-7-0-11-released/

Not-cherry-picked-because: unstable is using the 8.x branch


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 492025`
Commit: `56e9f5ec4ab031cb9e115dd764947747e8589e78`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>suricata</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
