### PR TITLE
ap-visual-sorting: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ap/ap-visual-sorting/default.nix
+++ b/pkgs/by-name/ap/ap-visual-sorting/default.nix
@@ -1,0 +1,48 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, gcc
+, glibc.dev
+, stdenv.cc.libc 
+, raylib 
+# weitere Dependencies hier
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ap-visual-sorting";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "cedric-star";
+    repo = "ap-visual-sorting";
+    rev = "main";
+    hash = "sha256-0zzq0zybv9vjsvjl1hcnxw19smnb76ldiz2jj9h5v06nzrpf8yi0="; # wird berechnet
+  };
+
+  buildInputs = with pkgs; [
+    glibc.dev 
+    stdenv.cc.libc
+    raylib
+  ];
+
+  nativeBuildInputs = with pkgs; [
+    gcc
+  ];
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp MySorter $out/bin/ap-visual-sorting
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Visualize Sorting Algorithms written in C (testet only for x86_64-linux)";
+    homepage = "https://github.com/cedric-star/ap-visual-sorting";
+    license = licenses.mit; # oder passende Lizenz
+    maintainers = with maintainers; [ cedric-star ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
