### PR TITLE
winePackages: Move `lib.makeExtensible` into `wine-packages.nix`

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -12645,31 +12645,7 @@ with pkgs;
 
   wibo = pkgsi686Linux.callPackage ../applications/emulators/wibo { };
 
-  winePackagesFor =
-    wineBuild:
-    lib.makeExtensible (
-      self: with self; {
-        callPackage = newScope self;
-
-        inherit wineBuild;
-
-        inherit (callPackage ./wine-packages.nix { })
-          minimal
-          base
-          full
-          stable
-          stableFull
-          unstable
-          unstableFull
-          staging
-          stagingFull
-          wayland
-          waylandFull
-          yabridge
-          fonts
-          ;
-      }
-    );
+  winePackagesFor = wineBuild: callPackage ./wine-packages.nix { inherit wineBuild; };
 
   winePackages = recurseIntoAttrs (winePackagesFor (config.wine.build or "wine32"));
   wine64Packages = recurseIntoAttrs (winePackagesFor "wine64");

--- a/pkgs/top-level/wine-packages.nix
+++ b/pkgs/top-level/wine-packages.nix
@@ -2,73 +2,83 @@
   lib,
   stdenv,
   config,
-  callPackage,
+  # not for anything bound in the package set, do note
+  pkgs,
+  newScope,
   wineBuild,
 }:
 
-rec {
-  fonts = callPackage ../applications/emulators/wine/fonts.nix { };
-  minimal = callPackage ../applications/emulators/wine {
-    wineRelease = config.wine.release or "stable";
-    inherit wineBuild;
-  };
+lib.makeExtensible (
+  self:
+  let
+    callPackage = newScope self;
+  in
+  {
+    inherit callPackage wineBuild;
 
-  base = minimal.override {
-    gettextSupport = true;
-    fontconfigSupport = stdenv.hostPlatform.isLinux;
-    alsaSupport = stdenv.hostPlatform.isLinux;
-    openglSupport = true;
-    vulkanSupport = true;
-    tlsSupport = true;
-    cupsSupport = true;
-    dbusSupport = stdenv.hostPlatform.isLinux;
-    cairoSupport = stdenv.hostPlatform.isLinux;
-    cursesSupport = true;
-    saneSupport = stdenv.hostPlatform.isLinux;
-    pulseaudioSupport = config.pulseaudio or stdenv.hostPlatform.isLinux;
-    udevSupport = stdenv.hostPlatform.isLinux;
-    xineramaSupport = stdenv.hostPlatform.isLinux;
-    sdlSupport = true;
-    mingwSupport = true;
-    usbSupport = true;
-    waylandSupport = stdenv.hostPlatform.isLinux;
-    x11Support = stdenv.hostPlatform.isLinux;
-    ffmpegSupport = true;
-  };
+    fonts = callPackage ../applications/emulators/wine/fonts.nix { };
+    minimal = callPackage ../applications/emulators/wine {
+      wineRelease = config.wine.release or "stable";
+      inherit wineBuild;
+    };
 
-  full = base.override {
-    gtkSupport = stdenv.hostPlatform.isLinux;
-    gstreamerSupport = true;
-    openclSupport = true;
-    odbcSupport = true;
-    netapiSupport = stdenv.hostPlatform.isLinux;
-    vaSupport = stdenv.hostPlatform.isLinux;
-    pcapSupport = true;
-    v4lSupport = stdenv.hostPlatform.isLinux;
-    gphoto2Support = true;
-    krb5Support = true;
-    embedInstallers = true;
-  };
+    base = self.minimal.override {
+      gettextSupport = true;
+      fontconfigSupport = stdenv.hostPlatform.isLinux;
+      alsaSupport = stdenv.hostPlatform.isLinux;
+      openglSupport = true;
+      vulkanSupport = true;
+      tlsSupport = true;
+      cupsSupport = true;
+      dbusSupport = stdenv.hostPlatform.isLinux;
+      cairoSupport = stdenv.hostPlatform.isLinux;
+      cursesSupport = true;
+      saneSupport = stdenv.hostPlatform.isLinux;
+      pulseaudioSupport = config.pulseaudio or stdenv.hostPlatform.isLinux;
+      udevSupport = stdenv.hostPlatform.isLinux;
+      xineramaSupport = stdenv.hostPlatform.isLinux;
+      sdlSupport = true;
+      mingwSupport = true;
+      usbSupport = true;
+      waylandSupport = stdenv.hostPlatform.isLinux;
+      x11Support = stdenv.hostPlatform.isLinux;
+      ffmpegSupport = true;
+    };
 
-  stable = base.override { wineRelease = "stable"; };
-  stableFull = full.override { wineRelease = "stable"; };
+    full = self.base.override {
+      gtkSupport = stdenv.hostPlatform.isLinux;
+      gstreamerSupport = true;
+      openclSupport = true;
+      odbcSupport = true;
+      netapiSupport = stdenv.hostPlatform.isLinux;
+      vaSupport = stdenv.hostPlatform.isLinux;
+      pcapSupport = true;
+      v4lSupport = stdenv.hostPlatform.isLinux;
+      gphoto2Support = true;
+      krb5Support = true;
+      embedInstallers = true;
+    };
 
-  unstable = base.override { wineRelease = "unstable"; };
-  unstableFull = full.override { wineRelease = "unstable"; };
+    stable = self.base.override { wineRelease = "stable"; };
+    stableFull = self.full.override { wineRelease = "stable"; };
 
-  staging = base.override { wineRelease = "staging"; };
-  stagingFull = full.override { wineRelease = "staging"; };
+    unstable = self.base.override { wineRelease = "unstable"; };
+    unstableFull = self.full.override { wineRelease = "unstable"; };
 
-  wayland = base.override {
-    x11Support = false;
-  };
-  waylandFull = full.override {
-    x11Support = false;
-  };
+    staging = self.base.override { wineRelease = "staging"; };
+    stagingFull = self.full.override { wineRelease = "staging"; };
 
-  yabridge =
-    let
-      yabridge = base.override { wineRelease = "yabridge"; };
-    in
-    if wineBuild == "wineWow" then yabridge else lib.dontDistribute yabridge;
-}
+    wayland = self.base.override {
+      x11Support = false;
+    };
+    waylandFull = self.full.override {
+      x11Support = false;
+    };
+
+    yabridge =
+      let
+        yabridge = self.base.override { wineRelease = "yabridge"; };
+      in
+      if wineBuild == "wineWow" then yabridge else lib.dontDistribute yabridge;
+  }
+)


### PR DESCRIPTION
This simplifies things, and makes allows for nice late binding.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
