### PR TITLE
home-assistant-custom-components.omnik_inverter: 2.6.4 -> 3.0.0

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/omnik_inverter/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/omnik_inverter/package.nix
@@ -8,13 +8,13 @@
 buildHomeAssistantComponent rec {
   owner = "robbinjanssen";
   domain = "omnik_inverter";
-  version = "2.6.4";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "robbinjanssen";
     repo = "home-assistant-omnik-inverter";
-    tag = "v${version}";
-    hash = "sha256-O1NxT7u27xLydPqEqH72laU0tlYVrMPo0TwWIVNJ+0Q=";
+    tag = version;
+    hash = "sha256-L9us48J8fpIK3QHeEe3VhIAYBXbYegWYDi7OjeUollU=";
   };
 
   dependencies = [
@@ -24,7 +24,7 @@ buildHomeAssistantComponent rec {
   doCheck = false; # no tests
 
   meta = {
-    changelog = "https://github.com/robbinjanssen/home-assistant-omnik-inverter/releases/tag/v${version}";
+    changelog = "https://github.com/robbinjanssen/home-assistant-omnik-inverter/releases/tag/${src.tag}";
     description = "Omnik Inverter integration will scrape data from an Omnik inverter connected to your local network";
     homepage = "https://github.com/robbinjanssen/home-assistant-omnik-inverter";
     maintainers = with lib.maintainers; [ _9R ];


### PR DESCRIPTION
Diff: https://github.com/robbinjanssen/home-assistant-omnik-inverter/compare/v2.6.4...3.0.0

Changelog: https://github.com/robbinjanssen/home-assistant-omnik-inverter/releases/tag/3.0.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
