### PR TITLE
python3Packages.devpi-ldap: 2.1.1-unstable-2023-11-28 -> 2.1.1-unstable-2026-01-22

### DIFF
--- a/pkgs/development/python-modules/devpi-ldap/default.nix
+++ b/pkgs/development/python-modules/devpi-ldap/default.nix
@@ -12,12 +12,13 @@
   pythonAtLeast,
   pyyaml,
   setuptools,
+  setuptools-changelog-shortener,
   webtest,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "devpi-ldap";
-  version = "2.1.1-unstable-2023-11-28";
+  version = "2.1.1-unstable-2026-01-22";
   pyproject = true;
 
   # build-system broken for 3.14, package incompatible <3.13
@@ -26,11 +27,14 @@ buildPythonPackage {
   src = fetchFromGitHub {
     owner = "devpi";
     repo = "devpi-ldap";
-    rev = "281a21d4e8d11bfec7dca2cf23fa39660a6d5796";
-    hash = "sha256-vwX0bOb2byN3M6iBk0tZJy8H39fjwBYvA0Nxi7OTzFQ=";
+    rev = "5846e66a9206079c16321bd0f65c565ebe32be5f";
+    hash = "sha256-2LpreWmG6WMRrc5L7ylSej5Ce6VhfNDAW2eoJ76D49o=";
   };
 
-  build-system = [ setuptools ];
+  build-system = [
+    setuptools
+    setuptools-changelog-shortener
+  ];
 
   dependencies = [
     devpi-server
@@ -52,8 +56,8 @@ buildPythonPackage {
   meta = {
     description = "LDAP authentication for devpi-server";
     homepage = "https://github.com/devpi/devpi-ldap";
-    changelog = "https://github.com/devpi/devpi-ldap/blob/main/CHANGELOG.rst";
+    changelog = "https://github.com/devpi/devpi-ldap/blob/${finalAttrs.src.rev}/CHANGELOG.rst";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ confus ];
   };
-}
+})


### PR DESCRIPTION
bump devpi-ldap

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
