### PR TITLE
freebsd.{drm-kmod,drm-kmod-firmware}: update

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod-firmware.nix
@@ -12,13 +12,13 @@ mkDerivation rec {
   pname =
     "drm-kmod-firmware" + lib.optionalString withAmd "-amd" + lib.optionalString withIntel "-intel";
 
-  version = "20230625_4"; # there is a _8 but freebsd-ports is pinned to _4
+  version = "20250109";
 
   src = fetchFromGitHub {
     owner = "freebsd";
     repo = "drm-kmod-firmware";
     rev = version;
-    hash = "sha256-RS8uXZMYoHfjDSC0OUJUU81eR8rLlEgFhuh+Y7+kXtA=";
+    hash = "sha256-Z+hZpOogUI4GCZcRYElkO0oeCAG0WhBFh7kS3wuo43c=";
   };
 
   outputs = [
@@ -53,6 +53,7 @@ mkDerivation rec {
 
   makeFlags = [
     "DEBUG_FLAGS=-g"
+    "XARGS_J=xargs-j"
   ];
 
   meta = {

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/package.nix
@@ -52,6 +52,7 @@ mkDerivation rec {
     "-Wno-format" # error: passing 'printf' format string where 'freebsd_kprintf' format string is expected
     "-Wno-sometimes-uninitialized" # this one is actually kind of concerning but it does trip
     "-Wno-unused-function"
+    "-Wno-default-const-init-var-unsafe"
   ];
 
   env = sys.passthru.env;
@@ -68,6 +69,7 @@ mkDerivation rec {
 
   makeFlags = [
     "DEBUG_FLAGS=-g"
+    "XARGS_J=xargs-j"
   ];
 
   meta = {

--- a/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/versions.json
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/drm-kmod/versions.json
@@ -1,26 +1,26 @@
 {
   "5.10-lts": {
-    "hash": "sha256-cmjdoqgCs4Rm7z0VzlDB5eJGdEWKl9uqZ+vcHqc6gbU=",
+    "hash": "sha256-P0rV4lGcPFL4z//Zid3s50tZDwrdih7yJGw5txVh/ew=",
     "owner": "freebsd",
     "repo": "drm-kmod",
-    "rev": "17498c322eeae74eea80d4c2589540a059bb59e5"
+    "rev": "fd1a91620908344a77a60736692b1abf67427b84"
   },
   "5.15-lts": {
-    "hash": "sha256-R/OHaqjzY4CkUeW/zNj34UzUr8nRk0iALShHQa7efZU=",
+    "hash": "sha256-tRr7g4FmNr5qROBwU3+HuGiSGtrkFiBh/PZbAoQg/uM=",
     "owner": "freebsd",
     "repo": "drm-kmod",
-    "rev": "9efcad4186ed869300e41b759598c3cb057b0753"
+    "rev": "97cdc23a6ef02e856ee09a854afcc53f67e5fa7c"
   },
   "6.1-lts": {
-    "hash": "sha256-CWLUA8SGhQ8FZ/8y1iKhLdK7qx0r4IHLnNG2+oQkHBw=",
+    "hash": "sha256-rM3nrx52yQbHwHy3VKlRCg3zdnZ4329UmylZTUIdfhg=",
     "owner": "freebsd",
     "repo": "drm-kmod",
-    "rev": "f52b90d97d3bcefe4b2f09cad1ae668ffff99c53"
+    "rev": "40c83387f83c520349b923fc34444f606e305390"
   },
   "6.6-lts": {
-    "hash": "sha256-XY+Q2AqS3t2rPL/aaFzjaOUgAn5IL0bXUPjkzp+qz1Y=",
+    "hash": "sha256-+OO+iG1geZ7R5fQt+Dugn0PA9r5dTrStaGvZdDr7NuA=",
     "owner": "freebsd",
     "repo": "drm-kmod",
-    "rev": "b0b44e1905934a37d8d4870791b36b3e8ff1face"
+    "rev": "732602980c17f544df5c53c587d0097e4a7322ae"
   }
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update and fix build for drm-kmod and the associated firmware package

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux (cross for x86_64-freebsd)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
