### PR TITLE
vtk: fix build with boost 1.89

### DIFF
--- a/pkgs/development/libraries/vtk/boost-1.89.patch
+++ b/pkgs/development/libraries/vtk/boost-1.89.patch
@@ -1,0 +1,13 @@
+diff --git a/IO/LAS/CMakeLists.txt b/IO/LAS/CMakeLists.txt
+index aa5b7d6ed4..d67d4326c4 100644
+--- a/IO/LAS/CMakeLists.txt
++++ b/IO/LAS/CMakeLists.txt
+@@ -15,7 +15,7 @@ if (libLAS_VERSION VERSION_LESS "1.8.2" OR
+       iostreams program_options serialization thread)
+   else ()
+     set(boost_components
+-      program_options thread system iostreams filesystem)
++      program_options thread serialization iostreams filesystem)
+   endif ()
+   vtk_module_find_package(PRIVATE_IF_SHARED
+     PACKAGE Boost

--- a/pkgs/development/libraries/vtk/default.nix
+++ b/pkgs/development/libraries/vtk/default.nix
@@ -9,5 +9,15 @@ in
   vtk_9_5 = mkVtk {
     version = "9.5.2";
     sourceSha256 = "sha256-zuZLmNJw/3MC2vHvE0WN/11awey0XUdyODX399ViyYk=";
+    patches = [
+      # Finding `Boost::system` fails because the stub compiled library of
+      # Boost.System, which has been a header-only library since 1.69, was
+      # removed in 1.89.
+      # See https://www.boost.org/releases/1.89.0/ for details.
+      #
+      # Also, the link interface of libLAS contains `Boost::serialization`
+      # as a dependency, so we need to add that to `boost_components`.
+      ./boost-1.89.patch
+    ];
   };
 }


### PR DESCRIPTION
Finding `Boost::system` fails because the stub compiled library of Boost.System, which has been a header-only library since 1.69, [was removed in 1.89](https://www.boost.org/releases/1.89.0/).

Also, the link interface of libLAS contains `Boost::serialization` as a dependency, so we need to add that to `boost_components`.

Depends on #492224
Tracking: #485826

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — on top of #492224
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
