### PR TITLE
premake5: 5.0.0-beta4 -> 5.0.0-beta8

### DIFF
--- a/pkgs/by-name/ed/edopro/package.nix
+++ b/pkgs/by-name/ed/edopro/package.nix
@@ -232,7 +232,7 @@ let
     # (can't use --prebuilt-core or let it build a core on its own without making core updates impossible)
     postPatch = ''
       substituteInPlace premake5.lua \
-        --replace-fail 'flags "LinkTimeOptimization"' 'removeflags "LinkTimeOptimization"'
+        --replace-fail 'flags "LinkTimeOptimization"' 'linktimeoptimization "Off"'
 
       substituteInPlace gframe/game.cpp \
         --replace-fail 'ocgcore = LoadOCGcore(Utils::GetWorkingDirectory())' 'ocgcore = LoadOCGcore("${lib.getLib ocgcore}/lib/")'

--- a/pkgs/development/tools/misc/premake/5.nix
+++ b/pkgs/development/tools/misc/premake/5.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "premake5";
-  version = "5.0.0-beta4";
+  version = "5.0.0-beta8";
 
   src = fetchFromGitHub {
     owner = "premake";
     repo = "premake-core";
     rev = "v${finalAttrs.version}";
-    sha256 = "sha256-sNLCyIHWDW/8jIrMFCZAqtWsh4SRugqtPR4HaoW/Vzk=";
+    hash = "sha256-Tl/XU9Hy/VZw59S4K478EaLgE88/oTzLCe+DoVwtlcU=";
   };
 
   buildInputs = [

--- a/pkgs/development/tools/misc/premake/no-curl-ca.patch
+++ b/pkgs/development/tools/misc/premake/no-curl-ca.patch
@@ -1,17 +1,8 @@
-From a26e36d55cd2447488e01b2ff4ac65e2596862cd Mon Sep 17 00:00:00 2001
-From: Ellie Hermaszewska <git@monoid.al>
-Date: Mon, 3 Oct 2022 16:50:33 +0800
-Subject: [PATCH] Do not set CURL_CA_BUNDLE
-
----
- contrib/curl/premake5.lua | 13 -------------
- 1 file changed, 13 deletions(-)
-
 diff --git a/contrib/curl/premake5.lua b/contrib/curl/premake5.lua
-index 474f5cfa..553bbd02 100644
+index b1e32fd..26dd399 100644
 --- a/contrib/curl/premake5.lua
 +++ b/contrib/curl/premake5.lua
-@@ -36,21 +36,6 @@ project "curl-lib"
+@@ -36,22 +36,6 @@ project "curl-lib"
  
  		-- find the location of the ca bundle
  		local ca = nil
@@ -24,6 +15,7 @@ index 474f5cfa..553bbd02 100644
 -			"/usr/local/share/certs/ca-root-nss.crt",
 -			"/etc/certs/ca-certificates.crt",
 -			"/etc/ssl/cert.pem",
+-			"/etc/ssl/cacert.pem",
 -			"/boot/system/data/ssl/CARootCertificates.pem" } do
 -			if os.isfile(f) then
 -				ca = f
@@ -33,6 +25,3 @@ index 474f5cfa..553bbd02 100644
  		if ca then
  			defines { 'CURL_CA_BUNDLE="' .. ca .. '"', 'CURL_CA_PATH="' .. path.getdirectory(ca) .. '"' }
  		end
--- 
-2.37.2
-


### PR DESCRIPTION
Update premake5 to the latest beta, as it is required to update the zeroad package to the latest release. The only change necessary was to update the curl patch. I checked that `--help` & `--version` run and manually tried to build all packages that depend on it (`nixpkgs-review` crashed on my laptop unfortunately). For `edopro` I had to rename a deprecated flag, `xenia-canary` and `zeroad-unwrapped` still build without issue, `otfcc` is marked broken and `yojimbo` is depends on `mbedtls_2`, which is marked insecure and appears to have test failures with `NIXPKGS_ALLOW_INSECURE=1` on the current master.

Pinging @sarahec as the premake5 maintainer and @chvp for zeroad.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
