### PR TITLE
niftyreg: 1.3.9 -> 2.0.0; unbreak

### DIFF
--- a/pkgs/by-name/ni/niftyreg/package.nix
+++ b/pkgs/by-name/ni/niftyreg/package.nix
@@ -1,32 +1,50 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  catch2_3,
   cmake,
+  ctestCheckHook,
+  libpng,
   zlib,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "niftyreg";
-  version = "1.3.9";
+  version = "2.0.0";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/niftyreg/nifty_reg-${finalAttrs.version}/nifty_reg-${finalAttrs.version}.tar.gz";
-    sha256 = "07v9v9s41lvw72wpb1jgh2nzanyc994779bd35p76vg8mzifmprl";
+  src = fetchFromGitHub {
+    owner = "KCL-BMEIS";
+    repo = "niftyreg";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BtAbcxqvZ5Kt2UMqtnx0aQg73ligQNTktKZjoa+GXvk=";
   };
-
-  env.NIX_CFLAGS_COMPILE = toString [ "-Wno-error=narrowing" ];
-
-  nativeBuildInputs = [ cmake ];
-  buildInputs = [ zlib ];
 
   postPatch = ''
     substituteInPlace CMakeLists.txt \
-      --replace-fail "cmake_minimum_required(VERSION 2.8.0)" "cmake_minimum_required(VERSION 3.10)"
+      --replace-fail 'message(FATAL_ERROR "Git not found. Please install Git to get the version information.")' 'set(''${PROJECT_NAME}_VERSION ${finalAttrs.src.tag})'
   '';
 
+  nativeBuildInputs = [
+    cmake
+    ctestCheckHook
+    catch2_3
+  ];
+
+  buildInputs = [
+    libpng
+    zlib
+  ];
+
+  cmakeFlags = [ "-DBUILD_TESTING=ON" ];
+
+  doCheck = true;
+
+  # fails due to very slight numerical tolerance issue
+  ctestFlags = [ "--exclude-regex=Regression Deformation Field" ];
+
   meta = {
-    homepage = "http://cmictig.cs.ucl.ac.uk/wiki/index.php/NiftyReg";
+    homepage = "https://github.com/KCL-BMEIS/niftyreg";
     description = "Medical image registration software";
     maintainers = with lib.maintainers; [ bcdarwin ];
     platforms = [ "x86_64-linux" ];


### PR DESCRIPTION
 * updated source location from SourceForge to GitHub
 * use system instead of vendored png
 * enabled unit tests

[changelog](https://github.com/KCL-BMEIS/niftyreg/releases/tag/v2.0.0)

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
