### PR TITLE
portunus: 2.1.4 -> 2.2.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -112,6 +112,8 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
 
   The way keybinds and actions are handled have been completely revamped. Please refer to the [default config](https://raw.githubusercontent.com/abenz1267/walker/refs/heads/master/resources/config.toml).
 
+- [services.portunus](#opt-services.portunus.enable) has been upgraded to 2.2.0, which includes a bug fix that may cause existing databases to be rejected if user accounts are configured with malformed email addresses. Please refer to [the upstream release announcement](https://github.com/majewsky/portunus/releases/tag/v2.2.0) for details and instructions on how to fix problematic database entries.
+
 - Support for `reiserfs` in nixpkgs has been removed, following the removal in Linux 6.13.
 
 - `services.tor` no longer bind mounts Unix sockets of onion services into its chroot

--- a/pkgs/by-name/po/portunus/package.nix
+++ b/pkgs/by-name/po/portunus/package.nix
@@ -8,13 +8,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "portunus";
-  version = "2.1.4";
+  version = "2.2.0";
 
   src = fetchFromGitHub {
     owner = "majewsky";
     repo = "portunus";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-xZb2+IIZkZd/yGr0+FK7Bi3sZpPMfGz/QmUKn/clrwE=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-PvsqI0kwO0pA2xOouI3DmhwzDCrtyBXCBXyWDy4bEmI=";
   };
 
   buildInputs = [ libxcrypt ];


### PR DESCRIPTION
Ref: <https://github.com/majewsky/portunus/releases/tag/v2.2.0>

@SuperSandro2000 Can you please take care of the testing?

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
