### PR TITLE
devede: 4.21.0 -> 4.21.3.1

### DIFF
--- a/pkgs/by-name/de/devede/package.nix
+++ b/pkgs/by-name/de/devede/package.nix
@@ -8,7 +8,6 @@
   cdrkit,
   dvdauthor,
   gtk3,
-  gettext,
   wrapGAppsHook3,
   gdk-pixbuf,
   gobject-introspection,
@@ -22,23 +21,25 @@ let
     pygobject3
     urllib3
     setuptools
+    setuptools-gettext
+    importlib-metadata
     ;
 in
 buildPythonApplication (finalAttrs: {
   pname = "devede";
-  version = "4.21.0";
-  format = "setuptools";
+  version = "4.21.3.1";
+  format = "pyproject";
   namePrefix = "";
 
   src = fetchFromGitLab {
     owner = "rastersoft";
     repo = "devedeng";
     rev = finalAttrs.version;
-    hash = "sha256-sLJkIKw0ciX6spugbdO0eZ1dIkoHfuu5e/f2XwA70a0=";
+    hash = "sha256-81H063PpBF/+JDsRgBLwfAevb11yNkDtH4KdtOAL/Fg=";
   };
 
   nativeBuildInputs = [
-    gettext
+    setuptools-gettext
     wrapGAppsHook3
     gobject-introspection
   ];
@@ -59,6 +60,7 @@ buildPythonApplication (finalAttrs: {
     cdrkit
     urllib3
     setuptools
+    importlib-metadata
   ];
 
   postPatch = ''
@@ -68,7 +70,7 @@ buildPythonApplication (finalAttrs: {
       --replace "/usr/local/share" "$out/share"
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = ./update.sh;
 
   meta = {
     description = "DVD Creator for Linux";

--- a/pkgs/by-name/de/devede/update.sh
+++ b/pkgs/by-name/de/devede/update.sh
@@ -1,0 +1,7 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p curl nix-update xmlstarlet
+
+set -euo pipefail
+
+latest_tag=$(curl -s "https://gitlab.com/rastersoft/devedeng/-/tags?format=atom" | xmlstarlet sel -t -v "(//*[local-name()='entry']/*[local-name()='title'])[1]")
+nix-update devede --version $latest_tag


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Upstream usually doesn't make gitlab releases so use the latest tag instead for updates.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
