### PR TITLE
xwayland-run: 0.0.4 -> 0.0.5

### DIFF
--- a/pkgs/by-name/xw/xwayland-run/package.nix
+++ b/pkgs/by-name/xw/xwayland-run/package.nix
@@ -12,9 +12,12 @@
   withKwin ? false,
   kdePackages,
   withMutter ? false,
-  gnome,
+  mutter,
   withDbus ? withMutter,
+  phoc,
+  withPhoc ? false,
   dbus, # Since 0.0.3, mutter compositors run with their own DBUS sessions
+  xwayland-run,
 }:
 let
   compositors = [
@@ -22,19 +25,20 @@ let
   ]
   ++ lib.optional withCage cage
   ++ lib.optional withKwin kdePackages.kwin
-  ++ lib.optional withMutter gnome.mutter
+  ++ lib.optional withMutter mutter
+  ++ lib.optional withPhoc phoc
   ++ lib.optional withDbus dbus;
 in
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "xwayland-run";
-  version = "0.0.4";
+  version = "0.0.5";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "ofourdan";
     repo = "xwayland-run";
     rev = finalAttrs.version;
-    hash = "sha256-FP/2KNPehZEGKXr+fKdVj4DXzRMpfc3x7K6vH6ZsGdo=";
+    hash = "sha256-TVoMbFQ5OIJkTX3/tuwylW+Bdx/gl1omObj0c3JjICM=";
   };
 
   pyproject = false;
@@ -70,6 +74,15 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
         )
       }
   '';
+
+  passthru.tests = {
+    build = xwayland-run.override {
+      withCage = true;
+      withKwin = true;
+      withMutter = true;
+      withPhoc = true;
+    };
+  };
 
   meta = {
     changelog = "https://gitlab.freedesktop.org/ofourdan/xwayland-run/-/releases/${finalAttrs.src.rev}";


### PR DESCRIPTION
- Update to version 0.0.5
- fix the gnome.mutter usage
- add test, to make sure the package builds with the optional compositors

Release: https://gitlab.freedesktop.org/ofourdan/xwayland-run/-/releases/0.0.5

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
