### PR TITLE
waybar-niri-windows: init at 2.3.1

### DIFF
--- a/pkgs/by-name/wa/waybar-niri-windows/package.nix
+++ b/pkgs/by-name/wa/waybar-niri-windows/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  nix-update-script,
+  buildGoModule,
+  fetchFromGitHub,
+  gtk3,
+  pkg-config,
+}:
+buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
+  pname = "waybar-niri-windows";
+  version = "2.3.1";
+
+  src = fetchFromGitHub {
+    owner = "calico32";
+    repo = "waybar-niri-windows";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-bnPxKRugnIGj/Od8R+6PAl0MRhhl361H9rYydCWQ/yw=";
+  };
+
+  vendorHash = "sha256-jK87vZYfUe8znk65SmJ1mN8qP5K3dtt950hKGWTYXs4=";
+
+  buildInputs = [
+    gtk3
+  ];
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  # use custom command because when setting GOFLAGS evaluation fails, but .so file is needed
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mv waybar-niri-windows.so $out/lib
+    ln -s $out/lib/waybar-niri-windows.so $out/lib/plugin.so
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Niri window minimap/focus indicator for Waybar";
+    homepage = "https://github.com/calico32/waybar-niri-windows";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ istudyatuni ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/calico32/waybar-niri-windows

Build takes ~~4m 34s~~ 1m 37s on my machine

Configuring via home-manager module:

```nix
"cffi/niri-windows" = {
  module_path = "${pkgs.waybar-niri-windows}/lib/plugin.so";
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
