### PR TITLE
cubiomes-viewer: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/cu/cubiomes-viewer/package.nix
+++ b/pkgs/by-name/cu/cubiomes-viewer/package.nix
@@ -52,8 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
         ''
           cp cubiomes-viewer $out/bin
 
-          mkdir -p $out/share/{pixmaps,applications}
-          cp rc/icons/map.png $out/share/pixmaps/com.github.cubitect.cubiomes-viewer.png
+          mkdir -p $out/share/{icons/hicolor/34x29/apps,applications}
+          cp rc/icons/map.png $out/share/icons/hicolor/34x29/apps/com.github.cubitect.cubiomes-viewer.png
           cp etc/com.github.cubitect.cubiomes-viewer.desktop $out/share/applications
         ''
     }


### PR DESCRIPTION
Related to #428824.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
