### PR TITLE
radicle-node-unstable: init at 1.7.0-rc.1

### DIFF
--- a/pkgs/by-name/ra/radicle-node/unstable.nix
+++ b/pkgs/by-name/ra/radicle-node/unstable.nix
@@ -1,0 +1,8 @@
+{ radicle-node }:
+
+radicle-node.override {
+  version = "1.7.0-rc.1";
+  srcHash = "sha256-eq7rUzTbmPb0pRfcFnWP4vrbCTbXW9N4BleDCMUnLH8=";
+  cargoHash = "sha256-OkgWdu+7FY1tq0bjMbhjqjlJT9ZUgR8i12LhqyFJi+A=";
+  updateScript = ./update-unstable.sh;
+}

--- a/pkgs/by-name/ra/radicle-node/update-unstable.sh
+++ b/pkgs/by-name/ra/radicle-node/update-unstable.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils gnugrep common-updater-scripts nix-update
+
+version=$(list-git-tags | grep -oP '^releases/\K\d+\.\d+\.\d+.*' | sort -rV | head -1)
+nix-update --version="$version" radicle-node-unstable --override-filename pkgs/by-name/ra/radicle-node/unstable.nix

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12811,6 +12811,8 @@ with pkgs;
 
   xp-pen-deco-01-v2-driver = libsForQt5.xp-pen-deco-01-v2-driver;
 
+  radicle-node-unstable = callPackage ../by-name/ra/radicle-node/unstable.nix { };
+
   newlib-nano = newlib.override {
     nanoizeNewlib = true;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
