### PR TITLE
nixos/restic: Rewrite module to be more flexible

### DIFF
--- a/nixos/modules/services/backup/restic.nix
+++ b/nixos/modules/services/backup/restic.nix
@@ -1,533 +1,395 @@
 {
-  config,
-  lib,
   pkgs,
+  lib,
+  config,
   utils,
   ...
 }:
 let
-  # Type for a valid systemd unit option. Needed for correctly passing "timerConfig" to "systemd.timers"
-  inherit (utils.systemdUtils.unitOptions) unitOption;
+  additionalArguments = lib.mkOption {
+    type = with lib.types; listOf str;
+    default = [ ];
+    example = [ "--retry-lock 10m" ];
+    description = "Additional arguments to pass to the command.";
+  };
+  getRepositoryEnvironment =
+    repositoryName: repository:
+    {
+      RESTIC_CACHE_DIR = "/var/cache/restic-backups-${repositoryName}";
+      RESTIC_PASSWORD_FILE = repository.passwordFile;
+    }
+    // lib.optionalAttrs (repository.repository != null) {
+      RESTIC_REPOSITORY = repository.repository;
+    }
+    // lib.optionalAttrs (repository.repositoryFile != null) {
+      RESTIC_REPOSITORY_FILE = repository.repositoryFile;
+    }
+    // lib.optionalAttrs (repository.progressFps != null) {
+      RESTIC_PROGRESS_FPS = toString repository.progressFps;
+    };
 in
 {
   options.services.restic.backups = lib.mkOption {
-    description = ''
-      Periodic backups to create with Restic.
-    '';
+    description = "A repository configuration for restic.";
     type = lib.types.attrsOf (
-      lib.types.submodule (
-        { name, ... }:
-        {
-          options = {
-            passwordFile = lib.mkOption {
-              type = with lib.types; nullOr str;
-              default = null;
-              description = ''
-                Read the repository password from a file.
-              '';
-              example = "/etc/nixos/restic-password";
-            };
+      lib.types.submodule (_: {
+        options = {
+          package = lib.mkPackageOption pkgs "restic" { };
 
-            environmentFile = lib.mkOption {
-              type = with lib.types; nullOr str;
-              default = null;
-              description = ''
-                file containing the credentials to access the repository, in the
-                format of an EnvironmentFile as described by {manpage}`systemd.exec(5)`
-              '';
-            };
+          inherit additionalArguments;
 
-            rcloneOptions = lib.mkOption {
-              type =
-                with lib.types;
-                nullOr (
-                  attrsOf (oneOf [
-                    str
-                    bool
-                  ])
-                );
-              default = null;
-              description = ''
-                Options to pass to rclone to control its behavior.
-                See <https://rclone.org/docs/#options> for
-                available options. When specifying option names, strip the
-                leading `--`. To set a flag such as
-                `--drive-use-trash`, which does not take a value,
-                set the value to the Boolean `true`.
-              '';
-              example = {
-                bwlimit = "10M";
-                drive-use-trash = "true";
-              };
-            };
-
-            rcloneConfig = lib.mkOption {
-              type =
-                with lib.types;
-                nullOr (
-                  attrsOf (oneOf [
-                    str
-                    bool
-                  ])
-                );
-              default = null;
-              description = ''
-                Configuration for the rclone remote being used for backup.
-                See the remote's specific options under rclone's docs at
-                <https://rclone.org/docs/>. When specifying
-                option names, use the "config" name specified in the docs.
-                For example, to set `--b2-hard-delete` for a B2
-                remote, use `hard_delete = true` in the
-                attribute set.
-                Warning: Secrets set in here will be world-readable in the Nix
-                store! Consider using the `rcloneConfigFile`
-                option instead to specify secret values separately. Note that
-                options set here will override those set in the config file.
-              '';
-              example = {
-                type = "b2";
-                account = "xxx";
-                key = "xxx";
-                hard_delete = true;
-              };
-            };
-
-            rcloneConfigFile = lib.mkOption {
-              type = with lib.types; nullOr path;
-              default = null;
-              description = ''
-                Path to the file containing rclone configuration. This file
-                must contain configuration for the remote specified in this backup
-                set and also must be readable by root. Options set in
-                `rcloneConfig` will override those set in this
-                file.
-              '';
-            };
-
-            inhibitsSleep = lib.mkOption {
-              default = false;
-              type = lib.types.bool;
-              example = true;
-              description = ''
-                Prevents the system from sleeping while backing up.
-              '';
-            };
-
-            repository = lib.mkOption {
-              type = with lib.types; nullOr str;
-              default = null;
-              description = ''
-                repository to backup to.
-              '';
-              example = "sftp:backup@192.168.1.100:/backups/${name}";
-            };
-
-            repositoryFile = lib.mkOption {
-              type = with lib.types; nullOr path;
-              default = null;
-              description = ''
-                Path to the file containing the repository location to backup to.
-              '';
-            };
-
-            paths = lib.mkOption {
-              # This is nullable for legacy reasons only. We should consider making it a pure listOf
-              # after some time has passed since this comment was added.
-              type = lib.types.nullOr (lib.types.listOf lib.types.str);
-              default = [ ];
-              description = ''
-                Which paths to backup, in addition to ones specified via
-                `dynamicFilesFrom`.  If null or an empty array and
-                `dynamicFilesFrom` is also null, no backup command will be run.
-                 This can be used to create a prune-only job.
-              '';
-              example = [
-                "/var/lib/postgresql"
-                "/home/user/backup"
-              ];
-            };
-
-            command = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [ ];
-              description = ''
-                Command to pass to --stdin-from-command. If null or an empty array, and `paths`/`dynamicFilesFrom`
-                are also null, no backup command will be run.
-              '';
-              example = [
-                "sudo"
-                "-u"
-                "postgres"
-                "pg_dumpall"
-              ];
-            };
-
-            exclude = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [ ];
-              description = ''
-                Patterns to exclude when backing up. See
-                https://restic.readthedocs.io/en/latest/040_backup.html#excluding-files for
-                details on syntax.
-              '';
-              example = [
-                "/var/cache"
-                "/home/*/.cache"
-                ".git"
-              ];
-            };
-
-            timerConfig = lib.mkOption {
-              type = lib.types.nullOr (lib.types.attrsOf unitOption);
-              default = {
-                OnCalendar = "daily";
-                Persistent = true;
-              };
-              description = ''
-                When to run the backup. See {manpage}`systemd.timer(5)` for
-                details. If null no timer is created and the backup will only
-                run when explicitly started.
-              '';
-              example = {
-                OnCalendar = "00:05";
-                RandomizedDelaySec = "5h";
-                Persistent = true;
-              };
-            };
-
-            user = lib.mkOption {
-              type = lib.types.str;
-              default = "root";
-              description = ''
-                As which user the backup should run.
-              '';
-              example = "postgresql";
-            };
-
-            extraBackupArgs = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [ ];
-              description = ''
-                Extra arguments passed to restic backup.
-              '';
-              example = [
-                "--cleanup-cache"
-                "--exclude-file=/etc/nixos/restic-ignore"
-              ];
-            };
-
-            extraOptions = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [ ];
-              description = ''
-                Extra extended options to be passed to the restic --option flag.
-              '';
-              example = [
-                "sftp.command='ssh backup@192.168.1.100 -i /home/user/.ssh/id_rsa -s sftp'"
-              ];
-            };
-
-            initialize = lib.mkOption {
-              type = lib.types.bool;
-              default = false;
-              description = ''
-                Create the repository if it doesn't exist.
-              '';
-            };
-
-            pruneOpts = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [ ];
-              description = ''
-                A list of options (--keep-\* et al.) for 'restic forget
-                --prune', to automatically prune old snapshots.  The
-                'forget' command is run *after* the 'backup' command, so
-                keep that in mind when constructing the --keep-\* options.
-              '';
-              example = [
-                "--keep-daily 7"
-                "--keep-weekly 5"
-                "--keep-monthly 12"
-                "--keep-yearly 75"
-              ];
-            };
-
-            runCheck = lib.mkOption {
-              type = lib.types.bool;
-              default = builtins.length config.services.restic.backups.${name}.checkOpts > 0;
-              defaultText = lib.literalExpression "builtins.length config.services.backups.${name}.checkOpts > 0";
-              description = "Whether to run the `check` command with the provided `checkOpts` options.";
-              example = true;
-            };
-
-            checkOpts = lib.mkOption {
-              type = lib.types.listOf lib.types.str;
-              default = [ ];
-              description = ''
-                A list of options for 'restic check'.
-              '';
-              example = [
-                "--with-cache"
-              ];
-            };
-
-            dynamicFilesFrom = lib.mkOption {
-              type = with lib.types; nullOr str;
-              default = null;
-              description = ''
-                A script that produces a list of files to back up.  The
-                results of this command are given to the '--files-from'
-                option. The result is merged with paths specified via `paths`.
-              '';
-              example = "find /home/matt/git -type d -name .git";
-            };
-
-            backupPrepareCommand = lib.mkOption {
-              type = with lib.types; nullOr str;
-              default = null;
-              description = ''
-                A script that must run before starting the backup process.
-              '';
-            };
-
-            backupCleanupCommand = lib.mkOption {
-              type = with lib.types; nullOr str;
-              default = null;
-              description = ''
-                A script that must run after finishing the backup process.
-              '';
-            };
-
-            package = lib.mkPackageOption pkgs "restic" { };
-
-            createWrapper = lib.mkOption {
-              type = lib.types.bool;
-              default = true;
-              description = ''
-                Whether to generate and add a script to the system path, that has the same environment variables set
-                as the systemd service. This can be used to e.g. mount snapshots or perform other opterations, without
-                having to manually specify most options.
-              '';
-            };
-
-            progressFps = lib.mkOption {
-              type = with lib.types; nullOr numbers.nonnegative;
-              default = null;
-              description = ''
-                Controls the frequency of progress reporting.
-              '';
-              example = 0.1;
-            };
+          repository = lib.mkOption {
+            type = with lib.types; nullOr str;
+            default = null;
+            example = "sftp:root@example.com:/backups";
+            description = "Repository to use.";
           };
-        }
-      )
-    );
-    default = { };
-    example = {
-      localbackup = {
-        paths = [ "/home" ];
-        exclude = [ "/home/*/.cache" ];
-        repository = "/mnt/backup-hdd";
-        passwordFile = "/etc/nixos/secrets/restic-password";
-        initialize = true;
-      };
-      remotebackup = {
-        paths = [ "/home" ];
-        repository = "sftp:backup@host:/backups/home";
-        passwordFile = "/etc/nixos/secrets/restic-password";
-        extraOptions = [
-          "sftp.command='ssh backup@host -i /etc/nixos/secrets/backup-private-key -s sftp'"
-        ];
-        timerConfig = {
-          OnCalendar = "00:05";
-          RandomizedDelaySec = "5h";
+
+          repositoryFile = lib.mkOption {
+            type =
+              with lib.types;
+              nullOr (pathWith {
+                inStore = false;
+                absolute = true;
+              });
+            default = null;
+            example = "/run/secrets/restic-repository";
+            description = "Path to a file containing the repository to use.";
+          };
+
+          passwordFile = lib.mkOption {
+            type = lib.types.pathWith {
+              inStore = false;
+              absolute = true;
+            };
+            example = "/run/secrets/restic-repository-password";
+            description = "Path to a file containing the repository password.";
+          };
+
+          createWrapper = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = ''
+              Whether to generate and add a script to the system path, that has the same environment variables set
+              as the systemd service. This can be used to e.g. mount snapshots or perform other operations, without
+              having to manually specify most options.
+            '';
+          };
+
+          progressFps = lib.mkOption {
+            type = with lib.types; nullOr numbers.nonnegative;
+            default = null;
+            example = 0.1;
+            description = "Controls the frequency of progress reporting";
+          };
+
+          jobs = lib.mkOption {
+            type = lib.types.attrsOf (
+              lib.types.submodule (_: {
+                options = {
+                  inherit additionalArguments;
+
+                  inhibit = {
+                    enable = lib.mkEnableOption "systemd-inhibit";
+
+                    mode = lib.mkOption {
+                      type = lib.types.enum [
+                        "block"
+                        "delay"
+                        "block-weak"
+                      ];
+                      default = "block";
+                      description = ''
+                        Configure how the lock is held.
+
+                        For more details see https://www.freedesktop.org/software/systemd/man/latest/systemd-inhibit.html.
+                      '';
+                    };
+
+                    what = lib.mkOption {
+                      type =
+                        with lib.types;
+                        listOf (enum [
+                          "shutdown"
+                          "sleep"
+                          "idle"
+                          "handle-power-key"
+                          "handle-reboot-key"
+                          "handle-suspend-key"
+                          "handle-hibernate-key"
+                          "handle-lid-switch"
+                        ]);
+                      default = [
+                        "idle"
+                        "sleep"
+                        "shutdown"
+                      ];
+                      description = ''
+                        Configure which operations to inhibit.
+
+                        For more details see https://www.freedesktop.org/software/systemd/man/latest/systemd-inhibit.html.
+                      '';
+                    };
+                  };
+
+                  timerConfig = lib.mkOption {
+                    type = with lib.types; nullOr (attrsOf utils.systemdUtils.unitOptions.unitOption);
+                    default = null;
+                    example = {
+                      OnCalendar = "hourly";
+                      RandomizedDelaySec = "1h";
+                      FixedRandomDelay = true;
+                      Persistent = true;
+                    };
+                    description = ''
+                      When to run the backup. If null no timer is created and the backup will only run when explicitly started.
+
+                      For more details see https://www.freedesktop.org/software/systemd/man/latest/systemd.timer.html.
+                    '';
+                  };
+
+                  user = lib.mkOption {
+                    type = lib.types.str;
+                    default = "root";
+                    example = "postgresql";
+                    description = "As which user the job should run.";
+                  };
+
+                  initialize = lib.mkOption {
+                    type = lib.types.bool;
+                    default = false;
+                    description = "Create the repository if it does not exist.";
+                  };
+
+                  backup = {
+                    enable = lib.mkEnableOption "restic backup";
+
+                    inherit additionalArguments;
+
+                    readOnlyPaths = lib.mkOption {
+                      type = lib.types.bool;
+                      default = true;
+                      description = "Bind mount the paths read-only, to prevent changing files during a backup.";
+                    };
+
+                    paths = lib.mkOption {
+                      type =
+                        with lib.types;
+                        listOf (pathWith {
+                          inStore = false;
+                          absolute = true;
+                        });
+                      default = [ ];
+                      example = [
+                        "/var"
+                        "/home"
+                      ];
+                      description = "Paths to backup.";
+                    };
+
+                    excludePaths = lib.mkOption {
+                      type =
+                        with lib.types;
+                        listOf (pathWith {
+                          inStore = false;
+                          absolute = true;
+                        });
+                      default = [ ];
+                      example = [
+                        "/var/cache"
+                        "/home/*/.cache"
+                      ];
+                      description = ''
+                        Paths to exclude from backup.
+                        Supports pattern matching.
+
+                        For more details see https://restic.readthedocs.io/en/stable/040_backup.html#excluding-files.
+                      '';
+                    };
+
+                    prepareCommand = lib.mkOption {
+                      type = lib.types.str;
+                      default = "";
+                      description = "A script that must run before starting the backup.";
+                    };
+
+                    cleanupCommand = lib.mkOption {
+                      type = lib.types.str;
+                      default = "";
+                      description = "A script that must run after finishing the backup.";
+                    };
+                  };
+
+                  forget = {
+                    enable = lib.mkEnableOption "restic forget";
+
+                    inherit additionalArguments;
+                  };
+
+                  prune = {
+                    enable = lib.mkEnableOption "restic prune";
+
+                    inherit additionalArguments;
+                  };
+
+                  check = {
+                    enable = lib.mkEnableOption "restic check";
+
+                    inherit additionalArguments;
+                  };
+                };
+              })
+            );
+          };
         };
-      };
-      commandbackup = {
-        command = [
-          "\${lib.getExe pkgs.sudo}"
-          "-u postgres"
-          "\${pkgs.postgresql}/bin/pg_dumpall"
-        ];
-        extraBackupArgs = [ "--tag database" ];
-        repository = "s3:example.com/mybucket";
-        passwordFile = "/etc/nixos/secrets/restic-password";
-        environmentFile = "/etc/nixos/secrets/restic-environment";
-        pruneOpts = [
-          "--keep-daily 14"
-          "--keep-weekly 4"
-          "--keep-monthly 2"
-          "--group-by tags"
-        ];
-      };
-    };
+      })
+    );
   };
 
   config = {
     assertions = lib.flatten (
-      lib.mapAttrsToList (name: backup: [
-        {
-          assertion =
-            ((backup.repository == null) != (backup.repositoryFile == null))
-            || (backup.environmentFile != null);
-          message = "services.restic.backups.${name}: exactly one of repository, repositoryFile or environmentFile should be set";
-        }
-        {
-          assertion =
-            let
-              fileBackup = (backup.paths != null && backup.paths != [ ]) || backup.dynamicFilesFrom != null;
-              commandBackup = backup.command != [ ];
-            in
-            !(fileBackup && commandBackup);
-          message = "services.restic.backups.${name}: cannot do both a command backup and a file backup at the same time.";
-        }
-        {
-          assertion = (backup.passwordFile != null) || (backup.environmentFile != null);
-          message = "services.restic.backups.${name}: passwordFile or environmentFile must be set";
-        }
-      ]) config.services.restic.backups
+      lib.mapAttrsToList (
+        repositoryName: repository:
+        [
+          {
+            assertion = (repository.repository == null) != (repository.repositoryFile == null);
+            message = "Exactly one of `services.restic.backups.${repositoryName}.repository` or `services.restic.backups.${repositoryName}.repositoryFile` must be set.";
+          }
+        ]
+        ++ (lib.mapAttrsToList (jobName: job: [
+          {
+            assertion = job.backup.enable || job.forget.enable || job.prune.enable || job.check.enable;
+            message = "Any of `backup.enable`, `forget.enable`, `prune.enable` or `check.enable` must be `true` in `services.restic.backups.${repositoryName}.jobs.${jobName}`.";
+          }
+          {
+            assertion = !job.backup.enable || builtins.length job.backup.paths > 0;
+            message = "`services.restic.backups.${repositoryName}.jobs.${jobName}.paths` must not be empty if `services.restic.backups.${repositoryName}.jobs.${jobName}.backup.enable` is `true`.";
+          }
+        ]) repository.jobs)
+      ) config.services.restic.backups
     );
-    systemd.services = lib.mapAttrs' (
-      name: backup:
-      let
-        extraOptions = lib.concatMapStrings (arg: " -o ${arg}") backup.extraOptions;
-        inhibitCmd = lib.concatStringsSep " " [
-          "${pkgs.systemd}/bin/systemd-inhibit"
-          "--mode='block'"
-          "--who='restic'"
-          "--what='sleep'"
-          "--why=${lib.escapeShellArg "Scheduled backup ${name}"} "
-        ];
-        resticCmd = "${lib.optionalString backup.inhibitsSleep inhibitCmd}${lib.getExe backup.package}${extraOptions}";
-        excludeFlags = lib.optional (
-          backup.exclude != [ ]
-        ) "--exclude-file=${pkgs.writeText "exclude-patterns" (lib.concatStringsSep "\n" backup.exclude)}";
-        filesFromTmpFile = "/run/restic-backups-${name}/includes";
-        fileBackup = (backup.dynamicFilesFrom != null) || (backup.paths != null && backup.paths != [ ]);
-        commandBackup = backup.command != [ ];
-        doBackup = fileBackup || commandBackup;
-        pruneCmd = lib.optionals (builtins.length backup.pruneOpts > 0) [
-          (resticCmd + " unlock")
-          (resticCmd + " forget --prune " + (lib.concatStringsSep " " backup.pruneOpts))
-        ];
-        checkCmd = lib.optionals backup.runCheck [
-          (resticCmd + " check " + (lib.concatStringsSep " " backup.checkOpts))
-        ];
-        # Helper functions for rclone remotes
-        rcloneRemoteName = builtins.elemAt (lib.splitString ":" backup.repository) 1;
-        rcloneAttrToOpt = v: "RCLONE_" + lib.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] v);
-        rcloneAttrToConf = v: "RCLONE_CONFIG_" + lib.toUpper (rcloneRemoteName + "_" + v);
-        toRcloneVal = v: if lib.isBool v then lib.boolToString v else v;
-      in
-      lib.nameValuePair "restic-backups-${name}" (
-        {
-          environment = {
-            # not %C, because that wouldn't work in the wrapper script
-            RESTIC_CACHE_DIR = "/var/cache/restic-backups-${name}";
-            RESTIC_PASSWORD_FILE = backup.passwordFile;
-            RESTIC_REPOSITORY = backup.repository;
-            RESTIC_REPOSITORY_FILE = backup.repositoryFile;
-          }
-          // lib.optionalAttrs (backup.rcloneOptions != null) (
-            lib.mapAttrs' (
-              name: value: lib.nameValuePair (rcloneAttrToOpt name) (toRcloneVal value)
-            ) backup.rcloneOptions
-          )
-          // lib.optionalAttrs (backup.rcloneConfigFile != null) {
-            RCLONE_CONFIG = backup.rcloneConfigFile;
-          }
-          // lib.optionalAttrs (backup.rcloneConfig != null) (
-            lib.mapAttrs' (
-              name: value: lib.nameValuePair (rcloneAttrToConf name) (toRcloneVal value)
-            ) backup.rcloneConfig
-          )
-          // lib.optionalAttrs (backup.progressFps != null) {
-            RESTIC_PROGRESS_FPS = toString backup.progressFps;
-          };
-          path = [ config.programs.ssh.package ];
-          restartIfChanged = false;
-          wants = [ "network-online.target" ];
-          after = [ "network-online.target" ];
-          serviceConfig = {
-            Type = "oneshot";
-            ExecStart =
-              lib.optionals doBackup [
-                "${resticCmd} backup ${
-                  lib.concatStringsSep " " (
-                    backup.extraBackupArgs
-                    ++ lib.optionals fileBackup (excludeFlags ++ [ "--files-from=${filesFromTmpFile}" ])
-                    ++ lib.optionals commandBackup ([ "--stdin-from-command=true --" ] ++ backup.command)
-                  )
-                }"
-              ]
-              ++ pruneCmd
-              ++ checkCmd;
-            User = backup.user;
-            RuntimeDirectory = "restic-backups-${name}";
-            CacheDirectory = "restic-backups-${name}";
-            CacheDirectoryMode = "0700";
-            PrivateTmp = true;
-          }
-          // lib.optionalAttrs (backup.environmentFile != null) {
-            EnvironmentFile = backup.environmentFile;
-          };
-        }
-        // lib.optionalAttrs (backup.initialize || doBackup || backup.backupPrepareCommand != null) {
-          preStart = ''
-            ${lib.optionalString (backup.backupPrepareCommand != null) ''
-              ${pkgs.writeScript "backupPrepareCommand" backup.backupPrepareCommand}
-            ''}
-            ${lib.optionalString backup.initialize ''
-              ${resticCmd} cat config > /dev/null || ${resticCmd} init
-            ''}
-            ${lib.optionalString (backup.paths != null && backup.paths != [ ]) ''
-              cat ${pkgs.writeText "staticPaths" (lib.concatLines backup.paths)} >> ${filesFromTmpFile}
-            ''}
-            ${lib.optionalString (backup.dynamicFilesFrom != null) ''
-              ${pkgs.writeScript "dynamicFilesFromScript" backup.dynamicFilesFrom} >> ${filesFromTmpFile}
-            ''}
-          '';
-        }
-        // lib.optionalAttrs (doBackup || backup.backupCleanupCommand != null) {
-          postStop = ''
-            ${lib.optionalString (backup.backupCleanupCommand != null) ''
-              ${pkgs.writeScript "backupCleanupCommand" backup.backupCleanupCommand}
-            ''}
-            ${lib.optionalString fileBackup ''
-              rm -f ${filesFromTmpFile}
-            ''}
-          '';
-        }
-      )
-    ) config.services.restic.backups;
-    systemd.timers = lib.mapAttrs' (
-      name: backup:
-      lib.nameValuePair "restic-backups-${name}" {
-        wantedBy = [ "timers.target" ];
-        inherit (backup) timerConfig;
-      }
-    ) (lib.filterAttrs (_: backup: backup.timerConfig != null) config.services.restic.backups);
 
-    # generate wrapper scripts, as described in the createWrapper option
+    systemd = {
+      services = lib.mergeAttrsList (
+        lib.mapAttrsToList (
+          repositoryName: repository:
+          lib.mapAttrs' (
+            jobName: job:
+            lib.nameValuePair "restic-backups-${repositoryName}-${jobName}" {
+              environment = getRepositoryEnvironment repositoryName repository;
+              restartIfChanged = false;
+              serviceConfig = {
+                Type = "oneshot";
+                RuntimeDirectory = "restic-backups-${repositoryName}";
+                CacheDirectory = "restic-backups-${repositoryName}";
+                CacheDirectoryMode = "0700";
+                User = config.users.users.${job.user}.name;
+                BindReadOnlyPaths = lib.mkIf (job.backup.enable && job.backup.readOnlyPaths) job.backup.paths;
+                ExecStart =
+                  let
+                    resticCmd = lib.concatStringsSep " " (
+                      [ (lib.getExe repository.package) ] ++ repository.additionalArguments ++ job.additionalArguments
+                    );
+                    script = lib.getExe (
+                      pkgs.writeShellScriptBin "restic-backups-${repositoryName}-${jobName}" ''
+                        set -euo pipefail
+
+                        ${lib.optionalString job.initialize ''
+                          ${resticCmd} cat config > /dev/null || ${resticCmd} init
+                        ''}
+
+                        ${lib.optionalString job.backup.enable ''
+                          ${job.backup.prepareCommand}
+
+                          ${resticCmd} unlock
+                          ${lib.concatStringsSep " " (
+                            [
+                              resticCmd
+                              "backup"
+                            ]
+                            ++ job.backup.additionalArguments
+                            ++ (map (path: "--exclude ${lib.escapeShellArg path}") job.backup.excludePaths)
+                            ++ (map lib.escapeShellArg job.backup.paths)
+                          )}
+
+                          ${job.backup.cleanupCommand}
+                        ''}
+
+                        ${lib.optionalString job.forget.enable ''
+                          ${resticCmd} unlock
+                          ${lib.concatStringsSep " " (
+                            [
+                              resticCmd
+                              "forget"
+                            ]
+                            ++ job.forget.additionalArguments
+                          )}
+                        ''}
+
+                        ${lib.optionalString job.prune.enable ''
+                          ${resticCmd} unlock
+                          ${lib.concatStringsSep " " (
+                            [
+                              resticCmd
+                              "prune"
+                            ]
+                            ++ job.prune.additionalArguments
+                          )}
+                        ''}
+
+                        ${lib.optionalString job.check.enable ''
+                          ${resticCmd} unlock
+                          ${lib.concatStringsSep " " (
+                            [
+                              resticCmd
+                              "check"
+                            ]
+                            ++ job.check.additionalArguments
+                          )}
+                        ''}
+                      ''
+                    );
+                  in
+                  if job.inhibit.enable then
+                    "${lib.getExe' pkgs.systemd "systemd-inhibit"} --mode='${job.inhibit.mode}' --what='${lib.concatStringsSep ":" job.inhibit.what}' --who='restic-backups-${repositoryName}' --why=${lib.escapeShellArg "Restic job '${jobName}' on repository '${repositoryName}'"} ${script}"
+                  else
+                    script;
+              };
+            }
+          ) repository.jobs
+        ) config.services.restic.backups
+      );
+
+      timers = lib.mergeAttrsList (
+        lib.mapAttrsToList (
+          repositoryName: repository:
+          lib.mapAttrs' (
+            jobName: job:
+            lib.nameValuePair "restic-backups-${repositoryName}-${jobName}" {
+              wantedBy = [ "timers.target" ];
+              inherit (job) timerConfig;
+            }
+          ) (lib.filterAttrs (_: job: job.timerConfig != null) repository.jobs)
+        ) config.services.restic.backups
+      );
+    };
+
     environment.systemPackages = lib.mapAttrsToList (
-      name: backup:
+      repositoryName: repository:
       let
-        extraOptions = lib.concatMapStrings (arg: " -o ${arg}") backup.extraOptions;
-        resticCmd = "${lib.getExe backup.package}${extraOptions}";
+        resticCmd = lib.concatStringsSep " " (
+          [ (lib.getExe repository.package) ] ++ repository.additionalArguments
+        );
       in
-      pkgs.writeShellScriptBin "restic-${name}" ''
-        set -a  # automatically export variables
-        ${lib.optionalString (backup.environmentFile != null) "source ${backup.environmentFile}"}
-        # set same environment variables as the systemd service
-        ${lib.pipe config.systemd.services."restic-backups-${name}".environment [
-          (lib.filterAttrs (n: v: v != null && n != "PATH"))
-          (lib.mapAttrs (_: v: "${v}"))
-          lib.toShellVars
-        ]}
-        PATH=${config.systemd.services."restic-backups-${name}".environment.PATH}:$PATH
-
-        exec ${resticCmd} "$@"
+      pkgs.writeShellScriptBin "restic-${repositoryName}" ''
+        ${
+          lib.concatStringsSep " " (
+            lib.mapAttrsToList (name: value: "${name}=${lib.escapeShellArg value}") (
+              getRepositoryEnvironment repositoryName repository
+            )
+          )
+        } ${resticCmd} "$@"
       ''
-    ) (lib.filterAttrs (_: v: v.createWrapper) config.services.restic.backups);
+    ) (lib.filterAttrs (_: repository: repository.createWrapper) config.services.restic.backups);
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This rewrite is not done, I only implemented the minimal changes that are needed to support my setup. Some things I also removed intentionally, because they were not necessary or already possible in different ways. This code is running successfully on all my machines already.

I'm putting this out here so people know that I'm working on it (and don't accidentally duplicate the work). I'm also happy to already gather some feedback.

Closes https://github.com/NixOS/nixpkgs/issues/412106
Closes https://github.com/NixOS/nixpkgs/issues/216457
Closes https://github.com/NixOS/nixpkgs/issues/468191
Closes https://github.com/NixOS/nixpkgs/issues/465973
Closes https://github.com/NixOS/nixpkgs/issues/456723

TODO:
- [ ] Add all missing options that actually make sense
- [ ] Update tests
- [ ] Update docs
- [ ] Update release notes

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
