### PR TITLE
clamtk: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/cl/clamtk/package.nix
+++ b/pkgs/by-name/cl/clamtk/package.nix
@@ -47,12 +47,13 @@ perlPackages.buildPerlPackage rec {
 
   postPatch = ''
     # Set correct nix paths in perl scripts
+    # Point to share/icons/hicolor/128x128/apps as only clamtk.png will be used
     substituteInPlace lib/App.pm \
       --replace /usr/bin/freshclam ${lib.getBin clamav}/bin/freshclam \
       --replace /usr/bin/sigtool ${lib.getBin clamav}/bin/sigtool \
       --replace /usr/bin/clamscan ${lib.getBin clamav}/bin/clamscan \
       --replace /usr/bin/clamdscan ${lib.getBin clamav}/bin/clamdscan \
-      --replace /usr/share/pixmaps $out/share/pixmaps
+      --replace /usr/share/pixmaps $out/share/icons/hicolor/128x128/apps
 
     # We want to catch the crontab wrapper on NixOS and the
     # System crontab on non-NixOS so we don't give a full path.
@@ -67,7 +68,9 @@ perlPackages.buildPerlPackage rec {
     install -Dm755 clamtk -t $out/bin
     install -Dm444 lib/*.pm -t $out/lib/perl5/site_perl/ClamTk
     install -Dm444 clamtk.desktop -t $out/share/applications
-    install -Dm444 images/* -t $out/share/pixmaps
+    install -Dm444 images/clamtk.png -t $out/share/icons/hicolor/128x128/apps
+    install -Dm444 images/clamtk.xpm -t $out/share/icons/hicolor/32x32/apps
+    install -Dm444 images/clamtk_300x300.png $out/share/icons/hicolor/300x300/apps/clamtk.png
     install -Dm444 clamtk.1.gz -t $out/share/man/man1
     install -Dm444 {CHANGES,LICENSE,*.md} -t $out/share/doc/clamtk
 


### PR DESCRIPTION
Related to #428824.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
