### PR TITLE
xwayland: fix build on FreeBSD

### DIFF
--- a/pkgs/by-name/xw/xwayland/package.nix
+++ b/pkgs/by-name/xw/xwayland/package.nix
@@ -1,6 +1,8 @@
 {
   dri-pkgconfig-stub,
   egl-wayland,
+  epoll-shim,
+  evdev-proto,
   bash,
   libepoxy,
   fetchurl,
@@ -98,7 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
     libxres
     libxt
     libdrm
-    libtirpc
     libxcb
     libxkbfile
     libxshmfence
@@ -106,13 +107,20 @@ stdenv.mkDerivation (finalAttrs: {
     mesa-gl-headers
     openssl
     pixman
-    systemd
     wayland
     wayland-protocols
     xkbcomp
     xorgproto
     xtrans
     zlib
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    libtirpc
+    systemd
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
+    epoll-shim
+    evdev-proto
   ]
   ++ lib.optionals withLibunwind [
     libunwind
@@ -141,6 +149,6 @@ stdenv.mkDerivation (finalAttrs: {
       emantor
       k900
     ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.freebsd;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Change dependencies to build xwayland on FreeBSD.

This reorders dependencies, so will cause a mass rebuild and is thus in staging.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
