### PR TITLE
eclipse-mat: move icon to spec-compliant location

### DIFF
--- a/pkgs/by-name/ec/eclipse-mat/package.nix
+++ b/pkgs/by-name/ec/eclipse-mat/package.nix
@@ -87,9 +87,12 @@ stdenv.mkDerivation rec {
     # Create desktop item.
     mkdir -p $out/share/applications
     cp ${desktopItem}/share/applications/* $out/share/applications
-    mkdir -p $out/share/pixmaps
-    find $out/mat/plugins -name 'eclipse*.png' -type f -exec cp {} $out/share/pixmaps \;
-    mv $out/share/pixmaps/eclipse64.png $out/share/pixmaps/eclipse.png
+    iconDir=$(dirname $(ls $out/mat/plugins/*/eclipse64.png))
+    for x in 16 22 24 32 48 64 128 256 512 1024; do
+      install -Dm444 $iconDir/eclipse$x.png $out/share/icons/hicolor/''${x}x''${x}/apps/eclipse.png
+    done
+    install -Dm444 $iconDir/eclipse_lg.png $out/share/icons/hicolor/116x302/apps/eclipse_lg.png
+    install -Dm444 $iconDir/eclipse_lg@2x.png $out/share/icons/hicolor/232x604/apps/eclipse_lg.png
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Related to #428824.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
