### PR TITLE
authentik: add updateScript

### DIFF
--- a/pkgs/by-name/au/authentik/README.md
+++ b/pkgs/by-name/au/authentik/README.md
@@ -1,0 +1,37 @@
+# authentik
+
+## Update Procedure
+
+This section describes a rough outline of the steps needed to update the `authentik` packages.
+
+For minor updates, this could be all that is required for an update, but major version updates
+usually involve updates to the build process and internal dependencies.
+
+- Run `update.sh`:
+
+  This will update the version and hashes of the build in two stages:
+
+  1) Update the version and fetch the sources
+
+  2) Try to build all FOD dependencies for `aarch64-linux` and `x86_64-linux`
+
+  For the second step to succeed, you must ensure `nix` can build packages for both systems.
+
+  The script will pass everything after the first `--` to `nix build`, so you can add builders for other systems like so:
+
+  ```
+  -- --builders 'aarch64-builder aarch64-linux - 2 25'
+  ```
+
+  If some of the builds fail, you can restart the script and it will only rebuild the missing ones.
+
+  **Note:**  For the script to function correctly, the FOD's must be independent of another.
+
+  E.g. the `proxy` component depends on `authentik-community` via `postPatch`. This has to be
+  avoided with `overrideModAttrs.postPatch = ""` for the `goModules` FOD build.
+
+- Ensure the `project.dependencies` from `${src}/pyproject.toml` match the `authentik-django` dependencies.
+
+- Ensure other packages from the `authentik-community` are up-to-date. At the time of writing, this includes:
+
+  - `python-kadmin-rs`

--- a/pkgs/by-name/au/authentik/ldap.nix
+++ b/pkgs/by-name/au/authentik/ldap.nix
@@ -2,13 +2,13 @@
   buildGoModule,
   authentik,
   apiGoVendorHook,
-  vendorHash,
+  proxy,
 }:
 
 buildGoModule {
   pname = "authentik-ldap-outpost";
   inherit (authentik) version src;
-  inherit vendorHash;
+  inherit (proxy) vendorHash;
 
   nativeBuildInputs = [ apiGoVendorHook ];
 

--- a/pkgs/by-name/au/authentik/outposts.nix
+++ b/pkgs/by-name/au/authentik/outposts.nix
@@ -1,11 +1,8 @@
 {
   callPackage,
-  authentik,
-  apiGoVendorHook ? authentik.apiGoVendorHook,
-  vendorHash ? authentik.proxy.vendorHash,
 }:
 {
-  ldap = callPackage ./ldap.nix { inherit apiGoVendorHook vendorHash; };
-  proxy = callPackage ./proxy.nix { inherit apiGoVendorHook vendorHash; };
-  radius = callPackage ./radius.nix { inherit apiGoVendorHook vendorHash; };
+  ldap = callPackage ./ldap.nix { };
+  proxy = callPackage ./proxy.nix { };
+  radius = callPackage ./radius.nix { };
 }

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
+  newScope,
   stdenvNoCC,
-  callPackages,
   cacert,
   fetchFromGitHub,
   buildGoModule,
@@ -15,639 +15,665 @@
   typescript,
   makeSetupHook,
   writeShellScript,
+  testers,
 }:
+# Use makeScope to allow overriding the attributes of all dependencies.
+#
+# Example overlay:
+#
+# ```
+# (final: prev: {
+#   authentik = prev.authentik.overrideScope (afinal: aprev: {
+#     authentik = aprev.authentik.overrideAttrs (oldAttrs: {
+#       src = final.applyPatches {
+#         src = oldAttrs.src;
+#         patches = [
+#           (final.fetchpatch {
+#             url = "...";
+#             sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+#           })
+#         ];
+#       };
+#     });
+#   });
+# })
+# ```
+(lib.makeScope newScope (
+  scope:
+  let
+    nodejs = nodejs_24;
 
-let
-  nodejs = nodejs_24;
+    source = lib.fromJSON (lib.readFile ./source.json);
 
-  version = "2025.12.4";
+    # inherit version and src from the authentik package, so they are overridable with `overrideScope`.
+    inherit (scope.authentik) version src;
 
-  src = fetchFromGitHub {
-    owner = "goauthentik";
-    repo = "authentik";
-    tag = "version/${version}";
-    hash = "sha256-alTyrMBbjZbw4jhEna8saabf93sqSrZCu+Z5xH3pZ7M=";
-  };
+    meta = {
+      description = "Authentication glue you need";
+      changelog = "https://github.com/goauthentik/authentik/releases/tag/version%2F${version}";
+      homepage = "https://goauthentik.io/";
+      license = lib.licenses.mit;
+      platforms = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      maintainers = with lib.maintainers; [
+        jvanbruegge
+        risson
+      ];
+    };
+  in
+  {
+    client-go = stdenvNoCC.mkDerivation {
+      pname = "authentik-client-go";
+      version = source.clientgo.version;
+      inherit meta;
 
-  meta = {
-    description = "Authentication glue you need";
-    changelog = "https://github.com/goauthentik/authentik/releases/tag/version%2F${version}";
-    homepage = "https://goauthentik.io/";
-    license = lib.licenses.mit;
-    platforms = [
-      "aarch64-linux"
-      "x86_64-linux"
-    ];
-    maintainers = with lib.maintainers; [
-      jvanbruegge
-      risson
-    ];
-  };
+      src = fetchFromGitHub {
+        owner = "goauthentik";
+        repo = "client-go";
+        tag = "v${source.clientgo.version}";
+        hash = source.clientgo.hash;
+      };
 
-  client-go = stdenvNoCC.mkDerivation {
-    pname = "authentik-client-go";
-    version = "3.${version}";
-    inherit meta;
+      patches = [
+        ./client-go-config.patch
+      ];
 
-    src = fetchFromGitHub {
-      owner = "goauthentik";
-      repo = "client-go";
-      tag = "v3.${version}";
-      hash = "sha256-+/CfOE2HkBU+ZddvdXGenB/z8xNFk8cujpZpMXyh3cY=";
+      postPatch = ''
+        substituteInPlace ./config.yaml \
+          --replace-fail '/local' "$(pwd)"
+      '';
+
+      nativeBuildInputs = [
+        openapi-generator-cli
+        go
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        openapi-generator-cli generate \
+          -i ${src}/schema.yml -o $out \
+          -g go \
+          -c ./config.yaml
+
+        gofmt -w $out
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+
+        cp go.mod go.sum $out
+
+        cd $out
+        rm -rf test
+        rm -f .travis.yml git_push.sh
+
+        runHook postInstall
+      '';
     };
 
-    patches = [
-      ./client-go-config.patch
-    ];
-
-    postPatch = ''
-      substituteInPlace ./config.yaml \
-        --replace-fail '/local' "$(pwd)"
-    '';
-
-    nativeBuildInputs = [
-      openapi-generator-cli
-      go
-    ];
-
-    buildPhase = ''
-      runHook preBuild
-
-      openapi-generator-cli generate \
-        -i ${src}/schema.yml -o $out \
-        -g go \
-        -c ./config.yaml
-
-      gofmt -w $out
-
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-
-      cp go.mod go.sum $out
-
-      cd $out
-      rm -rf test
-      rm -f .travis.yml git_push.sh
-
-      runHook postInstall
-    '';
-  };
-
-  client-ts = stdenvNoCC.mkDerivation {
-    pname = "authentik-client-ts";
-    inherit version src meta;
-
-    postPatch = ''
-      substituteInPlace ./scripts/api/ts-config.yaml \
-        --replace-fail '/local' "$(pwd)"
-    '';
-
-    nativeBuildInputs = [
-      nodejs
-      openapi-generator-cli
-      typescript
-    ];
-
-    buildPhase = ''
-      runHook preBuild
-
-      openapi-generator-cli generate \
-        -i ./schema.yml -o $out \
-        -g typescript-fetch \
-        -c ./scripts/api/ts-config.yaml \
-        --additional-properties=npmVersion=${version} \
-        --git-repo-id authentik --git-user-id goauthentik
-
-      cd $out
-      npm run build
-
-      runHook postBuild
-    '';
-  };
-
-  # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
-  website-deps = stdenvNoCC.mkDerivation {
-    pname = "authentik-website-deps";
-    inherit src version meta;
-
-    sourceRoot = "${src.name}/website";
-
-    outputHash =
-      {
-        "aarch64-linux" = "sha256-GL5FPIBnoEXYtw8DPJpRPe3tT3qioN4AdoeOmCoiYsM=";
-        "x86_64-linux" = "sha256-AnceTipq6uUvTbOAZanVshAbAJ9LS1kwImbttTOcWxc=";
-      }
-      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-website-deps: unsupported host platform");
-
-    outputHashMode = "recursive";
-
-    nativeBuildInputs = [
-      nodejs
-      cacert
-    ];
-
-    buildPhase = ''
-      npm ci --cache ./cache
-
-      rm -r ./cache node_modules/.package-lock.json
-    '';
-
-    # dependencies of workspace projects are installed into separate node_modules folders with
-    # symlinks between them, so we have to copy all of them
-    installPhase = ''
-      mkdir $out
-      echo "Copying node_modules folders:"
-      find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
-    '';
-
-    dontCheckForBrokenSymlinks = true;
-    dontPatchShebangs = true;
-  };
-
-  website = stdenvNoCC.mkDerivation {
-    pname = "authentik-website";
-    inherit src version meta;
-
-    nativeBuildInputs = [ nodejs ];
-
-    sourceRoot = "${src.name}/website";
-
-    buildPhase = ''
-      runHook preBuild
-
-      buildRoot=$PWD
-      pushd ${website-deps}
-      find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
-      popd
-
-      chmod -R +w node_modules
-
-      pushd node_modules/.bin
-      patchShebangs $(readlink docusaurus) $(readlink run-s)
-      popd
-      npm run build:api
-
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      mkdir $out
-      cp -r api/build $out/help
-    '';
-  };
-
-  # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
-  webui-deps = stdenvNoCC.mkDerivation {
-    pname = "authentik-webui-deps";
-    inherit src version meta;
-
-    sourceRoot = "${src.name}/web";
-
-    outputHash =
-      {
-        "aarch64-linux" = "sha256-eZZ5Ynj81KwFsU5emPtYZ2CxO8MFvWbJnCHs+L88KQQ=";
-        "x86_64-linux" = "sha256-yUAyyO1NFav1EptrRYGSzC8dxCxYVj0FmzHk8IckFZM=";
-      }
-      .${stdenvNoCC.hostPlatform.system} or (throw "authentik-webui-deps: unsupported host platform");
-    outputHashMode = "recursive";
-
-    nativeBuildInputs = [
-      nodejs
-      cacert
-    ];
-
-    buildPhase = ''
-      npm ci --cache ./cache --ignore-scripts
-
-      rm -r ./cache node_modules/.package-lock.json
-    '';
-
-    # dependencies of workspace projects are installed into separate node_modules folders with
-    # symlinks between them, so we have to copy all of them
-    installPhase = ''
-      mkdir $out
-      echo "Copying node_modules folders:"
-      find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
-    '';
-
-    dontCheckForBrokenSymlinks = true;
-    dontPatchShebangs = true;
-  };
-
-  webui = stdenvNoCC.mkDerivation {
-    pname = "authentik-webui";
-    inherit src version meta;
-
-    sourceRoot = "${src.name}/web";
-
-    nativeBuildInputs = [
-      nodejs
-    ];
-
-    postPatch = ''
-      substituteInPlace packages/core/version/node.js \
-        --replace-fail 'import PackageJSON from "../../../../package.json" with { type: "json" };' "" \
-        --replace-fail '(PackageJSON.version);' '"${version}";'
-    '';
-
-    buildPhase = ''
-      runHook preBuild
-
-      buildRoot=$PWD
-      pushd ${webui-deps}
-      find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
-      popd
-
-      chmod -R +w node_modules/@goauthentik
-      rm -R node_modules/@goauthentik/api
-      ln -sn ${client-ts} node_modules/@goauthentik/api
-
-      pushd node_modules/.bin
-      patchShebangs $(readlink rollup)
-      patchShebangs $(readlink wireit)
-      patchShebangs $(readlink lit-localize)
-      popd
-
-      npm run build
-
-      runHook postBuild
-    '';
-
-    CHROMEDRIVER_FILEPATH = lib.getExe chromedriver;
-
-    installPhase = ''
-      runHook preInstall
-      mkdir $out
-      cp -r dist $out/dist
-      cp -r authentik $out/authentik
-      runHook postInstall
-    '';
-
-    NODE_ENV = "production";
-    NODE_OPTIONS = "--openssl-legacy-provider";
-
-    npmInstallFlags = [
-      "--include=dev"
-      "--ignore-scripts"
-    ];
-  };
-
-  python = python3.override {
-    self = python;
-    packageOverrides = final: prev: {
-      # https://github.com/goauthentik/authentik/pull/16324
-      django = final.django_5;
-
-      ak-guardian = final.buildPythonPackage {
-        pname = "ak-guardian";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/ak-guardian";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs = with final; [
-          django
-          typing-extensions
-        ];
-      };
-
-      django-channels-postgres = final.buildPythonPackage {
-        pname = "django-channels-postgres";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/django-channels-postgres";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs =
-          with final;
-          [
-            channels
+    client-ts = stdenvNoCC.mkDerivation {
+      pname = "authentik-client-ts";
+      inherit version src meta;
+
+      postPatch = ''
+        substituteInPlace ./scripts/api/ts-config.yaml \
+          --replace-fail '/local' "$(pwd)"
+      '';
+
+      nativeBuildInputs = [
+        nodejs
+        openapi-generator-cli
+        typescript
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+
+        openapi-generator-cli generate \
+          -i ./schema.yml -o $out \
+          -g typescript-fetch \
+          -c ./scripts/api/ts-config.yaml \
+          --additional-properties=npmVersion=${version} \
+          --git-repo-id authentik --git-user-id goauthentik
+
+        cd $out
+        npm run build
+
+        runHook postBuild
+      '';
+    };
+
+    # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
+    website-deps = stdenvNoCC.mkDerivation {
+      pname = "authentik-website-deps";
+      inherit version src meta;
+
+      sourceRoot = "${src.name}/website";
+
+      outputHash =
+        source.websiteHashes.${stdenvNoCC.hostPlatform.system}
+          or (throw "authentik-website-deps: unsupported host platform");
+      outputHashMode = "recursive";
+
+      nativeBuildInputs = [
+        nodejs
+        cacert
+      ];
+
+      buildPhase = ''
+        npm ci --cache ./cache
+
+        rm -r ./cache node_modules/.package-lock.json
+      '';
+
+      # dependencies of workspace projects are installed into separate node_modules folders with
+      # symlinks between them, so we have to copy all of them
+      installPhase = ''
+        mkdir $out
+        echo "Copying node_modules folders:"
+        find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
+      '';
+
+      dontCheckForBrokenSymlinks = true;
+      dontPatchShebangs = true;
+    };
+
+    website = stdenvNoCC.mkDerivation {
+      pname = "authentik-website";
+      inherit version src meta;
+
+      nativeBuildInputs = [ nodejs ];
+
+      sourceRoot = "${src.name}/website";
+
+      buildPhase = ''
+        runHook preBuild
+
+        buildRoot=$PWD
+        pushd ${scope.website-deps}
+        find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
+        popd
+
+        chmod -R +w node_modules
+
+        pushd node_modules/.bin
+        patchShebangs $(readlink docusaurus) $(readlink run-s)
+        popd
+        npm run build:api
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        mkdir $out
+        cp -r api/build $out/help
+      '';
+    };
+
+    # prefetch-npm-deps does not save all dependencies even though the lockfile is fine
+    webui-deps = stdenvNoCC.mkDerivation {
+      pname = "authentik-webui-deps";
+      inherit version src meta;
+
+      sourceRoot = "${src.name}/web";
+
+      outputHash =
+        source.webuiHashes.${stdenvNoCC.hostPlatform.system}
+          or (throw "authentik-webui-deps: unsupported host platform");
+      outputHashMode = "recursive";
+
+      nativeBuildInputs = [
+        nodejs
+        cacert
+      ];
+
+      buildPhase = ''
+        npm ci --cache ./cache --ignore-scripts
+
+        rm -r ./cache node_modules/.package-lock.json
+      '';
+
+      # dependencies of workspace projects are installed into separate node_modules folders with
+      # symlinks between them, so we have to copy all of them
+      installPhase = ''
+        mkdir $out
+        echo "Copying node_modules folders:"
+        find -type d -name node_modules -prune -print -exec mkdir -p $out/{} \; -exec cp -rT {} $out/{} \;
+      '';
+
+      dontCheckForBrokenSymlinks = true;
+      dontPatchShebangs = true;
+    };
+
+    webui = stdenvNoCC.mkDerivation {
+      pname = "authentik-webui";
+      inherit version src meta;
+
+      sourceRoot = "${src.name}/web";
+
+      nativeBuildInputs = [
+        nodejs
+      ];
+
+      postPatch = ''
+        substituteInPlace packages/core/version/node.js \
+          --replace-fail 'import PackageJSON from "../../../../package.json" with { type: "json" };' "" \
+          --replace-fail '(PackageJSON.version);' '"${version}";'
+      '';
+
+      buildPhase = ''
+        runHook preBuild
+
+        buildRoot=$PWD
+        pushd ${scope.webui-deps}
+        find -type d -name node_modules -prune -print -exec cp -rT {} $buildRoot/{} \;
+        popd
+
+        chmod -R +w node_modules/@goauthentik
+        rm -R node_modules/@goauthentik/api
+        ln -sn ${scope.client-ts} node_modules/@goauthentik/api
+
+        pushd node_modules/.bin
+        patchShebangs $(readlink rollup)
+        patchShebangs $(readlink wireit)
+        patchShebangs $(readlink lit-localize)
+        popd
+
+        npm run build
+
+        runHook postBuild
+      '';
+
+      CHROMEDRIVER_FILEPATH = lib.getExe chromedriver;
+
+      installPhase = ''
+        runHook preInstall
+        mkdir $out
+        cp -r dist $out/dist
+        cp -r authentik $out/authentik
+        runHook postInstall
+      '';
+
+      NODE_ENV = "production";
+      NODE_OPTIONS = "--openssl-legacy-provider";
+
+      npmInstallFlags = [
+        "--include=dev"
+        "--ignore-scripts"
+      ];
+    };
+
+    python = python3.override {
+      self = scope.python;
+      packageOverrides = final: prev: {
+        django = final.django_5;
+
+        ak-guardian = final.buildPythonPackage {
+          pname = "ak-guardian";
+          inherit version src meta;
+          pyproject = true;
+
+          sourceRoot = "${src.name}/packages/ak-guardian";
+
+          build-system = with final; [ hatchling ];
+
+          propagatedBuildInputs = with final; [
             django
-            django-pgtrigger
-            msgpack
-            psycopg
-            structlog
-          ]
-          ++ psycopg.optional-dependencies.pool;
-      };
-
-      django-dramatiq-postgres = final.buildPythonPackage {
-        pname = "django-dramatiq-postgres";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/django-dramatiq-postgres";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs =
-          with final;
-          [
-            cron-converter
-            django
-            django-pglock
-            django-pgtrigger
-            dramatiq
-            structlog
-            tenacity
-          ]
-          ++ dramatiq.optional-dependencies.watch;
-      };
-
-      django-postgres-cache = final.buildPythonPackage {
-        pname = "django-postgres-cache";
-        inherit version src meta;
-        pyproject = true;
-
-        sourceRoot = "${src.name}/packages/django-postgres-cache";
-
-        build-system = with final; [ hatchling ];
-
-        propagatedBuildInputs = with final; [
-          django
-          django-postgres-extra
-        ];
-      };
-
-      # Running authentik currently requires a custom version.
-      # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.
-      # See https://github.com/goauthentik/authentik/pull/14057 for latest version bump.
-      djangorestframework = final.buildPythonPackage {
-        pname = "djangorestframework";
-        version = "3.16.0";
-        format = "setuptools";
-
-        src = fetchFromGitHub {
-          owner = "authentik-community";
-          repo = "django-rest-framework";
-          rev = "896722bab969fabc74a08b827da59409cf9f1a4e";
-          hash = "sha256-YrEDEU3qtw/iyQM3CoB8wYx57zuPNXiJx6ZjrIwnCNU=";
+            typing-extensions
+          ];
         };
 
-        propagatedBuildInputs = with final; [
-          django
-          pytz
-        ];
+        django-channels-postgres = final.buildPythonPackage {
+          pname = "django-channels-postgres";
+          inherit version src meta;
+          pyproject = true;
 
-        nativeCheckInputs = with final; [
-          pytest-django
-          pytest7CheckHook
+          sourceRoot = "${src.name}/packages/django-channels-postgres";
 
-          # optional tests
-          coreapi
-          django-guardian
-          inflection
-          pyyaml
-          uritemplate
-        ];
+          build-system = with final; [ hatchling ];
 
-        disabledTests = [
-          "test_ignore_validation_for_unchanged_fields"
-          "test_invalid_inputs"
-          "test_shell_code_example_rendering"
-          "test_unique_together_condition"
-          "test_unique_together_with_source"
-        ];
+          propagatedBuildInputs =
+            with final;
+            [
+              channels
+              django
+              django-pgtrigger
+              msgpack
+              psycopg
+              structlog
+            ]
+            ++ psycopg.optional-dependencies.pool;
+        };
 
-        pythonImportsCheck = [ "rest_framework" ];
+        django-dramatiq-postgres = final.buildPythonPackage {
+          pname = "django-dramatiq-postgres";
+          inherit version src meta;
+          pyproject = true;
+
+          sourceRoot = "${src.name}/packages/django-dramatiq-postgres";
+
+          build-system = with final; [ hatchling ];
+
+          propagatedBuildInputs =
+            with final;
+            [
+              cron-converter
+              django
+              django-pglock
+              django-pgtrigger
+              dramatiq
+              structlog
+              tenacity
+            ]
+            ++ dramatiq.optional-dependencies.watch;
+        };
+
+        django-postgres-cache = final.buildPythonPackage {
+          pname = "django-postgres-cache";
+          inherit version src meta;
+          pyproject = true;
+
+          sourceRoot = "${src.name}/packages/django-postgres-cache";
+
+          build-system = with final; [ hatchling ];
+
+          propagatedBuildInputs = with final; [
+            django
+            django-postgres-extra
+          ];
+        };
+
+        # Running authentik currently requires a custom version.
+        # Look in `pyproject.toml` for changes to the rev in the `[tool.uv.sources]` section.
+        # See https://github.com/goauthentik/authentik/pull/14057 for latest version bump.
+        djangorestframework = final.buildPythonPackage {
+          pname = "djangorestframework";
+          version = "3.16.0";
+          format = "setuptools";
+
+          src = fetchFromGitHub {
+            owner = "authentik-community";
+            repo = "django-rest-framework";
+            rev = "896722bab969fabc74a08b827da59409cf9f1a4e";
+            hash = "sha256-YrEDEU3qtw/iyQM3CoB8wYx57zuPNXiJx6ZjrIwnCNU=";
+          };
+
+          propagatedBuildInputs = with final; [
+            django
+            pytz
+          ];
+
+          nativeCheckInputs = with final; [
+            pytest-django
+            pytest7CheckHook
+
+            # optional tests
+            coreapi
+            django-guardian
+            inflection
+            pyyaml
+            uritemplate
+          ];
+
+          disabledTests = [
+            "test_ignore_validation_for_unchanged_fields"
+            "test_invalid_inputs"
+            "test_shell_code_example_rendering"
+            "test_unique_together_condition"
+            "test_unique_together_with_source"
+          ];
+
+          pythonImportsCheck = [ "rest_framework" ];
+        };
+
+        # authentik is currently not compatible with v1.18 and fails with the following error:
+        # > AttributeError: 'Namespace' object has no attribute 'worker_fork_timeout'. Did you mean: 'worker_shutdown_timeout'?
+        dramatiq = prev.dramatiq.overrideAttrs (_: rec {
+          version = "1.17.1";
+
+          src = fetchFromGitHub {
+            owner = "Bogdanp";
+            repo = "dramatiq";
+            tag = "v${version}";
+            hash = "sha256-NeUGhG+H6r+JGd2qnJxRUbQ61G7n+3tsuDugTin3iJ4=";
+          };
+        });
+
+        authentik-django = final.buildPythonPackage {
+          pname = "authentik-django";
+          inherit version src meta;
+          pyproject = true;
+
+          postPatch = ''
+            substituteInPlace authentik/root/settings.py \
+              --replace-fail 'Path(__file__).absolute().parent.parent.parent' "Path(\"$out\")"
+            substituteInPlace authentik/lib/default.yml \
+              --replace-fail '/blueprints' "$out/blueprints"
+            substituteInPlace authentik/stages/email/utils.py \
+              --replace-fail 'web/' '${scope.webui}/'
+            # allways allow file upload if the data directoy exists
+            substituteInPlace authentik/admin/files/backends/file.py \
+              --replace-fail "and (self._base_dir.is_mount() or (self._base_dir / self.usage.value).is_mount())" ""
+          '';
+
+          build-system = [
+            final.hatchling
+          ];
+
+          pythonRemoveDeps = [ "dumb-init" ];
+
+          pythonRelaxDeps = true;
+
+          dependencies =
+            with final;
+            [
+              ak-guardian
+              argon2-cffi
+              cachetools
+              channels
+              cryptography
+              dacite
+              deepmerge
+              defusedxml
+              django
+              django-channels-postgres
+              django-countries
+              django-cte
+              django-dramatiq-postgres
+              django-filter
+              django-model-utils
+              django-pglock
+              django-pgtrigger
+              django-postgres-cache
+              django-postgres-extra
+              django-prometheus
+              django-storages
+              django-tenants
+              djangoql
+              djangorestframework
+              docker
+              drf-orjson-renderer
+              drf-spectacular
+              duo-client
+              fido2
+              geoip2
+              geopy
+              google-api-python-client
+              gunicorn
+              gssapi
+              jsonpatch
+              jwcrypto
+              kubernetes
+              ldap3
+              lxml
+              msgraph-sdk
+              opencontainers
+              packaging
+              paramiko
+              psycopg
+              pydantic
+              pydantic-scim
+              pyjwt
+              pyrad
+              python-kadmin-rs
+              pyyaml
+              requests-oauthlib
+              scim2-filter-parser
+              sentry-sdk
+              service-identity
+              setproctitle
+              structlog
+              swagger-spec-validator
+              twilio
+              ua-parser
+              unidecode
+              urllib3
+              uvicorn
+              watchdog
+              webauthn
+              wsproto
+              xmlsec
+              zxcvbn
+            ]
+            ++ django-storages.optional-dependencies.s3
+            ++ psycopg.optional-dependencies.c
+            ++ psycopg.optional-dependencies.pool
+            ++ uvicorn.optional-dependencies.standard;
+
+          postInstall = ''
+            mkdir -p $out/web $out/website
+            cp -r lifecycle manage.py $out/${prev.python.sitePackages}/
+            cp -r blueprints $out/
+            cp -r ${scope.webui}/dist ${scope.webui}/authentik $out/web/
+            cp -r ${scope.website} $out/website/help
+            ln -s $out/${prev.python.sitePackages}/authentik $out/authentik
+            ln -s $out/${prev.python.sitePackages}/lifecycle $out/lifecycle
+          '';
+        };
       };
+    };
 
-      # authentik is currently not compatible with v1.18 and fails with the following error:
-      # > AttributeError: 'Namespace' object has no attribute 'worker_fork_timeout'. Did you mean: 'worker_shutdown_timeout'?
-      dramatiq = prev.dramatiq.overrideAttrs (_: rec {
-        version = "1.17.1";
+    # Provide a setup-hook to configure the Go vendor directory with up-to-date API bindings.
+    # This is done to avoid the `vendorHash` depending on anything in the `client-go` build (e.g.
+    # openapi-generator-cli version updates changing the produced content) and invalidating the hash.
+    apiGoVendorHook =
+      makeSetupHook
+        {
+          name = "authentik-api-go-vendor-hook";
+        }
+        (
+          writeShellScript "authentik-api-go-vendor-hook" ''
+            authentikApiGoVendorHook() {
+              chmod -R +w vendor/goauthentik.io/api
+              rm -rf vendor/goauthentik.io/api/v3
+              cp -r ${scope.client-go} vendor/goauthentik.io/api/v3
+
+              echo "Finished authentikApiGoVendorHook"
+            }
+
+            # don't run for FOD, e.g. the `goModules` build
+            if [ -z ''${outputHash-} ]; then
+              postConfigureHooks+=(authentikApiGoVendorHook)
+            fi
+          ''
+        );
+
+    proxy = buildGoModule {
+      pname = "authentik-proxy";
+      inherit version src meta;
+
+      postPatch = ''
+        substituteInPlace internal/gounicorn/gounicorn.go \
+          --replace-fail './lifecycle' "${scope.python.pkgs.authentik-django}/lifecycle"
+        substituteInPlace web/static.go \
+          --replace-fail './web' "${scope.python.pkgs.authentik-django}/web"
+        substituteInPlace internal/web/static.go \
+          --replace-fail './web' "${scope.python.pkgs.authentik-django}/web"
+      '';
+
+      nativeBuildInputs = [ scope.apiGoVendorHook ];
+
+      env.CGO_ENABLED = 0;
+
+      # calculate the vendorHash without other dependencies, so it is only based on the `go.sum` file
+      overrideModAttrs.postPatch = "";
+
+      vendorHash = source.proxyVendorHash;
+
+      postInstall = ''
+        mv $out/bin/server $out/bin/authentik
+      '';
+
+      subPackages = [ "cmd/server" ];
+    };
+
+    authentik =
+      stdenvNoCC.mkDerivation {
+        pname = "authentik";
+        version = source.authentik.version;
 
         src = fetchFromGitHub {
-          owner = "Bogdanp";
-          repo = "dramatiq";
-          tag = "v${version}";
-          hash = "sha256-NeUGhG+H6r+JGd2qnJxRUbQ61G7n+3tsuDugTin3iJ4=";
+          owner = "goauthentik";
+          repo = "authentik";
+          tag = "version/${version}";
+          hash = source.authentik.hash;
         };
-      });
 
-      authentik-django = final.buildPythonPackage {
-        pname = "authentik-django";
-        inherit version src meta;
-        pyproject = true;
+        buildInputs = [ bash ];
 
         postPatch = ''
-          substituteInPlace authentik/root/settings.py \
-            --replace-fail 'Path(__file__).absolute().parent.parent.parent' "Path(\"$out\")"
-          substituteInPlace authentik/lib/default.yml \
-            --replace-fail '/blueprints' "$out/blueprints"
-          substituteInPlace authentik/stages/email/utils.py \
-            --replace-fail 'web/' '${webui}/'
-          # allways allow file upload if the data directoy exists
-          substituteInPlace authentik/admin/files/backends/file.py \
-            --replace-fail "and (self._base_dir.is_mount() or (self._base_dir / self.usage.value).is_mount())" ""
+          rm Makefile
+          patchShebangs lifecycle/ak
+
+          # This causes issues in systemd services
+          substituteInPlace lifecycle/ak \
+            --replace-fail 'printf' '>&2 printf' \
+            --replace-fail '>/dev/stderr' ""
         '';
 
-        build-system = [
-          final.hatchling
-        ];
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/bin
+          cp -r lifecycle/ak $out/bin/
 
-        pythonRemoveDeps = [ "dumb-init" ];
-
-        pythonRelaxDeps = true;
-
-        dependencies =
-          with final;
-          [
-            ak-guardian
-            argon2-cffi
-            cachetools
-            channels
-            cryptography
-            dacite
-            deepmerge
-            defusedxml
-            django
-            django-channels-postgres
-            django-countries
-            django-cte
-            django-dramatiq-postgres
-            django-filter
-            django-model-utils
-            django-pglock
-            django-pgtrigger
-            django-postgres-cache
-            django-postgres-extra
-            django-prometheus
-            django-storages
-            django-tenants
-            djangoql
-            djangorestframework
-            docker
-            drf-orjson-renderer
-            drf-spectacular
-            duo-client
-            fido2
-            geoip2
-            geopy
-            google-api-python-client
-            gunicorn
-            gssapi
-            jsonpatch
-            jwcrypto
-            kubernetes
-            ldap3
-            lxml
-            msgraph-sdk
-            opencontainers
-            packaging
-            paramiko
-            psycopg
-            pydantic
-            pydantic-scim
-            pyjwt
-            pyrad
-            python-kadmin-rs
-            pyyaml
-            requests-oauthlib
-            scim2-filter-parser
-            sentry-sdk
-            service-identity
-            setproctitle
-            structlog
-            swagger-spec-validator
-            twilio
-            ua-parser
-            unidecode
-            urllib3
-            uvicorn
-            watchdog
-            webauthn
-            wsproto
-            xmlsec
-            zxcvbn
-          ]
-          ++ django-storages.optional-dependencies.s3
-          ++ psycopg.optional-dependencies.c
-          ++ psycopg.optional-dependencies.pool
-          ++ uvicorn.optional-dependencies.standard;
-
-        postInstall = ''
-          mkdir -p $out/web $out/website
-          cp -r lifecycle manage.py $out/${prev.python.sitePackages}/
-          cp -r blueprints $out/
-          cp -r ${webui}/dist ${webui}/authentik $out/web/
-          cp -r ${website} $out/website/help
-          ln -s $out/${prev.python.sitePackages}/authentik $out/authentik
-          ln -s $out/${prev.python.sitePackages}/lifecycle $out/lifecycle
+          wrapProgram $out/bin/ak \
+            --prefix PATH : ${
+              lib.makeBinPath [
+                (scope.python.withPackages (ps: [ ps.authentik-django ]))
+                scope.proxy
+              ]
+            } \
+            --set TMPDIR /dev/shm \
+            --set PYTHONDONTWRITEBYTECODE 1 \
+            --set PYTHONUNBUFFERED 1
+          runHook postInstall
         '';
-      };
-    };
-  };
 
-  inherit (python.pkgs) authentik-django;
+        nativeBuildInputs = [ makeWrapper ];
 
-  # Provide a setup-hook to configure the Go vendor directory with up-to-date API bindings.
-  # This is done to avoid the `vendorHash` depending on anything in the `client-go` build (e.g.
-  # openapi-generator-cli version updates changing the produced content) and invalidating the hash.
-  apiGoVendorHook =
-    makeSetupHook
-      {
-        name = "authentik-api-go-vendor-hook";
+        passthru.components = scope;
+        passthru.outposts = scope.outposts;
+        passthru.tests.updateScript = testers.shellcheck {
+          name = "updateScript";
+          src = ./update.sh;
+        };
+        passthru.updateScript = {
+          command = [ ./update.sh ];
+          supportedFeatures = [ "commit" ];
+        };
+        meta = meta // {
+          mainProgram = "ak";
+        };
       }
-      (
-        writeShellScript "authentik-api-go-vendor-hook" ''
-          authentikApiGoVendorHook() {
-            chmod -R +w vendor/goauthentik.io/api
-            rm -rf vendor/goauthentik.io/api/v3
-            cp -r ${client-go} vendor/goauthentik.io/api/v3
+      // {
+        overrideScope = f: (scope.overrideScope f).authentik;
+      };
 
-            echo "Finished authentikApiGoVendorHook"
-          }
-
-          # don't run for FOD, e.g. the `goModules` build
-          if [ -z ''${outputHash-} ]; then
-            postConfigureHooks+=(authentikApiGoVendorHook)
-          fi
-        ''
-      );
-
-  proxy = buildGoModule {
-    pname = "authentik-proxy";
-    inherit version src meta;
-
-    postPatch = ''
-      substituteInPlace internal/gounicorn/gounicorn.go \
-        --replace-fail './lifecycle' "${authentik-django}/lifecycle"
-      substituteInPlace web/static.go \
-        --replace-fail './web' "${authentik-django}/web"
-      substituteInPlace internal/web/static.go \
-        --replace-fail './web' "${authentik-django}/web"
-    '';
-
-    nativeBuildInputs = [ apiGoVendorHook ];
-
-    env.CGO_ENABLED = 0;
-
-    # calculate the vendorHash without other dependencies, so it is only based on the `go.sum` file
-    overrideModAttrs.postPatch = "";
-
-    vendorHash = "sha256-pdQg02f1K4nOhsnadoplQYOhEybqZxn+yDQRN5RNygM=";
-
-    postInstall = ''
-      mv $out/bin/server $out/bin/authentik
-    '';
-
-    subPackages = [ "cmd/server" ];
-  };
-
-in
-stdenvNoCC.mkDerivation {
-  pname = "authentik";
-  inherit src version;
-
-  buildInputs = [ bash ];
-
-  postPatch = ''
-    rm Makefile
-    patchShebangs lifecycle/ak
-
-    # This causes issues in systemd services
-    substituteInPlace lifecycle/ak \
-      --replace-fail 'printf' '>&2 printf' \
-      --replace-fail '>/dev/stderr' ""
-  '';
-
-  installPhase = ''
-    runHook preInstall
-    mkdir -p $out/bin
-    cp -r lifecycle/ak $out/bin/
-
-    wrapProgram $out/bin/ak \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          (python.withPackages (ps: [ ps.authentik-django ]))
-          proxy
-        ]
-      } \
-      --set TMPDIR /dev/shm \
-      --set PYTHONDONTWRITEBYTECODE 1 \
-      --set PYTHONUNBUFFERED 1
-    runHook postInstall
-  '';
-
-  passthru = {
-    inherit proxy apiGoVendorHook;
-    outposts = callPackages ./outposts.nix {
-      inherit (proxy) vendorHash;
-      inherit apiGoVendorHook;
-    };
-  };
-
-  nativeBuildInputs = [ makeWrapper ];
-
-  meta = meta // {
-    mainProgram = "ak";
-  };
-}
+    outposts = scope.callPackage ./outposts.nix { };
+  }
+)).authentik

--- a/pkgs/by-name/au/authentik/proxy.nix
+++ b/pkgs/by-name/au/authentik/proxy.nix
@@ -2,13 +2,13 @@
   buildGoModule,
   authentik,
   apiGoVendorHook,
-  vendorHash,
+  proxy,
 }:
 
 buildGoModule {
   pname = "authentik-proxy-outpost";
   inherit (authentik) version src;
-  inherit vendorHash;
+  inherit (proxy) vendorHash;
 
   nativeBuildInputs = [ apiGoVendorHook ];
 

--- a/pkgs/by-name/au/authentik/radius.nix
+++ b/pkgs/by-name/au/authentik/radius.nix
@@ -2,13 +2,13 @@
   buildGoModule,
   authentik,
   apiGoVendorHook,
-  vendorHash,
+  proxy,
 }:
 
 buildGoModule {
   pname = "authentik-radius-outpost";
   inherit (authentik) version src;
-  inherit vendorHash;
+  inherit (proxy) vendorHash;
 
   nativeBuildInputs = [ apiGoVendorHook ];
 

--- a/pkgs/by-name/au/authentik/source.json
+++ b/pkgs/by-name/au/authentik/source.json
@@ -1,0 +1,19 @@
+{
+  "authentik": {
+    "version": "2025.12.4",
+    "hash": "sha256-alTyrMBbjZbw4jhEna8saabf93sqSrZCu+Z5xH3pZ7M="
+  },
+  "clientgo": {
+    "version": "3.2025.12.4",
+    "hash": "sha256-+/CfOE2HkBU+ZddvdXGenB/z8xNFk8cujpZpMXyh3cY="
+  },
+  "proxyVendorHash": "sha256-pdQg02f1K4nOhsnadoplQYOhEybqZxn+yDQRN5RNygM=",
+  "websiteHashes": {
+    "aarch64-linux": "sha256-GL5FPIBnoEXYtw8DPJpRPe3tT3qioN4AdoeOmCoiYsM=",
+    "x86_64-linux": "sha256-AnceTipq6uUvTbOAZanVshAbAJ9LS1kwImbttTOcWxc="
+  },
+  "webuiHashes": {
+    "aarch64-linux": "sha256-eZZ5Ynj81KwFsU5emPtYZ2CxO8MFvWbJnCHs+L88KQQ=",
+    "x86_64-linux": "sha256-yUAyyO1NFav1EptrRYGSzC8dxCxYVj0FmzHk8IckFZM="
+  }
+}

--- a/pkgs/by-name/au/authentik/update.sh
+++ b/pkgs/by-name/au/authentik/update.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p coreutils curl jq nix nix-prefetch-github ripgrep
+# shellcheck shell=bash
+
+set -euo pipefail
+[[ -z "${XTRACE:-}" ]] || set -x
+
+# using UPDATE_NIX_ATTR_PATH to detect if this is being called from update.nix
+[[ -n "${UPDATE_NIX_ATTR_PATH:-}" ]] && inUpdateNix=1 || inUpdateNix=0
+
+show_help() {
+  cat <<"EOF"
+Usage: ${0##*/} [-?h] [-a authentikVersion] [-c clientgoVersion] [-- <nix build args>...]
+
+Create and update the `source.json` file for the `authentik` package.
+
+The script tries to only update missing dependency hashes if possible.
+If the `authentikVersion` changes, all hashes are considered missing.
+
+To assist with building dependencies for different architectures (aarch64-linux and x86_64-linux at the moment),
+all remaining arguments after the first `--` will be passed to the `nix-build` commands.
+
+For example: --builders "buildhost aarch64-linux - 2"
+
+  -?|-h                Display this help and exit
+  -a authentikVersion  Specify the authentik source version (default: fetch latest tag)
+  -c clientgoVersion   Specify the client-go source version (default: 3.<authentikVersion>)
+EOF
+}
+
+authentikVersion=
+clientgoVersion=
+while getopts "?ha:c:" opt; do
+  case "$opt" in
+  a) authentikVersion=$OPTARG;;
+  c) clientgoVersion=$OPTARG;;
+  *) show_help; exit 0;;
+  esac
+done
+
+shift $((OPTIND-1))
+if [[ $# -gt 0 && "$1" = "--" ]]; then
+  shift
+fi
+
+root="$(dirname "$(readlink -f "$0")")"
+json="$root/source.json"
+fake="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+if [[ -n "$authentikVersion" ]]; then
+  authentikTag="version/$authentikVersion"
+else
+  authentikTag="$(curl -fsS https://api.github.com/repos/goauthentik/authentik/releases/latest | jq -r '.tag_name')"
+  authentikVersion="${authentikTag#version/}"
+fi
+
+if [[ -z "$clientgoVersion" ]]; then
+  clientgoVersion="3.$authentikVersion"
+fi
+clientgoTag="v$clientgoVersion"
+
+prevAuthentikVersion=
+prevClientgoVersion=
+if [[ -f "$json" ]]; then
+  prevAuthentikVersion="$(jq -r .authentik.version "$json" || :)"
+  prevClientgoVersion="$(jq -r .clientgo.version "$json" || :)"
+fi
+
+# if the version has not changed, try to restore the previous hashes, otherwise start fresh
+if [[ "$prevAuthentikVersion" == "$authentikVersion" ]]; then
+  authentikHash="$(jq -r .authentik.hash "$json" || :)"
+  proxyVendorHash="$(jq -r .proxyVendorHash "$json" || :)"
+  website_aarch64="$(jq -r '.websiteHashes["aarch64-linux"]' "$json" || :)"
+  website_x86_64="$(jq -r '.websiteHashes["x86_64-linux"]' "$json" || :)"
+  webui_aarch64="$(jq -r '.webuiHashes["aarch64-linux"]' "$json" || :)"
+  webui_x86_64="$(jq -r '.webuiHashes["x86_64-linux"]' "$json" || :)"
+else
+  authentikHash=
+  proxyVendorHash=
+  website_aarch64=
+  website_x86_64=
+  webui_aarch64=
+  webui_x86_64=
+fi
+
+if [[ "$prevClientgoVersion" == "$clientgoVersion" ]]; then
+  clientgoHash="$(jq -r .clientgo.hash "$json" || :)"
+else
+  clientgoHash=
+fi
+
+# use the fake hash for everything, that does not look like an SRI hash
+[[ "$authentikHash" == sha256-* ]] || authentikHash="$fake"
+[[ "$clientgoHash" == sha256-* ]] || clientgoHash="$fake"
+[[ "$proxyVendorHash" == sha256-* ]] || proxyVendorHash="$fake"
+[[ "$website_aarch64" == sha256-* ]] || website_aarch64="$fake"
+[[ "$website_x86_64" == sha256-* ]] || website_x86_64="$fake"
+[[ "$webui_aarch64" == sha256-* ]] || webui_aarch64="$fake"
+[[ "$webui_x86_64" == sha256-* ]] || webui_x86_64="$fake"
+
+# first, update the source hashes (must succeed)
+[[ $authentikHash != "$fake" ]] || authentikHash="$(nix-prefetch-github goauthentik authentik --rev "$authentikTag" -v | jq -r .hash)"
+[[ $clientgoHash != "$fake" ]] || clientgoHash="$(nix-prefetch-github goauthentik client-go --rev "$clientgoTag" -v | jq -r .hash)"
+
+function writeJson() {
+  jq -n \
+    --arg authentikVersion "$authentikVersion" --arg authentikHash "$authentikHash" \
+    --arg clientgoVersion "$clientgoVersion" --arg clientgoHash "$clientgoHash" \
+    --arg proxyVendorHash "$proxyVendorHash" \
+    --arg website_aarch64 "$website_aarch64" --arg website_x86_64 "$website_x86_64" \
+    --arg webui_aarch64 "$webui_aarch64" --arg webui_x86_64 "$webui_x86_64" \
+    '{
+      "authentik": {"version": $authentikVersion, "hash": $authentikHash},
+      "clientgo": {"version": $clientgoVersion, "hash": $clientgoHash},
+      $proxyVendorHash,
+      "websiteHashes": {"aarch64-linux": $website_aarch64, "x86_64-linux": $website_x86_64},
+      "webuiHashes": {"aarch64-linux": $webui_aarch64, "x86_64-linux": $webui_x86_64}
+    }' >"$json"
+}
+
+writeJson
+
+# second, build the dependencies (may succeed)
+function getHash() {
+  nix-build --keep-going --no-link -A "$@" 2>&1 \
+    | tee /dev/stderr | rg -aor '$1' '\bgot:\s+(\S+)'
+}
+
+# run all the required build processes in parallel
+# copy the resulting stdout descriptors for reading later
+[[ $proxyVendorHash != "$fake" ]] || {
+  coproc proxyVendorHashC { getHash authentik.components.proxy.goModules "$@"; }
+  exec {proxyVendorHashFd}<&"${proxyVendorHashC[0]}"
+}
+[[ $website_aarch64 != "$fake" ]] || {
+  coproc website_aarch64C { getHash authentik.components.website-deps --system aarch64-linux "$@"; }
+  exec {website_aarch64Fd}<&"${website_aarch64C[0]}"
+}
+[[ $website_x86_64 != "$fake" ]] || {
+  coproc website_x86_64C { getHash authentik.components.website-deps --system x86_64-linux "$@"; }
+  exec {website_x86_64Fd}<&"${website_x86_64C[0]}"
+}
+[[ $webui_aarch64 != "$fake" ]] || {
+  coproc webui_aarch64C { getHash authentik.components.webui-deps --system aarch64-linux "$@"; }
+  exec {webui_aarch64Fd}<&"${webui_aarch64C[0]}"
+}
+[[ $webui_x86_64 != "$fake" ]] || {
+  coproc webui_x86_64C { getHash authentik.components.webui-deps --system x86_64-linux "$@"; }
+  exec {webui_x86_64Fd}<&"${webui_x86_64C[0]}"
+}
+wait || :
+
+[[ -z ${proxyVendorHashFd:-} ]] || read -r -u "$proxyVendorHashFd" proxyVendorHash || :
+[[ -z ${website_aarch64Fd:-} ]] || read -r -u "$website_aarch64Fd" website_aarch64 || :
+[[ -z ${website_x86_64Fd:-} ]] || read -r -u "$website_x86_64Fd" website_x86_64 || :
+[[ -z ${webui_aarch64Fd:-} ]] || read -r -u "$webui_aarch64Fd" webui_aarch64 || :
+[[ -z ${webui_x86_64Fd:-} ]] || read -r -u "$webui_x86_64Fd" webui_x86_64 || :
+
+# even if a command failed, ensure the output is an SRI hash
+[[ "$authentikHash" == sha256-* ]] || authentikHash="$fake"
+[[ "$clientgoHash" == sha256-* ]] || clientgoHash="$fake"
+[[ "$proxyVendorHash" == sha256-* ]] || proxyVendorHash="$fake"
+[[ "$website_aarch64" == sha256-* ]] || website_aarch64="$fake"
+[[ "$website_x86_64" == sha256-* ]] || website_x86_64="$fake"
+[[ "$webui_aarch64" == sha256-* ]] || webui_aarch64="$fake"
+[[ "$webui_x86_64" == sha256-* ]] || webui_x86_64="$fake"
+
+writeJson
+
+# if any hash is unknown, ensure update.nix doesn't commit the changes
+if [[ "$authentikHash" == "$fake" || "$clientgoHash" == "$fake" || "$proxyVendorHash" == "$fake" ||
+      "$website_aarch64" == "$fake" || "$website_x86_64" == "$fake" ||
+      "$webui_aarch64" == "$fake" || "$webui_x86_64" == "$fake" ]]; then
+
+  # dump the json content if we might run in a git worktree
+  if (( inUpdateNix )); then
+    echo -e "\n$json content:" >&2
+    cat "$json" >&2
+  fi
+
+  echo -e "\nCould not determine all hashes. Automatic update failed." >&2
+  exit 1
+fi
+
+if (( inUpdateNix )); then
+  jq -n \
+    --arg attrPath "authentik,authentik-outposts" \
+    --arg newVersion "$authentikVersion" \
+    '[{ $attrPath, $newVersion }]'
+fi

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1377,7 +1377,7 @@ with pkgs;
 
   arpack-mpi = arpack.override { useMpi = true; };
 
-  authentik-outposts = recurseIntoAttrs (callPackages ../by-name/au/authentik/outposts.nix { });
+  authentik-outposts = recurseIntoAttrs authentik.outposts;
 
   autoflake = with python3.pkgs; toPythonApplication autoflake;
 


### PR DESCRIPTION
I was tired of replacing all the hashes (currently 7) manually for each update twice (first invalidate, then insert new), so I created an `updateScript` to automate the process.

This restructures the build a bit and puts all dependencies into a scope, which makes it a) possible to access them from the update script via the `components` attribute and b) override any build step externally.

Introducing the scope sadly involves a indentation change in `package.nix`, which results in a nearly 100% diff. But there is no actual change to the build process, so the resulting derivations stay the same as before.

The script tries to only rebuild unknown hashes, as the build process for some dependencies (specially on lower power `aarch64-linux` machines) will take some time. To actually build all the hashes, nix must be able to perform builds for `x86_64-linux` and `aarch64-linux`, but builders can be specified on the cli when necessary.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #334356

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
