### PR TITLE
signal-desktop-bin: 7.89.0 -> 7.90.0

### DIFF
--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-aarch64.nix
@@ -1,7 +1,7 @@
 { callPackage, commandLineArgs }:
 callPackage ./generic.nix { inherit commandLineArgs; } {
   pname = "signal-desktop-bin";
-  version = "7.89.0";
+  version = "7.90.0";
 
   libdir = "usr/lib64/signal-desktop";
   bindir = "usr/bin";
@@ -10,6 +10,6 @@ callPackage ./generic.nix { inherit commandLineArgs; } {
     bsdtar -xf $downloadedFile -C "$out"
   '';
 
-  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/10118373-signal-desktop/signal-desktop-7.89.0-1.fc42.aarch64.rpm";
-  hash = "sha256-cqGdY5CEWK5T04Pa9ZAyOqmlsO476vGXkos6gdWahcU=";
+  url = "https://download.copr.fedorainfracloud.org/results/useidel/signal-desktop/fedora-42-aarch64/10149422-signal-desktop/signal-desktop-7.90.0-1.fc42.aarch64.rpm";
+  hash = "sha256-+6aIB/UF7oZ7I4MtDsYCOhQxiaTpIyXGZ5WLdJto7Us=";
 }

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop-darwin.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop-darwin.nix
@@ -6,11 +6,11 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "signal-desktop-bin";
-  version = "7.89.0";
+  version = "7.90.0";
 
   src = fetchurl {
     url = "https://updates.signal.org/desktop/signal-desktop-mac-universal-${finalAttrs.version}.dmg";
-    hash = "sha256-Y2xUCWDRsb+A2GypvxZPc1VChRX3ElgrPOeeu4w4FRU=";
+    hash = "sha256-61JsAPeGVNJpuUDAv3nA0WNr15C+e5NvsT0ICT2dolc=";
   };
   sourceRoot = ".";
 

--- a/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
+++ b/pkgs/by-name/si/signal-desktop-bin/signal-desktop.nix
@@ -1,12 +1,12 @@
 { callPackage, commandLineArgs }:
 callPackage ./generic.nix { inherit commandLineArgs; } rec {
   pname = "signal-desktop-bin";
-  version = "7.89.0";
+  version = "7.90.0";
 
   libdir = "opt/Signal";
   bindir = libdir;
   extractPkg = "dpkg-deb -x $downloadedFile $out";
 
   url = "https://updates.signal.org/desktop/apt/pool/s/signal-desktop/signal-desktop_${version}_amd64.deb";
-  hash = "sha256-qGzQ+ZtOCKu69EBEoxVjR5PzgtlrSNBW6SBZ9eG3ooU=";
+  hash = "sha256-m9tBldv1WvfdLrORIuJQYBQ72rBRHgXSAk0PrwZtAB4=";
 }


### PR DESCRIPTION
https://github.com/signalapp/Signal-Desktop/compare/v7.89.0...v7.90.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
