### PR TITLE
treewide: move CGO_* env vars into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/av/avalanche-cli/package.nix
+++ b/pkgs/by-name/av/avalanche-cli/package.nix
@@ -26,10 +26,12 @@ buildGoModule (finalAttrs: {
   proxyVendor = true;
   vendorHash = "sha256-0+YwlCHjiU46y333RSuaha4pLKFTYlj+M9+TFAALamY=";
 
-  # Fix error: 'Caught SIGILL in blst_cgo_init'
-  # https://github.com/bnb-chain/bsc/issues/1521
-  CGO_CFLAGS = "-O -D__BLST_PORTABLE__";
-  CGO_CFLAGS_ALLOW = "-O -D__BLST_PORTABLE__";
+  env = {
+    # Fix error: 'Caught SIGILL in blst_cgo_init'
+    # https://github.com/bnb-chain/bsc/issues/1521
+    CGO_CFLAGS = "-O -D__BLST_PORTABLE__";
+    CGO_CFLAGS_ALLOW = "-O -D__BLST_PORTABLE__";
+  };
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/bl/blockbook/package.nix
+++ b/pkgs/by-name/bl/blockbook/package.nix
@@ -49,7 +49,7 @@ buildGoModule rec {
     "-X github.com/trezor/blockbook/common.buildDate=unknown"
   ];
 
-  CGO_LDFLAGS = [
+  env.CGO_LDFLAGS = toString [
     "-L${lib.getLib stdenv.cc.cc}/lib"
     "-lrocksdb"
     "-lz"

--- a/pkgs/by-name/co/coroot-node-agent/package.nix
+++ b/pkgs/by-name/co/coroot-node-agent/package.nix
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
 
   buildInputs = [ systemdLibs ];
 
-  CGO_CFLAGS = "-I ${systemdLibs}/include";
+  env.CGO_CFLAGS = "-I ${systemdLibs}/include";
 
   ldflags = [
     "-extldflags='-Wl,-z,lazy'"

--- a/pkgs/by-name/ec/ecapture/package.nix
+++ b/pkgs/by-name/ec/ecapture/package.nix
@@ -52,7 +52,11 @@ buildGoModule rec {
     glibc
   ];
 
-  CGO_LDFLAGS = "-lpcap -lpthread -static";
+  env.CGO_LDFLAGS = toString [
+    "-lpcap"
+    "-lpthread"
+    "-static"
+  ];
 
   ldflags = [
     "-extldflags '-static'"

--- a/pkgs/by-name/ex/exportarr/package.nix
+++ b/pkgs/by-name/ex/exportarr/package.nix
@@ -20,7 +20,7 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/exportarr" ];
 
-  CGO_ENABLE = 0;
+  env.CGO_ENABLE = 0;
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/in/incus/generic.nix
+++ b/pkgs/by-name/in/incus/generic.nix
@@ -109,7 +109,7 @@ buildGoModule (finalAttrs: {
   tags = [ "libsqlite3" ];
 
   # required for go-cowsql.
-  CGO_LDFLAGS_ALLOW = "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)";
+  env.CGO_LDFLAGS_ALLOW = "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)";
 
   # add our lxc location to incus's acceptable rootFsPaths
   # this is necessary for tmpfs/tmpfs-overlay to work

--- a/pkgs/by-name/ma/mautrix-signal/package.nix
+++ b/pkgs/by-name/ma/mautrix-signal/package.nix
@@ -42,7 +42,9 @@ buildGoModule rec {
 
   tags = lib.optional withGoolm "goolm";
 
-  CGO_LDFLAGS = lib.optional withGoolm [ cppStdLib ];
+  env = lib.optionalAttrs withGoolm {
+    CGO_LDFLAGS = toString [ cppStdLib ];
+  };
 
   vendorHash = "sha256-TFz5P8czj8J9+QTFHjffCldw8Je2+DiM49W7jv5rY/I=";
 

--- a/pkgs/by-name/na/navidrome/package.nix
+++ b/pkgs/by-name/na/navidrome/package.nix
@@ -64,7 +64,9 @@ buildGoModule (finalAttrs: {
     "-X github.com/navidrome/navidrome/consts.gitTag=v${finalAttrs.version}"
   ];
 
-  CGO_CFLAGS = lib.optionals stdenv.cc.isGNU [ "-Wno-return-local-addr" ];
+  env = lib.optionalAttrs stdenv.cc.isGNU {
+    CGO_CFLAGS = toString [ "-Wno-return-local-addr" ];
+  };
 
   postPatch = ''
     patchShebangs ui/bin/update-workbox.sh

--- a/pkgs/by-name/ne/netcap/package.nix
+++ b/pkgs/by-name/ne/netcap/package.nix
@@ -40,22 +40,27 @@ buildGoModule (finalAttrs: {
   ];
 
   ldflags = [
-    "-s -w"
+    "-s"
+    "-w"
   ];
 
   tags = lib.optionals (!withDpi) [
     "nodpi"
   ];
 
-  CGO_LDFLAGS = lib.optionalString withDpi ''
-    -L${ndpi}/lib -lndpi
-    -L${libprotoident}/lib -lndpi
-  '';
+  env = lib.optionalAttrs withDpi {
+    CGO_LDFLAGS = toString [
+      "-L${ndpi}/lib"
+      "-lndpi"
+      "-L${libprotoident}/lib"
+      "-lndpi"
+    ];
 
-  CGO_CFLAGS = lib.optionalString withDpi ''
-    -I${ndpi}/include
-    -I${libprotoident}/include
-  '';
+    CGO_CFLAGS = toString [
+      "-I${ndpi}/include"
+      "-I${libprotoident}/include"
+    ];
+  };
 
   postInstall = ''
     mv $out/bin/cmd $out/bin/net

--- a/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-dcgm-exporter/package.nix
@@ -19,7 +19,7 @@ buildGoModule rec {
     hash = "sha256-NafQWP1NxHTwmOND8ovy3oVia7qq0rCwZYE3VNlMBKQ=";
   };
 
-  CGO_LDFLAGS = "-ldcgm";
+  env.CGO_LDFLAGS = "-ldcgm";
 
   buildInputs = [
     dcgm

--- a/pkgs/by-name/pr/prometheus-ebpf-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-ebpf-exporter/package.nix
@@ -38,7 +38,7 @@ buildGoModule.override { stdenv = clangStdenv; } (finalAttrs: {
     libz
   ];
 
-  CGO_LDFLAGS = "-l bpf";
+  env.CGO_LDFLAGS = "-l bpf";
 
   hardeningDisable = [ "zerocallusedregs" ];
 

--- a/pkgs/by-name/st/step-kms-plugin/package.nix
+++ b/pkgs/by-name/st/step-kms-plugin/package.nix
@@ -42,7 +42,7 @@ buildGoModule rec {
     "-X github.com/smallstep/step-kms-plugin/cmd.Version=${version}"
   ];
 
-  CGO_CFLAGS = "-I${lib.getDev pcsclite}/include/PCSC/";
+  env.CGO_CFLAGS = "-I${lib.getDev pcsclite}/include/PCSC/";
 
   meta = {
     description = "Step plugin to manage keys and certificates on cloud KMSs and HSMs";

--- a/pkgs/by-name/tb/tbls/package.nix
+++ b/pkgs/by-name/tb/tbls/package.nix
@@ -32,7 +32,7 @@ buildGoModule (finalAttrs: {
     "-w"
   ];
 
-  CGO_CFLAGS = [ "-Wno-format-security" ];
+  env.CGO_CFLAGS = toString [ "-Wno-format-security" ];
 
   preCheck = ''
     # Remove tests that require additional services.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
