### PR TITLE
gnu-smalltalk: fix uncompilable error

### DIFF
--- a/pkgs/by-name/gn/gnu-smalltalk/package.nix
+++ b/pkgs/by-name/gn/gnu-smalltalk/package.nix
@@ -50,6 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   enableParallelBuilding = true;
+  env.NIX_CFLAGS_COMPILE = "-std=gnu99";
 
   # The dependencies and their justification are explained at
   # http://smalltalk.gnu.org/download


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Previous building error (selected):

```
       > regex.c:3476:23: error: too many arguments to function 'memcmp_translate'; expected 0, have 3
       >  3476 |                     ? memcmp_translate (d, d2, mcnt)
       >       |                       ^~~~~~~~~~~~~~~~  ~
```

And so on. The problem is that the compile phase could not be successful until a `-std=gnu99` (or 89, whatever) flag was added. Therefore, I add this flag.

@oxalica, since I don't consider myself an active maintainer. Would you like to add your name to the `meta.maintainers` field if you would like to take the responsibility of notifying me of the maintenance issues on this package?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
