### PR TITLE
vintagestory-pre: init at 1.22.pre.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5201,6 +5201,12 @@
     githubId = 27779510;
     keys = [ { fingerprint = "FDF5 EF67 8CC1 FE22 1845  6A22 CF7B BB5B C756 1BD3"; } ];
   };
+  codyhahn = {
+    name = "Cody Hahn";
+    github = "codyhahn";
+    githubId = 137955581;
+    email = "codyhahn@proton.me";
+  };
   codyopel = {
     email = "codyopel@gmail.com";
     github = "codyopel";

--- a/pkgs/by-name/vi/vintagestory-pre/package.nix
+++ b/pkgs/by-name/vi/vintagestory-pre/package.nix
@@ -1,0 +1,104 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+  libx11,
+  libxi,
+  libxcursor,
+  gtk2,
+  sqlite,
+  openal,
+  cairo,
+  libGLU,
+  SDL2,
+  freealut,
+  libglvnd,
+  pipewire,
+  libpulseaudio,
+  dotnet-runtime_10,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vintagestory-pre";
+  version = "1.22.0-pre.3";
+
+  src = fetchurl {
+    url = "https://cdn.vintagestory.at/gamefiles/pre/vs_client_linux-x64_${version}.tar.gz";
+    hash = "sha256-pMXBNuKO5ZAh76JkGXabN+KeRvoGGBtUN5qWDmVnT1E=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    copyDesktopItems
+  ];
+
+  runtimeLibs = lib.makeLibraryPath [
+    gtk2
+    sqlite
+    openal
+    cairo
+    libGLU
+    SDL2
+    freealut
+    libglvnd
+    pipewire
+    libpulseaudio
+    libx11
+    libxi
+    libxcursor
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "vintagestory-pre";
+      desktopName = "Vintage Story (Pre-release)";
+      exec = "vintagestory-pre";
+      icon = "vintagestory";
+      comment = "Innovate and explore in a sandbox world";
+      categories = [ "Game" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/vintagestory-pre $out/bin $out/share/pixmaps $out/share/fonts/truetype
+    cp -r * $out/share/vintagestory-pre
+    cp $out/share/vintagestory-pre/assets/gameicon.png $out/share/pixmaps/vintagestory.png
+    cp $out/share/vintagestory-pre/assets/game/fonts/*.ttf $out/share/fonts/truetype
+
+    runHook postInstall
+  '';
+
+  preFixup = ''
+    makeWrapper ${dotnet-runtime_10}/bin/dotnet $out/bin/vintagestory-pre \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --set-default mesa_glthread true \
+      --add-flags $out/share/vintagestory-pre/Vintagestory.dll
+
+    makeWrapper ${dotnet-runtime_10}/bin/dotnet $out/bin/vintagestory-server-pre \
+      --prefix LD_LIBRARY_PATH : "${runtimeLibs}" \
+      --set-default mesa_glthread true \
+      --add-flags $out/share/vintagestory-pre/VintagestoryServer.dll
+
+    find "$out/share/vintagestory-pre/assets/" -not -path "*/fonts/*" -regex ".*/.*[A-Z].*" | while read -r file; do
+      local filename="$(basename -- "$file")"
+      ln -sf "$filename" "''${file%/*}"/"''${filename,,}"
+    done
+  '';
+
+  meta = {
+    description = "In-development indie sandbox game about innovation and exploration (pre-release version)";
+    homepage = "https://www.vintagestory.at/";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      codyhahn
+    ];
+    mainProgram = "vintagestory-pre";
+  };
+}


### PR DESCRIPTION
Add new package, `vintagestory-pre`, which provides the latest pre-release (unstable) version of the game.

Uses pname `vintagestory-pre` because `vintagestory` is used by the stable package. This also allows both the stable and pre-release versions to be installed concurrently, if desired.

Home page: https://www.vintagestory.at/
Latest pre-release notes: https://info.vintagestory.at/v1dot22#pre3

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.