### PR TITLE
wayfire: update ecosystem to 0.11.0

### DIFF
--- a/nixos/modules/programs/wayland/wayland-session.nix
+++ b/nixos/modules/programs/wayland/wayland-session.nix
@@ -10,6 +10,7 @@
   security = {
     polkit.enable = true;
     pam.services.swaylock = { };
+    pam.services.wf-locker = { };
   };
 
   programs = {

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -33,7 +33,7 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire";
-  version = "0.10.1";
+  version = "0.11.0-unstable-2026-02-20";
 
   outputs = [
     "out"
@@ -43,9 +43,9 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire";
-    rev = "v${finalAttrs.version}";
+    rev = "ad2c781a4c76b7539fa86e39fd3ef07ea3465070";
     fetchSubmodules = true;
-    hash = "sha256-yiqtnsXxvC7vk22ZQ5OFt5uX40FCRGWpfZrax9GItAg=";
+    hash = "sha256-NADPszDx4D/1SlCvkS4IQaTP7O0+6FVzKWitxyBzyLA=";
   };
 
   postPatch = ''
@@ -67,12 +67,9 @@ stdenv.mkDerivation (finalAttrs: {
     libevdev
     libinput
     libjpeg
-    libxkbcommon
     libxml2
     vulkan-headers
-    wayland-protocols
     libxcb-wm
-    yyjson
   ];
 
   propagatedBuildInputs = [
@@ -81,6 +78,9 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     cairo
     pango
+    yyjson
+    libxkbcommon
+    wayland-protocols
   ];
 
   nativeCheckInputs = [

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -22,18 +22,18 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots_0_19,
+  wlroots_0_20,
   pango,
   libxcb-wm,
   yyjson,
 }:
 let
-  wlroots = wlroots_0_19;
+  wlroots = wlroots_0_20;
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire";
-  version = "0.11.0-unstable-2026-02-20";
+  version = "0.11.0-unstable-2026-04-17";
 
   outputs = [
     "out"
@@ -43,9 +43,9 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire";
-    rev = "ad2c781a4c76b7539fa86e39fd3ef07ea3465070";
+    rev = "9a568ffd7a2af8780926da50f89908ec4f38bf3a";
     fetchSubmodules = true;
-    hash = "sha256-NADPszDx4D/1SlCvkS4IQaTP7O0+6FVzKWitxyBzyLA=";
+    hash = "sha256-sIwBNBY0qN+4+a9KAS8WDGCNyrX5O0tKPPIT8ebLRqo=";
   };
 
   postPatch = ''

--- a/pkgs/applications/window-managers/wayfire/default.nix
+++ b/pkgs/applications/window-managers/wayfire/default.nix
@@ -22,18 +22,20 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots_0_19,
+  wlroots_0_20,
   pango,
   libxcb-wm,
   yyjson,
+  libgbm,
+  fetchpatch,
 }:
 let
-  wlroots = wlroots_0_19;
+  wlroots = wlroots_0_20;
 in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire";
-  version = "0.10.1";
+  version = "0.11.0";
 
   outputs = [
     "out"
@@ -45,13 +47,22 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "wayfire";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-yiqtnsXxvC7vk22ZQ5OFt5uX40FCRGWpfZrax9GItAg=";
+    hash = "sha256-G6GakEpnqw3xORXP7mr2YoyAEymozV0CYeof+a1Nh74=";
   };
 
-  postPatch = ''
-    substituteInPlace plugins/common/wayfire/plugins/common/cairo-util.hpp \
-      --replace "<drm_fourcc.h>" "<libdrm/drm_fourcc.h>"
-  '';
+  patches = [
+    (fetchpatch {
+      name = "wayfire_fix_hermiticity";
+      url = "https://github.com/WayfireWM/wayfire/commit/6cf51df330564d97d922cdaa84e0e130311d8337.patch";
+      hash = "sha256-Drs5wuyF4cfzm3Jdv0fv05FeWjqNhHfVzJK7ZLM04v0=";
+    })
+
+    (fetchpatch {
+      name = "wayfire_fix_squeezimize";
+      url = "https://github.com/WayfireWM/wayfire/commit/2bd9c6d175a788ba057add7eb762e8b0ca4ea7cd.patch";
+      hash = "sha256-pG6tnYiff9gj1AM6mNzhmU8JjoevSlMWeY0XREYq38Q=";
+    })
+  ];
 
   nativeBuildInputs = [
     meson
@@ -67,12 +78,9 @@ stdenv.mkDerivation (finalAttrs: {
     libevdev
     libinput
     libjpeg
-    libxkbcommon
     libxml2
     vulkan-headers
-    wayland-protocols
     libxcb-wm
-    yyjson
   ];
 
   propagatedBuildInputs = [
@@ -81,6 +89,11 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     cairo
     pango
+
+    yyjson
+    wayland-protocols
+    libxkbcommon
+    libgbm
   ];
 
   nativeCheckInputs = [

--- a/pkgs/applications/window-managers/wayfire/pixdecor.nix
+++ b/pkgs/applications/window-managers/wayfire/pixdecor.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  wayfire,
+  wf-config,
+  libdrm,
+  vulkan-headers,
+  libxcb-wm,
+  gtkmm3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pixdecor";
+  version = "0.1.0-unstable-2026-07-13";
+
+  src = fetchFromGitHub {
+    owner = "soreau";
+    repo = "pixdecor";
+    rev = "76a0e8996b41f0df87f0d9c65c816693f1c3fefc";
+    hash = "sha256-qYDqPOJBgM/byaJXI851NswtqLcMpGmeekEca5hI1hE=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    wayfire
+    wf-config
+    libdrm
+    libxcb-wm
+    vulkan-headers
+    gtkmm3
+  ];
+
+  env = {
+    PKG_CONFIG_WAYFIRE_METADATADIR = "${placeholder "out"}/share/wayfire/metadata";
+  };
+
+  meta = {
+    homepage = "https://github.com/WayfireWM/wayfire-plugins-extra";
+    description = "Additional plugins for Wayfire";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wineee ];
+    inherit (wayfire.meta) platforms;
+  };
+})

--- a/pkgs/applications/window-managers/wayfire/plugins.nix
+++ b/pkgs/applications/window-managers/wayfire/plugins.nix
@@ -11,6 +11,7 @@ lib.makeScope pkgs.newScope (
   in
   {
     wayfire-plugins-extra = callPackage ./wayfire-plugins-extra.nix { };
+    pixdecor = callPackage ./pixdecor.nix { };
     wcm = callPackage ./wcm.nix { };
     wf-shell = callPackage ./wf-shell.nix { };
   }

--- a/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
+++ b/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire-plugins-extra";
-  version = "0.10.0";
+  version = "0.11.0-unstable-2025-12-18";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire-plugins-extra";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-C5dgs81R4XuPjIm7sj1Mtu4IMIRBEYU6izg2olymeVI=";
+    rev = "439a9b4dc66f1174f97e0db18b15726751fbf6d1";
+    hash = "sha256-lBLdlWcT2byEiPKoadKvWVHYNrhGGkliF3CSPwV0S5s=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
+++ b/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
@@ -24,13 +24,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire-plugins-extra";
-  version = "0.11.0-unstable-2025-12-18";
+  version = "0.11.0-unstable-2026-04-23";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire-plugins-extra";
-    rev = "439a9b4dc66f1174f97e0db18b15726751fbf6d1";
-    hash = "sha256-lBLdlWcT2byEiPKoadKvWVHYNrhGGkliF3CSPwV0S5s=";
+    rev = "a65af2577986fbbdf8100048ad9943aff8ab27ff";
+    hash = "sha256-U6QllOwGbJQJECe1ofoiV659cLOJyIvYwqshYCCXlFg=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
+++ b/pkgs/applications/window-managers/wayfire/wayfire-plugins-extra.nix
@@ -18,19 +18,20 @@
   gtkmm3,
   withFiltersPlugin ? true,
   withFocusRequestPlugin ? true,
-  withPixdecorPlugin ? true,
+  # Pixdecor is broken here. Use pixdecor.
+  withPixdecorPlugin ? false,
   withWayfireShadowsPlugin ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wayfire-plugins-extra";
-  version = "0.10.0";
+  version = "0.11.0-unstable-2026-07-17";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wayfire-plugins-extra";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-C5dgs81R4XuPjIm7sj1Mtu4IMIRBEYU6izg2olymeVI=";
+    rev = "4290ddf13bfadb344d45cb25c47f7825bbdc8a30";
+    hash = "sha256-HhCGB4ZslglB4o+xZ1gUmeUKWTR1VPnYS2Maqi++OaY=";
     fetchSubmodules = true;
   };
 
@@ -71,5 +72,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ wineee ];
     inherit (wayfire.meta) platforms;
+
+    problems = lib.optionalAttrs withPixdecorPlugin {
+      broken.message = "Pixdecor is broken in wayfire-plugins-extra. Use `wayfirePlugins.pixdecor` instead if you want it.";
+    };
   };
 })

--- a/pkgs/applications/window-managers/wayfire/wcm.nix
+++ b/pkgs/applications/window-managers/wayfire/wcm.nix
@@ -19,12 +19,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wcm";
-  version = "0.10.0";
+  version = "0.11.0-unstable-2025-11-23";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wcm";
-    rev = "v${finalAttrs.version}";
+    rev = "d7e3d6783f3e7d10c3c4edf556be7a5342626065";
     fetchSubmodules = true;
     hash = "sha256-O4BYwb+GOMZIn3I2B/WMJ5tUZlaegvwBuyNK9l/gxvQ=";
   };

--- a/pkgs/applications/window-managers/wayfire/wcm.nix
+++ b/pkgs/applications/window-managers/wayfire/wcm.nix
@@ -15,18 +15,19 @@
   libevdev,
   libxml2,
   libxkbcommon,
+  fmt,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wcm";
-  version = "0.10.0";
+  version = "0.11.0-unstable-2026-07-28";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wcm";
-    rev = "v${finalAttrs.version}";
+    rev = "14f2e03fc4bfa3a20d10b913461636363e39240c";
     fetchSubmodules = true;
-    hash = "sha256-O4BYwb+GOMZIn3I2B/WMJ5tUZlaegvwBuyNK9l/gxvQ=";
+    hash = "sha256-ShclD93AQDHXwjCDTN8zom1xr3v4oMKLzO2q7B3ZAPg=";
   };
 
   nativeBuildInputs = [
@@ -35,6 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wayland-scanner
     wrapGAppsHook3
+    fmt.dev
   ];
 
   buildInputs = [
@@ -46,6 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     libevdev
     libxml2
     libxkbcommon
+    fmt
   ];
 
   meta = {

--- a/pkgs/applications/window-managers/wayfire/wf-config.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-config.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wf-config";
-  version = "0.10.0";
+  version = "0.11.0-unstable-2026-02-20";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wf-config";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-WcGt6yl2LpLnAOVtiCyMyWsoMAUMG1MYhvW/m2DDMX4=";
+    rev = "a2051f5d131a23acdcd96bfeb509d01cf57139ec";
+    hash = "sha256-K6VKGeUM9pP0jHw9jIvV5vUdNYfPBldBXG82/WqbYro=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/wayfire/wf-config.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-config.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wf-config";
-  version = "0.10.0";
+  version = "0.11.0";
 
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wf-config";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-WcGt6yl2LpLnAOVtiCyMyWsoMAUMG1MYhvW/m2DDMX4=";
+    hash = "sha256-hZcmnteB8/DbKjQGY1QLSI32z+OBnp1b8RjJ8pPH1JY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/wayfire/wf-shell.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-shell.nix
@@ -8,15 +8,23 @@
   wayland-scanner,
   wayfire,
   alsa-lib,
-  gtkmm3,
-  gtk-layer-shell,
+  gtkmm4,
+  gtk4-layer-shell,
   pulseaudio,
-  libdbusmenu-gtk3,
+  pipewire,
+  wireplumber,
+  libdbusmenu,
+  libepoxy,
+  linux-pam,
+  vala,
+  gobject-introspection,
+  openssl,
+  inotify-tools,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wf-shell";
-  version = "0.10.0";
+  version = "0.11.0-unstable-2026-02-21";
   outputs = [
     "out"
     "man"
@@ -25,9 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wf-shell";
-    rev = "v${finalAttrs.version}";
+    rev = "6057938099a2abe829fd3f8a3f466889327d92a3";
     fetchSubmodules = true;
-    hash = "sha256-PLTeFGecxVwU2LdwnDwiWB1OcbaZjJemMpT0pcCFf/w=";
+    hash = "sha256-dMetnyr8ntmJybPialubLwsrv3ST7utWmnIY05u6t/4=";
   };
 
   nativeBuildInputs = [
@@ -35,18 +43,33 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     wayland-scanner
+    vala
+    gobject-introspection
   ];
 
   buildInputs = [
     wayfire
     alsa-lib
-    gtkmm3
-    gtk-layer-shell
+    gtkmm4
+    gtk4-layer-shell
     pulseaudio
-    libdbusmenu-gtk3
+    wireplumber
+    libdbusmenu
+    libepoxy
+    linux-pam
+    pipewire.dev
+
+    #wf-json
+    openssl
+
+    #wayland-logout
+    inotify-tools
   ];
 
-  mesonFlags = [ "--sysconfdir /etc" ];
+  postPatch = ''
+    substituteInPlace data/meson.build \
+      --replace-fail "/etc/pam.d/" "etc/pam.d"
+  '';
 
   meta = {
     homepage = "https://github.com/WayfireWM/wf-shell";

--- a/pkgs/applications/window-managers/wayfire/wf-shell.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-shell.nix
@@ -24,7 +24,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wf-shell";
-  version = "0.11.0-unstable-2026-02-21";
+  version = "0.11.0-unstable-2026-04-26";
   outputs = [
     "out"
     "man"
@@ -33,9 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "WayfireWM";
     repo = "wf-shell";
-    rev = "6057938099a2abe829fd3f8a3f466889327d92a3";
+    rev = "d340a173acfa2fe4bcf8088e154f76c43b5d4ab9";
     fetchSubmodules = true;
-    hash = "sha256-dMetnyr8ntmJybPialubLwsrv3ST7utWmnIY05u6t/4=";
+    hash = "sha256-I2PnrBrcD0VaxztJB6JyzfuYP6J0mXJ7ATrqgUzeCiM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/wayfire/wf-shell.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-shell.nix
@@ -8,15 +8,27 @@
   wayland-scanner,
   wayfire,
   alsa-lib,
-  gtkmm3,
-  gtk-layer-shell,
+  gtkmm4,
+  gtk4-layer-shell,
   pulseaudio,
-  libdbusmenu-gtk3,
+  pipewire,
+  wireplumber,
+  libdbusmenu,
+  libepoxy,
+  linux-pam,
+  vala,
+  gobject-introspection,
+  openssl,
+  inotify-tools,
+  wayland-protocols,
+  ddcutil,
+  libxkbcommon,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "wf-shell";
-  version = "0.10.0";
+  version = "0.11.0";
   outputs = [
     "out"
     "man"
@@ -27,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "wf-shell";
     rev = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-PLTeFGecxVwU2LdwnDwiWB1OcbaZjJemMpT0pcCFf/w=";
+    hash = "sha256-1HNjCW0a4qygUW+/On5A19lsigkGDCHyFXEf3jvP22o=";
   };
 
   nativeBuildInputs = [
@@ -35,18 +47,39 @@ stdenv.mkDerivation (finalAttrs: {
     ninja
     pkg-config
     wayland-scanner
+    libxkbcommon.dev
   ];
 
   buildInputs = [
     wayfire
     alsa-lib
-    gtkmm3
-    gtk-layer-shell
+    gtkmm4
+    gtk4-layer-shell
     pulseaudio
-    libdbusmenu-gtk3
+    libdbusmenu
+    ddcutil
+
+    vala
+    gobject-introspection
+
+    wireplumber
+    libdbusmenu
+    libepoxy
+    linux-pam
+    pipewire.dev
+
+    openssl
+
+    inotify-tools
   ];
 
-  mesonFlags = [ "--sysconfdir /etc" ];
+  patches = [
+    (fetchpatch {
+      name = "wf-shell_fix_meson";
+      url = "https://github.com/WayfireWM/wf-shell/commit/8be3ff5671d51b9ea6455b82aff3b7ffad3ef48e.patch";
+      hash = "sha256-0z5Nc/wylHIQgfbnLSbxL3hHpXp2gjLdiCEes8lHV6U=";
+    })
+  ];
 
   meta = {
     homepage = "https://github.com/WayfireWM/wf-shell";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -9622,6 +9622,7 @@ with pkgs;
     plugins = with wayfirePlugins; [
       wcm
       wf-shell
+      pixdecor
     ];
   };
 


### PR DESCRIPTION
Updates the whole ecosystem.

Adds pixdecor, updates wayfire-plugins-extra to latest. Now you can enjoy the burn and carpet animations. These are the more notable changes one might look for.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
