### PR TITLE
heroic{,-unwrapped}: 2.19.1 -> 2.20.0; gogdl: 1.2.0 -> 1.2.1; heroic-unwrapped.legendary: 0.20.39 -> 0.20.41

### DIFF
--- a/pkgs/by-name/go/gogdl/package.nix
+++ b/pkgs/by-name/go/gogdl/package.nix
@@ -6,16 +6,15 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "gogdl";
-  version = "1.2.0";
+  version = "1.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "heroic-gogdl";
-    # two commits after the v1.2.0 tag, because the release messed up submodule fetching
-    rev = "9759dfb1f50e0c68854f938e9568d84cab59652c";
+    tag = "v${finalAttrs.version}";
     fetchSubmodules = true;
-    hash = "sha256-yjiPHEiZjs9TnBRaKzm1TpLcPK0tfIrzM30DX66m+1Y=";
+    hash = "sha256-qYarDcwrVrTpLHQYdWQvXL5+V1wMyL06+n5t6LXKBHI=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/he/heroic-unwrapped/legendary.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/legendary.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "legendary-heroic";
-  version = "0.20.39";
+  version = "0.20.41";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "legendary";
     tag = finalAttrs.version;
-    hash = "sha256-2+9MRbwugBlBdZQQo6BUcLmwCqVdTAv9CZ+sPu5VAxY=";
+    hash = "sha256-zX5Lyj8IDHETFyEpUaFnGaYZVs1hDy9rtwab1+rNlrw=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -30,13 +30,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "heroic-unwrapped";
-  version = "2.19.1";
+  version = "2.20.0";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "HeroicGamesLauncher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-e+/FRvG9u6ZQsMGD5hqY+yLPjsbLSrjC9Wp0xdxVk6w=";
+    hash = "sha256-gjQPQ/PwpDlBUfNF1JAlWUDGJa+7hwoQtouihdSCDqI=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-uwJYOm+2wGNRHAiIw1UjCBLBW6kjtj6AFLWihCqtL28=";
+    hash = "sha256-JLUiPNxcOpwkYaabl2kP73fgr+WFyXQW8y6qDIb5gt4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changelog: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/releases/tag/v2.20.0
Diff: https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher/compare/v2.19.1...v2.20.0

Changelog: https://github.com/Heroic-Games-Launcher/heroic-gogdl/releases/tag/v1.2.1
Diff: https://github.com/Heroic-Games-Launcher/heroic-gogdl/compare/v1.2.0...v1.2.1

Changelog: https://github.com/Heroic-Games-Launcher/legendary/releases/tag/0.20.41
Diff: https://github.com/Heroic-Games-Launcher/legendary/compare/0.20.39...0.20.41

Closes: #488691

## Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
