### PR TITLE
org-freedesktop-filemanager1-common: init at 0-unstable-2025-10-12

### DIFF
--- a/pkgs/by-name/or/org-freedesktop-filemanager1-common/package.nix
+++ b/pkgs/by-name/or/org-freedesktop-filemanager1-common/package.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  dbus,
+  systemdLibs,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "org-freedesktop-filemanager1-common";
+  version = "0-unstable-2025-10-12";
+
+  src = fetchFromGitHub {
+    owner = "boydaihungst";
+    repo = "org.freedesktop.FileManager1.common";
+    rev = "7f516129ac71be409dc415421859de68c1a2ed0e";
+    hash = "sha256-FCmNqz8JaP6XUaJOoWw5Lfls3ThdY+Yv2kRdk8XIRic=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    dbus
+    systemdLibs
+  ];
+
+  postInstall = ''
+    for file in $out/share/org.freedesktop.FileManager1.common/*-wrapper.sh; do
+      name=''${file##*/}
+      name=''${name%-wrapper.sh}
+      sed -i "s|^cmd=.*|cmd=\"$name\"|" "$file"
+    done
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Using File Manager DBus Interface to open file manager and hover over file(s)/folder(s)";
+    homepage = "https://github.com/boydaihungst/org.freedesktop.FileManager1.common";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ anninzy ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Using File Manager DBus Interface to open file manager and hover over file(s)/folder(s)

https://github.com/boydaihungst/org.freedesktop.FileManager1.common

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
