### PR TITLE
nixos-install-tools: remove broken passthru test

### DIFF
--- a/pkgs/by-name/ni/nixos-install-tools/package.nix
+++ b/pkgs/by-name/ni/nixos-install-tools/package.nix
@@ -1,14 +1,12 @@
 {
   buildEnv,
   lib,
-  man,
   nixos,
   # TODO: replace indirect self-reference by proper self-reference
   #       https://github.com/NixOS/nixpkgs/pull/119942
   nixos-install-tools,
   nixos-install,
   nixos-enter,
-  runCommand,
   nixosTests,
   binlore,
 }:
@@ -41,32 +39,7 @@ in
     platforms = lib.platforms.linux;
   };
 
-  passthru.tests = {
-    nixos-tests = lib.recurseIntoAttrs nixosTests.installer;
-    nixos-install-help =
-      runCommand "test-nixos-install-help"
-        {
-          nativeBuildInputs = [
-            man
-            nixos-install-tools
-          ];
-          meta.description = ''
-            Make sure that --help works. It's somewhat non-trivial because it
-            requires man.
-          '';
-        }
-        ''
-          nixos-install --help | grep -F "System Manager's Manual"
-          nixos-install --help | grep -F 'configuration.nix'
-          nixos-generate-config --help | grep -F "System Manager's Manual"
-          nixos-generate-config --help | grep -F 'hardware-configuration.nix'
-
-          # FIXME: Tries to call unshare, which it must not do for --help
-          # nixos-enter --help | grep -F 'NixOS Reference Pages'
-
-          touch $out
-        '';
-  };
+  passthru.tests = lib.recurseIntoAttrs nixosTests.installer;
 
   # no documented flags show signs of exec; skim of source suggests
   # it's just --help execing man


### PR DESCRIPTION
nixos-install-tools.passthru.tests.nixos-install-help has been broken since 0c601b12bf4e (nixos/manual: translate manpages to mdoc, 2023-01-09), apparently without anyone noticing or caring.  All it's supposed to do is check that `nixos-install --help` and `nixos-generate-config --help` produce vaguely sensible output, and those are the sorts of failures I'd expect to be spotted very quickly anyway.

Rather than trying to repair this fragile and low-value test, just remove it entirely.

Fixes #491791.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
