### PR TITLE
python3Packages.triton: move env vars into env for structuredAttrs

### DIFF
--- a/pkgs/development/python-modules/triton/default.nix
+++ b/pkgs/development/python-modules/triton/default.nix
@@ -151,12 +151,6 @@ buildPythonPackage (finalAttrs: {
     setuptools
   ];
 
-  NIX_CFLAGS_COMPILE = lib.optionals cudaSupport [
-    # Pybind11 started generating strange errors since python 3.12. Observed only in the CUDA branch.
-    # https://gist.github.com/SomeoneSerge/7d390b2b1313957c378e99ed57168219#file-gistfile0-txt-L1042
-    "-Wno-stringop-overread"
-  ];
-
   preConfigure =
     # Ensure that the build process uses the requested number of cores
     ''
@@ -170,6 +164,12 @@ buildPythonPackage (finalAttrs: {
   // lib.optionalAttrs cudaSupport {
     CC = lib.getExe' cudaPackages.backendStdenv.cc "cc";
     CXX = lib.getExe' cudaPackages.backendStdenv.cc "c++";
+
+    NIX_CFLAGS_COMPILE = toString [
+      # Pybind11 started generating strange errors since python 3.12. Observed only in the CUDA branch.
+      # https://gist.github.com/SomeoneSerge/7d390b2b1313957c378e99ed57168219#file-gistfile0-txt-L1042
+      "-Wno-stringop-overread"
+    ];
 
     # TODO: Unused because of how TRITON_OFFLINE_BUILD currently works (subject to change)
     TRITON_PTXAS_PATH = lib.getExe' cudaPackages.cuda_nvcc "ptxas"; # Make sure cudaPackages is the right version each update (See python/setup.py)


### PR DESCRIPTION
The diff looks like the conditional is lost, but the variable is moved inside a `lib.optionalAttrs cudaSupport`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
