### PR TITLE
mldonkey: fix build with gcc 14+

### DIFF
--- a/pkgs/applications/networking/p2p/mldonkey/default.nix
+++ b/pkgs/applications/networking/p2p/mldonkey/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
   '';
 
   env = {
-    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=incompatible-pointer-types -DPROTOTYPES=1";
   }
   # https://github.com/ygrek/mldonkey/issues/117
   // lib.optionalAttrs stdenv.cc.isClang {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Resolves https://github.com/NixOS/nixpkgs/issues/492815

### The Root Cause
Modern compilers like GCC 14/15 have become much stricter with old C code. MLDonkey contains some "ancient" parts (like the MD4 hash implementation) that use coding styles from the 80s and 90s. 

The main culprit is a macro called `PROTOTYPES` in `md4.h`. By default, it's turned off, which hides function arguments from the compiler. So, the compiler sees a function declared with no arguments, but then sees it called with three. While older GCC versions let this slide, GCC 14 considers this a fatal "too many arguments" error and kills the build.

### The Solution
1. **Force `-DPROTOTYPES=1`**: This tells the code to use modern ANSI C declarations. It aligns the function definitions with their actual usage, satisfying the compiler's strict argument checks.
2. **Downgrade Legacy Errors**: MLDonkey is full of "old-school" quirks like implicit integers and incompatible pointer types. Instead of rewriting decades-old code, we use `-Wno-error=...` flags to turn these fatal errors back into warnings. It essentially tells the compiler: "Yes, I know it's old code; just let it pass."

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
