### PR TITLE
kara: 0.8.0 -> 0.8.0-unstable-2026-02-20

### DIFF
--- a/pkgs/by-name/ka/kara/package.nix
+++ b/pkgs/by-name/ka/kara/package.nix
@@ -35,7 +35,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_PREFIX=$out/share/plasma/plasmoids/org.dhruv8sh.kara"
-    "-DCMAKE_BUILD_TYPE=Release"
     "-DKDE_INSTALL_USE_QT_SYS_PATHS=OFF"
   ];
 

--- a/pkgs/by-name/ka/kara/package.nix
+++ b/pkgs/by-name/ka/kara/package.nix
@@ -4,6 +4,8 @@
   fetchFromGitHub,
   nix-update-script,
   kdePackages,
+  cmake,
+  qt6,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kara";
@@ -16,21 +18,21 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-SqFEtz4X9ZbzA4hEgHLDIqhQE0kuB6ht5i1gyFeEHyM=";
   };
 
-  nativeBuildInputs = with pkgs; [
+  nativeBuildInputs = [
     cmake
-    extra-cmake-modules
+    kdePackages.extra-cmake-modules
     qt6.wrapQtAppsHook
   ];
 
-  buildInputs = with pkgs.kdePackages; [
-    libplasma
-    plasma-activities
-    plasma-workspace
-    kwin
-    kcoreaddons
-    kconfig
-    kpackage
-    kdeclarative
+  buildInputs = [
+    kdePackages.libplasma
+    kdePackages.plasma-activities
+    kdePackages.plasma-workspace
+    kdePackages.kwin
+    kdePackages.kcoreaddons
+    kdePackages.kconfig
+    kdePackages.kpackage
+    kdePackages.kdeclarative
   ];
 
   cmakeFlags = [

--- a/pkgs/by-name/ka/kara/package.nix
+++ b/pkgs/by-name/ka/kara/package.nix
@@ -39,12 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     "-DKDE_INSTALL_USE_QT_SYS_PATHS=OFF"
   ];
 
-  installPhase = ''
-    runHook preInstall
-    cmake --install .
-    runHook postInstall
-  '';
-
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/ka/kara/package.nix
+++ b/pkgs/by-name/ka/kara/package.nix
@@ -7,22 +7,41 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "kara";
-  version = "0.8.0";
+  version = "0.8.0-unstable-2026-02-20";
 
   src = fetchFromGitHub {
     owner = "dhruv8sh";
     repo = "kara";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-gdYwgHNnkvayd7GK9H8AZHeKL589hU6MN9DXiUkSU3A=";
+    rev = "2c9f7926d2da41324e9f56355be314a5c76fe022";
+    hash = "sha256-SqFEtz4X9ZbzA4hEgHLDIqhQE0kuB6ht5i1gyFeEHyM=";
   };
+
+  nativeBuildInputs = with pkgs; [
+    cmake
+    extra-cmake-modules
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = with pkgs.kdePackages; [
+    libplasma
+    plasma-activities
+    plasma-workspace
+    kwin
+    kcoreaddons
+    kconfig
+    kpackage
+    kdeclarative
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_INSTALL_PREFIX=$out/share/plasma/plasmoids/org.dhruv8sh.kara"
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DKDE_INSTALL_USE_QT_SYS_PATHS=OFF"
+  ];
 
   installPhase = ''
     runHook preInstall
-
-    mkdir -p $out/share/plasma/plasmoids/org.dhruv8sh.kara
-    cp metadata.json $out/share/plasma/plasmoids/org.dhruv8sh.kara
-    cp -r contents $out/share/plasma/plasmoids/org.dhruv8sh.kara
-
+    cmake --install .
     runHook postInstall
   '';
 


### PR DESCRIPTION
As mentioned on matrix, the plasma 6.6 update broke kara, see this issue: https://github.com/dhruv8sh/kara/issues/41. The maintainer of kara refactored the plugin to C++, which has fixed the issue. See this commit: https://github.com/dhruv8sh/kara/commit/2c9f7926d2da41324e9f56355be314a5c76fe022

It was suggested on matrix that I pin the update to the commit that contains this fix, so that's what I have done. Once the maintainer has tagged a new version the package should be pinned to that.

This updates the package to the C++ implementation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
