### PR TITLE
linux/buildLinux: remove forced `CONFIG_MODULES=y`

### DIFF
--- a/pkgs/os-specific/linux/kernel/generic.nix
+++ b/pkgs/os-specific/linux/kernel/generic.nix
@@ -296,7 +296,6 @@ let
         pos = builtins.unsafeGetAttrPos "version" args;
 
         config = {
-          CONFIG_MODULES = "y";
           CONFIG_FW_LOADER = "y";
           CONFIG_RUST = if withRust then "y" else "n";
         };


### PR DESCRIPTION
It seems weird to prescribe the module system per default for every kernel. Generally, `generic.nix` provides powerful and useful abstraction over Linux kernel configuration, but especially in embedded environments it is not always desirable to have the module system enabled. Currently, I have it enabled only then to ship an empty modules dir.

Whoever needs this, can still enable it via the `structuredExtraConfig` argument. (Or gets it implicitly because defconfig usually enables it). The `linux/kernel/build.nix` already autodetects whether modules are enabled (tracked in the `isModular` let binding).

@ma27 seeing that you have recently contributed to that file, would you mind giving feedback?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
