### PR TITLE
 leet-helix: init at 0.2.3-unstable-2026-02-24

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22612,6 +22612,13 @@
     githubId = 61013287;
     name = "Ricardo Steijn";
   };
+  ricardomaps = {
+    email = "ricardomapurungajunior@gmail.com";
+    github = "ricardomaps";
+    githubId = 49507078;
+    name = "Ricardo Mapurunga Junior";
+    matrix = "@ricmaps:matrix.org";
+  };
   richar = {
     github = "ri-char";
     githubId = 17962023;

--- a/pkgs/by-name/le/leet-helix/package.nix
+++ b/pkgs/by-name/le/leet-helix/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+  nix-update-script,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "leet-helix";
+  version = "0.2.3-unstable-2026-02-24";
+
+  src = fetchFromGitHub {
+    owner = "Jarrlist";
+    repo = "LeetHelix";
+    rev = "d6e07920242ce852453d3d3b47d9418fda8baa8a";
+    hash = "sha256-29RMI66tvSJxh1P2osRCJLvIXbwPy2lPPqtEsKQIWe4=";
+  };
+
+  pyproject = true;
+
+  dependencies = with python3Packages; [
+    typer
+    rich
+    sqlmodel
+    sqlite-utils
+  ];
+
+  build-system = [ python3Packages.hatchling ];
+
+  # necessary for tests which require a writable home
+  preBuild = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  doCheck = true;
+
+  nativeCheckInputs = [ python3Packages.pytestCheckHook ];
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch=HEAD" ]; };
+
+  meta = {
+    description = "Game to practice your Helix editor skills with code challenges";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/Jarrlist/LeetHelix";
+    maintainers = [ lib.maintainers.ricardomaps ];
+    platforms = lib.platforms.all;
+    mainProgram = "leet";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds LeetHelix, a terminal game to practice your skills with the Helix editor
Homepage: [https://github.com/Jarrlist/LeetHelix](https://github.com/Jarrlist/LeetHelix)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
