### PR TITLE
python3Packages.mpd2: 3.1.1 -> 3.1.2

### DIFF
--- a/pkgs/development/python-modules/mpd2/default.nix
+++ b/pkgs/development/python-modules/mpd2/default.nix
@@ -1,32 +1,34 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   twisted,
   unittestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "python-mpd2";
-  version = "3.1.1";
+  version = "3.1.2";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-S67DWEzEPtmUjVVZB5+vwmebBrKt4nPpCbNYJlSys/U=";
+  src = fetchFromGitHub {
+    owner = "Mic92";
+    repo = "python-mpd2";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3isX3e4Fu1orxuRsC3u8RxoFDQcE4XxQhf8PIHdo/e4=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools ];
 
   optional-dependencies = {
     twisted = [ twisted ];
   };
 
-  nativeCheckInputs = [ unittestCheckHook ] ++ optional-dependencies.twisted;
+  nativeCheckInputs = [ unittestCheckHook ] ++ finalAttrs.passthru.optional-dependencies.twisted;
 
   meta = {
-    changelog = "https://github.com/Mic92/python-mpd2/blob/v${version}/doc/changes.rst";
+    changelog = "https://github.com/Mic92/python-mpd2/blob/${finalAttrs.src.tag}/doc/changes.rst";
     description = "Python client module for the Music Player Daemon";
     homepage = "https://github.com/Mic92/python-mpd2";
     license = lib.licenses.lgpl3Plus;
@@ -35,4 +37,4 @@ buildPythonPackage rec {
       hexa
     ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/Mic92/python-mpd2/blob/v3.1.2/doc/changes.rst


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
