### PR TITLE
microsoft-edge: 145.0.3800.58 -> 144.0.3719.115

### DIFF
--- a/pkgs/by-name/mi/microsoft-edge/package.nix
+++ b/pkgs/by-name/mi/microsoft-edge/package.nix
@@ -162,7 +162,7 @@ let
 in
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "microsoft-edge";
-  version = "145.0.3800.58";
+  version = "144.0.3719.115";
 
   src = fetchurl {
     url = "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_${finalAttrs.version}-1_amd64.deb";


### PR DESCRIPTION
Revert https://github.com/NixOS/nixpkgs/pull/490349 as upstream link is missing.

Fix https://github.com/NixOS/nixpkgs/issues/492012.

```console
$ curl --head --location https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_144.0.3719.115-1_amd64.deb
HTTP/2 200
date: Thu, 19 Feb 2026 14:04:55 GMT
content-type: application/octet-stream
content-length: 181007738
last-modified: Thu, 05 Feb 2026 19:06:31 GMT
etag: "0x8DE64E9AC3CC986"
x-ms-request-id: b65fd00e-101e-0045-3da8-a17dfc000000
x-ms-version: 2026-02-06
x-ms-version-id: 2026-02-05T19:06:31.3011590Z
x-ms-is-current-version: true
x-ms-creation-time: Thu, 05 Feb 2026 19:06:31 GMT
x-ms-lease-status: unlocked
x-ms-lease-state: available
x-ms-blob-type: BlockBlob
content-disposition: attachment;filename=microsoft-edge-stable_144.0.3719.115-1_amd64.deb
x-ms-server-encrypted: true
x-ms-access-tier: Hot
x-ms-access-tier-inferred: true
x-ms-last-access-time: Wed, 18 Feb 2026 21:21:50 GMT
strict-transport-security: max-age=31536000; includeSubDomains
x-content-type-options: nosniff
x-azure-ref: 20260219T140455Z-16967fb6997n9dsphC1SVGgkhw00000019zg000000003re7
x-cache: TCP_MISS
cache-control: public, max-age=31536000
x-fd-int-roxy-purgeid: 0
accept-ranges: bytes
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
