### PR TITLE
libphonenumber: unpin boost, fix build with boost 1.89

### DIFF
--- a/pkgs/by-name/li/libphonenumber/boost-1.89.patch
+++ b/pkgs/by-name/li/libphonenumber/boost-1.89.patch
@@ -1,0 +1,22 @@
+From 72c1023fbf00fc48866acab05f6ccebcae7f3213 Mon Sep 17 00:00:00 2001
+From: Michael Cho <michael@michaelcho.dev>
+Date: Mon, 11 Aug 2025 17:08:15 -0400
+Subject: [PATCH] Fix build with Boost 1.89.0
+
+---
+ cpp/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cpp/CMakeLists.txt b/cpp/CMakeLists.txt
+index 27e4680ccc..39f05d2c9a 100644
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -145,7 +145,7 @@ if (USE_BOOST)
+   if (WIN32)
+     set (Boost_USE_STATIC_LIBS ON)
+   endif ()
+-  find_package (Boost 1.40.0 COMPONENTS date_time system thread)
++  find_package (Boost 1.40.0 COMPONENTS date_time thread OPTIONAL_COMPONENTS system)
+   if (NOT Boost_FOUND)
+     print_error ("Boost Date_Time/System/Thread" "Boost")
+   endif ()

--- a/pkgs/by-name/li/libphonenumber/package.nix
+++ b/pkgs/by-name/li/libphonenumber/package.nix
@@ -8,8 +8,7 @@
   gtest,
   jre,
   pkg-config,
-  # complains about missing boost.system on 1.89
-  boost188,
+  boost,
   icu,
   protobuf,
 }:
@@ -31,6 +30,11 @@ stdenv.mkDerivation (finalAttrs: {
     ./build-reproducibility.patch
     # Fix include directory in generated cmake files with split outputs
     ./cmake-include-dir.patch
+    # Finding `boost_system` fails because the stub compiled library of
+    # Boost.System, which has been a header-only library since 1.69, was
+    # removed in 1.89.
+    # Upstream PR: https://github.com/google/libphonenumber/pull/3903
+    ./boost-1.89.patch
   ];
 
   outputs = [
@@ -53,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = lib.optionals enableTests [
-    boost188
+    boost
   ];
 
   cmakeDir = "../cpp";


### PR DESCRIPTION
Finding `boost_system` fails because the stub compiled library of Boost.System, which has been a header-only library since 1.69, [was removed in 1.89](https://www.boost.org/releases/1.89.0/).

Upstream PR: https://github.com/google/libphonenumber/pull/3903

(As discussed in the Matrix Staging room)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
