### PR TITLE
[Backport release-25.11] apko: 0.30.22 -> 1.1.9

### DIFF
--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "0.30.26";
+  version = "0.30.27";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lJV5WyhbMC0L0kNzo/Yv1yWLAFZ69QojRUpamJnbf3U=";
+    hash = "sha256-lter7nuNM62J1+unCgnkG7pU6lvNK3LjXS6FaW8NDjY=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-BXWaXdlqaw2SACFGAebnmeQSWdq/htvWVqXVYcUlLP8=";
+  vendorHash = "sha256-1VKvW34w88Xc5/2h3WrutZK1ziGaLLgwf9bTSSIDF/A=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "1.0.4";
+  version = "1.0.5";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-18i2xiVDjIRG0RD5R7t2BsyB9N+hhYOOByV6snGBCkM=";
+    hash = "sha256-7KDyTXqIM4hUnNVJt4xwsuUdP0eYSF+fSBRuSKs8VzQ=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-P8/0VSx4JfWgbMUuvo1Z0BhtC1TgGITSHLMHSzigeEg=";
+  vendorHash = "sha256-vHTJCfXVlbBLQXC/tsXJsGoACcxAhJmFlU/tq10836Q=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "0.30.27";
+  version = "0.30.31";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-lter7nuNM62J1+unCgnkG7pU6lvNK3LjXS6FaW8NDjY=";
+    hash = "sha256-/XxG6UadYaeeusgH53NVFjuEriUxkf5A9h2wGdps0NQ=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-1VKvW34w88Xc5/2h3WrutZK1ziGaLLgwf9bTSSIDF/A=";
+  vendorHash = "sha256-+rgkyTmuD3OMil5vO9xDcAvNl19JfvqPz3zotDiGPCU=";
 
   nativeBuildInputs = [ installShellFiles ];
 
@@ -60,8 +60,8 @@ buildGoModule (finalAttrs: {
   '';
 
   checkFlags = [
-    # requires networking (apk.chainreg.biz)
-    "-skip=TestInitDB_ChainguardDiscovery"
+    # requires networking (apk.chainreg.biz and dl-cdn.alpinelinux.org)
+    "-skip=TestInitDB_ChainguardDiscovery|TestFetchPackage"
   ];
 
   postInstall =

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "1.0.5";
+  version = "1.1.4";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7KDyTXqIM4hUnNVJt4xwsuUdP0eYSF+fSBRuSKs8VzQ=";
+    hash = "sha256-8nxz8Qmo1waHa3c6qbb5cy+mMT2kaWcHSl4uW3qrBsI=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,11 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-vHTJCfXVlbBLQXC/tsXJsGoACcxAhJmFlU/tq10836Q=";
+  vendorHash = "sha256-vGtxVQSesrqWnYJT7B2KhWiYtUFsYVPdI/ZEbpFmkOc=";
+
+  excludedPackages = [
+    "internal/gen-jsonschema"
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "1.1.4";
+  version = "1.1.6";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-8nxz8Qmo1waHa3c6qbb5cy+mMT2kaWcHSl4uW3qrBsI=";
+    hash = "sha256-7WNWbTs+r3L2O6ixK1yEElwdFfRPqx2yX+nPRy3nSEM=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-vGtxVQSesrqWnYJT7B2KhWiYtUFsYVPdI/ZEbpFmkOc=";
+  vendorHash = "sha256-mSnEga9JtS1ObMJpS0uo1RZs2ubpTwsErtmD8rMe5gg=";
 
   excludedPackages = [
     "internal/gen-jsonschema"

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "0.30.35";
+  version = "1.0.2";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-2jgIJ1vEaIdfWouQeK/WnHXymcNRwawW9nnsXkamQaQ=";
+    hash = "sha256-rUJ/znxHysPdy4AFujbisUrCW0L0cgh03jLt3YY/tis=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-KBLthYP5dwtuzfa4f1KARmG5ecStzTwsnX2E95z3S2Q=";
+  vendorHash = "sha256-ol9uJq/HPdv5E2MB+KUturqwsa8s3xqULwXu9bAWjr0=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "1.0.2";
+  version = "1.0.4";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-rUJ/znxHysPdy4AFujbisUrCW0L0cgh03jLt3YY/tis=";
+    hash = "sha256-18i2xiVDjIRG0RD5R7t2BsyB9N+hhYOOByV6snGBCkM=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-ol9uJq/HPdv5E2MB+KUturqwsa8s3xqULwXu9bAWjr0=";
+  vendorHash = "sha256-P8/0VSx4JfWgbMUuvo1Z0BhtC1TgGITSHLMHSzigeEg=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "1.1.6";
+  version = "1.1.9";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-7WNWbTs+r3L2O6ixK1yEElwdFfRPqx2yX+nPRy3nSEM=";
+    hash = "sha256-gYLLKejvyQTbDEua51RxxQy1aSUsp8EJrg/7b5xrEBs=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-mSnEga9JtS1ObMJpS0uo1RZs2ubpTwsErtmD8rMe5gg=";
+  vendorHash = "sha256-Iv9aRb4soepckHl0cQMb3TqHjiNn19QLFCprTunWiO8=";
 
   excludedPackages = [
     "internal/gen-jsonschema"

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "0.30.31";
+  version = "0.30.34";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-/XxG6UadYaeeusgH53NVFjuEriUxkf5A9h2wGdps0NQ=";
+    hash = "sha256-kKYjy3Z5Irel+P2B2Ri6hyPJZ+UuWg7vJypOSN0Rdqw=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -61,7 +61,7 @@ buildGoModule (finalAttrs: {
 
   checkFlags = [
     # requires networking (apk.chainreg.biz and dl-cdn.alpinelinux.org)
-    "-skip=TestInitDB_ChainguardDiscovery|TestFetchPackage"
+    "-skip=TestInitDB_ChainguardDiscovery|TestFetchPackage|TestLock/apko-discover"
   ];
 
   postInstall =

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "0.30.34";
+  version = "0.30.35";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-kKYjy3Z5Irel+P2B2Ri6hyPJZ+UuWg7vJypOSN0Rdqw=";
+    hash = "sha256-2jgIJ1vEaIdfWouQeK/WnHXymcNRwawW9nnsXkamQaQ=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-+rgkyTmuD3OMil5vO9xDcAvNl19JfvqPz3zotDiGPCU=";
+  vendorHash = "sha256-KBLthYP5dwtuzfa4f1KARmG5ecStzTwsnX2E95z3S2Q=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ap/apko/package.nix
+++ b/pkgs/by-name/ap/apko/package.nix
@@ -11,13 +11,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "apko";
-  version = "0.30.22";
+  version = "0.30.26";
 
   src = fetchFromGitHub {
     owner = "chainguard-dev";
     repo = "apko";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wHspbxGnTOFF6zKWlW0OjgxmYPdoG2LWUTq2lH7i5Fk=";
+    hash = "sha256-lJV5WyhbMC0L0kNzo/Yv1yWLAFZ69QojRUpamJnbf3U=";
     # populate values that require us to use git. By doing this in postFetch we
     # can delete .git afterwards and maintain better reproducibility of the src.
     leaveDotGit = true;
@@ -29,7 +29,7 @@ buildGoModule (finalAttrs: {
       find "$out" -name .git -print0 | xargs -0 rm -rf
     '';
   };
-  vendorHash = "sha256-6AP2cf5URe2vVKVYl9O00CbGPXD8Zg1OE8V8rF9+/MI=";
+  vendorHash = "sha256-BXWaXdlqaw2SACFGAebnmeQSWdq/htvWVqXVYcUlLP8=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Fixes CVE-2026-25140.
Fixes #487279.

No breaking changes announced in the release notes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
