### PR TITLE
nixos/atticd: use `garage` in the test instead of `minio`

### DIFF
--- a/nixos/tests/atticd.nix
+++ b/nixos/tests/atticd.nix
@@ -1,13 +1,10 @@
 { lib, pkgs, ... }:
 
 let
-  accessKey = "BKIKJAA5BMMU2RHO6IBB";
-  secretKey = "V7f1CwQqAcwo80UEIJEjc5gVQUSSx5ohQ9GSrr12";
+  accessKey = "GKaaaaaaaaaaaaaaaaaaaaaaaa";
+  secretKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  s3Addr = "127.0.0.1:9000";
 
-  minioCredentialsFile = pkgs.writeText "minio-credentials-full" ''
-    MINIO_ROOT_USER=${accessKey}
-    MINIO_ROOT_PASSWORD=${secretKey}
-  '';
   environmentFile = pkgs.runCommand "atticd-env" { } ''
     echo ATTIC_SERVER_TOKEN_RS256_SECRET_BASE64="$(${lib.getExe pkgs.openssl} genrsa -traditional 4096 | ${pkgs.coreutils}/bin/base64 -w0)" > $out
   '';
@@ -36,8 +33,8 @@ in
           storage = {
             type = "s3";
             bucket = "attic";
-            region = "us-east-1";
-            endpoint = "http://127.0.0.1:9000";
+            region = "garage";
+            endpoint = "http://${s3Addr}";
 
             credentials = {
               access_key_id = accessKey;
@@ -49,14 +46,24 @@ in
         inherit environmentFile;
       };
 
-      services.minio = {
+      services.garage = {
         enable = true;
-        rootCredentialsFile = minioCredentialsFile;
+        package = pkgs.garage_2;
+        settings = {
+          rpc_bind_addr = "127.0.0.1:3901";
+          rpc_public_addr = "127.0.0.1:3901";
+          rpc_secret = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+          replication_factor = 1;
+
+          s3_api = {
+            s3_region = "garage";
+            api_bind_addr = s3Addr;
+          };
+        };
       };
 
       environment.systemPackages = [
         pkgs.attic-client
-        pkgs.minio-client
       ];
     };
   };
@@ -74,15 +81,19 @@ in
           local.succeed("attic push test-cache ${environmentFile}")
 
       with subtest("s3 storage push"):
-          s3.wait_for_unit("atticd.service")
-          s3.wait_for_unit("minio.service")
-          s3.wait_for_open_port(9000)
+          s3.wait_for_unit("garage.service")
+          s3.wait_for_open_port(3901)
+          garage_node_id = s3.succeed("garage status | tail -n1 | awk '{ print $1 }'")
           s3.succeed(
-              "mc alias set minio "
-              + "http://localhost:9000 "
-              + "${accessKey} ${secretKey} --api s3v4",
-              "mc mb minio/attic",
+              f"garage layout assign -c 100MB -z garage {garage_node_id}",
+              "garage layout apply --version 1",
+              "garage key import ${accessKey} ${secretKey} --yes",
+              "garage bucket create attic",
+              "garage bucket allow --read --write --owner attic --key ${accessKey}"
           )
+
+          s3.wait_for_unit("atticd.service")
+          s3.wait_for_open_port(9000)
           token = s3.succeed("atticd-atticadm make-token --sub stop --validity 1y --create-cache '*' --pull '*' --push '*' --delete '*' --configure-cache '*' --configure-cache-retention '*'").strip()
 
           s3.succeed(f"attic login s3 http://localhost:8080 {token}")


### PR DESCRIPTION
Related #490996, `minio` is not supported upstream anymore.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
