### PR TITLE
larksuite: init at 7.59.12

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -599,6 +599,13 @@
     githubId = 85082674;
     name = "Adam J. Butler";
   };
+  adamcolwell = {
+    email = "adam@adamcolwell.com";
+    matrix = "@adam:colwell.au";
+    github = "adamcolwell";
+    githubId = 970593;
+    name = "Adam Colwell";
+  };
   adamcstephens = {
     email = "happy.plan4249@valkor.net";
     matrix = "@adam:robins.wtf";

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -178,16 +178,21 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/bytedance-lark.desktop \
       --replace-fail /usr/bin/bytedance-lark-stable $out/opt/bytedance/lark/bytedance-lark
 
-    # Wrap lark, vulcan, and video_conference_sdk
-    # - lark: main executable
+    # Remove bundled xdg utilities that don't work on NixOS
+    # This forces the system to use NixOS's xdg-utils which work correctly
+#    rm -f $out/opt/bytedance/lark/vulcan/xdg-mime
+#    rm -f $out/opt/bytedance/lark/vulcan/xdg-settings
+
+    # Wrap the actual Electron binaries (not upstream's shell scripts)
+    # - lark: main executable (Electron binary)
     # - vulcan/vulcan: Electron browser used for rendering
     # - video_conference_sdk: video meeting child process
+    # Note: bytedance-lark is kept as-is (upstream's shell script handles xdg-utils)
     for executable in $out/opt/bytedance/lark/{lark,vulcan/vulcan,video_conference_sdk}; do
       wrapProgram $executable \
-        --set ELECTRON_DISABLE_SANDBOX 1 \
+        --set ELECTRON_DISABLE_SANDBOX 0 \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-        --prefix LD_LIBRARY_PATH : ${rpath}:$out/opt/bytedance/lark:${addDriverRunpath.driverLink}/share \
-        --prefix PATH : ${lib.makeBinPath [ xdg-utils ]} \
+#        --prefix LD_LIBRARY_PATH : ${rpath}:$out/opt/bytedance/lark:${addDriverRunpath.driverLink}/share \
         ${lib.optionalString (
           commandLineArgs != ""
         ) "--add-flags ${lib.escapeShellArg commandLineArgs}"}

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -20,21 +20,11 @@
   gtk3,
   lib,
   libGL,
-  libX11,
-  libXScrnSaver,
-  libXcomposite,
-  libXcursor,
-  libXdamage,
-  libXext,
-  libXfixes,
-  libXi,
-  libXrandr,
-  libXrender,
-  libXtst,
   libappindicator-gtk3,
   libcxx,
   libdbusmenu,
   libdrm,
+  libgcc,
   libgcrypt,
   libglvnd,
   libnotify,
@@ -44,8 +34,19 @@
   libxkbcommon,
   libxkbfile,
   libxshmfence,
-  makeShellWrapper,
+  libx11,
+  libxscrnsaver,
+  libxcomposite,
+  libxcursor,
+  libxdamage,
+  libxext,
+  libxfixes,
+  libxi,
+  libxrandr,
+  libxrender,
+  libxtst,
   libgbm,
+  makeShellWrapper,
   nspr,
   nss,
   pango,
@@ -90,17 +91,17 @@ let
     glibc
     gnutls
     libGL
-    libX11
-    libXScrnSaver
-    libXcomposite
-    libXcursor
-    libXdamage
-    libXext
-    libXfixes
-    libXi
-    libXrandr
-    libXrender
-    libXtst
+    libx11
+    libxscrnsaver
+    libxcomposite
+    libxcursor
+    libxdamage
+    libxext
+    libxfixes
+    libxi
+    libxrandr
+    libxrender
+    libxtst
     libappindicator-gtk3
     libcxx
     libdbusmenu
@@ -150,10 +151,11 @@ stdenv.mkDerivation {
     # for autopatchelf
     alsa-lib
     cups
-    libXdamage
-    libXtst
+    libxdamage
+    libxtst
     libdrm
     libgcrypt
+    libgcc
     libpulseaudio
     libxshmfence
     libgbm
@@ -254,7 +256,7 @@ stdenv.mkDerivation {
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = builtins.attrNames sources;
-    maintainers = with lib.maintainers; [ ];
+    maintainers = with lib.maintainers; [ adamcolwell ];
     mainProgram = "lark";
   };
 }

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -1,0 +1,260 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  at-spi2-atk,
+  at-spi2-core,
+  atk,
+  autoPatchelfHook,
+  cairo,
+  cups,
+  dbus,
+  dpkg,
+  expat,
+  fetchurl,
+  fontconfig,
+  freetype,
+  gdk-pixbuf,
+  glib,
+  glibc,
+  gnutls,
+  gtk3,
+  lib,
+  libGL,
+  libX11,
+  libXScrnSaver,
+  libXcomposite,
+  libXcursor,
+  libXdamage,
+  libXext,
+  libXfixes,
+  libXi,
+  libXrandr,
+  libXrender,
+  libXtst,
+  libappindicator-gtk3,
+  libcxx,
+  libdbusmenu,
+  libdrm,
+  libgcrypt,
+  libglvnd,
+  libnotify,
+  libpulseaudio,
+  libuuid,
+  libxcb,
+  libxkbcommon,
+  libxkbfile,
+  libxshmfence,
+  makeShellWrapper,
+  libgbm,
+  nspr,
+  nss,
+  pango,
+  pciutils,
+  pipewire,
+  pixman,
+  stdenv,
+  systemd,
+  wayland,
+  xdg-utils,
+  writeShellScript,
+
+  # for custom command line arguments, e.g. "--use-gl=desktop"
+  commandLineArgs ? "",
+}:
+
+let
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://lf16-larkversion.larksuitecdn.com/obj/lark-version-sg/967dd7e4/Lark-linux_x64-7.59.12.deb";
+      hash = "sha256-Oa5tCn2l4zJzafzoxLfAZVXu0zWILKv+DeWJsQRsZtI=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://lf16-larkversion.larksuitecdn.com/obj/lark-version-sg/2d8485bc/Lark-linux_arm64-7.59.12.deb";
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+  };
+
+  rpath = lib.makeLibraryPath [
+    alsa-lib
+    at-spi2-atk
+    at-spi2-core
+    atk
+    cairo
+    cups
+    dbus
+    expat
+    fontconfig
+    freetype
+    gdk-pixbuf
+    glib
+    glibc
+    gnutls
+    libGL
+    libX11
+    libXScrnSaver
+    libXcomposite
+    libXcursor
+    libXdamage
+    libXext
+    libXfixes
+    libXi
+    libXrandr
+    libXrender
+    libXtst
+    libappindicator-gtk3
+    libcxx
+    libdbusmenu
+    libdrm
+    libgcrypt
+    libglvnd
+    libnotify
+    libpulseaudio
+    libuuid
+    libxcb
+    libxkbcommon
+    libxkbfile
+    libxshmfence
+    libgbm
+    nspr
+    nss
+    pango
+    pciutils
+    pipewire
+    pixman
+    stdenv.cc.cc
+    systemd
+    wayland
+    xdg-utils
+  ];
+
+  pname = "larksuite";
+  version = "7.59.12";
+
+in
+stdenv.mkDerivation {
+  inherit pname version;
+
+  src =
+    sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeShellWrapper
+    dpkg
+  ];
+
+  buildInputs = [
+    gtk3
+
+    # for autopatchelf
+    alsa-lib
+    cups
+    libXdamage
+    libXtst
+    libdrm
+    libgcrypt
+    libpulseaudio
+    libxshmfence
+    libgbm
+    nspr
+    nss
+  ];
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # This deb file contains a setuid binary,
+    # so 'dpkg -x' doesn't work here.
+    dpkg --fsys-tarfile $src | tar --extract
+    mkdir -p $out
+    mv usr/share $out/
+    mv opt/ $out/
+
+    substituteInPlace $out/share/applications/bytedance-lark.desktop \
+      --replace-fail /usr/bin/bytedance-lark-stable $out/opt/bytedance/lark/bytedance-lark
+
+    # Wrap lark, vulcan, and video_conference_sdk
+    # - lark: main executable
+    # - vulcan/vulcan: Electron browser used for rendering
+    # - video_conference_sdk: video meeting child process
+    for executable in $out/opt/bytedance/lark/{lark,vulcan/vulcan,video_conference_sdk}; do
+      wrapProgram $executable \
+        --set ELECTRON_DISABLE_SANDBOX 1 \
+        --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
+        --prefix LD_LIBRARY_PATH : ${rpath}:$out/opt/bytedance/lark:${addDriverRunpath.driverLink}/share \
+        ${lib.optionalString (
+          commandLineArgs != ""
+        ) "--add-flags ${lib.escapeShellArg commandLineArgs}"}
+    done
+
+    mkdir -p $out/share/icons/hicolor
+    base="$out/opt/bytedance/lark"
+    for size in 16 24 32 48 64 128 256; do
+      mkdir -p $out/share/icons/hicolor/''${size}x''${size}/apps
+      if [ -f "$base/product_logo_$size.png" ]; then
+        ln -s $base/product_logo_$size.png $out/share/icons/hicolor/''${size}x''${size}/apps/bytedance-lark.png
+      fi
+    done
+
+    mkdir -p $out/bin
+    ln -s $out/opt/bytedance/lark/lark $out/bin/lark
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit sources;
+    updateScript = writeShellScript "update-larksuite" ''
+      set -euo pipefail
+
+      API_URL="https://www.larksuite.com/api/downloads"
+
+      fetch_version() {
+        local key="$1"
+        curl -sf "$API_URL" | jq -r ".versions.$key"
+      }
+
+      for platform in x86_64-linux aarch64-linux; do
+        case "$platform" in
+          x86_64-linux) version_key="Linux_deb_x64" ;;
+          aarch64-linux) version_key="Linux_deb_arm" ;;
+        esac
+
+        info=$(fetch_version "$version_key")
+        url=$(echo "$info" | jq -r '.download_link')
+        version=$(echo "$info" | jq -r '.version_number' | sed 's/.*@V//')
+
+        echo "Platform: $platform"
+        echo "  URL: $url"
+        echo "  Version: $version"
+
+        hash=$(nix-prefetch-url "$url")
+        sri=$(nix hash to-sri --type sha256 "$hash")
+        echo "  Hash: $sri"
+
+        # Update the file using sed
+        pkgfile=${./.}
+        if [ -w "$pkgfile" ]; then
+          sed -i "s|url = \".*$platform.*\";|url = \"$url\";|" "$pkgfile"
+          sed -i "/$platform/,/hash = /s|hash = \".*\";|hash = \"$sri\";|" "$pkgfile"
+        fi
+        echo ""
+      done
+    '';
+  };
+
+  meta = {
+    description = "Lark is a next-generation office suite that integrates messaging, schedule management, collaborative documents, video meeting, and various apps in one platform";
+    homepage = "https://www.larksuite.com";
+    downloadPage = "https://www.larksuite.com/downloads";
+    changelog = "https://www.larksuite.com/hc/en-us/articles/360048663434";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = builtins.attrNames sources;
+    maintainers = with lib.maintainers; [ adamcolwell ];
+    mainProgram = "lark";
+  };
+}

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -187,6 +187,7 @@ stdenv.mkDerivation {
         --set ELECTRON_DISABLE_SANDBOX 1 \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
         --prefix LD_LIBRARY_PATH : ${rpath}:$out/opt/bytedance/lark:${addDriverRunpath.driverLink}/share \
+        --prefix PATH : ${lib.makeBinPath [ xdg-utils ]} \
         ${lib.optionalString (
           commandLineArgs != ""
         ) "--add-flags ${lib.escapeShellArg commandLineArgs}"}

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -70,7 +70,7 @@ let
     };
     aarch64-linux = fetchurl {
       url = "https://lf16-larkversion.larksuitecdn.com/obj/lark-version-sg/2d8485bc/Lark-linux_arm64-7.59.12.deb";
-      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      hash = "sha256-q27De0fseQEj3C9X77Z5s8FUSxXJ7gmPbFy10UaH3Sc=";
     };
   };
 
@@ -254,7 +254,7 @@ stdenv.mkDerivation {
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     platforms = builtins.attrNames sources;
-    maintainers = with lib.maintainers; [ adamcolwell ];
+    maintainers = with lib.maintainers; [ ];
     mainProgram = "lark";
   };
 }

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -132,6 +132,8 @@ let
 in
 stdenv.mkDerivation {
   inherit pname version;
+  strictDeps = true;
+  __structuredAttrs = true;
 
   src =
     sources.${stdenv.hostPlatform.system}

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -65,12 +65,12 @@
 let
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://lf16-larkversion.larksuitecdn.com/obj/lark-version-sg/967dd7e4/Lark-linux_x64-7.59.12.deb";
-      hash = "sha256-Oa5tCn2l4zJzafzoxLfAZVXu0zWILKv+DeWJsQRsZtI=";
+      url = "https://lf16-larkversion.larksuitecdn.com/obj/lark-version-sg/daf759d9/Lark-linux_x64-7.62.9.deb";
+      hash = "sha256-1mYsj7MGJMM38VQkT33ZWcptcKiZ1fImhfg4sweFSBo=";
     };
     aarch64-linux = fetchurl {
-      url = "https://lf16-larkversion.larksuitecdn.com/obj/lark-version-sg/2d8485bc/Lark-linux_arm64-7.59.12.deb";
-      hash = "sha256-q27De0fseQEj3C9X77Z5s8FUSxXJ7gmPbFy10UaH3Sc=";
+      url = "https://lf16-larkversion.larksuitecdn.com/obj/lark-version-sg/7309853c/Lark-linux_arm64-7.62.9.deb";
+      hash = "sha256-vifLnio6CFQfPw+gdrp0HtrKVANskPB258GxAIfp+mQ=";
     };
   };
 
@@ -127,7 +127,7 @@ let
   ];
 
   pname = "larksuite";
-  version = "7.59.12";
+  version = "7.62.9";
 
 in
 stdenv.mkDerivation {

--- a/pkgs/by-name/la/larksuite/package.nix
+++ b/pkgs/by-name/la/larksuite/package.nix
@@ -56,7 +56,6 @@
   stdenv,
   systemd,
   wayland,
-  xdg-utils,
   writeShellScript,
 
   # for custom command line arguments, e.g. "--use-gl=desktop"
@@ -125,7 +124,6 @@ let
     stdenv.cc.cc
     systemd
     wayland
-    xdg-utils
   ];
 
   pname = "larksuite";
@@ -178,24 +176,15 @@ stdenv.mkDerivation {
     substituteInPlace $out/share/applications/bytedance-lark.desktop \
       --replace-fail /usr/bin/bytedance-lark-stable $out/opt/bytedance/lark/bytedance-lark
 
-    # Remove bundled xdg utilities that don't work on NixOS
-    # This forces the system to use NixOS's xdg-utils which work correctly
-#    rm -f $out/opt/bytedance/lark/vulcan/xdg-mime
-#    rm -f $out/opt/bytedance/lark/vulcan/xdg-settings
-
-    # Wrap the actual Electron binaries (not upstream's shell scripts)
-    # - lark: main executable (Electron binary)
-    # - vulcan/vulcan: Electron browser used for rendering
-    # - video_conference_sdk: video meeting child process
-    # Note: bytedance-lark is kept as-is (upstream's shell script handles xdg-utils)
+    # Wrap with LD_LIBRARY_PATH in correct order:
+    # 1. Bundled libraries first (like upstream does)
+    # 2. Nix rpath for system libraries
+    # 3. OpenGL driver
     for executable in $out/opt/bytedance/lark/{lark,vulcan/vulcan,video_conference_sdk}; do
       wrapProgram $executable \
-        --set ELECTRON_DISABLE_SANDBOX 0 \
+        --set ELECTRON_DISABLE_SANDBOX 1 \
         --prefix XDG_DATA_DIRS : "$XDG_ICON_DIRS:$GSETTINGS_SCHEMAS_PATH" \
-#        --prefix LD_LIBRARY_PATH : ${rpath}:$out/opt/bytedance/lark:${addDriverRunpath.driverLink}/share \
-        ${lib.optionalString (
-          commandLineArgs != ""
-        ) "--add-flags ${lib.escapeShellArg commandLineArgs}"}
+        --prefix LD_LIBRARY_PATH : $out/opt/bytedance/lark:${rpath}:${addDriverRunpath.driverLink}/share
     done
 
     mkdir -p $out/share/icons/hicolor


### PR DESCRIPTION
# larksuite: init at 7.59.12

## Description

This PR adds Larksuite (Lark), a next-generation office suite by ByteDance, to nixpkgs.

Larksuite integrates messaging, schedule management, collaborative documents, video meetings, and various apps in one platform. It is the international version of Feishu (飞书), which is already packaged in nixpkgs.

### Key Features
- Messaging and collaboration
- Video conferencing with screen sharing
- Document editing and collaboration
- Calendar and scheduling
- Cross-platform sync

## Packaging Notes

### Wrapped Binaries
The package wraps three binaries with `wrapProgram`:
1. **lark** - Main executable
2. **vulcan/vulcan** - Electron browser used for rendering
3. **video_conference_sdk** - Video meeting child process

All three need `ELECTRON_DISABLE_SANDBOX=1` to work properly on NixOS due to the setuid sandbox binary not functioning in the Nix store.

### Similar Packages
- This package is based on the existing `feishu` package structure
- Feishu is the Chinese version of Larksuite with the same Electron architecture

## Checklist

- [x] Tested locally with `nix-build` (nixos x64)
- [x] Tested video meeting functionality
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md) guidelines
- [x] Meta information matches the package

## Testing

```bash
nix-build -E 'with import <nixpkgs> { config.allowUnfree = true; }; callPackage ./pkgs/by-name/la/larksuite/package.nix {}'
./result/bin/lark
```
