### PR TITLE
home-assistant-custom-components.browser-mod: init at 2.7.4

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/browser-mod/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/browser-mod/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  fetchNpmDeps,
+  nodejs,
+  npmHooks,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "thomasloven";
+  domain = "browser_mod";
+  version = "2.7.4";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "hass-browser_mod";
+    tag = "v${version}";
+    hash = "sha256-UFHdoIfmN0BUBRAze3mC3mgbV00rrjmKlAiBc4FuiZA=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    npmHooks.npmBuildHook
+    npmHooks.npmConfigHook
+  ];
+
+  npmDeps = fetchNpmDeps {
+    inherit src;
+    hash = "sha256-gvONQGQ91XZAygXDZnu7R/BPKa9T9l3f3EE6o39t0G0=";
+  };
+
+  npmBuildScript = "build";
+
+  meta = {
+    description = "Home Assistant integration to turn your browser into a controllable entity and media player";
+    homepage = "https://github.com/thomasloven/hass-browser_mod";
+    changelog = "https://github.com/thomasloven/hass-browser_mod/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ SuperSandro2000 ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
