### PR TITLE
nixos/guix: refactor substituters options

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -23,6 +23,8 @@
   no longer sets `programs.pqos-wrapper.enable = true`
   as the corresponding module has been deleted.
 
+- Default substituter URLs and keys for Guix (`services.guix.substituters.urls` and `services.guix.substituters.authorizedKeys` respectively) are now set in the module's config, making them of the same priority as user-defined values, and accessing options' defaults (like `options.services.guix.substituters.urls.default`) is no longer necessary.
+
 ## Other Notable Changes {#sec-release-26.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -141,16 +141,16 @@ in
     substituters = {
       urls = lib.mkOption {
         type = with lib.types; listOf str;
-        default = [
+        # defaults are set in `config` for consistent priority
+        default = lib.warn "nope (url)" [ ]; # WIP
+        defaultText = [
           "https://ci.guix.gnu.org"
           "https://bordeaux.guix.gnu.org"
         ];
-        example = lib.literalExpression ''
-          options.services.guix.substituters.urls.default ++ [
-            "https://guix.example.com"
-            "https://guix.example.org"
-          ]
-        '';
+        example = [
+          "https://guix.example.com"
+          "https://guix.example.org"
+        ];
         description = ''
           A list of substitute servers' URLs for the Guix daemon to download
           substitutes from.
@@ -159,15 +159,16 @@ in
 
       authorizedKeys = lib.mkOption {
         type = with lib.types; listOf path;
-        default = [
-          "${cfg.package}/share/guix/ci.guix.gnu.org.pub"
-          "${cfg.package}/share/guix/bordeaux.guix.gnu.org.pub"
-        ];
-        defaultText = ''
-          The packaged signing keys from {option}`services.guix.package`.
+        # defaults are set in `config` for consistent priority
+        default = lib.warn "nope (keys)" [ ]; # WIP
+        defaultText = lib.literalExpression ''
+          [
+            "''${config.services.guix.package}/share/guix/ci.guix.gnu.org.pub"
+            "''${config.services.guix.package}/share/guix/bordeaux.guix.gnu.org.pub"
+          ]
         '';
         example = lib.literalExpression ''
-          options.services.guix.substituters.authorizedKeys.default ++ [
+          [
             (pkgs.fetchurl {
               url = "https://guix.example.com/signing-key.pub";
               hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
@@ -266,224 +267,235 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable (
-    lib.mkMerge [
-      {
-        environment.systemPackages = [ package ];
-
-        users.users = guixBuildUsers cfg.nrBuildUsers;
-        users.groups.${cfg.group} = { };
-
-        # Guix uses Avahi (through guile-avahi) both for the auto-discovering and
-        # advertising substitute servers in the local network.
-        services.avahi.enable = lib.mkDefault true;
-        services.avahi.publish.enable = lib.mkDefault true;
-        services.avahi.publish.userServices = lib.mkDefault true;
-
-        # It's similar to Nix daemon so there's no question whether or not this
-        # should be sandboxed.
-        systemd.services.guix-daemon = {
-          environment = serviceEnv // config.networking.proxy.envVars;
-          script = ''
-            exec ${lib.getExe' package "guix-daemon"} \
-              --build-users-group=${cfg.group} \
-              ${
-                lib.optionalString (
-                  cfg.substituters.urls != [ ]
-                ) "--substitute-urls='${lib.concatStringsSep " " cfg.substituters.urls}'"
-              } \
-              ${lib.escapeShellArgs cfg.extraArgs}
-          '';
-          serviceConfig = {
-            OOMPolicy = "continue";
-            RemainAfterExit = "yes";
-            Restart = "always";
-            TasksMax = 8192;
-          };
-          unitConfig.RequiresMountsFor = [
-            cfg.storeDir
-            cfg.stateDir
-          ];
-          wantedBy = [ "multi-user.target" ];
-        };
-
-        # This is based from Nix daemon socket unit from upstream Nix package.
-        # Guix build daemon has support for systemd-style socket activation.
-        systemd.sockets.guix-daemon = {
-          description = "Guix daemon socket";
-          before = [ "multi-user.target" ];
-          listenStreams = [ "${cfg.stateDir}/guix/daemon-socket/socket" ];
-          unitConfig.RequiresMountsFor = [
-            cfg.storeDir
-            cfg.stateDir
-          ];
-          wantedBy = [ "sockets.target" ];
-        };
-
-        systemd.mounts = [
-          {
-            description = "Guix read-only store directory";
-            before = [ "guix-daemon.service" ];
-            what = cfg.storeDir;
-            where = cfg.storeDir;
-            type = "none";
-            options = "bind,ro";
-
-            unitConfig.DefaultDependencies = false;
-            wantedBy = [ "guix-daemon.service" ];
-          }
+  config = lib.mkMerge [
+    {
+      services.guix.substituters = {
+        urls = [
+          "https://ci.guix.gnu.org"
+          "https://bordeaux.guix.gnu.org"
         ];
+        authorizedKeys = [
+          "${cfg.package}/share/guix/ci.guix.gnu.org.pub"
+          "${cfg.package}/share/guix/bordeaux.guix.gnu.org.pub"
+        ];
+      };
+    }
 
-        # Make transferring files from one store to another easier with the usual
-        # case being of most substitutes from the official Guix CI instance.
-        environment.etc."guix/acl".source = aclFile;
+    (lib.mkIf cfg.enable {
+      environment.systemPackages = [ package ];
 
-        # Link the usual Guix profiles to the home directory. This is useful in
-        # ephemeral setups where only certain part of the filesystem is
-        # persistent (e.g., "Erase my darlings"-type of setup).
-        system.userActivationScripts.guix-activate-user-profiles.text =
-          let
-            guixProfile = profile: "${cfg.stateDir}/guix/profiles/per-user/\${USER}/${profile}";
-            linkProfile =
-              profile: location:
-              let
-                userProfile = guixProfile profile;
-              in
-              ''
-                [ -d "${userProfile}" ] && ln -sfn "${userProfile}" "${location}"
-              '';
-            linkProfileToPath =
-              acc: profile: location:
-              acc + (linkProfile profile location);
+      users.users = guixBuildUsers cfg.nrBuildUsers;
+      users.groups.${cfg.group} = { };
 
-            # This should contain export-only Guix user profiles. The rest of it is
-            # handled manually in the activation script.
-            guixUserProfiles' = lib.attrsets.removeAttrs guixUserProfiles [ "guix-home" ];
+      # Guix uses Avahi (through guile-avahi) both for the auto-discovering and
+      # advertising substitute servers in the local network.
+      services.avahi.enable = lib.mkDefault true;
+      services.avahi.publish.enable = lib.mkDefault true;
+      services.avahi.publish.userServices = lib.mkDefault true;
 
-            linkExportsScript = lib.foldlAttrs linkProfileToPath "" guixUserProfiles';
-          in
-          ''
-            # Don't export this please! It is only expected to be used for this
-            # activation script and nothing else.
-            XDG_CONFIG_HOME=''${XDG_CONFIG_HOME:-$HOME/.config}
-
-            # Linking the usual Guix profiles into the home directory.
-            ${linkExportsScript}
-
-            # Activate all of the default Guix non-exports profiles manually.
-            ${linkProfile "guix-home" "$HOME/.guix-home"}
-            [ -L "$HOME/.guix-home" ] && "$HOME/.guix-home/activate"
-          '';
-
-        # GUIX_LOCPATH is basically LOCPATH but for Guix libc which in turn used by
-        # virtually every Guix-built packages. This is so that Guix-installed
-        # applications wouldn't use incompatible locale data and not touch its host
-        # system.
-        environment.sessionVariables.GUIX_LOCPATH = lib.makeSearchPath "lib/locale" guixProfiles;
-
-        # What Guix profiles export is very similar to Nix profiles so it is
-        # acceptable to list it here. Also, it is more likely that the user would
-        # want to use packages explicitly installed from Guix so we're putting it
-        # first.
-        environment.profiles = lib.mkBefore guixProfiles;
-      }
-
-      (lib.mkIf cfg.publish.enable {
-        systemd.services.guix-publish = {
-          description = "Guix remote store";
-          environment = serviceEnv;
-
-          # Mounts will be required by the daemon service anyways so there's no
-          # need add RequiresMountsFor= or something similar.
-          requires = [ "guix-daemon.service" ];
-          after = [ "guix-daemon.service" ];
-          partOf = [ "guix-daemon.service" ];
-
-          preStart = lib.mkIf cfg.publish.generateKeyPair ''
-            # Generate the keypair if it's missing.
-            [ -f "/etc/guix/signing-key.sec" ] && [ -f "/etc/guix/signing-key.pub" ] || \
-              ${lib.getExe' package "guix"} archive --generate-key || {
-                rm /etc/guix/signing-key.*;
-                ${lib.getExe' package "guix"} archive --generate-key;
-              }
-          '';
-          script = ''
-            exec ${lib.getExe' package "guix"} publish \
-              --user=${cfg.publish.user} --port=${toString cfg.publish.port} \
-              ${lib.escapeShellArgs cfg.publish.extraArgs}
-          '';
-
-          serviceConfig = {
-            Restart = "always";
-            RestartSec = 10;
-
-            ProtectClock = true;
-            ProtectHostname = true;
-            ProtectKernelTunables = true;
-            ProtectKernelModules = true;
-            ProtectControlGroups = true;
-            SystemCallFilter = [
-              "@system-service"
-              "@debug"
-              "@setuid"
-            ];
-
-            RestrictNamespaces = true;
-            RestrictAddressFamilies = [
-              "AF_UNIX"
-              "AF_INET"
-              "AF_INET6"
-            ];
-
-            # While the permissions can be set, it is assumed to be taken by Guix
-            # daemon service which it has already done the setup.
-            ConfigurationDirectory = "guix";
-
-            AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
-            CapabilityBoundingSet = [
-              "CAP_NET_BIND_SERVICE"
-              "CAP_SETUID"
-              "CAP_SETGID"
-            ];
-          };
-          wantedBy = [ "multi-user.target" ];
+      # It's similar to Nix daemon so there's no question whether or not this
+      # should be sandboxed.
+      systemd.services.guix-daemon = {
+        environment = serviceEnv // config.networking.proxy.envVars;
+        script = ''
+          exec ${lib.getExe' package "guix-daemon"} \
+            --build-users-group=${cfg.group} \
+            ${
+              lib.optionalString (
+                cfg.substituters.urls != [ ]
+              ) "--substitute-urls='${lib.concatStringsSep " " cfg.substituters.urls}'"
+            } \
+            ${lib.escapeShellArgs cfg.extraArgs}
+        '';
+        serviceConfig = {
+          OOMPolicy = "continue";
+          RemainAfterExit = "yes";
+          Restart = "always";
+          TasksMax = 8192;
         };
+        unitConfig.RequiresMountsFor = [
+          cfg.storeDir
+          cfg.stateDir
+        ];
+        wantedBy = [ "multi-user.target" ];
+      };
 
-        users.users.guix-publish = lib.mkIf (cfg.publish.user == "guix-publish") {
-          description = "Guix publish user";
-          group = config.users.groups.guix-publish.name;
-          isSystemUser = true;
+      # This is based from Nix daemon socket unit from upstream Nix package.
+      # Guix build daemon has support for systemd-style socket activation.
+      systemd.sockets.guix-daemon = {
+        description = "Guix daemon socket";
+        before = [ "multi-user.target" ];
+        listenStreams = [ "${cfg.stateDir}/guix/daemon-socket/socket" ];
+        unitConfig.RequiresMountsFor = [
+          cfg.storeDir
+          cfg.stateDir
+        ];
+        wantedBy = [ "sockets.target" ];
+      };
+
+      systemd.mounts = [
+        {
+          description = "Guix read-only store directory";
+          before = [ "guix-daemon.service" ];
+          what = cfg.storeDir;
+          where = cfg.storeDir;
+          type = "none";
+          options = "bind,ro";
+
+          unitConfig.DefaultDependencies = false;
+          wantedBy = [ "guix-daemon.service" ];
+        }
+      ];
+
+      # Make transferring files from one store to another easier with the usual
+      # case being of most substitutes from the official Guix CI instance.
+      environment.etc."guix/acl".source = aclFile;
+
+      # Link the usual Guix profiles to the home directory. This is useful in
+      # ephemeral setups where only certain part of the filesystem is
+      # persistent (e.g., "Erase my darlings"-type of setup).
+      system.userActivationScripts.guix-activate-user-profiles.text =
+        let
+          guixProfile = profile: "${cfg.stateDir}/guix/profiles/per-user/\${USER}/${profile}";
+          linkProfile =
+            profile: location:
+            let
+              userProfile = guixProfile profile;
+            in
+            ''
+              [ -d "${userProfile}" ] && ln -sfn "${userProfile}" "${location}"
+            '';
+          linkProfileToPath =
+            acc: profile: location:
+            acc + (linkProfile profile location);
+
+          # This should contain export-only Guix user profiles. The rest of it is
+          # handled manually in the activation script.
+          guixUserProfiles' = lib.attrsets.removeAttrs guixUserProfiles [ "guix-home" ];
+
+          linkExportsScript = lib.foldlAttrs linkProfileToPath "" guixUserProfiles';
+        in
+        ''
+          # Don't export this please! It is only expected to be used for this
+          # activation script and nothing else.
+          XDG_CONFIG_HOME=''${XDG_CONFIG_HOME:-$HOME/.config}
+
+          # Linking the usual Guix profiles into the home directory.
+          ${linkExportsScript}
+
+          # Activate all of the default Guix non-exports profiles manually.
+          ${linkProfile "guix-home" "$HOME/.guix-home"}
+          [ -L "$HOME/.guix-home" ] && "$HOME/.guix-home/activate"
+        '';
+
+      # GUIX_LOCPATH is basically LOCPATH but for Guix libc which in turn used by
+      # virtually every Guix-built packages. This is so that Guix-installed
+      # applications wouldn't use incompatible locale data and not touch its host
+      # system.
+      environment.sessionVariables.GUIX_LOCPATH = lib.makeSearchPath "lib/locale" guixProfiles;
+
+      # What Guix profiles export is very similar to Nix profiles so it is
+      # acceptable to list it here. Also, it is more likely that the user would
+      # want to use packages explicitly installed from Guix so we're putting it
+      # first.
+      environment.profiles = lib.mkBefore guixProfiles;
+    })
+
+    (lib.mkIf (cfg.enable && cfg.publish.enable) {
+      systemd.services.guix-publish = {
+        description = "Guix remote store";
+        environment = serviceEnv;
+
+        # Mounts will be required by the daemon service anyways so there's no
+        # need add RequiresMountsFor= or something similar.
+        requires = [ "guix-daemon.service" ];
+        after = [ "guix-daemon.service" ];
+        partOf = [ "guix-daemon.service" ];
+
+        preStart = lib.mkIf cfg.publish.generateKeyPair ''
+          # Generate the keypair if it's missing.
+          [ -f "/etc/guix/signing-key.sec" ] && [ -f "/etc/guix/signing-key.pub" ] || \
+            ${lib.getExe' package "guix"} archive --generate-key || {
+              rm /etc/guix/signing-key.*;
+              ${lib.getExe' package "guix"} archive --generate-key;
+            }
+        '';
+        script = ''
+          exec ${lib.getExe' package "guix"} publish \
+            --user=${cfg.publish.user} --port=${toString cfg.publish.port} \
+            ${lib.escapeShellArgs cfg.publish.extraArgs}
+        '';
+
+        serviceConfig = {
+          Restart = "always";
+          RestartSec = 10;
+
+          ProtectClock = true;
+          ProtectHostname = true;
+          ProtectKernelTunables = true;
+          ProtectKernelModules = true;
+          ProtectControlGroups = true;
+          SystemCallFilter = [
+            "@system-service"
+            "@debug"
+            "@setuid"
+          ];
+
+          RestrictNamespaces = true;
+          RestrictAddressFamilies = [
+            "AF_UNIX"
+            "AF_INET"
+            "AF_INET6"
+          ];
+
+          # While the permissions can be set, it is assumed to be taken by Guix
+          # daemon service which it has already done the setup.
+          ConfigurationDirectory = "guix";
+
+          AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+          CapabilityBoundingSet = [
+            "CAP_NET_BIND_SERVICE"
+            "CAP_SETUID"
+            "CAP_SETGID"
+          ];
         };
-        users.groups.guix-publish = { };
-      })
+        wantedBy = [ "multi-user.target" ];
+      };
 
-      (lib.mkIf cfg.gc.enable {
-        # This service should be handled by root to collect all garbage by all
-        # users.
-        systemd.services.guix-gc = {
-          description = "Guix garbage collection";
-          startAt = cfg.gc.dates;
-          script = ''
-            exec ${lib.getExe' package "guix"} gc ${lib.escapeShellArgs cfg.gc.extraArgs}
-          '';
-          serviceConfig = {
-            Type = "oneshot";
-            PrivateDevices = true;
-            PrivateNetwork = true;
-            ProtectControlGroups = true;
-            ProtectHostname = true;
-            ProtectKernelTunables = true;
-            SystemCallFilter = [
-              "@default"
-              "@file-system"
-              "@basic-io"
-              "@system-service"
-            ];
-          };
+      users.users.guix-publish = lib.mkIf (cfg.publish.user == "guix-publish") {
+        description = "Guix publish user";
+        group = config.users.groups.guix-publish.name;
+        isSystemUser = true;
+      };
+      users.groups.guix-publish = { };
+    })
+
+    (lib.mkIf (cfg.enable && cfg.gc.enable) {
+      # This service should be handled by root to collect all garbage by all
+      # users.
+      systemd.services.guix-gc = {
+        description = "Guix garbage collection";
+        startAt = cfg.gc.dates;
+        script = ''
+          exec ${lib.getExe' package "guix"} gc ${lib.escapeShellArgs cfg.gc.extraArgs}
+        '';
+        serviceConfig = {
+          Type = "oneshot";
+          PrivateDevices = true;
+          PrivateNetwork = true;
+          ProtectControlGroups = true;
+          ProtectHostname = true;
+          ProtectKernelTunables = true;
+          SystemCallFilter = [
+            "@default"
+            "@file-system"
+            "@basic-io"
+            "@system-service"
+          ];
         };
+      };
 
-        systemd.timers.guix-gc.timerConfig.Persistent = true;
-      })
-    ]
-  );
+      systemd.timers.guix-gc.timerConfig.Persistent = true;
+    })
+  ];
 }

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -144,7 +144,6 @@ in
         default = [
           "https://ci.guix.gnu.org"
           "https://bordeaux.guix.gnu.org"
-          "https://berlin.guix.gnu.org"
         ];
         example = lib.literalExpression ''
           options.services.guix.substituters.urls.default ++ [
@@ -163,7 +162,6 @@ in
         default = [
           "${cfg.package}/share/guix/ci.guix.gnu.org.pub"
           "${cfg.package}/share/guix/bordeaux.guix.gnu.org.pub"
-          "${cfg.package}/share/guix/berlin.guix.gnu.org.pub"
         ];
         defaultText = ''
           The packaged signing keys from {option}`services.guix.package`.

--- a/nixos/modules/services/misc/guix/default.nix
+++ b/nixos/modules/services/misc/guix/default.nix
@@ -168,12 +168,14 @@ in
         '';
         example = lib.literalExpression ''
           options.services.guix.substituters.authorizedKeys.default ++ [
-            (builtins.fetchurl {
+            (pkgs.fetchurl {
               url = "https://guix.example.com/signing-key.pub";
+              hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             })
 
-            (builtins.fetchurl {
+            (pkgs.fetchurl {
               url = "https://guix.example.org/static/signing-key.pub";
+              hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
             })
           ]
         '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
> [!note]
> large diff because of indentation

Originally, the only way to extend the lists of substituters was to reference the default values:
```nix
options.services.guix.substituters.urls.default ++ [
  "https://guix.example.com"
  "https://guix.example.org"
]
```
I don't like how clunky it is, so I propose this change: default lists are defined in this module's `config` section, so that they have the same priority as the user-defined ones.

Before:
```nix
nix-repl> :p (nixos {services.guix={enable=true;substituters={urls=["https://substitutes.nonguix.org"];authorizedKeys=[./nonguix.pub];};};}).config.services.guix.substituters
{
  authorizedKeys = [ /home/acid/.local/src/nixpkgs/nonguix.pub ];
  urls = [ "https://substitutes.nonguix.org" ];
}
```

After:
```nix
nix-repl> :p (nixos {services.guix={enable=true;substituters={urls=["https://substitutes.nonguix.org"];authorizedKeys=[./nonguix.pub];};};}).config.services.guix.substituters
{
  authorizedKeys = [
    /home/acid/.local/src/nixpkgs/nonguix.pub
    "/nix/store/kaq6n7gqx27bz8j2r2mpnwrjp7xizlyc-guix-1.5.0/share/guix/ci.guix.gnu.org.pub"
    "/nix/store/kaq6n7gqx27bz8j2r2mpnwrjp7xizlyc-guix-1.5.0/share/guix/bordeaux.guix.gnu.org.pub"
    "/nix/store/kaq6n7gqx27bz8j2r2mpnwrjp7xizlyc-guix-1.5.0/share/guix/berlin.guix.gnu.org.pub"
  ];
  urls = [
    "https://substitutes.nonguix.org"
    "https://ci.guix.gnu.org"
    "https://bordeaux.guix.gnu.org"
    "https://berlin.guix.gnu.org"
  ];
}
```

Pros:
- less clunky if you want to add your own entries
- just listing extra entries now does not overrides the defaults

Cons:
- ~~breaking change: if you relied on using `options...default`, you'll actually override those~~ irrelevant

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
- [x] Follows the new LLM policy (specifically: entirely human-made)

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
