### PR TITLE
mtproxy: init at 1-unstable-2025-11-04

### DIFF
--- a/pkgs/by-name/mt/mtproxy/package.nix
+++ b/pkgs/by-name/mt/mtproxy/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  openssl,
+  zlib,
+}:
+stdenv.mkDerivation {
+  pname = "mtproxy";
+  version = "1-unstable-2025-11-04";
+  src = fetchFromGitHub {
+    owner = "TelegramMessenger";
+    repo = "MTProxy";
+    rev = "cafc3380a81671579ce366d0594b9a8e450827e9";
+    hash = "sha256-tY2iwNAQIL8sCUuddy9Lm/d/W1notL27HhRtOa25VsE=";
+  };
+  buildInputs = [
+    openssl
+    zlib
+  ];
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp objs/bin/mtproto-proxy $out/bin/
+    runHook postInstall
+  '';
+  meta = {
+    description = "Simple MT-Proto proxy";
+    mainProgram = "mtproto-proxy";
+    homepage = "https://github.com/TelegramMessenger/MTProxy";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ nix-julia ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
