### PR TITLE
cropgui: init at 0.9

### DIFF
--- a/pkgs/by-name/cr/cropgui/package.nix
+++ b/pkgs/by-name/cr/cropgui/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitea,
+  makeWrapper,
+  libjpeg,
+  exiftool,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "cropgui";
+  version = "0.9";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "jepler";
+    repo = "cropgui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pmo36mWTwDzqE5osXUsM3YzOAPXewLjfrDHIg6hCYjY=";
+  };
+
+  pyproject = false;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  dependencies = with python3Packages; [
+    pillow
+    tkinter
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/${python3Packages.python.sitePackages}
+    cp *.py $out/${python3Packages.python.sitePackages}
+
+    install -Dm755 cropgui.desktop $out/share/applications/cropgui.desktop
+    install -Dm644 cropgui.png $out/share/icons/hicolor/48x48/apps/cropgui.png
+
+    mkdir -p $out/bin
+    makeWrapper $out/${python3Packages.python.sitePackages}/cropgui.py $out/bin/cropgui \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          libjpeg
+          exiftool
+        ]
+      } \
+      --prefix PYTHONPATH : "$out/${python3Packages.python.sitePackages}:$PYTHONPATH"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Gtk frontend for lossless cropping of jpeg images";
+    homepage = "https://codeberg.org/jepler/cropgui";
+    license = lib.licenses.gpl2Only;
+    maintainers = [ lib.maintainers.dwoffinden ];
+    mainProgram = "cropgui";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
