### PR TITLE
python3Packages.geopandas: 1.1.1 -> 1.1.2

### DIFF
--- a/pkgs/development/python-modules/geopandas/default.nix
+++ b/pkgs/development/python-modules/geopandas/default.nix
@@ -27,26 +27,17 @@
 
 buildPythonPackage rec {
   pname = "geopandas";
-  version = "1.1.1";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "geopandas";
     repo = "geopandas";
     tag = "v${version}";
-    hash = "sha256-7ZsO4jresikA17M8cyHskdcVnTscGHxTCLJv5p1SvfI=";
+    hash = "sha256-TBb9Bb12OZ9RWiwAGU6JKqiumw1C11USycpKM8mJVdU=";
   };
 
   build-system = [ setuptools ];
-
-  patches = [
-    # fix tests for geos 3.14
-    # see https://github.com/geopandas/geopandas/pull/3645
-    (fetchpatch {
-      url = "https://patch-diff.githubusercontent.com/raw/geopandas/geopandas/pull/3645.patch";
-      hash = "sha256-TLJixFRR+g739PLgwhTGuwYTVJ4SRr2BMGD14CLgmcY=";
-    })
-  ];
 
   dependencies = [
     packaging


### PR DESCRIPTION

Updated ``geopandas``.

For full list of changes:

https://github.com/geopandas/geopandas/compare/v1.1.1...v1.1.2

``pyogrio`` update will also work with this version of ``geopandas`` (https://github.com/NixOS/nixpkgs/pull/465840)

## nixpkgs-review results:

~~~
4 packages marked as broken and skipped:
python313Packages.geoarrow-pandas python313Packages.geoarrow-pandas.dist python314Packages.geoarrow-pandas python314Packages.geoarrow-pandas.dist

12 packages failed to build:
python313Packages.odc-geo python313Packages.odc-geo.dist python313Packages.odc-loader python313Packages.odc-loader.dist python313Packages.odc-stac python313Packages.odc-stac.dist python314Packages.odc-geo python314Packages.odc-geo.dist python314Packages.odc-loader python314Packages.odc-loader.dist python314Packages.odc-stac python314Packages.odc-stac.dist

73 packages built:
python313Packages.bsuite python313Packages.bsuite.dist python313Packages.folium python313Packages.folium.dist python313Packages.geoarrow-pyarrow python313Packages.geoarrow-pyarrow.dist python313Packages.geodatasets python313Packages.geodatasets.dist python313Packages.geopandas python313Packages.geopandas.dist python313Packages.geoparquet python313Packages.geoparquet.dist python313Packages.inequality python313Packages.inequality.dist python313Packages.libpysal python313Packages.libpysal.dist python313Packages.lida python313Packages.lida.dist python313Packages.mapclassify python313Packages.mapclassify.dist python313Packages.momepy python313Packages.momepy.dist python313Packages.msticpy python313Packages.msticpy.dist python313Packages.osmnx python313Packages.osmnx.dist python313Packages.pandera python313Packages.pandera.dist python313Packages.plotnine python313Packages.plotnine.dist python313Packages.shimmy python313Packages.shimmy.dist python313Packages.streamlit-folium python313Packages.streamlit-folium.dist python313Packages.vmas python313Packages.vmas.dist python313Packages.wktutils python313Packages.wktutils.dist python314Packages.bsuite python314Packages.bsuite.dist python314Packages.folium python314Packages.folium.dist python314Packages.geoarrow-pyarrow python314Packages.geoarrow-pyarrow.dist python314Packages.geodatasets python314Packages.geodatasets.dist python314Packages.geopandas python314Packages.geopandas.dist python314Packages.geoparquet python314Packages.geoparquet.dist python314Packages.inequality python314Packages.inequality.dist python314Packages.libpysal python314Packages.libpysal.dist python314Packages.lida python314Packages.lida.dist python314Packages.mapclassify python314Packages.mapclassify.dist python314Packages.momepy python314Packages.momepy.dist python314Packages.msticpy python314Packages.msticpy.dist python314Packages.osmnx python314Packages.osmnx.dist python314Packages.pandera python314Packages.pandera.dist python314Packages.plotnine python314Packages.plotnine.dist python314Packages.streamlit-folium python314Packages.streamlit-folium.dist python314Packages.wktutils python314Packages.wktutils.dist supercell-wx
~~~

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
