### PR TITLE
antora: 3.1.9 -> 3.1.14

### DIFF
--- a/pkgs/by-name/an/antora/package.nix
+++ b/pkgs/by-name/an/antora/package.nix
@@ -8,21 +8,24 @@
 
 buildNpmPackage rec {
   pname = "antora";
-  version = "3.1.9";
+  version = "3.1.14";
 
   src = fetchFromGitLab {
     owner = "antora";
     repo = "antora";
     tag = "v${version}";
-    hash = "sha256-hkavYC2LO8NRIRwHNWIJLRDkVnhAB4Di3IqL8uGt+U8=";
+    hash = "sha256-9x80aBm2ZBj389kX2wioe7BtaNjR7p9aEZg7o49v0vY=";
   };
 
-  npmDepsHash = "sha256-ngreuitwUcIDVF6vW7fZA1OaVxr9fv7s0IjCErXlcxg=";
+  npmDepsHash = "sha256-s/f6/PxvSIlhFsCbsD25MPrk67vKXrnDqbfbW72Tr4I=";
 
   # This is to stop tests from being ran, as some of them fail due to trying to query remote repositories
+  # Also disable the postbuild lint step which tries to download @biomejs/biome at build time
   postPatch = ''
-    substituteInPlace package.json --replace \
+    substituteInPlace package.json --replace-warn \
       '"_mocha"' '""'
+    substituteInPlace package.json --replace-warn \
+      '"npm run lint"' '""'
   '';
 
   postInstall = ''


### PR DESCRIPTION
https://gitlab.com/antora/antora/-/releases/v3.1.14

Version 3.1.14 adds a lint step (`@biomejs/biome`) to the build process via `npx -y`, which attempts to download the linter at build time. Since this is not possible in the nix sandbox, the `postbuild` script is patched out alongside the existing mocha test patch.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
