### PR TITLE
neovim: disable python3 and ruby providers by default

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -201,6 +201,7 @@
 
 - `mold` is now wrapped by default.
 
+- `neovim` now disables by default the `python3` and `ruby` providers, unused by most users and reducing closure size from 365MiB to 240MiB.
 
 ### Deprecations {#sec-nixpkgs-release-26.05-lib-deprecations}
 

--- a/pkgs/applications/editors/neovim/utils.nix
+++ b/pkgs/applications/editors/neovim/utils.nix
@@ -177,7 +177,7 @@ let
       # the function you would have passed to python.withPackages
       extraPythonPackages ? (_: [ ]),
       # the function you would have passed to python.withPackages
-      withPython3 ? true,
+      withPython3 ? false,
       extraPython3Packages ? (_: [ ]),
       # the function you would have passed to lua.withPackages
       extraLuaPackages ? (_: [ ]),
@@ -243,9 +243,9 @@ let
   */
   generateProviderRc =
     {
-      withPython3 ? true,
+      withPython3 ? false,
       withNodeJs ? false,
-      withRuby ? true,
+      withRuby ? false,
       # Perl is problematic https://github.com/NixOS/nixpkgs/issues/132368
       withPerl ? false,
 

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -37,14 +37,14 @@ let
       # should contain all args but the binary. Can be either a string or list
       wrapperArgs ? [ ],
       withPython2 ? false,
-      withPython3 ? true,
+      withPython3 ? false,
       # the function you would have passed to python3.withPackages
       extraPython3Packages ? (_: [ ]),
 
       waylandSupport ? lib.meta.availableOn stdenv.hostPlatform wayland,
       withNodeJs ? false,
       withPerl ? false,
-      withRuby ? true,
+      withRuby ? false,
 
       # wether to create symlinks in $out/bin/vi(m) -> $out/bin/nvim
       vimAlias ? false,


### PR DESCRIPTION
Providers are the thing I spend most of my time on while admittedly very few users use it (I can only think of deoplete now) and it's going to disappear anyway. We have no tests for it because of the previous reasons.

Before this patch:
nix path-info -Sh .#neovim
/nix/store/smd007xlbsx35y42rri5xlqhjgajz9in-neovim-0.11.6	365.0 MiB

After:
nix path-info -Sh .#neovim
/nix/store/4cr60j05l3pirhhrcs5hqb9rzj854n5r-neovim-0.11.6	240.6 MiB

It's not a fix for https://github.com/NixOS/nixpkgs/pull/487390 but can mitigate it and I had plans to do it anyway.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
