### PR TITLE
ci/eval: only evaluate the NixOS test on Linux

### DIFF
--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -67,7 +67,9 @@ let
 
   nixosJobs = import (path + "/nixos/release.nix") {
     inherit attrNamesOnly;
-    supportedSystems = if systems == null then [ builtins.currentSystem ] else systems;
+    supportedSystems = lib.filter (lib.hasSuffix "-linux") (
+      if systems == null then [ builtins.currentSystem ] else systems
+    );
   };
 
   recurseIntoAttrs = attrs: attrs // { recurseForDerivations = true; };
@@ -101,6 +103,6 @@ in
 tweak (
   (removeAttrs nixpkgsJobs blacklist)
   // {
-    nixosTests.simple = nixosJobs.tests.simple;
+    nixosTests = lib.filterAttrs (name: _: name == "simple") nixosJobs.tests;
   }
 )


### PR DESCRIPTION
It does evaluate for macOS – at least when I’m not busy adding a warning to `x86_64-darwin` – but Darwin‐only changes to the test driver won’t cause rebuilds on Hydra anyway.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
