### PR TITLE
happy-coder: migrate to monorepo source

### DIFF
--- a/pkgs/by-name/ha/happy-coder/package.nix
+++ b/pkgs/by-name/ha/happy-coder/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "happy-coder";
-  version = "1.1.6-unstable-2026-04-17";
+  version = "1.1.8-unstable-2026-04-30";
 
   src = fetchFromGitHub {
     owner = "slopus";
     repo = "happy";
-    rev = "c8c389f7e6ded2d02e65775884aeea53408fee97";
-    hash = "sha256-YoXslJyNvg5ZNnYWmwyJWWIz0q84+au8UNaZ/K69pFY=";
+    rev = "df4cdae8e7fca04c0c65aef933bb28a01a346d77";
+    hash = "sha256-FUs/0gqm0rlpThqaOTC1otFPoAnFyFhBrKHcbGefO9o=";
   };
 
   pnpmWorkspaces = [ "happy..." ];
@@ -31,7 +31,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_10;
     fetcherVersion = 3;
-    hash = "sha256-sWRISfCsWQslNhucMiRhIf8ncU4OFaOYOrcc/1ATI98=";
+    hash = "sha256-STnqzVxClUfuf2la2R6yeIrNbaXsTpT6tX9xUJoLsK4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ha/happy-coder/package.nix
+++ b/pkgs/by-name/ha/happy-coder/package.nix
@@ -2,58 +2,100 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchYarnDeps,
-  yarnConfigHook,
-  yarnBuildHook,
-  yarnInstallHook,
+  fetchPnpmDeps,
+  pnpm_10,
+  pnpmConfigHook,
   nodejs,
-  makeWrapper,
+  makeBinaryWrapper,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "happy-coder";
-  version = "0.11.2";
+  version = "1.1.6-unstable-2026-04-17";
 
   src = fetchFromGitHub {
     owner = "slopus";
-    repo = "happy-cli";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-WKzbpxHqE3Dxqy/PDj51tM9+Wl2Pallfrc5UU2MxNn8=";
+    repo = "happy";
+    rev = "c8c389f7e6ded2d02e65775884aeea53408fee97";
+    hash = "sha256-YoXslJyNvg5ZNnYWmwyJWWIz0q84+au8UNaZ/K69pFY=";
   };
 
-  yarnOfflineCache = fetchYarnDeps {
-    yarnLock = finalAttrs.src + "/yarn.lock";
-    hash = "sha256-3/qcbCJ+Iwc+9zPCHKsCv05QZHPUp0it+QR3z7m+ssw=";
+  pnpmWorkspaces = [ "happy..." ];
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      ;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-sWRISfCsWQslNhucMiRhIf8ncU4OFaOYOrcc/1ATI98=";
   };
 
   nativeBuildInputs = [
     nodejs
-    yarnConfigHook
-    yarnBuildHook
-    yarnInstallHook
-    makeWrapper
+    pnpmConfigHook
+    pnpm_10
+    makeBinaryWrapper
   ];
 
-  # Currently `happy` requires `node` to start its daemon
-  postInstall = ''
-    wrapProgram $out/bin/happy \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          nodejs
-        ]
-      }
-    wrapProgram $out/bin/happy-mcp \
-      --prefix PATH : ${
-        lib.makeBinPath [
-          nodejs
-        ]
-      }
+  strictDeps = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm --filter happy... build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    local packageOut="$out/lib/node_modules/happy-coder"
+    mkdir -p "$packageOut/node_modules/@slopus/happy-wire"
+    mkdir -p "$out/bin"
+
+    # Reinstall the filtered workspace in production mode so the copied
+    # runtime tree only contains dependencies needed by the CLI package.
+    rm -rf node_modules packages/happy-cli/node_modules packages/happy-wire/node_modules
+    pnpm install --offline --prod --ignore-scripts --frozen-lockfile --filter happy...
+
+    cp -r packages/happy-cli/dist "$packageOut/dist"
+    cp -r packages/happy-cli/bin "$packageOut/bin"
+    cp -r packages/happy-cli/scripts "$packageOut/scripts"
+    cp -r packages/happy-cli/tools "$packageOut/tools"
+    cp packages/happy-cli/package.json "$packageOut/package.json"
+
+    cp -r node_modules/. "$packageOut/node_modules/"
+
+    cp -r packages/happy-wire/dist "$packageOut/node_modules/@slopus/happy-wire/dist"
+    cp packages/happy-wire/package.json "$packageOut/node_modules/@slopus/happy-wire/package.json"
+    if [ -f packages/happy-wire/README.md ]; then
+      cp packages/happy-wire/README.md "$packageOut/node_modules/@slopus/happy-wire/README.md"
+    fi
+
+    patchShebangs "$packageOut/bin" "$packageOut/scripts"
+    node "$packageOut/scripts/unpack-tools.cjs"
+
+    makeBinaryWrapper ${lib.getExe nodejs} "$out/bin/happy" \
+      --add-flags "--no-warnings" \
+      --add-flags "--no-deprecation" \
+      --add-flags "$packageOut/bin/happy.mjs"
+
+    makeBinaryWrapper ${lib.getExe nodejs} "$out/bin/happy-mcp" \
+      --add-flags "--no-warnings" \
+      --add-flags "--no-deprecation" \
+      --add-flags "$packageOut/bin/happy-mcp.mjs"
+
+    runHook postInstall
   '';
 
   meta = {
-    description = "Mobile and web client wrapper for Claude Code and Codex with end-to-end encryption";
-    homepage = "https://github.com/slopus/happy-cli";
-    changelog = "https://github.com/slopus/happy-cli/releases/tag/v${finalAttrs.version}";
+    description = "Mobile and web client for Claude Code and Codex";
+    homepage = "https://happy.engineering";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ onsails ];
     mainProgram = "happy";


### PR DESCRIPTION
## Summary
- The `happy-cli` repo has been [archived](https://github.com/slopus/happy-cli) and merged into the main [happy monorepo](https://github.com/slopus/happy)
- Updates the derivation to build the CLI from the monorepo, handling yarn workspaces with nohoisted dependencies
- Includes a minor patch for a TypeScript type error on the current HEAD

## Test plan
- [x] `nix-build -A happy-coder` succeeds
- [x] `happy --help` works correctly
- [x] `happy --version` reports `0.14.0-0`
- [x] `happy-mcp --help` works correctly
- [x] `nix fmt` passes with no changes
- [x] Tested functionality on local system