### PR TITLE
zeroad: 0.27.1 -> 0.28.0

### DIFF
--- a/pkgs/by-name/ze/zeroad-data/package.nix
+++ b/pkgs/by-name/ze/zeroad-data/package.nix
@@ -11,11 +11,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://releases.wildfiregames.com/0ad-${finalAttrs.version}-unix-data.tar.xz";
-    hash = "sha256-g34tbd8TiwJfwCAXJF11gaS7hP2UtCwOYF0yG3AXqZg=";
+    hash = "sha256-6ESzCuIQLEfgpP/y8ODvBboM67GJCqcidvoSRXw5Um8=";
   };
 
   installPhase = ''
-    rm binaries/data/tools/fontbuilder/fonts/*.txt
     mkdir -p $out/share/0ad
     cp -r binaries/data $out/share/0ad/
   '';

--- a/pkgs/by-name/ze/zeroad-unwrapped/package.nix
+++ b/pkgs/by-name/ze/zeroad-unwrapped/package.nix
@@ -3,11 +3,12 @@
   lib,
   perl,
   fetchurl,
+  fetchpatch,
   python3,
   fmt_9,
   libidn,
   pkg-config,
-  spidermonkey_115,
+  spidermonkey_128,
   boost,
   icu,
   libxml2,
@@ -38,15 +39,30 @@
 }:
 
 # You can find more instructions on how to build 0ad here:
-#    https://trac.wildfiregames.com/wiki/BuildInstructions
+# https://gitea.wildfiregames.com/0ad/0ad/wiki/BuildInstructions
 
+let
+  # When updating 0 A.D., check for necessary SpiderMonkey patches here:
+  # https://gitea.wildfiregames.com/0ad/0ad/src/branch/main/libraries/source/spidermonkey/patches
+  spidermonkey = spidermonkey_128.overrideAttrs (old: {
+    # Fix segfault during GUI GC (fixed in v140)
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1982134
+    patches = old.patches or [ ] ++ [
+      (fetchpatch {
+        name = "fix-extra-gc-tracing.patch";
+        url = "https://github.com/mozilla-firefox/firefox/commit/bf1994b05baea60f84309475cd544fe89acf82f2.patch";
+        hash = "sha256-3sTcZb34yHheqK7O9aHSwMife3uJnf3us+0sPJ2NzKs=";
+      })
+    ];
+  });
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "0ad";
-  version = "0.27.1";
+  version = "0.28.0";
 
   src = fetchurl {
     url = "https://releases.wildfiregames.com/0ad-${finalAttrs.version}-unix-build.tar.xz";
-    hash = "sha256-oKU1XutZaNJPKDdwc2FQ2XTa/sugd1TUZicH3BcBa/s=";
+    hash = "sha256-J+IXdV73apIv5Y2/WT2W5Utu0jddI/VIw1YZqmvVpCo=";
   };
 
   nativeBuildInputs = [
@@ -56,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    spidermonkey_115
+    spidermonkey
     boost
     icu
     libxml2

--- a/pkgs/by-name/ze/zeroad-unwrapped/rootdir_env.patch
+++ b/pkgs/by-name/ze/zeroad-unwrapped/rootdir_env.patch
@@ -1,10 +1,13 @@
 diff --git a/source/ps/GameSetup/Paths.cpp b/source/ps/GameSetup/Paths.cpp
-index 474364e..bf084b4 100644
+index 4a692713..c393e7d5 100644
 --- a/source/ps/GameSetup/Paths.cpp
 +++ b/source/ps/GameSetup/Paths.cpp
-@@ -155,32 +155,8 @@ Paths::Paths(const CmdLineArgs& args)
+@@ -166,34 +166,9 @@ Paths::Paths(const CmdLineArgs& args)
+ }
  
- /*static*/ OsPath Paths::Root(const OsPath& argv0)
+ 
+-/*static*/ OsPath Paths::Root(const OsPath& argv0)
++/*static*/ OsPath Paths::Root([[maybe_unused]] const OsPath& argv0)
  {
 -#if OS_ANDROID
 -	return OsPath("/sdcard/0ad"); // TODO: this is kind of bogus
@@ -32,8 +35,7 @@ index 474364e..bf084b4 100644
 -	return pathname;
 -
 -#endif
-+        UNUSED2(argv0);
 +        return OsPath(getenv("ZEROAD_ROOTDIR"));
  }
  
- /*static*/ OsPath Paths::RootData(const OsPath& argv0)
+ /*static*/ OsPath Paths::RootData([[maybe_unused]] const OsPath& argv0)


### PR DESCRIPTION
Update 0 A.D. to the recent [Release 28](https://play0ad.com/new-release-0-a-d-release-28-boiorix/). This relies on the premake5 update #492252, but I wasn’t sure how nixpkgs handles dependent package updates so I’m submitting this as a separate PR. I guess I’ll have to rebase on master once that PR is merged and before this one gets merged?

**Warning:** I’ve tried launching a game I keep getting a crash with a segmentation fault after a few minutes. I can’t tell if that’s in any way related to NixOS or if it’s just a bug with the new version and my setup.

Maintainer: @chvp 

Closes #493870

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
