### PR TITLE
nixos/ssh: fix bug where SSH_ASKPASS is an empty string instead of unset

### DIFF
--- a/nixos/modules/programs/ssh.nix
+++ b/nixos/modules/programs/ssh.nix
@@ -402,8 +402,10 @@ in
         export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"
       fi
     '';
-
-    environment.variables.SSH_ASKPASS = lib.optionalString cfg.enableAskPassword cfg.askPassword;
+    # Cant use optionalString, as openssh assumes that if its set then it points to a valid binary instead of using a default
+    environment.variables = lib.optionalAttrs cfg.enableAskPassword {
+      SSH_ASKPASS = cfg.askPassword;
+    };
 
   };
 }


### PR DESCRIPTION
openssh assumes that if its set, it points to a valid executable. this causes openssh to try and run it instead of running a fallback executable.

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests] (`sshwifty`, `ssh-agent-auth`, `ssh-audit`).
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
