### PR TITLE
home-assistant-custom-components.auto-entities: 1.16.1 -> 2.0.0, switch to fork

### DIFF
--- a/pkgs/servers/home-assistant/custom-lovelace-modules/auto-entities/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/auto-entities/package.nix
@@ -6,30 +6,33 @@
 
 buildNpmPackage rec {
   pname = "auto-entities";
-  version = "1.16.1";
+  version = "2.0.0";
 
   src = fetchFromGitHub {
-    owner = "thomasloven";
+    owner = "Lint-Free-Technology";
     repo = "lovelace-auto-entities";
     tag = "v${version}";
-    hash = "sha256-yMqf4LA/fBTIrrYwacUTb2fL758ZB1k471vdsHAiOj8=";
+    hash = "sha256-W6D9z4D00wIVmrUo9KFlttK2k013kHbWXKwbyh9bsLY=";
   };
 
-  npmDepsHash = "sha256-XLhTLK08zW1BFj/PI8/61FWzoyvWi5X5sEkGlF1IuZU=";
+  npmDepsHash = "sha256-H9Mt5lBZAZwkGfPSRlbgPaqHETWxI7Wge7zEPLcdvgE=";
 
   installPhase = ''
     runHook preInstall
 
-    install -D auto-entities.js $out/auto-entities.js
+    install -D dist/auto-entities.js $out/auto-entities.js
 
     runHook postInstall
   '';
 
   meta = {
     description = "Automatically populate the entities-list of lovelace cards";
-    homepage = "https://github.com/thomasloven/lovelace-auto-entities";
-    changelog = "https://github.com/thomasloven/lovelace-auto-entities/releases/tag/v${version}";
+    homepage = "https://github.com/Lint-Free-Technology/lovelace-auto-entities";
+    changelog = "https://github.com/Lint-Free-Technology/lovelace-auto-entities/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ kranzes ];
+    maintainers = with lib.maintainers; [
+      kranzes
+      SuperSandro2000
+    ];
   };
 }


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
