### PR TITLE
treewide: move CFLAGS into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/bf/bftpd/package.nix
+++ b/pkgs/by-name/bf/bftpd/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libxcrypt ];
 
-  CFLAGS = "-std=gnu89";
+  env.CFLAGS = "-std=gnu89";
 
   preConfigure = ''
     sed -re 's/-[og] 0//g' -i Makefile*

--- a/pkgs/by-name/bu/bumblebee/package.nix
+++ b/pkgs/by-name/bu/bumblebee/package.nix
@@ -166,7 +166,7 @@ stdenv.mkDerivation rec {
     "CONF_MODPATH_NVIDIA=${nvidia_x11.bin}/lib/xorg/modules"
   ];
 
-  CFLAGS = [
+  env.CFLAGS = toString [
     "-DX_MODULE_APPENDS=\\\"${xmodules}\\\""
   ];
 

--- a/pkgs/by-name/cp/cpp-redis/package.nix
+++ b/pkgs/by-name/cp/cpp-redis/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     cmake
     pkg-config
   ];
-  CFLAGS = "-D_GLIBCXX_USE_NANOSLEEP";
+  env.CFLAGS = "-D_GLIBCXX_USE_NANOSLEEP";
   patches = [
     ./01-fix-sleep_for.patch
   ];

--- a/pkgs/by-name/cu/curlftpfs/package.nix
+++ b/pkgs/by-name/cu/curlftpfs/package.nix
@@ -39,7 +39,9 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  CFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-D__off_t=off_t";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CFLAGS = "-D__off_t=off_t";
+  };
 
   postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
     # Fix the build on macOS with macFUSE installed. Needs autoreconfHook for

--- a/pkgs/by-name/de/deadpixi-sam-unstable/package.nix
+++ b/pkgs/by-name/de/deadpixi-sam-unstable/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
       --replace "RXPATH=/usr/bin/ssh" "RXPATH=ssh"
   '';
 
-  CFLAGS = "-D_DARWIN_C_SOURCE";
+  env.CFLAGS = "-D_DARWIN_C_SOURCE";
   makeFlags = [ "DESTDIR=$(out)" ];
   buildInputs = [
     libx11

--- a/pkgs/by-name/dr/dropbear/package.nix
+++ b/pkgs/by-name/dr/dropbear/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-DR98pxHPwzbcioXmcsq5z9giOgL+LaCkp661jJ4RNjQ=";
   };
 
-  CFLAGS = lib.pipe (lib.attrNames dflags) [
+  env.CFLAGS = lib.pipe (lib.attrNames dflags) [
     (map (name: "-D${name}=\\\"${dflags.${name}}\\\""))
     (lib.concatStringsSep " ")
   ];

--- a/pkgs/by-name/du/dumpasn1/package.nix
+++ b/pkgs/by-name/du/dumpasn1/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-r40czSLdjCYbt73zK7exCoP/kMq6+pyJfz9LKJLLaXM=";
   };
 
-  CFLAGS = ''-DDUMPASN1_CONFIG_PATH='"$(out)/etc/"' '';
+  env.CFLAGS = ''-DDUMPASN1_CONFIG_PATH='"$(out)/etc/"' '';
 
   makeFlags = [ "prefix=$(out)" ];
 

--- a/pkgs/by-name/ef/eflite/package.nix
+++ b/pkgs/by-name/ef/eflite/package.nix
@@ -44,7 +44,9 @@ stdenv.mkDerivation (finalAttrs: {
     ./format.patch
   ];
 
-  CFLAGS = lib.optionalString debug " -DDEBUG=2";
+  env = lib.optionalAttrs debug {
+    CFLAGS = " -DDEBUG=2";
+  };
 
   meta = {
     homepage = "https://eflite.sourceforge.net";

--- a/pkgs/by-name/ex/exifprobe/package.nix
+++ b/pkgs/by-name/ex/exifprobe/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     sha256 = "1c1fhc0v1m452lgnfcijnvrc0by06qfbhn3zkliqi60kv8l2isbp";
   };
 
-  CFLAGS = [ "-O2" ];
+  env.CFLAGS = toString [ "-O2" ];
 
   installFlags = [ "DESTDIR=$(out)" ];
 

--- a/pkgs/by-name/fc/fcrackzip/package.nix
+++ b/pkgs/by-name/fc/fcrackzip/package.nix
@@ -12,7 +12,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "0l1qsk949vnz18k4vjf3ppq8p497966x4c7f2yx18x8pk35whn2a";
   };
 
-  CFLAGS = "-std=gnu89";
+  env.CFLAGS = "-std=gnu89";
 
   # 'fcrackzip --use-unzip' cannot deal with file names containing a single quote
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=430387

--- a/pkgs/by-name/fm/fmi-reference-fmus/package.nix
+++ b/pkgs/by-name/fm/fmi-reference-fmus/package.nix
@@ -31,7 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-DFMI_VERSION=${toString FMIVersion}"
     (lib.cmakeBool "WITH_FMUSIM" false)
   ];
-  CFLAGS = lib.optionalString (FMIVersion == 3) "-Wno-stringop-truncation";
+
+  env = lib.optionalAttrs (FMIVersion == 3) {
+    CFLAGS = "-Wno-stringop-truncation";
+  };
 
   meta = {
     # CMakeLists.txt explicitly states support for aarch64-darwin, but

--- a/pkgs/by-name/fo/foot/package.nix
+++ b/pkgs/by-name/fo/foot/package.nix
@@ -138,7 +138,7 @@ stdenv.mkDerivation {
 
   # recommended build flags for performance optimized foot builds
   # https://codeberg.org/dnkl/foot/src/branch/master/INSTALL.md#release-build
-  CFLAGS = if !doPgo then "-O3" else pgoCflags;
+  env.CFLAGS = if !doPgo then "-O3" else pgoCflags;
 
   # ar with gcc plugins for lto objects
   preConfigure = ''

--- a/pkgs/by-name/gn/gnome-network-displays/package.nix
+++ b/pkgs/by-name/gn/gnome-network-displays/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
     Hence, this is not necessarily an upstream issue, but could be something
     wrong with how our gst_all_1 depend on each other.
   */
-  CFLAGS = "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0";
+  env.CFLAGS = "-I${gst_all_1.gst-plugins-base.dev}/include/gstreamer-1.0";
 
   preConfigure = ''
     patchShebangs ./build-aux/meson/postinstall.py

--- a/pkgs/by-name/gt/gtypist/package.nix
+++ b/pkgs/by-name/gt/gtypist/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ymGAVOkfHtXvBD/MQ1ALutcByVnDGETUaI/yKEmsJS0=";
   };
 
-  CFLAGS = "-std=gnu99";
+  env.CFLAGS = "-std=gnu99";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/by-name/kn/knot-dns/package.nix
+++ b/pkgs/by-name/kn/knot-dns/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation (finalAttrs: {
   enableParallelBuilding = true;
   strictDeps = true;
 
-  CFLAGS = [
+  env.CFLAGS = toString [
     "-O2"
     "-DNDEBUG"
   ];

--- a/pkgs/by-name/le/lepton-eda/package.nix
+++ b/pkgs/by-name/le/lepton-eda/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     "--with-gtk3"
   ];
 
-  CFLAGS = [
+  env.CFLAGS = toString [
     "-DSCM_DEBUG_TYPING_STRICTNESS=2"
   ];
 

--- a/pkgs/by-name/li/libnixxml/package.nix
+++ b/pkgs/by-name/li/libnixxml/package.nix
@@ -45,7 +45,8 @@ stdenv.mkDerivation {
     "--with-gd"
     "--with-glib"
   ];
-  CFLAGS = [
+
+  env.CFLAGS = toString [
     "-Wall"
     "-std=c90"
   ];

--- a/pkgs/by-name/li/libspf2/package.nix
+++ b/pkgs/by-name/li/libspf2/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
       -e '/bin_PROGRAMS/s/spf_example_static//' src/spf_example/Makefile.am
   '';
 
-  CFLAGS = "-Wno-error=implicit-function-declaration";
+  env.CFLAGS = "-Wno-error=implicit-function-declaration";
 
   doCheck = true;
 

--- a/pkgs/by-name/li/libxmi/package.nix
+++ b/pkgs/by-name/li/libxmi/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "03d4ikh29l38rl1wavb0icw7m5pp7yilnv7bb2k8qij1dinsymlx";
   };
 
-  CFLAGS = "-std=gnu89";
+  env.CFLAGS = "-std=gnu89";
 
   # For the x86_64 GNU/Linux arch to be recognized by 'configure'
   preConfigure = "cp ${libtool}/share/libtool/build-aux/config.sub .";

--- a/pkgs/by-name/na/nasty/package.nix
+++ b/pkgs/by-name/na/nasty/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # does not apply cleanly with patchPhase/fetchpatch
   # https://sources.debian.net/src/nasty/0.6-3/debian/patches/02_add_largefile_support.patch
-  CFLAGS = "-D_FILE_OFFSET_BITS=64";
+  env.CFLAGS = "-D_FILE_OFFSET_BITS=64";
 
   buildInputs = [ gpgme ];
 

--- a/pkgs/by-name/pr/pragha/package.nix
+++ b/pkgs/by-name/pr/pragha/package.nix
@@ -103,9 +103,10 @@ stdenv.mkDerivation (finalAttrs: {
   # ++ lib.optional withRygel rygel
   ;
 
-  CFLAGS = [ "-DHAVE_PARANOIA_NEW_INCLUDES" ];
-
-  env.NIX_CFLAGS_COMPILE = "-I${lib.getDev gst_all_1.gst-plugins-base}/include/gstreamer-1.0";
+  env = {
+    CFLAGS = toString [ "-DHAVE_PARANOIA_NEW_INCLUDES" ];
+    NIX_CFLAGS_COMPILE = "-I${lib.getDev gst_all_1.gst-plugins-base}/include/gstreamer-1.0";
+  };
 
   postInstall = ''
     qtWrapperArgs+=(--prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "$GST_PLUGIN_SYSTEM_PATH_1_0")

--- a/pkgs/by-name/qb/qbootctl/package.nix
+++ b/pkgs/by-name/qb/qbootctl/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
     linuxHeaders
   ];
 
-  CFLAGS = [ "-I${linuxHeaders}/include" ];
+  env.CFLAGS = toString [ "-I${linuxHeaders}/include" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/st/stp/package.nix
+++ b/pkgs/by-name/st/stp/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation (finalAttrs: {
   #
   # TODO: Remove these CFLAGS when they update to the version that pulls `abc` in with a submodule.
   # https://github.com/stp/stp/issues/498#issuecomment-2611251631
-  CFLAGS = [ "-fsigned-char" ];
+  env.CFLAGS = toString [ "-fsigned-char" ];
 
   outputs = [
     "dev"

--- a/pkgs/by-name/sy/symmetrica/package.nix
+++ b/pkgs/by-name/sy/symmetrica/package.nix
@@ -29,7 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   # clang warning: passing arguments to '...' without a prototype is deprecated
   # in all versions of C and is not supported in C23.
-  CFLAGS = "-std=c99 -Wno-deprecated-non-prototype";
+  env.CFLAGS = toString [
+    "-std=c99"
+    "-Wno-deprecated-non-prototype"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/sy/syncterm/package.nix
+++ b/pkgs/by-name/sy/syncterm/package.nix
@@ -24,16 +24,18 @@ stdenv.mkDerivation (finalAttrs: {
   # We can't use sourceRoot, as the cherry-picked patches apply to files outside of it.
   postPatch = "cd src/syncterm";
 
-  CFLAGS = [
-    "-DHAS_INTTYPES_H"
-    "-DXPDEV_DONT_DEFINE_INTTYPES"
+  env.CFLAGS = toString (
+    [
+      "-DHAS_INTTYPES_H"
+      "-DXPDEV_DONT_DEFINE_INTTYPES"
 
-    "-Wno-unused-result"
-    "-Wformat-overflow=0"
-  ]
-  ++ (lib.optionals stdenv.hostPlatform.isLinux [
-    "-DUSE_ALSA_SOUND" # Don't use OSS for beeps.
-  ]);
+      "-Wno-unused-result"
+      "-Wformat-overflow=0"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "-DUSE_ALSA_SOUND" # Don't use OSS for beeps.
+    ]
+  );
 
   makeFlags = [
     "PREFIX=$(out)"

--- a/pkgs/by-name/un/unixcw/package.nix
+++ b/pkgs/by-name/un/unixcw/package.nix
@@ -43,7 +43,10 @@ stdenv.mkDerivation (finalAttrs: {
     ncurses
   ];
 
-  CFLAGS = "-lasound -lpulse-simple";
+  env.CFLAGS = toString [
+    "-lasound"
+    "-lpulse-simple"
+  ];
 
   meta = {
     description = "Sound characters as Morse code on the soundcard or console speaker";

--- a/pkgs/tools/misc/dvtm/dvtm.nix
+++ b/pkgs/tools/misc/dvtm/dvtm.nix
@@ -17,7 +17,9 @@ stdenv.mkDerivation {
     patches
     ;
 
-  CFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-D_DARWIN_C_SOURCE";
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    CFLAGS = "-D_DARWIN_C_SOURCE";
+  };
 
   postPatch = lib.optionalString (customConfig != null) ''
     cp ${builtins.toFile "config.h" customConfig} ./config.h


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
