### PR TITLE
bento: 1.14.1 -> 1.15.0

### DIFF
--- a/pkgs/by-name/be/bento/package.nix
+++ b/pkgs/by-name/be/bento/package.nix
@@ -8,17 +8,17 @@
 
 buildGoModule (finalAttrs: {
   pname = "bento";
-  version = "1.14.1";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "warpstreamlabs";
     repo = "bento";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hnDWnN07sf8ymSbwrVIQJrgiEKr81osswcGi8emSGac=";
+    hash = "sha256-XFp10TcDDbFe6A5QVvvd2YJqdBe96RmJ/WQIt2SITtg=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-pCfDRnCoEjeuFuLthk6zQ1Gh4Cb+Ix9J+lh1sqA1Bf8=";
+  vendorHash = "sha256-TVsRjN/BDLN+8Qt2m70vrd5rx5wE+yUesiUB8i3vPmc=";
 
   subPackages = [
     "cmd/bento"


### PR DESCRIPTION
  https://github.com/warpstreamlabs/bento/releases/tag/v1.15.0

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [x] aarch64-linux (cross-compiled via `pkgsCross.aarch64-multiplatform`)
    - [ ] x86_64-darwin
    - [x] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
    - `versionCheckHook` passes (built-in to package)
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  Commit message:

  bento: 1.14.1 -> 1.15.0

  https://github.com/warpstreamlabs/bento/releases/tag/v1.15.0