### PR TITLE
waylandpp: don't wrap `env.FONTCONFIG_FILE` string in list

### DIFF
--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -34,9 +34,11 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   # Complains about not being able to find the fontconfig config file otherwise
-  env.FONTCONFIG_FILE = lib.optional docSupport (makeFontsConf {
-    fontDirectories = [ ];
-  });
+  env = lib.optionalAttrs docSupport {
+    FONTCONFIG_FILE = makeFontsConf {
+      fontDirectories = [ ];
+    };
+  };
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Follow-up to https://github.com/NixOS/nixpkgs/pull/492165

Fixes:
```
error: The `env` attribute set can only contain derivation, string, boolean or integer attributes. The `FONTCONFIG_FILE` attribute is of type list.
note: trace involved the following derivations:
 derivation 'man-paths'
 derivation 'android-studio-2025.2.3.9'
 derivation 'androidsdk'
 derivation 'androidsdk-tools'
 derivation 'android-sdk-emulator-36.3.10'
 derivation 'waylandpp-1.0.1'