### PR TITLE
asio: fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/as/asio/boost-1.89.patch
+++ b/pkgs/by-name/as/asio/boost-1.89.patch
@@ -1,0 +1,16 @@
+diff --git a/src/examples/cpp11/Makefile.am b/src/examples/cpp11/Makefile.am
+index a132a469f..65eb90a6d 100644
+--- a/src/examples/cpp11/Makefile.am
++++ b/src/examples/cpp11/Makefile.am
+@@ -289,9 +289,9 @@ endif
+ 
+ if HAVE_BOOST_COROUTINE
+ spawn_echo_server_SOURCES = spawn/echo_server.cpp
+-spawn_echo_server_LDADD = $(LDADD) -lboost_coroutine -lboost_context -lboost_thread -lboost_chrono -lboost_system
++spawn_echo_server_LDADD = $(LDADD) -lboost_coroutine -lboost_context -lboost_thread -lboost_chrono
+ spawn_parallel_grep_SOURCES = spawn/parallel_grep.cpp
+-spawn_parallel_grep_LDADD = $(LDADD) -lboost_coroutine -lboost_context -lboost_thread -lboost_chrono -lboost_system
++spawn_parallel_grep_LDADD = $(LDADD) -lboost_coroutine -lboost_context -lboost_thread -lboost_chrono
+ endif
+ 
+ EXTRA_DIST = \

--- a/pkgs/by-name/as/asio/package.nix
+++ b/pkgs/by-name/as/asio/package.nix
@@ -29,6 +29,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   sourceRoot = "${finalAttrs.src.name}/asio";
 
+  patches = [
+    # Linking against `boost_system` fails because the stub compiled library
+    # of Boost.System, which has been a header-only library since 1.69, was
+    # removed in 1.89.
+    # Upstream issue: https://github.com/chriskohlhoff/asio/issues/1716
+    ./boost-1.89.patch
+  ];
+
   nativeBuildInputs = [
     autoreconfHook
     pkg-config


### PR DESCRIPTION
Linking against `boost_system` fails because the stub compiled library of Boost.System, which has been a header-only library since 1.69, [was removed in 1.89](https://www.boost.org/releases/1.89.0/).

Hydra: https://hydra.nixos.org/build/321278285/nixlog/4
Upstream issue: https://github.com/chriskohlhoff/asio/issues/1716
Tracking: https://github.com/NixOS/nixpkgs/issues/485826

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `asio` (same as `asio_1_36_0`) & `asio_1_32_0`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
