### PR TITLE
nixos/libretranslate: expose argos-translate settings and switch to minisbd

### DIFF
--- a/nixos/modules/services/web-apps/libretranslate.nix
+++ b/nixos/modules/services/web-apps/libretranslate.nix
@@ -131,13 +131,13 @@ in
           ];
           description = ''
             Sentence boundary detection.
-            - default: Argos's default behavior
+            - default: upstream Argos's default behavior
             - argostranslate: Argos's Translate's SBD
             - stanza: use Stanza for sentence splitting
             - spacy: use SPACY for sentence splitting
-            - minisbd: use minisbd for sentence splitting
+            - minisbd: use minisbd for sentence splitting (recommended by languagetool)
           '';
-          default = "default";
+          default = "minisbd";
           example = "spacy";
         };
       };

--- a/nixos/modules/services/web-apps/libretranslate.nix
+++ b/nixos/modules/services/web-apps/libretranslate.nix
@@ -100,6 +100,48 @@ in
         description = "Configure nginx as a reverse proxy for LibreTranslate.";
       };
 
+      # https://github.com/argosopentech/argos-translate/blob/master/docs/settings.md
+      argosSettings = {
+        computeType = lib.mkOption {
+          type = lib.types.enum [
+            "auto"
+            "float32"
+            "int8"
+            "int8_float32"
+          ];
+          description = ''
+            Translation model precision and quantization.
+
+            - `auto`: default
+            - `float32`: highest accuracy
+            - `int8`: fastest, some accuracy loss
+            - `int8_float32`: best balance of speed/accuracy
+          '';
+          default = "auto";
+          example = "int8_float32";
+        };
+        chunkType = lib.mkOption {
+          # NOTE: "none" is not included because it's not actually supported in argos-translate.
+          type = lib.types.enum [
+            "default"
+            "argostranslate"
+            "stanza"
+            "spacy"
+            "minisbd"
+          ];
+          description = ''
+            Sentence boundary detection.
+            - default: Argos's default behavior
+            - argostranslate: Argos's Translate's SBD
+            - stanza: use Stanza for sentence splitting
+            - spacy: use SPACY for sentence splitting
+            - minisbd: use minisbd for sentence splitting
+          '';
+          default = "default";
+          example = "spacy";
+        };
+      };
+
       extraArgs = lib.mkOption {
         type =
           with lib.types;
@@ -140,7 +182,9 @@ in
       wantedBy = [ "multi-user.target" ];
       environment = {
         HOME = cfg.dataDir;
-        PYTHONUNBUFFERED = "1"; # ensure stdout is logged to journal
+        PYTHONUNBUFFERED = "1";
+        ARGOS_COMPUTE_TYPE = cfg.argosSettings.computeType;
+        ARGOS_CHUNK_TYPE = lib.strings.toUpper cfg.argosSettings.chunkType; # ensure stdout is logged to journal
       };
       serviceConfig = lib.mkMerge [
         {


### PR DESCRIPTION
1. Expose the `computeType` and `chunkType` argos-translate settings. I haven't exposed the rest because I'm not sure how they interact with LibreTranslate.

2. Set `chunkType` to `minisbd` by default per LibreTranslate's [dockerfile entrypoint]( https://github.com/LibreTranslate/LibreTranslate/blob/main/scripts/entrypoint.sh).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test