### PR TITLE
dart: use dart-source in linux

### DIFF
--- a/pkgs/development/compilers/dart/source/default.nix
+++ b/pkgs/development/compilers/dart/source/default.nix
@@ -4,7 +4,7 @@
   callPackage,
   cacert,
   curlMinimal,
-  dart,
+  dart-bin,
   debug ? false,
   fetchurl,
   gn,
@@ -126,7 +126,7 @@ let
         cp --recursive sdk $out
       '';
 in
-dart.overrideAttrs (oldAttrs: {
+dart-bin.overrideAttrs (oldAttrs: {
   inherit version src;
 
   nativeBuildInputs = [
@@ -172,7 +172,7 @@ dart.overrideAttrs (oldAttrs: {
     export PATH=$PWD/.bin-tools:$PATH
   ''
   + ''
-    ln --symbolic ${buildPackages.dart} tools/sdks/dart-sdk
+    ln --symbolic ${buildPackages.dart-bin} tools/sdks/dart-sdk
     ln --symbolic --force ${lib.getExe buildPackages.gn} buildtools/gn
     mkdir --parents buildtools/ninja
     ln --symbolic --force ${lib.getExe buildPackages.samurai} buildtools/ninja/ninja

--- a/pkgs/development/compilers/flutter/default.nix
+++ b/pkgs/development/compilers/flutter/default.nix
@@ -4,6 +4,7 @@
   fetchzip,
   fetchFromGitHub,
   dart,
+  dart-bin,
   lib,
   stdenv,
   runCommand,
@@ -57,14 +58,14 @@ let
           in
           (
             if lib.versionAtLeast version "3.41" then
-              (dart.overrideAttrs (oldAttrs: {
+              (dart-bin.overrideAttrs (oldAttrs: {
                 version = dartVersion;
                 src = oldAttrs.src.overrideAttrs (_: {
                   inherit hash;
                 });
               }))
             else
-              (dart.overrideAttrs (_: {
+              (dart-bin.overrideAttrs (_: {
                 # This overrideAttrs is used to replace the version in src.url
                 version = dartVersion;
                 __intentionallyOverridingVersion = true;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12709,7 +12709,12 @@ with pkgs;
 
   zncModules = recurseIntoAttrs (callPackage ../applications/networking/znc/modules.nix { });
 
-  dart = callPackage ../development/compilers/dart { };
+  inherit
+    ({
+      dart-bin = callPackage ../development/compilers/dart { };
+    })
+    dart-bin
+    ;
 
   inherit
     ({
@@ -12717,6 +12722,8 @@ with pkgs;
     })
     dart-source
     ;
+
+  dart = if stdenv.hostPlatform.isLinux then dart-source else dart-bin;
 
   pub2nix = recurseIntoAttrs (callPackage ../build-support/dart/pub2nix { });
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
