### PR TITLE
iloader: init at 2.2.6

### DIFF
--- a/pkgs/by-name/il/iloader/disable-update.patch
+++ b/pkgs/by-name/il/iloader/disable-update.patch
@@ -1,0 +1,20 @@
+--- a/src/App.tsx
++++ b/src/App.tsx
+@@ -22,7 +22,7 @@ import { AppIds } from "./pages/AppIds";
+ import { Settings } from "./pages/Settings";
+ import { Pairing } from "./pages/Pairing";
+ import { getVersion } from "@tauri-apps/api/app";
+-import { checkForUpdates } from "./update";
++// import { checkForUpdates } from "./update";
+ import logo from "./iloader.svg";
+ import { GlassCard } from "./components/GlassCard";
+ import { useTranslation } from "react-i18next";
+@@ -70,7 +70,7 @@ function App() {
+   }, []);
+ 
+   useEffect(() => {
+-    checkForUpdates();
++    // checkForUpdates();
+   }, []);
+ 
+   useEffect(() => {

--- a/pkgs/by-name/il/iloader/package.nix
+++ b/pkgs/by-name/il/iloader/package.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  rustPlatform,
+  nodejs,
+  cargo-tauri,
+  bun,
+  writableTmpDirAsHomeHook,
+
+  glib,
+  glib-networking,
+  gst_all_1,
+  openssl,
+  pkg-config,
+  webkitgtk_4_1,
+  wrapGAppsHook3,
+  makeWrapper,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "iloader";
+  version = "2.2.4";
+
+  src = fetchFromGitHub {
+    owner = "nab138";
+    repo = "iloader";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-cKUyxNsnqG1GSD+zMNjIoOkl4+IHRfWLQQo8IDjIS/o=";
+  };
+
+  nodeModules = stdenv.mkDerivation {
+    pname = "${finalAttrs.pname}-node_modules";
+    inherit (finalAttrs) src version;
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r node_modules $out/node_modules
+
+      runHook postInstall
+    '';
+
+    outputHash = "sha256-zB0BJrQuoIu7Y67WMfrVRsPPnJ6mhd5srL2M3zW6+1Q=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+  cargoHash = "sha256-ryXbUBNtMjZcQGivnjqRBxbGsW6UAJbU38rTqzwvH+Y=";
+
+  doCheck = false;
+
+  patches = [ ./disable-update.patch ];
+
+  postPatch = ''
+    cp -r ${finalAttrs.nodeModules}/node_modules .
+    chmod -R +w node_modules
+    patchShebangs --build node_modules
+  '';
+
+  nativeBuildInputs = [
+    bun
+    cargo-tauri.hook
+    nodejs
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook3 ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeWrapper ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    webkitgtk_4_1
+    glib
+    glib-networking
+    openssl
+  ];
+
+  tauriBuildFlags = [
+    "--config"
+    "ci.conf.json"
+    "--no-sign"
+  ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/iloader.app/Contents/MacOS/iloader $out/bin/iloader
+  '';
+
+  meta = {
+    changelog = "https://github.com/nab138/iloader/releases/tag/v${finalAttrs.version}";
+    description = "User friendly sideloader";
+    homepage = "https://github.com/nab138/iloader";
+    license = lib.licenses.mit;
+    mainProgram = "iloader";
+    maintainers = with lib.maintainers; [ ern775 ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+})

--- a/pkgs/by-name/il/iloader/package.nix
+++ b/pkgs/by-name/il/iloader/package.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+
+  rustPlatform,
+  nodejs,
+  cargo-tauri,
+  bun,
+  writableTmpDirAsHomeHook,
+
+  glib,
+  glib-networking,
+  gst_all_1,
+  openssl,
+  pkg-config,
+  webkitgtk_4_1,
+  wrapGAppsHook3,
+  makeWrapper,
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "iloader";
+  version = "2.2.6";
+
+  src = fetchFromGitHub {
+    owner = "nab138";
+    repo = "iloader";
+    rev = "v${finalAttrs.version}";
+    sha256 = "sha256-zSl08bhJ/OrdcvvL1ciybxgnLqrg4IinmcGXrsPQYyQ=";
+  };
+
+  nodeModules = stdenv.mkDerivation {
+    pname = "${finalAttrs.pname}-node_modules";
+    inherit (finalAttrs) src version;
+
+    nativeBuildInputs = [
+      bun
+      writableTmpDirAsHomeHook
+    ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      bun install \
+        --cpu="*" \
+        --frozen-lockfile \
+        --ignore-scripts \
+        --no-progress \
+        --os="*"
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+      cp -r node_modules $out/node_modules
+
+      runHook postInstall
+    '';
+
+    outputHash = "sha256-zB0BJrQuoIu7Y67WMfrVRsPPnJ6mhd5srL2M3zW6+1Q=";
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  };
+
+  cargoRoot = "src-tauri";
+  buildAndTestSubdir = "src-tauri";
+  cargoHash = "sha256-6nDqIikItl5SuHN2o/iQREiOkY+bYkP7akShOEtY9JY=";
+
+  doCheck = false;
+
+  patches = [ ./disable-update.patch ];
+
+  postPatch = ''
+    cp -r ${finalAttrs.nodeModules}/node_modules .
+    chmod -R +w node_modules
+    patchShebangs --build node_modules
+  '';
+
+  nativeBuildInputs = [
+    bun
+    cargo-tauri.hook
+    nodejs
+    pkg-config
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ wrapGAppsHook3 ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ makeWrapper ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    webkitgtk_4_1
+    glib
+    glib-networking
+    openssl
+  ];
+
+  tauriBuildFlags = [
+    "--config"
+    "ci.conf.json"
+    "--no-sign"
+  ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p $out/bin
+    makeWrapper $out/Applications/iloader.app/Contents/MacOS/iloader $out/bin/iloader
+  '';
+
+  meta = {
+    changelog = "https://github.com/nab138/iloader/releases/tag/v${finalAttrs.version}";
+    description = "User friendly sideloader";
+    homepage = "https://github.com/nab138/iloader";
+    license = lib.licenses.mit;
+    mainProgram = "iloader";
+    maintainers = with lib.maintainers; [ ern775 ];
+    platforms = [
+      "aarch64-linux"
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Homepage link: https://github.com/nab138/iloader

Added iloader, a user friendly app for sideloading .ipa files to apple devices.
I have personally tested it and can confirm it works without issue.

Even though it's a fairly new project, it has been getting more attention recently. I believe it's mature enough to add to nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
