### PR TITLE
freeipa: Add support for subUIDs and subGIDs

### DIFF
--- a/nixos/modules/config/nsswitch.nix
+++ b/nixos/modules/config/nsswitch.nix
@@ -97,6 +97,30 @@
         '';
         default = [ ];
       };
+
+      subuid = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          List of subuid entries to configure in {file}`/etc/nsswitch.conf`.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [ ];
+      };
+
+      subgid = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        description = ''
+          List of subgid entries to configure in {file}`/etc/nsswitch.conf`.
+
+          Note that "files" is always prepended.
+
+          This option only takes effect if nscd is enabled.
+        '';
+        default = [ ];
+      };
     };
   };
 
@@ -133,6 +157,9 @@
       services:  ${lib.concatStringsSep " " config.system.nssDatabases.services}
       protocols: files
       rpc:       files
+
+      subuid:    ${lib.concatStringsSep " " config.system.nssDatabases.subuid}
+      subgid:    ${lib.concatStringsSep " " config.system.nssDatabases.subgid}
     '';
 
     system.nssDatabases = {
@@ -145,6 +172,8 @@
         (lib.mkOrder 1499 [ "dns" ])
       ];
       services = lib.mkBefore [ "files" ];
+      subuid = lib.mkBefore [ "files" ];
+      subgid = lib.mkBefore [ "files" ];
     };
   };
 }

--- a/nixos/modules/security/ipa.nix
+++ b/nixos/modules/security/ipa.nix
@@ -307,6 +307,7 @@ in
           allowed_uids = lib.concatStringsSep ", " cfg.ifpAllowedUids;
         };
       };
+      subIDsIntegration = true;
     };
 
     networking.timeServers = lib.optional cfg.useAsTimeserver cfg.server;

--- a/nixos/modules/services/misc/sssd.nix
+++ b/nixos/modules/services/misc/sssd.nix
@@ -93,6 +93,15 @@ in
           Kerberos will be configured to cache credentials in SSS.
         '';
       };
+
+      subIDsIntegration = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to use SSS as a source for subuid and subgid.
+        '';
+      };
+
       environmentFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
@@ -245,6 +254,11 @@ in
       };
       services.openssh.authorizedKeysCommand = "/etc/ssh/authorized_keys_command";
       services.openssh.authorizedKeysCommandUser = "nobody";
+    })
+
+    (lib.mkIf cfg.subIDsIntegration {
+      system.nssDatabases.subuid = [ "sss" ];
+      system.nssDatabases.subgid = [ "sss" ];
     })
   ];
 


### PR DESCRIPTION
Enabled support for getting subUID and subGID from FreeIPA to support things like rootless podman.

## Things done


- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
