### PR TITLE
daggerfall-unity: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -72,10 +72,10 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir --parents "$out/bin" "$out/share/doc" "$out/share/pixmaps/"
+    mkdir --parents "$out/bin" "$out/share/doc" "$out/share/icons/hicolor/128x128/apps/"
     cp --recursive * "$out"
-    ln --symbolic "../${finalAttrs.meta.mainProgram}" "$out/bin/"
-    ln --symbolic ../../DaggerfallUnity_Data/Resources/UnityPlayer.png "$out/share/pixmaps/"
+    ln --symbolic "$out/${finalAttrs.meta.mainProgram}" "$out/bin/"
+    ln --symbolic $out/DaggerfallUnity_Data/Resources/UnityPlayer.png $out/share/icons/hicolor/128x128/apps/daggerfall-unity.png
 
     ${lib.strings.concatMapStringsSep "\n" (file: ''
       cp "${file}" "$out/share/doc/${file.name}"
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
       name = "daggerfall-unity";
       desktopName = "Daggerfall Unity";
       comment = finalAttrs.meta.description;
-      icon = "UnityPlayer";
+      icon = "daggerfall-unity";
       exec = finalAttrs.meta.mainProgram;
       categories = [ "Game" ];
     })


### PR DESCRIPTION
Related to #428824.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
