### PR TITLE
[25.11] traefik: 3.6.7 -> 3.6.8

### DIFF
--- a/pkgs/by-name/tr/traefik/package.nix
+++ b/pkgs/by-name/tr/traefik/package.nix
@@ -1,23 +1,25 @@
 {
   lib,
   fetchzip,
-  buildGo124Module,
+  buildGo125Module,
   nixosTests,
   nix-update-script,
 }:
 
-buildGo124Module (finalAttrs: {
+buildGo125Module (finalAttrs: {
   pname = "traefik";
-  version = "3.6.7";
+  version = "3.6.8";
 
   # Archive with static assets for webui
   src = fetchzip {
     url = "https://github.com/traefik/traefik/releases/download/v${finalAttrs.version}/traefik-v${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-tfCVNfY2qqhTBv6nhHqcoZ5GP7xoCBJNBkEfoMFH5vI=";
+    hash = "sha256-tZSU4DER94BTPrn1wxfew/xoADtvtRAu3O1O7dR3s+c=";
     stripRoot = false;
   };
 
-  vendorHash = "sha256-GON72ov1RxO59s42T2wZ5mESJ5fKMPqa8VZqfKDfxnw=";
+  vendorHash = "sha256-ZvAVsyET2g9Y+N7pPn+JG8th2I385wgp5hTgEG9d26o=";
+
+  proxyVendor = true;
 
   subPackages = [ "cmd/traefik" ];
 


### PR DESCRIPTION
Backport of #491315 to `release-25.11`.

Update `traefik` from 3.6.7 to 3.6.8

- Fixes [CVE-2026-25949](https://nvd.nist.gov/vuln/detail/CVE-2026-25949)
- [GitHub Advisory](https://github.com/advisories/GHSA-89p3-4642-cr2w)
- [Upstream Patch](https://github.com/traefik/traefik/commit/31e566e9f1d7888ccb6fbc18bfed427203c35678)
- [Tracker Issue](https://github.com/NixOS/nixpkgs/issues/490704)

Closes https://github.com/NixOS/nixpkgs/issues/490704

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test