### PR TITLE
python3Packages.tinygrad: skip failing test on x86_64-darwin

### DIFF
--- a/pkgs/development/python-modules/tinygrad/default.nix
+++ b/pkgs/development/python-modules/tinygrad/default.nix
@@ -253,6 +253,15 @@ buildPythonPackage (finalAttrs: {
     # AttributeError: module 'tinygrad.runtime.autogen.libclang' has no attribute 'clang_parseTranslationUnit'
     "test_gen_from_header"
     "test_struct_ordering"
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+    # AssertionError: Expected 1 operations, got 3
+    # assert 3 == 1
+    #  +  where 3 = len([ExecItem(ast=UOp(Ops.SINK, dtypes.void, arg=None, src=...
+    #  +  and   1 = len([{'cnt': 3, 'type': 'graph'}])
+    #
+    # test/test_jit.py:695: AssertionError
+    "TestJitGraphSplit"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
>     assert len(got) == len(validate), f"Expected {len(validate)} operations, got {len(got)}"
E     AssertionError: Expected 1 operations, got 3
E     assert 3 == 1
E      +  where 3 = len([ExecItem(ast=UOp(Ops.SINK, dtypes.void, arg=None, src=(\n  UOp(Ops.END, dtypes.void, arg=None, src=(\n    UOp(Ops.STORE...dd__', caller='', backward=False),), fixedvars={}, prg=<tinygrad.engine.realize.CompiledRunner object at 0x118a7e450>)])
E      +  and   1 = len([{'cnt': 3, 'type': 'graph'}])

test/test_jit.py:695: AssertionError
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
