### PR TITLE
antigravity: 1.16.5 -> 1.18.3

### DIFF
--- a/pkgs/by-name/an/antigravity/information.json
+++ b/pkgs/by-name/an/antigravity/information.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.16.5",
+  "version": "1.18.3",
   "vscodeVersion": "1.107.0",
   "sources": {
     "x86_64-linux": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.16.5-6703236727046144/linux-x64/Antigravity.tar.gz",
-      "sha256": "1953c62452d32a72e595f7fa832c7a7ed9072d22c9cf99df3a22c249a97f5e97"
+      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.3-4739469533380608/linux-x64/Antigravity.tar.gz",
+      "sha256": "4c7fe48c954e4d255c5d3ea4c74f168a4a7187fd2beedb223423cb57481c9638"
     },
     "aarch64-linux": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.16.5-6703236727046144/linux-arm/Antigravity.tar.gz",
-      "sha256": "b828e4a6e5133283b418a3e2afd2f97111ffc804cc2eef56c0e2327396b8ad97"
+      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.3-4739469533380608/linux-arm/Antigravity.tar.gz",
+      "sha256": "258778041c502e7ce74b39959e9b93d28f5c1d8154e553863f58a365e5a9fca5"
     },
     "x86_64-darwin": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.16.5-6703236727046144/darwin-x64/Antigravity.zip",
-      "sha256": "6d859d2427ac9f4cbd435e1568d6a626186e153f38263c4dd3e1c16672f79005"
+      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.3-4739469533380608/darwin-x64/Antigravity.zip",
+      "sha256": "9e5b9bca3807df01684af506515f7c6f2b3635b2e5a778c170b7d1543dbedf19"
     },
     "aarch64-darwin": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.16.5-6703236727046144/darwin-arm/Antigravity.zip",
-      "sha256": "4b4ece88e76e01ffe7e774a8eadb21134011d0177adb90464ef8f6c2102ff45d"
+      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.3-4739469533380608/darwin-arm/Antigravity.zip",
+      "sha256": "cbd77fd2efe472eb36287feb3212ec7df4e81e49d8801e77fe0fa1c5ee5b30e8"
     }
   }
 }


### PR DESCRIPTION
Updates antigravity from 1.16.5 to 1.18.3. Run via the existing update script. All 4 platforms updated automatically.