### PR TITLE
subversion*: move env variables into env for structuredAttrs

### DIFF
--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -90,10 +90,18 @@ let
           rm subversion/bindings/swig/proxy/{perlrun.swg,pyrun.swg,python.swg,rubydef.swg,rubyhead.swg,rubytracking.swg,runtime.swg,swigrun.swg}
         '';
 
-        # We are hitting the following issue even with APR 1.6.x
-        # -> https://issues.apache.org/jira/browse/SVN-4813
-        # "-P" CPPFLAG is needed to build Python bindings and subversionClient
-        CPPFLAGS = [ "-P" ];
+        env = {
+          # We are hitting the following issue even with APR 1.6.x
+          # -> https://issues.apache.org/jira/browse/SVN-4813
+          # "-P" CPPFLAG is needed to build Python bindings and subversionClient
+          CPPFLAGS = toString [ "-P" ];
+        }
+        // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+          CXX = "clang++";
+          CC = "clang";
+          CPP = "clang -E";
+          CXXCPP = "clang++ -E";
+        };
 
         preConfigure = ''
           ./autogen.sh
@@ -167,13 +175,6 @@ let
           maintainers = with lib.maintainers; [ lovek323 ];
           platforms = lib.platforms.linux ++ lib.platforms.darwin;
         };
-
-      }
-      // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-        CXX = "clang++";
-        CC = "clang";
-        CPP = "clang -E";
-        CXXCPP = "clang++ -E";
       }
     );
 

--- a/pkgs/applications/version-management/subversion/default.nix
+++ b/pkgs/applications/version-management/subversion/default.nix
@@ -42,141 +42,139 @@ let
       sha256,
       extraPatches ? [ ],
     }:
-    stdenv.mkDerivation (
-      rec {
-        inherit version;
-        pname = "subversion${lib.optionalString (!bdbSupport && perlBindings && pythonBindings) "-client"}";
+    stdenv.mkDerivation rec {
+      inherit version;
+      pname = "subversion${lib.optionalString (!bdbSupport && perlBindings && pythonBindings) "-client"}";
 
-        src = fetchurl {
-          url = "mirror://apache/subversion/subversion-${version}.tar.bz2";
-          inherit sha256;
-        };
+      src = fetchurl {
+        url = "mirror://apache/subversion/subversion-${version}.tar.bz2";
+        inherit sha256;
+      };
 
-        # Can't do separate $lib and $bin, as libs reference bins
-        outputs = [
-          "out"
-          "dev"
-          "man"
-        ];
+      # Can't do separate $lib and $bin, as libs reference bins
+      outputs = [
+        "out"
+        "dev"
+        "man"
+      ];
 
-        nativeBuildInputs = [
-          autoconf
-          libtool
-          python3
-        ];
+      nativeBuildInputs = [
+        autoconf
+        libtool
+        python3
+      ];
 
-        buildInputs = [
-          zlib
-          apr
-          aprutil
-          sqlite
-          openssl
-          lz4
-          utf8proc
-        ]
-        ++ lib.optional httpSupport serf
-        ++ lib.optionals pythonBindings [
-          python3
-          py3c
-        ]
-        ++ lib.optional perlBindings perl
-        ++ lib.optional saslSupport sasl;
+      buildInputs = [
+        zlib
+        apr
+        aprutil
+        sqlite
+        openssl
+        lz4
+        utf8proc
+      ]
+      ++ lib.optional httpSupport serf
+      ++ lib.optionals pythonBindings [
+        python3
+        py3c
+      ]
+      ++ lib.optional perlBindings perl
+      ++ lib.optional saslSupport sasl;
 
-        patches = [ ./apr-1.patch ] ++ extraPatches;
+      patches = [ ./apr-1.patch ] ++ extraPatches;
 
-        # remove vendored swig-3 files as these will shadow the swig provided
-        # ones and result in compile errors
-        postPatch = ''
-          rm subversion/bindings/swig/proxy/{perlrun.swg,pyrun.swg,python.swg,rubydef.swg,rubyhead.swg,rubytracking.swg,runtime.swg,swigrun.swg}
-        '';
+      # remove vendored swig-3 files as these will shadow the swig provided
+      # ones and result in compile errors
+      postPatch = ''
+        rm subversion/bindings/swig/proxy/{perlrun.swg,pyrun.swg,python.swg,rubydef.swg,rubyhead.swg,rubytracking.swg,runtime.swg,swigrun.swg}
+      '';
 
-        env = {
-          # We are hitting the following issue even with APR 1.6.x
-          # -> https://issues.apache.org/jira/browse/SVN-4813
-          # "-P" CPPFLAG is needed to build Python bindings and subversionClient
-          CPPFLAGS = toString [ "-P" ];
-        }
-        // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-          CXX = "clang++";
-          CC = "clang";
-          CPP = "clang -E";
-          CXXCPP = "clang++ -E";
-        };
-
-        preConfigure = ''
-          ./autogen.sh
-        '';
-
-        configureFlags = [
-          (lib.withFeature bdbSupport "berkeley-db")
-          (lib.withFeatureAs httpServer "apxs" "${apacheHttpd.dev}/bin/apxs")
-          (lib.withFeatureAs (pythonBindings || perlBindings) "swig" swig)
-          (lib.withFeatureAs saslSupport "sasl" sasl)
-          (lib.withFeatureAs httpSupport "serf" serf)
-          "--with-zlib=${zlib.dev}"
-          "--with-sqlite=${sqlite.dev}"
-          "--with-apr=${apr.dev}"
-          "--with-apr-util=${aprutil.dev}"
-        ]
-        ++ lib.optionals javahlBindings [
-          "--enable-javahl"
-          "--with-jdk=${jdk}"
-        ];
-
-        preBuild = ''
-          makeFlagsArray=(APACHE_LIBEXECDIR=$out/modules)
-        '';
-
-        postInstall = ''
-          if test -n "$pythonBindings"; then
-              make swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
-              make install-swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
-          fi
-
-          if test -n "$perlBindings"; then
-              make swig-pl-lib
-              make install-swig-pl-lib
-              cd subversion/bindings/swig/perl/native
-              perl Makefile.PL PREFIX=$out
-              make install
-              cd -
-          fi
-
-          mkdir -p $out/share/bash-completion/completions
-          cp tools/client-side/bash_completion $out/share/bash-completion/completions/subversion
-
-          for f in $out/lib/*.la $out/lib/python*/site-packages/*/*.la; do
-            substituteInPlace $f \
-              --replace "${expat.dev}/lib" "${expat.out}/lib" \
-              --replace "${zlib.dev}/lib" "${zlib.out}/lib" \
-              --replace "${sqlite.dev}/lib" "${sqlite.out}/lib" \
-              --replace "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
-          done
-        '';
-
-        inherit perlBindings pythonBindings;
-
-        enableParallelBuilding = true;
-        # Missing install dependencies:
-        # libtool:   error: error: relink 'libsvn_ra_serf-1.la' with the above command before installing it
-        # make: *** [build-outputs.mk:1316: install-serf-lib] Error 1
-        enableParallelInstalling = false;
-
-        nativeCheckInputs = [ python3 ];
-        doCheck = false; # fails 10 out of ~2300 tests
-
-        passthru.tests = { inherit (nixosTests) svnserve; };
-
-        meta = {
-          description = "Version control system intended to be a compelling replacement for CVS in the open source community";
-          license = lib.licenses.asl20;
-          homepage = "https://subversion.apache.org/";
-          mainProgram = "svn";
-          maintainers = with lib.maintainers; [ lovek323 ];
-          platforms = lib.platforms.linux ++ lib.platforms.darwin;
-        };
+      env = {
+        # We are hitting the following issue even with APR 1.6.x
+        # -> https://issues.apache.org/jira/browse/SVN-4813
+        # "-P" CPPFLAG is needed to build Python bindings and subversionClient
+        CPPFLAGS = toString [ "-P" ];
       }
-    );
+      // lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+        CXX = "clang++";
+        CC = "clang";
+        CPP = "clang -E";
+        CXXCPP = "clang++ -E";
+      };
+
+      preConfigure = ''
+        ./autogen.sh
+      '';
+
+      configureFlags = [
+        (lib.withFeature bdbSupport "berkeley-db")
+        (lib.withFeatureAs httpServer "apxs" "${apacheHttpd.dev}/bin/apxs")
+        (lib.withFeatureAs (pythonBindings || perlBindings) "swig" swig)
+        (lib.withFeatureAs saslSupport "sasl" sasl)
+        (lib.withFeatureAs httpSupport "serf" serf)
+        "--with-zlib=${zlib.dev}"
+        "--with-sqlite=${sqlite.dev}"
+        "--with-apr=${apr.dev}"
+        "--with-apr-util=${aprutil.dev}"
+      ]
+      ++ lib.optionals javahlBindings [
+        "--enable-javahl"
+        "--with-jdk=${jdk}"
+      ];
+
+      preBuild = ''
+        makeFlagsArray=(APACHE_LIBEXECDIR=$out/modules)
+      '';
+
+      postInstall = ''
+        if test -n "$pythonBindings"; then
+            make swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
+            make install-swig-py swig_pydir=$(toPythonPath $out)/libsvn swig_pydir_extra=$(toPythonPath $out)/svn
+        fi
+
+        if test -n "$perlBindings"; then
+            make swig-pl-lib
+            make install-swig-pl-lib
+            cd subversion/bindings/swig/perl/native
+            perl Makefile.PL PREFIX=$out
+            make install
+            cd -
+        fi
+
+        mkdir -p $out/share/bash-completion/completions
+        cp tools/client-side/bash_completion $out/share/bash-completion/completions/subversion
+
+        for f in $out/lib/*.la $out/lib/python*/site-packages/*/*.la; do
+          substituteInPlace $f \
+            --replace "${expat.dev}/lib" "${expat.out}/lib" \
+            --replace "${zlib.dev}/lib" "${zlib.out}/lib" \
+            --replace "${sqlite.dev}/lib" "${sqlite.out}/lib" \
+            --replace "${openssl.dev}/lib" "${lib.getLib openssl}/lib"
+        done
+      '';
+
+      inherit perlBindings pythonBindings;
+
+      enableParallelBuilding = true;
+      # Missing install dependencies:
+      # libtool:   error: error: relink 'libsvn_ra_serf-1.la' with the above command before installing it
+      # make: *** [build-outputs.mk:1316: install-serf-lib] Error 1
+      enableParallelInstalling = false;
+
+      nativeCheckInputs = [ python3 ];
+      doCheck = false; # fails 10 out of ~2300 tests
+
+      passthru.tests = { inherit (nixosTests) svnserve; };
+
+      meta = {
+        description = "Version control system intended to be a compelling replacement for CVS in the open source community";
+        license = lib.licenses.asl20;
+        homepage = "https://subversion.apache.org/";
+        mainProgram = "svn";
+        maintainers = with lib.maintainers; [ lovek323 ];
+        platforms = lib.platforms.linux ++ lib.platforms.darwin;
+      };
+    };
 
 in
 {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
