### PR TITLE
htslib: add libdeflate as a build dependency

### DIFF
--- a/pkgs/by-name/ht/htslib/package.nix
+++ b/pkgs/by-name/ht/htslib/package.nix
@@ -7,6 +7,7 @@
   bzip2,
   xz,
   curl,
+  libdeflate,
   perl,
 }:
 
@@ -34,6 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     bzip2
     xz
     curl
+    libdeflate
   ];
 
   configureFlags =


### PR DESCRIPTION
Using libdeflate significantly speeds up tabix query operations. This also makes it consistent with htslib from other linux package managers as well as conda that are built with libdeflate support.

From the htslib INSTALL page:
'libdeflate (optional, but strongly recommended for faster gzip)'  
(https://github.com/samtools/htslib/blob/acc28ac1e52efcdd9a06706aaf0021e1082ef1ba/INSTALL#L41C1-L41C68)

If this is merged I can make a PR for rPackages.iscream (which I maintain) to use this updated htslib instead of overriding it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
