### PR TITLE
keeper-password-manager-desktop: init at 17.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18329,6 +18329,12 @@
     githubId = 6295090;
     name = "Mats";
   };
+  mylesbolton = {
+    email = "nixos.github@mylesbolton.com";
+    github = "MylesBolton";
+    githubId = 38015231;
+    name = "Myles Bolton";
+  };
   mymindstorm = {
     name = "Brendan Early";
     email = "mymindstorm@evermiss.net";

--- a/pkgs/by-name/ke/keeper-desktop/package.nix
+++ b/pkgs/by-name/ke/keeper-desktop/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  makeWrapper,
+  libsecret,
+  pcsclite,
+  alsa-lib,
+  at-spi2-core,
+  cairo,
+  cups,
+  dbus,
+  expat,
+  gdk-pixbuf,
+  glib,
+  gtk3,
+  libxkbcommon,
+  mesa,
+  nspr,
+  nss,
+  pango,
+  udev,
+  libx11,
+  libxcomposite,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxrandr,
+  libxcb,
+  libglvnd,
+  libuuid,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "keeper-password-manager-desktop";
+  version = "17.5.0";
+
+  src = fetchurl {
+    url = "https://www.keepersecurity.com/desktop_electron/Linux/repo/deb/keeperpasswordmanager_${version}_amd64.deb";
+    hash = "sha256-aezUmacR4FcGRLM/tLpLAnCmt0hWilFLL20NwMPDI/o=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    alsa-lib
+    at-spi2-core
+    cairo
+    cups
+    dbus
+    expat
+    gdk-pixbuf
+    glib
+    gtk3
+    libsecret
+    libxkbcommon
+    mesa
+    nspr
+    nss
+    pango
+    pcsclite
+    udev
+    libx11
+    libxcomposite
+    libxdamage
+    libxext
+    libxfixes
+    libxrandr
+    libglvnd
+    libxcb
+    libuuid
+  ];
+
+  unpackPhase = ''
+    dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/lib $out/share
+
+    cp -r usr/lib/keeperpasswordmanager $out/lib/
+    cp -r usr/share/* $out/share/
+
+    makeWrapper $out/lib/keeperpasswordmanager/keeperpasswordmanager $out/bin/keeperpasswordmanager \
+      --prefix LD_LIBRARY_PATH : "${
+        lib.makeLibraryPath [
+          libglvnd
+          udev
+          libuuid
+        ]
+      }" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+
+    substituteInPlace $out/share/applications/keeperpasswordmanager.desktop \
+      --replace "Exec=/usr/lib/keeperpasswordmanager/keeperpasswordmanager" "Exec=$out/bin/keeperpasswordmanager" \
+      --replace "Exec=/opt/keeperpasswordmanager/keeperpasswordmanager" "Exec=$out/bin/keeperpasswordmanager"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Keeper Password Manager Desktop App";
+    homepage = "https://keepersecurity.com";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "keeperpasswordmanager";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    maintainers = with maintainers; [ mylesbolton ];
+  };
+}

--- a/pkgs/by-name/ke/keeper-desktop/package.nix
+++ b/pkgs/by-name/ke/keeper-desktop/package.nix
@@ -36,7 +36,8 @@
 stdenv.mkDerivation rec {
   pname = "keeper-password-manager-desktop";
   version = "17.5.0";
-
+  __structuredAttrs = true;
+  
   src = fetchurl {
     url = "https://www.keepersecurity.com/desktop_electron/Linux/repo/deb/keeperpasswordmanager_${version}_amd64.deb";
     hash = "sha256-aezUmacR4FcGRLM/tLpLAnCmt0hWilFLL20NwMPDI/o=";

--- a/pkgs/by-name/ke/keeper-desktop/package.nix
+++ b/pkgs/by-name/ke/keeper-desktop/package.nix
@@ -107,13 +107,13 @@ stdenv.mkDerivation rec {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Keeper Password Manager Desktop App";
     homepage = "https://keepersecurity.com";
-    license = licenses.unfree;
+    license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
     mainProgram = "keeperpasswordmanager";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    maintainers = with maintainers; [ mylesbolton ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ mylesbolton ];
   };
 }


### PR DESCRIPTION
<!--
Keeper Password Manager Desktop APP
Homepage: https://www.keepersecurity.com/

Keeper is a password manager, this is the desktop app.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
