### PR TITLE
rke2_1_{32,33,34}: update

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_32/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "8d0c3980463addca09a3833d805472a3c7be5506821af44e06a5ea86a0886339"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "41986d200020dc3701a6c856abe9ddf6528d4ccff6cb7c25cd4134d76db7ea20"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "750f8ba9afb11c61d13ee5cd4e3126da5b6dab9f05b079934504665e84103c0f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "e423f7a8e0ce39534ded83bba7775c69ef29b374ec9da9f66d62cee7fa6a8c5b"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "6b6bf994fda7fa6e128cdd8d43202da44a9cd573a4e6297cbf1943ce7c7db24f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "5b2eed3462d4e50938c773232b3ab9b2645eeb63f86c6b4e1c94ca001581b328"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "b91c5d578d79132166706372210f215db3542bcd4c639ea4459af48364716bf7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "58c2942534eb1bba50e72f19db7da3b982e933380461b4489f9df57a08fbf983"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "6cdcdac6ac35650ad0baf654438bd16129810b110955c1f3571c174046b95a9c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "0f351f3c8b10db857c7fb4258d0699b0644dc14da780461022b5437b277191b4"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "66343e33391790e004829f41906db086b9dbefa08b5c7c554beb2d1e9d4b4095"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "a7c22d3de484a2f9e9b6ca9d2a454d392160a1fada9a958917f2aa3bf3f38b81"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "6d63a70fb0eb1b868e51c6660def5c28e4fbe88fcf2df8e32c7d1e25391426aa"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "90a3f2f93055fed4b2990de9cbdb89bc444424d9e7798944c5850e209b62fd6b"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "ba652613f19e1195e4a05f7538a9181565dc0a8d939b4717e55ea439dae4dcda"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "50f4d1b1bb03523b922d7ce989d2d83f009d751d7fbf4aa8821fe52c9b9fd96d"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "eb8ed504c28b0e7f6804a91aff8ff83d55c8ed4d3a9aa199d40629286c659726"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "96a22c3e25093a0fe244180bb4156ddd1c8718e522297f8a45505d9946297f49"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "443b46e15b352da76faa0832e347915a6e8d74f6e5978e093e588fdf41cfb6f7"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "1899735f0c9bf506a4a510301cbb4848030d34c37584f5ba6a83ffcbcc06dc5a"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "52c2fad399e622209388e27f563d8d4fd1cd7dc3e4c690b13a82dfa2f5512e50"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "d4c93346ccb0298b6e8d8301971cef71f0ab2e60daed43f898883d595febc59c"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "63e4cebff2d8a2fc688dce5509f5a1eb1853f18dfe03341cf720eaed2f9c425c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "b7b737cb758527ce045fa189891bff4a7ec6199ed152a04271ac52be4d541027"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "3856334a4c01c6f3bf4edefdcf35c22934bb374247ec68f922c47d20df06a14b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "380f47b868a8fbe25b5bcad2a181c0eae9586423383ff84e54ed2bdef21ec5fc"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "f262578106dd97865cfadf1844b8d4cb0f802684324dd4802e7d21a7691c5a5e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "39be1f6bec9aef6352711e95a6b5c0f9dcaed86830dfb853d88034cc0e069d2e"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "014252467ef853a76cdb6b3ca36cb9f02e0c87e432952f2a284924e9093bd828"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "1cfe8fc43cffd97c4be1257a2c4295343c78ae17790df7440834995ed03b19f2"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "533d173db72c3b470f588d34d9d0ea5d99d97bd95a3e1c84ce40e8f9c3c5a6fe"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "b3cb602f172cd9a3145afa7cd0af9c02a0451163a9d0972d4c2f6cb3838be64d"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "6f2c18a776b7606eebba37a77a60c9af947277ec580a89ee0d78c3cdfdcee19a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "b85385c0b94747af38453a57219348ae6c048526dfeac548af4d8b8a44f459b3"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "e4dc998d92eaf65d64bc2a5d6e0de6aaa681e5472d299d24ae0839b62f76d0be"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "d843630e86003cf4b18a1ef070b44c3a73e1431770244e853eafcecdb714bfa3"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "cf943bf7c49860e44f4495080b6a67c03254a66a14fd4c717d002b85a960d294"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "b35d755a8e4d27774496619676c1bf23870a99f532de6826137c9c3406d90202"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "4573fdf31346c635565c85df827890566be50a511d90430f6f6344822a57c840"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "c94fecb19b6b1eaa347c49fc60def2e1251d866714e9ab05ea6ce29d5da41fb3"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "832c0c23264dd7465cdc9a5aaa15c08f4d3beae9f4cc340f22fde1b29f8df829"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "c3d3613c1c980bea49ace10e89559eff886d3f86a8fc9a35f314903f8414e1d8"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "8cbb615444176d41b4b2a5c1e9c45bf790226557881f2f824a85870ce5411340"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "852ace7b2824bb2a191fcf8ab40f625596ea33b3460ca897d04f97d4a319ec4f"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "72c48dae8447f53098dd29929d0807dbcad35785ca5b947d4945352068d4fd21"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "775b52176ae09fa3e758b7cf4137e81fdcc0e2b4525359b86bdf3167acc02d9d"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "7aec3ca5df97a15a3fba6ad41b1c66ff0d89ce7566f2a77a67119fcc306aefd6"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "166d640c5a11ac3d23bc2f95a46b47e345311af2c5186753320a32acb2092491"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "6e71cc84fa4db154a078b54dbc4c529343e239d2ee18a0c42182d78c42d235c5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "725d693a24711ac0b235c907a2353ededb21d9666819ecb6a5c2149470832a80"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "11b14a77520d4a2d4576d29726a48df6099efbd3698acb9f21539f4aecd8cb07"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "8d3884444e465f8f41a8fc64d2af0a9ee010239ab5d7cc531fdad8e8e48952f9"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "2c1a493889a2680107e3ddd243d51bf4b8cb39438f296ff1c5f67018f8a16f01"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "535b58068296a8f9226e36f969527bca3a23ac1a917b0d99b4ac97e558041aa1"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "e937a9f50c49e1ff9fee82701253eff96988c515a80b8ead262a0936749d117d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "ba77ac84eda9704594aa9eb6629430f7b60606fb532e245c21bf4ca0f7fbee9b"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "8cfc99966860bbc8ac394aaa742b849030fb34c76fad80f92ab01bfd61e439fa"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "7682596ee35cdab6c049289ff751d83ce68cbf9771f543b6971452ec93dd16f8"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "83fb940a35c030c0ada591b30929f891f313496759a3aa0bd5956d2fb5352d81"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "ffdcdf38e2b9d7ceaa9d158f55294ea350015fa69e9b1a18587e8eb6bff7847e"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "2530f1eb0652d5a6ecef756762b313f3353d6248fca71f38fb4345c22a2ae6c3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "f1860511e58d40827c20d742e0012b4a2eb7c1d3f69d442186f66aedfb7a1638"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "10d15dfa11d37bfa6818f50e143ee9747667412d87546c48c213d1f3ea592e94"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "9b19e64407a5e12c73d9c00a121e1d78481ef2fa2e7597a9e20a201a6c527013"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "e4ece48e2c1a7a300c7b8d3cf741274708bc6684a2c895eeb11125a56b00be89"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "83cfd9e7f8e4763e0fae6be5fa006c86caa43e6ddf8751c31c93dbbffc02c509"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.32.11%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "b2da9f611dbc21f9c084e294ca36e9d5028a31318b6692f25ef0b37079b4fc9f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.12%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "29305bfc62707f37a51b263c9a93620f1491b76b494432aca9d512262f5d11b6"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_32/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.32.11+rke2r3";
-  rke2Commit = "17d79026f5b83f1ca4af3feadc4756cc0cce0ba1";
-  rke2TarballHash = "sha256-lu5Au09HF8Vhle/caMYIlrtxplbikzS4JpFvZwbm5Bg=";
-  rke2VendorHash = "sha256-wniGN8nRXo8GDKXG5wt/Ulv5A4IIIyVh6GFpfFfebRQ=";
-  k8sImageTag = "v1.32.11-rke2r3-build20260127";
+  rke2Version = "1.32.12+rke2r1";
+  rke2Commit = "74d4362acaa7234e3fc909841cdaf906c73eb6f5";
+  rke2TarballHash = "sha256-DC0XG/m6/ApzLUFBykGGHNBRTPYhCqAJNxhYpXk4Zzc=";
+  rke2VendorHash = "sha256-wMxOKsnf6s3CB2+ocjHovXa/RUJPAZT0WubcnUZMiV8=";
+  k8sImageTag = "v1.32.12-rke2r1-build20260210";
   etcdVersion = "v3.5.26-k3s1-build20260126";
   pauseVersion = "3.6";
-  ccmVersion = "v1.32.11-0.20251210094421-ded016535487-build20251210";
-  dockerizedVersion = "v1.32.11-rke2r3";
-  helmJobVersion = "v0.9.12-build20251215";
+  ccmVersion = "v1.32.12-0.20260211145907-0dc662e80238-build20260211";
+  dockerizedVersion = "v1.32.12-rke2r1";
+  helmJobVersion = "v0.9.14-build20260210";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_33/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "cb42dab5e5d6b22a97f7c7b00bd366b0cb4d880faa4ea8471240010bf3fee06a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "2910dbfb8e1757da596cbe0dc9040b47cb465d900fba641aba9d6c7e7f9f89c2"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "792fc6b5e017d22a7cc8ad15f90c848fa5f30fa2b70daf7da55942779209f1d1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "eddf7009b6eb86092b3478ac3e05a6092cc7213a0e0414f4f70388de5f9126be"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "1b03d015afa029e41c26bcf5a711a341be10500c13a38e7b595a7e5415db1705"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "921d65d0b56ecaa07be68486781ca8e70f302d19962a25c9a194b9063aca8c0d"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "bfb9f3177f242ecf224146e92a1f3120b503a5ca27f9b7f98853de2e8d9b4d44"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "3548ad9d6b8f58d7715c3c20e088a86ffb7b6de0f26ac46b8dcbf88c42463722"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "63a203c9503258029af30935856d27e71df3ac35f39f48d94a422db54ed3c077"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "5a9f80bc26caade70a8c12391e1059c8fa1986f1f1940c426b0106a7dd44e746"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "b3b7091d62221ef06cecd4073404013d2e5428efb2b1bcbcf157ba4abca83ef9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "7e3f80b037079922f6a0aaf5a701459ef550d67ca31119a0c74955254fa52b1e"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "2ba37d5f570aeec35084457f0cd95e319bc9049f893c3542721320601a3b01ee"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "0f690921d2e6564cc2dc635f8a8bff9a6ea0cc9102b69ae3483ba811cfe227dc"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "59d2f4aff4e91135efcd6ea98e1d8d5e2464d5edbdcd1d21f6789158cb48c968"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "50f4d1b1bb03523b922d7ce989d2d83f009d751d7fbf4aa8821fe52c9b9fd96d"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "639bd3f26fb9f710d4ca31ab53ce9c84484c20f08d078399ff39c5e74b05e00b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "f662366fbb5640d698e653634372b695586ef615aa00b333734a472a9396c11b"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "7f9331159a77073291fcd5d3bbe739749f110e6b37b5d89c1c7a27aa1e2b97c0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "5cfe063d25d30c92864adce166bf42f12a298b2754b150a5b7f6971a2ec42223"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "d46cdcc7f9966ed3da12d0ee6fa8573f9b9b5240b96d98dec182f56d73c2b497"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "57e8ed0c6e1dff9d389e7ee73ba175fdfe8258a89a4156a8c6f7acd1c34b4431"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "358c297f40be38aabca1d3fc23bd7fa75be38068592dbe9bb41fb25050694d06"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "a9ecf7c81e9752351e5895753415bb4c1d15cce5e99b9b2eb7b0ec1eb022f642"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "3ae923d05c1cad4bda2b9c9485150b6a9d25b9df67868b0257ecb3a16d3536cf"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "0bdf829a73f66deaa824dffb57740c166f8ba6c374847eca2a2670971c99c281"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "11d55e64e2cca2109f21f351f1f0f721f5bd6c66034bdf565b152e70b4aa173b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "d9ffc827deda8b3286503a7577617d06d1b9d925a5984ffc2acbe677bea07949"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "be0ca650fb5c02aa603c75fb121b90a42a3b238f4cca55779fd9706c5b275066"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "e7d3f58d535db9ca7bf01518db35d3768f22978c9401238ca2475f4b6477f618"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "beac78c4a796e42f2416b7cefbcdd9b7806f49b59c2faa995632b8d8421c14b5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "0f32a127391e09d0b245207e4785afc541ec936597055ac09d85d7eaf090e547"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "0da13ac23c3a5c3178383bb17fee989834a110e41ffe11780d3e7855445eebae"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "f319b0f22b4d3e6021559ca2881a44b936318a36d8163542c7feebe4cc2f702e"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "e4dc998d92eaf65d64bc2a5d6e0de6aaa681e5472d299d24ae0839b62f76d0be"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "99e1aa2dcf3f39d736abaf8cddf229d9931ab4c80940881cd7c6b89ff357bd17"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "5a4a349c2cfa222397ce2d937982f3247bfffe73807440851e0c41c721583693"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "392b74460ac3bb3474ce04f19935432675884bcc2ae35ae6f9cf580dfc8213c0"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "3e613cdb185cff68b8cb657cbe89f29858828cb5fec4763b25b0450f617f54ac"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "c94fecb19b6b1eaa347c49fc60def2e1251d866714e9ab05ea6ce29d5da41fb3"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "d1b18a768857ad1f288b1d1db8065b5d668212a3270d08360fe7870bbf7593b3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "2a062316cbd4942d1786468d41cfdfc7dad6ac52a4a96a2197ed71f875980d20"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "493ff33611a271cb0e71642bd63d9b65d9032833fdd6f2a8e01e797624408e18"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "e6cf677021b2c5e448faec2aedc4b2aa3b5db8410318f96f2ea156bab380e708"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "118a8ede1ee0836ac1b891381a1211ede372d55c37f9edebe8060955f2a6ea9d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "4d90036f9fce836fc38623e120e6d9237b2a580717361fc86c1e4ccdadc16a5a"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "aeccc7ede79366078b5fc964b41db6b579277a1170d62dc75de9f887262b9cac"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "391888ab6a14ce3674fb5828a420677e37389b4090c30c9d4177ff5aaa8d7124"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "b3411609c02fcac85c29fcfb251c0ab19896c6af65dcfc1fa539c696a73236e9"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "a7c646feb9d06f894bf35900aa2eabc9634399758f399217823630154ee5023b"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "e17c910d4609162de2416845fbd600711488566b4369e896e17249b1e2f00d4f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "035612c8628d1d18548082bfd72db0393949fbfd5f21a35d96e22dc7070a5d52"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "d44e4f67971a2c2f9cea7a83777dba707a5c5bafef6cb9e7f45c0e84e8634f66"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "ef91e7d9b352303e086f8167527dce337f5ddf8d79833c8180f5548ceb7aeff7"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "e937a9f50c49e1ff9fee82701253eff96988c515a80b8ead262a0936749d117d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "00f7366eae2e397625e56a1d014632de37ec545276e2632920a416289e175493"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "7831e03c29ff17d25131ef6982d7595f098af7abb99a2f040a186e9fbc5e094b"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "234b205b7ca6698759aff22a3a5b4b2c426224c035added48f5317f37322a690"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "83fb940a35c030c0ada591b30929f891f313496759a3aa0bd5956d2fb5352d81"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "ffdcdf38e2b9d7ceaa9d158f55294ea350015fa69e9b1a18587e8eb6bff7847e"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "d7e6f2685bccd21af7abc539d8cdb72ebc6a69bad654308ecbc9a8d5d5d9de3d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "6351a0ceebbb0f643de5cb1003b0cc27ca51e3974fdcac3eb3b893c3b15c827a"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "10d15dfa11d37bfa6818f50e143ee9747667412d87546c48c213d1f3ea592e94"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "9b19e64407a5e12c73d9c00a121e1d78481ef2fa2e7597a9e20a201a6c527013"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "3e40be7b6b4c22ba3e2c1bbb14d82002ef68ea6368633326fe8881251afc79c1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "d4a7b1e21fb54d53c1ef4e571f52cbc8c41b6b74e4824eb27536ebb6a2277df2"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.33.7%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "3b7472d2058fa9a7c9285def8c30a32b8ccb0ffdae25ab94021d6cd7ea514066"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.33.8%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "a40b47dc7ba754fc4259106087e327de76269c8be926e5f710c0a2e77fcf900b"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_33/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.33.7+rke2r3";
-  rke2Commit = "7e4fd1a82edf497cab91c220144619bbad659cf4";
-  rke2TarballHash = "sha256-kyTKacfVD93cwozXkjusR/eshibIyAPEmEyhRiAvppw=";
-  rke2VendorHash = "sha256-P6p//+38sM0dobc+Xx0Gd+A01cJsUUE+eblUtc3Cet4=";
-  k8sImageTag = "v1.33.7-rke2r3-build20260127";
+  rke2Version = "1.33.8+rke2r1";
+  rke2Commit = "eb75e3c1774cee5a584259d6fee77eb8cfa9b430";
+  rke2TarballHash = "sha256-lurKGrJYKyNVU+MF6k7LFLM+FDnRk0QErcSrookZm7M=";
+  rke2VendorHash = "sha256-vobzaY0eyTSEaZ1AwWaPuK6VhTcRW1YO9gIpMgsQo0g=";
+  k8sImageTag = "v1.33.8-rke2r1-build20260210";
   etcdVersion = "v3.5.26-k3s1-build20260126";
   pauseVersion = "3.6";
-  ccmVersion = "v1.33.7-0.20251210094413-291666bcc1a4-build20251210";
-  dockerizedVersion = "v1.33.7-rke2r3";
-  helmJobVersion = "v0.9.12-build20251215";
+  ccmVersion = "v1.33.8-0.20260211145912-3552cfc26032-build20260211";
+  dockerizedVersion = "v1.33.8-rke2r1";
+  helmJobVersion = "v0.9.14-build20260210";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/1_34/images-versions.json
@@ -1,138 +1,138 @@
 {
   "images-calico-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-amd64.tar.gz",
-    "sha256": "3afe223e395bc988b49edd2d18293448dc267a31a9085250c54d13fb81a66c3d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "8427d2a464b9b8222d57d8ccf22c119c14a68490b150ea8d72d861baf04025aa"
   },
   "images-calico-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-amd64.tar.zst",
-    "sha256": "7e2aee7d34c13b088f9548764ec962233989749214ba906a7276729cede72e74"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "d6c24b04a544481730141ead0b8a30e8c64d95457455149412fd94f34e3b81c6"
   },
   "images-calico-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-arm64.tar.gz",
-    "sha256": "4a2c4145e58c053239af5154402f8ccaffa4780bbd546a54ff725ad22eeb1dc4"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "a4015e2c69d6d5411214f5b003b3de17c989d87cc20652e85e06fb299c2bf29c"
   },
   "images-calico-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-calico.linux-arm64.tar.zst",
-    "sha256": "237b907abf607a8319a6ce7e667ea479a9472e11f6ed23912830899cbe787600"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "15ba95a0fc562a284dbcb6918f8234c1d2a98f4744fe5cde852ae1ab108db57a"
   },
   "images-canal-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-amd64.tar.gz",
-    "sha256": "751fee624d7f58b6c7d408d17aefabafc55832b1935244add05e3cef566a20f1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "264f2abe24c1cd918f41a1299ccbc94edecfabb19c04738db60fb514b4dc39c4"
   },
   "images-canal-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-amd64.tar.zst",
-    "sha256": "66343e33391790e004829f41906db086b9dbefa08b5c7c554beb2d1e9d4b4095"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "a7c22d3de484a2f9e9b6ca9d2a454d392160a1fada9a958917f2aa3bf3f38b81"
   },
   "images-canal-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-arm64.tar.gz",
-    "sha256": "6b7280c45b1d0a6f46143d7a722dc20f5a08715dfd8955a7984e21f9e7c7e2c0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "9a2fa03658ad6f1dbb29bf862509b47d6fc88ba200cefeedc439f1c504ba14cb"
   },
   "images-canal-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-canal.linux-arm64.tar.zst",
-    "sha256": "ba652613f19e1195e4a05f7538a9181565dc0a8d939b4717e55ea439dae4dcda"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "8b8af6dadeb165fed27993f0763c31f2fc55742e152c6432d712aa13841650b5"
   },
   "images-cilium-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-amd64.tar.gz",
-    "sha256": "d93ed1d3f08889c94f194355c686cd170707cc10439a0794d4ac62813667871a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "71eb1303f40f52951049194f821fd1c229c8bcad1580d029c86d98c4a359e4ba"
   },
   "images-cilium-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-amd64.tar.zst",
-    "sha256": "8113765a4640591976507a4ff4403c516db0ebe214d538a1a3510bafcfad2216"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "8835471b4cf5ab8e4e02d3f3fe07badb88448ccfd79af3fa9a327d207358d76a"
   },
   "images-cilium-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-arm64.tar.gz",
-    "sha256": "acfe7b49804be0d410bf2e804f094bc8826e78502f4f9d0f2bc3d313cca7309d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "3990fcb9ce30f490bbce5ee99ba6d02688025820711136ec00f3f17063e366ee"
   },
   "images-cilium-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-cilium.linux-arm64.tar.zst",
-    "sha256": "ecf563e46c8b6c0ac0ae29d05002255d22744bab89e5e17cf03a79758b8d68f0"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "88509175bda1a8046b4ca70361c9dc762a4696520fc63b1b87df71fc87f3e230"
   },
   "images-core-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-amd64.tar.gz",
-    "sha256": "164eef1322de2340e4af5e2451bcf2e72dcae002a983d3f1d51e27b95100daef"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "3efae5cf7d76fb44c144fb3928c721dc2a6045dabbfe2ddb4822fc0710074989"
   },
   "images-core-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-amd64.tar.zst",
-    "sha256": "6a90ab3f9a9c1037a3c299afee21af063d69ee5b1a30d5fa09450e5ae5d302db"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "305e2d1acb10f931d74e1428f0dc5e8e1ff06eb2f70a3c82d1033afa4d30de64"
   },
   "images-core-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-arm64.tar.gz",
-    "sha256": "5b5d5643d5106fda9e4eb54632cc18fe714611f557ccdfc75a5ff3966614978c"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "8f979ebd5bb4a213d3d9cb96d9ec8a3d6d719857da6aeb7eeb4aa470684ccfcc"
   },
   "images-core-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-core.linux-arm64.tar.zst",
-    "sha256": "bdfd862680c1d3c5d4f0d35b390d63437d36e831fd7eccbec603b447e5874e2a"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "4467d5e8ef4184f698597f742a6d9797bb5f791f8862c39cde62e2d111a30aff"
   },
   "images-flannel-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-amd64.tar.gz",
-    "sha256": "b630aa6867bb8cd8074bdffc43c1a86793c1f266a7ae2d87365a31d45a3e6da3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "eefef243ff9de14ecf40a315977a43d7b4b81ad0d9de6d034cf520acd1825eaf"
   },
   "images-flannel-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-amd64.tar.zst",
-    "sha256": "e4dc998d92eaf65d64bc2a5d6e0de6aaa681e5472d299d24ae0839b62f76d0be"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "d843630e86003cf4b18a1ef070b44c3a73e1431770244e853eafcecdb714bfa3"
   },
   "images-flannel-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-arm64.tar.gz",
-    "sha256": "637cada2e40ac5ea63779c870afdfd6a4d54b56e9ac692363b2a9d51e91870c5"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "1e708c26c939942b396daee8a6e22487349f5b21c3f8bea31790c584fa02cbc3"
   },
   "images-flannel-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-flannel.linux-arm64.tar.zst",
-    "sha256": "3e613cdb185cff68b8cb657cbe89f29858828cb5fec4763b25b0450f617f54ac"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "fd01dba6b0b12d99e575f6c6f428be59d93d7bf89eba6721dab5f9727483facb"
   },
   "images-harvester-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-amd64.tar.gz",
-    "sha256": "83865ff5837bc7c4ca4b5355b0c4868df1e2d13f20119c89565ba01aada42f4e"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "b6074547e56309e8d07a96ce5309eb7375a88618809a52096613dc200d11a8db"
   },
   "images-harvester-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-amd64.tar.zst",
-    "sha256": "0919a88bc0d260f0fa17a1df0fe00964fc70b3b77f0080ce9797852841b91b7d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "d034bf81cf1e323cf40c22f8e9a1a506a3db629672b57a6c0e23a191b30ce300"
   },
   "images-harvester-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-arm64.tar.gz",
-    "sha256": "4414e1eedaed610df4ced07da07ee7b0d0cacd890061d626bbaeb8282d69fbd1"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "2444019dda146101a517b7595da9a4ff413d42471d97524a69f46829bf2d7782"
   },
   "images-harvester-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-harvester.linux-arm64.tar.zst",
-    "sha256": "4bf1d69a6fc62d953a481af4ec9f229ed8edce6343dd74a18bc2e9caa0aa4e9d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "a1d7ba943006b17d61808c0073f802c0a186d34d297abd6c577f5dbacfea41a7"
   },
   "images-multus-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-amd64.tar.gz",
-    "sha256": "cdf7c04f270b83147ccd0a2fa05c09511852e40bc14d8ef65f018ac66a714621"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "e0149402647c3aebe207dfb18ede2d4f49291dfddeefba918dd8b9728e6df342"
   },
   "images-multus-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-amd64.tar.zst",
-    "sha256": "7183250ff5fd40b8dbe21ce22b7eaee19dbc78a8986b935b4b8aeee1105ce098"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "83c9451a8dfc116bddc38146f2a6eddef95d09348386e2b11c7d5479a114de34"
   },
   "images-multus-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-arm64.tar.gz",
-    "sha256": "2c1a493889a2680107e3ddd243d51bf4b8cb39438f296ff1c5f67018f8a16f01"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "d7a67efe62637f373dedb2888f4d4f72d81471c62ced92d2a19ace9c6db3762e"
   },
   "images-multus-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-multus.linux-arm64.tar.zst",
-    "sha256": "e937a9f50c49e1ff9fee82701253eff96988c515a80b8ead262a0936749d117d"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "27b8fbe74bcc4d7956b7a341e107b279372a295ae6a37855b20340defd8a6768"
   },
   "images-traefik-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-amd64.tar.gz",
-    "sha256": "61a8cd4da4450b2196efcf4c210036dddc5496d233b4816212d8277a595f45d2"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "3ac31747dd5c8402d46f5dbcfcc5648175fa406424e3b3e2ce714b4d0599ab0a"
   },
   "images-traefik-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-amd64.tar.zst",
-    "sha256": "83fb940a35c030c0ada591b30929f891f313496759a3aa0bd5956d2fb5352d81"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "ffdcdf38e2b9d7ceaa9d158f55294ea350015fa69e9b1a18587e8eb6bff7847e"
   },
   "images-traefik-linux-arm64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-arm64.tar.gz",
-    "sha256": "2530f1eb0652d5a6ecef756762b313f3353d6248fca71f38fb4345c22a2ae6c3"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "a1c0816943fca028cf86d968773637ab5c5f6e6e89008e36c8055b4a97a91b2d"
   },
   "images-traefik-linux-arm64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-traefik.linux-arm64.tar.zst",
-    "sha256": "10d15dfa11d37bfa6818f50e143ee9747667412d87546c48c213d1f3ea592e94"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "9b19e64407a5e12c73d9c00a121e1d78481ef2fa2e7597a9e20a201a6c527013"
   },
   "images-vsphere-linux-amd64-tar-gz": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.gz",
-    "sha256": "e6fba5a4ea6274527d9532782f5cab62b810cd2243ca17ebba7749d412c7ae4f"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "9a2954842500e3d74b0c82c79a9ec17135faf4a8001e0a07b96cfaf9b5a4ad3b"
   },
   "images-vsphere-linux-amd64-tar-zst": {
-    "url": "https://github.com/rancher/rke2/releases/download/v1.34.3%2Brke2r3/rke2-images-vsphere.linux-amd64.tar.zst",
-    "sha256": "67372b6c334a4565361adb349a4f79bcf502c447c1333c48756cf7e7183b9b32"
+    "url": "https://github.com/rancher/rke2/releases/download/v1.34.4%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "d79bec5e7a5f22e5d84b3ad271b91035602f03d1988192d193c58965de2b240d"
   }
 }

--- a/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/1_34/versions.nix
@@ -1,13 +1,13 @@
 {
-  rke2Version = "1.34.3+rke2r3";
-  rke2Commit = "7598946e0086a9131564ccbb3c142b3fa54516ad";
-  rke2TarballHash = "sha256-qPpEcuW56RnOxnODAfaX/dVEW83axhVAEwiuBPg1wwU=";
-  rke2VendorHash = "sha256-RXvIbt98LuvH0HWKS0DYkrSxJYbb+XNBs+8Xr6EVwu4=";
-  k8sImageTag = "v1.34.3-rke2r3-build20260127";
+  rke2Version = "1.34.4+rke2r1";
+  rke2Commit = "c6b97dc03cefec17e8454a6f45b29f4e3d0a81d6";
+  rke2TarballHash = "sha256-aYqmYongTjCKh5ntRhyv8w/+MUDjY7HLqkgWvQacR2M=";
+  rke2VendorHash = "sha256-Asuqicq2xXdT3nL1OZ6M8yEPzhECNvrC9Yswc4g+oHQ=";
+  k8sImageTag = "v1.34.4-rke2r1-build20260210";
   etcdVersion = "v3.6.7-k3s1-build20260126";
   pauseVersion = "3.6";
-  ccmVersion = "v1.34.3-0.20251210094406-1ff6ebef7028-build20251210";
-  dockerizedVersion = "v1.34.3-rke2r3";
-  helmJobVersion = "v0.9.12-build20251215";
+  ccmVersion = "v1.34.4-0.20260211145917-c6017918a65c-build20260211";
+  dockerizedVersion = "v1.34.4-rke2r1";
+  helmJobVersion = "v0.9.14-build20260210";
   imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }


### PR DESCRIPTION
No change to the tests was necessary unlike #491421, but since the new 1.35 RKE2 version also requires go >= 1.25.6 it'll have to be updated later. Tests passed for me.

cc @rorosen @zimbatm @stefan-bordei

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
