### PR TITLE
python3Packages.fing-agent-api: init at 1.0.3

### DIFF
--- a/pkgs/development/python-modules/fing-agent-api/default.nix
+++ b/pkgs/development/python-modules/fing-agent-api/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  httpx,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fing-agent-api";
+  version = "1.0.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fingltd";
+    repo = "fing-agent-pyapi";
+    tag = finalAttrs.version;
+    hash = "sha256-tkFTkWYvWw/x2k+jT6lu/Takacm6aDX4hn8thnGZf5g=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ httpx ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "fing_agent_api" ];
+
+  meta = {
+    changelog = "https://github.com/fingltd/fing-agent-pyapi/releases/tag/${finalAttrs.version}";
+    description = "Python library for interacting with the Fingbox local APIs";
+    homepage = "https://github.com/fingltd/fing-agent-pyapi";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1775,7 +1775,8 @@
       ];
     "fing" =
       ps: with ps; [
-      ]; # missing inputs: fing_agent_api
+        fing-agent-api
+      ];
     "fints" =
       ps: with ps; [
         fints
@@ -7410,6 +7411,7 @@
     "file_upload"
     "filesize"
     "filter"
+    "fing"
     "fints"
     "firefly_iii"
     "fireservicerota"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5458,6 +5458,8 @@ self: super: with self; {
 
   finetuning-scheduler = callPackage ../development/python-modules/finetuning-scheduler { };
 
+  fing-agent-api = callPackage ../development/python-modules/fing-agent-api { };
+
   fingerprints = callPackage ../development/python-modules/fingerprints { };
 
   finitude = callPackage ../development/python-modules/finitude { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/fing-agent-api/
- https://github.com/fingltd/fing-agent-pyapi
- https://www.home-assistant.io/integrations/fing/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
