### PR TITLE
mmlgui: migrate to by-name

### DIFF
--- a/pkgs/by-name/mm/mmlgui/package.nix
+++ b/pkgs/by-name/mm/mmlgui/package.nix
@@ -11,7 +11,15 @@
   libxdmcp,
   cppunit,
 }:
-
+let
+  libvgm' = libvgm.override {
+    withAllEmulators = false;
+    emulators = [
+      "_PRESET_SMD"
+    ];
+    enableLibplayer = false;
+  };
+in
 stdenv.mkDerivation {
   pname = "mmlgui";
   version = "210420-preview-unstable-2026-01-09";
@@ -52,7 +60,7 @@ stdenv.mkDerivation {
 
   buildInputs = [
     glfw
-    libvgm
+    libvgm'
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     libx11

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10320,16 +10320,6 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };
 
-  mmlgui = callPackage ../applications/audio/mmlgui {
-    libvgm = libvgm.override {
-      withAllEmulators = false;
-      emulators = [
-        "_PRESET_SMD"
-      ];
-      enableLibplayer = false;
-    };
-  };
-
   monotone = callPackage ../applications/version-management/monotone {
     lua = lua5;
   };


### PR DESCRIPTION
This pull request refactors the packaging of `mmlgui` by moving its package definition and centralizing the customization of its `libvgm` dependency. The main improvements are in code organization and maintainability.

Package relocation and dependency management:

* Moved the `mmlgui` package definition from `pkgs/applications/audio/mmlgui/default.nix` to `pkgs/by-name/mm/mmlgui/package.nix`, reflecting a new package organization structure.
* Refactored the way `libvgm` is customized for `mmlgui` by defining the override directly in the package file instead of in `all-packages.nix`, making dependency management more localized and maintainable. 

* Removed the explicit `mmlgui` entry from `pkgs/top-level/all-packages.nix`, as it is now managed via the new structure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
