### PR TITLE
xla: add aarch64-darwin support

### DIFF
--- a/pkgs/by-name/ba/bazel_7/nix-build-bazel-package-hacks.patch
+++ b/pkgs/by-name/ba/bazel_7/nix-build-bazel-package-hacks.patch
@@ -10,9 +10,9 @@ index 53e6494656..22261cd268 100644
  import java.util.Map;
  import java.util.Optional;
  import java.util.TreeMap;
-@@ -193,16 +194,11 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
+@@ -193,16 +194,15 @@ public final class RepositoryDelegatorFunction implements SkyFunction {
        }
- 
+
        if (shouldUseCachedRepos(env, handler, repoRoot, rule)) {
 -        // Make sure marker file is up-to-date; correctly describes the current repository state
 -        byte[] markerHash = digestWriter.areRepositoryAndMarkerFileConsistent(handler, env);
@@ -20,8 +20,12 @@ index 53e6494656..22261cd268 100644
 -          return null;
 -        }
 -        if (markerHash != null) { // repo exist & up-to-date
-+        {
-+          // Nix hack: Always consider cached dirs as up-to-date
++        // Nix hack: Skip marker file validation but only for repos that have
++        // been fully initialized. Check for common root files that indicate a
++        // real repo, not an empty dir created by module extensions before the
++        // repository rule has had a chance to run.
++        if (repoRoot.getChild("BUILD").exists() || repoRoot.getChild("BUILD.bazel").exists()
++            || repoRoot.getChild("WORKSPACE").exists() || repoRoot.getChild("WORKSPACE.bazel").exists()) {
            return RepositoryDirectoryValue.builder()
                .setPath(repoRoot)
 -              .setDigest(markerHash)
@@ -30,8 +34,6 @@ index 53e6494656..22261cd268 100644
                .build();
          }
        }
-
-
 diff --git a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java b/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
 index 649647c5f2..64d05b530c 100644
 --- a/src/main/java/com/google/devtools/build/lib/shell/JavaSubprocessFactory.java
@@ -43,4 +45,4 @@ index 649647c5f2..64d05b530c 100644
 -      builder.environment().clear();
        builder.environment().putAll(params.getEnv());
      }
- 
+

--- a/pkgs/by-name/xl/xla/package.nix
+++ b/pkgs/by-name/xl/xla/package.nix
@@ -1,6 +1,7 @@
 {
   bazel_7,
   buildBazelPackage,
+  cctools,
   curl,
   double-conversion,
   fetchFromGitHub,
@@ -18,6 +19,7 @@
   python3,
   snappy,
   sqlite,
+  stdenv,
   which,
   zlib,
 }:
@@ -71,7 +73,8 @@ in
     gitMinimal
     pythonEnv # necessary for some patchShebang'ing
     which
-  ];
+  ]
+  ++ lib.optional stdenv.hostPlatform.isDarwin cctools.libtool;
 
   buildInputs = [
     curl
@@ -136,6 +139,14 @@ in
     "--host_cxxopt=cstdint"
     # Exclude mobile/iOS targets that have Bazel incompatibilities
     "--build_tag_filters=-mobile,-ios"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Set macOS deployment target to suppress availability errors (e.g.
+    # futimens requires 10.13+) in both target and host-tool builds.
+    "--copt=-mmacosx-version-min=11.0"
+    "--host_copt=-mmacosx-version-min=11.0"
+    "--linkopt=-mmacosx-version-min=11.0"
+    "--host_linkopt=-mmacosx-version-min=11.0"
   ];
 
   removeRulesCC = false;
@@ -146,10 +157,16 @@ in
   removeLocal = false;
 
   fetchAttrs = {
-    sha256 = "sha256-OJfSqDlEC+yhWwwMwaD5HGvuHm8OWk+yQxmbH0/gZ88=";
+    sha256 =
+      {
+        x86_64-linux = "sha256-OJfSqDlEC+yhWwwMwaD5HGvuHm8OWk+yQxmbH0/gZ88=";
+        aarch64-darwin = "sha256-sKxtdgozCV1on1gd+bm8FKyFxP0u70Hs24OdLNA3jh0=";
+      }
+      .${stdenv.hostPlatform.system} or (throw "unsupported system: ${stdenv.hostPlatform.system}");
     preInstall = ''
       rm -rf $bazelOut/external/{local_config_python,\@local_config_python.marker}
       rm -rf $bazelOut/external/{local_config_sh,\@local_config_sh.marker}
+      rm -rf $bazelOut/external/{local_config_xcode,\@local_config_xcode.marker}
       rm -rf $bazelOut/external/{local_execution_config_python,\@local_execution_config_python.marker}
       rm -rf $bazelOut/external/{local_jdk,\@local_jdk.marker}
     '';
@@ -187,18 +204,9 @@ in
     homepage = "https://github.com/openxla/xla";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ samuela ];
-    platforms = lib.platforms.unix;
-    badPlatforms = [
-      # ERROR: /build/output/external/local_config_cc/BUILD: no such target
-      # '@@local_config_cc//:cc-compiler-k8': target 'cc-compiler-k8' not declared in package ''
-      # defined by /build/output/external/local_config_cc/BUILD
-      "aarch64-linux"
-
-      # Bazel fails to build on darwin:
-      # ERROR: no such package '@@bazel_tools~xcode_configure_extension~local_config_xcode//':
-      # BUILD file not found in directory '' of external repository @@bazel_tools~xcode_configure_extension~local_config_xcode.
-      # Add a BUILD file to a directory to mark it as a package.
-      lib.systems.inspect.patterns.isDarwin
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
     ];
   };
 }


### PR DESCRIPTION
## Summary

- **bazel_7**: Fix `enableNixHacks` patch to check for `BUILD`/`BUILD.bazel`/`WORKSPACE`/`WORKSPACE.bazel` before treating cached repos as up-to-date. The previous unconditional skip caused darwin builds to fail because empty dirs created by module extensions were returned before repository rules could run.
- **xla**: Add aarch64-darwin (Apple Silicon) support:
  - Add `cctools.libtool` for darwin toolchain detection
  - Set macOS deployment target (`-mmacosx-version-min=11.0`) via `--copt`/`--host_copt`/`--linkopt`/`--host_linkopt` to fix `futimens` availability errors in LLVM host tool builds
  - Add per-platform `fetchAttrs.sha256` (preserves existing x86_64-linux hash)
  - Remove `badPlatforms` since darwin now builds successfully

Fixes https://github.com/NixOS/nixpkgs/issues/390395