### PR TITLE
cine: init at 1.0.9

### DIFF
--- a/pkgs/by-name/ci/cine/package.nix
+++ b/pkgs/by-name/ci/cine/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  fetchFromGitHub,
+  cmake,
+  meson,
+  ninja,
+  wrapGAppsHook4,
+  appstream,
+  blueprint-compiler,
+  desktop-file-utils,
+  gettext,
+  glib,
+  gtk4,
+  libadwaita,
+  libGL,
+  pkg-config,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "cine";
+  version = "1.0.9";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "diegopvlk";
+    repo = "Cine";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aw+M1wCGSbRRmKKcgyM4luEr0WtPLw/v7SqBE1B5H9U=";
+    fetchSubmodules = true;
+  };
+
+  strictDeps = true;
+  dontWrapGApps = true;
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    cmake
+    pkg-config
+    wrapGAppsHook4
+    blueprint-compiler
+    desktop-file-utils
+    appstream
+  ];
+
+  buildInputs = [
+    gettext
+    glib
+    gtk4
+    libadwaita
+  ];
+
+  dependencies = with python3Packages; [
+    pygobject3
+    mpv
+  ];
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+    makeWrapperArgs+=(--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libGL ]})
+  '';
+
+  meta = {
+    description = "Video Player for Linux";
+    homepage = "https://github.com/diegopvlk/Cine";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ pancaek ];
+    mainProgram = "cine";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
This is my first time packaging something like this, mainly I'm not sure if the `LD_LIBRARY_PATH` bit is the right way to fix the dlopen error. It seems to work but I'm not sure it's proper.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
