### PR TITLE
devpi-server: 6.15.0 -> 6.19.1

### DIFF
--- a/pkgs/development/python-modules/devpi-ldap/default.nix
+++ b/pkgs/development/python-modules/devpi-ldap/default.nix
@@ -9,6 +9,7 @@
   pytest-flake8,
   pytestCheckHook,
   pythonOlder,
+  pythonAtLeast,
   pyyaml,
   setuptools,
   webtest,
@@ -19,7 +20,8 @@ buildPythonPackage {
   version = "2.1.1-unstable-2023-11-28";
   pyproject = true;
 
-  disabled = pythonOlder "3.13";
+  # build-system broken for 3.14, package incompatible <3.13
+  disabled = pythonOlder "3.13" || pythonAtLeast "3.14";
 
   src = fetchFromGitHub {
     owner = "devpi";

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -123,7 +123,7 @@ buildPythonApplication rec {
     };
   };
 
-  # devpi uses a monorepo for server,common,client and web
+  # devpi uses a monorepo for server, common, client and web
   passthru.updateScript = gitUpdater {
     rev-prefix = "server-";
   };
@@ -133,6 +133,9 @@ buildPythonApplication rec {
     description = "Github-style pypi index server and packaging meta tool";
     changelog = "https://github.com/devpi/devpi/blob/${src.rev}/server/CHANGELOG";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ makefu ];
+    maintainers = with lib.maintainers; [
+      confus
+      makefu
+    ];
   };
 }

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -22,6 +22,7 @@
   pytestCheckHook,
   repoze-lru,
   setuptools,
+  setuptools-changelog-shortener,
   strictyaml,
   waitress,
   webtest,
@@ -32,25 +33,21 @@
 
 buildPythonApplication rec {
   pname = "devpi-server";
-  version = "6.15.0";
+  version = "6.19.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
     rev = "server-${version}";
-    hash = "sha256-tKR1xZju5bDbFu8t3SunTM8FlaXodSm/OjJ3Jfl7Dzk=";
+    hash = "sha256-YFY2iLnORzFxnfGYU2kCpJL8CZi+lALIkL1bRpfd4NE=";
   };
 
   sourceRoot = "${src.name}/server";
 
-  postPatch = ''
-    substituteInPlace tox.ini \
-      --replace "--flake8" ""
-  '';
-
   nativeBuildInputs = [
     setuptools
+    setuptools-changelog-shortener
   ];
 
   propagatedBuildInputs = [
@@ -102,12 +99,7 @@ buildPythonApplication rec {
     "test_devpi_server/test_streaming_replica_nginx.py"
   ];
   disabledTests = [
-    "root_passwd_hash_option"
-    "TestMirrorIndexThings"
-    "test_auth_mirror_url_no_hash"
-    "test_auth_mirror_url_with_hash"
-    "test_auth_mirror_url_hidden_in_logs"
-    "test_simplelinks_timeout"
+    "test_fetch_later_deleted" # incompatible with newer pytest
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/tools/devpi-server/default.nix
+++ b/pkgs/development/tools/devpi-server/default.nix
@@ -31,7 +31,7 @@
   nixosTests,
 }:
 
-buildPythonApplication rec {
+buildPythonApplication (finalAttrs: {
   pname = "devpi-server";
   version = "6.19.1";
   pyproject = true;
@@ -39,18 +39,18 @@ buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi";
-    rev = "server-${version}";
+    tag = "server-${finalAttrs.version}";
     hash = "sha256-YFY2iLnORzFxnfGYU2kCpJL8CZi+lALIkL1bRpfd4NE=";
   };
 
-  sourceRoot = "${src.name}/server";
+  sourceRoot = "${finalAttrs.src.name}/server";
 
-  nativeBuildInputs = [
+  build-system = [
     setuptools
     setuptools-changelog-shortener
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     aiohttp
     appdirs
     defusedxml
@@ -123,11 +123,11 @@ buildPythonApplication rec {
   meta = {
     homepage = "http://doc.devpi.net";
     description = "Github-style pypi index server and packaging meta tool";
-    changelog = "https://github.com/devpi/devpi/blob/${src.rev}/server/CHANGELOG";
+    changelog = "https://github.com/devpi/devpi/blob/${finalAttrs.src.tag}/server/CHANGELOG";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       confus
       makefu
     ];
   };
-}
+})


### PR DESCRIPTION
bump devpi-server from 6.15.0 to 6.19.1

changelog: https://github.com/devpi/devpi/blob/main/server/CHANGELOG
changeset: https://github.com/devpi/devpi/compare/server-6.15.0...server-6.19.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
