### PR TITLE
websurfx: cleanup, websurfx: 1.24.47 -> 1.24.48

### DIFF
--- a/pkgs/by-name/we/websurfx/package.nix
+++ b/pkgs/by-name/we/websurfx/package.nix
@@ -9,13 +9,13 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "websurfx";
-  version = "1.24.47";
+  version = "1.24.48";
 
   src = fetchFromGitHub {
     owner = "neon-mmd";
     repo = "websurfx";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-CIGq1uQl5RcxzoX7mnruFDNlgP5RlVLT6/e2ClGaQGE=";
+    hash = "sha256-Fpw8zXku9Gw62jKek/3ou7ykuoTvmiVIzWk5BqYRF5E=";
   };
 
   cargoHash = "sha256-8zp8qsD2D9wSaeXY2JQuP4evXFDASOwMeOYe3HbHYp4=";

--- a/pkgs/by-name/we/websurfx/package.nix
+++ b/pkgs/by-name/we/websurfx/package.nix
@@ -1,33 +1,27 @@
 {
-  lib,
   fetchFromGitHub,
-  rustPlatform,
+  lib,
+  nix-update-script,
   openssl,
   pkg-config,
+  rustPlatform,
 }:
-let
-  version = "1.24.47";
-in
-rustPlatform.buildRustPackage {
+
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "websurfx";
-  inherit version;
+  version = "1.24.47";
 
   src = fetchFromGitHub {
     owner = "neon-mmd";
     repo = "websurfx";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-CIGq1uQl5RcxzoX7mnruFDNlgP5RlVLT6/e2ClGaQGE=";
   };
 
-  nativeBuildInputs = [
-    pkg-config
-  ];
-
-  buildInputs = [
-    openssl
-  ];
-
   cargoHash = "sha256-8zp8qsD2D9wSaeXY2JQuP4evXFDASOwMeOYe3HbHYp4=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
 
   postPatch = ''
     substituteInPlace src/handler.rs \
@@ -38,10 +32,11 @@ rustPlatform.buildRustPackage {
   postInstall = ''
     mkdir -p $out/etc/xdg
     mkdir -p $out/opt/websurfx
-
-    cp -r websurfx $out/etc/xdg/
-    cp -r public $out/opt/websurfx/
+    cp -r websurfx $out/etc/xdg
+    cp -r public $out/opt/websurfx
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Open source alternative to searx";
@@ -55,4 +50,4 @@ rustPlatform.buildRustPackage {
     maintainers = with lib.maintainers; [ theobori ];
     mainProgram = "websurfx";
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
