### PR TITLE
haskellPackages.require: jailbreak

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1197,6 +1197,10 @@ with haskellLib;
     broken = pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isi686;
   }) super.vimus;
 
+  # 2026-02-19: too strict bounds on bytestring (<0.11) and text (<2)
+  # https://github.com/theam/require/pull/31
+  require = doJailbreak super.require;
+
   # https://github.com/kazu-yamamoto/logger/issues/42
   logger = dontCheck super.logger;
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5367,7 +5367,6 @@ broken-packages:
   - reqcatcher # failure in job https://hydra.nixos.org/build/295096611 at 2025-04-22
   - request # failure in job https://hydra.nixos.org/build/233256702 at 2023-09-02
   - request-monad # failure in job https://hydra.nixos.org/build/233204896 at 2023-09-02
-  - require # failure in job https://hydra.nixos.org/build/233203170 at 2023-09-02
   - rescue # failure in job https://hydra.nixos.org/build/233230073 at 2023-09-02
   - reservoir # failure in job https://hydra.nixos.org/build/233194430 at 2023-09-02
   - resolve # failure in job https://hydra.nixos.org/build/233224070 at 2023-09-02

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/transitive-broken.yaml
@@ -3486,7 +3486,6 @@ dont-distribute-packages:
  - timeprint
  - timezone-unix
  - tinkoff-invest-sdk
- - tintin
  - tinytools-vty
  - tip-haskell-frontend
  - tip-lib


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Too strict bounds on `bytestring` and `text`. [Relevant PR](https://github.com/theam/require/pull/31). 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux (wsl)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran (running) `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
