### PR TITLE
mailman: unpin Django

### DIFF
--- a/pkgs/development/python-modules/django-mailman3/default.nix
+++ b/pkgs/development/python-modules/django-mailman3/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  fetchpatch,
 
   # build-system
   pdm-backend,
@@ -29,6 +30,18 @@ buildPythonPackage rec {
     inherit version;
     hash = "sha256-+ZFrJpy5xdW6Yde/XEvxoAN8+TSQdiI0PfjZ7bHG0Rs=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "django-5.2.patch";
+      url = "https://gitlab.com/mailman/django-mailman3/-/commit/465c1ffc77556bb8a80a678f53a40f16b9766cc6.patch";
+      excludes = [
+        ".gitlab-ci.yml"
+        "README.rst"
+      ];
+      hash = "sha256-gSFczuNLlMclqixOu6ElS0BewUTGyhP6RXtE/waLzyo=";
+    })
+  ];
 
   pythonRelaxDeps = [ "django-allauth" ];
 
@@ -65,6 +78,6 @@ buildPythonPackage rec {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ qyliss ];
     broken =
-      lib.versionAtLeast django-allauth.version "65.0.0" || lib.versionAtLeast django.version "5.1";
+      lib.versionAtLeast django-allauth.version "65.0.0" || lib.versionAtLeast django.version "5.3";
   };
 }

--- a/pkgs/servers/mail/mailman/default.nix
+++ b/pkgs/servers/mail/mailman/default.nix
@@ -1,7 +1,7 @@
 {
   newScope,
   lib,
-  python312,
+  python3,
 }:
 
 let
@@ -13,7 +13,7 @@ let
     {
       callPackage = newScope self;
 
-      python3 = callPackage ./python.nix { python3 = python312; };
+      python3 = callPackage ./python.nix { inherit python3; };
 
       hyperkitty = callPackage ./hyperkitty.nix { };
 

--- a/pkgs/servers/mail/mailman/hyperkitty.nix
+++ b/pkgs/servers/mail/mailman/hyperkitty.nix
@@ -30,7 +30,18 @@ buildPythonPackage rec {
       url = "https://gitlab.com/mailman/hyperkitty/-/commit/6c3d402dc0981e545081a3baf13db7e491356e75.patch";
       hash = "sha256-ep9cFZe9/sIfIP80pLBOMYkJKWvNT7DRqg80DQSdRFw=";
     })
+    # Fix test with Django 5.2
+    (fetchpatch {
+      url = "https://gitlab.com/mailman/hyperkitty/-/commit/e815be11752ac6a3e839b155f0c43808619c56b0.patch";
+      hash = "sha256-fsJyNsh3l5iR9WgsiEsHlptkN+nlWoop0m2STyucDEc=";
+    })
   ];
+
+  prePatch = ''
+    # Upstream: https://gitlab.com/mailman/hyperkitty/-/commit/b8b7536c2cb7380ec55ed62140617cff8ae36b1d
+    substituteInPlace pyproject.toml \
+      --replace-fail '"django>=4.2,<5.1"' '"django>=4.2,<5.3"'
+  '';
 
   build-system = [
     pdm-backend

--- a/pkgs/servers/mail/mailman/python.nix
+++ b/pkgs/servers/mail/mailman/python.nix
@@ -26,8 +26,7 @@ lib.fix (
             [1] 72a14ea563a3f5bf85db659349a533fe75a8b0ce
             [2] f931bc81d63f5cfda55ac73d754c87b3fd63b291
           */
-          # https://gitlab.com/mailman/hyperkitty/-/merge_requests/681
-          django = super.django_4;
+          django = super.django_5;
 
           django-allauth = super.django-allauth.overrideAttrs (
             new:

--- a/pkgs/servers/mail/mailman/web.nix
+++ b/pkgs/servers/mail/mailman/web.nix
@@ -2,6 +2,7 @@
   lib,
   python3,
   fetchPypi,
+  fetchpatch,
   sassc,
   hyperkitty,
   postorius,
@@ -19,6 +20,15 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-3wnduej6xMQzrjGhGXQznfJud/Uoy3BDduukRJeahL8=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "django-5.2.patch";
+      url = "https://gitlab.com/mailman/mailman-web/-/commit/bf3eae03ba6ed416ff58e63ea30dd4b95f310e46.patch";
+      includes = [ "pyproject.toml" ];
+      hash = "sha256-NcXFXYJe3ve4qAGzOVZv9hBx4MTwxRtIYp1GRD1g0qw=";
+    })
+  ];
 
   postPatch = ''
     # Upstream seems to mostly target installing on top of existing


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/issues/490868

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
