### PR TITLE
graphicsmagick: remove libheifSupport option

### DIFF
--- a/pkgs/by-name/gr/graphicsmagick/package.nix
+++ b/pkgs/by-name/gr/graphicsmagick/package.nix
@@ -16,7 +16,6 @@
   libtool,
   libwebp,
   libxml2,
-  libheifSupport ? true,
   libheif,
   nukeReferences,
   pkg-config,
@@ -49,14 +48,14 @@ stdenv.mkDerivation (finalAttrs: {
     libx11
     libjpeg
     libjxl
+    libheif
     libpng
     libtiff
     libtool
     libwebp
     libxml2
     zlib
-  ]
-  ++ lib.optionals libheifSupport [ libheif ];
+  ];
 
   nativeBuildInputs = [
     nukeReferences


### PR DESCRIPTION
All other dependencies do not have an option, so I am not sure why a libheif one exists.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
