### PR TITLE
libsmb2: init at 6.2

### DIFF
--- a/pkgs/by-name/li/libsmb2/fix_version.patch
+++ b/pkgs/by-name/li/libsmb2/fix_version.patch
@@ -1,0 +1,14 @@
+--- a/CMakeLists.txt	2026-02-16 12:09:21.737951500 +0100
++++ b/CMakeLists.txt	2026-02-16 12:09:47.681936339 +0100
+@@ -29,9 +29,9 @@
+   else()
+     project(libsmb2
+             LANGUAGES C
+-            VERSION 6.1.0
++            VERSION 6.2.0
+     )  
+-    set(VERSION 6.1.0)
++    set(VERSION 6.2.0)
+     set(PACKAGE "libsmb2")
+     set(PACKAGE_BUGREPORT "ronniesahlberg@gmail.com")
+     set(PACKAGE_NAME "libsmb2")

--- a/pkgs/by-name/li/libsmb2/package.nix
+++ b/pkgs/by-name/li/libsmb2/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  krb5,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libsmb2";
+  version = "6.2";
+
+  src = fetchFromGitHub {
+    owner = "sahlberg";
+    repo = "libsmb2";
+    tag = "libsmb2-${finalAttrs.version}";
+    hash = "sha256-2leW52nOtRo+jYdU0LhM2Qt0teimJg3QXxXVEydtKtQ=";
+  };
+
+  patches = [ ./fix_version.patch ];
+
+  nativeBuildInputs = [ cmake ];
+
+  postInstall = ''
+    mv $out/lib/cmake/libsmb2/libsmb2-config-version.cmake $out/lib/cmake/libsmb2/libsmb2-config.cmake
+  '';
+
+  meta = {
+    description = "Userspace client/server library for accessing or serving SMB2/SMB3 shares on a network";
+    homepage = "https://github.com/sahlberg/libsmb2";
+    license = lib.licenses.lgpl21;
+    maintainers = with lib.maintainers; [ spreetin ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
A library for communicating over the smb protoctol, versions 2 and 3. I've used this derivation in a project I'm developing, so can confirm that the library works as advertised using the derivation.

The latest release is version 6.2. This was a small fix update for 6.1, and upstream failed to update the version string in CMakeLists.txt before release, so I included a patch to fix this issue.

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
