### PR TITLE
python3Packages.shared: 0.0.27 -> 0.0.32

### DIFF
--- a/pkgs/development/python-modules/shared/default.nix
+++ b/pkgs/development/python-modules/shared/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
+  fetchPypi,
   kvf,
   paradict,
   probed,
@@ -10,14 +10,12 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "shared";
-  version = "0.0.27";
+  version = "0.0.32";
   pyproject = true;
 
-  src = fetchFromGitHub {
-    owner = "pyrustic";
-    repo = "shared";
-    tag = finalAttrs.version;
-    hash = "sha256-5O/eaVL83gWoh0msparEjcTU+5K532f495OVwkoyJO8=";
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-cwityVwNqxTQyZY1zYBJ0fAEzH/vc5bT/kcyPDTsWMY=";
   };
 
   build-system = [ setuptools ];
@@ -36,7 +34,6 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Data exchange and persistence based on human-readable files";
     homepage = "https://github.com/pyrustic/shared";
-    changelog = "https://github.com/pyrustic/shared/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };


### PR DESCRIPTION
The existing version requires a package we haven't packaged yet, and the new one doesn't.

But the new one isn't tagged on GitHub. (And the changelog no longer exists.)

Fixes build failure on staging-next.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
