### PR TITLE
lobster: 2025.3 -> 2026.1

### DIFF
--- a/pkgs/by-name/lo/lobster/package.nix
+++ b/pkgs/by-name/lo/lobster/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   callPackage,
 
@@ -15,22 +14,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lobster";
-  version = "2025.3";
+  version = "2026.1";
 
   src = fetchFromGitHub {
     owner = "aardappel";
     repo = "lobster";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-YGtjoRBGOqkcHaiZNPVFOoeLitJTG/M0I08EPZVCfj0=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-kN4KYd0wTHqF3J4wFGHLmHifkxsb6J+Ex7gGRGnFiGk=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "cmake-fix.patch";
-      url = "https://github.com/aardappel/lobster/commit/a5f46ed65cad43ea70c8a6af5ea2fd5a018c8941.patch?full_index=1";
-      hash = "sha256-91pmoTPLD2Fo2SuCKngdRxXFUty5lOyA4oX8zaJ0ON0=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
   buildInputs = lib.optionals (!stdenv.hostPlatform.isDarwin) [


### PR DESCRIPTION
Fixes:
* CVE-2026-2259 / https://github.com/NixOS/nixpkgs/issues/489348
* CVE-2026-2258 / https://github.com/NixOS/nixpkgs/issues/489346

Changes:
https://github.com/aardappel/lobster/compare/v2025.3...v2026.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 492060`
Commit: `18cc6be0fc2b70695f9a92d782be1e823cf15a1c`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>lobster</li>
  </ul>
</details>

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
