### PR TITLE
osmscout-server: migrate to by-name

### DIFF
--- a/pkgs/by-name/os/osmscout-server/package.nix
+++ b/pkgs/by-name/os/osmscout-server/package.nix
@@ -3,22 +3,18 @@
   stdenv,
   fetchFromGitHub,
   pkg-config,
-  qmake,
-  qttools,
-  wrapQtAppsHook,
   boost,
-  kirigami2,
+  libsForQt5,
   kyotocabinet,
   libmicrohttpd,
   libosmscout,
   libpostal,
   marisa,
   osrm-backend,
-  protobuf,
-  qtquickcontrols2,
-  qtlocation,
+  protobuf_21,
   sqlite,
   valhalla,
+  abseil-cpp_202103,
 }:
 
 let
@@ -27,6 +23,11 @@ let
     repo = "date";
     rev = "a45ea7c17b4a7f320e199b71436074bd624c9e15";
     hash = "sha256-Mq7Yd+y8M3JNG9BEScwVEmxGWYEy6gaNNSlTGgR9LB4=";
+  };
+  protobuf' = protobuf_21.override {
+    abseil-cpp = abseil-cpp_202103.override {
+      cxxStandard = "17";
+    };
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -42,16 +43,16 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    qmake
+    libsForQt5.qmake
     pkg-config
-    qttools
-    wrapQtAppsHook
+    libsForQt5.qttools
+    libsForQt5.wrapQtAppsHook
   ];
 
   buildInputs = [
-    kirigami2
-    qtquickcontrols2
-    qtlocation
+    libsForQt5.kirigami2
+    libsForQt5.qtquickcontrols2
+    libsForQt5.qtlocation
     valhalla
     libosmscout
     osrm-backend
@@ -61,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     marisa
     kyotocabinet
     boost
-    protobuf
+    protobuf'
     date
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10545,14 +10545,6 @@ with pkgs;
     ocamlPackages = ocaml-ng.ocamlPackages_4_14;
   };
 
-  osmscout-server = libsForQt5.callPackage ../applications/misc/osmscout-server {
-    protobuf = protobuf_21.override {
-      abseil-cpp = abseil-cpp_202103.override {
-        cxxStandard = "17";
-      };
-    };
-  };
-
   pantalaimon = callPackage ../applications/networking/instant-messengers/pantalaimon { };
 
   pantalaimon-headless = callPackage ../applications/networking/instant-messengers/pantalaimon {


### PR DESCRIPTION
This pull request refactors the packaging for `osmscout-server` to improve dependency management and update its location in the repository. The main changes involve moving the package definition, updating its dependencies to use the `libsForQt5` set, and improving how `protobuf` and `abseil-cpp` are handled.

**Refactoring and package relocation:**
* Moved the `osmscout-server` package definition from `pkgs/applications/misc/osmscout-server/default.nix` to `pkgs/by-name/os/osmscout-server/package.nix` for better organization.

**Dependency updates and improvements:**
* Updated Qt-related dependencies to use the `libsForQt5` set, ensuring better compatibility and reducing redundancy in specifying Qt packages.

* Switched from `protobuf` to `protobuf_21` and introduced a custom override to ensure it uses a compatible version of `abseil-cpp` with C++17 support.

* Updated the package inputs to use these new dependency versions and overrides, improving build reliability.

**Repository maintenance:**
* Removed the old `osmscout-server` package definition from `all-packages.nix`, as it is now referenced by its new location and with improved dependency handling.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
