### PR TITLE
sc: 2024-08-15 -> 7.16_1.1.4, add meta.platforms

### DIFF
--- a/pkgs/by-name/sc/sc/package.nix
+++ b/pkgs/by-name/sc/sc/package.nix
@@ -42,6 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     homepage = "https://github.com/n-t-roff/sc";
     license = lib.licenses.unlicense;
+    platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.claes ];
   };
 })

--- a/pkgs/by-name/sc/sc/package.nix
+++ b/pkgs/by-name/sc/sc/package.nix
@@ -5,15 +5,15 @@
   bison,
   lib,
 }:
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sc";
-  version = "2024-08-15";
+  version = "7.16_1.1.4";
 
   src = fetchFromGitHub {
     repo = "sc";
     owner = "n-t-roff";
-    rev = "e029bc0fb5fa29da1fd23b04fa2a97039a96d2ba";
-    hash = "sha256-JQY+ixHL+TpP4YRpgB9GP4jO5+PBMS/v5Ad3Ux0+yuQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-qC7UQQqprT0Td7TCCe7iB9qJIBp47GW3aBAon27Katg=";
   };
 
   buildInputs = [ ncurses ];
@@ -44,4 +44,4 @@ stdenv.mkDerivation {
     license = lib.licenses.unlicense;
     maintainers = [ lib.maintainers.claes ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This fixes GCC builds and closes #492855
Includes release 7.16_1.1.3, which occurred after the last nixpkgs version bump, release notes found here: https://github.com/n-t-roff/sc/releases/tag/7.16_1.1.3

UPDATE: They put out a new version at the same commit, so I've changed the update to have proper naming.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
