### PR TITLE
sile.tests: fix the eval

### DIFF
--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -161,7 +161,7 @@ stdenv.mkDerivation (finalAttrs: {
             poppler-utils
             finalAttrs.finalPackage
           ];
-          inherit (finalAttrs) FONTCONFIG_FILE;
+          env.FONTCONFIG_FILE = finalAttrs.env.FONTCONFIG_FILE;
         }
         ''
           output=$(mktemp -t selfcheck-XXXXXX.pdf)


### PR DESCRIPTION
Without the chnage the eval fails on `master` as:

    $ nix build --no-link -f. sile.tests
    error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'sile-test'
         whose name attribute is located at pkgs/stdenv/generic/make-derivation.nix:536:13

       … while evaluating attribute 'FONTCONFIG_FILE' of derivation 'sile-test'
         at pkgs/by-name/si/sile/package.nix:164:32:
          163|           ];
          164|           inherit (finalAttrs) FONTCONFIG_FILE;
             |                                ^
          165|         }

       error: attribute 'FONTCONFIG_FILE' missing
       at pkgs/by-name/si/sile/package.nix:164:32:
          163|           ];
          164|           inherit (finalAttrs) FONTCONFIG_FILE;
             |                                ^
          165|         }


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
