### PR TITLE
treewide: move env vars into env for structuredAttrs

### DIFF
--- a/pkgs/applications/audio/mopidy/moped.nix
+++ b/pkgs/applications/audio/mopidy/moped.nix
@@ -17,7 +17,7 @@ pythonPackages.buildPythonApplication rec {
     sha256 = "15461174037d87af93dd59a236d4275c5abf71cea0670ffff24a7d0399a8a2e4";
   };
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
   buildInputs = [ glibcLocales ];
 
   build-system = [ pythonPackages.setuptools ];

--- a/pkgs/applications/graphics/rawtherapee/default.nix
+++ b/pkgs/applications/graphics/rawtherapee/default.nix
@@ -116,12 +116,18 @@ stdenv.mkDerivation rec {
     "-DCMAKE_OSX_DEPLOYMENT_TARGET=${stdenv.hostPlatform.darwinMinVersion}"
   ];
 
-  CMAKE_CXX_FLAGS = toString [
-    "-std=c++11"
-    "-Wno-deprecated-declarations"
-    "-Wno-unused-result"
-  ];
-  env.CXXFLAGS = "-include cstdint"; # needed at least with gcc13 on aarch64-linux
+  env = {
+    CMAKE_CXX_FLAGS = toString [
+      "-std=c++11"
+      "-Wno-deprecated-declarations"
+      "-Wno-unused-result"
+    ];
+    # needed at least with gcc13 on aarch64-linux
+    CXXFLAGS = toString [
+      "-include"
+      "cstdint"
+    ];
+  };
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/Applications/RawTherapee.app $out/bin

--- a/pkgs/applications/networking/instant-messengers/profanity/default.nix
+++ b/pkgs/applications/networking/instant-messengers/profanity/default.nix
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
 
-  LC_ALL = "en_US.utf8";
+  env.LC_ALL = "en_US.utf8";
 
   meta = {
     homepage = "https://profanity-im.github.io";

--- a/pkgs/by-name/an/animeko/package.nix
+++ b/pkgs/by-name/an/animeko/package.nix
@@ -144,7 +144,10 @@ stdenv.mkDerivation (finalAttrs: {
     useBwrap = false;
   };
 
-  env.JAVA_HOME = jetbrains.jdk;
+  env = {
+    JAVA_HOME = jetbrains.jdk;
+    ANDROID_SDK_HOME = "$(pwd)";
+  };
 
   gradleFlags = [
     "-Dorg.gradle.java.home=${jetbrains.jdk}"
@@ -256,8 +259,6 @@ stdenv.mkDerivation (finalAttrs: {
     rm -r $out/lib/app/resources/lib
     ln -sf ${libvlc}/lib $out/lib/app/resources/
   '';
-
-  ANDROID_SDK_HOME = "$(pwd)";
 
   passthru.updateScript = writeShellScript "update-animeko" ''
     ${lib.getExe nix-update} animeko

--- a/pkgs/by-name/ar/arc-theme/package.nix
+++ b/pkgs/by-name/ar/arc-theme/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   '';
 
   # Fontconfig error: Cannot load default config file: No such file: (null)
-  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+  env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
   mesonFlags = [
     # "-Dthemes=cinnamon,gnome-shell,gtk2,gtk3,plank,xfwm,metacity"

--- a/pkgs/by-name/ar/ardour_8/package.nix
+++ b/pkgs/by-name/ar/ardour_8/package.nix
@@ -216,7 +216,7 @@ stdenv.mkDerivation (
         }"
     '';
 
-    LINKFLAGS = "-lpthread";
+    env.LINKFLAGS = "-lpthread";
 
     meta = {
       description = "Multi-track hard disk recording software";

--- a/pkgs/by-name/ar/art/package.nix
+++ b/pkgs/by-name/ar/art/package.nix
@@ -105,12 +105,18 @@ stdenv.mkDerivation (finalAttrs: {
     "-DCTL_INCLUDE_DIR=${color-transformation-language}/include/CTL"
   ];
 
-  CMAKE_CXX_FLAGS = toString [
-    "-std=c++11"
-    "-Wno-deprecated-declarations"
-    "-Wno-unused-result"
-  ];
-  env.CXXFLAGS = "-include cstdint"; # needed at least with gcc13 on aarch64-linux
+  env = {
+    CMAKE_CXX_FLAGS = toString [
+      "-std=c++11"
+      "-Wno-deprecated-declarations"
+      "-Wno-unused-result"
+    ];
+    # needed at least with gcc13 on aarch64-linux
+    CXXFLAGS = toString [
+      "-include"
+      "cstdint"
+    ];
+  };
 
   meta = {
     description = "Raw converter based on RawTherapee";

--- a/pkgs/by-name/aw/awsume/package.nix
+++ b/pkgs/by-name/aw/awsume/package.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     hash = "sha256-lm9YANYckyHDoNbB1wytBm55iyBmUuxFPmZupfpReqc=";
   };
 
-  AWSUME_SKIP_ALIAS_SETUP = 1;
+  env.AWSUME_SKIP_ALIAS_SETUP = 1;
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/ca/canon-capt/package.nix
+++ b/pkgs/by-name/ca/canon-capt/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation {
   # Fix for 'ppdc: Unable to find include file "<font.defs>"', which blocks '*.ppd' generation.
   # Issue occurs in hermetic sandbox; this workaround is the current solution.
   # Source: https://github.com/NixOS/nixpkgs/blob/9997402000a82eda4327fde36291234118c7515e/pkgs/misc/drivers/hplip/default.nix#L160
-  CUPS_DATADIR = "${cups}/share/cups";
+  env.CUPS_DATADIR = "${cups}/share/cups";
 
   configurePhase = ''
     runHook preConfigure

--- a/pkgs/by-name/ca/capitaine-cursors/package.nix
+++ b/pkgs/by-name/ca/capitaine-cursors/package.nix
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   # Complains about not being able to find the fontconfig config file otherwise
-  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+  env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
   buildInputs = [
     inkscape

--- a/pkgs/by-name/cr/crosvm/package.nix
+++ b/pkgs/by-name/cr/crosvm/package.nix
@@ -56,8 +56,10 @@ rustPlatform.buildRustPackage {
     patchShebangs third_party/minijail/tools/*.py
   '';
 
-  CROSVM_USE_SYSTEM_MINIGBM = true;
-  CROSVM_USE_SYSTEM_VIRGLRENDERER = true;
+  env = {
+    CROSVM_USE_SYSTEM_MINIGBM = true;
+    CROSVM_USE_SYSTEM_VIRGLRENDERER = true;
+  };
 
   buildFeatures = [ "virgl_renderer" ];
 

--- a/pkgs/by-name/de/devpi-client/package.nix
+++ b/pkgs/by-name/de/devpi-client/package.nix
@@ -60,7 +60,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "--fast"
   ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   __darwinAllowLocalNetworking = true;
 

--- a/pkgs/by-name/di/direnv/package.nix
+++ b/pkgs/by-name/di/direnv/package.nix
@@ -23,7 +23,7 @@ buildGoModule (finalAttrs: {
   vendorHash = "sha256-SAIGFQGACTB3Q0KnIdiKKNYY6fVjf/09wGqNr0Hkg+M=";
 
   # we have no bash at the moment for windows
-  BASH_PATH = lib.optionalString (!stdenv.hostPlatform.isWindows) "${bash}/bin/bash";
+  env.BASH_PATH = lib.optionalString (!stdenv.hostPlatform.isWindows) "${bash}/bin/bash";
 
   # replace the build phase to use the GNUMakefile instead
   buildPhase = ''

--- a/pkgs/by-name/dy/dynamic-colors/package.nix
+++ b/pkgs/by-name/dy/dynamic-colors/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-jSdwq9WwYZP8MK6z7zJa0q93xfanr6iuvAt8YQkQxxE=";
   };
 
-  PREFIX = placeholder "out";
+  env.PREFIX = placeholder "out";
 
   postPatch = ''
     substituteInPlace bin/dynamic-colors \

--- a/pkgs/by-name/fe/feedgnuplot/package.nix
+++ b/pkgs/by-name/fe/feedgnuplot/package.nix
@@ -46,7 +46,7 @@ perlPackages.buildPerlPackage rec {
   ]);
 
   # Fontconfig error: Cannot load default config file
-  FONTCONFIG_FILE = fontsConf;
+  env.FONTCONFIG_FILE = fontsConf;
 
   postPatch = ''
     patchShebangs .

--- a/pkgs/by-name/gi/git-vendor/package.nix
+++ b/pkgs/by-name/gi/git-vendor/package.nix
@@ -29,9 +29,11 @@ stdenv.mkDerivation {
     "out"
   ];
 
-  PREFIX = (placeholder "out");
-  BINPREFIX = "${placeholder "bin"}/bin";
-  MANPREFIX = "${placeholder "man"}/share/man/man1";
+  env = {
+    PREFIX = (placeholder "out");
+    BINPREFIX = "${placeholder "bin"}/bin";
+    MANPREFIX = "${placeholder "man"}/share/man/man1";
+  };
 
   buildInputs = [
     # stubbing out a `git config` check that `make install` tries to do

--- a/pkgs/by-name/gl/glom/package.nix
+++ b/pkgs/by-name/gl/glom/package.nix
@@ -135,7 +135,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Fontconfig error: Cannot load default config file
-  FONTCONFIG_FILE = makeFontsConf {
+  env.FONTCONFIG_FILE = makeFontsConf {
     fontDirectories = [ freefont_ttf ];
   };
 

--- a/pkgs/by-name/gt/gtkmm4/package.nix
+++ b/pkgs/by-name/gt/gtkmm4/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Tests require fontconfig.
-  FONTCONFIG_FILE = makeFontsConf {
+  env.FONTCONFIG_FILE = makeFontsConf {
     fontDirectories = [ ];
   };
 

--- a/pkgs/by-name/hp/hplip/package.nix
+++ b/pkgs/by-name/hp/hplip/package.nix
@@ -203,12 +203,6 @@ python3Packages.buildPythonApplication {
     ++ lib.optional withStaticPPDInstall "--enable-cups-ppd-install"
     ++ lib.optional withQt5 "--enable-qt5";
 
-  # Prevent 'ppdc: Unable to find include file "<font.defs>"' which prevent
-  # generation of '*.ppd' files.
-  # This seems to be a 'ppdc' issue when the tool is run in a hermetic sandbox.
-  # Could not find how to fix the problem in 'ppdc' so this is a workaround.
-  CUPS_DATADIR = "${cups}/share/cups";
-
   makeFlags =
     let
       out = placeholder "out";
@@ -234,6 +228,12 @@ python3Packages.buildPythonApplication {
   enableParallelInstalling = false;
 
   env = {
+    # Prevent 'ppdc: Unable to find include file "<font.defs>"' which prevent
+    # generation of '*.ppd' files.
+    # This seems to be a 'ppdc' issue when the tool is run in a hermetic sandbox.
+    # Could not find how to fix the problem in 'ppdc' so this is a workaround.
+    CUPS_DATADIR = "${cups}/share/cups";
+
     NIX_CFLAGS_COMPILE = toString [
       "-Wno-error=implicit-int"
       "-Wno-error=implicit-function-declaration"

--- a/pkgs/by-name/ht/httpstat/package.nix
+++ b/pkgs/by-name/ht/httpstat/package.nix
@@ -23,7 +23,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   buildInputs = [ glibcLocales ];
   runtimeDeps = [ curl ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   meta = {
     description = "Curl statistics made simple";

--- a/pkgs/by-name/i3/i3minator/package.nix
+++ b/pkgs/by-name/i3/i3minator/package.nix
@@ -17,7 +17,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     sha256 = "07dic5d2m0zw0psginpl43xn0mpxw7wilj49d02knz69f7c416lm";
   };
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
   buildInputs = [ glibcLocales ];
 
   build-system = [

--- a/pkgs/by-name/li/libaccounts-glib/package.nix
+++ b/pkgs/by-name/li/libaccounts-glib/package.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
       --replace "subdir('tests')" ""
   '';
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   mesonFlags = [
     "-Dinstall-py-overrides=true"

--- a/pkgs/by-name/li/libcamera/package.nix
+++ b/pkgs/by-name/li/libcamera/package.nix
@@ -123,11 +123,13 @@ stdenv.mkDerivation rec {
     "-Ddocumentation=disabled"
   ];
 
-  # Fixes error on a deprecated declaration
-  env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
+  env = {
+    # Fixes error on a deprecated declaration
+    NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
-  # Silence fontconfig warnings about missing config
-  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+    # Silence fontconfig warnings about missing config
+    FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+  };
 
   meta = {
     description = "Open source camera stack and framework for Linux, Android, and ChromeOS";

--- a/pkgs/by-name/li/libmatthew_java/package.nix
+++ b/pkgs/by-name/li/libmatthew_java/package.nix
@@ -15,8 +15,12 @@ stdenv.mkDerivation (finalAttrs: {
     url = "https://src.fedoraproject.org/repo/pkgs/libmatthew-java/libmatthew-java-${finalAttrs.version}.tar.gz/8455b8751083ce25c99c2840609271f5/libmatthew-java-${finalAttrs.version}.tar.gz";
     sha256 = "1yldkhsdzm0a41a0i881bin2jklhp85y3ah245jd6fz3npcx7l85";
   };
-  JAVA_HOME = jdk;
-  PREFIX = "\${out}";
+
+  env = {
+    JAVA_HOME = jdk;
+    PREFIX = "\${out}";
+  };
+
   buildInputs = [ jdk ];
 
   meta = {

--- a/pkgs/by-name/li/libnest2d/package.nix
+++ b/pkgs/by-name/li/libnest2d/package.nix
@@ -37,7 +37,8 @@ stdenv.mkDerivation {
   ];
   nativeBuildInputs = [ cmake ];
 
-  CLIPPER_PATH = "${clipper.out}";
+  env.CLIPPER_PATH = clipper.out;
+
   cmakeFlags = [ "-DLIBNEST2D_HEADER_ONLY=OFF" ];
 
   meta = {

--- a/pkgs/by-name/li/lilypond/package.nix
+++ b/pkgs/by-name/li/lilypond/package.nix
@@ -147,7 +147,11 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
   };
 
-  FONTCONFIG_FILE = lib.optional stdenv.hostPlatform.isDarwin (makeFontsConf {
-    fontDirectories = [ freefont_ttf ];
-  });
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    FONTCONFIG_FILE = (
+      makeFontsConf {
+        fontDirectories = [ freefont_ttf ];
+      }
+    );
+  };
 })

--- a/pkgs/by-name/mi/midisheetmusic/package.nix
+++ b/pkgs/by-name/mi/midisheetmusic/package.nix
@@ -74,7 +74,7 @@ stdenv.mkDerivation {
   '';
 
   # This fixes tests that fail because of missing fonts
-  FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
+  env.FONTCONFIG_FILE = makeFontsConf { fontDirectories = [ ]; };
 
   installPhase = ''
     mkdir -p $out/share/applications $out/share/pixmaps $out/bin

--- a/pkgs/by-name/mi/mission-planner/package.nix
+++ b/pkgs/by-name/mi/mission-planner/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     runHook postUnpack
   '';
 
-  AOT_FILES = [
+  env.AOT_FILES = toString [
     "MissionPlanner.exe"
     "MissionPlanner.*.dll"
   ];

--- a/pkgs/by-name/n2/n2n/package.nix
+++ b/pkgs/by-name/n2/n2n/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./autogen.sh
   '';
 
-  PREFIX = placeholder "out";
+  env.PREFIX = placeholder "out";
 
   meta = {
     description = "Peer-to-peer VPN";

--- a/pkgs/by-name/pa/pango/package.nix
+++ b/pkgs/by-name/pa/pango/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Fontconfig error: Cannot load default config file
-  FONTCONFIG_FILE = makeFontsConf {
+  env.FONTCONFIG_FILE = makeFontsConf {
     fontDirectories = [ freefont_ttf ];
   };
 

--- a/pkgs/by-name/pi/pick/package.nix
+++ b/pkgs/by-name/pi/pick/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ ncurses ];
 
-  PREFIX = placeholder "out";
+  env.PREFIX = placeholder "out";
 
   meta = {
     inherit (finalAttrs.src.meta) homepage;

--- a/pkgs/by-name/pr/professor/package.nix
+++ b/pkgs/by-name/pr/professor/package.nix
@@ -49,8 +49,10 @@ stdenv.mkDerivation {
     yoda
   ];
 
-  CPPFLAGS = [ "-I${eigen}/include/eigen3" ];
-  PREFIX = placeholder "out";
+  env = {
+    CPPFLAGS = toString [ "-I${eigen}/include/eigen3" ];
+    PREFIX = placeholder "out";
+  };
 
   postInstall = ''
     for prog in "$out"/bin/*; do

--- a/pkgs/by-name/ro/routino/package.nix
+++ b/pkgs/by-name/ro/routino/package.nix
@@ -46,7 +46,9 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
-  CLANG = lib.optionalString stdenv.cc.isClang "1";
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    CLANG = "1";
+  };
 
   makeFlags = [ "prefix=$(out)" ];
 

--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -97,13 +97,16 @@ stdenv.mkDerivation (finalAttrs: {
     install -Dm0644 documentation/sile.pdf $out/share/doc/sile/manual.pdf
   '';
 
-  FONTCONFIG_FILE = makeFontsConf {
-    fontDirectories = [
-      gentium-plus
-    ];
+  env = {
+    FONTCONFIG_FILE = makeFontsConf {
+      fontDirectories = [
+        gentium-plus
+      ];
+    };
+    LUA = "${finalAttrs.finalPackage.passthru.luaEnv}/bin/lua";
   };
+
   strictDeps = true;
-  env.LUA = "${finalAttrs.finalPackage.passthru.luaEnv}/bin/lua";
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/st/stardust-xr-server/package.nix
+++ b/pkgs/by-name/st/stardust-xr-server/package.nix
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     libxfixes
   ];
 
-  CPM_SOURCE_CACHE = "./build";
+  env.CPM_SOURCE_CACHE = "./build";
 
   postPatch = ''
     install -D ${cpm-cmake}/share/cpm/CPM.cmake $(echo $cargoDepsCopy/stereokit-sys-*/StereoKit)/build/cpm/CPM_0.32.2.cmake

--- a/pkgs/by-name/te/telepathy-glib/package.nix
+++ b/pkgs/by-name/te/telepathy-glib/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--enable-vala-bindings"
   ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/to/tokstat/package.nix
+++ b/pkgs/by-name/to/tokstat/package.nix
@@ -35,7 +35,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   # For keyring support
-  PKG_CONFIG_PATH = lib.optionalString stdenv.hostPlatform.isLinux "${dbus.dev}/lib/pkgconfig";
+  env = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+    PKG_CONFIG_PATH = "${dbus.dev}/lib/pkgconfig";
+  };
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     # Generate shell completions

--- a/pkgs/by-name/to/topydo/package.nix
+++ b/pkgs/by-name/to/topydo/package.nix
@@ -47,7 +47,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     substituteInPlace test/test_revert_command.py --replace 'test_revert_ls' 'dont_test_revert_ls'
   '';
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   meta = {
     description = "Cli todo application compatible with the todo.txt format";

--- a/pkgs/by-name/tu/turses/package.nix
+++ b/pkgs/by-name/tu/turses/package.nix
@@ -71,7 +71,7 @@ buildPythonPackage rec {
     tox
   ];
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   patches = [
     (fetchpatch {

--- a/pkgs/by-name/vt/vtsls/package.nix
+++ b/pkgs/by-name/vt/vtsls/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [ ./vtsls-build-patch.patch ];
 
   # Skips manual confirmations during build
-  CI = true;
+  env.CI = true;
 
   buildPhase = ''
     runHook preBuild

--- a/pkgs/by-name/ya/yafetch/package.nix
+++ b/pkgs/by-name/ya/yafetch/package.nix
@@ -24,7 +24,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   '';
 
   # Fixes installation path
-  PREFIX = placeholder "out";
+  env.PREFIX = placeholder "out";
 
   meta = {
     homepage = "https://github.com/kira64xyz/yafetch";

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Complains about not being able to find the fontconfig config file otherwise
-  FONTCONFIG_FILE = lib.optional docSupport (makeFontsConf {
+  env.FONTCONFIG_FILE = lib.optional docSupport (makeFontsConf {
     fontDirectories = [ ];
   });
 

--- a/pkgs/development/python-modules/rainbowstream/default.nix
+++ b/pkgs/development/python-modules/rainbowstream/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage {
     sed -i 's/requests.*"/requests"/' setup.py
   '';
 
-  LC_ALL = "en_US.UTF-8";
+  env.LC_ALL = "en_US.UTF-8";
 
   postInstall = ''
     mkdir -p $out/lib

--- a/pkgs/tools/networking/openvpn/update-systemd-resolved.nix
+++ b/pkgs/tools/networking/openvpn/update-systemd-resolved.nix
@@ -9,7 +9,7 @@
   util-linux,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "update-systemd-resolved";
   # when updating this, check if additional binaries need injecting into PATH
   version = "1.3.0";
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "jonathanio";
     repo = "update-systemd-resolved";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-lYJTR3oBmpENcqNHa9PFXsw7ly6agwjBWf4UXf1d8Kc=";
   };
 
@@ -26,10 +26,10 @@ stdenv.mkDerivation rec {
     ./update-systemd-resolved.patch
   ];
 
-  PREFIX = "${placeholder "out"}/libexec/openvpn";
+  env.PREFIX = "${placeholder "out"}/libexec/openvpn";
 
   postInstall = ''
-    substituteInPlace ${PREFIX}/update-systemd-resolved \
+    substituteInPlace ${finalAttrs.env.PREFIX}/update-systemd-resolved \
       --subst-var-by PATH ${
         lib.makeBinPath [
           coreutils
@@ -48,4 +48,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ eadwu ];
     platforms = lib.platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Getting some stragglers, mainly C/CGO/NIX related vars remaining.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
