### PR TITLE
nixosTests.lomiri-music-app: Reduce flakiness related to slow mediascanner

### DIFF
--- a/nixos/tests/lomiri-music-app.nix
+++ b/nixos/tests/lomiri-music-app.nix
@@ -133,6 +133,11 @@ in
     # mediascanner2 needs to have run, is only started automatically by Lomiri
     machine.systemctl("start mediascanner-2.0.service", "root")
 
+    # Need to wait abit to make sure our test file gets scanned & added to the database.
+    # No good feedback on when this is done... Prolly some time after extractor sub-service is started.
+    machine.wait_for_console_text("Successfully activated service 'com.lomiri.MediaScanner2.Extractor'")
+    machine.sleep(10)
+
     with subtest("lomiri music launches"):
         machine.succeed("lomiri-music-app >&2 &")
         machine.wait_for_console_text("Queue is empty")


### PR DESCRIPTION
When lomiri-music-app is started before mediascanner has indexed any suitable media, navigation gets stuck on a "no music found, please connect device" page.

mediascanner doesn't log when it is done processing media files, and inspecting ~/.cache/mediascanner-2.0/mediastore.db is prolly not great either.

Let's assume for now that when the extractor sub-service gets spun up, we're getting close. Also sleep abit afterwards just in case.

---

The page in question:

<img width="1024" height="768" alt="lomiri-music-albums-maybe" src="https://github.com/user-attachments/assets/2ed2ac32-841b-41a1-b1c6-fb46e19d5ce4" />

Needed this change for this test to pass in #492354.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
