### PR TITLE
microhs: 0.14.21.0 -> 0.15.3.0; add updateScript

### DIFF
--- a/pkgs/by-name/mi/microhs/package.nix
+++ b/pkgs/by-name/mi/microhs/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "microhs";
-  version = "0.14.21.0";
+  version = "0.15.3.0";
 
   src = fetchFromGitHub {
     owner = "augustss";
     repo = "MicroHs";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Tq8fjI3LCP4NWrmbMP0xyhY2fjRmsMCEvgfDQ/SB5Bo=";
+    hash = "sha256-JuqdArVzziJC4/QZLfPguXbd+ZiPD3bgf1mGYghkxy0=";
   };
 
   # mcabal doesn't seem to respect the make flag and fails with /homeless-shelter

--- a/pkgs/by-name/mi/microhs/package.nix
+++ b/pkgs/by-name/mi/microhs/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   lib,
   writableTmpDirAsHomeHook,
-  writeTextDir,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -29,8 +29,11 @@ stdenv.mkDerivation (finalAttrs: {
   # The MicroCabal that is installed by `make install` is pregenerated, does not respect MCABAL above, and so is not useable
   postInstall = "rm $out/bin/mcabal";
 
-  passthru.tests = {
-    hello-world = callPackage ./test-hello-world.nix { microhs = finalAttrs.finalPackage; };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests = {
+      hello-world = callPackage ./test-hello-world.nix { microhs = finalAttrs.finalPackage; };
+    };
   };
 
   meta = {


### PR DESCRIPTION
Bumps the package and adds an updateScript using `nix-update-script`, which I was using anyways to update the package.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
