### PR TITLE
signal-desktop: fix runtime dependencies

### DIFF
--- a/pkgs/by-name/si/signal-desktop/package.nix
+++ b/pkgs/by-name/si/signal-desktop/package.nix
@@ -16,6 +16,7 @@
   replaceVars,
   noto-fonts-color-emoji,
   nixosTests,
+  xdg-utils,
 
   # command line arguments which are always set e.g "--password-store=kwallet6"
   commandLineArgs ? "",
@@ -109,6 +110,12 @@ stdenv.mkDerivation (finalAttrs: {
     python3
     jq
   ];
+
+  # Signal executes `xdg-settings` on startup in the node process.
+  runtimeDependencies = [
+    xdg-utils
+  ];
+
   buildInputs = (lib.optional (!withAppleEmojis) noto-fonts-color-emoji-png);
 
   patches = [


### PR DESCRIPTION
Add runtime dependency `xdg-utils`.
Also its weird that some `runtimeDependencies` from `signal-desktop-bin` do now show up in this build script.

Signal executes `xdg-settings` during startup in the Node process (AFAICS).
When I `jail.nix`ed it, the following appears:

```
NODE_ENV production
NODE_CONFIG_DIR /nix/store/2rvfb6iw6x00c169iqm2496sw1hjqyyc-signal-desktop-7.89.0/share/signal-desktop/app.asar/config
NODE_CONFIG {}
ALLOW_CONFIG_MUTATIONS undefined
HOSTNAME jail
NODE_APP_INSTANCE undefined
SUPPRESS_NO_CONFIG_WARNING undefined
SIGNAL_ENABLE_HTTP undefined
userData: /home/nixos/.config/Signal
LaunchProcess: failed to execvp:
xdg-settings
LaunchProcess: failed to execvp:
xdg-settings
(node:2) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `electron --trace-deprecation ...` to show where the warning was created)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
