### PR TITLE
rubyPackages.faraday: 2.14.0 -> 2.14.1

### DIFF
--- a/pkgs/top-level/ruby-packages.nix
+++ b/pkgs/top-level/ruby-packages.nix
@@ -1302,10 +1302,10 @@
     platforms = [ ];
     source = {
       remotes = [ "https://rubygems.org" ];
-      sha256 = "1ka175ci0q9ylpcy651pjj580diplkaskycn4n7jcmbyv7jwz6c6";
+      sha256 = "077n5ss3z3ds4vj54w201kd12smai853dp9c9n7ii7g3q7nwwg54";
       type = "gem";
     };
-    version = "2.14.0";
+    version = "2.14.1";
   };
   faraday-net_http = {
     dependencies = [ "net-http" ];


### PR DESCRIPTION
Fixes CVE-2026-25765 / https://github.com/lostisland/faraday/security/advisories/GHSA-33mh-2634-fwr2
Fixes #489340

Changes:
https://github.com/lostisland/faraday/releases/tag/v2.14.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 492061`
Commit: `67dbf90e678b54a3e9de0587a4eb311fb85ac226`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 24 packages built:</summary>
  <ul>
    <li>rubyPackages.faraday (rubyPackages_3_3.faraday)</li>
    <li>rubyPackages.github-pages (rubyPackages_3_3.github-pages)</li>
    <li>rubyPackages.github-pages-health-check (rubyPackages_3_3.github-pages-health-check)</li>
    <li>rubyPackages.jekyll-gist (rubyPackages_3_3.jekyll-gist)</li>
    <li>rubyPackages.jekyll-github-metadata (rubyPackages_3_3.jekyll-github-metadata)</li>
    <li>rubyPackages.jekyll-theme-primer (rubyPackages_3_3.jekyll-theme-primer)</li>
    <li>rubyPackages.octokit (rubyPackages_3_3.octokit)</li>
    <li>rubyPackages.sawyer (rubyPackages_3_3.sawyer)</li>
    <li>rubyPackages_3_4.faraday</li>
    <li>rubyPackages_3_4.github-pages</li>
    <li>rubyPackages_3_4.github-pages-health-check</li>
    <li>rubyPackages_3_4.jekyll-gist</li>
    <li>rubyPackages_3_4.jekyll-github-metadata</li>
    <li>rubyPackages_3_4.jekyll-theme-primer</li>
    <li>rubyPackages_3_4.octokit</li>
    <li>rubyPackages_3_4.sawyer</li>
    <li>rubyPackages_4_0.faraday</li>
    <li>rubyPackages_4_0.github-pages</li>
    <li>rubyPackages_4_0.github-pages-health-check</li>
    <li>rubyPackages_4_0.jekyll-gist</li>
    <li>rubyPackages_4_0.jekyll-github-metadata</li>
    <li>rubyPackages_4_0.jekyll-theme-primer</li>
    <li>rubyPackages_4_0.octokit</li>
    <li>rubyPackages_4_0.sawyer</li>
  </ul>
</details>


[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
