### PR TITLE
python313Packages.scikit-build-core: backport upstream patch for Darwin

### DIFF
--- a/pkgs/development/python-modules/scikit-build-core/default.nix
+++ b/pkgs/development/python-modules/scikit-build-core/default.nix
@@ -49,6 +49,8 @@ buildPythonPackage rec {
     })
   ];
 
+  postPatch = "";
+
   build-system = [
     hatch-vcs
     hatchling

--- a/pkgs/development/python-modules/scikit-build-core/default.nix
+++ b/pkgs/development/python-modules/scikit-build-core/default.nix
@@ -1,7 +1,9 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   hatch-vcs,
@@ -37,7 +39,15 @@ buildPythonPackage rec {
     hash = "sha256-zBTDacTkeclz+/X0SUl1xkxLz4zsfeLOD4Ew0V1Y1iU=";
   };
 
-  postPatch = "";
+  # TODO: Rebuild avoidance; clean up on `staging`.
+  ${if stdenv.hostPlatform.isDarwin then "patches" else null} = [
+    # Backport an upstream commit to fix the tests on Darwin.
+    (fetchpatch {
+      url = "https://github.com/scikit-build/scikit-build-core/commit/c30f52a3b2bd01dc05f23d3b89332c213006afe0.patch";
+      excludes = [ ".github/workflows/ci.yml" ];
+      hash = "sha256-5E9QfF5UcSNY1wzHzieEEHEPYzPjUTb66CKCodYb9vo=";
+    })
+  ];
 
   build-system = [
     hatch-vcs


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
