### PR TITLE
treewide: move NIX_CFLAGS_LINK vars into env for structuredAttrs

### DIFF
--- a/pkgs/applications/graphics/apngasm/2.nix
+++ b/pkgs/applications/graphics/apngasm/2.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     rm -rf libpng zlib zopfli
   '';
 
-  NIX_CFLAGS_LINK = "-lzopfli";
+  env.NIX_CFLAGS_LINK = "-lzopfli";
 
   installPhase = ''
     install -Dt $out/bin apngasm

--- a/pkgs/by-name/ap/aprutil/package.nix
+++ b/pkgs/by-name/ap/aprutil/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional stdenv.hostPlatform.isFreeBSD ./include-static-dependencies.patch;
 
-  NIX_CFLAGS_LINK = [ "-lcrypt" ];
+  env.NIX_CFLAGS_LINK = toString [ "-lcrypt" ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/ds/dsniff/package.nix
+++ b/pkgs/by-name/ds/dsniff/package.nix
@@ -103,8 +103,19 @@ stdenv.mkDerivation (finalAttrs: {
     libnsl
     libnl
   ];
-  NIX_CFLAGS_LINK = "-lglib-2.0 -lpthread -ltirpc -lnl-3 -lnl-genl-3";
-  env.NIX_CFLAGS_COMPILE = toString [ "-I${libtirpc.dev}/include/tirpc" ];
+
+  env = {
+    NIX_CFLAGS_LINK = toString [
+      "-lglib-2.0"
+      "-lpthread"
+      "-ltirpc"
+      "-lnl-3"
+      "-lnl-genl-3"
+    ];
+    NIX_CFLAGS_COMPILE = toString [
+      "-I${libtirpc.dev}/include/tirpc"
+    ];
+  };
   postPatch = ''
     for patch in debian/patches/*.patch; do
       patch < $patch

--- a/pkgs/by-name/he/hebbot/package.nix
+++ b/pkgs/by-name/he/hebbot/package.nix
@@ -40,12 +40,11 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   env = {
     OPENSSL_NO_VENDOR = 1;
+    NIX_CFLAGS_LINK = toString [
+      "-L${lib.getLib openssl}/lib"
+      "-L${lib.getLib sqlite}/lib"
+    ];
   };
-
-  NIX_CFLAGS_LINK = [
-    "-L${lib.getLib openssl}/lib"
-    "-L${lib.getLib sqlite}/lib"
-  ];
 
   passthru.updateScript = unstableGitUpdater { };
 

--- a/pkgs/by-name/io/iortcw/sp.nix
+++ b/pkgs/by-name/io/iortcw/sp.nix
@@ -47,11 +47,15 @@ stdenv.mkDerivation (finalAttrs: {
   ];
   nativeBuildInputs = [ makeWrapper ];
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-I${lib.getInclude SDL2}/include/SDL2"
-    "-I${opusfile.dev}/include/opus"
-  ];
-  NIX_CFLAGS_LINK = [ "-lSDL2" ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-I${lib.getInclude SDL2}/include/SDL2"
+      "-I${opusfile.dev}/include/opus"
+    ];
+    NIX_CFLAGS_LINK = toString [
+      "-lSDL2"
+    ];
+  };
 
   postInstall = ''
     for i in `find $out/opt/iortcw -maxdepth 1 -type f -executable`; do

--- a/pkgs/by-name/li/libsndfile/package.nix
+++ b/pkgs/by-name/li/libsndfile/package.nix
@@ -78,7 +78,10 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # Needed on Darwin.
-  NIX_CFLAGS_LINK = "-logg -lvorbis";
+  env.NIX_CFLAGS_LINK = toString [
+    "-logg"
+    "-lvorbis"
+  ];
 
   doCheck = true;
   preCheck = ''

--- a/pkgs/by-name/op/openspades/package.nix
+++ b/pkgs/by-name/op/openspades/package.nix
@@ -93,7 +93,7 @@ stdenv.mkDerivation rec {
     cp $notoFont $out/share/games/openspades/Resources/
   '';
 
-  NIX_CFLAGS_LINK = "-lopenal";
+  env.NIX_CFLAGS_LINK = "-lopenal";
 
   meta = {
     description = "Compatible client of Ace of Spades 0.75";

--- a/pkgs/by-name/to/tor/package.nix
+++ b/pkgs/by-name/to/tor/package.nix
@@ -85,7 +85,9 @@ stdenv.mkDerivation (finalAttrs: {
       # cross compiles correctly but needs the following
       lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--disable-tool-name-check" ];
 
-  NIX_CFLAGS_LINK = lib.optionalString stdenv.cc.isGNU "-lgcc_s";
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    NIX_CFLAGS_LINK = "-lgcc_s";
+  };
 
   postPatch = ''
     substituteInPlace contrib/client-tools/torify \

--- a/pkgs/by-name/uf/ufoai/package.nix
+++ b/pkgs/by-name/uf/ufoai/package.nix
@@ -30,12 +30,21 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "1drhh08cqqkwv1yz3z4ngkplr23pqqrdx6cp8c3isy320gy25cvb";
   };
 
-  # Workaround build failure on -fno-common toolchains:
-  #   ld: r_gl.h:52: multiple definition of `qglGenBuffers';
-  #     r_gl.h:52: first defined here
-  # TODO: drop once release contains upstream fix:
-  #   https://github.com/ufoai/ufoai/commit/8a3075fffdad294e
-  env.NIX_CFLAGS_COMPILE = "-fcommon";
+  env = {
+    # Workaround build failure on -fno-common toolchains:
+    #   ld: r_gl.h:52: multiple definition of `qglGenBuffers';
+    #     r_gl.h:52: first defined here
+    # TODO: drop once release contains upstream fix:
+    #   https://github.com/ufoai/ufoai/commit/8a3075fffdad294e
+    NIX_CFLAGS_COMPILE = "-fcommon";
+    NIX_CFLAGS_LINK = toString [
+      # to avoid occasional runtime error in finding libgcc_s.so.1
+      "-lgcc_s"
+      # tests are underlinked against libm:
+      # ld: release-linux-x86_64/testall/client/sound/s_mix.c.o: undefined reference to symbol 'acos@@GLIBC_2.2.5'
+      "-lm"
+    ];
+  };
 
   preConfigure = ''tar xvf "${finalAttrs.srcData}"'';
 
@@ -58,14 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
     gettext
     cunit
-  ];
-
-  NIX_CFLAGS_LINK = [
-    # to avoid occasional runtime error in finding libgcc_s.so.1
-    "-lgcc_s"
-    # tests are underlinked against libm:
-    # ld: release-linux-x86_64/testall/client/sound/s_mix.c.o: undefined reference to symbol 'acos@@GLIBC_2.2.5'
-    "-lm"
   ];
 
   meta = {

--- a/pkgs/by-name/xb/xbill/package.nix
+++ b/pkgs/by-name/xb/xbill/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     motif
   ];
 
-  NIX_CFLAGS_LINK = "-lXpm";
+  env.NIX_CFLAGS_LINK = "-lXpm";
 
   configureFlags = [
     "--with-x"

--- a/pkgs/by-name/zd/zdoom/package.nix
+++ b/pkgs/by-name/zd/zdoom/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = ".";
 
-  NIX_CFLAGS_LINK = [
+  env.NIX_CFLAGS_LINK = toString [
     "-lopenal"
     "-lfluidsynth"
   ];

--- a/pkgs/by-name/ze/zeroad-unwrapped/package.nix
+++ b/pkgs/by-name/ze/zeroad-unwrapped/package.nix
@@ -87,18 +87,20 @@ stdenv.mkDerivation (finalAttrs: {
   ]
   ++ lib.optional withEditor wxGTK32;
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-I${xorgproto}/include"
-    "-I${libx11.dev}/include"
-    "-I${libxcursor.dev}/include"
-    "-I${SDL2}/include/SDL2"
-    "-I${fmt_9.dev}/include"
-    "-I${nvidia-texture-tools.dev}/include"
-  ];
+  env = {
+    NIX_CFLAGS_COMPILE = toString [
+      "-I${xorgproto}/include"
+      "-I${libx11.dev}/include"
+      "-I${libxcursor.dev}/include"
+      "-I${SDL2}/include/SDL2"
+      "-I${fmt_9.dev}/include"
+      "-I${nvidia-texture-tools.dev}/include"
+    ];
 
-  NIX_CFLAGS_LINK = toString [
-    "-L${nvidia-texture-tools.lib}/lib/static"
-  ];
+    NIX_CFLAGS_LINK = toString [
+      "-L${nvidia-texture-tools.lib}/lib/static"
+    ];
+  };
 
   patches = [
     ./rootdir_env.patch

--- a/pkgs/development/libraries/librdf/redland.nix
+++ b/pkgs/development/libraries/librdf/redland.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
   ];
 
   # Fix broken DT_NEEDED in lib/redland/librdf_storage_sqlite.so.
-  NIX_CFLAGS_LINK = "-lraptor2";
+  env.NIX_CFLAGS_LINK = "-lraptor2";
 
   doCheck = false; # fails 1 out of 17 tests with a segmentation fault
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
