### PR TITLE
verifpal: 0.24.4 -> 0.31.2

### DIFF
--- a/pkgs/by-name/ve/verifpal/package.nix
+++ b/pkgs/by-name/ve/verifpal/package.nix
@@ -7,26 +7,20 @@
 
 buildGoModule (finalAttrs: {
   pname = "verifpal";
-  version = "0.27.4";
+  version = "0.31.2";
 
   src = fetchFromGitHub {
     owner = "symbolicsoft";
     repo = "verifpal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-kBeQ7U97Ezj85A/FbNnE1dXR7VJzx0EUrDbzwOgKl8E=";
+    hash = "sha256-k8SGCo36tk4Etg4jt0NDeEj1BmSYjaZZptNNnrOXs4E=";
   };
 
-  vendorHash = "sha256-FvboLGdT+/W5on7NSzRp9QfV2peNVICypSFWAGFakLU=";
+  vendorHash = "sha256-Vg375DBPvurRpwl918AGQU+wJGnB1tYisgch9FA+Y/g=";
 
   nativeBuildInputs = [ pigeon ];
 
   subPackages = [ "cmd/verifpal" ];
-
-  # goversioninfo is for Windows only and can be skipped during go generate
-  preBuild = ''
-    substituteInPlace cmd/verifpal/main.go --replace "go:generate goversioninfo" "(disabled goversioninfo)"
-    go generate verifpal.com/cmd/verifpal
-  '';
 
   meta = {
     homepage = "https://verifpal.com/";


### PR DESCRIPTION
Update verifpal from  0.27.4 to version 0.31.2.

The changelog for this version can be found [here](https://github.com/symbolicsoft/verifpal/releases/tag/v0.31.2)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
