### PR TITLE
python3Packages.fish-audio-sdk: init at 1.2.0

### DIFF
--- a/pkgs/development/python-modules/fish-audio-sdk/default.nix
+++ b/pkgs/development/python-modules/fish-audio-sdk/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  httpx,
+  httpx-ws,
+  ormsgpack,
+  pydantic,
+  typing-extensions,
+  pytestCheckHook,
+  pytest-asyncio,
+  pytest-cov-stub,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "fish-audio-sdk";
+  version = "1.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "fishaudio";
+    repo = "fish-audio-python";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ht3lVuJE1wv+Ky/q5quhO8C4mkw6EO4LkO/wSevRUhg=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [
+    httpx
+    httpx-ws
+    ormsgpack
+    pydantic
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+  ];
+
+  # tests require network access and a valid API key
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "fishaudio"
+    "fish_audio_sdk"
+  ];
+
+  meta = {
+    description = "Official Python library for the Fish Audio API";
+    homepage = "https://github.com/fishaudio/fish-audio-python";
+    changelog = "https://github.com/fishaudio/fish-audio-python/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -1797,7 +1797,8 @@
       ];
     "fish_audio" =
       ps: with ps; [
-      ]; # missing inputs: fish-audio-sdk
+        fish-audio-sdk
+      ];
     "fitbit" =
       ps: with ps; [
         fitbit
@@ -7414,6 +7415,7 @@
     "firefly_iii"
     "fireservicerota"
     "firmata"
+    "fish_audio"
     "fitbit"
     "fivem"
     "fjaraskupan"

--- a/pkgs/servers/home-assistant/tests.nix
+++ b/pkgs/servers/home-assistant/tests.nix
@@ -41,6 +41,7 @@ let
     environment_canada = getComponentDeps "camera";
     esphome = getComponentDeps "camera";
     fan = getComponentDeps "conversation";
+    fish_audio = getComponentDeps "tts";
     foscam = getComponentDeps "camera";
     freebox = getComponentDeps "camera";
     fully_kiosk = getComponentDeps "camera";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5492,6 +5492,8 @@ self: super: with self; {
 
   fiscalyear = callPackage ../development/python-modules/fiscalyear { };
 
+  fish-audio-sdk = callPackage ../development/python-modules/fish-audio-sdk { };
+
   fissix = callPackage ../development/python-modules/fissix { };
 
   fitbit = callPackage ../development/python-modules/fitbit { };


### PR DESCRIPTION
- https://pypi.org/project/fish-audio-sdk/
- https://github.com/fishaudio/fish-audio-python
- https://www.home-assistant.io/integrations/fish_audio/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
