### PR TITLE
labgrid.coordinator.service: Provide the service

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -604,6 +604,7 @@
   ./services/development/hoogle.nix
   ./services/development/jupyter/default.nix
   ./services/development/jupyterhub/default.nix
+  ./services/development/labgrid/coordinator.nix
   ./services/development/livebook.nix
   ./services/development/lorri.nix
   ./services/development/nixseparatedebuginfod2.nix

--- a/nixos/modules/services/development/labgrid/coordinator.nix
+++ b/nixos/modules/services/development/labgrid/coordinator.nix
@@ -1,0 +1,96 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.labgrid.coordinator;
+in
+{
+  meta = {
+    maintainers = with lib.maintainers; [
+      aiyion
+      emantor
+    ];
+  };
+
+  options = {
+    services.labgrid.coordinator = {
+      bindAddress = lib.mkOption {
+        default = "0.0.0.0";
+        type = lib.types.str;
+        description = "Bind address for the labgrid coordinator.";
+      };
+
+      debug = lib.mkOption {
+        default = false;
+        type = with lib.types; bool;
+        description = ''
+          Whether to enable debug mode.
+        '';
+      };
+
+      enable = lib.mkEnableOption "Labgrid Coordinator";
+
+      openFirewall = lib.mkOption {
+        default = false;
+        type = with lib.types; bool;
+        description = ''
+          Whether to automatically open the coordinator listen port in the firewall.
+        '';
+      };
+
+      package = lib.mkPackageOption pkgs [ "python3Packages" "labgrid" ] { };
+
+      port = lib.mkOption {
+        default = 20408;
+        type = lib.types.port;
+        description = "Coordinator port to bind to.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [ cfg.port ];
+
+    systemd.services.labgrid-coordinator = {
+      after = [ "network-online.target" ];
+      description = "Labgrid Coordinator";
+      serviceConfig = {
+        Environment = ''"PYTHONUNBUFFERED=1"'';
+        ExecStart = "${lib.getBin cfg.package}/bin/labgrid-coordinator ${lib.optionalString cfg.debug "--debug"} --listen ${cfg.bindAddress}:${toString cfg.port}";
+        Restart = "on-failure";
+        DynamicUser = "yes";
+        StateDirectory = "labgrid-coordinator";
+        WorkingDirectory = "/var/lib/labgrid-coordinator";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictRealtime = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6";
+        RestrictNamespaces = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+          "~@resources"
+        ];
+      };
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -853,6 +853,7 @@ in
     inherit runTest;
     inherit (pkgs) lib;
   };
+  labgrid = runTest ./labgrid.nix;
   lact = runTest ./lact.nix;
   ladybird = runTest ./ladybird.nix;
   languagetool = runTest ./languagetool.nix;

--- a/nixos/tests/labgrid.nix
+++ b/nixos/tests/labgrid.nix
@@ -1,0 +1,61 @@
+{ pkgs, ... }:
+{
+  name = "Labgrid";
+  meta.maintainers = with pkgs.lib.maintainers; [
+    aiyion
+    emantor
+  ];
+
+  nodes.coordinator =
+    { pkgs, ... }:
+    {
+      services.labgrid.coordinator.enable = true;
+      services.labgrid.coordinator.openFirewall = true;
+    };
+
+  nodes.client =
+    { pkgs, ... }:
+    {
+      environment.variables = {
+        LG_COORDINATOR = "coordinator:20408";
+      };
+      environment.systemPackages = [ pkgs.python3Packages.labgrid ];
+    };
+
+  testScript =
+    { nodes, ... }:
+    #python
+    ''
+      def assert_contains(haystack, needle):
+          if needle not in haystack:
+              print("The haystack that will cause the following exception is:")
+              print("---")
+              print(haystack)
+              print("---")
+              raise Exception(f"Expected string '{needle}' was not found")
+
+      with subtest("Wait for coordinator startup"):
+          coordinator.start()
+          coordinator.wait_for_unit("labgrid-coordinator.service")
+          coordinator.wait_for_open_port(20408)
+
+      with subtest("Connect from client"):
+          client.start()
+          out = client.succeed("labgrid-client resources")
+
+      with subtest("Create place"):
+          client.succeed("labgrid-client -p testplace create")
+          out = client.succeed("labgrid-client places")
+          assert_contains(out, "testplace")
+          # Give the coordinator enough time to persist place creation
+          coordinator.wait_until_succeeds("grep -q testplace /var/lib/labgrid-coordinator/places.yaml")
+
+      with subtest("Test coordinator persistence"):
+          coordinator.shutdown()
+          coordinator.start()
+          coordinator.wait_for_unit("labgrid-coordinator.service")
+          coordinator.wait_for_open_port(20408)
+          out = client.succeed("labgrid-client places")
+          assert_contains(out, "testplace")
+    '';
+}

--- a/nixos/tests/labgrid.nix
+++ b/nixos/tests/labgrid.nix
@@ -57,5 +57,10 @@
           coordinator.wait_for_open_port(20408)
           out = client.succeed("labgrid-client places")
           assert_contains(out, "testplace")
+
+      with subtest("Check systemd hardening does not degrade unnoticed"):
+          exact_threshold = 11
+          out = coordinator.fail(f"systemd-analyze security labgrid-coordinator.service --threshold={exact_threshold-1}")
+          out = coordinator.succeed(f"systemd-analyze security labgrid-coordinator.service --threshold={exact_threshold}")
     '';
 }


### PR DESCRIPTION
```
based on the example in contrib/ in the project repo.

Provide three new options:
- enable (default: False)
- debug (default: False)
- bindAddress (default: 0.0.0.0)
- package (default: python313Packages.labgrid)
- port (default: 22408)
```

@Emantor depending on your input the maintainership of this module can lie with us, me or you. Similar goes for the package itself: I intend to use it at work, might as well have my employer pay for some of the hours I spend in maintenance, if you want to share maintainership. Both are completely your choice.

The listen option resembles the CLI parameter.
I think it might be cleaner to use two different options `host` and `port` instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - ~[Package tests] at `passthru.tests`~.
  - ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. **used this file as import in my nix config and launched the service.**
- Nixpkgs Release Notes
  - ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
