### PR TITLE
tests.*: extend the existing `config`

### DIFF
--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -1,4 +1,6 @@
 {
+  stdenv,
+  config,
   runCommand,
   testers,
   fetchgit,
@@ -239,8 +241,11 @@
   withGitConfig =
     let
       pkgs = import ../../.. {
-        config.gitConfig = {
-          url."https://github.com".insteadOf = "https://doesntexist.forsure";
+        system = stdenv.hostPlatform.system;
+        config = config // {
+          gitConfig = {
+            url."https://github.com".insteadOf = "https://doesntexist.forsure";
+          };
         };
       };
     in

--- a/pkgs/test/config.nix
+++ b/pkgs/test/config.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  config,
   pkgs,
   ...
 }:
@@ -17,7 +18,7 @@ lib.recurseIntoAttrs {
     let
       pkgs' = import ../.. {
         system = pkgs.stdenv.hostPlatform.system;
-        config = {
+        config = config // {
           permittedInsecurePackages = builtins.seq pkgs'.glibc.version [ ];
         };
       };

--- a/pkgs/test/cross/default.nix
+++ b/pkgs/test/cross/default.nix
@@ -1,4 +1,8 @@
-{ pkgs, lib }:
+{
+  pkgs,
+  config,
+  lib,
+}:
 
 let
 
@@ -78,6 +82,7 @@ let
           crossPkgs = import pkgs.path {
             localSystem = { inherit (pkgs.stdenv.hostPlatform) config; };
             crossSystem = crossSystemFun system;
+            inherit config;
           };
 
           emulator = crossPkgs.stdenv.hostPlatform.emulator pkgs;

--- a/pkgs/test/stdenv/default.nix
+++ b/pkgs/test/stdenv/default.nix
@@ -5,6 +5,7 @@
   stdenv,
   pkgs,
   lib,
+  config,
   testers,
 }:
 
@@ -20,7 +21,7 @@ let
   # use a early stdenv so when hacking on stdenv this test can be run quickly
   bootStdenv = earlyPkgs.stdenv.__bootPackages.stdenv.__bootPackages.stdenv or earlyPkgs.stdenv;
   pkgsStructured = import pkgs.path {
-    config = {
+    config = config // {
       structuredAttrsByDefault = true;
     };
     inherit (stdenv.hostPlatform) system;


### PR DESCRIPTION
There can be load‐bearing things in `config` (e.g. forbidden licences, EULA agreements, and – in my case – a flag to silence a warning that would otherwise break CI). We should probably find a better solution for this kind of thing in general other than re‐importing Nixpkgs, but this fixes the immediate issue.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
