### PR TITLE
harper: 1.7.0 -> 1.8.0

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/elijah-potter.harper/default.nix
@@ -13,7 +13,7 @@ vscode-utils.buildVscodeMarketplaceExtension {
     name = "harper";
     publisher = "elijah-potter";
     version = harper.version;
-    hash = "sha256-7WneJ4RNJ02SaceEp3su8be/jkZMIy1dSEH1Ay31wLM=";
+    hash = "sha256-3pIxfUZzUQ73AKlmcThjcuPA4kG8HBBRU0HOjn1x62g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ha/harper/package.nix
+++ b/pkgs/by-name/ha/harper/package.nix
@@ -8,18 +8,18 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "harper";
-  version = "1.7.0";
+  version = "1.8.0";
 
   src = fetchFromGitHub {
     owner = "Automattic";
     repo = "harper";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-qXWoG5IjBvPK1GZqdWOlWne0CF99/VDWpe1ZW//mFxI=";
+    hash = "sha256-6QjYRWYFpsqxkpIMY7kcJ2z4jiiKXpG4sXT8Xwuzk78=";
   };
 
   buildAndTestSubdir = "harper-ls";
 
-  cargoHash = "sha256-9ziHYBOCBo8006sag/C7VcUcf45Q1X82DL4DIPWa0lQ=";
+  cargoHash = "sha256-bUsD09JoTAz6LcfjWZh0ekdDfyZ0uDOKuOOHkxZ80jU=";
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
Changelog: https://github.com/Automattic/harper/releases/tag/v1.8.0
Diff: https://github.com/Automattic/harper/compare/v1.7.0...v1.8.0

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
