### PR TITLE
.github: drop `x86_64-darwin`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@ For new packages please briefly describe the package or provide a link to its ho
 - Built on platform:
   - [ ] x86_64-linux
   - [ ] aarch64-linux
-  - [ ] x86_64-darwin
   - [ ] aarch64-darwin
 - Tested, as applicable:
   - [ ] [NixOS tests] in [nixos/tests].

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,21 +34,18 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-24.04
-            name: x86_64-linux
-            systems: x86_64-linux
+            system: x86_64-linux
             builds: [shell, manual-nixos, lib-tests, tarball]
             desc: shell, docs, lib, tarball
           - runner: ubuntu-24.04-arm
-            name: aarch64-linux
-            systems: aarch64-linux
+            system: aarch64-linux
             builds: [shell, manual-nixos, manual-nixpkgs]
             desc: shell, docs
           - runner: macos-14
-            name: darwin
-            systems: aarch64-darwin x86_64-darwin
+            system: aarch64-darwin
             builds: [shell]
             desc: shell
-    name: '${{ matrix.name }}: ${{ matrix.desc }}'
+    name: '${{ matrix.system }}: ${{ matrix.desc }}'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     steps:
@@ -80,7 +77,9 @@ jobs:
 
       - name: Build shell
         if: contains(matrix.builds, 'shell')
-        run: echo "${{ matrix.systems }}" | xargs -n1 nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A shell --argstr system
+        env:
+          system: ${{ matrix.system }}
+        run: nix-build-uncached nixpkgs/untrusted/ci --arg nixpkgs ./nixpkgs/untrusted-pinned -A shell --argstr system "$system"
 
       - name: Build NixOS manual
         if: |
@@ -108,5 +107,5 @@ jobs:
           contains(fromJSON(inputs.baseBranch).type, 'primary')
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ inputs.artifact-prefix }}nixos-manual-${{ matrix.name }}
+          name: ${{ inputs.artifact-prefix }}nixos-manual-${{ matrix.system }}
           path: nixos-manual


### PR DESCRIPTION
The follow‐up to https://github.com/NixOS/nixpkgs/pull/492100 (which this will appear to include, until that PR and its requirements are merged), for after branch‐off in a few months’ time. Just opening this as a draft to check against CI for now.

This depends on https://github.com/NixOS/nixpkgs/pull/492103 for Hydra, although that won’t show up in CI so I haven’t included it here.

I’ve kept this PR to just the initial breaking changes, release notes, and error handling; the tree after this PR is still formally incorrect in that there are still references to the removed `pkgsCross.x86_64-darwin` in `passthru.tests`, update scripts that will break because of the platform no longer existing, etc., along with a ton of optional clean‐up left to do. I have a very large stack to address those, which I will push out incrementally, but it would be unreviewable if bundled all into one PR. I’ve pushed this branch to the main Nixpkgs repository so that I can stack those PRs on top of this one for easier review.

---

This will apply to the stable release branches too, but that seems unavoidable: we use `nixpkgs-unstable` in `ci/pinned.json`, which means that the development shell for stable release branches is based on the unstable branch. Once we drop support for a system on the unstable branch, it can no longer be used for Nixpkgs development on the next pin, even when targeting already‐released stable branches.

Since Nixpkgs contributors would generally be expected to be less likely to be using deprecated platforms, and we usually operate with a backport workflow where changes target the unstable branch first, this is probably acceptable. A potential alternative would be to pin the stable branch for CI instead.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
