### PR TITLE
picoclaw: init at 0.2.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16175,6 +16175,12 @@
     githubId = 115060;
     name = "Marek Maksimczyk";
   };
+  manfredmacx = {
+    email = "mfmacx@proton.me";
+    github = "manfredmacx";
+    githubId = 222261305;
+    name = "Manfred Macx";
+  };
   Mange = {
     name = "Magnus Bergmark";
     email = "me@mange.dev";

--- a/pkgs/by-name/pi/picoclaw/package.nix
+++ b/pkgs/by-name/pi/picoclaw/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "picoclaw";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "sipeed";
+    repo = "picoclaw";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zCeURNN152yL3Qi1UFDvSB85xflbLAMzQUTwGThALss=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-CsTGC5Ajo9RV6rJPQgnFqA+bQ2TEafI4tt3iXpVwaeY=";
+
+  preBuild = ''
+    go generate ./...
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/sipeed/picoclaw/cmd/picoclaw/internal.version=${finalAttrs.version}"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+
+  checkFlags =
+    let
+      skippedTests = [
+        "TestGetVersion"
+        "TestCodexCliProvider_MockCLI_Success"
+        "TestCodexCliProvider_MockCLI_Error"
+        "TestCodexCliProvider_MockCLI_WithModel"
+      ];
+    in
+    [ "-skip=^${builtins.concatStringsSep "$|^" skippedTests}$" ];
+
+  meta = {
+    description = "Tiny, Fast, and Deployable anywhere - automate the mundane, unleash your creativity";
+    homepage = "https://github.com/sipeed/picoclaw";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      manfredmacx
+      drupol
+    ];
+    mainProgram = "picoclaw";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added picoclaw, low memory footprint openclaw alternative. Runs it as a systemd service, and provides access to the cli, in order to run status checks.

https://github.com/sipeed/picoclaw

Config examples found here https://github.com/sipeed/picoclaw/blob/394d1d1197897989d4547037e993f678afb98f60/config/config.example.json

There are some workarounds in here to deal with go version constraints and permissions. Open to ideas to untangle this now or later.

To test:

```
services.picoclaw = {
    enable = true;
    modelName = "mistralmed";
    modelFallbacks = [
      "mygroq"
      "openrouter1"
    ];
    modelList = [
      {
        model_name = "mygroq";
        model = "groq/llama-3.3-70b-versatile";
        api_key = "";
        api_base = "https://api.groq.com/openai/v1";
      }
      {
        model_name = "openrouter1";
        model = "openrouter/stepfun/step-3.5-flash:free";
        api_key = "";
        api_base = "https://openrouter.ai/api/v1";
      }
      {
        model_name = "mistralmed";
        model = "mistral/mistral-medium-latest";
        api_key = "";
        api_base = "https://api.mistral.ai/v1";
      }
    ];
    channels = {
      telegram = {
        enabled = true;
        token = "";
        allow_from = [
          "mybot"
        ];
      };
    };
  };
}
```
Then run `picoclaw status` to check the token works and the model is recognised. Then run `picoclaw agent` to start interactive mode and say hi to the model.

Note: much of the scaffolding was generated with claude, but it has been tested manually.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
