### PR TITLE
librelane: improve derivation and add updateScript

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  nix-update-script,
 
   # nativeBuildInputs
   makeWrapper,
@@ -65,8 +66,13 @@ python3Packages.buildPythonApplication (finalAttrs: {
   ];
 
   postInstall = ''
-    cp -r librelane/scripts $out/${python3Packages.python.sitePackages}/librelane/
-    cp -r librelane/examples $out/${python3Packages.python.sitePackages}/librelane/
+    # Create the site-packages subdirectory for librelane
+    dest="$out/${python3Packages.python.sitePackages}/librelane"
+    mkdir -p "$dest"
+
+    # Copy scripts and examples from the source into the installation
+    cp -r librelane/scripts "$dest/"
+    cp -r librelane/examples "$dest/"
   '';
 
   postFixup = ''
@@ -85,6 +91,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
         ]
       }
   '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "ASIC implementation flow infrastructure";


### PR DESCRIPTION
- Add pythonRelaxDepsHook to fix click dependency relaxation
- Fix postInstall by ensuring destination directory exists before copying
- Add passthru.updateScript for automated updates

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

Also ```librelane --smoke-test``` passes:

```
* Antenna
Passed ✅

* LVS
Passed ✅

* DRC
Passed ✅

[19:43:02] INFO     Saving views to '/tmp/tmphbkcw9uslibrelane/smoke_test_design/runs/RUN_2026-02-19_19-41-45/final'…                       state.py:209
[19:43:02] INFO     Flow complete.                                                                                                     sequential.py:413
Classic - Stage 79 - Report Manufacturability ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79/79 0:01:16
[19:43:02] WARNING  The following warnings were generated by the flow:                                                                       flow.py:699
[19:43:02] WARNING  [Odb.CustomIOPlacement] Overriding minimum distance 0.1 with 0.42 for pins on side N to avoid overlap.                   flow.py:701
[19:43:02] WARNING  [OpenROAD.RepairDesignPostGPL] [STA-1140]                                                                                flow.py:701
                    /home/gonsolo/.ciel/ciel/sky130/versions/8afc8346a57fe1ab7934ba5a6056ea8b43078e71/sky130A/libs.ref/sky130_fd_sc_hd/lib/s            
                    ky130_fd_sc_hd__tt_025C_1v80.lib line 1, library sky130_fd_sc_hd__tt_025C_1v80 already exists. (and 17 similar warnings)            
[19:43:02] WARNING  [OpenROAD.RepairDesignPostGPL] [RSZ-0020] found 2 floating nets.                                                         flow.py:701
[19:43:02] WARNING  [OpenROAD.DetailedRouting] [DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon (and 9  flow.py:701
                    similar warnings)                                                                                                                   
[19:43:02] WARNING  [Checker.WireLength] Threshold for Threshold-surpassing long wires is not set. The checker will be skipped.              flow.py:701
[19:43:02] WARNING  [OpenROAD.IRDropReport] 'VSRC_LOC_FILES' was not given a value, which may make the results of IR drop analysis           flow.py:701
                    inaccurate. If you are not integrating a top-level chip for manufacture, you may ignore this warning, otherwise, see the            
                    documentation for 'VSRC_LOC_FILES'.                                                                                                 
[19:43:02] INFO     Smoke test passed.             
```