### PR TITLE
maintainers: drop amiloradovsky

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1556,12 +1556,6 @@
     githubId = 1358320;
     name = "Arie Middelkoop";
   };
-  amiloradovsky = {
-    email = "miloradovsky@gmail.com";
-    github = "amiloradovsky";
-    githubId = 20530052;
-    name = "Andrew Miloradovsky";
-  };
   aminechikhaoui = {
     email = "amine.chikhaoui91@gmail.com";
     github = "AmineChikhaoui";

--- a/pkgs/applications/window-managers/evilwm/default.nix
+++ b/pkgs/applications/window-managers/evilwm/default.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation rec {
       url = "http://www.6809.org.uk/evilwm/";
       free = true;
     }; # like BSD/MIT, but Share-Alike'y; See README.
-    maintainers = with lib.maintainers; [ amiloradovsky ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "evilwm";
   };

--- a/pkgs/by-name/op/opencascade-occt/package.nix
+++ b/pkgs/by-name/op/opencascade-occt/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.lgpl21; # essentially...
     # The special exception defined in the file OCCT_LGPL_EXCEPTION.txt
     # are basically about making the license a little less share-alike.
-    maintainers = with lib.maintainers; [ amiloradovsky ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/pl/planner/package.nix
+++ b/pkgs/by-name/pl/planner/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "planner";
     homepage = "https://gitlab.gnome.org/World/planner";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ amiloradovsky ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 })

--- a/pkgs/by-name/sy/systemc/package.nix
+++ b/pkgs/by-name/sy/systemc/package.nix
@@ -31,6 +31,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://systemc.org/";
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [ amiloradovsky ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ve/verilator/package.nix
+++ b/pkgs/by-name/ve/verilator/package.nix
@@ -103,7 +103,6 @@ stdenv.mkDerivation (finalAttrs: {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       thoughtpolice
-      amiloradovsky
     ];
   };
 })

--- a/pkgs/by-name/xm/xmagnify/package.nix
+++ b/pkgs/by-name/xm/xmagnify/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tiny screen magnifier for X11";
     homepage = "https://gitlab.com/amiloradovsky/magnify";
     license = lib.licenses.mit; # or GPL2+, optionally
-    maintainers = with lib.maintainers; [ amiloradovsky ];
+    maintainers = [ ];
     mainProgram = "magnify";
     platforms = lib.platforms.all;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Aamiloradovsky) since 2023 despite over 100 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2024-01-01+user-review-requested%3Aamiloradovsky+). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@amiloradovsky if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
