### PR TITLE
maintainers: drop atila

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2548,12 +2548,6 @@
     githubId = 6553158;
     name = "Joel Höner";
   };
-  atila = {
-    name = "Átila Saraiva";
-    email = "atilasaraiva@gmail.com";
-    github = "AtilaSaraiva";
-    githubId = 29521461;
-  };
   atkinschang = {
     email = "atkinschang+nixpkgs@gmail.com";
     github = "AtkinsChang";

--- a/pkgs/applications/office/mendeley/default.nix
+++ b/pkgs/applications/office/mendeley/default.nix
@@ -40,7 +40,7 @@ appimageTools.wrapType2 {
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
     platforms = [ "x86_64-linux" ];
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     mainProgram = "mendeley-reference-manager";
   };
 

--- a/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-vkcapture.nix
@@ -85,7 +85,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/nowrep/obs-vkcapture";
     changelog = "https://github.com/nowrep/obs-vkcapture/releases/tag/v${finalAttrs.version}";
     maintainers = with lib.maintainers; [
-      atila
       pedrohlc
     ];
     license = lib.licenses.gpl2Only;

--- a/pkgs/by-name/bo/borg-sans-mono/package.nix
+++ b/pkgs/by-name/bo/borg-sans-mono/package.nix
@@ -27,6 +27,6 @@ stdenvNoCC.mkDerivation {
     homepage = "https://github.com/marnen/borg-sans-mono";
     license = lib.licenses.asl20;
     platforms = lib.platforms.all;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/bt/btdu/package.nix
+++ b/pkgs/by-name/bt/btdu/package.nix
@@ -39,7 +39,6 @@ buildDubPackage rec {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      atila
       cybershadow
     ];
     mainProgram = "btdu";

--- a/pkgs/by-name/di/distrobox/package.nix
+++ b/pkgs/by-name/di/distrobox/package.nix
@@ -67,7 +67,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     homepage = "https://distrobox.it/";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     mainProgram = "distrobox";
   };
 })

--- a/pkgs/by-name/dr/droidmote/package.nix
+++ b/pkgs/by-name/dr/droidmote/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
     homepage = "https://www.videomap.it/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     platforms = lib.attrNames srcs;
   };
 }

--- a/pkgs/by-name/ha/halide/package.nix
+++ b/pkgs/by-name/ha/halide/package.nix
@@ -152,7 +152,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     maintainers = with lib.maintainers; [
       ck3d
-      atila
       twesterhout
     ];
     broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;

--- a/pkgs/by-name/ir/irpf/package.nix
+++ b/pkgs/by-name/ir/irpf/package.nix
@@ -90,7 +90,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     platforms = lib.platforms.all;
     sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
     maintainers = with lib.maintainers; [
-      atila
       rafaelrc
     ];
     mainProgram = "irpf";

--- a/pkgs/by-name/ko/kompute/package.nix
+++ b/pkgs/by-name/ko/kompute/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://kompute.cc/";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/mp/mpvpaper/package.nix
+++ b/pkgs/by-name/mp/mpvpaper/package.nix
@@ -61,6 +61,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.linux;
     mainProgram = "mpvpaper";
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ob/obsidian/package.nix
+++ b/pkgs/by-name/ob/obsidian/package.nix
@@ -21,7 +21,6 @@ let
     mainProgram = "obsidian";
     license = lib.licenses.obsidian;
     maintainers = with lib.maintainers; [
-      atila
       conradmearns
       zaninime
       qbit

--- a/pkgs/by-name/oi/oil-buku/package.nix
+++ b/pkgs/by-name/oi/oil-buku/package.nix
@@ -46,7 +46,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Search-as-you-type cli frontend for the buku bookmarks manager using peco";
     homepage = "https://github.com/AndreiUlmeyda/oil";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     mainProgram = "oil";
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/su/subnetcalc/package.nix
+++ b/pkgs/by-name/su/subnetcalc/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
       type, scope, interface ID, etc.).
     '';
     mainProgram = "subnetcalc";
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sw/swaytools/package.nix
+++ b/pkgs/by-name/sw/swaytools/package.nix
@@ -27,7 +27,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     homepage = "https://github.com/tmccombs/swaytools";
     description = "Collection of simple tools for sway (and i3)";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/sw/swayws/package.nix
+++ b/pkgs/by-name/sw/swayws/package.nix
@@ -28,6 +28,6 @@ rustPlatform.buildRustPackage {
     mainProgram = "swayws";
     homepage = "https://gitlab.com/w0lff/swayws";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/by-name/zo/zotero-beta/package.nix
+++ b/pkgs/by-name/zo/zotero-beta/package.nix
@@ -133,7 +133,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.agpl3Only;
     platforms = [ "x86_64-linux" ];
     maintainers = with lib.maintainers; [
-      atila
       justanotherariel
     ];
   };

--- a/pkgs/by-name/zo/zotero/package.nix
+++ b/pkgs/by-name/zo/zotero/package.nix
@@ -319,7 +319,6 @@ buildNpmPackage (finalAttrs: {
     license = lib.licenses.agpl3Only;
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     maintainers = with lib.maintainers; [
-      atila
       justanotherariel
       mynacol
     ];

--- a/pkgs/development/python-modules/archspec/default.nix
+++ b/pkgs/development/python-modules/archspec/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
       mit
       asl20
     ];
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     mainProgram = "archspec";
   };
 }

--- a/pkgs/development/python-modules/codepy/default.nix
+++ b/pkgs/development/python-modules/codepy/default.nix
@@ -43,6 +43,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/inducer/codepy";
     description = "Generate and execute native code at run time, from Python";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/contexttimer/default.nix
+++ b/pkgs/development/python-modules/contexttimer/default.nix
@@ -40,6 +40,6 @@ buildPythonPackage {
     homepage = "https://github.com/brouberol/contexttimer";
     description = "Timer as a context manager";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/deepwave/default.nix
+++ b/pkgs/development/python-modules/deepwave/default.nix
@@ -68,6 +68,6 @@ buildPythonPackage rec {
     homepage = "https://github.com/ar4/deepwave";
     license = lib.licenses.mit;
     platforms = lib.intersectLists lib.platforms.x86_64 lib.platforms.linux;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/devito/default.nix
+++ b/pkgs/development/python-modules/devito/default.nix
@@ -154,6 +154,6 @@ buildPythonPackage rec {
     homepage = "https://www.devitoproject.org/";
     changelog = "https://github.com/devitocodes/devito/releases/tag/v${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/hpccm/default.nix
+++ b/pkgs/development/python-modules/hpccm/default.nix
@@ -48,7 +48,7 @@ buildPythonPackage rec {
     homepage = "https://github.com/NVIDIA/hpc-container-maker";
     changelog = "https://github.com/NVIDIA/hpc-container-maker/blob/${src.tag}/CHANGELOG.md";
     license = lib.licenses.asl20;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
     mainProgram = "hpccm";
     platforms = lib.platforms.x86;
   };

--- a/pkgs/development/python-modules/pyrevolve/default.nix
+++ b/pkgs/development/python-modules/pyrevolve/default.nix
@@ -51,6 +51,6 @@ buildPythonPackage rec {
     changelog = "https://github.com/devitocodes/pyrevolve/releases/tag/${src.tag}";
     description = "Python library to manage checkpointing for adjoints";
     license = lib.licenses.epl10;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/segyio/default.nix
+++ b/pkgs/development/python-modules/segyio/default.nix
@@ -57,6 +57,6 @@ buildPythonPackage rec {
     description = "Fast Python library for SEGY files";
     homepage = "https://github.com/equinor/segyio";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/development/python-modules/tiler/default.nix
+++ b/pkgs/development/python-modules/tiler/default.nix
@@ -39,6 +39,6 @@ buildPythonPackage rec {
     description = "N-dimensional NumPy array tiling and merging with overlapping, padding and tapering";
     homepage = "https://the-lay.github.io/tiler/";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ atila ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -49,7 +49,6 @@ stdenv.mkDerivation {
     ];
     maintainers = with lib.maintainers; [
       tvorog
-      atila
     ];
     platforms = lib.platforms.linux;
     broken = kernel.kernelOlder "4.20";


### PR DESCRIPTION
## Reasons

- Last commented in [October 2024](https://github.com/NixOS/nixpkgs/issues?q=commenter%3AAtilaSaraiva)
- Hasn't created any PRs / Issues since [November 2024](https://github.com/NixOS/nixpkgs/issues?q=author%3AAtilaSaraiva)
- About 300 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3AAtilaSaraiva%20-commenter%3AAtilaSaraiva%20-author%3AAtilaSaraiva%20-reviewed-by%3AAtilaSaraiva%20created%3A%3E%40today-2y) PRs / Issues

See [lossing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this.

## Packages 

Those packages only have them as their maintainer and are looking for at least one new maintainer.

- [ ] borg-sans-mono
- [ ] distrobox
- [ ] droidmote
- [ ] kompute
- [ ] mendeley
- [ ] mpvpaper
- [ ] oil-buku
- [ ] subnetcalc
- [ ] swaytools
- [ ] pythonPackages.archspec
- [ ] pythonPackages.codepy
- [ ] pythonPackages.contexttimer
- [ ] pythonPackages.devito
- [ ] pythonPackages.hpccm
- [ ] pythonPackages.pyrevolve
- [ ] pythonPackages.tiler