### PR TITLE
Freeipa subUID and subGID

### DIFF
--- a/doc/release-notes/rl-2605.section.md
+++ b/doc/release-notes/rl-2605.section.md
@@ -187,8 +187,6 @@
 - `openrgb` was updated to 1.0rc2, which now uses Plugin API version 4.
   Some existing OpenRGB plugins may be incompatible or require updates.
 
-- the `neovim` wrapper sets provider-related configuration in its generated config rather than as wrapper arguments. It should not affect configuration unless you set `wrapRc` to false.
-
 - We now use the upstream wrapper script for Gradle, supporting both the `JAVA_HOME` and `GRADLE_OPTS` environment variables.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-26.05-lib}

--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -97,6 +97,30 @@
         '';
         default = [ ];
       };
+
+      subuid = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          List of subuid entries to configure in {file}`/etc/nsswitch.conf`.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [ ];
+      };
+
+      subgid = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          List of subgid entries to configure in {file}`/etc/nsswitch.conf`.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [ ];
+      };
     };
   };
 
@@ -133,6 +157,9 @@
       services:  ${lib.concatStringsSep " " config.system.nssDatabases.services}
       protocols: files
       rpc:       files
+
+      subuid:    ${lib.concatStringsSep " " config.system.nssDatabases.subuid}
+      subgid:    ${lib.concatStringsSep " " config.system.nssDatabases.subgid}
     '';
 
     system.nssDatabases = {
@@ -145,6 +172,8 @@
         (lib.mkOrder 1499 [ "dns" ])
       ];
       services = lib.mkBefore [ "files" ];
+      subuid = lib.mkBefore [ "files" ];
+      subgid = lib.mkBefore [ "files" ];
     };
   };
 }

--- a/nixos/modules/security/ipa.nix
+++ b/nixos/modules/security/ipa.nix
@@ -307,6 +307,7 @@ in
           allowed_uids = lib.concatStringsSep ", " cfg.ifpAllowedUids;
         };
       };
+      subIDsIntegration = true;
     };
 
     networking.timeServers = lib.optional cfg.useAsTimeserver cfg.server;

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -93,6 +93,15 @@ in
           Kerberos will be configured to cache credentials in SSS.
         '';
       };
+
+      subIDsIntegration = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to use SSS as a source for subuid and subgid.
+        '';
+      };
+
       environmentFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
@@ -245,6 +254,11 @@ in
       };
       services.openssh.authorizedKeysCommand = "/etc/ssh/authorized_keys_command";
       services.openssh.authorizedKeysCommandUser = "nobody";
+    })
+
+    (lib.mkIf cfg.subIDsIntegration {
+      system.nssDatabases.subuid = [ "sss" ];
+      system.nssDatabases.subgid = [ "sss" ];
     })
   ];
 

--- a/pkgs/by-name/au/authentik/client-go-config.patch
+++ b/pkgs/by-name/au/authentik/client-go-config.patch
@@ -1,0 +1,9 @@
+diff --git a/config.yaml b/config.yaml
+index 2f07ea7..0f90432 100644
+--- a/config.yaml
++++ b/config.yaml
+@@ -4,3 +4,4 @@ additionalProperties:
+   packageName: api
+   enumClassPrefix: true
+   useOneOfDiscriminatorLookup: true
++  disallowAdditionalPropertiesIfNotPresent: false

--- a/pkgs/by-name/au/authentik/ldap.nix
+++ b/pkgs/by-name/au/authentik/ldap.nix
@@ -1,6 +1,7 @@
 {
   buildGoModule,
   authentik,
+  apiGoVendorHook,
   vendorHash,
 }:
 
@@ -8,6 +9,8 @@ buildGoModule {
   pname = "authentik-ldap-outpost";
   inherit (authentik) version src;
   inherit vendorHash;
+
+  nativeBuildInputs = [ apiGoVendorHook ];
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/au/authentik/outposts.nix
+++ b/pkgs/by-name/au/authentik/outposts.nix
@@ -1,10 +1,11 @@
 {
   callPackage,
   authentik,
+  apiGoVendorHook ? authentik.apiGoVendorHook,
   vendorHash ? authentik.proxy.vendorHash,
 }:
 {
-  ldap = callPackage ./ldap.nix { inherit vendorHash; };
-  proxy = callPackage ./proxy.nix { inherit vendorHash; };
-  radius = callPackage ./radius.nix { inherit vendorHash; };
+  ldap = callPackage ./ldap.nix { inherit apiGoVendorHook vendorHash; };
+  proxy = callPackage ./proxy.nix { inherit apiGoVendorHook vendorHash; };
+  radius = callPackage ./radius.nix { inherit apiGoVendorHook vendorHash; };
 }

--- a/pkgs/by-name/au/authentik/proxy.nix
+++ b/pkgs/by-name/au/authentik/proxy.nix
@@ -1,6 +1,7 @@
 {
   buildGoModule,
   authentik,
+  apiGoVendorHook,
   vendorHash,
 }:
 
@@ -8,6 +9,8 @@ buildGoModule {
   pname = "authentik-proxy-outpost";
   inherit (authentik) version src;
   inherit vendorHash;
+
+  nativeBuildInputs = [ apiGoVendorHook ];
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/au/authentik/radius.nix
+++ b/pkgs/by-name/au/authentik/radius.nix
@@ -1,6 +1,7 @@
 {
   buildGoModule,
   authentik,
+  apiGoVendorHook,
   vendorHash,
 }:
 
@@ -8,6 +9,8 @@ buildGoModule {
   pname = "authentik-radius-outpost";
   inherit (authentik) version src;
   inherit vendorHash;
+
+  nativeBuildInputs = [ apiGoVendorHook ];
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/cl/cljfmt/package.nix
+++ b/pkgs/by-name/cl/cljfmt/package.nix
@@ -8,11 +8,11 @@
 
 buildGraalvmNativeImage (finalAttrs: {
   pname = "cljfmt";
-  version = "0.15.6";
+  version = "0.16.0";
 
   src = fetchurl {
     url = "https://github.com/weavejester/cljfmt/releases/download/${finalAttrs.version}/cljfmt-${finalAttrs.version}-standalone.jar";
-    hash = "sha256-/ihm/b/B9cSay2Zgshie7D0KwaKuIjiNI5FOnWOHfOw=";
+    hash = "sha256-56llKSnJJzjv9mf33ir7b3gk8Jp+jxyuax6vEXj0xDk=";
   };
 
   extraNativeImageBuildArgs = [

--- a/pkgs/by-name/fl/floorp-bin-unwrapped/sources.json
+++ b/pkgs/by-name/fl/floorp-bin-unwrapped/sources.json
@@ -1,21 +1,21 @@
 {
-  "version": "12.10.3",
+  "version": "12.10.4",
   "sources": {
     "aarch64-linux": {
-      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.3/floorp-linux-aarch64.tar.xz",
-      "sha256": "b2f62db7941f819375a9f8627bd55442c30310e93cb270621fdf9e5c707801e3"
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.4/floorp-linux-aarch64.tar.xz",
+      "sha256": "6fb5030be0209744dd9aac0fa5645c45a21d135d4e487836a300359a695327e5"
     },
     "x86_64-linux": {
-      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.3/floorp-linux-x86_64.tar.xz",
-      "sha256": "fb866cd00da594c5c6435238e32ac2c13eaca40ead4936656aee88ea3446983f"
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.4/floorp-linux-x86_64.tar.xz",
+      "sha256": "1cc457b0b23d29d863749a9a4f000b47fa480aa0579774bb39eff5978160df21"
     },
     "aarch64-darwin": {
-      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.3/floorp-macOS-universal.dmg",
-      "sha256": "56477ebaae97aee37c0a93294f8770ae901bf2e35d2be03540daf0a779db6dae"
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.4/floorp-macOS-universal.dmg",
+      "sha256": "1fa4e85c9aa58d989f0aa01389c0b3a5f231ad08485606427498777daba81398"
     },
     "x86_64-darwin": {
-      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.3/floorp-macOS-universal.dmg",
-      "sha256": "56477ebaae97aee37c0a93294f8770ae901bf2e35d2be03540daf0a779db6dae"
+      "url": "https://github.com/Floorp-Projects/Floorp/releases/download/v12.10.4/floorp-macOS-universal.dmg",
+      "sha256": "1fa4e85c9aa58d989f0aa01389c0b3a5f231ad08485606427498777daba81398"
     }
   }
 }

--- a/pkgs/by-name/ni/nirius/package.nix
+++ b/pkgs/by-name/ni/nirius/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nirius";
-  version = "0.6.1";
+  version = "0.7.0";
 
   src = fetchFromSourcehut {
     owner = "~tsdh";
     repo = "nirius";
     rev = "nirius-${finalAttrs.version}";
-    hash = "sha256-KAh45AcNB9Y4ahxamtI6/z3l1xg6yf17h4rnZl3w89I=";
+    hash = "sha256-e/3FOlA29u214gs8Y4Tvk+XJUhT5Bn4GLrptbqrDRw8=";
   };
 
-  cargoHash = "sha256-p123QvlB/j0b5kFjICcTI/5ZKL8pzGfIvH80doAhqFA=";
+  cargoHash = "sha256-4tdPm4+ykEjGeYpQxR3M8Zh84VMDkkQXAaWlehunZ8c=";
 
   meta = {
     description = "Utility commands for the niri wayland compositor";

--- a/pkgs/development/python-modules/iamdata/default.nix
+++ b/pkgs/development/python-modules/iamdata/default.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "iamdata";
-  version = "0.1.202602181";
+  version = "0.1.202602191";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cloud-copilot";
     repo = "iam-data-python";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6HLwpTFTqS3T6VQ9jwr7+wVv8ARLDbh9a/68txWMvJU=";
+    hash = "sha256-yvfJith7JfwO6lO57K3y98vqGHkEiEzmfM0WAktufck=";
   };
 
   __darwinAllowLocalNetworking = true;


### PR DESCRIPTION
Enabled support for getting subUID and subGID from FreeIPA to support things like rootless podman.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
