### PR TITLE
sddm themes: avoid .dev outputs propagation

### DIFF
--- a/pkgs/by-name/ca/catppuccin-sddm-corners/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm-corners/package.nix
@@ -21,11 +21,12 @@ stdenvNoCC.mkDerivation {
   dontBuild = true;
   dontWrapQtApps = true;
 
-  propagatedUserEnvPkgs = with qt6; [
-    qt5compat
-    qtwayland
-    qtquick3d
-    qtsvg
+  propagatedBuildInputs = with qt6; [
+    # avoid .dev outputs propagation
+    qt5compat.out
+    qtwayland.out
+    qtquick3d.out
+    qtsvg.out
   ];
 
   installPhase = ''

--- a/pkgs/by-name/ca/catppuccin-sddm/package.nix
+++ b/pkgs/by-name/ca/catppuccin-sddm/package.nix
@@ -35,7 +35,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
-    kdePackages.qtsvg
+    # avoid .dev outputs propagation
+    kdePackages.qtsvg.out
   ];
 
   postPatch = ''
@@ -89,11 +90,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     ''}
 
     runHook postInstall
-  '';
-
-  postFixup = ''
-    mkdir -p $out/nix-support
-    echo ${kdePackages.qtsvg} >> $out/nix-support/propagated-user-env-packages
   '';
 
   meta = {

--- a/pkgs/by-name/el/elegant-sddm/package.nix
+++ b/pkgs/by-name/el/elegant-sddm/package.nix
@@ -27,7 +27,8 @@ stdenvNoCC.mkDerivation {
 
   dontWrapQtApps = true;
   propagatedBuildInputs = [
-    kdePackages.qt5compat
+    # avoid .dev outputs propagation
+    kdePackages.qt5compat.out
   ];
 
   installPhase = ''

--- a/pkgs/by-name/no/nordic/package.nix
+++ b/pkgs/by-name/no/nordic/package.nix
@@ -149,13 +149,11 @@ stdenvNoCC.mkDerivation {
   '';
 
   postFixup = ''
-    # Propagate sddm theme dependencies to user env otherwise sddm
-    # does not find them. Putting them in buildInputs is not enough.
-
     mkdir -p $sddm/nix-support
 
-    printWords ${kdePackages.breeze-icons} ${kdePackages.libplasma} ${kdePackages.plasma-workspace} \
-      >> $sddm/nix-support/propagated-user-env-packages
+    # avoid .dev outputs propagation
+    printWords ${kdePackages.breeze-icons.out} ${kdePackages.libplasma.out} ${kdePackages.plasma-workspace.out} \
+      >> $sddm/nix-support/propagated-build-inputs
   '';
 
   meta = {

--- a/pkgs/by-name/sd/sddm-chili-theme/package.nix
+++ b/pkgs/by-name/sd/sddm-chili-theme/package.nix
@@ -30,7 +30,9 @@ stdenv.mkDerivation {
   };
 
   propagatedBuildInputs = [
-    libsForQt5.qtgraphicaleffects
+    # avoid .dev outputs propagation
+    libsForQt5.qtgraphicaleffects.out
+    libsForQt5.qtquickcontrols.out
   ];
 
   dontWrapQtApps = true;
@@ -43,11 +45,6 @@ stdenv.mkDerivation {
     mv * $out/share/sddm/themes/chili/
   '';
 
-  postFixup = ''
-    mkdir -p $out/nix-support
-
-    echo ${libsForQt5.qtgraphicaleffects} >> $out/nix-support/propagated-user-env-packages
-  '';
   meta = {
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ sents ];

--- a/pkgs/by-name/sd/sddm-sugar-dark/package.nix
+++ b/pkgs/by-name/sd/sddm-sugar-dark/package.nix
@@ -20,7 +20,10 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   dontWrapQtApps = true;
 
-  buildInputs = with libsForQt5.qt5; [ qtgraphicaleffects ];
+  propagatedBuildInputs = [
+    # avoid .dev outputs propagation
+    libsForQt5.qtgraphicaleffects.out
+  ];
 
   installPhase =
     let

--- a/pkgs/by-name/ut/utterly-nord-plasma/package.nix
+++ b/pkgs/by-name/ut/utterly-nord-plasma/package.nix
@@ -16,12 +16,15 @@ stdenv.mkDerivation {
     hash = "sha256-moLgBFR+BgoiEBzV3y/LA6JZfLHrG1weL1+h8LN9ztA=";
   };
 
-  propagatedUserEnvPkgs = with kdePackages; [
-    breeze-icons
-    kdeclarative
+  dontWrapQtApps = true;
+
+  propagatedBuildInputs = with kdePackages; [
+    # avoid .dev outputs propagation
+    qt5compat.out
     kirigami
-    libplasma
-    plasma-workspace
+    libplasma.out
+    plasma5support.out
+    plasma-workspace.out
   ];
 
   installPhase = ''

--- a/pkgs/by-name/wh/where-is-my-sddm-theme/package.nix
+++ b/pkgs/by-name/wh/where-is-my-sddm-theme/package.nix
@@ -43,12 +43,13 @@ lib.checkListOfEnum "where-is-my-sddm-theme: variant" validVariants variants
       hash = "sha256-+R0PX84SL2qH8rZMfk3tqkhGWPR6DpY1LgX9bifNYCg=";
     };
 
-    propagatedUserEnvPkgs =
+    propagatedBuildInputs =
       [ ]
       ++ lib.optionals (lib.elem "qt5" variants) [ libsForQt5.qtgraphicaleffects ]
+      # avoid .dev outputs propagation
       ++ lib.optionals (lib.elem "qt6" variants) [
-        qt6.qt5compat
-        qt6.qtsvg
+        qt6.qt5compat.out
+        qt6.qtsvg.out
       ];
 
     installPhase = ''


### PR DESCRIPTION
Multi-output Qt/KDE packages default to their `-dev` output when used in `propagatedBuildInputs` without an explicit output selector. This causes SDDM theme packages to drag `-dev` outputs (and their transitive build-time deps) into the system closure unnecessarily.

Fix by explicitly selecting `.out` on all Qt/KDE deps. Also switch themes using `propagatedUserEnvPkgs` or manual `nix-support/propagated-user-env-packages` to `propagatedBuildInputs` so deps correctly flow through the SDDM wrapper's `extraPackages → buildInputs → wrapQtAppsHook` path.

| Package | Change |
|---|---|
| **catppuccin-sddm** | `.out` on `propagatedBuildInputs`, removed redundant `postFixup` |
| **catppuccin-sddm-corners** | `propagatedUserEnvPkgs` → `propagatedBuildInputs` with `.out` |
| **where-is-my-sddm-theme** | `propagatedUserEnvPkgs` → `propagatedBuildInputs` with `.out` |
| **elegant-sddm** | Added `.out` to `propagatedBuildInputs` |
| **sddm-chili-theme** | Added `.out`, removed redundant `postFixup` |
| **sddm-sugar-dark** | `buildInputs` → `propagatedBuildInputs` with `.out` |
| **utterly-nord-plasma** | `propagatedUserEnvPkgs` → `propagatedBuildInputs` with `.out`, added `dontWrapQtApps`, trimmed deps to actual QML imports |
| **nordic** | `propagated-user-env-packages` → `propagated-build-inputs` with `.out` in `postFixup` |

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test