### PR TITLE
top-level: add error for `x86_64-darwin` deprecation

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -512,6 +512,30 @@
   "sec-nixpkgs-release-25.05-notable-changes": [
     "release-notes.html#sec-nixpkgs-release-25.05-notable-changes"
   ],
+  "sec-nixpkgs-release-26.11": [
+    "release-notes.html#sec-nixpkgs-release-26.11"
+  ],
+  "sec-nixpkgs-release-26.11-highlights": [
+    "release-notes.html#sec-nixpkgs-release-26.11-highlights"
+  ],
+  "sec-nixpkgs-release-26.11-incompatibilities": [
+    "release-notes.html#sec-nixpkgs-release-26.11-incompatibilities"
+  ],
+  "sec-nixpkgs-release-26.11-lib": [
+    "release-notes.html#sec-nixpkgs-release-26.11-lib"
+  ],
+  "sec-nixpkgs-release-26.11-lib-additions-improvements": [
+    "release-notes.html#sec-nixpkgs-release-26.11-lib-additions-improvements"
+  ],
+  "sec-nixpkgs-release-26.11-lib-breaking": [
+    "release-notes.html#sec-nixpkgs-release-26.11-lib-breaking"
+  ],
+  "sec-nixpkgs-release-26.11-lib-deprecations": [
+    "release-notes.html#sec-nixpkgs-release-26.11-lib-deprecations"
+  ],
+  "sec-nixpkgs-release-26.11-notable-changes": [
+    "release-notes.html#sec-nixpkgs-release-26.11-notable-changes"
+  ],
   "sec-nrfutil": [
     "index.html#sec-nrfutil"
   ],
@@ -982,6 +1006,9 @@
   ],
   "x86_64-darwin-26.05": [
     "release-notes.html#x86_64-darwin-26.05"
+  ],
+  "x86_64-darwin-26.11": [
+    "release-notes.html#x86_64-darwin-26.11"
   ],
   "zip-files": [
     "index.html#zip-files"

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1091,6 +1091,9 @@
   "x86_64-darwin-26.05": [
     "release-notes.html#x86_64-darwin-26.05"
   ],
+  "x86_64-darwin-26.11": [
+    "release-notes.html#x86_64-darwin-26.11"
+  ],
   "zip-files": [
     "index.html#zip-files"
   ],

--- a/doc/release-notes/release-notes.md
+++ b/doc/release-notes/release-notes.md
@@ -3,6 +3,7 @@
 This section lists the release notes for each stable version of Nixpkgs and the current unstable revision.
 
 ```{=include=} sections
+rl-2611.section.md
 rl-2605.section.md
 rl-2511.section.md
 rl-2505.section.md

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -1,0 +1,45 @@
+# Nixpkgs 26.11 (2026.11/??) {#sec-nixpkgs-release-26.11}
+
+## Highlights {#sec-nixpkgs-release-26.11-highlights}
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
+- Create the first release note entry in this section!
+
+## Backward Incompatibilities {#sec-nixpkgs-release-26.11-incompatibilities}
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
+- []{#x86_64-darwin-26.11}
+
+  Support for `x86_64-darwin` has been dropped, due to Apple’s deprecation of the platform and limited build infrastructure and developer time.
+  We will no longer build packages for the platform or support building them from source.
+
+  The Nixpkgs 26.05 stable branch will still maintain platform support and binaries will be built until it goes out of support at the end of 2026.
+  Users of `x86_64-darwin` will receive an error message explaining how to switch to 26.05.
+
+  By the time of this release, Homebrew will offer only limited [Tier 3](https://docs.brew.sh/Support-Tiers#tier-3) support for the platform, but MacPorts will likely continue to support it for a long time.
+  We also recommend users consider installing NixOS, which should continue to run on essentially all Intel Macs, especially after Apple stops security support for macOS 26 in 2028.
+
+## Other Notable Changes {#sec-nixpkgs-release-26.11-notable-changes}
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
+- Create the first release note entry in this section!
+
+## Nixpkgs Library {#sec-nixpkgs-release-26.11-lib}
+
+<!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
+
+### Breaking changes {#sec-nixpkgs-release-26.11-lib-breaking}
+
+- Create the first release note entry in this section!
+
+
+### Deprecations {#sec-nixpkgs-release-26.11-lib-deprecations}
+
+- Create the first release note entry in this section!
+
+
+### Additions and Improvements {#sec-nixpkgs-release-26.11-lib-additions-improvements}
+
+- Create the first release note entry in this section!

--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -10,6 +10,17 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- []{#x86_64-darwin-26.11}
+
+  Support for `x86_64-darwin` has been dropped, due to Apple’s deprecation of the platform and limited build infrastructure and developer time.
+  We will no longer build packages for the platform or support building them from source.
+
+  The Nixpkgs 26.05 stable branch will still maintain platform support and binaries will be built until it goes out of support at the end of 2026.
+  Users of `x86_64-darwin` will receive an error message explaining how to switch to 26.05.
+
+  By the time of this release, Homebrew will offer only limited [Tier 3](https://docs.brew.sh/Support-Tiers#tier-3) support for the platform, but MacPorts will likely continue to support it for a long time.
+  We also recommend users consider installing NixOS, which should continue to run on essentially all Intel Macs, especially after Apple stops security support for macOS 26 in 2028.
+
 - Paths under `/etc/xdg/` from packages in `environment.systemPackages` are no longer linked into the global `/etc/` by default. Modules depending on such directories must declare them explicitly using `environment.pathsToLink`.
 - `databricks-cli` has been updated from `0.290.2` to `1.x.x`, the first major release. OAuth tokens for interactive logins (`auth_type = databricks-cli`) are now stored in the OS-native secure store by default (Secret Service on Linux) instead of `~/.databricks/token-cache.json`; cached tokens from older versions are not migrated, so run `databricks auth login` once per profile after upgrading. To keep the previous file-backed storage, set `DATABRICKS_AUTH_STORAGE=plaintext` or add `auth_storage = plaintext` under `[__settings__]` in `~/.databrickscfg`. Additionally, the `vector_search_endpoints` DABs resource renamed `min_qps` to `target_qps` (and the `vector-search-endpoints` command renamed `--min-qps` to `--target-qps`). See the [upstream changelog](https://github.com/databricks/cli/blob/main/CHANGELOG.md) for details.
 

--- a/doc/stdenv/cross-compilation.chapter.md
+++ b/doc/stdenv/cross-compilation.chapter.md
@@ -48,7 +48,7 @@ The exact schema these fields follow is a bit ill-defined due to a long and conv
 
 `system`
 
-: This is a two-component shorthand for the platform. Examples of this would be "x86_64-darwin" and "i686-linux"; see `lib.systems.doubles` for more. The first component corresponds to the CPU architecture of the platform and the second to the operating system of the platform (`[cpu]-[os]`). This format has built-in support in Nix, such as the `builtins.currentSystem` impure string.
+: This is a two-component shorthand for the platform. Examples of this would be "aarch64-darwin" and "i686-linux"; see `lib.systems.doubles` for more. The first component corresponds to the CPU architecture of the platform and the second to the operating system of the platform (`[cpu]-[os]`). This format has built-in support in Nix, such as the `builtins.currentSystem` impure string.
 
 `config`
 

--- a/doc/stdenv/cross-compilation.chapter.md
+++ b/doc/stdenv/cross-compilation.chapter.md
@@ -50,7 +50,7 @@ The exact schema these fields follow is a bit ill-defined due to a long and conv
 
 `system`
 
-: This is a two-component shorthand for the platform. Examples of this would be "x86_64-darwin" and "i686-linux"; see `lib.systems.doubles` for more. The first component corresponds to the CPU architecture of the platform and the second to the operating system of the platform (`[cpu]-[os]`). This format has built-in support in Nix, such as the `builtins.currentSystem` impure string.
+: This is a two-component shorthand for the platform. Examples of this would be "aarch64-darwin" and "i686-linux"; see `lib.systems.doubles` for more. The first component corresponds to the CPU architecture of the platform and the second to the operating system of the platform (`[cpu]-[os]`). This format has built-in support in Nix, such as the `builtins.currentSystem` impure string.
 
 `config`
 

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -11,7 +11,6 @@ let
     "x86_64-cygwin"
 
     # Darwin
-    "x86_64-darwin"
     "aarch64-darwin"
 
     # FreeBSD

--- a/lib/systems/doubles.nix
+++ b/lib/systems/doubles.nix
@@ -19,7 +19,6 @@ let
     "x86_64-cygwin"
 
     # Darwin
-    "x86_64-darwin"
     "aarch64-darwin"
 
     # FreeBSD

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -331,12 +331,6 @@ rec {
     platform = { };
   };
 
-  x86_64-darwin = {
-    config = "x86_64-apple-darwin";
-    xcodePlatform = "MacOSX";
-    platform = { };
-  };
-
   #
   # UEFI
   #

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -332,12 +332,6 @@ rec {
     platform = { };
   };
 
-  x86_64-darwin = {
-    config = "x86_64-apple-darwin";
-    xcodePlatform = "MacOSX";
-    platform = { };
-  };
-
   #
   # UEFI
   #

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -127,7 +127,6 @@ lib.runTests (
     ];
     testx86_64 = mseteq x86_64 [
       "x86_64-linux"
-      "x86_64-darwin"
       "x86_64-freebsd"
       "x86_64-genode"
       "x86_64-redox"
@@ -145,7 +144,6 @@ lib.runTests (
       "x86_64-cygwin"
     ];
     testdarwin = mseteq darwin [
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
     testfreebsd = mseteq freebsd [

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1589,6 +1589,7 @@ mapAliases {
   pinentry = throw "'pinentry' has been removed. Pick an appropriate variant like 'pinentry-curses' or 'pinentry-gnome3'"; # Converted to throw 2025-10-26
   pingvin-share = throw "'pingvin-share' has been removed as it was broken and archived upstream"; # Added 2025-11-08
   piper-train = throw "piper-train is now part of the piper package using the `withTrain` override"; # Added 2025-09-03
+  pkgsx86_64Darwin = throw "pkgsx86_64Darwin has been removed, as support for the platform has been dropped; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.11"; # Added 2026-??-??
   plant-it = throw "plant-it backend was discontinued in september 2025"; # Added 2026-01-30
   plant-it-frontend = throw "plant-it-frontend has been presented as being Android-only since the server-side was discontinued in september 2025"; # Added 2026-01-30
   plasma-applet-volumewin7mixer = throw "'plasma-applet-volumewin7mixer' has been removed, as it is only compatible with Plasma 5, which is EOL"; # Added 2025-08-20

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1793,6 +1793,7 @@ mapAliases {
   pingvin-share = throw "'pingvin-share' has been removed as it was broken and archived upstream"; # Added 2025-11-08
   pipecontrol = throw "'pipecontrol' has been removed due to outdated KF5 dependencies."; # Added 2026-05-01
   piper-train = throw "piper-train is now part of the piper package using the `withTrain` override"; # Added 2025-09-03
+  pkgsx86_64Darwin = throw "pkgsx86_64Darwin has been removed, as support for the platform has been dropped; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.11"; # Added 2026-06-21
   plandex = throw "plandex has been removed, as it is not maintained anymore"; # Added 2026-05-18
   plandex-server = throw "plandex has been removed, as it is not maintained anymore"; # Added 2026-05-18
   plant-it = throw "plant-it backend was discontinued in september 2025"; # Added 2026-01-30

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -440,18 +440,18 @@ let
     };
 
     allowDeprecatedx86_64Darwin = mkOption {
-      # `force` does nothing; it’s reserved for forward compatibility
-      # with 26.11. We hide it from the documentation to avoid a
-      # footgun, as it will make the error in 26.11 less useful.
-      type = types.either types.bool (types.enum [ "force" ]) // {
-        inherit (types.bool) description descriptionClass;
-      };
+      # `true` does nothing; it silenced the warning in 26.05.
+      type = types.either types.bool (types.enum [ "force" ]);
       default = false;
       description = ''
-        Silence the warning for the upcoming deprecation of the
-        `x86_64-darwin` platform in Nixpkgs 26.11.
+        Set to `"force"` to allow evaluating for the `x86_64-darwin`
+        platform despite its deprecation in Nixpkgs 26.11.
 
-        See the [release notes](#x86_64-darwin-26.05) for more
+        This is not expected to function, and Hydra will not build
+        binaries for the platform. It is provided only as an escape
+        hatch for custom setups, and comes with no support.
+
+        See the [release notes](#x86_64-darwin-26.11) for more
         information.
       '';
     };

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -454,18 +454,18 @@ let
     };
 
     allowDeprecatedx86_64Darwin = mkOption {
-      # `force` does nothing; it’s reserved for forward compatibility
-      # with 26.11. We hide it from the documentation to avoid a
-      # footgun, as it will make the error in 26.11 less useful.
-      type = types.either types.bool (types.enum [ "force" ]) // {
-        inherit (types.bool) description descriptionClass;
-      };
+      # `true` does nothing; it silenced the warning in 26.05.
+      type = types.either types.bool (types.enum [ "force" ]);
       default = false;
       description = ''
-        Silence the warning for the upcoming deprecation of the
-        `x86_64-darwin` platform in Nixpkgs 26.11.
+        Set to `"force"` to allow evaluating for the `x86_64-darwin`
+        platform despite its deprecation in Nixpkgs 26.11.
 
-        See the [release notes](#x86_64-darwin-26.05) for more
+        This is not expected to function, and Hydra will not build
+        binaries for the platform. It is provided only as an escape
+        hatch for custom setups, and comes with no support.
+
+        See the [release notes](#x86_64-darwin-26.11) for more
         information.
       '';
     };

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -18,25 +18,6 @@
   or dot-files.
 */
 
-let
-  # We hoist this above the closure so that the same thunk is shared
-  # between multiple imports of Nixpkgs. This ensures that commands
-  # like `nix eval nixpkgs#legacyPackages.x86_64-darwin.pkgsStatic.hello`
-  # print only one warning, which would otherwise be spammy in common
-  # scenarios that instantiate many copies of Nixpkgs.
-  #
-  # Unfortunately, flakes’ handling of transitive dependencies mean
-  # that it’s still likely users will see multiple warnings, but
-  # there’s nothing we can do about that within the constraints of the
-  # Nix language.
-  x86_64DarwinDeprecationWarning =
-    pristineLib.warn
-      "Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05"
-      (x: x);
-
-  pristineLib = import ../../lib;
-in
-
 {
   # The system packages will be built on. See the manual for the
   # subtle division of labor between these two `*System`s and the three
@@ -74,6 +55,8 @@ let # Rename the function arguments
 
 in
 let
+  pristineLib = import ../../lib;
+
   lib =
     if __allowFileset then
       pristineLib
@@ -93,7 +76,33 @@ let
         }
       );
 
-  inherit (lib) throwIfNot;
+  inherit (lib) throwIfNot throwIf;
+
+  x86_64DarwinDeprecationMessage = ''
+    Nixpkgs 26.11 has dropped support for x86_64-darwin.
+
+    The 26.05 stable branch still supports x86_64-darwin, and will
+    receive security fixes until the end of 2026. If you use channels,
+    you can switch to 26.05 as follows:
+
+        $ sudo nix-channel --add https://nixos.org/channels/nixpkgs-26.05-darwin nixpkgs
+        $ sudo nix-channel --update
+
+    If this doesn’t work, you may need to run:
+
+        # Lack of sudo is deliberate:
+        $ nix-channel --remove nixpkgs
+
+    If you use flakes, switch your flake input:
+
+        inputs.nixpkgs = {
+          url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
+        };
+
+    See the release notes for more information and alternatives:
+
+      https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.11
+  '';
 
   checked =
     (throwIfNot (lib.isList overlays) "The overlays argument to nixpkgs must be a list.")
@@ -101,15 +110,10 @@ let
       (throwIfNot (lib.isList crossOverlays) "The crossOverlays argument to nixpkgs must be a list.")
       (throwIfNot (lib.all lib.isFunction crossOverlays) "All crossOverlays passed to nixpkgs must be functions.")
       (
-        if
-          (
-            ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
-            && config.allowDeprecatedx86_64Darwin == false
-          )
-        then
-          x86_64DarwinDeprecationWarning
-        else
-          x: x
+        throwIf (
+          ((localSystem.isDarwin && localSystem.isx86) || (crossSystem.isDarwin && crossSystem.isx86))
+          && config.allowDeprecatedx86_64Darwin != "force"
+        ) x86_64DarwinDeprecationMessage
       );
 
   localSystem = lib.systems.elaborate args.localSystem;

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -68,7 +68,6 @@ let
       pkgs_aarch64_darwin = packageSet' { system = "aarch64-darwin"; };
       pkgs_armv6l_linux = packageSet' { system = "armv6l-linux"; };
       pkgs_armv7l_linux = packageSet' { system = "armv7l-linux"; };
-      pkgs_x86_64_darwin = packageSet' { system = "x86_64-darwin"; };
       pkgs_x86_64_freebsd = packageSet' { system = "x86_64-freebsd"; };
       pkgs_i686_freebsd = packageSet' { system = "i686-freebsd"; };
       pkgs_i686_cygwin = packageSet' { system = "i686-cygwin"; };
@@ -90,8 +89,6 @@ let
       pkgs_armv6l_linux
     else if system == "armv7l-linux" then
       pkgs_armv7l_linux
-    else if system == "x86_64-darwin" then
-      pkgs_x86_64_darwin
     else if system == "x86_64-freebsd" then
       pkgs_x86_64_freebsd
     else if system == "i686-freebsd" then

--- a/pkgs/top-level/release-lib.nix
+++ b/pkgs/top-level/release-lib.nix
@@ -65,7 +65,6 @@ let
       pkgs_aarch64_darwin = packageSet' { system = "aarch64-darwin"; };
       pkgs_armv6l_linux = packageSet' { system = "armv6l-linux"; };
       pkgs_armv7l_linux = packageSet' { system = "armv7l-linux"; };
-      pkgs_x86_64_darwin = packageSet' { system = "x86_64-darwin"; };
       pkgs_x86_64_freebsd = packageSet' { system = "x86_64-freebsd"; };
       pkgs_i686_freebsd = packageSet' { system = "i686-freebsd"; };
       pkgs_i686_cygwin = packageSet' { system = "i686-cygwin"; };
@@ -87,8 +86,6 @@ let
       pkgs_armv6l_linux
     else if system == "armv7l-linux" then
       pkgs_armv7l_linux
-    else if system == "x86_64-darwin" then
-      pkgs_x86_64_darwin
     else if system == "x86_64-freebsd" then
       pkgs_x86_64_freebsd
     else if system == "i686-freebsd" then

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -91,28 +91,6 @@ self: super: {
     else
       throw "Musl libc only supports 64-bit Linux systems, and i686-linux.";
 
-  # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
-  pkgsx86_64Darwin =
-    if stdenv.hostPlatform.isDarwin then
-      nixpkgsFun {
-        overlays = [
-          (self': super': {
-            pkgsx86_64Darwin = super';
-          })
-        ]
-        ++ overlays;
-        localSystem = {
-          config = lib.systems.parse.tripleFromSystem (
-            stdenv.hostPlatform.parsed
-            // {
-              cpu = lib.systems.parse.cpuTypes.x86_64;
-            }
-          );
-        };
-      }
-    else
-      throw "x86_64 Darwin package set can only be used on Darwin systems.";
-
   # Full package set with rocm on cuda off
   # Mostly useful for asserting pkgs.pkgsRocm.torchWithRocm == pkgs.torchWithRocm and similar
   pkgsRocm = nixpkgsFun {

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -81,28 +81,6 @@ self: super: {
     else
       throw "Musl libc only supports 64-bit Linux systems, and i686-linux.";
 
-  # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
-  pkgsx86_64Darwin =
-    if stdenv.hostPlatform.isDarwin then
-      nixpkgsFun {
-        overlays = [
-          (self': super': {
-            pkgsx86_64Darwin = super';
-          })
-        ]
-        ++ overlays;
-        localSystem = {
-          config = lib.systems.parse.tripleFromSystem (
-            stdenv.hostPlatform.parsed
-            // {
-              cpu = lib.systems.parse.cpuTypes.x86_64;
-            }
-          );
-        };
-      }
-    else
-      throw "x86_64 Darwin package set can only be used on Darwin systems.";
-
   # Full package set with rocm on cuda off
   # Mostly useful for asserting pkgs.pkgsRocm.torchWithRocm == pkgs.torchWithRocm and similar
   pkgsRocm = nixpkgsFun {


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/492160; these are the first commits that would require the CI changes to be merged first.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test