### PR TITLE
cro-mag-rally: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/cr/cro-mag-rally/package.nix
+++ b/pkgs/by-name/cr/cro-mag-rally/package.nix
@@ -37,8 +37,8 @@ stdenv.mkDerivation (finalAttrs: {
     mv Data ReadMe.txt $out/share/CroMagRally/
     install -Dm755 CroMagRally $out/bin/CroMagRally
     wrapProgram $out/bin/CroMagRally --chdir $out/share/CroMagRally
-    install -Dm644 ${finalAttrs.src}/packaging/io.jor.cromagrally.desktop $out/share/applications/cromagrally.desktop
-    install -Dm644 ${finalAttrs.src}/packaging/io.jor.cromagrally.png $out/share/pixmaps/io.jor.cromagrally.png
+    install -Dm644 ../packaging/io.jor.cromagrally.desktop $out/share/applications/cromagrally.desktop
+    install -Dm644 ../packaging/io.jor.cromagrally.png -t $out/share/icons/hicolor/256x256/apps/
 
     runHook postInstall
   '';


### PR DESCRIPTION
Related to #428824.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
