### PR TITLE
{coq,rocq}Packages.mk{Coq,Rocq}Derivation: move env variables into env for structuredAttrs

### DIFF
--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -99,6 +99,7 @@ let
       "dropDerivationAttrs"
       "keepAttrs"
       "enableParallelBuilding"
+      "env"
     ]
     ++ dropAttrs
   ) keepAttrs;
@@ -179,6 +180,7 @@ let
         }
       ]
       [ "COQDOCINSTALL=$(out)/share/coq/${coq.coq-version}/user-contrib" ];
+  COQUSERCONTRIB = "$out/lib/coq/${coq.coq-version}/user-contrib";
 in
 
 stdenv.mkDerivation (
@@ -207,6 +209,15 @@ stdenv.mkDerivation (
           "mkCoqDerivation: enableParallelBuilding is enabled by default; remove the explicit setting"
           enableParallelBuilding;
 
+      env =
+        optionalAttrs setCOQBIN {
+          COQBIN = "${coq}/bin/";
+        }
+        // optionalAttrs (args ? useMelquiondRemake) {
+          inherit COQUSERCONTRIB;
+        }
+        // (args.env or { });
+
       meta =
         (
           {
@@ -228,7 +239,6 @@ stdenv.mkDerivation (
         // (args.meta or { });
 
     }
-    // (optionalAttrs setCOQBIN { COQBIN = "${coq}/bin/"; })
     // (optionalAttrs (!args ? installPhase && !args ? useMelquiondRemake) {
       installFlags = coqlib-flags ++ docdir-flags ++ extraInstallFlags;
     })
@@ -246,8 +256,7 @@ stdenv.mkDerivation (
         runHook postInstall
       '';
     })
-    // (optionalAttrs (args ? useMelquiondRemake) rec {
-      COQUSERCONTRIB = "$out/lib/coq/${coq.coq-version}/user-contrib";
+    // (optionalAttrs (args ? useMelquiondRemake) {
       preConfigurePhases = [ "autoconf" ];
       configureFlags = [ "--libdir=${COQUSERCONTRIB}/${useMelquiondRemake.logpath or ""}" ];
       buildPhase = "./remake -j$NIX_BUILD_CORES";

--- a/pkgs/build-support/coq/default.nix
+++ b/pkgs/build-support/coq/default.nix
@@ -98,6 +98,7 @@ let
       "dropAttrs"
       "dropDerivationAttrs"
       "keepAttrs"
+      "env"
     ]
     ++ dropAttrs
   ) keepAttrs;
@@ -162,8 +163,8 @@ let
     "COQPLUGININSTALL=$(OCAMLFIND_DESTDIR)"
   ];
   docdir-flags = [ "COQDOCINSTALL=$(out)/share/coq/${coq.coq-version}/user-contrib" ];
+  COQUSERCONTRIB = "$out/lib/coq/${coq.coq-version}/user-contrib";
 in
-
 stdenv.mkDerivation (
   removeAttrs (
     {
@@ -187,6 +188,15 @@ stdenv.mkDerivation (
         args.overrideBuildInputs or ([ coq ] ++ (args.buildInputs or [ ]) ++ extraBuildInputs);
       inherit enableParallelBuilding;
 
+      env =
+        optionalAttrs setCOQBIN {
+          COQBIN = "${coq}/bin/";
+        }
+        // optionalAttrs (args ? useMelquiondRemake) {
+          inherit COQUSERCONTRIB;
+        }
+        // (args.env or { });
+
       meta =
         (
           {
@@ -208,7 +218,6 @@ stdenv.mkDerivation (
         // (args.meta or { });
 
     }
-    // (optionalAttrs setCOQBIN { COQBIN = "${coq}/bin/"; })
     // (optionalAttrs (!args ? installPhase && !args ? useMelquiondRemake) {
       installFlags = coqlib-flags ++ docdir-flags ++ extraInstallFlags;
     })
@@ -226,8 +235,7 @@ stdenv.mkDerivation (
         runHook postInstall
       '';
     })
-    // (optionalAttrs (args ? useMelquiondRemake) rec {
-      COQUSERCONTRIB = "$out/lib/coq/${coq.coq-version}/user-contrib";
+    // (optionalAttrs (args ? useMelquiondRemake) {
       preConfigurePhases = [ "autoconf" ];
       configureFlags = [ "--libdir=${COQUSERCONTRIB}/${useMelquiondRemake.logpath or ""}" ];
       buildPhase = "./remake -j$NIX_BUILD_CORES";

--- a/pkgs/build-support/rocq/default.nix
+++ b/pkgs/build-support/rocq/default.nix
@@ -98,6 +98,7 @@ let
       "dropAttrs"
       "dropDerivationAttrs"
       "keepAttrs"
+      "env"
     ]
     ++ dropAttrs
   ) keepAttrs;
@@ -162,6 +163,7 @@ let
     "COQPLUGININSTALL=$(OCAMLFIND_DESTDIR)"
   ];
   docdir-flags = [ "COQDOCINSTALL=$(out)/share/coq/${rocq-core.rocq-version}/user-contrib" ];
+  COQUSERCONTRIB = "$out/lib/coq/${rocq-core.rocq-version}/user-contrib";
 in
 
 stdenv.mkDerivation (
@@ -187,6 +189,15 @@ stdenv.mkDerivation (
         args.overrideBuildInputs or ([ rocq-core ] ++ (args.buildInputs or [ ]) ++ extraBuildInputs);
       inherit enableParallelBuilding;
 
+      env =
+        optionalAttrs setROCQBIN {
+          ROCQBIN = "${rocq-core}/bin/";
+        }
+        // optionalAttrs (args ? useMelquiondRemake) {
+          inherit COQUSERCONTRIB;
+        }
+        // (args.env or { });
+
       meta =
         (
           {
@@ -208,7 +219,6 @@ stdenv.mkDerivation (
         // (args.meta or { });
 
     }
-    // (optionalAttrs setROCQBIN { ROCQBIN = "${rocq-core}/bin/"; })
     // (optionalAttrs (!args ? installPhase && !args ? useMelquiondRemake) {
       installFlags = rocqlib-flags ++ docdir-flags ++ extraInstallFlags;
     })
@@ -226,8 +236,7 @@ stdenv.mkDerivation (
         runHook postInstall
       '';
     })
-    // (optionalAttrs (args ? useMelquiondRemake) rec {
-      COQUSERCONTRIB = "$out/lib/coq/${rocq-core.rocq-version}/user-contrib";
+    // (optionalAttrs (args ? useMelquiondRemake) {
       preConfigurePhases = [ "autoconf" ];
       configureFlags = [ "--libdir=${COQUSERCONTRIB}/${useMelquiondRemake.logpath or ""}" ];
       buildPhase = "./remake -j$NIX_BUILD_CORES";


### PR DESCRIPTION
This probably needs some careful review because of the conditional variables.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
