### PR TITLE
GnuCOBOL package cleanup

### DIFF
--- a/pkgs/by-name/gn/gnucobol/package.nix
+++ b/pkgs/by-name/gn/gnucobol/package.nix
@@ -2,9 +2,11 @@
   lib,
   stdenv,
   fetchurl,
-  autoconf,
-  automake,
-  libtool,
+  # build files (VCS checkout only)
+  # autoconf,
+  # automake,
+  # libtool,
+  # configure helper
   pkg-config,
   # libs
   cjson,
@@ -12,10 +14,10 @@
   gmp,
   libxml2,
   ncurses,
-  # docs
-  help2man,
-  texinfo,
-  texliveBasic,
+  # docs (VCS checkout only)
+  # help2man,
+  # texinfo,
+  # texliveBasic,
   # test
   perl,
 }:
@@ -35,15 +37,20 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-O7SK9GztR3n6z0H9wu5g5My4bqqZ0BCzZoUxXfOcLuI=";
   };
 
+  # most are VCS checkout only
+  # nativeBuildInputs = [
+  #   pkg-config
+  #   autoconf
+  #   automake
+  #   help2man
+  #   libtool
+  #   perl
+  #   texinfo
+  #   texliveBasic
+  # ];
   nativeBuildInputs = [
     pkg-config
-    autoconf
-    automake
-    help2man
-    libtool
     perl
-    texinfo
-    texliveBasic
   ];
 
   buildInputs = [
@@ -81,9 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   preConfigure = ''
-    autoconf
-    aclocal
-    automake
+    # ./autogen.sh  only needed when building from VCS checkout
   ''
   + lib.optionalString stdenv.hostPlatform.isDarwin ''
     # when building with nix on darwin, configure will use GNU strip,
@@ -97,17 +102,10 @@ stdenv.mkDerivation (finalAttrs: {
   # See: https://gcc.gnu.org/gcc-15/porting_to.html
   env.CFLAGS =
     let
-      # Clang needs -Wno-error=implicit-function-declaration for xmlCleanupParser
-      clangFlags = "-Wno-error=implicit-function-declaration";
       # GCC 15+ needs additional flags for incompatible pointer type errors
-      gcc15Flags = "-Wno-error=incompatible-pointer-types -std=gnu11";
+      gcc15Flags = "-Wno-error=incompatible-pointer-types -std=gnu17";
     in
-    if stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "15.0.0" then
-      gcc15Flags
-    else if stdenv.cc.isClang then
-      clangFlags
-    else
-      "";
+    if stdenv.cc.isGNU && lib.versionAtLeast stdenv.cc.version "15.0.0" then gcc15Flags else "";
 
   enableParallelBuilding = true;
 
@@ -124,17 +122,17 @@ stdenv.mkDerivation (finalAttrs: {
   installCheckPhase = ''
     runHook preInstallCheck
 
-    # Run tests
+    # Run tests (parallel via autoconf testscript)
     TESTSUITEFLAGS="--jobs=$NIX_BUILD_CORES" make check
 
-    # Run NIST tests
+    # Run NIST tests (parallel via make)
     cp -v ${nistTestSuite} ./tests/cobol85/newcob.val.tar.gz
-    TESTSUITEFLAGS="--jobs=$NIX_BUILD_CORES" make test
+    make test --jobs=$NIX_BUILD_CORES
 
     # Sanity check
     message="Hello, COBOL!"
-    # XXX: Don't for a second think you can just get rid of these spaces, they
-    # are load bearing.
+    # Note: since GC 3.2 there is an auto-check for the source format,
+    # for older versions we need an explicit --free to get rid of the spaces.
     tee hello.cbl <<EOF
            IDENTIFICATION DIVISION.
            PROGRAM-ID. HELLO.
@@ -154,8 +152,8 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Free/libre COBOL compiler";
     homepage = "https://gnu.org/software/gnucobol/";
     license = with lib.licenses; [
-      gpl3Only
-      lgpl3Only
+      gpl3Plus
+      lgpl3Plus
     ];
     mainProgram = "cobc";
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
## Summary of changes

* fix license
* no rebuilt of distributed build env, less tools needed
* no ignored missing function declations for clang (we fix this via patch)
* gcc15 with gnu17 instead of gnu11
* parallel NIST tests

## Things done

only did the changes noted above for maintainers (or last changeing person @mrdavidlaing) to handle the nix part;
note:
* if there is no VCS build the related entries may be deleted
* the COBOL test source may be adjusted for no leading spaces - either with explicit -fformat=free or GC 3.2+ auto-recognition or with (older) alias --free
* the sanity check should be done after the install, the rest before
* in case of failing "make check" (currently for darwin) I found no error logs - using `| make check TESTSUITEFLAGS="--recheck --verbose"` would provide those in the build output itself

Note: I've adjusted the cflags setting per linter warnings, even if I like the old format better...