### PR TITLE
[25.11] tcpflow: 1.6.1 -> 1.6.1-unstable-2026-01-29

### DIFF
--- a/pkgs/by-name/tc/tcpflow/package.nix
+++ b/pkgs/by-name/tc/tcpflow/package.nix
@@ -14,13 +14,15 @@
 
 stdenv.mkDerivation rec {
   pname = "tcpflow";
-  version = "1.6.1";
+  version = "1.6.1-unstable-2026-01-29";
 
   src = fetchFromGitHub {
     owner = "simsong";
     repo = "tcpflow";
-    tag = "tcpflow-${version}";
-    sha256 = "0vbm097jhi5n8pg08ia1yhzc225zv9948blb76f4br739l9l22vq";
+    ## Upstream updated the version inside the repository but did not tag
+    # tag = "tcpflow-${finalAttrs.version}";
+    rev = "8d47b53a54da58e9c9b78efed8b379d98c6113e4";
+    hash = "sha256-fGKclipEU/5oAUwUWnyCVAuDjmzdExWC26qgobybz8s=";
     fetchSubmodules = true;
   };
 
@@ -40,10 +42,6 @@ stdenv.mkDerivation rec {
     substituteInPlace bootstrap.sh \
       --replace ".git" "" \
       --replace "/bin/rm" "rm"
-    # Temporary fix for a build error:
-    # https://src.fedoraproject.org/rpms/tcpflow/blob/979e250032b90de2d6b9e5b94b5203d98cccedad/f/tcpflow-1.6.1-format.patch
-    substituteInPlace src/datalink.cpp \
-      --replace 'DEBUG(6)(s.c_str());' 'DEBUG(6) ("%s", s.c_str());'
   '';
 
   preConfigure = "bash ./bootstrap.sh";


### PR DESCRIPTION
(upstream-marked as 1.6.2 in source but not tagged yet)

Includes a fix for CVE-2026-25061 a.k.a.
https://github.com/simsong/tcpflow/security/advisories/GHSA-q5q6-frrv-9rj6

Fixes: #488127
(cherry picked from commit c72820c805349850a7f50d39bc14e8f45b7be36e)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
