### PR TITLE
sddm-astronaut: refactor, update, reduce closure size, add qweered as a maintainer

### DIFF
--- a/pkgs/by-name/sd/sddm-astronaut/package.nix
+++ b/pkgs/by-name/sd/sddm-astronaut/package.nix
@@ -57,6 +57,7 @@ stdenvNoCC.mkDerivation {
     maintainers = with lib.maintainers; [
       danid3v
       uxodb
+      qweered
     ];
   };
 }

--- a/pkgs/by-name/sd/sddm-astronaut/package.nix
+++ b/pkgs/by-name/sd/sddm-astronaut/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   kdePackages,
   formats,
+  nix-update-script,
   themeConfig ? null,
   embeddedTheme ? "astronaut",
 }:
@@ -45,6 +46,8 @@ stdenvNoCC.mkDerivation {
     chmod u+w ${basePath}/Themes/
     ln -sf ${configFile} ${basePath}/Themes/${embeddedTheme}.conf.user
   '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Modern looking qt6 sddm theme";

--- a/pkgs/by-name/sd/sddm-astronaut/package.nix
+++ b/pkgs/by-name/sd/sddm-astronaut/package.nix
@@ -15,13 +15,13 @@ let
 in
 stdenvNoCC.mkDerivation {
   pname = "sddm-astronaut";
-  version = "1.0-unstable-2025-01-05";
+  version = "0-unstable-2025-12-06";
 
   src = fetchFromGitHub {
     owner = "Keyitdev";
     repo = "sddm-astronaut-theme";
-    rev = "11c0bf6147bbea466ce2e2b0559e9a9abdbcc7c3";
-    hash = "sha256-gBSz+k/qgEaIWh1Txdgwlou/Lfrfv3ABzyxYwlrLjDk=";
+    rev = "d73842c761f7d7859f3bdd80e4360f09180fad41";
+    hash = "sha256-+94WVxOWfVhIEiVNWwnNBRmN+d1kbZCIF10Gjorea9M=";
   };
 
   dontWrapQtApps = true;

--- a/pkgs/by-name/sd/sddm-astronaut/package.nix
+++ b/pkgs/by-name/sd/sddm-astronaut/package.nix
@@ -7,7 +7,12 @@
   themeConfig ? null,
   embeddedTheme ? "astronaut",
 }:
-stdenvNoCC.mkDerivation rec {
+let
+  configFile = (formats.ini { }).generate "" { General = themeConfig; };
+  basePath = "$out/share/sddm/themes/sddm-astronaut-theme";
+  sedString = "ConfigFile=Themes/";
+in
+stdenvNoCC.mkDerivation {
   pname = "sddm-astronaut";
   version = "1.0-unstable-2025-01-05";
 
@@ -26,34 +31,25 @@ stdenvNoCC.mkDerivation rec {
     qtvirtualkeyboard
   ];
 
-  installPhase =
-    let
-      iniFormat = formats.ini { };
-      configFile = iniFormat.generate "" { General = themeConfig; };
+  installPhase = ''
+    mkdir -p ${basePath}
+    cp -r $src/* ${basePath}
+  ''
+  + lib.optionalString (embeddedTheme != "astronaut") ''
 
-      basePath = "$out/share/sddm/themes/sddm-astronaut-theme";
-      sedString = "ConfigFile=Themes/";
-    in
-    ''
-      mkdir -p ${basePath}
-      cp -r $src/* ${basePath}
-    ''
-    + lib.optionalString (embeddedTheme != "astronaut") ''
-
-      # Replaces astronaut.conf with embedded theme in metadata.desktop on line 9.
-      # ConfigFile=Themes/astronaut.conf.
-      sed -i "s|^${sedString}.*\\.conf$|${sedString}${embeddedTheme}.conf|" ${basePath}/metadata.desktop
-    ''
-    + lib.optionalString (themeConfig != null) ''
-      chmod u+w ${basePath}/Themes/
-      ln -sf ${configFile} ${basePath}/Themes/${embeddedTheme}.conf.user
-    '';
+    # Replaces astronaut.conf with embedded theme in metadata.desktop on line 9.
+    # ConfigFile=Themes/astronaut.conf.
+    sed -i "s|^${sedString}.*\\.conf$|${sedString}${embeddedTheme}.conf|" ${basePath}/metadata.desktop
+  ''
+  + lib.optionalString (themeConfig != null) ''
+    chmod u+w ${basePath}/Themes/
+    ln -sf ${configFile} ${basePath}/Themes/${embeddedTheme}.conf.user
+  '';
 
   meta = {
     description = "Modern looking qt6 sddm theme";
-    homepage = "https://github.com/${src.owner}/${src.repo}";
+    homepage = "https://github.com/Keyitdev/sddm-astronaut-theme";
     license = lib.licenses.gpl3;
-
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       danid3v

--- a/pkgs/by-name/sd/sddm-astronaut/package.nix
+++ b/pkgs/by-name/sd/sddm-astronaut/package.nix
@@ -27,9 +27,10 @@ stdenvNoCC.mkDerivation {
   dontWrapQtApps = true;
 
   propagatedBuildInputs = with kdePackages; [
-    qtsvg
-    qtmultimedia
-    qtvirtualkeyboard
+    # avoid .dev outputs propagation
+    qtsvg.out
+    qtmultimedia.out
+    qtvirtualkeyboard.out
   ];
 
   installPhase = ''


### PR DESCRIPTION
## Things done

Tested theme myself, everything works
```nix
CHANGED
[D*] sddm-astronaut    1.0-unstable-2025-01-05 -> 0-unstable-2025-12-06

REMOVED
[R.] gst-libav         1.26.5-dev
[R.] gst-plugins-bad   1.26.5-dev
[R.] gst-plugins-base  1.26.5-dev
[R.] gst-plugins-good  1.26.5-dev
[R.] gstreamer         1.26.5-dev
[R.] gstreamer-vaapi   1.26.5, 1.26.5-dev
[R.] hunspell          1.7.2-bin, 1.7.2-dev
[R*] pipewire          1.4.9-dev
[R.] qtdeclarative     6.10.1-dev
[R.] qtlanguageserver  6.10.1, 6.10.1-dev
[R.] qtmultimedia      6.10.1-dev
[R.] qtquick3d         6.10.1-dev
[R.] qtshadertools     6.10.1-dev
[R.] qtvirtualkeyboard 6.10.1-dev

SIZE: 17.1 GiB -> 17.1 GiB
DIFF: -21.6 MiB
```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
