### PR TITLE
flower: init at 0.0.1

### DIFF
--- a/pkgs/by-name/fl/flower/package.nix
+++ b/pkgs/by-name/fl/flower/package.nix
@@ -2,11 +2,11 @@
   lib,
   stdenv,
   fetchFromGitea,
-  fetchFromGitHub,
   clojure,
   graalvmPackages,
   git,
   cmake,
+  ninja,
   zlib,
   cacert,
 }:
@@ -19,15 +19,8 @@ let
     domain = "codeberg.org";
     owner = "jyn514";
     repo = "flower";
-    rev = "fc051518d4";
+    rev = "fc051518d4ff298344f869b184574ae6a4a2df79";
     hash = "sha256-etVQnrdGzOfrohZ4rWAk3Pk1PylUFIho30JLwwfOMHo=";
-  };
-
-  ninjaSrc = fetchFromGitHub {
-    owner = "ninja-build";
-    repo = "ninja";
-    rev = "bee2e3943ca5d853a6ea7a2091e88b5149ced9cf";
-    hash = "sha256-meb5gtUWt8LI+gqxVN3+nxlDsbQJXevsPcUWlYrzhf8=";
   };
 
   # Pre-download Clojure dependencies into a Fixed-Output Derivation.
@@ -92,10 +85,6 @@ stdenv.mkDerivation {
     [ -d ${deps}/.gitlibs ] && cp -R ${deps}/.gitlibs $HOME/
     chmod -R u+w $HOME/.m2 $HOME/.gitlibs || true
 
-    mkdir -p target/ninja
-    cp -R ${ninjaSrc}/* target/ninja/
-    chmod -R u+w target/ninja
-
     # Provide a dummy git repository. `native.clj` uses `git describe --always`
     # and expects a tracked `defaults` folder to generate `MANIFEST.txt`.
     git init -b main || git init
@@ -129,18 +118,13 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Static site generator that grows with you";
     homepage = "https://flower.jyn.dev";
     changelog = "https://codeberg.org/jyn514/flower/src/branch/main/CHANGELOG.md";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "flower";
-    maintainers = with maintainers; [ philocalyst ];
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+    maintainers = with lib.maintainers; [ philocalyst ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/fl/flower/package.nix
+++ b/pkgs/by-name/fl/flower/package.nix
@@ -1,0 +1,146 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  fetchFromGitHub,
+  clojure,
+  graalvmPackages,
+  git,
+  cmake,
+  zlib,
+  cacert,
+}:
+
+let
+  pname = "flower";
+  version = "0.0.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "jyn514";
+    repo = "flower";
+    rev = "fc051518d4";
+    hash = "sha256-etVQnrdGzOfrohZ4rWAk3Pk1PylUFIho30JLwwfOMHo=";
+  };
+
+  ninjaSrc = fetchFromGitHub {
+    owner = "ninja-build";
+    repo = "ninja";
+    rev = "bee2e3943ca5d853a6ea7a2091e88b5149ced9cf";
+    hash = "sha256-meb5gtUWt8LI+gqxVN3+nxlDsbQJXevsPcUWlYrzhf8=";
+  };
+
+  # Pre-download Clojure dependencies into a Fixed-Output Derivation.
+  deps = stdenv.mkDerivation {
+    pname = "flower-deps";
+    inherit version src;
+
+    nativeBuildInputs = [
+      clojure
+      git
+      cacert
+    ];
+
+    buildPhase = ''
+      export HOME="$(pwd)"
+      export _JAVA_OPTIONS="-Duser.home=$HOME -Xmx2g"
+      export GITLIBS="$HOME/.gitlibs"
+
+      set -e
+
+      clojure -P
+      clojure -P -T:build
+      clojure -P -M:dev:test
+    '';
+
+    installPhase = ''
+      mkdir -p $out
+      [ -d $HOME/.m2 ] && cp -a $HOME/.m2 $out/
+      [ -d $HOME/.gitlibs ] && cp -a $HOME/.gitlibs $out/
+    '';
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "sha256-sO2VFyP+SqSIr28YQtLhu2glufaNQEg8pyE7wY4S7YQ=";
+  };
+
+in
+stdenv.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    clojure
+    graalvmPackages.graalvm-ce
+    git
+    cmake
+    cacert
+  ];
+
+  buildInputs = [
+    zlib
+  ];
+
+  configurePhase = ''
+    runHook preConfigure
+
+    export HOME="$(pwd)"
+    export _JAVA_OPTIONS="-Duser.home=$HOME"
+    export GITLIBS="$HOME/.gitlibs"
+
+    # Restore cached Clojure dependencies
+    [ -d ${deps}/.m2 ] && cp -R ${deps}/.m2 $HOME/
+    [ -d ${deps}/.gitlibs ] && cp -R ${deps}/.gitlibs $HOME/
+    chmod -R u+w $HOME/.m2 $HOME/.gitlibs || true
+
+    mkdir -p target/ninja
+    cp -R ${ninjaSrc}/* target/ninja/
+    chmod -R u+w target/ninja
+
+    # Provide a dummy git repository. `native.clj` uses `git describe --always`
+    # and expects a tracked `defaults` folder to generate `MANIFEST.txt`.
+    git init -b main || git init
+    git config user.name "Nix Build"
+    git config user.email "nix-build@localhost"
+    git add .
+    git commit -m "Dummy commit"
+
+    runHook postConfigure
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    # Setting CI=true triggers `--parallelism=4` and `-J-Xmx4g` in `native.clj`,
+    # preventing GraalVM from exhausting memory.
+    export CI=true
+
+    # Passing `:include-untracked true` ensures `MANIFEST.txt` contains all default files
+    # even if git tracking is slightly off due to our dummy repo initialization.
+    clojure -T:build native :include-untracked true
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 target/flower $out/bin/flower
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Static site generator that grows with you";
+    homepage = "https://flower.jyn.dev";
+    changelog = "https://codeberg.org/jyn514/flower/src/branch/main/CHANGELOG.md";
+    license = licenses.mit;
+    mainProgram = "flower";
+    maintainers = with maintainers; [ philocalyst ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
