### PR TITLE
qimgv: update to `1.0.3-unstable-2026-01-19`, add blur support

### DIFF
--- a/pkgs/by-name/qi/qimgv/package.nix
+++ b/pkgs/by-name/qi/qimgv/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation {
   pname = "qimgv";
-  version = "1.0.3-unstable-2024-10-11";
+  version = "1.0.3-unstable-2026-01-19";
 
   src = fetchFromGitHub {
     owner = "easymodo";
     repo = "qimgv";
-    rev = "a4d475fae07847be7c106cb628fb97dad51ab920";
-    sha256 = "sha256-iURUJiPe8hbCnpaf6lk8OVSzVqrJKGab889yOic5yLI=";
+    rev = "3127a2d211b124ad4fcf853d01e6df9323bdfdc3";
+    sha256 = "sha256-avn02kdMyA5PZUSykxgIk1I78zHQ/WKd26tQO8lMOow=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/qi/qimgv/package.nix
+++ b/pkgs/by-name/qi/qimgv/package.nix
@@ -30,6 +30,7 @@ stdenv.mkDerivation {
   cmakeFlags = [
     "-DVIDEO_SUPPORT=ON"
     "-DUSE_QT5=OFF"
+    "-DKDE_SUPPORT=ON"
   ];
 
   buildInputs = [
@@ -41,6 +42,7 @@ stdenv.mkDerivation {
     kdePackages.qtsvg
     kdePackages.qttools
     kdePackages.kimageformats
+    kdePackages.kwindowsystem
   ];
 
   postPatch = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update to the latest commit. This brings better support for Qt6 (currently we set `-DUSE_QT5=OFF` but that flag doesn't even exist on the commit we are building from), improves mouse handling on Wayland, adds some translations and some other general improvements. See the [full diff](https://github.com/easymodo/qimgv/compare/a4d475fae07847be7c106cb628fb97dad51ab920...3127a2d211b124ad4fcf853d01e6df9323bdfdc3) for more context.

I've also turned on support for background blur when using KDE. I'm not sure whether this should be enabled by default or be guarded behind some flag, let me know what you think, I'll update the patch accordingly.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
