### PR TITLE
popt: fix sysconfdir and split outputs

### DIFF
--- a/pkgs/by-name/po/popt/package.nix
+++ b/pkgs/by-name/po/popt/package.nix
@@ -41,6 +41,12 @@ stdenv.mkDerivation (finalAttrs: {
       })
     ];
 
+  outputs = [
+    "out"
+    "dev"
+    "man"
+  ];
+
   configureFlags = [
     # Otherwise, it configures sysconfdir as $out/etc.
     "--sysconfdir=/etc"

--- a/pkgs/by-name/po/popt/package.nix
+++ b/pkgs/by-name/po/popt/package.nix
@@ -41,6 +41,11 @@ stdenv.mkDerivation (finalAttrs: {
       })
     ];
 
+  configureFlags = [
+    # Otherwise, it configures sysconfdir as $out/etc.
+    "--sysconfdir=/etc"
+  ];
+
   doCheck = false; # fails
 
   meta = {


### PR DESCRIPTION
While stracing a program that uses popt for parsing command line    
options, we can observe that it tries to look for the configuration file    
in /nix/store/../etc instead of /etc:

openat(AT_FDCWD, "/nix/store/yywbzjm7yy89y5z23jazngbv4585rqbr-popt-1.19/etc/popt", O_RDONLY) = -1 ENOENT (No such file or directory)

This is obviously wrong, as it would hinder a user from modifying the    
system-wide popt configuration (e.g. using environment.etc on a NixOS    
system). Let's fix this issue by explicitly setting --sysconfdir to    
/etc.

Signed-off-by: David Wronek <david.wronek@mainlining.org>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
