### PR TITLE
libjxl: 0.11.1 -> 0.11.2

### DIFF
--- a/pkgs/by-name/li/libjxl/package.nix
+++ b/pkgs/by-name/li/libjxl/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   brotli,
   cmake,
   ctestCheckHook,
@@ -32,7 +31,7 @@ in
 
 stdenv.mkDerivation rec {
   pname = "libjxl";
-  version = "0.11.1";
+  version = "0.11.2";
 
   outputs = [
     "out"
@@ -43,7 +42,7 @@ stdenv.mkDerivation rec {
     owner = "libjxl";
     repo = "libjxl";
     tag = "v${version}";
-    hash = "sha256-ORwhKOp5Nog366UkLbuWpjz/6sJhxUO6+SkoJGH+3fE=";
+    hash = "sha256-L4/BY68ZBCpebQxryR7D1CxrsneYvw8B8EvW2mkF7bA=";
     # There are various submodules in `third_party/`.
     fetchSubmodules = true;
   };
@@ -144,17 +143,6 @@ stdenv.mkDerivation rec {
     shopt -s extglob
     rm -rf third_party/!(sjpeg)/
     shopt -u extglob
-
-    # Fix the build with CMake 4.
-    #
-    # See:
-    #
-    # * <https://github.com/webmproject/sjpeg/commit/9990bdceb22612a62f1492462ef7423f48154072>
-    # * <https://github.com/webmproject/sjpeg/commit/94e0df6d0f8b44228de5be0ff35efb9f946a13c9>
-    substituteInPlace third_party/sjpeg/CMakeLists.txt \
-      --replace-fail \
-        'cmake_minimum_required(VERSION 2.8.7)' \
-        'cmake_minimum_required(VERSION 3.5...3.10)'
 
     substituteInPlace plugins/gdk-pixbuf/jxl.thumbnailer \
       --replace '/usr/bin/gdk-pixbuf-thumbnailer' "$out/libexec/gdk-pixbuf-thumbnailer-jxl"


### PR DESCRIPTION
Add patch for CVE-2025-12474 to `libjxl`

This patch backports an upstream fix to address the vulnerability without updating the package version.

- Fixes [CVE-2025-12474](https://nvd.nist.gov/vuln/detail/CVE-2025-12474)
- [GitHub Advisory](https://github.com/advisories/GHSA-9gvg-fw8p-72fv)
- [Upstream Patch](https://github.com/libjxl/libjxl/commit/4523cf652f568f1fbb57bf9a10ae3caae785cd9f)
- [Tracker Issue](https://github.com/NixOS/nixpkgs/issues/490675)

Closes https://github.com/NixOS/nixpkgs/issues/490675


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
