### PR TITLE
adguardhome: improve update script

### DIFF
--- a/pkgs/by-name/ad/adguardhome/update.sh
+++ b/pkgs/by-name/ad/adguardhome/update.sh
@@ -1,5 +1,5 @@
-#! /usr/bin/env nix-shell
-#! nix-shell -i bash -p curl gnugrep jq nix-prefetch nix-update
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -I nixpkgs=. -i bash -p bash cacert common-updater-scripts curl gnugrep jq nix nix-prefetch nix-update
 
 # This file is based on /pkgs/servers/gotify/update.sh
 
@@ -13,7 +13,7 @@ version=$(jq -r '.tag_name' <<<"$latest_release")
 echo "got version $version"
 
 schema_version=$(curl --silent "https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/${version}/internal/configmigrate/configmigrate.go" \
-    | grep -Po '(?<=const LastSchemaVersion uint = )[[:digit:]]+$')
+  | grep -Po '(?<=const LastSchemaVersion uint = )[[:digit:]]+$')
 
 echo "got schema_version $schema_version"
 


### PR DESCRIPTION
Improve update script as proposed by @liquidnya <https://github.com/NixOS/nixpkgs/pull/393454#issuecomment-3770093877>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
