### PR TITLE
lycheeslicer: fix desktop file Exec path

### DIFF
--- a/pkgs/by-name/ly/lycheeslicer/package.nix
+++ b/pkgs/by-name/ly/lycheeslicer/package.nix
@@ -22,7 +22,7 @@ let
     comment = "All-in-one 3D slicer for Resin and Filament";
     desktopName = "LycheeSlicer";
     noDisplay = false;
-    exec = "lychee";
+    exec = "lycheeslicer";
     terminal = false;
     mimeTypes = [ "model/stl" ];
     categories = [ "Graphics" ];


### PR DESCRIPTION
The .desktop file used `Exec=lychee`, but the actual binary is named `lycheeslicer`. This prevented launching the application from the desktop environment. Change to the correct executable name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/` (launched application from desktop entry)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module
  - [ ] Module update: when the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs