### PR TITLE
wordpressPackages.plugins.hcaptcha-for-forms-and-more: CVE-2026-25315…

### DIFF
--- a/pkgs/servers/web-apps/wordpress/packages/plugins.json
+++ b/pkgs/servers/web-apps/wordpress/packages/plugins.json
@@ -66,10 +66,10 @@
     "version": "22.5.0"
   },
   "hcaptcha-for-forms-and-more": {
-    "path": "hcaptcha-for-forms-and-more/tags/4.22.0",
-    "rev": "3441969",
-    "sha256": "1rargx812pi98mf0qynr5lcxs4y1fg7jpgxd96r72i97q8ck20l3",
-    "version": "4.22.0"
+    "path": "hcaptcha-for-forms-and-more/tags/4.23.0",
+    "rev": "3456290",
+    "sha256": "222ae768d76ba2e447185619357e5adc0282f14451534b11dcd6a2358f0d212e",
+    "version": "4.23.0"
   },
   "hello-dolly": {
     "path": "hello-dolly/tags/1.7.2",


### PR DESCRIPTION
Fixes [CVE-2026-25315](https://nvd.nist.gov/vuln/detail/CVE-2026-25315).

Closes #492396

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
