### PR TITLE
lycheeslicer: fix desktop file by correcting binary name

### DIFF
--- a/pkgs/by-name/ly/lycheeslicer/package.nix
+++ b/pkgs/by-name/ly/lycheeslicer/package.nix
@@ -22,7 +22,7 @@ let
     comment = "All-in-one 3D slicer for Resin and Filament";
     desktopName = "LycheeSlicer";
     noDisplay = false;
-    exec = "lychee";
+    exec = "lycheeslicer";
     terminal = false;
     mimeTypes = [ "model/stl" ];
     categories = [ "Graphics" ];


### PR DESCRIPTION
Fixed binary name for lycheeslicer to match the desktop file entry.

Previously, the package installed a binary with a name different from the one referenced in the `.desktop` file. This caused the application launcher to fail when trying to start LycheeSlicer from the desktop environment.

After changing the binary name to the expected one, the desktop file now correctly launches the application. I have manually verified that the application starts and runs as expected from both the terminal and the desktop launcher.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test