### PR TITLE
upki: init at 0.1.0

### DIFF
--- a/pkgs/by-name/up/upki/package.nix
+++ b/pkgs/by-name/up/upki/package.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  stdenv,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "upki";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "rustls";
+    repo = "upki";
+    tag = "upki-${finalAttrs.version}";
+    hash = "sha256-F+35W3lCoZ4Oq5tq2zbtBeU7lXVx9/tA3OY2UvkqsWU=";
+  };
+
+  cargoHash = "sha256-RXWeZT9c1lSVrz4J0XdxOmLmYtzwJgIQlXrvwGvkB78=";
+
+  buildAndTestSubdir = "upki";
+
+  # upki uses inta_cmd to run some integration tests
+  # It needs some help to find the binary to run
+  preCheck = ''
+    export CARGO_BIN_EXE_upki="$(pwd)"/target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/upki
+  '';
+
+  checkFlags = [
+    # Skip integration tests having some expectations on the current state of the system
+    "--skip=fetch_of_empty_manifest"
+    "--skip=full_fetch_and_incremental_update"
+    "--skip=full_fetch_and_incremental_update"
+    "--skip=full_fetch"
+    "--skip=typical_incremental_fetch_dry_run"
+    "--skip=typical_incremental_fetch"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Platform-independent browser-grade certificate infrastructure";
+    homepage = "https://github.com/rustls/upki/tree/main/upki";
+    changelog = "https://github.com/rustls/upki/releases/tag/upki-${finalAttrs.version}";
+    license = with lib.licenses; [
+      mit
+      asl20
+    ];
+    maintainers = [ lib.maintainers.lesuisse ];
+    mainProgram = "upki";
+  };
+})


### PR DESCRIPTION
https://github.com/rustls/upki/tree/main/upki

Not creating a NixOS module to set the config and
setup a timer to fetch the crlite filters at this time. [Ubuntu is leading the pack here](https://discourse.ubuntu.com/t/an-update-on-upki/77063) so I would like to let them define appropriate default values first.

```
$ curl -sw '%{certs}' https://revoked.badssl.com/ | ./result/bin/upki revocation check
CertainlyRevoked
$ curl -sw '%{certs}' https://nixos.org | ./result/bin/upki revocation check
NotRevoked
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
