### PR TITLE
python3Packages.google-cloud-org-policy: 1.16.0 -> 1.16.1

### DIFF
--- a/pkgs/development/python-modules/google-cloud-org-policy/default.nix
+++ b/pkgs/development/python-modules/google-cloud-org-policy/default.nix
@@ -12,13 +12,13 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "google-cloud-org-policy";
-  version = "1.16.0";
+  version = "1.16.1";
   pyproject = true;
 
   src = fetchPypi {
     pname = "google_cloud_org_policy";
     inherit (finalAttrs) version;
-    hash = "sha256-xyFHEn2I2YCa+HOLKr40gG6sUpw83FeqkVzAihuEKhM=";
+    hash = "sha256-KleKj6JhG4pi/XAM82C/VndJED2nvK1+NzvT1lm7zpE=";
   };
 
   build-system = [ setuptools ];
@@ -43,9 +43,9 @@ buildPythonPackage (finalAttrs: {
   pythonImportsCheck = [ "google.cloud.orgpolicy" ];
 
   meta = {
-    description = "Protobufs for Google Cloud Organization Policy";
-    homepage = "https://github.com/googleapis/python-org-policy";
-    changelog = "https://github.com/googleapis/python-org-policy/blob/v${finalAttrs.version}/CHANGELOG.md";
+    description = "Python Client for Organization Policy";
+    homepage = "https://github.com/googleapis/google-cloud-python/blob/main/packages/${finalAttrs.pname}";
+    changelog = "https://github.com/googleapis/google-cloud-python/blob/${finalAttrs.pname}-v${finalAttrs.version}/packages/${finalAttrs.pname}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ austinbutler ];
   };


### PR DESCRIPTION
- Upgrades to latest version
- [Changelog](https://github.com/googleapis/google-cloud-python/blob/google-cloud-org-policy-v1.16.1/packages/google-cloud-org-policy/CHANGELOG.md)
- Same as https://github.com/NixOS/nixpkgs/pull/489536 but fixes broken links

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test