### PR TITLE
treewide: move CPPFLAGS into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/pd/pdnsd/package.nix
+++ b/pkgs/by-name/pd/pdnsd/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
   configureFlags = [ "--enable-ipv6" ];
 
   # fix ipv6 on darwin
-  CPPFLAGS = "-D__APPLE_USE_RFC_3542";
+  env.CPPFLAGS = "-D__APPLE_USE_RFC_3542";
 
   meta = {
     description = "Permanent DNS caching";

--- a/pkgs/by-name/pg/pgadmin4/package.nix
+++ b/pkgs/by-name/pg/pgadmin4/package.nix
@@ -58,7 +58,7 @@ pythonPackages.buildPythonApplication rec {
   };
 
   # from Dockerfile
-  CPPFLAGS = "-DPNG_ARM_NEON_OPT=0";
+  env.CPPFLAGS = "-DPNG_ARM_NEON_OPT=0";
 
   format = "setuptools";
 

--- a/pkgs/by-name/rk/rkdeveloptool/package.nix
+++ b/pkgs/by-name/rk/rkdeveloptool/package.nix
@@ -26,9 +26,10 @@ stdenv.mkDerivation {
   buildInputs = [ libusb1 ];
 
   # main.cpp:1568:36: error: '%s' directive output may be truncated writing up to 557 bytes into a region of size 5
-  CPPFLAGS =
+  env.CPPFLAGS = toString (
     lib.optionals stdenv.cc.isGNU [ "-Wno-error=format-truncation" ]
-    ++ lib.optionals stdenv.isDarwin [ "-Wno-error=vla-cxx-extension" ];
+    ++ lib.optionals stdenv.isDarwin [ "-Wno-error=vla-cxx-extension" ]
+  );
 
   meta = {
     homepage = "https://github.com/rockchip-linux/rkdeveloptool";

--- a/pkgs/by-name/so/sooperlooper/package.nix
+++ b/pkgs/by-name/so/sooperlooper/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # see https://bugs.gentoo.org/925275
-  CPPFLAGS = "-fpermissive";
+  env.CPPFLAGS = "-fpermissive";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
