### PR TITLE
top-level: add warning for `x86_64-darwin` deprecation

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -869,6 +869,9 @@
   "tar-files": [
     "index.html#tar-files"
   ],
+  "x86_64-darwin-26.05": [
+    "release-notes.html#x86_64-darwin-26.05"
+  ],
   "zip-files": [
     "index.html#zip-files"
   ],

--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -12,6 +12,27 @@
 - Ruby default version has been updated from 3.3 to 3.4.
   Refer to the [upstream release announcement](https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/) for details.
 
+- []{#x86_64-darwin-26.05}
+
+  **This will be the last release of Nixpkgs to support `x86_64-darwin`.**
+  Platform support will be maintained and binaries built until Nixpkgs 26.05 goes out of support at the end of 2026.
+  For 26.11, due to Apple’s deprecation of the platform and limited build infrastructure and developer time, we will no longer build packages for `x86_64-darwin` or support building them from source.
+
+  By the time of 26.11’s release, Homebrew will offer only limited [Tier 3](https://docs.brew.sh/Support-Tiers#tier-3) support for the platform, but MacPorts will likely continue to support it for a long time.
+  We also recommend users consider installing NixOS, which should continue to run on essentially all Intel Macs, especially after Apple stops security support for macOS 26 in 2028.
+
+  A warning will be displayed for `x86_64-darwin` users; you can set [](#opt-allowDeprecatedx86_64Darwin) in the [Nixpkgs configuration](https://nixos.org/manual/nixpkgs/stable/#chap-packageconfig) to silence it.
+  The {file}`~/.config/nixpkgs/config.nix` file will not work for users of flakes, who can instead replace `nixpkgs.legacyPackages.x86_64-darwin` with
+
+  ```nix
+  import nixpkgs {
+    system = "x86_64-darwin";
+    config.allowDeprecatedx86_64Darwin = true;
+  }
+  ```
+
+  nix-darwin users can set [`nixpkgs.config.allowDeprecatedx86_64Darwin`](https://nix-darwin.github.io/nix-darwin/manual/index.html#opt-nixpkgs.config) in their system configurations.
+
 - The Factor programming language has been updated to Version 0.101 bringing various improvements to UI rendering and HiDPI support as well as support for Unicode 17.0.0.
   Starting from Version 0.100, the Factor VM is compiled with Clang.
 

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -451,8 +451,8 @@ let
         Silence the warning for the upcoming deprecation of the
         `x86_64-darwin` platform in Nixpkgs 26.11.
 
-        This does nothing in 25.11, and is provided there for forward
-        compatibility of configurations with 26.05.
+        See the [release notes](#x86_64-darwin-26.05) for more
+        information.
       '';
     };
 

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -18,6 +18,25 @@
   or dot-files.
 */
 
+let
+  # We hoist this above the closure so that the same thunk is shared
+  # between multiple imports of Nixpkgs. This ensures that commands
+  # like `nix eval nixpkgs#legacyPackages.x86_64-darwin.pkgsStatic.hello`
+  # print only one warning, which would otherwise be spammy in common
+  # scenarios that instantiate many copies of Nixpkgs.
+  #
+  # Unfortunately, flakes’ handling of transitive dependencies mean
+  # that it’s still likely users will see multiple warnings, but
+  # there’s nothing we can do about that within the constraints of the
+  # Nix language.
+  x86_64DarwinDeprecationWarning =
+    pristineLib.warn
+      "Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05"
+      (x: x);
+
+  pristineLib = import ../../lib;
+in
+
 {
   # The system packages will be built on. See the manual for the
   # subtle division of labor between these two `*System`s and the three
@@ -55,8 +74,6 @@ let # Rename the function arguments
 
 in
 let
-  pristineLib = import ../../lib;
-
   lib =
     if __allowFileset then
       pristineLib
@@ -82,8 +99,17 @@ let
     (throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list.")
       (throwIfNot (lib.all lib.isFunction overlays) "All overlays passed to nixpkgs must be functions.")
       (throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list.")
+      (throwIfNot (lib.all lib.isFunction crossOverlays) "All crossOverlays passed to nixpkgs must be functions.")
       (
-        throwIfNot (lib.all lib.isFunction crossOverlays) "All crossOverlays passed to nixpkgs must be functions."
+        if
+          (
+            ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
+            && config.allowDeprecatedx86_64Darwin == false
+          )
+        then
+          x86_64DarwinDeprecationWarning
+        else
+          x: x
       );
 
   localSystem = lib.systems.elaborate args.localSystem;

--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -56,7 +56,7 @@ pkgs.runCommand "nixpkgs-release-checks"
           set -x
           nix-env -f $src \
               --show-trace --argstr system "$platform" \
-              --arg config '{ allowAliases = false; }' \
+              --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
               --option experimental-features 'no-url-literals' \
               -qa --drv-path --system-filter \* --system \
               "''${opts[@]}" 2> eval-warnings.log > packages1
@@ -72,7 +72,7 @@ pkgs.runCommand "nixpkgs-release-checks"
 
         nix-env -f $src2 \
             --show-trace --argstr system "$platform" \
-            --arg config '{ allowAliases = false; }' \
+            --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
             --option experimental-features 'no-url-literals' \
             -qa --drv-path --system-filter \* --system \
             "''${opts[@]}" > packages2
@@ -95,7 +95,7 @@ pkgs.runCommand "nixpkgs-release-checks"
 
         nix-env -f $src \
             --show-trace --argstr system "$platform" \
-            --arg config '{ allowAliases = false; }' \
+            --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
             --option experimental-features 'no-url-literals' \
             -qa --drv-path --system-filter \* --system --meta --xml \
             "''${opts[@]}" > /dev/null


### PR DESCRIPTION
We’ve never deprecated a platform in widespread use before, and it seems prudent to warn users about the upcoming end of support so they can plan appropriately.

I tried to make this relatively unobtrusive by taking advantage of the import cache and offering a way to turn it off, but I anticipate there might still be issues with e.g. `nix shell nixpkgs#…` and spammy warnings from multiple instantiations of Nixpkgs. I’m not sure there’s much we can do about that unless we take a different strategy entirely; `nix shell --impure nixpkgs#…` with a `~/.config/nixpkgs/config.nix` is about the best UX we can hope to offer with the restrictions of flakes.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
