### PR TITLE
semgrep: 1.145.0 -> 1.152.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4453,6 +4453,12 @@
     githubId = 495429;
     name = "Claas Augner";
   };
+  caverav = {
+    email = "camilo@fvv.cl";
+    github = "caverav";
+    githubId = 66751764;
+    name = "Camilo Vera Vidales";
+  };
   cawilliamson = {
     email = "home@chrisaw.com";
     github = "cawilliamson";

--- a/pkgs/development/python-modules/opentelemetry-instrumentation-threading/default.nix
+++ b/pkgs/development/python-modules/opentelemetry-instrumentation-threading/default.nix
@@ -1,0 +1,37 @@
+{
+  buildPythonPackage,
+  hatchling,
+  opentelemetry-api,
+  opentelemetry-instrumentation,
+  opentelemetry-test-utils,
+  pytestCheckHook,
+  wrapt,
+}:
+
+buildPythonPackage {
+  inherit (opentelemetry-instrumentation) version src;
+  pname = "opentelemetry-instrumentation-threading";
+  pyproject = true;
+
+  sourceRoot = "${opentelemetry-instrumentation.src.name}/instrumentation/opentelemetry-instrumentation-threading";
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    opentelemetry-api
+    opentelemetry-instrumentation
+    wrapt
+  ];
+
+  nativeCheckInputs = [
+    opentelemetry-test-utils
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "opentelemetry.instrumentation.threading" ];
+
+  meta = opentelemetry-instrumentation.meta // {
+    description = "Thread context propagation support for OpenTelemetry";
+    homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-threading";
+  };
+}

--- a/pkgs/development/python-modules/semgrep/common.nix
+++ b/pkgs/development/python-modules/semgrep/common.nix
@@ -1,9 +1,9 @@
 { lib }:
 
 rec {
-  version = "1.145.0";
+  version = "1.152.0";
 
-  srcHash = "sha256-yeTToWfCchGHGsSx/Ly3FQmj7K8iW66qItYs0MVtJvo=";
+  srcHash = "sha256-CwF9URo3nUfkIWP277y03Bq9P6FUC4CQLjuiYwCPR6M=";
 
   # submodule dependencies
   # these are fetched so we:
@@ -13,8 +13,8 @@ rec {
     "cli/src/semgrep/semgrep_interfaces" = {
       owner = "semgrep";
       repo = "semgrep-interfaces";
-      rev = "e5da9678488bc24e0d5c27a4de71ad67d375cc58";
-      hash = "sha256-9ilDZQmKYD2JN+CQ8VVyNyrjKYXttF+3KspRPHhuPF8=";
+      rev = "76ce6450aba3422c297b35a16e38b9fd740fc860";
+      hash = "sha256-hU76aICQEI7n4tWwZX2fRjgiVw811E4UDkfqQqxX8c0=";
     };
   };
 
@@ -25,19 +25,19 @@ rec {
   core = {
     x86_64-linux = {
       platform = "musllinux_1_0_x86_64.manylinux2014_x86_64";
-      hash = "sha256-W6qWqGiuqOJcBAvTIbTCj4aMLMiAhabJ22lldu3cAR4=";
+      hash = "sha256-XFZfCxvfCSAs2NxCCbmIU2uN0StNwEPSGaTmaHpYMPo=";
     };
     aarch64-linux = {
       platform = "musllinux_1_0_aarch64.manylinux2014_aarch64";
-      hash = "sha256-WM2aq4PpYSNqB8PONJAqrYAzQNhIoK1MQvqoJri4S/Q=";
+      hash = "sha256-XdmzHKizsxrls1Ry7pW40f4BRjA6HEayhDUXuxDHoWk=";
     };
     x86_64-darwin = {
       platform = "macosx_10_14_x86_64";
-      hash = "sha256-cpE+GBOZnWsNKRTFzpAQCl+JaqPl0bgLvW4GFdwnMQc=";
+      hash = "sha256-4ZVFhsN5VyDE/VTnzfellv2dHQIT2nCTKd/54UBRPw0=";
     };
     aarch64-darwin = {
       platform = "macosx_11_0_arm64";
-      hash = "sha256-FAjHtlrGLOGxE7c0/Qd+SpX6NTIh09zDbVAbxQHCDKc=";
+      hash = "sha256-rEK6kAEKdwIOcmdMhyjTn5MIXbEwLPqrZV3pg3cQINk=";
     };
   };
 

--- a/pkgs/development/python-modules/semgrep/common.nix
+++ b/pkgs/development/python-modules/semgrep/common.nix
@@ -57,6 +57,7 @@ rec {
     maintainers = with lib.maintainers; [
       jk
       ambroisie
+      caverav
     ];
   };
 }

--- a/pkgs/development/python-modules/semgrep/default.nix
+++ b/pkgs/development/python-modules/semgrep/default.nix
@@ -21,6 +21,7 @@
   opentelemetry-api,
   opentelemetry-exporter-otlp-proto-http,
   opentelemetry-instrumentation-requests,
+  opentelemetry-instrumentation-threading,
   opentelemetry-sdk,
   mcp,
   packaging,
@@ -32,6 +33,7 @@
   requests,
   rich,
   ruamel-yaml,
+  semantic-version,
   tomli,
   tqdm,
   types-freezegun,
@@ -94,6 +96,7 @@ buildPythonPackage rec {
     requests
     rich
     ruamel-yaml
+    semantic-version
     tqdm
     packaging
     jsonschema
@@ -109,6 +112,7 @@ buildPythonPackage rec {
     opentelemetry-sdk
     opentelemetry-exporter-otlp-proto-http
     opentelemetry-instrumentation-requests
+    opentelemetry-instrumentation-threading
   ];
 
   doCheck = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11630,6 +11630,10 @@ self: super: with self; {
     callPackage ../development/python-modules/opentelemetry-instrumentation-sqlalchemy
       { };
 
+  opentelemetry-instrumentation-threading =
+    callPackage ../development/python-modules/opentelemetry-instrumentation-threading
+      { };
+
   opentelemetry-instrumentation-urllib3 =
     callPackage ../development/python-modules/opentelemetry-instrumentation-urllib3
       { };


### PR DESCRIPTION
## Summary
  - update `semgrep` from `1.145.0` to `1.152.0`
  - refresh `srcHash`, semgrep-core wheel hashes, and semgrep-interfaces submodule rev/hash via `pkgs/development/python-modules/semgrep/update.sh`
  - add missing runtime deps required by upstream `cli/pyproject.toml` in `1.152.0`:
    - `opentelemetry-instrumentation-threading`
    - `semantic-version`
  - package and register `python3Packages.opentelemetry-instrumentation-threading` from the already-pinned opentelemetry contrib source set

Upstream release:
  - https://github.com/semgrep/semgrep/releases/tag/v1.152.0
  - https://github.com/semgrep/semgrep/blob/v1.152.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
