### PR TITLE
unifont: 16.0.03 -> 17.0.03, add update script

### DIFF
--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -73,7 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
       gpl2Plus
       fontException
     ];
-    maintainers = [ lib.maintainers.rycee ];
+    maintainers = with lib.maintainers; [
+      rycee
+      qweered
+    ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -62,6 +62,8 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  passthru.updateScript = ./update.sh;
+
   meta = {
     description = "Unicode font for Base Multilingual Plane";
     homepage = "https://unifoundry.com/unifont/";

--- a/pkgs/by-name/un/unifont/package.nix
+++ b/pkgs/by-name/un/unifont/package.nix
@@ -9,21 +9,21 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "unifont";
-  version = "16.0.03";
+  version = "17.0.03";
 
   otf = fetchurl {
     url = "mirror://gnu/unifont/unifont-${finalAttrs.version}/unifont-${finalAttrs.version}.otf";
-    hash = "sha256-9TnyHLrjkWoJP4GdNsR3EtVwGshtrO2KaOzPe9nTPAw=";
+    hash = "sha256-JgccWpdTPO/cvGsGRefuJ5QTBJB58J9ZKyaRbKbCG/U=";
   };
 
   pcf = fetchurl {
     url = "mirror://gnu/unifont/unifont-${finalAttrs.version}/unifont-${finalAttrs.version}.pcf.gz";
-    hash = "sha256-ysKULOBusx4n7NfYRAzEoRfqaTNn5JtjigTVmb7wozY=";
+    hash = "sha256-byijyRE71OdtTqYdymQV73yds1an+AuRbJFTlRsaj+0=";
   };
 
   bdf = fetchurl {
     url = "mirror://gnu/unifont/unifont-${finalAttrs.version}/unifont-${finalAttrs.version}.bdf.gz";
-    hash = "sha256-fz0WZKwcBR9ZoaE2DdZU942CwkamiMNC6GPOx/a6ldQ=";
+    hash = "sha256-MNUDAtrKYx4s9FTZdHEX2YyfNcCxivT2fS+l4RaZIDM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/un/unifont/update.sh
+++ b/pkgs/by-name/un/unifont/update.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -euo pipefail
+
+latest=$(curl -sL "https://ftp.gnu.org/gnu/unifont/" | grep -oP 'unifont-\K\d+\.\d+\.\d+' | sort -V | tail -1)
+
+update-source-version unifont "$latest" --ignore-same-version --source-key=otf
+update-source-version unifont "$latest" --ignore-same-version --source-key=pcf
+update-source-version unifont "$latest" --ignore-same-version --source-key=bdf


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
