### PR TITLE
[25.11] godot_4_6: 4.6-stable -> 4.6.1-stable

### DIFF
--- a/pkgs/development/tools/godot/4.6/default.nix
+++ b/pkgs/development/tools/godot/4.6/default.nix
@@ -1,11 +1,11 @@
 {
-  version = "4.6-stable";
-  hash = "sha256-lK9KQsmrNZLx7yP3PwbN93otwkWq2H+nWt85WH/u8oI=";
+  version = "4.6.1-stable";
+  hash = "sha256-C3AX+Gl6a3nX/k0TP6FYjYCK9AbKmtku+1ilYBu0R74=";
   default = {
-    exportTemplatesHash = "sha256-OzCsjBdy8l9d+l9lkiyrCpDnuWAXaJEjfFdyUV68zEY=";
+    exportTemplatesHash = "sha256-5tNyr9T9+q6VceteNWivzZbObbmlaSRANBVPrwrGmHU=";
   };
   mono = {
-    exportTemplatesHash = "sha256-RgVug5TNHx+FzPqr3f/Bpn9ZW/2Z+9ps1ir6dR2/xRk=";
+    exportTemplatesHash = "sha256-V5JmHtCJVQNX4OEJVK9pWEa+CjLtdJT6QKAAnjtaPqk=";
     nugetDeps = ./deps.json;
   };
 }

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -414,19 +414,36 @@ let
 
         strictDeps = true;
 
-        patches = [
-          ./Linux-fix-missing-library-with-builtin_glslang-false.patch
-        ]
-        ++ lib.optionals (lib.versionOlder version "4.4") [
-          (fetchpatch {
-            name = "wayland-header-fix.patch";
-            url = "https://github.com/godotengine/godot/commit/6ce71f0fb0a091cffb6adb4af8ab3f716ad8930b.patch";
-            hash = "sha256-hgAtAtCghF5InyGLdE9M+9PjPS1BWXWGKgIAyeuqkoU=";
-          })
-          # Fix a crash in the mono test project build. It no longer seems to
-          # happen in 4.4, but an existing fix couldn't be identified.
-          ./CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
-        ];
+        patches =
+          lib.optionals (lib.versionOlder version "4.6") [
+            ./Linux-fix-missing-library-with-builtin_glslang-false.patch
+          ]
+          ++ lib.optionals (lib.versionAtLeast version "4.6") [
+            # https://github.com/godotengine/godot/pull/115450
+            (fetchpatch {
+              name = "fix-tls-handshake-fail-preventing-assetlib-use.patch";
+              url = "https://github.com/godotengine/godot/commit/29acd734c71f06268d6ef4715d7df70b14731f48.patch";
+              hash = "sha256-wxkr6jPtutUTG+mYrXoxcDcWIIZghlSJ79XqhFh/0P4=";
+            })
+          ]
+          ++ lib.optionals (lib.versionOlder version "4.4") [
+            (fetchpatch {
+              name = "wayland-header-fix.patch";
+              url = "https://github.com/godotengine/godot/commit/6ce71f0fb0a091cffb6adb4af8ab3f716ad8930b.patch";
+              hash = "sha256-hgAtAtCghF5InyGLdE9M+9PjPS1BWXWGKgIAyeuqkoU=";
+            })
+            (fetchpatch {
+              name = "thorvg-header-fix.patch";
+              url = "https://github.com/godotengine/godot/commit/1823460787a6c1bb8e4eaf21ac2a3f90d24d5ee0.patch";
+              hash = "sha256-PcHEMXd0v2c3j6Eitxt5uWi6cD+OmsBAn3TNMNRNPog=";
+            })
+            # Fix a crash in the mono test project build. It no longer seems to
+            # happen in 4.4, but an existing fix couldn't be identified.
+            ./CSharpLanguage-fix-crash-in-reload_assemblies-after-.patch
+          ]
+          ++ lib.optional (
+            stdenv.hostPlatform.isDarwin && lib.versionAtLeast version "4.4"
+          ) ./fix-moltenvk-detection.patch;
 
         postPatch = ''
           # this stops scons from hiding e.g. NIX_CFLAGS_COMPILE


### PR DESCRIPTION
godot_4_6: 4.6-stable -> 4.6.1-stable

(manual cherry-pick from #491826)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
