### PR TITLE
librelane: 3.0.0.dev50 -> 3.0.0.dev52

### DIFF
--- a/pkgs/by-name/li/librelane/package.nix
+++ b/pkgs/by-name/li/librelane/package.nix
@@ -23,14 +23,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "librelane";
-  version = "3.0.0.dev50";
+  version = "3.0.0.dev52";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "librelane";
     repo = "librelane";
     tag = finalAttrs.version;
-    hash = "sha256-YDLX/aZEutoJ9Nu0aLvvDLwGH3HEGP+vtHdPFDbjEEU=";
+    hash = "sha256-0Sh5KR0Yc4gVT2d88z1GCJZmnsE4CYMsecLjQwm/Rxs=";
   };
 
   build-system = [


### PR DESCRIPTION
https://github.com/librelane/librelane/compare/3.0.0.dev50...3.0.0.dev52

Depends on #492208.

## Things done

- Built on platform:
  - [x] x86_64-linux
- Tested, as applicable:
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.

- [x] Smoke test passes.