### PR TITLE
yquake2: move icon to spec-compliant location and fix build with GCC 15

### DIFF
--- a/pkgs/games/quake2/yquake2/default.nix
+++ b/pkgs/games/quake2/yquake2/default.nix
@@ -74,7 +74,7 @@ let
       ln -s $out/lib/yquake2/quake2 $out/bin/yquake2
       ln -s $out/lib/yquake2/q2ded $out/bin/yq2ded
       cp $src/stuff/yq2.cfg $out/share/games/quake2/baseq2
-      install -Dm644 stuff/icon/Quake2.png $out/share/pixmaps/yamagi-quake2.png;
+      install -Dm644 stuff/icon/Quake2.png $out/share/icons/hicolor/512x512/apps/yamagi-quake2.png;
       runHook postInstall
     '';
 

--- a/pkgs/games/quake2/yquake2/games.nix
+++ b/pkgs/games/quake2/yquake2/games.nix
@@ -48,6 +48,12 @@ let
         rev = "${lib.toUpper id}_${builtins.replaceStrings [ "." ] [ "_" ] version}";
       };
 
+      env =
+        # Uses `false` and `true` as enum constants, which are keywords in C23 (GCC 15 default)
+        lib.optionalAttrs stdenv.cc.isGNU {
+          NIX_CFLAGS_COMPILE = "-std=gnu17";
+        };
+
       installPhase = ''
         runHook preInstall
         mkdir -p $out/lib/yquake2/${id}

--- a/pkgs/games/quake2/yquake2/wrapper.nix
+++ b/pkgs/games/quake2/yquake2/wrapper.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation {
       --add-flags "+set game ${game.id}"
   '') games
   + ''
-    install -Dm644 ${yquake2}/share/pixmaps/yamagi-quake2.png $out/share/pixmaps/yamagi-quake2.png;
+    install -Dm644 ${yquake2}/share/icons/hicolor/512x512/apps/yamagi-quake2.png $out/share/icons/hicolor/512x512/apps/yamagi-quake2.png;
     runHook postInstall
   '';
 


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/475479 and https://github.com/NixOS/nixpkgs/issues/428824

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
