### PR TITLE
fetchurl/mirrors: remove funet.fi from KDE mirror list

### DIFF
--- a/pkgs/build-support/fetchurl/mirrors.nix
+++ b/pkgs/build-support/fetchurl/mirrors.nix
@@ -112,9 +112,9 @@
     "ftp://ftp.sunet.se/mirror/imagemagick.org/ftp/" # also contains older versions removed from most mirrors
   ];
 
+  # See https://download.kde.org/ls-lR.mirrorlist
   kde = [
     "https://download.kde.org/"
-    "https://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/"
   ];
 
   # kernel.org's /pub (/pub/{linux,software}) tree


### PR DESCRIPTION
<del> It's broken and excluded by https://download.kde.org/ls-lR.mirrorlist </del> it serves different krita source file, https://ftp.funet.fi/pub/mirrors/ftp.kde.org/pub/kde/stable/krita/5.2.14/krita-5.2.14.tar.gz is abnormally large  (509MB vs. 267MB from official download.kde.org).

In https://github.com/NixOS/nixpkgs/pull/470107#issuecomment-3646208910 I falled back to it and got confused why it serves wrong file, it turns out the mirror has already been excluded be upstream.

If we really want a fallback we can add another mirror as fallback, but I guess it might be simpler if we only keep `download.kde.org`. If we add unreliable mirrors maintainer might accidentally opened a PR with wrong sha256sum if they fallback to corrupted mirror.

## Things done

Tested that fetching krita source still works after this change

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
