### PR TITLE
haskellPackages.hip: increase simplifier ticks

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2519,6 +2519,14 @@ with haskellLib;
     ];
   }) super.hexstring;
 
+  # 2026-02-19: GHC 9.10 increased simplifier ticks, need higher threshold
+  # https://github.com/lehins/hip/issues/56
+  hip = overrideCabal (drv: {
+    configureFlags = (drv.configureFlags or [ ]) ++ [
+      "--ghc-options=-fsimpl-tick-factor=200"
+    ];
+  }) super.hip;
+
   # Disabling doctests.
   regex-tdfa = overrideCabal {
     testTargets = [ "regex-tdfa-unittest" ];

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -2805,7 +2805,6 @@ broken-packages:
   - hint-server # failure in job https://hydra.nixos.org/build/233240346 at 2023-09-02
   - hinter # failure in job https://hydra.nixos.org/build/233245954 at 2023-09-02
   - hinterface # failure in job https://hydra.nixos.org/build/233250383 at 2023-09-02
-  - hip # failure in job https://hydra.nixos.org/build/307610903 at 2025-09-19
   - hipchat-hs # failure in job https://hydra.nixos.org/build/233198550 at 2023-09-02
   - Hipmunk # failure in job https://hydra.nixos.org/build/233259272 at 2023-09-02
   - hips # failure in job https://hydra.nixos.org/build/252728413 at 2024-03-16

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -2576,7 +2576,6 @@ dont-distribute-packages:
  - penny-bin
  - penny-lib
  - peparser
- - perceptual-hash
  - perdure
  - perf-analysis
  - perfecthash


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

GHC 9.10 made it so that the build fails with the default GHC setting of `-fsmipl-tick-factor=100`. Increasing it to `200` fixes this. Compilation time is not significantly longer than before, suggesting this change is mostly innocent. 

Relevant [issue](https://github.com/lehins/hip/issues/56) and [PR](https://github.com/lehins/hip/pull/57)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable: (no semantic changes to library, not applicable)
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran (running) `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
