### PR TITLE
[Backport release-25.11] heroic{,-unwrapped}: 2.19.1 -> 2.20.0; gogdl: 1.2.0 -> 1.2.1; heroic-unwrapped.legendary: 0.20.39 -> 0.20.41

### DIFF
--- a/pkgs/by-name/go/gogdl/package.nix
+++ b/pkgs/by-name/go/gogdl/package.nix
@@ -4,21 +4,18 @@
   fetchFromGitHub,
 }:
 
-python3Packages.buildPythonApplication {
+python3Packages.buildPythonApplication rec {
   pname = "gogdl";
-  version = "1.2.0";
-  format = "pyproject";
+  version = "1.2.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "heroic-gogdl";
-    # two commits after the v1.2.0 tag, because the release messed up submodule fetching
-    rev = "9759dfb1f50e0c68854f938e9568d84cab59652c";
+    tag = "v${version}";
     fetchSubmodules = true;
-    hash = "sha256-yjiPHEiZjs9TnBRaKzm1TpLcPK0tfIrzM30DX66m+1Y=";
+    hash = "sha256-qYarDcwrVrTpLHQYdWQvXL5+V1wMyL06+n5t6LXKBHI=";
   };
-
-  disabled = python3Packages.pythonOlder "3.8";
 
   build-system = with python3Packages; [
     setuptools

--- a/pkgs/by-name/he/heroic-unwrapped/legendary.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/legendary.nix
@@ -4,20 +4,17 @@
   fetchFromGitHub,
   python3Packages,
 }:
-let
-  version = "0.20.39";
-in
-python3Packages.buildPythonApplication {
-  inherit version;
+
+python3Packages.buildPythonApplication rec {
   pname = "legendary-heroic";
-  format = "pyproject";
+  version = "0.20.41";
+  pyproject = true;
 
   src = fetchFromGitHub {
-    inherit version;
     owner = "Heroic-Games-Launcher";
     repo = "legendary";
     tag = version;
-    hash = "sha256-2+9MRbwugBlBdZQQo6BUcLmwCqVdTAv9CZ+sPu5VAxY=";
+    hash = "sha256-zX5Lyj8IDHETFyEpUaFnGaYZVs1hDy9rtwab1+rNlrw=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/he/heroic-unwrapped/package.nix
+++ b/pkgs/by-name/he/heroic-unwrapped/package.nix
@@ -30,13 +30,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "heroic-unwrapped";
-  version = "2.19.1";
+  version = "2.20.0";
 
   src = fetchFromGitHub {
     owner = "Heroic-Games-Launcher";
     repo = "HeroicGamesLauncher";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-e+/FRvG9u6ZQsMGD5hqY+yLPjsbLSrjC9Wp0xdxVk6w=";
+    hash = "sha256-gjQPQ/PwpDlBUfNF1JAlWUDGJa+7hwoQtouihdSCDqI=";
   };
 
   pnpmDeps = fetchPnpmDeps {
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     inherit pnpm;
     fetcherVersion = 3;
-    hash = "sha256-uwJYOm+2wGNRHAiIw1UjCBLBW6kjtj6AFLWihCqtL28=";
+    hash = "sha256-JLUiPNxcOpwkYaabl2kP73fgr+WFyXQW8y6qDIb5gt4=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Backport of https://github.com/NixOS/nixpkgs/pull/492615

Can't have an exact backport because of some treewides and the fact that finalAttrs support was not backported.



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
