### PR TITLE
ocamlPackages.yocaml*: init at 3.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/yocaml/cmarkit.nix
+++ b/pkgs/development/ocaml-modules/yocaml/cmarkit.nix
@@ -1,0 +1,35 @@
+{
+  buildDunePackage,
+  mdx,
+  yocaml,
+  cmarkit,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_cmarkit";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    cmarkit
+    yocaml
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "Yocaml plugin for using Markdown (via Cmarkit package) as a Markup language";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/default.nix
+++ b/pkgs/development/ocaml-modules/yocaml/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchurl,
+  buildDunePackage,
+  logs,
+  fmt,
+  alcotest,
+  qcheck,
+  qcheck-alcotest,
+  ppx_expect,
+  mdx,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml";
+  version = "3.0.0";
+
+  minimalOCamlVersion = "5.1.1";
+
+  src = fetchurl {
+    url = "https://github.com/xhtmlboi/yocaml/releases/download/v${finalAttrs.version}/yocaml-${finalAttrs.version}.tbz";
+    hash = "sha256-xSN8XzRfdsgp/Z9OxfzQUFHm9DcrJOz3mKSMJknOmg4=";
+  };
+
+  propagatedBuildInputs = [
+    logs
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    alcotest
+    fmt
+    (mdx.override { inherit logs; })
+    ppx_expect
+    qcheck-alcotest
+    qcheck
+  ];
+
+  meta = {
+    homepage = "https://github.com/xhtmlboi/yocaml";
+    description = "Framework for creating static site generators";
+    changelog = "https://github.com/xhtmlboi/yocaml/blob/main/CHANGES.md";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ rpqt ];
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/eio.nix
+++ b/pkgs/development/ocaml-modules/yocaml/eio.nix
@@ -1,0 +1,43 @@
+{
+  buildDunePackage,
+  mdx,
+  yocaml,
+  yocaml_runtime,
+  eio,
+  eio_main,
+  cohttp-eio,
+  logs,
+  magic-mime,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_eio";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    yocaml
+    yocaml_runtime
+    eio
+    eio_main
+    cohttp-eio
+    magic-mime
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "The Eio runtime for YOCaml";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/jingoo.nix
+++ b/pkgs/development/ocaml-modules/yocaml/jingoo.nix
@@ -1,0 +1,35 @@
+{
+  buildDunePackage,
+  mdx,
+  yocaml,
+  jingoo,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_jingoo";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    yocaml
+    jingoo
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "Yocaml plugin for using Jingoo as a template language";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/mustache.nix
+++ b/pkgs/development/ocaml-modules/yocaml/mustache.nix
@@ -1,0 +1,35 @@
+{
+  buildDunePackage,
+  mdx,
+  yocaml,
+  mustache,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_mustache";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    yocaml
+    mustache
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "Yocaml plugin for using Mustache as a template language";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/otoml.nix
+++ b/pkgs/development/ocaml-modules/yocaml/otoml.nix
@@ -1,0 +1,35 @@
+{
+  buildDunePackage,
+  mdx,
+  yocaml,
+  otoml,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_otoml";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    yocaml
+    otoml
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "Plugin for describing metadata with TOML, based on the OTOML package";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/runtime.nix
+++ b/pkgs/development/ocaml-modules/yocaml/runtime.nix
@@ -1,0 +1,37 @@
+{
+  buildDunePackage,
+  yocaml,
+  mdx,
+  fmt,
+  digestif,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_runtime";
+  inherit (yocaml)
+    src
+    version
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    digestif
+    fmt
+    logs
+    yocaml
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "Tool for describing runtimes (using Logs and Digestif)";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/syndication.nix
+++ b/pkgs/development/ocaml-modules/yocaml/syndication.nix
@@ -1,0 +1,43 @@
+{
+  buildDunePackage,
+  mdx,
+  yocaml,
+  fmt,
+  alcotest,
+  ppx_expect,
+  qcheck,
+  qcheck-alcotest,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_syndication";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    yocaml
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+    fmt
+    alcotest
+    ppx_expect
+    qcheck
+    qcheck-alcotest
+  ];
+
+  meta = yocaml.meta // {
+    description = "Yocaml plugin for dealing with RSS and Atom feed";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/unix.nix
+++ b/pkgs/development/ocaml-modules/yocaml/unix.nix
@@ -1,0 +1,37 @@
+{
+  buildDunePackage,
+  mdx,
+  httpcats,
+  yocaml,
+  yocaml_runtime,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_unix";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    httpcats
+    yocaml
+    yocaml_runtime
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "The Unix runtime for YOCaml";
+  };
+})

--- a/pkgs/development/ocaml-modules/yocaml/yaml.nix
+++ b/pkgs/development/ocaml-modules/yocaml/yaml.nix
@@ -1,0 +1,35 @@
+{
+  buildDunePackage,
+  mdx,
+  yocaml,
+  yaml,
+  logs,
+}:
+
+buildDunePackage (finalAttrs: {
+  pname = "yocaml_yaml";
+
+  inherit (yocaml)
+    version
+    src
+    ;
+
+  minimalOCamlVersion = "5.1.1";
+
+  propagatedBuildInputs = [
+    yocaml
+    yaml
+  ];
+
+  doCheck = true;
+  nativeCheckInputs = [
+    mdx.bin
+  ];
+  checkInputs = [
+    (mdx.override { inherit logs; })
+  ];
+
+  meta = yocaml.meta // {
+    description = "Yocaml plugin for dealing with Yaml as metadata provider";
+  };
+})

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2255,6 +2255,8 @@ let
 
         yocaml_cmarkit = callPackage ../development/ocaml-modules/yocaml/cmarkit.nix { };
 
+        yocaml_eio = callPackage ../development/ocaml-modules/yocaml/eio.nix { };
+
         yocaml_jingoo = callPackage ../development/ocaml-modules/yocaml/jingoo.nix { };
 
         yocaml_mustache = callPackage ../development/ocaml-modules/yocaml/mustache.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2259,6 +2259,8 @@ let
 
         yocaml_unix = callPackage ../development/ocaml-modules/yocaml/unix.nix { };
 
+        yocaml_yaml = callPackage ../development/ocaml-modules/yocaml/yaml.nix { };
+
         yojson = callPackage ../development/ocaml-modules/yojson { };
 
         yojson_2 = yojson.overrideAttrs (_: {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2251,6 +2251,8 @@ let
 
         yaml-sexp = callPackage ../development/ocaml-modules/yaml/yaml-sexp.nix { };
 
+        yocaml = callPackage ../development/ocaml-modules/yocaml { };
+
         yojson = callPackage ../development/ocaml-modules/yojson { };
 
         yojson_2 = yojson.overrideAttrs (_: {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2253,6 +2253,8 @@ let
 
         yocaml = callPackage ../development/ocaml-modules/yocaml { };
 
+        yocaml_otoml = callPackage ../development/ocaml-modules/yocaml/otoml.nix { };
+
         yocaml_runtime = callPackage ../development/ocaml-modules/yocaml/runtime.nix { };
 
         yocaml_unix = callPackage ../development/ocaml-modules/yocaml/unix.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2257,6 +2257,8 @@ let
 
         yocaml_jingoo = callPackage ../development/ocaml-modules/yocaml/jingoo.nix { };
 
+        yocaml_mustache = callPackage ../development/ocaml-modules/yocaml/mustache.nix { };
+
         yocaml_otoml = callPackage ../development/ocaml-modules/yocaml/otoml.nix { };
 
         yocaml_runtime = callPackage ../development/ocaml-modules/yocaml/runtime.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2257,6 +2257,8 @@ let
 
         yocaml_runtime = callPackage ../development/ocaml-modules/yocaml/runtime.nix { };
 
+        yocaml_syndication = callPackage ../development/ocaml-modules/yocaml/syndication.nix { };
+
         yocaml_unix = callPackage ../development/ocaml-modules/yocaml/unix.nix { };
 
         yocaml_yaml = callPackage ../development/ocaml-modules/yocaml/yaml.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2253,6 +2253,8 @@ let
 
         yocaml = callPackage ../development/ocaml-modules/yocaml { };
 
+        yocaml_cmarkit = callPackage ../development/ocaml-modules/yocaml/cmarkit.nix { };
+
         yocaml_otoml = callPackage ../development/ocaml-modules/yocaml/otoml.nix { };
 
         yocaml_runtime = callPackage ../development/ocaml-modules/yocaml/runtime.nix { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2253,6 +2253,8 @@ let
 
         yocaml = callPackage ../development/ocaml-modules/yocaml { };
 
+        yocaml_runtime = callPackage ../development/ocaml-modules/yocaml/runtime.nix { };
+
         yojson = callPackage ../development/ocaml-modules/yojson { };
 
         yojson_2 = yojson.overrideAttrs (_: {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2255,6 +2255,8 @@ let
 
         yocaml_runtime = callPackage ../development/ocaml-modules/yocaml/runtime.nix { };
 
+        yocaml_unix = callPackage ../development/ocaml-modules/yocaml/unix.nix { };
+
         yojson = callPackage ../development/ocaml-modules/yojson { };
 
         yojson_2 = yojson.overrideAttrs (_: {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2255,6 +2255,8 @@ let
 
         yocaml_cmarkit = callPackage ../development/ocaml-modules/yocaml/cmarkit.nix { };
 
+        yocaml_jingoo = callPackage ../development/ocaml-modules/yocaml/jingoo.nix { };
+
         yocaml_otoml = callPackage ../development/ocaml-modules/yocaml/otoml.nix { };
 
         yocaml_runtime = callPackage ../development/ocaml-modules/yocaml/runtime.nix { };


### PR DESCRIPTION
[YOCaml](https://github.com/xhtmlboi/yocaml) is a framework used to describe build systems in OCaml, with an API suited for creating static site generators. This adds the core library and multiple common plugins from the main repository.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
