### PR TITLE
rcp: 0.21.1 -> 0.31.0

### DIFF
--- a/pkgs/by-name/rc/rcp/package.nix
+++ b/pkgs/by-name/rc/rcp/package.nix
@@ -1,22 +1,21 @@
 {
   lib,
-  stdenv,
+  pkgsStatic,
   fetchFromGitHub,
-  rustPlatform,
 }:
 
-rustPlatform.buildRustPackage (finalAttrs: {
+pkgsStatic.rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rcp";
-  version = "0.21.1";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "wykurz";
     repo = "rcp";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-ayT8lp8XqkvtUaff2Iy+5IVyJ/ukKl0qruEWjBlgAvo=";
+    hash = "sha256-ghFVGbud3aKJPvjNchsgPUSioNAxg4TJlUIYMp9+cJo=";
   };
 
-  cargoHash = "sha256-AcH5V5hapVQgGrwWAEN6Xpj00RRNqZiCSn+/onpmd50=";
+  cargoHash = "sha256-eyIO8lxmGdZKEDW+GSVARm5u3X0vx1RJLG8Ljbk0Zb8=";
 
   env.RUSTFLAGS = "--cfg tokio_unstable";
 
@@ -25,8 +24,23 @@ rustPlatform.buildRustPackage (finalAttrs: {
     "--skip=copy::copy_tests::check_default_mode"
     "--skip=test_weird_permissions"
     "--skip=test_edge_case_special_permissions"
+    "--skip=test_default_strips_special_bits_on_directories"
+    "--skip=test_default_strips_special_bits_on_files"
+    "--skip=test_default_preserves_special_bits_on_directories"
+    "--skip=test_preserve_all_preserves_special_bits_on_directories"
+    "--skip=test_preserve_all_preserves_special_bits_on_files"
+    "--skip=test_preserve_settings_dir_gid_time_7777"
+    "--skip=test_preserve_settings_dir_7777_preserves_special_bits"
+    "--skip=test_preserve_settings_file_7777_preserves_special_bits"
+    "--skip=test_preserve_settings_none_strips_special_bits_on_directories"
+    # this test expects overwrite behavior that doesn't work in a sandbox
+    "--skip=test_overwrite_behavior"
     # these tests require network access to determine local IP address
     "--skip=test_remote"
+    # these tests expect to find version/git info from Cargo.toml, which isn't available in the sandbox
+    "--skip=version::tests::test_current_version"
+    "--skip=test_protocol_version_has_git_info"
+    "--skip=test_rcpd_protocol_version_has_git_info"
   ];
 
   meta = {
@@ -36,8 +50,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     license = with lib.licenses; [ mit ];
     mainProgram = "rcp";
     maintainers = with lib.maintainers; [ wykurz ];
-    # Building procfs on an for a unsupported platform. Currently only linux and android are supported
-    # (Your current target_os is macos)
-    broken = stdenv.hostPlatform.isDarwin;
+    # procfs only supports Linux and Android
+    broken = pkgsStatic.stdenv.hostPlatform.isDarwin;
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
