### PR TITLE
Healthchecks: update django version

### DIFF
--- a/pkgs/by-name/he/healthchecks/package.nix
+++ b/pkgs/by-name/he/healthchecks/package.nix
@@ -9,7 +9,7 @@ let
   py = python3.override {
     self = py;
     packageOverrides = final: prev: {
-      django = prev.django_5;
+      django = prev.django_6;
     };
   };
 in

--- a/pkgs/development/python-modules/django/6.nix
+++ b/pkgs/development/python-modules/django/6.nix
@@ -1,0 +1,139 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  replaceVars,
+
+  # build-system
+  setuptools,
+
+  # patched in
+  geos,
+  gdal,
+  withGdal ? false,
+
+  # dependencies
+  asgiref,
+  sqlparse,
+
+  # optional-dependencies
+  argon2-cffi,
+  bcrypt,
+
+  # tests
+  aiosmtpd,
+  docutils,
+  geoip2,
+  jinja2,
+  numpy,
+  pillow,
+  pylibmc,
+  pymemcache,
+  python,
+  pyyaml,
+  pytz,
+  redis,
+  selenium,
+  tblib,
+  tzdata,
+}:
+
+buildPythonPackage rec {
+  pname = "django";
+  version = "6.0.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "django";
+    repo = "django";
+    tag = version;
+    hash = "sha256-59zbILbU+G9q7hwF8IbipykZLCWEHEx+cLRglJpvuQw=";
+  };
+
+  patches = [
+    (replaceVars ./django_6_set_zoneinfo_dir.patch {
+      zoneinfo = tzdata + "/share/zoneinfo";
+    })
+    # prevent tests from messing with our pythonpath
+    ./django_6_tests_pythonpath.patch
+    # disable test that expects timezone issues
+    ./django_6_disable_failing_tests.patch
+  ]
+  ++ lib.optionals withGdal [
+    (replaceVars ./django_6_set_geos_gdal_lib.patch {
+      inherit geos gdal;
+      extension = stdenv.hostPlatform.extensions.sharedLibrary;
+    })
+  ];
+
+  postPatch = ''
+    substituteInPlace tests/utils_tests/test_autoreload.py \
+      --replace-fail "/usr/bin/python" "${python.interpreter}"
+  '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    asgiref
+    sqlparse
+  ];
+
+  optional-dependencies = {
+    argon2 = [ argon2-cffi ];
+    bcrypt = [ bcrypt ];
+  };
+
+  nativeCheckInputs = [
+    # tests/requirements/py3.txt
+    aiosmtpd
+    docutils
+    geoip2
+    jinja2
+    numpy
+    pillow
+    pylibmc
+    pymemcache
+    pyyaml
+    pytz
+    redis
+    selenium
+    tblib
+    tzdata
+  ]
+  ++ lib.concatAttrValues optional-dependencies;
+
+  preCheck = ''
+    # make sure the installed library gets imported
+    rm -rf django
+
+    # fails to import github_links from docs/_ext/github_links.py
+    rm tests/sphinx/test_github_links.py
+
+    # provide timezone data, works only on linux
+    export TZDIR=${tzdata}/${python.sitePackages}/tzdata/zoneinfo
+
+    export PYTHONPATH=$PWD/docs/_ext:$PYTHONPATH
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    pushd tests
+    # without --parallel=1, tests fail with an "unexpected error due to a database lock" on Darwin
+    ${python.interpreter} runtests.py --settings=test_sqlite ${lib.optionalString stdenv.hostPlatform.isDarwin "--parallel=1"}
+    popd
+
+    runHook postCheck
+  '';
+
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    changelog = "https://docs.djangoproject.com/en/${lib.versions.majorMinor version}/releases/${version}/";
+    description = "High-level Python Web framework that encourages rapid development and clean, pragmatic design";
+    homepage = "https://www.djangoproject.com";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ ];
+  };
+}

--- a/pkgs/development/python-modules/django/django_6_disable_failing_tests.patch
+++ b/pkgs/development/python-modules/django/django_6_disable_failing_tests.patch
@@ -1,0 +1,31 @@
+diff --git a/tests/settings_tests/tests.py b/tests/settings_tests/tests.py
+--- a/tests/settings_tests/tests.py
++++ b/tests/settings_tests/tests.py
+@@ -2,7 +2,7 @@ import os
+ import sys
+ import unittest
+ from types import ModuleType, SimpleNamespace
+-from unittest import mock
++from unittest import mock, skip
+
+ from django.conf import ENVIRONMENT_VARIABLE, LazySettings, Settings, settings
+ from django.core.exceptions import ImproperlyConfigured
+@@ -335,6 +335,7 @@ class SettingsTests(SimpleTestCase):
+             getattr(s, "foo")
+
+     @requires_tz_support
++    @skip("Assertion fails, exception does not get raised")
+     @mock.patch("django.conf.global_settings.TIME_ZONE", "test")
+     def test_incorrect_timezone(self):
+         with self.assertRaisesMessage(ValueError, "Incorrect timezone setting: test"):
+diff --git a/tests/admin_docs/test_utils.py b/tests/admin_docs/test_utils.py
+--- a/tests/admin_docs/test_utils.py
++++ b/tests/admin_docs/test_utils.py
+@@ -125,6 +125,7 @@ class TestUtils(AdminDocsSimpleTestCase):
+         self.assertEqual(trimmed, "")
+
+
++    @unittest.skip("Incompatible with docutils 0.21+")
+     def test_publish_parts(self):
+         """
+         Django shouldn't break the default role for interpreted text

--- a/pkgs/development/python-modules/django/django_6_set_geos_gdal_lib.patch
+++ b/pkgs/development/python-modules/django/django_6_set_geos_gdal_lib.patch
@@ -1,0 +1,24 @@
+diff --git a/django/contrib/gis/gdal/libgdal.py b/django/contrib/gis/gdal/libgdal.py
+--- a/django/contrib/gis/gdal/libgdal.py
++++ b/django/contrib/gis/gdal/libgdal.py
+@@ -15,7 +15,7 @@ try:
+
+     lib_path = settings.GDAL_LIBRARY_PATH
+ except (AttributeError, ImportError, ImproperlyConfigured, OSError):
+-    lib_path = None
++    lib_path = "@gdal@/lib/libgdal@extension@"
+
+ if lib_path:
+     lib_names = None
+diff --git a/django/contrib/gis/geos/libgeos.py b/django/contrib/gis/geos/libgeos.py
+--- a/django/contrib/gis/geos/libgeos.py
++++ b/django/contrib/gis/geos/libgeos.py
+@@ -25,7 +25,7 @@ def load_geos():
+
+         lib_path = settings.GEOS_LIBRARY_PATH
+     except (AttributeError, ImportError, ImproperlyConfigured, OSError):
+-        lib_path = None
++        lib_path = "@geos@/lib/libgeos_c@extension@"
+
+     # Setting the appropriate names for the GEOS-C library.
+     if lib_path:

--- a/pkgs/development/python-modules/django/django_6_set_zoneinfo_dir.patch
+++ b/pkgs/development/python-modules/django/django_6_set_zoneinfo_dir.patch
@@ -1,0 +1,12 @@
+diff --git a/django/conf/__init__.py b/django/conf/__init__.py
+--- a/django/conf/__init__.py
++++ b/django/conf/__init__.py
+@@ -208,7 +208,7 @@ class Settings:
+         if hasattr(time, "tzset") and self.TIME_ZONE:
+             # When we can, attempt to validate the timezone. If we can't find
+             # this file, no check happens and it's harmless.
+-            zoneinfo_root = Path("/usr/share/zoneinfo")
++            zoneinfo_root = Path("@zoneinfo@")
+             zone_info_file = zoneinfo_root.joinpath(*self.TIME_ZONE.split("/"))
+             if zoneinfo_root.exists() and not zone_info_file.exists():
+                 raise ValueError("Incorrect timezone setting: %s" % self.TIME_ZONE)

--- a/pkgs/development/python-modules/django/django_6_tests_pythonpath.patch
+++ b/pkgs/development/python-modules/django/django_6_tests_pythonpath.patch
@@ -1,0 +1,11 @@
+diff --git a/tests/admin_scripts/tests.py b/tests/admin_scripts/tests.py
+--- a/tests/admin_scripts/tests.py
++++ b/tests/admin_scripts/tests.py
+@@ -126,6 +126,7 @@ class AdminScriptTestCase(SimpleTestCase):
+             del test_environ["DJANGO_SETTINGS_MODULE"]
+         python_path = [base_dir, django_dir, tests_dir]
+         python_path.extend(ext_backend_base_dirs)
++        python_path.extend(sys.path)
+         test_environ["PYTHONPATH"] = os.pathsep.join(python_path)
+         test_environ["PYTHONWARNINGS"] = ""
+

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4388,6 +4388,8 @@ self: super: with self; {
 
   django_5 = callPackage ../development/python-modules/django/5.nix { };
 
+  django_6 = callPackage ../development/python-modules/django/6.nix { };
+
   djangocms-admin-style = callPackage ../development/python-modules/djangocms-admin-style { };
 
   djangocms-alias = callPackage ../development/python-modules/djangocms-alias { };


### PR DESCRIPTION
Healthchecks currently throws a HTTP 500 when calling the ping endoint. This totally breaks the functionality of this service. It has also been reported in issue #490368. This happens because healthchecks updated it's django dependecy from django 5 to django 6. This pull requests adds django 6 and updates the django dependency for healthchecks.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
