### PR TITLE
[25.11] bazarr: 1.5.3 -> 1.5.5, add diogotcorreia as maintainer

### DIFF
--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -17,11 +17,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bazarr";
-  version = "1.5.4";
+  version = "1.5.5";
 
   src = fetchzip {
     url = "https://github.com/morpheus65535/bazarr/releases/download/v${version}/bazarr.zip";
-    hash = "sha256-NHfEhatHs03DdiyMwpZdJwi55NBHoaPXMmhkq+D1bqE=";
+    hash = "sha256-YiR/hi+/vptjHxwBYsq/W3QdjT12+pv74AuU1ggM084=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -17,11 +17,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "bazarr";
-  version = "1.5.3";
+  version = "1.5.4";
 
   src = fetchzip {
     url = "https://github.com/morpheus65535/bazarr/releases/download/v${version}/bazarr.zip";
-    hash = "sha256-2JzsGnGgrkD5G0ZmrphkPZTnak3gdkHloXRKA+p9Y/0=";
+    hash = "sha256-NHfEhatHs03DdiyMwpZdJwi55NBHoaPXMmhkq+D1bqE=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/ba/bazarr/package.nix
+++ b/pkgs/by-name/ba/bazarr/package.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation rec {
     homepage = "https://www.bazarr.media/";
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ diogotcorreia ];
     mainProgram = "bazarr";
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
Backport of:
- https://github.com/NixOS/nixpkgs/pull/476997
- https://github.com/NixOS/nixpkgs/pull/487904
- https://github.com/NixOS/nixpkgs/pull/492431

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
