### PR TITLE
freeswitch: revert moving CXXFLAGS into env for structuredAttrs

### DIFF
--- a/pkgs/by-name/fr/freeswitch/package.nix
+++ b/pkgs/by-name/fr/freeswitch/package.nix
@@ -159,19 +159,17 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  env = {
-    NIX_CFLAGS_COMPILE = toString [
-      "-Wno-error"
-      # https://github.com/signalwire/freeswitch/issues/2495
-      "-Wno-incompatible-pointer-types"
-    ];
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error"
+    # https://github.com/signalwire/freeswitch/issues/2495
+    "-Wno-incompatible-pointer-types"
+  ];
 
-    # Using c++14 because of build error
-    # gsm_at.h:94:32: error: ISO C++17 does not allow dynamic exception specifications
-    CXXFLAGS = "-std=c++14";
+  # Using c++14 because of build error
+  # gsm_at.h:94:32: error: ISO C++17 does not allow dynamic exception specifications
+  CXXFLAGS = "-std=c++14";
 
-    CFLAGS = "-D_ANSI_SOURCE";
-  };
+  CFLAGS = "-D_ANSI_SOURCE";
 
   hardeningDisable = [ "format" ];
 


### PR DESCRIPTION
This caused a build failure that the CXXFLAGS value was supposed to address.

This reverts commit bf9bd3c0fdf044fc2dfad87fa45ff4f686eb3308.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
