### PR TITLE
rstudio: 2026.01.0+392 -> 2026.01.1+403, change pname to lowercase

### DIFF
--- a/pkgs/by-name/rs/rstudio/package.nix
+++ b/pkgs/by-name/rs/rstudio/package.nix
@@ -83,21 +83,21 @@ let
     ln -s ${quarto}/share $out/share
   '';
 in
-stdenv.mkDerivation rec {
-  pname = "RStudio";
-  version = "2026.01.0+392";
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rstudio";
+  version = "2026.01.1+403";
 
   src = fetchFromGitHub {
     owner = "rstudio";
     repo = "rstudio";
-    tag = "v${version}";
-    hash = "sha256-Q79uoNKh4plRFTe3uOTr27Hh/fMMkCbRPveZyq7cHQk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-s+t48LLvxdit6US6MB4DvpEZtUY6SSK5Qha1k4VW0Qk=";
   };
 
   # sources fetched into _deps via cmake's FetchContent
   extSrcs = stdenv.mkDerivation {
-    name = "${pname}-${version}-ext-srcs";
-    inherit src;
+    name = "rstudio-${finalAttrs.version}-ext-srcs";
+    inherit (finalAttrs) src;
 
     nativeBuildInputs = [
       cacert
@@ -192,10 +192,10 @@ stdenv.mkDerivation rec {
     # on Darwin, cmake uses find_library to locate R instead of using the PATH
     NIX_LDFLAGS = "-L${R}/lib/R/lib";
 
-    RSTUDIO_VERSION_MAJOR = lib.versions.major version;
-    RSTUDIO_VERSION_MINOR = lib.versions.minor version;
-    RSTUDIO_VERSION_PATCH = lib.versions.patch version;
-    RSTUDIO_VERSION_SUFFIX = "+" + toString (lib.tail (lib.splitString "+" version));
+    RSTUDIO_VERSION_MAJOR = lib.versions.major finalAttrs.version;
+    RSTUDIO_VERSION_MINOR = lib.versions.minor finalAttrs.version;
+    RSTUDIO_VERSION_PATCH = lib.versions.patch finalAttrs.version;
+    RSTUDIO_VERSION_SUFFIX = "+" + toString (lib.tail (lib.splitString "+" finalAttrs.version));
   };
 
   patches = [
@@ -246,9 +246,9 @@ stdenv.mkDerivation rec {
   makeCacheWritable = true;
 
   npmDeps = fetchNpmDeps {
-    name = "rstudio-${version}-npm-deps";
-    inherit src;
-    postPatch = "cd ${npmRoot}";
+    name = "rstudio-${finalAttrs.version}-npm-deps";
+    inherit (finalAttrs) src;
+    postPatch = "cd ${finalAttrs.npmRoot}";
     hash = "sha256-7gXLCFhan/TCTlc2okMWuWzfRYXmuwcqhmGKAqJOEM0=";
   };
 
@@ -359,7 +359,7 @@ stdenv.mkDerivation rec {
   };
 
   meta = {
-    changelog = "https://github.com/rstudio/rstudio/tree/${src.rev}/version/news";
+    changelog = "https://github.com/rstudio/rstudio/tree/${finalAttrs.src.rev}/version/news";
     description = "Set of integrated tools for the R language";
     homepage = "https://www.rstudio.com/";
     license = lib.licenses.agpl3Only;
@@ -371,4 +371,4 @@ stdenv.mkDerivation rec {
     # rstudio-server on darwin is only partially supported by upstream
     platforms = lib.platforms.linux ++ lib.optionals (!server) lib.platforms.darwin;
   };
-}
+})


### PR DESCRIPTION
https://github.com/rstudio/rstudio/blob/refs/tags/v2026.01.1%2B403/version/news/NEWS-2026.01.1-apple-blossom.md

Also use finalAttrs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
