### PR TITLE
caringcaribou: init at 0.6

### DIFF
--- a/pkgs/by-name/ca/caringcaribou/package.nix
+++ b/pkgs/by-name/ca/caringcaribou/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchpatch,
+  python3Packages,
+  versionCheckHook,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "caringcaribou";
+  version = "0.6";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "CaringCaribou";
+    repo = "caringcaribou";
+    tag = finalAttrs.version;
+    hash = "sha256-x6yDJtyhzUpRLfmXOHkC+IjIcO+oUBrJbNooBX+g+wc=";
+  };
+
+  patches = [
+    # Backport pyproject.toml with entry points
+    (fetchpatch {
+      url = "https://github.com/CaringCaribou/caringcaribou/commit/8ee77ef127f26ae4121ceb2706bbb49513d39785.patch";
+      hash = "sha256-bVbCORfKciojJkVmnB5vmVS/k4T9tDuthqi5wyAuOXg=";
+    })
+    (fetchpatch {
+      url = "https://github.com/CaringCaribou/caringcaribou/commit/f05c5cec0e643654587fd346378be2ad69ef4d17.patch";
+      hash = "sha256-+XyTpB1HGW1/rzUfn8FuKeOMza5JU11iFWfuzpOzO5c=";
+    })
+
+    # Backport fix that removes the deprecated pkg_resources library usage
+    (fetchpatch {
+      url = "https://github.com/CaringCaribou/caringcaribou/commit/93d9518df4f496efccefd8d637802b99be9fa83c.patch";
+      hash = "sha256-bknn5HfkyU5iDekl8Tq5sdASQx6wXEi+Yhfa4L11vio=";
+    })
+  ];
+
+  build-system = [
+    python3Packages.setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    python-can
+    doipclient
+  ];
+
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # can.exceptions.CanInterfaceNotImplementedError: Unknown interface type "None"
+    "caringcaribou/tests/test_iso_15765_2.py"
+    "caringcaribou/tests/test_iso_14229_1.py"
+    "caringcaribou/tests/test_module_uds.py"
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Friendly automatic security exploration tool";
+    homepage = "https://github.com/CaringCaribou/caringcaribou";
+    changelog = "https://github.com/CaringCaribou/caringcaribou/releases/tag/${finalAttrs.version}";
+    mainProgram = "caringcaribou";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      mana-byte
+      RossSmyth
+    ];
+  };
+})

--- a/pkgs/development/python-modules/doipclient/default.nix
+++ b/pkgs/development/python-modules/doipclient/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  udsoncan,
+  pytestCheckHook,
+  pytest-mock,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "doipclient";
+  version = "1.1.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jacobschaer";
+    repo = "python-doipclient";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Hufp5nKuvURKVFwc0H94PrWg04m6zF+y8gZS0HqQ94g=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    udsoncan
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ];
+
+  pythonImportsCheck = [ "doipclient" ];
+
+  meta = {
+    description = "Enables Diagnostic over IP communication with automotive ECUs";
+    homepage = "https://github.com/jacobschaer/python-doipclient";
+    changelog = "https://github.com/jacobschaer/python-doipclient/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mana-byte
+      RossSmyth
+    ];
+  };
+})

--- a/pkgs/development/python-modules/udsoncan/default.nix
+++ b/pkgs/development/python-modules/udsoncan/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  pytestCheckHook,
+}:
+buildPythonPackage (finalAttrs: {
+  pname = "udsoncan";
+  version = "1.25.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pylessard";
+    repo = "python-udsoncan";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-71l4bWuFJEUeNGbNylhQg57mTE2oeuhlwBNVPNNrnIQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  disabledTestPaths = [
+    # PytestUnhandledThreadExceptionWarning: Exception in thread Thread-853
+    "test/client"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "udsoncan" ];
+
+  meta = {
+    description = "Implementation of the Unified Diagnostic Services (UDS) protocol defined by ISO-14229";
+    homepage = "https://udsoncan.readthedocs.io/en/v${finalAttrs.version}/";
+    changelog = "https://github.com/pylessard/python-udsoncan/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
+      mana-byte
+      RossSmyth
+    ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4528,6 +4528,8 @@ self: super: with self; {
 
   dohq-artifactory = callPackage ../development/python-modules/dohq-artifactory { };
 
+  doipclient = callPackage ../development/python-modules/doipclient { };
+
   doit = callPackage ../development/python-modules/doit { };
 
   doit-py = callPackage ../development/python-modules/doit-py { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20031,6 +20031,8 @@ self: super: with self; {
 
   udatetime = callPackage ../development/python-modules/udatetime { };
 
+  udsoncan = callPackage ../development/python-modules/udsoncan { };
+
   ueagle = callPackage ../development/python-modules/ueagle { };
 
   ueberzug = callPackage ../development/python-modules/ueberzug {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Continuation of https://github.com/NixOS/nixpkgs/pull/486665

Added packages:
- https://github.com/CaringCaribou/caringcaribou init at 0.6
- https://github.com/pylessard/python-udsoncan/ init at 1.25.2
- https://github.com/jacobschaer/python-doipclient init at 1.1.8

Caringcaribou : A friendly automotive security exploration tool.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
