### PR TITLE
various: switch buildRustPackage packages to finalAttrs pattern

### DIFF
--- a/pkgs/by-name/am/amdgpu_top/package.nix
+++ b/pkgs/by-name/am/amdgpu_top/package.nix
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   '';
 
   postFixup = ''
-    patchelf --set-rpath "${lib.makeLibraryPath finalAttrs.buildInputs}" $out/bin/${finalAttrs.pname}
+    patchelf --set-rpath "${lib.makeLibraryPath finalAttrs.buildInputs}" $out/bin/${finalAttrs.meta.mainProgram}
   '';
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/am/amdgpu_top/package.nix
+++ b/pkgs/by-name/am/amdgpu_top/package.nix
@@ -14,14 +14,14 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "amdgpu_top";
   version = "0.11.2";
 
   src = fetchFromGitHub {
     owner = "Umio-Yasuno";
     repo = "amdgpu_top";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-yw73bKO91O05WBQNwjcQ+AqxYgGXXC7XJzUnMx5/IWc=";
   };
 
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   postFixup = ''
-    patchelf --set-rpath "${lib.makeLibraryPath buildInputs}" $out/bin/${pname}
+    patchelf --set-rpath "${lib.makeLibraryPath finalAttrs.buildInputs}" $out/bin/${finalAttrs.pname}
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -62,4 +62,4 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.linux;
     mainProgram = "amdgpu_top";
   };
-}
+})

--- a/pkgs/by-name/an/ansi/package.nix
+++ b/pkgs/by-name/an/ansi/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ansi-escape-sequences-cli";
   version = "0.2.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-55CdEw1bVgabWRbZIRe9jytwDf70Y92nITwDRQaTXaQ=";
   };
 
@@ -26,4 +26,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ phip1611 ];
     mainProgram = "ansi";
   };
-}
+})

--- a/pkgs/by-name/ap/apkeep/package.nix
+++ b/pkgs/by-name/ap/apkeep/package.nix
@@ -6,12 +6,12 @@
   pkg-config,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "apkeep";
   version = "0.18.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Sk8CQaMXtPPJh2nGgGthyzuvkVViQ0jtqPjAqo2dtpg=";
   };
 
@@ -32,9 +32,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Command-line tool for downloading APK files from various sources";
     homepage = "https://github.com/EFForg/apkeep";
-    changelog = "https://github.com/EFForg/apkeep/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/EFForg/apkeep/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "apkeep";
   };
-}
+})

--- a/pkgs/by-name/as/asahi-bless/package.nix
+++ b/pkgs/by-name/as/asahi-bless/package.nix
@@ -4,17 +4,17 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-bless";
   version = "0.4.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-SNaA+CEuCBwo4c54qWGs5AdkBYb9IWY1cQ0dRd/noe8=";
   };
 
   cargoHash = "sha256-nfSJ9RkzFAWlxlfoUKk8ZmIXDJXoSyHCGgRgMy9FDkw=";
-  cargoDepsName = pname;
+  cargoDepsName = finalAttrs.pname;
 
   meta = {
     description = "Tool to select active boot partition on ARM Macs";
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "asahi-bless";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/as/asahi-btsync/package.nix
+++ b/pkgs/by-name/as/asahi-btsync/package.nix
@@ -4,17 +4,17 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-btsync";
   version = "0.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-jp05WcwY1cWh4mBQj+3jRCZoG32OhDvTB84hOAGemX8=";
   };
 
   cargoHash = "sha256-gGWhi0T7xDIsbzfw/KL3TSneLvQaiz/2xbpHeZt1i3I=";
-  cargoDepsName = pname;
+  cargoDepsName = finalAttrs.pname;
 
   meta = {
     description = "Tool to sync Bluetooth pairing keys with macos on ARM Macs";
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "asahi-btsync";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/as/asahi-nvram/package.nix
+++ b/pkgs/by-name/as/asahi-nvram/package.nix
@@ -4,17 +4,17 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-nvram";
   version = "0.2.3";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-zfUvPHAPrYhzgeiirGuqZaWnLBH0PHsqOUy2e972bWM=";
   };
 
   cargoHash = "sha256-NW/puo/Xoum7DjSQjBgilQcKbY3mAfVgXxUK6+1H1JI=";
-  cargoDepsName = pname;
+  cargoDepsName = finalAttrs.pname;
 
   meta = {
     description = "Tool to read and write nvram variables on ARM Macs";
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "asahi-nvram";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/as/asahi-wifisync/package.nix
+++ b/pkgs/by-name/as/asahi-wifisync/package.nix
@@ -4,17 +4,17 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asahi-wifisync";
   version = "0.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-wKd6rUUnegvl6cHODVQlllaOXuAGlmwx9gr73I/2l/c=";
   };
 
   cargoHash = "sha256-ZxgRxQyDID3mBpr8dhHScctk14Pm9V51Gn24d24JyVk=";
-  cargoDepsName = pname;
+  cargoDepsName = finalAttrs.pname;
 
   meta = {
     description = "Tool to sync Wifi passwords with macos on ARM Macs";
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "asahi-wifisync";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/as/asciinema-scenario/package.nix
+++ b/pkgs/by-name/as/asciinema-scenario/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "asciinema-scenario";
   version = "0.3.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-fnX5CIYLdFqi04PQPVIAYDGn+xXi016l8pPcIrYIhmQ=";
   };
 
@@ -21,4 +21,4 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     mainProgram = "asciinema-scenario";
   };
-}
+})

--- a/pkgs/by-name/au/authoscope/package.nix
+++ b/pkgs/by-name/au/authoscope/package.nix
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   postInstall = ''
-    installManPage docs/${finalAttrs.pname}.1
+    installManPage docs/authoscope.1
   '';
 
   # Tests requires access to httpin.org

--- a/pkgs/by-name/au/authoscope/package.nix
+++ b/pkgs/by-name/au/authoscope/package.nix
@@ -10,14 +10,14 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "authoscope";
   version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "kpcyrd";
     repo = "authoscope";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-SKgb/N249s0+Rb59moBT/MeFb4zAAElCMQJto0diyUk=";
   };
 
@@ -35,7 +35,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   postInstall = ''
-    installManPage docs/${pname}.1
+    installManPage docs/${finalAttrs.pname}.1
   '';
 
   # Tests requires access to httpin.org
@@ -46,8 +46,8 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Scriptable network authentication cracker";
     homepage = "https://github.com/kpcyrd/authoscope";
-    changelog = "https://github.com/kpcyrd/authoscope/releases/tag/v${version}";
+    changelog = "https://github.com/kpcyrd/authoscope/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ fab ];
   };
-}
+})

--- a/pkgs/by-name/ba/bao/package.nix
+++ b/pkgs/by-name/ba/bao/package.nix
@@ -4,13 +4,13 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bao";
   version = "0.13.1";
 
   src = fetchCrate {
-    inherit version;
-    pname = "${pname}_bin";
+    inherit (finalAttrs) version;
+    pname = "${finalAttrs.pname}_bin";
     hash = "sha256-8h5otpu3z2Hgy0jMCITJNr8Q4iVdlR5Lea2X+WuenWs=";
   };
 
@@ -26,4 +26,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "bao";
   };
-}
+})

--- a/pkgs/by-name/bk/bk/package.nix
+++ b/pkgs/by-name/bk/bk/package.nix
@@ -6,12 +6,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "bk";
   version = "0.6.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-rSMvx/zUZqRRgj48TVVG7RwQT8e70m0kertRJysDY4Y=";
   };
 
@@ -39,4 +39,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ vuimuich ];
     mainProgram = "bk";
   };
-}
+})

--- a/pkgs/by-name/bo/book-summary/package.nix
+++ b/pkgs/by-name/bo/book-summary/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "book-summary";
   version = "0.2.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-dxM6bqgHp4IaG03NriHvoT3al2u5Sz/I5ajlgzpjG1c=";
   };
 
@@ -21,4 +21,4 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/dvogt23/book-summary";
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/by-name/br/browsers/package.nix
+++ b/pkgs/by-name/br/browsers/package.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     mv $out/share/applications/software.Browsers.template.desktop $out/share/applications/software.Browsers.desktop
     substituteInPlace \
         $out/share/applications/software.Browsers.desktop \
-        --replace-fail 'Exec=€ExecCommand€' 'Exec=${finalAttrs.pname} %u'
+        --replace-fail 'Exec=€ExecCommand€' 'Exec=${finalAttrs.meta.mainProgram} %u'
     cp -r resources $out
     for size in 16 32 128 256 512; do
       install -m 444 \

--- a/pkgs/by-name/ca/cargo-all-features/package.nix
+++ b/pkgs/by-name/ca/cargo-all-features/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-all-features";
   version = "1.12.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-pD0lyI2zSOeEDk1Lch4Qf5mo8Z8Peiy2XF5iQ62vsaI=";
   };
 
@@ -31,4 +31,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-apk/package.nix
+++ b/pkgs/by-name/ca/cargo-apk/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-apk";
   version = "0.9.6";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-1vCrM+0SNefd7FrRXnSjLhM3/MSVJfcL4k1qAstX+/A=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [ nickcao ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-audit/package.nix
+++ b/pkgs/by-name/ca/cargo-audit/package.nix
@@ -7,12 +7,12 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-audit";
   version = "0.22.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Ha2yVyu9331NaqiW91NEwCTIeW+3XPiqZzmatN5KOws=";
   };
 
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage rec {
     description = "Audit Cargo.lock files for crates with security vulnerabilities";
     mainProgram = "cargo-audit";
     homepage = "https://rustsec.org";
-    changelog = "https://github.com/rustsec/rustsec/blob/cargo-audit/v${version}/cargo-audit/CHANGELOG.md";
+    changelog = "https://github.com/rustsec/rustsec/blob/cargo-audit/v${finalAttrs.version}/cargo-audit/CHANGELOG.md";
     license = with lib.licenses; [
       mit # or
       asl20
@@ -46,4 +46,4 @@ rustPlatform.buildRustPackage rec {
       jk
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-bazel/package.nix
+++ b/pkgs/by-name/ca/cargo-bazel/package.nix
@@ -6,12 +6,12 @@
   libz,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-bazel";
   version = "0.17.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-KWcxZxzDbiBfBpr37M6HoqHMCYXq6sTVxU9KR3PIiJc=";
   };
 
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ rickvanprim ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-binutils/package.nix
+++ b/pkgs/by-name/ca/cargo-binutils/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-binutils";
   version = "0.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-AF1MRBH8ULnHNHT2FS/LxMH+b06QMTIZMIR8mmkn17c=";
   };
 
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
       In order for this to work, you either need to run `rustup component add llvm-tools` or install the `llvm-tools` component using your Nix library (e.g. fenix or rust-overlay)
     '';
     homepage = "https://github.com/rust-embedded/cargo-binutils";
-    changelog = "https://github.com/rust-embedded/cargo-binutils/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/rust-embedded/cargo-binutils/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit
@@ -32,4 +32,4 @@ rustPlatform.buildRustPackage rec {
       newam
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-bolero/package.nix
+++ b/pkgs/by-name/ca/cargo-bolero/package.nix
@@ -8,12 +8,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-bolero";
   version = "0.13.4";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-lfBpHaY2UCBMg45S4IW8fcpkGkKJoT4qqR2yq5KiXuE=";
   };
 
@@ -36,4 +36,4 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ ekleog ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-c/package.nix
+++ b/pkgs/by-name/ca/cargo-c/package.nix
@@ -14,13 +14,13 @@ let
   # this version may need to be updated along with package version
   cargoVersion = "0.93.0";
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-c";
   version = "0.10.19";
 
   src = fetchCrate {
-    inherit pname;
-    version = "${version}+cargo-${cargoVersion}";
+    inherit (finalAttrs) pname;
+    version = "${finalAttrs.version}+cargo-${cargoVersion}";
     hash = "sha256-PrBmB+0tmU2MAUnRr+wx4g9hu0Y9i6WfR8U89bwiLVY=";
   };
 
@@ -63,11 +63,11 @@ rustPlatform.buildRustPackage rec {
       to be used by any C (and C-compatible) software.
     '';
     homepage = "https://github.com/lu-zero/cargo-c";
-    changelog = "https://github.com/lu-zero/cargo-c/releases/tag/v${version}";
+    changelog = "https://github.com/lu-zero/cargo-c/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       cpu
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-chef/package.nix
+++ b/pkgs/by-name/ca/cargo-chef/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-chef";
   version = "0.1.75";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-FETYJrx5+yNOzMVIgJQ0yNLi2PB7cA128n8hAXIhx3E=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ kkharji ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-cyclonedx/package.nix
+++ b/pkgs/by-name/ca/cargo-cyclonedx/package.nix
@@ -8,14 +8,14 @@
   curl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-cyclonedx";
   version = "0.5.7";
 
   src = fetchFromGitHub {
     owner = "CycloneDX";
     repo = "cyclonedx-rust-cargo";
-    rev = "${pname}-${version}";
+    rev = "${finalAttrs.pname}-${finalAttrs.version}";
     hash = "sha256-T/9eHI2P8eCZAqMTeZz1yEi5nljQWfHrdNiU3h3h74U=";
   };
 
@@ -49,4 +49,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ nikstur ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-cyclonedx/package.nix
+++ b/pkgs/by-name/ca/cargo-cyclonedx/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   src = fetchFromGitHub {
     owner = "CycloneDX";
     repo = "cyclonedx-rust-cargo";
-    rev = "${finalAttrs.pname}-${finalAttrs.version}";
+    rev = "cargo-cyclonedx-${finalAttrs.version}";
     hash = "sha256-T/9eHI2P8eCZAqMTeZz1yEi5nljQWfHrdNiU3h3h74U=";
   };
 

--- a/pkgs/by-name/ca/cargo-gra/package.nix
+++ b/pkgs/by-name/ca/cargo-gra/package.nix
@@ -4,12 +4,12 @@
   lib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-gra";
   version = "0.6.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-JbBcpp/E3WlQrwdxMsbSdmIEnDTQj/1XDwAWJsniRu0=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-hf2/package.nix
+++ b/pkgs/by-name/ca/cargo-hf2/package.nix
@@ -6,12 +6,12 @@
   libusb1,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-hf2";
   version = "0.3.3";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-0o3j7YfgNNnfbrv9Gppo24DqYlDCxhtsJHIhAV214DU=";
   };
 
@@ -28,4 +28,4 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ astrobeastie ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-license/package.nix
+++ b/pkgs/by-name/ca/cargo-license/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-license";
   version = "0.7.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-bOBrjChkQM6POZZn53JmJcIn1x+ygF5mthZihMskxIk=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-lock/package.nix
+++ b/pkgs/by-name/ca/cargo-lock/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-lock";
   version = "11.0.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Gz459c2IWD19RGBg2TyHbI/VNCelha+R0FeNkAaHksU=";
   };
 
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "Self-contained Cargo.lock parser with graph analysis";
     mainProgram = "cargo-lock";
     homepage = "https://github.com/rustsec/rustsec/tree/main/cargo-lock";
-    changelog = "https://github.com/rustsec/rustsec/blob/cargo-lock/v${version}/cargo-lock/CHANGELOG.md";
+    changelog = "https://github.com/rustsec/rustsec/blob/cargo-lock/v${finalAttrs.version}/cargo-lock/CHANGELOG.md";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-mommy/package.nix
+++ b/pkgs/by-name/ca/cargo-mommy/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-mommy";
   version = "0.3.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-2WR6xUYL/bLgZlI4ADbPAtdLq0y4MoVP8Loxdu/58Wc=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [ GoldsteinE ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-public-api/package.nix
+++ b/pkgs/by-name/ca/cargo-public-api/package.nix
@@ -7,12 +7,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-public-api";
   version = "0.51.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-fnkoIXv6QYJPYtsLZldOEjOxke6YVDEds3jF5SGZGKE=";
   };
 
@@ -32,8 +32,8 @@ rustPlatform.buildRustPackage rec {
     description = "List and diff the public API of Rust library crates between releases and commits. Detect breaking API changes and semver violations";
     mainProgram = "cargo-public-api";
     homepage = "https://github.com/Enselic/cargo-public-api";
-    changelog = "https://github.com/Enselic/cargo-public-api/releases/tag/v${version}";
+    changelog = "https://github.com/Enselic/cargo-public-api/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ matthiasbeyer ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-rail/package.nix
+++ b/pkgs/by-name/ca/cargo-rail/package.nix
@@ -7,12 +7,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-rail";
   version = "0.7.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-L8yh47lYvXVGOr8jDZ4Gk2rIfUnr88q9OR5/iDrJua0=";
   };
 
@@ -60,9 +60,9 @@ rustPlatform.buildRustPackage rec {
     description = "Graph-aware monorepo orchestration for Rust workspaces";
     mainProgram = "cargo-rail";
     homepage = "https://github.com/loadingalias/cargo-rail";
-    changelog = "https://github.com/loadingalias/cargo-rail/releases/tag/v${version}";
+    changelog = "https://github.com/loadingalias/cargo-rail/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ matthiasbeyer ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-run-bin/package.nix
+++ b/pkgs/by-name/ca/cargo-run-bin/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-run-bin";
   version = "1.7.4";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-79DJ6j2sai1dTdcXf0qD97TCNZuGRSUobLGahoApMss=";
   };
 
@@ -22,11 +22,11 @@ rustPlatform.buildRustPackage rec {
     description = "Build, cache, and run binaries scoped in Cargo.toml rather than installing globally. This acts similarly to npm run and gomodrun, and allows your teams to always be running the same tooling versions";
     mainProgram = "cargo-bin";
     homepage = "https://github.com/dustinblackman/cargo-run-bin";
-    changelog = "https://github.com/dustinblackman/cargo-run-bin/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/dustinblackman/cargo-run-bin/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       mightyiam
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-tally/package.nix
+++ b/pkgs/by-name/ca/cargo-tally/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-tally";
   version = "1.0.73";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-aYVo/mI4YoohwxXoIL9vpuPN526sPnQMV1PnUqJEO2U=";
   };
 
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     description = "Graph the number of crates that depend on your crate over time";
     mainProgram = "cargo-tally";
     homepage = "https://github.com/dtolnay/cargo-tally";
-    changelog = "https://github.com/dtolnay/cargo-tally/releases/tag/${version}";
+    changelog = "https://github.com/dtolnay/cargo-tally/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -28,4 +28,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-toml-lint/package.nix
+++ b/pkgs/by-name/ca/cargo-toml-lint/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-toml-lint";
   version = "0.1.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-U3y9gnFvkqJmyFqRAUQorJQY0iRzAE9UUXzFmgZIyaM=";
   };
 
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
     description = "Simple linter for Cargo.toml manifests";
     mainProgram = "cargo-toml-lint";
     homepage = "https://github.com/fuellabs/cargo-toml-lint";
-    changelog = "https://github.com/fuellabs/cargo-toml-lint/releases/tag/v${version}";
+    changelog = "https://github.com/fuellabs/cargo-toml-lint/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-ui/package.nix
+++ b/pkgs/by-name/ca/cargo-ui/package.nix
@@ -16,12 +16,12 @@
   libxcb,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-ui";
   version = "0.3.3";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-M/ljgtTHMSc7rY/a8CpKGNuOSdVDwRt6+tzPPHdpKOw=";
   };
 
@@ -64,7 +64,7 @@ rustPlatform.buildRustPackage rec {
     description = "GUI for Cargo";
     mainProgram = "cargo-ui";
     homepage = "https://github.com/slint-ui/cargo-ui";
-    changelog = "https://github.com/slint-ui/cargo-ui/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/slint-ui/cargo-ui/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       mit
       asl20
@@ -74,4 +74,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-unused-features/package.nix
+++ b/pkgs/by-name/ca/cargo-unused-features/package.nix
@@ -8,12 +8,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-unused-features";
   version = "0.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-gdwIbbQDw/DgBV9zY2Rk/oWjPv1SS/+oFnocsMo2Axo=";
   };
 
@@ -43,4 +43,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "unused-features";
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-update/package.nix
+++ b/pkgs/by-name/ca/cargo-update/package.nix
@@ -14,12 +14,12 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-update";
   version = "18.1.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-q7o9CPz9d4cBkrrnp2JY4CZiYkKx/ebVlrS4D34RbIo=";
   };
 
@@ -63,7 +63,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Cargo subcommand for checking and applying updates to installed executables";
     homepage = "https://github.com/nabijaczleweli/cargo-update";
-    changelog = "https://github.com/nabijaczleweli/cargo-update/releases/tag/v${version}";
+    changelog = "https://github.com/nabijaczleweli/cargo-update/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       gerschtli
@@ -71,4 +71,4 @@ rustPlatform.buildRustPackage rec {
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/ca/cargo-workspaces/package.nix
+++ b/pkgs/by-name/ca/cargo-workspaces/package.nix
@@ -8,12 +8,12 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo-workspaces";
   version = "0.4.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-/h7v5Wq7YsNMVzLHw3QQmcknbjARpI7HFPAUGX72wZ0=";
   };
 
@@ -41,7 +41,7 @@ rustPlatform.buildRustPackage rec {
       commands and more.
     '';
     homepage = "https://github.com/pksunkara/cargo-workspaces";
-    changelog = "https://github.com/pksunkara/cargo-workspaces/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/pksunkara/cargo-workspaces/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       macalinao
@@ -49,4 +49,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "cargo-workspaces";
   };
-}
+})

--- a/pkgs/by-name/ca/cargo2junit/package.nix
+++ b/pkgs/by-name/ca/cargo2junit/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cargo2junit";
   version = "0.1.13";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-R3a87nXCnGhdeyR7409hFR5Cj3TFUWqaLNOtlXPsvto=";
   };
 
@@ -26,4 +26,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ alekseysidorov ];
   };
-}
+})

--- a/pkgs/by-name/cf/cfonts/package.nix
+++ b/pkgs/by-name/cf/cfonts/package.nix
@@ -3,12 +3,12 @@
   rustPlatform,
   fetchCrate,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cfonts";
   version = "1.3.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-rgdqQzJyb1/bYB3S1MD/53vdQ+GaxOvGHuPE6dxMRB0=";
   };
 
@@ -21,4 +21,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ leifhelm ];
     mainProgram = "cfonts";
   };
-}
+})

--- a/pkgs/by-name/ch/changelogging/package.nix
+++ b/pkgs/by-name/ch/changelogging/package.nix
@@ -6,12 +6,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "changelogging";
   version = "0.7.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-orTUCBHacD0MQNfhOUWdh9RxT/9YNvgfCHFDr2eNQic=";
   };
 
@@ -25,10 +25,10 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "CLI tool for building changelogs from fragments";
     homepage = "https://github.com/nekitdev/changelogging";
-    changelog = "https://github.com/nekitdev/changelogging/releases/tag/v${version}";
+    changelog = "https://github.com/nekitdev/changelogging/releases/tag/v${finalAttrs.version}";
     platforms = lib.platforms.all;
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.nekitdev ];
     mainProgram = "changelogging";
   };
-}
+})

--- a/pkgs/by-name/ch/checkpwn/package.nix
+++ b/pkgs/by-name/ch/checkpwn/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "checkpwn";
   version = "0.5.6";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-M0Jb+8rKn4KVuumNSsM6JEbSOoBOFy9mmXiCnUnDgak=";
   };
 
@@ -23,9 +23,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Check Have I Been Pwned and see if it's time for you to change passwords";
     homepage = "https://github.com/brycx/checkpwn";
-    changelog = "https://github.com/brycx/checkpwn/releases/tag/${version}";
+    changelog = "https://github.com/brycx/checkpwn/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "checkpwn";
   };
-}
+})

--- a/pkgs/by-name/ch/cherrybomb/package.nix
+++ b/pkgs/by-name/ch/cherrybomb/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cherrybomb";
   version = "1.0.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-MHKBP102U1Ug9wZm9x4+opZgG8f6Hx03FvoLV4qaDgY=";
   };
 
@@ -19,8 +19,8 @@ rustPlatform.buildRustPackage rec {
     description = "CLI tool that helps you avoid undefined user behavior by validating your API specifications";
     mainProgram = "cherrybomb";
     homepage = "https://github.com/blst-security/cherrybomb";
-    changelog = "https://github.com/blst-security/cherrybomb/releases/tag/v${version}";
+    changelog = "https://github.com/blst-security/cherrybomb/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ci/citron/package.nix
+++ b/pkgs/by-name/ci/citron/package.nix
@@ -7,12 +7,12 @@
   pkg-config,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "citron";
   version = "0.15.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-6wJ4UfiwpV9zFuBR8SYj6eBiRqQitFs7wRe5R51Z3SA=";
   };
 
@@ -37,4 +37,4 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.linux;
     mainProgram = "citron";
   };
-}
+})

--- a/pkgs/by-name/cl/clang-tidy-sarif/package.nix
+++ b/pkgs/by-name/cl/clang-tidy-sarif/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
   versionCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clang-tidy-sarif";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-ALwEsF1n6WYqITfYTn8mIyn3sxTbDux17FxKIorKkFc=";
   };
 
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "clang-tidy-sarif";
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/by-name/cl/clini/package.nix
+++ b/pkgs/by-name/cl/clini/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clini";
   version = "0.1.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-+HnoYFRG7GGef5lV4CUsUzqPzFUzXDajprLu25SCMQo=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ Flakebi ];
     mainProgram = "clini";
   };
-}
+})

--- a/pkgs/by-name/cl/clippy-sarif/package.nix
+++ b/pkgs/by-name/cl/clippy-sarif/package.nix
@@ -6,12 +6,12 @@
   nix-update-script,
   versionCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "clippy-sarif";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-pqu7jIKksjn52benebICQEhgCW59MX+RRTcHm2ufjWE=";
   };
 
@@ -32,4 +32,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "clippy-sarif";
     inherit (clippy.meta) platforms;
   };
-}
+})

--- a/pkgs/by-name/co/colmena/package.nix
+++ b/pkgs/by-name/co/colmena/package.nix
@@ -12,14 +12,14 @@
   testers,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "colmena";
   version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "zhaofengli";
     repo = "colmena";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-01bfuSY4gnshhtqA1EJCw2CMsKkAx+dHS+sEpQ2+EAQ=";
   };
 
@@ -57,17 +57,17 @@ rustPlatform.buildRustPackage rec {
 
   passthru = {
     # We guarantee CLI and Nix API stability for the same minor version
-    apiVersion = builtins.concatStringsSep "." (lib.take 2 (lib.splitVersion version));
+    apiVersion = builtins.concatStringsSep "." (lib.take 2 (lib.splitVersion finalAttrs.version));
 
     tests.version = testers.testVersion { package = colmena; };
   };
 
   meta = {
     description = "Simple, stateless NixOS deployment tool";
-    homepage = "https://colmena.cli.rs/${passthru.apiVersion}";
+    homepage = "https://colmena.cli.rs/${finalAttrs.passthru.apiVersion}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ zhaofengli ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
     mainProgram = "colmena";
   };
-}
+})

--- a/pkgs/by-name/co/color-lsp/package.nix
+++ b/pkgs/by-name/co/color-lsp/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "color-lsp";
   version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "huacnlee";
     repo = "color-lsp";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-p58rAVznBzhBv7gVvaEjMpCrk9kFuEjUvY6U4uMXUE8=";
   };
 
@@ -37,4 +37,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "color-lsp";
   };
-}
+})

--- a/pkgs/by-name/cs/csv2svg/package.nix
+++ b/pkgs/by-name/cs/csv2svg/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "csv2svg";
   version = "0.1.9";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-3VebLFkeJLK97jqoPXt4Wt6QTR0Zyu+eQV9oaLBSeHE=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "csv2svg";
   };
-}
+})

--- a/pkgs/by-name/di/diffedit3/package.nix
+++ b/pkgs/by-name/di/diffedit3/package.nix
@@ -7,12 +7,12 @@
   diffedit3,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "diffedit3";
   version = "0.6.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-tlrP97XMAAnk5H5wTHPsP1DMSmDqV9wJp1n+22jUtnM=";
   };
 
@@ -32,4 +32,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "diffedit3";
     maintainers = with lib.maintainers; [ thoughtpolice ];
   };
-}
+})

--- a/pkgs/by-name/do/dotenvy/package.nix
+++ b/pkgs/by-name/do/dotenvy/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dotenvy";
   version = "0.15.7";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-virK/TpYBmwTf5UCQCqC/df8iKYAzPBfsQ1nQkFKF2Y=";
   };
 
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ phlip9 ];
   };
-}
+})

--- a/pkgs/by-name/do/dotslash/package.nix
+++ b/pkgs/by-name/do/dotslash/package.nix
@@ -7,12 +7,12 @@
   dotslash,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "dotslash";
   version = "0.5.7";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-VFesGum2xjknUuCwIojntdst5dmhvZb78ejJ2OG1FVI=";
   };
 
@@ -45,4 +45,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "dotslash";
     maintainers = with lib.maintainers; [ thoughtpolice ];
   };
-}
+})

--- a/pkgs/by-name/du/duckscript/package.nix
+++ b/pkgs/by-name/du/duckscript/package.nix
@@ -8,12 +8,12 @@
   libiconv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "duckscript_cli";
   version = "0.11.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-afxzZkmmYnprUBquH681VHMDs3Co9C71chNoKbu6lEY=";
   };
 
@@ -35,4 +35,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ mkg20001 ];
     mainProgram = "duck";
   };
-}
+})

--- a/pkgs/by-name/el/elf2uf2-rs/package.nix
+++ b/pkgs/by-name/el/elf2uf2-rs/package.nix
@@ -7,12 +7,12 @@
   udev,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "elf2uf2-rs";
   version = "2.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-e0i8ecjfNZxQgX5kDU1T8yAGUl4J7mbgG+ueBFsyTNA=";
   };
 
@@ -35,4 +35,4 @@ rustPlatform.buildRustPackage rec {
       moni
     ];
   };
-}
+})

--- a/pkgs/by-name/en/engage/package.nix
+++ b/pkgs/by-name/en/engage/package.nix
@@ -17,7 +17,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   env = {
-    ENGAGE_DOCS_LINK = "file://${placeholder "doc"}/share/doc/${finalAttrs.pname}/index.html";
+    ENGAGE_DOCS_LINK = "file://${placeholder "doc"}/share/doc/engage/index.html";
   };
 
   src = fetchFromGitLab {
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     ${lib.getExe mdbook} build
     mkdir -p "$doc/share/doc"
-    mv public "$doc/share/doc/${finalAttrs.pname}"
+    mv public "$doc/share/doc/engage"
   '';
 
   meta = {

--- a/pkgs/by-name/ev/eva/package.nix
+++ b/pkgs/by-name/ev/eva/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "eva";
   version = "0.3.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-eX2d9h6zNbheS68j3lyhJW05JZmQN2I2MdcmiZB8Mec=";
   };
 
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "eva";
   };
-}
+})

--- a/pkgs/by-name/ew/eww/package.nix
+++ b/pkgs/by-name/ew/eww/package.nix
@@ -13,7 +13,7 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "eww";
   version = "0.6.0-unstable-2025-06-30";
 
@@ -44,7 +44,7 @@ rustPlatform.buildRustPackage rec {
     "eww"
   ];
 
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   # requires unstable rust features
   env.RUSTC_BOOTSTRAP = 1;
@@ -76,4 +76,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "eww";
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/fa/faketty/package.nix
+++ b/pkgs/by-name/fa/faketty/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "faketty";
   version = "1.0.20";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-1AX2DBFOSUcORSQCo/5Vd8puE4hJU9VDfVqxcZDKrrY=";
   };
 
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Wrapper to execute a command in a pty, even if redirecting the output";
     homepage = "https://github.com/dtolnay/faketty";
-    changelog = "https://github.com/dtolnay/faketty/releases/tag/${version}";
+    changelog = "https://github.com/dtolnay/faketty/releases/tag/${finalAttrs.version}";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ figsoda ];
     mainProgram = "faketty";
   };
-}
+})

--- a/pkgs/by-name/fl/flowgger/package.nix
+++ b/pkgs/by-name/fl/flowgger/package.nix
@@ -7,12 +7,12 @@
   capnproto,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "flowgger";
   version = "0.3.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-eybahv1A/AIpAXGj6/md8k+b9fu9gSchU16fnAWZP2s=";
   };
 
@@ -38,4 +38,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "flowgger";
   };
-}
+})

--- a/pkgs/by-name/fo/fortanix-sgx-tools/package.nix
+++ b/pkgs/by-name/fo/fortanix-sgx-tools/package.nix
@@ -6,7 +6,7 @@
   openssl_3,
   protobuf,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "fortanix-sgx-tools";
   version = "0.6.1";
   nativeBuildInputs = [
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   ];
   buildInputs = [ openssl_3 ];
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-IVkmZs3imzj8uN8kqEzN/Oio3H+Nqzu8ORjARNx1TpQ=";
   };
 
@@ -27,4 +27,4 @@ rustPlatform.buildRustPackage rec {
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.mpl20;
   };
-}
+})

--- a/pkgs/by-name/fr/frawk/package.nix
+++ b/pkgs/by-name/fr/frawk/package.nix
@@ -15,12 +15,12 @@
 assert lib.assertMsg (
   !(lib.elem "default" features || lib.elem "llvm_backend" features)
 ) "LLVM support has been dropped due to LLVM 12 EOL.";
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "frawk";
   version = "0.4.8";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-wPnMJDx3aF1Slx5pjLfii366pgNU3FJBdznQLuUboYA=";
   };
 
@@ -51,11 +51,11 @@ rustPlatform.buildRustPackage rec {
     description = "Small programming language for writing short programs processing textual data";
     mainProgram = "frawk";
     homepage = "https://github.com/ezrosent/frawk";
-    changelog = "https://github.com/ezrosent/frawk/releases/tag/v${version}";
+    changelog = "https://github.com/ezrosent/frawk/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       mit # or
       asl20
     ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/fr/french-numbers/package.nix
+++ b/pkgs/by-name/fr/french-numbers/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "french-numbers";
   version = "1.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-6mcqT0RZddHlzjyZzx0JGTfCRcQ2UQ3Qlmk0VVNzsnI=";
   };
 
@@ -27,4 +27,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "french-numbers";
     maintainers = with lib.maintainers; [ samueltardieu ];
   };
-}
+})

--- a/pkgs/by-name/fu/furtherance/package.nix
+++ b/pkgs/by-name/fu/furtherance/package.nix
@@ -49,7 +49,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   ];
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-    patchelf $out/bin/${finalAttrs.pname} \
+    patchelf $out/bin/${finalAttrs.meta.mainProgram} \
       --add-rpath ${
         lib.makeLibraryPath [
           vulkan-loader

--- a/pkgs/by-name/ge/gel/package.nix
+++ b/pkgs/by-name/ge/gel/package.nix
@@ -14,19 +14,19 @@
   gel,
   testers,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gel";
   version = "7.10.2";
 
   src = fetchFromGitHub {
     owner = "geldata";
     repo = "gel-cli";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-Fy4J7puunqB5TeUsafnOotoWNvtTGiMJZ06YII14zIM=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     hash = "sha256-VRZjI8C0u+6MkQgzt0PApeUtrGR5UqvnLZxityMGnDo=";
   };
 
@@ -80,4 +80,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "gel";
   };
-}
+})

--- a/pkgs/by-name/ge/genemichaels/package.nix
+++ b/pkgs/by-name/ge/genemichaels/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "genemichaels";
   version = "0.9.5";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-KaGG2amPk/+fL7xLAfZw4SmCzXc+hS/9IkBG7G6sngI=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ djacu ];
     mainProgram = "genemichaels";
   };
-}
+})

--- a/pkgs/by-name/gh/gh-cal/package.nix
+++ b/pkgs/by-name/gh/gh-cal/package.nix
@@ -5,12 +5,12 @@
   pkg-config,
   openssl,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gh-cal";
   version = "0.1.3";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-x9DekflZoXxH964isWCi6YuV3v/iIyYOuRYVgKaUBx0=";
   };
 
@@ -26,4 +26,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ loicreynier ];
     mainProgram = "gh-cal";
   };
-}
+})

--- a/pkgs/by-name/gi/gitlab-timelogs/package.nix
+++ b/pkgs/by-name/gi/gitlab-timelogs/package.nix
@@ -8,12 +8,12 @@
   stdenv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gitlab-timelogs";
   version = "0.7.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-DNMJczR4yaglIOcNmb2E1g+UP0VeJaIb5TvdKUcWzc0=";
   };
 
@@ -37,11 +37,11 @@ rustPlatform.buildRustPackage rec {
       gitlab-timelogs is not associated with the official GitLab project!
     '';
     homepage = "https://github.com/phip1611/gitlab-timelogs";
-    changelog = "https://github.com/phip1611/gitlab-timelogs/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/phip1611/gitlab-timelogs/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [
       blitz
       phip1611
     ];
   };
-}
+})

--- a/pkgs/by-name/gl/globe-cli/package.nix
+++ b/pkgs/by-name/gl/globe-cli/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "globe-cli";
   version = "0.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Np1f/mSMIMZU3hE0Fur8bOHhOH3rZyroGiVAqfiIs7g=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ devhell ];
     mainProgram = "globe";
   };
-}
+})

--- a/pkgs/by-name/gp/gpustat/package.nix
+++ b/pkgs/by-name/gp/gpustat/package.nix
@@ -15,14 +15,14 @@
   makeWrapper,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "gpustat";
   version = "0.1.5";
 
   src = fetchFromGitHub {
     owner = "arduano";
     repo = "gpustat";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-M9P/qfw/tp9ogkNOE3b2fD2rGFnii1/VwmqJHqXb7Mg=";
   };
 
@@ -60,7 +60,7 @@ rustPlatform.buildRustPackage rec {
   # https://github.com/emilk/egui/issues/2486
   postFixup = ''
     wrapProgram $out/bin/gpustat \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath buildInputs}:/run/opengl-driver/lib"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath finalAttrs.buildInputs}:/run/opengl-driver/lib"
   '';
 
   meta = {
@@ -71,4 +71,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "gpustat";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/gr/grass-sass/package.nix
+++ b/pkgs/by-name/gr/grass-sass/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "grass";
   version = "0.13.4";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-uk4XLF0QsH9Nhz73PmdSpwhxPdCh+DlNNqtbJtLWgNI=";
   };
 
@@ -22,10 +22,10 @@ rustPlatform.buildRustPackage rec {
     description = "Sass compiler written purely in Rust";
     homepage = "https://github.com/connorskees/grass";
     changelog = "https://github.com/connorskees/grass/blob/master/CHANGELOG.md#${
-      lib.replaceStrings [ "." ] [ "" ] version
+      lib.replaceStrings [ "." ] [ "" ] finalAttrs.version
     }";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "grass";
   };
-}
+})

--- a/pkgs/by-name/ha/habitat/package.nix
+++ b/pkgs/by-name/ha/habitat/package.nix
@@ -11,14 +11,14 @@
   cacert,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "habitat";
   version = "1.6.1245";
 
   src = fetchFromGitHub {
     owner = "habitat-sh";
     repo = "habitat";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-n2ylJSCXPnnPHadfZaRS/3vxtnvkXhiTzCyObK7hmEk=";
   };
 
@@ -40,7 +40,7 @@ rustPlatform.buildRustPackage rec {
     "-p"
     "hab"
   ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   env = {
     OPENSSL_NO_VENDOR = true;
@@ -51,7 +51,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Application automation framework";
     homepage = "https://www.habitat.sh";
-    changelog = "https://github.com/habitat-sh/habitat/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/habitat-sh/habitat/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       rushmorem
@@ -60,4 +60,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "hab";
     platforms = [ "x86_64-linux" ];
   };
-}
+})

--- a/pkgs/by-name/ha/hadolint-sarif/package.nix
+++ b/pkgs/by-name/ha/hadolint-sarif/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
   versionCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hadolint-sarif";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-7xvo194lCQpDtLgwX6rZEkwG3hYTp5czjw4GrEaivsI=";
   };
 
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "hadolint-sarif";
   };
-}
+})

--- a/pkgs/by-name/ha/halloy/package.nix
+++ b/pkgs/by-name/ha/halloy/package.nix
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       desktopName = "Halloy";
       comment = "IRC client written in Rust";
       icon = "org.squidowl.halloy";
-      exec = finalAttrs.pname;
+      exec = finalAttrs.meta.mainProgram;
       terminal = false;
       mimeTypes = [
         "x-scheme-handler/irc"

--- a/pkgs/by-name/ha/halloy/package.nix
+++ b/pkgs/by-name/ha/halloy/package.nix
@@ -19,14 +19,14 @@
   alsa-lib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "halloy";
   version = "2026.2";
 
   src = fetchFromGitHub {
     owner = "squidowl";
     repo = "halloy";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-xx4r6vdUeh0yr986+Z67xtViQA7mMpsXmTohu3jIwMs=";
   };
 
@@ -58,7 +58,7 @@ rustPlatform.buildRustPackage rec {
       desktopName = "Halloy";
       comment = "IRC client written in Rust";
       icon = "org.squidowl.halloy";
-      exec = pname;
+      exec = finalAttrs.pname;
       terminal = false;
       mimeTypes = [
         "x-scheme-handler/irc"
@@ -99,11 +99,11 @@ rustPlatform.buildRustPackage rec {
     APP_DIR="$out/Applications/Halloy.app/Contents"
 
     mkdir -p "$APP_DIR/MacOS"
-    cp -r ${src}/assets/macos/Halloy.app/Contents/* "$APP_DIR"
+    cp -r ${finalAttrs.src}/assets/macos/Halloy.app/Contents/* "$APP_DIR"
 
     substituteInPlace "$APP_DIR/Info.plist" \
-      --replace-fail "{{ VERSION }}" "${version}" \
-      --replace-fail "{{ BUILD }}" "${version}-nixpkgs"
+      --replace-fail "{{ VERSION }}" "${finalAttrs.version}" \
+      --replace-fail "{{ BUILD }}" "${finalAttrs.version}-nixpkgs"
 
     makeWrapper "$out/bin/halloy" "$APP_DIR/MacOS/halloy"
   '';
@@ -113,7 +113,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "IRC application";
     homepage = "https://github.com/squidowl/halloy";
-    changelog = "https://github.com/squidowl/halloy/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/squidowl/halloy/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       fab
@@ -122,4 +122,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "halloy";
   };
-}
+})

--- a/pkgs/by-name/ha/hayagriva/package.nix
+++ b/pkgs/by-name/ha/hayagriva/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hayagriva";
   version = "0.9.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-9PGo/TPk5QuiVoa5wUGyHufW/VaxqhinxS+u2JMPZBY=";
   };
 
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Work with references: Literature database management, storage, and citation formatting";
     homepage = "https://github.com/typst/hayagriva";
-    changelog = "https://github.com/typst/hayagriva/releases/tag/v${version}";
+    changelog = "https://github.com/typst/hayagriva/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20
       mit
@@ -37,4 +37,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "hayagriva";
   };
-}
+})

--- a/pkgs/by-name/hu/huniq/package.nix
+++ b/pkgs/by-name/hu/huniq/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "huniq";
   version = "2.7.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-5GvHM05qY/Jj1mPYwn88Zybn6Nn5nJIaw0XP8iCcrwE=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.bsd3;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/hv/hvm/package.nix
+++ b/pkgs/by-name/hv/hvm/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "hvm";
   version = "2.0.22";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-AD8mv47m4E6H8BVkxTExyhrR7VEnuB/KxnRl2puPnX4=";
   };
 
@@ -28,4 +28,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/i3/i3-open-next-ws/package.nix
+++ b/pkgs/by-name/i3/i3-open-next-ws/package.nix
@@ -3,12 +3,12 @@
   rustPlatform,
   fetchCrate,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "i3-open-next-ws";
   version = "0.1.5";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-eYHCm8jEv6Ll6/h1kcYHNxWGnVWI41ZB96Jec9oZFsY=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ quantenzitrone ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/in/inputplug/package.nix
+++ b/pkgs/by-name/in/inputplug/package.nix
@@ -8,12 +8,12 @@
   stdenv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "inputplug";
   version = "0.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-8Gy0h0QMcittnjuKm+atIJNsY2d6Ua29oab4fkUU+wE=";
   };
 
@@ -40,4 +40,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ jecaro ];
     mainProgram = "inputplug";
   };
-}
+})

--- a/pkgs/by-name/jf/jfmt/package.nix
+++ b/pkgs/by-name/jf/jfmt/package.nix
@@ -4,14 +4,14 @@
   fetchFromGitHub,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "jfmt";
   version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "scruffystuffs";
-    repo = "${pname}.rs";
-    rev = "v${version}";
+    repo = "${finalAttrs.pname}.rs";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-X3wk669G07BTPAT5xGbAfIu2Qk90aaJIi1CLmOnSG80=";
   };
 
@@ -21,8 +21,8 @@ rustPlatform.buildRustPackage rec {
     description = "CLI utility to format json files";
     mainProgram = "jfmt";
     homepage = "https://github.com/scruffystuffs/jfmt.rs";
-    changelog = "https://github.com/scruffystuffs/jfmt.rs/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/scruffystuffs/jfmt.rs/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.psibi ];
   };
-}
+})

--- a/pkgs/by-name/jf/jfmt/package.nix
+++ b/pkgs/by-name/jf/jfmt/package.nix
@@ -10,7 +10,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchFromGitHub {
     owner = "scruffystuffs";
-    repo = "${finalAttrs.pname}.rs";
+    repo = "jfmt.rs";
     rev = "v${finalAttrs.version}";
     hash = "sha256-X3wk669G07BTPAT5xGbAfIu2Qk90aaJIi1CLmOnSG80=";
   };

--- a/pkgs/by-name/ju/just-formatter/package.nix
+++ b/pkgs/by-name/ju/just-formatter/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "just-formatter";
   version = "1.1.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-HTv55WquFieWmkEKX5sbBOVyYxzjcB/NrMkxbQsff90=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ vuimuich ];
     mainProgram = "just-formatter";
   };
-}
+})

--- a/pkgs/by-name/ke/keepass-diff/package.nix
+++ b/pkgs/by-name/ke/keepass-diff/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "keepass-diff";
   version = "1.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-CqLH5Dosp26YfqgOVcZilfo5svAEv+pAbi1zebGMnb4=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ wamserma ];
     mainProgram = "keepass-diff";
   };
-}
+})

--- a/pkgs/by-name/ki/kind2/package.nix
+++ b/pkgs/by-name/ki/kind2/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "kind2";
   version = "0.3.10";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-X2sjfYrSSym289jDJV3hNmcwyQCMnrabmGCUKD5wfdY=";
   };
 
@@ -32,4 +32,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/kr/krabby/package.nix
+++ b/pkgs/by-name/kr/krabby/package.nix
@@ -3,12 +3,12 @@
   rustPlatform,
   fetchCrate,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "krabby";
   version = "0.3.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-UcvCIazuVoqYb4iz62MrOVtQli4EqzrEpg3imv3sXHY=";
   };
 
@@ -17,9 +17,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Print pokemon sprites in your terminal";
     homepage = "https://github.com/yannjor/krabby";
-    changelog = "https://github.com/yannjor/krabby/releases/tag/v${version}";
+    changelog = "https://github.com/yannjor/krabby/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3;
     maintainers = with lib.maintainers; [ ruby0b ];
     mainProgram = "krabby";
   };
-}
+})

--- a/pkgs/by-name/le/lemmeknow/package.nix
+++ b/pkgs/by-name/le/lemmeknow/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lemmeknow";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Q82tP4xNWAooFjHeJCFmuULnWlFbgca/9Y2lm8rVXKs=";
   };
 
@@ -18,9 +18,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Tool to identify anything";
     homepage = "https://github.com/swanandx/lemmeknow";
-    changelog = "https://github.com/swanandx/lemmeknow/releases/tag/v${version}";
+    changelog = "https://github.com/swanandx/lemmeknow/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "lemmeknow";
   };
-}
+})

--- a/pkgs/by-name/li/license-generator/package.nix
+++ b/pkgs/by-name/li/license-generator/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "license-generator";
   version = "1.3.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-jp7NQfDh512oThZbLj0NbqcH7rxV2R0kDv1wsiTNf/M=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ loicreynier ];
     mainProgram = "license-generator";
   };
-}
+})

--- a/pkgs/by-name/lo/loco/package.nix
+++ b/pkgs/by-name/lo/loco/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
   nix-update-script,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "loco";
   version = "0.16.3";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-DdrLABMiTutIhUHvUw29DYZIT+YHLNJjoTT5kWMeAkU=";
   };
 
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ sebrut ];
     mainProgram = "loco";
   };
-}
+})

--- a/pkgs/by-name/ls/lscolors/package.nix
+++ b/pkgs/by-name/ls/lscolors/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "lscolors";
   version = "0.21.0";
 
   src = fetchCrate {
-    inherit version pname;
+    inherit (finalAttrs) version pname;
     hash = "sha256-75RE72Vy4HRRjwa7qOybnUAzxxhBUKSlKfrLrm6Ish8=";
   };
 
@@ -23,7 +23,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Rust library and tool to colorize paths using LS_COLORS";
     homepage = "https://github.com/sharkdp/lscolors";
-    changelog = "https://github.com/sharkdp/lscolors/releases/tag/v${version}";
+    changelog = "https://github.com/sharkdp/lscolors/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -31,4 +31,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "lscolors";
   };
-}
+})

--- a/pkgs/by-name/md/mdbook-katex/package.nix
+++ b/pkgs/by-name/md/mdbook-katex/package.nix
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   meta = {
     description = "Preprocessor for mdbook, rendering LaTeX equations to HTML at build time";
     mainProgram = "mdbook-katex";
-    homepage = "https://github.com/lzanini/${finalAttrs.pname}";
+    homepage = "https://github.com/lzanini/mdbook-katex";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       lovesegfault

--- a/pkgs/by-name/md/mdbook-katex/package.nix
+++ b/pkgs/by-name/md/mdbook-katex/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdbook-katex";
   version = "0.9.4";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-xwIW8igfxO9vsck8ktDBc7XFLuYzwqI3I4nLDTYC8JI=";
   };
 
@@ -18,11 +18,11 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Preprocessor for mdbook, rendering LaTeX equations to HTML at build time";
     mainProgram = "mdbook-katex";
-    homepage = "https://github.com/lzanini/${pname}";
+    homepage = "https://github.com/lzanini/${finalAttrs.pname}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [
       lovesegfault
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/md/mdbook-pdf/package.nix
+++ b/pkgs/by-name/md/mdbook-pdf/package.nix
@@ -6,12 +6,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdbook-pdf";
   version = "0.1.13";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-aADHRlIVWVc43DEfZx8ha/E4FaiAoKtjHccx+LAghtU=";
   };
 
@@ -35,11 +35,11 @@ rustPlatform.buildRustPackage rec {
     description = "Backend for mdBook written in Rust for generating PDF";
     mainProgram = "mdbook-pdf";
     homepage = "https://github.com/HollowMan6/mdbook-pdf";
-    changelog = "https://github.com/HollowMan6/mdbook-pdf/releases/tag/v${version}";
+    changelog = "https://github.com/HollowMan6/mdbook-pdf/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       hollowman6
       matthiasbeyer
     ];
   };
-}
+})

--- a/pkgs/by-name/md/mdevctl/package.nix
+++ b/pkgs/by-name/md/mdevctl/package.nix
@@ -7,12 +7,12 @@
   udevCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mdevctl";
   version = "1.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Zh+Dj3X87tTpqT/weZMpf7f3obqikjPy9pi50ifp6wQ=";
   };
 
@@ -49,4 +49,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ edwtjo ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/me/meow/package.nix
+++ b/pkgs/by-name/me/meow/package.nix
@@ -5,13 +5,13 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "meow";
   version = "2.1.5";
 
   src = fetchCrate {
-    inherit version;
-    crateName = "${pname}-cli";
+    inherit (finalAttrs) version;
+    crateName = "${finalAttrs.pname}-cli";
     sha256 = "sha256-6tf4/KRZj+1zlxnNgz3kw/HYR2QKg0kEwu+TbKah3e8=";
   };
 
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "meow";
     maintainers = with lib.maintainers; [ pixelsergey ];
   };
-}
+})

--- a/pkgs/by-name/mo/movine/package.nix
+++ b/pkgs/by-name/mo/movine/package.nix
@@ -6,12 +6,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "movine";
   version = "0.11.4";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-wa2GfV2Y8oX8G+1LbWnb2KH/+QbUYL9GXgOOVHpzbN8=";
   };
 
@@ -49,4 +49,4 @@ rustPlatform.buildRustPackage rec {
     '';
     maintainers = with lib.maintainers; [ netcrns ];
   };
-}
+})

--- a/pkgs/by-name/ne/nethoscope/package.nix
+++ b/pkgs/by-name/ne/nethoscope/package.nix
@@ -36,7 +36,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    if [[ "$(${expect}/bin/unbuffer "$out/bin/${finalAttrs.pname}" --help 2> /dev/null | strings | grep ${finalAttrs.version} | tr -d '\n')" == " ${finalAttrs.version}" ]]; then
+    if [[ "$(${expect}/bin/unbuffer "$out/bin/${finalAttrs.meta.mainProgram}" --help 2> /dev/null | strings | grep ${finalAttrs.version} | tr -d '\n')" == " ${finalAttrs.version}" ]]; then
       echo '${finalAttrs.pname} smoke check passed'
     else
       echo '${finalAttrs.pname} smoke check failed'

--- a/pkgs/by-name/ne/nethoscope/package.nix
+++ b/pkgs/by-name/ne/nethoscope/package.nix
@@ -8,14 +8,14 @@
   expect,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nethoscope";
   version = "0.1.1";
 
   src = fetchFromGitHub {
     owner = "vvilhonen";
     repo = "nethoscope";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-v7GO+d4b0N3heN10+WSUJEpcShKmx4BPR1FyZoELWzc=";
   };
 
@@ -36,10 +36,10 @@ rustPlatform.buildRustPackage rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    if [[ "$(${expect}/bin/unbuffer "$out/bin/${pname}" --help 2> /dev/null | strings | grep ${version} | tr -d '\n')" == " ${version}" ]]; then
-      echo '${pname} smoke check passed'
+    if [[ "$(${expect}/bin/unbuffer "$out/bin/${finalAttrs.pname}" --help 2> /dev/null | strings | grep ${finalAttrs.version} | tr -d '\n')" == " ${finalAttrs.version}" ]]; then
+      echo '${finalAttrs.pname} smoke check passed'
     else
-      echo '${pname} smoke check failed'
+      echo '${finalAttrs.pname} smoke check failed'
       return 1
     fi
   '';
@@ -57,4 +57,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "nethoscope";
   };
 
-}
+})

--- a/pkgs/by-name/nf/nflz/package.nix
+++ b/pkgs/by-name/nf/nflz/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nflz";
   version = "1.0.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-c9+79zrIU/M1Rh+DiaLJzbrNSa4IKrYk1gP0dsabUiw=";
   };
 
@@ -33,4 +33,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ phip1611 ];
     mainProgram = "nflz";
   };
-}
+})

--- a/pkgs/by-name/ni/nix-template/package.nix
+++ b/pkgs/by-name/ni/nix-template/package.nix
@@ -10,15 +10,15 @@
   pkg-config,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nix-template";
   version = "0.4.1";
 
   src = fetchFromGitHub {
-    name = "${pname}-${version}-src";
+    name = "${finalAttrs.pname}-${finalAttrs.version}-src";
     owner = "jonringer";
     repo = "nix-template";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     sha256 = "sha256-42u5FmTIKHpfQ2zZQXIrFkAN2/XvU0wWnCRrQkQzcNI=";
   };
 
@@ -48,9 +48,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Make creating nix expressions easy";
     homepage = "https://github.com/jonringer/nix-template/";
-    changelog = "https://github.com/jonringer/nix-template/releases/tag/v${version}";
+    changelog = "https://github.com/jonringer/nix-template/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.cc0;
     maintainers = [ ];
     mainProgram = "nix-template";
   };
-}
+})

--- a/pkgs/by-name/oc/oculante/package.nix
+++ b/pkgs/by-name/oc/oculante/package.nix
@@ -21,7 +21,7 @@
   wrapGAppsHook3,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "oculante";
   version = "0.9.2.1-unstable-2025-10-08";
 
@@ -76,7 +76,7 @@ rustPlatform.buildRustPackage rec {
 
   patchFlags = [
     "-p1"
-    "--directory=../${pname}-${version}-vendor"
+    "--directory=../${finalAttrs.pname}-${finalAttrs.version}-vendor"
   ];
 
   postInstall = ''
@@ -98,11 +98,11 @@ rustPlatform.buildRustPackage rec {
     broken = stdenv.hostPlatform.isDarwin;
     description = "Minimalistic crossplatform image viewer written in Rust";
     homepage = "https://github.com/woelper/oculante";
-    changelog = "https://github.com/woelper/oculante/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/woelper/oculante/blob/${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     mainProgram = "oculante";
     maintainers = with lib.maintainers; [
       dit7ya
     ];
   };
-}
+})

--- a/pkgs/by-name/ov/overlayed/package.nix
+++ b/pkgs/by-name/ov/overlayed/package.nix
@@ -17,14 +17,14 @@
   openssl,
   webkitgtk_4_1,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "overlayed";
   version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "overlayeddev";
     repo = "overlayed";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-3GFg8czBf1csojXUNC51xFXJnGuXltP6D46fCt6q24I=";
   };
 
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-6wN4nZQWrY0J5E+auj17B3iJ/84hzBXYA/bJsX/N5pk=";
 
   pnpmDeps = fetchPnpmDeps {
-    inherit pname version src;
+    inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
     fetcherVersion = 3;
     hash = "sha256-KJZuucXB7BEMnqPmgytveG/IBEzq4mgMo9ZJHPe/gVs=";
@@ -73,10 +73,10 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Modern discord voice chat overlay";
     homepage = "https://github.com/overlayeddev/overlayed";
-    changelog = "https://github.com/overlayeddev/overlayed/releases/tag/v${version}";
+    changelog = "https://github.com/overlayeddev/overlayed/releases/tag/v${finalAttrs.version}";
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ bot-wxt1221 ];
     license = lib.licenses.agpl3Plus;
     mainProgram = "overlayed";
   };
-}
+})

--- a/pkgs/by-name/pa/paging-calculator/package.nix
+++ b/pkgs/by-name/pa/paging-calculator/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "paging-calculator";
   version = "0.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-mTHBARrcq8cJxzh80v/fGr5vACAMyy/DhN8zpQTV0jM=";
   };
 
@@ -26,8 +26,8 @@ rustPlatform.buildRustPackage rec {
       which level of the page table.
     '';
     homepage = "https://github.com/phip1611/paging-calculator";
-    changelog = "https://github.com/phip1611/paging-calculator/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/phip1611/paging-calculator/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ phip1611 ];
   };
-}
+})

--- a/pkgs/by-name/pa/panamax/package.nix
+++ b/pkgs/by-name/pa/panamax/package.nix
@@ -8,12 +8,12 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "panamax";
   version = "1.0.14";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-gIgw6JMGpHNXE/PZoz3jRdmjIWy4hETYf24Nd7/Jr/g=";
   };
 
@@ -37,4 +37,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/pe/perseus-cli/package.nix
+++ b/pkgs/by-name/pe/perseus-cli/package.nix
@@ -6,12 +6,12 @@
   wasm-pack,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "perseus-cli";
   version = "0.3.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-IYjLx9/4oWSXa4jhOtGw1GOHmrR7LQ6bWyN5zbOuEFs=";
   };
 
@@ -31,4 +31,4 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     mainProgram = "perseus";
   };
-}
+})

--- a/pkgs/by-name/pi/pijul/package.nix
+++ b/pkgs/by-name/pi/pijul/package.nix
@@ -12,12 +12,12 @@
   libgit2 ? null,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pijul";
   version = "1.0.0-beta.9";
 
   src = fetchCrate {
-    inherit version pname;
+    inherit (finalAttrs) version pname;
     hash = "sha256-jy0mzgLw9iWuoWe2ictMTL3cHnjJ5kzs6TAK+pdm28g=";
   };
 
@@ -55,4 +55,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "pijul";
   };
-}
+})

--- a/pkgs/by-name/pi/pipe-rename/package.nix
+++ b/pkgs/by-name/pi/pipe-rename/package.nix
@@ -5,12 +5,12 @@
   python3,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pipe-rename";
   version = "1.6.6";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-eZldAhqmoIkNZaI6r31hI43KCPDDeWk3fKpY3/BaUQE=";
   };
 
@@ -35,4 +35,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "renamer";
   };
-}
+})

--- a/pkgs/by-name/pr/preserves-tools/package.nix
+++ b/pkgs/by-name/pr/preserves-tools/package.nix
@@ -6,12 +6,12 @@
   installShellFiles,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "preserves-tools";
   version = "4.996.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Uyh5mXCypX3TDxxJtnTe6lBoVI8aqdG56ywn7htDGUY=";
   };
 
@@ -31,4 +31,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.asl20;
     mainProgram = "preserves-tool";
   };
-}
+})

--- a/pkgs/by-name/pr/probe-rs-tools/package.nix
+++ b/pkgs/by-name/pr/probe-rs-tools/package.nix
@@ -16,20 +16,20 @@ let
     hash = "sha256-yjxld5ebm2jpfyzkw+vngBfHu5Nfh2ioLUKQQDY4KYo=";
   };
 in
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "probe-rs-tools";
   version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "probe-rs";
     repo = "probe-rs";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ZcH2FBKsbBtTYfRQgPfOOODDpyB7VydcO7F7pq8xzD0=";
   };
 
   cargoHash = "sha256-fVmwZw34lK6eKkqNT/SW5wzeeyWg6Qp48eso6yibICE=";
 
-  buildAndTestSubdir = pname;
+  buildAndTestSubdir = finalAttrs.pname;
 
   nativeBuildInputs = [
     # required by libz-sys, no option for dynamic linking
@@ -76,7 +76,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "CLI tool for on-chip debugging and flashing of ARM chips";
     homepage = "https://probe.rs/";
-    changelog = "https://github.com/probe-rs/probe-rs/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/probe-rs/probe-rs/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -86,4 +86,4 @@ rustPlatform.buildRustPackage rec {
       newam
     ];
   };
-}
+})

--- a/pkgs/by-name/pr/process-viewer/package.nix
+++ b/pkgs/by-name/pr/process-viewer/package.nix
@@ -6,12 +6,12 @@
   gtk4,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "process-viewer";
   version = "0.5.8";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-mEmtLCtHlrCurjKKJ3vEtEkLBik4LwuUED5UeQ1QLws=";
   };
 
@@ -34,4 +34,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ lib.maintainers.matthiasbeyer ];
     mainProgram = "process_viewer";
   };
-}
+})

--- a/pkgs/by-name/pr/prometheus-wireguard-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-wireguard-exporter/package.nix
@@ -7,14 +7,14 @@
   nixosTests,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wireguard-exporter";
   version = "3.6.6";
 
   src = fetchFromGitHub {
     owner = "MindFlavor";
     repo = "prometheus_wireguard_exporter";
-    rev = version;
+    rev = finalAttrs.version;
     sha256 = "sha256-2e31ZuGJvpvu7L2Lb+n6bZWpC1JhETzEzSiNaxxsAtA=";
   };
 
@@ -41,4 +41,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "prometheus_wireguard_exporter";
   };
-}
+})

--- a/pkgs/by-name/pr/protoc-gen-prost-crate/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost-crate/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "protoc-gen-prost-crate";
   version = "0.5.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-FBgvDhlyVAegF5n9U6Tunn+MpXdek4f1xWIS3sJ4soI=";
   };
 
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage rec {
       sitaaax
     ];
   };
-}
+})

--- a/pkgs/by-name/pr/protoc-gen-prost-serde/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost-serde/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "protoc-gen-prost-serde";
   version = "0.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-tgsGyUVoQZQcOqh56KGVwS3VcxwbKzBL3P2VpYs72Ok=";
   };
 
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage rec {
       sitaaax
     ];
   };
-}
+})

--- a/pkgs/by-name/pr/protoc-gen-prost/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-prost/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "protoc-gen-prost";
   version = "0.5.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-oeoPQ3hYMQl6sXszpnw6er2HBkxpo4s17XjR0VRKrSA=";
   };
 
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage rec {
       sitaaax
     ];
   };
-}
+})

--- a/pkgs/by-name/pr/protoc-gen-tonic/package.nix
+++ b/pkgs/by-name/pr/protoc-gen-tonic/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "protoc-gen-tonic";
   version = "0.5.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-F3AVlkyIbSaA6u7/Pm6qM9AuONddSwqcCU6OAHoVwxk=";
   };
 
@@ -29,4 +29,4 @@ rustPlatform.buildRustPackage rec {
       sitaaax
     ];
   };
-}
+})

--- a/pkgs/by-name/pr/protox/package.nix
+++ b/pkgs/by-name/pr/protox/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "protox";
   version = "0.9.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-3Bh+VDSsol2Pz3UVDSxx8KNJbzKParU/OoNcSNgVTJM=";
   };
 
@@ -24,11 +24,11 @@ rustPlatform.buildRustPackage rec {
     description = "Rust implementation of the protobuf compiler";
     mainProgram = "protox";
     homepage = "https://github.com/andrewhickman/protox";
-    changelog = "https://github.com/andrewhickman/protox/blob/${version}/CHANGELOG.md";
+    changelog = "https://github.com/andrewhickman/protox/blob/${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20
       mit
     ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/pu/pulldown-cmark/package.nix
+++ b/pkgs/by-name/pu/pulldown-cmark/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "pulldown-cmark";
   version = "0.13.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-iQjA2mt1l0mP8yevWwjrfN/u9FXBnIv+ObjMSOsqlhw=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ CobaltCause ];
     mainProgram = "pulldown-cmark";
   };
-}
+})

--- a/pkgs/by-name/ra/rav1e/package.nix
+++ b/pkgs/by-name/ra/rav1e/package.nix
@@ -11,12 +11,12 @@
   rav1e,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rav1e";
   version = "0.8.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-GCfh2v3w5C8h4GuPKkTMUAhPspT1W0drrRpELCJWeTI=";
   };
 
@@ -64,9 +64,9 @@ rustPlatform.buildRustPackage rec {
       Features: https://github.com/xiph/rav1e#features
     '';
     homepage = "https://github.com/xiph/rav1e";
-    changelog = "https://github.com/xiph/rav1e/releases/tag/v${version}";
+    changelog = "https://github.com/xiph/rav1e/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.bsd2;
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "rav1e";
   };
-}
+})

--- a/pkgs/by-name/ra/ravedude/package.nix
+++ b/pkgs/by-name/ra/ravedude/package.nix
@@ -12,12 +12,12 @@
   stdenv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ravedude";
   version = "0.2.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Ar2oQx7dKKfzkM3FMcJXiPHxNa0KcMRht38q+NgowfU=";
   };
 
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
     updateScript = nix-update-script { };
     tests.version = testers.testVersion {
       package = ravedude;
-      version = "v${version}";
+      version = "v${finalAttrs.version}";
     };
   };
 
@@ -56,4 +56,4 @@ rustPlatform.buildRustPackage rec {
     ];
     mainProgram = "ravedude";
   };
-}
+})

--- a/pkgs/by-name/rc/rclone-ui/package.nix
+++ b/pkgs/by-name/rc/rclone-ui/package.nix
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src-tauri/tauri.conf.json \
-      --replace-fail '"mainBinaryName": "Rclone UI"' '"mainBinaryName": "${finalAttrs.pname}"'
+      --replace-fail '"mainBinaryName": "Rclone UI"' '"mainBinaryName": "${finalAttrs.meta.mainProgram}"'
     substituteInPlace src-tauri/Cargo.toml \
        --replace-fail 'name = "app"' 'name = "${finalAttrs.pname}"'
   '';

--- a/pkgs/by-name/re/regex-cli/package.nix
+++ b/pkgs/by-name/re/regex-cli/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "regex-cli";
   version = "0.2.3";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-ytI1C2QRUfInIChwtSaHze7VJnP9UIcO93e2wjz2/I0=";
   };
 
@@ -28,4 +28,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [ mdaniels5757 ];
   };
-}
+})

--- a/pkgs/by-name/re/reshape/package.nix
+++ b/pkgs/by-name/re/reshape/package.nix
@@ -6,12 +6,12 @@
   postgresql,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "reshape";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-viS//3ZFqogI0BbZ0rypo5zpQUgqKiLgK585iw3BMgM=";
   };
 
@@ -34,8 +34,8 @@ rustPlatform.buildRustPackage rec {
     description = "Easy-to-use, zero-downtime schema migration tool for Postgres";
     mainProgram = "reshape";
     homepage = "https://github.com/fabianlindfors/reshape";
-    changelog = "https://github.com/fabianlindfors/reshape/releases/tag/v${version}";
+    changelog = "https://github.com/fabianlindfors/reshape/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ilyakooo0 ];
   };
-}
+})

--- a/pkgs/by-name/re/restic-browser/package.nix
+++ b/pkgs/by-name/re/restic-browser/package.nix
@@ -14,22 +14,22 @@
   nix-update-script,
   restic,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "restic-browser";
   version = "0.3.3";
 
   src = fetchFromGitHub {
     owner = "emuell";
     repo = "restic-browser";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-K8JEt1kOvu/G3S1O6W/ee2JM968bgPR/FeGaBKP6elU=";
   };
 
   cargoHash = "sha256-/EgSr46mJV84s/MG/3nUnU6XQ8RtEWiWo0gFtegblEQ=";
 
   npmDeps = fetchNpmDeps {
-    name = "${pname}-npm-deps-${version}";
-    inherit src;
+    name = "${finalAttrs.pname}-npm-deps-${finalAttrs.version}";
+    inherit (finalAttrs) src;
     hash = "sha256-uyn5cXMKm7+LLuF+n94pBTypLiPvfAs5INDEtd9cHs0=";
   };
 
@@ -51,11 +51,11 @@ rustPlatform.buildRustPackage rec {
   ];
 
   cargoRoot = "src-tauri";
-  buildAndTestSubdir = cargoRoot;
+  buildAndTestSubdir = finalAttrs.cargoRoot;
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/bin
-    ln -s $out/Applications/Restic-Browser.app/Contents/MacOS/Restic-Browser $out/bin/${meta.mainProgram}
+    ln -s $out/Applications/Restic-Browser.app/Contents/MacOS/Restic-Browser $out/bin/${finalAttrs.meta.mainProgram}
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -63,10 +63,10 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "GUI to browse and restore restic backup repositories";
     homepage = "https://github.com/emuell/restic-browser";
-    changelog = "https://github.com/emuell/restic-browser/releases/tag/v${version}";
+    changelog = "https://github.com/emuell/restic-browser/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ js6pak ];
     mainProgram = "restic-browser";
     platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
-}
+})

--- a/pkgs/by-name/rs/rsign2/package.nix
+++ b/pkgs/by-name/rs/rsign2/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rsign2";
   version = "0.6.5";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-cjucecEg5ERPsiaDuGESf2u9RTYHpQmHwWPnx1ask0I=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "rsign";
   };
-}
+})

--- a/pkgs/by-name/rs/rsonpath/package.nix
+++ b/pkgs/by-name/rs/rsonpath/package.nix
@@ -5,7 +5,7 @@
   unstableGitUpdater,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rsonpath";
   version = "0.9.1-unstable-2024-11-15";
 
@@ -23,14 +23,14 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-9pSn0f0VWsBg1z1UYGRtMb1z23htRm7qLmO80zvSjN8=";
 
   cargoBuildFlags = [ "-p=rsonpath" ];
-  cargoTestFlags = cargoBuildFlags;
+  cargoTestFlags = finalAttrs.cargoBuildFlags;
 
   meta = {
     description = "Experimental JSONPath engine for querying massive streamed datasets";
     homepage = "https://github.com/v0ldek/rsonpath";
-    changelog = "https://github.com/v0ldek/rsonpath/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/v0ldek/rsonpath/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "rq";
   };
-}
+})

--- a/pkgs/by-name/ru/rust-audit-info/package.nix
+++ b/pkgs/by-name/ru/rust-audit-info/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rust-audit-info";
   version = "0.5.4";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-zxdF65/9cgdDLM7HA30NCEZj1S5SogH+oM3aq55K0os=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/ru/rustfinity/package.nix
+++ b/pkgs/by-name/ru/rustfinity/package.nix
@@ -6,12 +6,12 @@
   pkg-config,
   openssl,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustfinity";
   version = "0.3.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-5UhKL6lXli1mGorThv3SFclVKDATmxklZQ+S5hwqQgc=";
   };
 
@@ -38,4 +38,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ nartsiss ];
     mainProgram = "rustfinity";
   };
-}
+})

--- a/pkgs/by-name/ru/rustycli/package.nix
+++ b/pkgs/by-name/ru/rustycli/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustycli";
   version = "0.1.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-4Txw6Cmwwgu7K8VIVoX9GR76VUqAEw6uYptmczbjqg0=";
   };
 
@@ -22,8 +22,8 @@ rustPlatform.buildRustPackage rec {
     description = "Access the rust playground right in terminal";
     mainProgram = "rustycli";
     homepage = "https://github.com/pwnwriter/rustycli";
-    changelog = "https://github.com/pwnwriter/rustycli/releases/tag/v${version}";
+    changelog = "https://github.com/pwnwriter/rustycli/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.matthiasbeyer ];
   };
-}
+})

--- a/pkgs/by-name/sa/safe-rm/package.nix
+++ b/pkgs/by-name/sa/safe-rm/package.nix
@@ -12,7 +12,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   src = fetchgit {
     url = "https://git.launchpad.net/safe-rm";
-    tag = "${finalAttrs.pname}-${finalAttrs.version}";
+    tag = "safe-rm-${finalAttrs.version}";
     sha256 = "sha256-7+4XwsjzLBCQmHDYNwhlN4Yg3eL43GUEbq8ROtuP2Kw=";
   };
 

--- a/pkgs/by-name/sa/safe-rm/package.nix
+++ b/pkgs/by-name/sa/safe-rm/package.nix
@@ -6,13 +6,13 @@
   installShellFiles,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "safe-rm";
   version = "1.1.0";
 
   src = fetchgit {
     url = "https://git.launchpad.net/safe-rm";
-    tag = "${pname}-${version}";
+    tag = "${finalAttrs.pname}-${finalAttrs.version}";
     sha256 = "sha256-7+4XwsjzLBCQmHDYNwhlN4Yg3eL43GUEbq8ROtuP2Kw=";
   };
 
@@ -40,4 +40,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ SuperSandro2000 ];
     mainProgram = "safe-rm";
   };
-}
+})

--- a/pkgs/by-name/sa/samply/package.nix
+++ b/pkgs/by-name/sa/samply/package.nix
@@ -6,12 +6,12 @@
   nix-update-script,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "samply";
   version = "0.13.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-zTwAsE6zXY3esO7x6UTCO2DbzdUSKZ6qc5Rr9qcI+Z8=";
   };
 
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Command line profiler for macOS and Linux";
     homepage = "https://github.com/mstange/samply";
-    changelog = "https://github.com/mstange/samply/releases/tag/samply-v${version}";
+    changelog = "https://github.com/mstange/samply/releases/tag/samply-v${finalAttrs.version}";
     license = with lib.licenses; [
       asl20
       mit
@@ -33,4 +33,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "samply";
   };
-}
+})

--- a/pkgs/by-name/sa/sarif-fmt/package.nix
+++ b/pkgs/by-name/sa/sarif-fmt/package.nix
@@ -6,12 +6,12 @@
   nix-update-script,
   versionCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sarif-fmt";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Xc9uc//5wTBWJ89mcaC/4c8/xtTvnu8g2Aa1viUhluo=";
   };
 
@@ -46,4 +46,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "sarif-fmt";
   };
-}
+})

--- a/pkgs/by-name/se/sea-orm-cli/package.nix
+++ b/pkgs/by-name/se/sea-orm-cli/package.nix
@@ -7,12 +7,12 @@
   nix-update-script,
   versionCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sea-orm-cli";
   version = "1.1.19";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-dsise5MDhR4pcD3ZWDUzTG0Q4Fg/VdKw2Q59/g6BabA=";
   };
 
@@ -40,4 +40,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [ traxys ];
   };
-}
+})

--- a/pkgs/by-name/sg/sgxs-tools/package.nix
+++ b/pkgs/by-name/sg/sgxs-tools/package.nix
@@ -6,7 +6,7 @@
   openssl_3,
   protobuf,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sgxs-tools";
   version = "0.9.2";
   nativeBuildInputs = [
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
   ];
   buildInputs = [ openssl_3 ];
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-vLbSjDULrYL8emQTha4fhEbr00OlhXNa00QhCKCnWDc=";
   };
 
@@ -27,4 +27,4 @@ rustPlatform.buildRustPackage rec {
     platforms = [ "x86_64-linux" ];
     license = lib.licenses.mpl20;
   };
-}
+})

--- a/pkgs/by-name/sh/shellcheck-sarif/package.nix
+++ b/pkgs/by-name/sh/shellcheck-sarif/package.nix
@@ -5,12 +5,12 @@
   nix-update-script,
   versionCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "shellcheck-sarif";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-G69DiDl78vkPuLodsRTL7dbbIFtNNF/XWuLZpCHKJws=";
   };
 
@@ -30,4 +30,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "shellcheck-sarif";
   };
-}
+})

--- a/pkgs/by-name/sh/shh/package.nix
+++ b/pkgs/by-name/sh/shh/package.nix
@@ -85,9 +85,9 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
     installManPage target/mangen/*
 
-    installShellCompletion --cmd ${finalAttrs.pname} \
-      target/shellcomplete/${finalAttrs.pname}.{bash,fish} \
-      --zsh target/shellcomplete/_${finalAttrs.pname}
+    installShellCompletion --cmd ${finalAttrs.meta.mainProgram} \
+      target/shellcomplete/${finalAttrs.meta.mainProgram}.{bash,fish} \
+      --zsh target/shellcomplete/_${finalAttrs.meta.mainProgram}
   '';
 
   # RUST_BACKTRACE = 1;

--- a/pkgs/by-name/si/sigi/package.nix
+++ b/pkgs/by-name/si/sigi/package.nix
@@ -7,12 +7,12 @@
   sigi,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sigi";
   version = "3.7.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Tsrfan7aejP2oy9x9VoTIq0ba0s0tnx1RTlAB0v6eis=";
   };
 
@@ -35,4 +35,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ booniepepper ];
     mainProgram = "sigi";
   };
-}
+})

--- a/pkgs/by-name/si/similarity/package.nix
+++ b/pkgs/by-name/si/similarity/package.nix
@@ -20,7 +20,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
   cargoHash = "sha256-7qLC1RvjBXd9JFrJdDTIngZhMvyQV1ko3MXRr/2y7hA=";
 
   nativeInstallCheckInputs = [ versionCheckHook ];
-  versionCheckProgram = "${placeholder "out"}/bin/${finalAttrs.pname}-ts";
+  versionCheckProgram = "${placeholder "out"}/bin/similarity-ts";
   doInstallCheck = true;
 
   passthru.updateScript = nix-update-script { };

--- a/pkgs/by-name/sl/slimevr/package.nix
+++ b/pkgs/by-name/sl/slimevr/package.nix
@@ -20,14 +20,14 @@
   libayatana-appindicator,
   udevCheckHook,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "slimevr";
   version = "18.1.0";
 
   src = fetchFromGitHub {
     owner = "SlimeVR";
     repo = "SlimeVR-Server";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-vU/dcKRlNsixr3TaCrqNkCd2ewAb38fLymb+ZslAum4=";
     # solarxr
     fetchSubmodules = true;
@@ -38,8 +38,8 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-X5IgWZlkvsstMN3YS4r+NJl6RVfREfZqKUrfsrUPQuU=";
 
   pnpmDeps = fetchPnpmDeps {
-    pname = "${pname}-pnpm-deps";
-    inherit version src;
+    pname = "${finalAttrs.pname}-pnpm-deps";
+    inherit (finalAttrs) version src;
     pnpm = pnpm_9;
     fetcherVersion = 3;
     hash = "sha256-deVfRZcMFkOVWXmNUiixmd5WBfIFKxG2Gw3CfshspYo=";
@@ -72,7 +72,7 @@ rustPlatform.buildRustPackage rec {
   patches = [
     # Upstream code uses Git to find the program version.
     (replaceVars ./gui-no-git.patch {
-      version = src.tag;
+      version = finalAttrs.src.tag;
     })
     # By default, SlimeVR will give a big warning about our `JAVA_TOOL_OPTIONS` changes.
     ./no-java-tool-options-warning.patch
@@ -121,7 +121,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = {
     homepage = "https://slimevr.dev";
-    changelog = "https://github.com/SlimeVR/SlimeVR-Server/releases/tag/v${version}";
+    changelog = "https://github.com/SlimeVR/SlimeVR-Server/releases/tag/v${finalAttrs.version}";
     description = "App for facilitating full-body tracking in virtual reality";
     longDescription = ''
       App for SlimeVR ecosystem. It orchestrates communication between multiple sensors and integrations, like SteamVR.
@@ -153,4 +153,4 @@ rustPlatform.buildRustPackage rec {
     broken = stdenv.hostPlatform.isDarwin;
     mainProgram = "slimevr";
   };
-}
+})

--- a/pkgs/by-name/sp/specr-transpile/package.nix
+++ b/pkgs/by-name/sp/specr-transpile/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "specr-transpile";
   version = "0.1.25";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-yB4b7VaZ22zk8jhQijBOWRks22TV19q9IQNlVXyBlss=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/by-name/sp/spr/package.nix
+++ b/pkgs/by-name/sp/spr/package.nix
@@ -6,12 +6,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "spr";
   version = "1.3.7";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-YmmPxsDoV1sYmqY0Jfqm3xTPmu7WWuIUQyOaICu3stM=";
   };
 
@@ -28,4 +28,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ spacedentist ];
   };
-}
+})

--- a/pkgs/by-name/ss/ssh-agent-switcher/package.nix
+++ b/pkgs/by-name/ss/ssh-agent-switcher/package.nix
@@ -8,14 +8,14 @@
   shtk,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ssh-agent-switcher";
   version = "1.0.1";
 
   src = fetchFromGitHub {
     owner = "jmmv";
     repo = "ssh-agent-switcher";
-    tag = "ssh-agent-switcher-${version}";
+    tag = "ssh-agent-switcher-${finalAttrs.version}";
     hash = "sha256-p9W0H25pWDB+GCrwLwuVruX9p8b8kICpp+6I11ym1aw=";
   };
 
@@ -56,10 +56,10 @@ rustPlatform.buildRustPackage rec {
       connection-specific forwarded agents.
     '';
     homepage = "https://github.com/jmmv/ssh-agent-switcher";
-    changelog = "https://github.com/jmmv/ssh-agent-switcher/blob/ssh-agent-switcher-${version}/NEWS.md";
+    changelog = "https://github.com/jmmv/ssh-agent-switcher/blob/ssh-agent-switcher-${finalAttrs.version}/NEWS.md";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.jmmv ];
     mainProgram = "ssh-agent-switcher";
     platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/st/star-history/package.nix
+++ b/pkgs/by-name/st/star-history/package.nix
@@ -6,12 +6,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "star-history";
   version = "1.0.32";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-JilIVnxSXEK525TK+mHal+37G7PYcaQogVC2ozYeLY4=";
   };
 
@@ -31,4 +31,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ lib.maintainers.matthiasbeyer ];
     mainProgram = "star-history";
   };
-}
+})

--- a/pkgs/by-name/st/starry/package.nix
+++ b/pkgs/by-name/st/starry/package.nix
@@ -6,12 +6,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "starry";
   version = "2.0.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-/ZUmMLEqlpqu+Ja/3XjFJf+OFZJCz7rp5MrQBEjwsXs=";
   };
 
@@ -32,4 +32,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "starry";
   };
-}
+})

--- a/pkgs/by-name/su/sudachi-rs/package.nix
+++ b/pkgs/by-name/su/sudachi-rs/package.nix
@@ -8,14 +8,14 @@
   writeScript,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "sudachi-rs";
   version = "0.6.10";
 
   src = fetchFromGitHub {
     owner = "WorksApplications";
     repo = "sudachi.rs";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-2sJ9diE/EjrQmFcCc4VluE4Gu4RebTYitd7zzfgj3g4=";
   };
 
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage rec {
     '';
     tests = {
       # detects an error that sudachidict is not found
-      cli = runCommand "${pname}-cli-test" { } ''
+      cli = runCommand "${finalAttrs.pname}-cli-test" { } ''
         mkdir $out
         echo "高輪ゲートウェイ駅" | ${lib.getExe sudachi-rs} > $out/result
       '';
@@ -58,9 +58,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Japanese morphological analyzer";
     homepage = "https://github.com/WorksApplications/sudachi.rs";
-    changelog = "https://github.com/WorksApplications/sudachi.rs/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/WorksApplications/sudachi.rs/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ natsukium ];
     mainProgram = "sudachi";
   };
-}
+})

--- a/pkgs/by-name/sv/svd2rust/package.nix
+++ b/pkgs/by-name/sv/svd2rust/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "svd2rust";
   version = "0.37.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-50g5YVmVYTLYJdaWXk91OYdlghDchkyHXS9j2Z7IXSw=";
   };
 
@@ -24,11 +24,11 @@ rustPlatform.buildRustPackage rec {
     description = "Generate Rust register maps (`struct`s) from SVD files";
     mainProgram = "svd2rust";
     homepage = "https://github.com/rust-embedded/svd2rust";
-    changelog = "https://github.com/rust-embedded/svd2rust/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/rust-embedded/svd2rust/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       mit
       asl20
     ];
     maintainers = with lib.maintainers; [ newam ];
   };
-}
+})

--- a/pkgs/by-name/sv/svdtools/package.nix
+++ b/pkgs/by-name/sv/svdtools/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "svdtools";
   version = "0.5.0";
 
   src = fetchCrate {
-    inherit version pname;
+    inherit (finalAttrs) version pname;
     hash = "sha256-2GemBVTRvYC5bvlYgJKmDJM78ZoE63B1QwV8cfSHYPg=";
   };
 
@@ -19,11 +19,11 @@ rustPlatform.buildRustPackage rec {
     description = "Tools to handle vendor-supplied, often buggy SVD files";
     mainProgram = "svdtools";
     homepage = "https://github.com/stm32-rs/svdtools";
-    changelog = "https://github.com/stm32-rs/svdtools/blob/v${version}/CHANGELOG-rust.md";
+    changelog = "https://github.com/stm32-rs/svdtools/blob/v${finalAttrs.version}/CHANGELOG-rust.md";
     license = with lib.licenses; [
       asl20 # or
       mit
     ];
     maintainers = with lib.maintainers; [ newam ];
   };
-}
+})

--- a/pkgs/by-name/sv/svlint/package.nix
+++ b/pkgs/by-name/sv/svlint/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "svlint";
   version = "0.9.5";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-RjdhXp9Dm6ZrRfJKsjnzAFgXTIQB3DJmDMwwtQD4Uzw=";
   };
 
@@ -24,8 +24,8 @@ rustPlatform.buildRustPackage rec {
     description = "SystemVerilog linter";
     mainProgram = "svlint";
     homepage = "https://github.com/dalance/svlint";
-    changelog = "https://github.com/dalance/svlint/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/dalance/svlint/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ trepetti ];
   };
-}
+})

--- a/pkgs/by-name/sw/swayr/package.nix
+++ b/pkgs/by-name/sw/swayr/package.nix
@@ -4,14 +4,14 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "swayr";
   version = "0.28.2";
 
   src = fetchFromSourcehut {
     owner = "~tsdh";
     repo = "swayr";
-    rev = "swayr-${version}";
+    rev = "swayr-${finalAttrs.version}";
     hash = "sha256-uT8MYgH9kANQ0t+7jqjOOvQIZf5ImdQruZLLlCejwcc=";
   };
 
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # don't build swayrbar
-  buildAndTestSubdir = pname;
+  buildAndTestSubdir = finalAttrs.pname;
 
   preCheck = ''
     export HOME=$TMPDIR
@@ -36,4 +36,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ artturin ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/sw/swayrbar/package.nix
+++ b/pkgs/by-name/sw/swayrbar/package.nix
@@ -7,21 +7,21 @@
   pulseaudio,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "swayrbar";
   version = "0.5.0";
 
   src = fetchFromSourcehut {
     owner = "~tsdh";
     repo = "swayr";
-    tag = "swayrbar-${version}";
+    tag = "swayrbar-${finalAttrs.version}";
     sha256 = "sha256-uT8MYgH9kANQ0t+7jqjOOvQIZf5ImdQruZLLlCejwcc=";
   };
 
   cargoHash = "sha256-Aj4U2xyfNhf3HDSEd1SQ5TyO2MXn2/hrfnG0ZayzMtU=";
 
   # don't build swayr
-  buildAndTestSubdir = pname;
+  buildAndTestSubdir = finalAttrs.pname;
 
   nativeBuildInputs = [ makeWrapper ];
 
@@ -43,4 +43,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ ilkecan ];
     mainProgram = "swayrbar";
   };
-}
+})

--- a/pkgs/by-name/sy/syndicate-server/package.nix
+++ b/pkgs/by-name/sy/syndicate-server/package.nix
@@ -7,14 +7,14 @@
   versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "syndicate-server";
   version = "0.50.1";
   src = fetchFromGitea {
     domain = "git.syndicate-lang.org";
     owner = "syndicate-lang";
     repo = "syndicate-rs";
-    rev = "${pname}-v${version}";
+    rev = "${finalAttrs.pname}-v${finalAttrs.version}";
     hash = "sha256-orQN83DE+ZNgdx2PVcYrte/rVDFFtuQuRDKzeumpsLo=";
   };
 
@@ -37,4 +37,4 @@ rustPlatform.buildRustPackage rec {
     mainProgram = "syndicate-server";
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/sy/syndicate-server/package.nix
+++ b/pkgs/by-name/sy/syndicate-server/package.nix
@@ -14,7 +14,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     domain = "git.syndicate-lang.org";
     owner = "syndicate-lang";
     repo = "syndicate-rs";
-    rev = "${finalAttrs.pname}-v${finalAttrs.version}";
+    rev = "syndicate-server-v${finalAttrs.version}";
     hash = "sha256-orQN83DE+ZNgdx2PVcYrte/rVDFFtuQuRDKzeumpsLo=";
   };
 

--- a/pkgs/by-name/ta/talecast/package.nix
+++ b/pkgs/by-name/ta/talecast/package.nix
@@ -9,12 +9,12 @@
   talecast,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "talecast";
   version = "0.1.39";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-RwB+X+i3CEcTyKac81he9/cT2aQ4M7AqgqSDBEvhFJU=";
   };
 
@@ -41,4 +41,4 @@ rustPlatform.buildRustPackage rec {
       getchoo
     ];
   };
-}
+})

--- a/pkgs/by-name/te/termimage/package.nix
+++ b/pkgs/by-name/te/termimage/package.nix
@@ -6,12 +6,12 @@
   ronn,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "termimage";
   version = "1.2.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-1FOPe466GqQfiIpsQT9DJn+FupI2vy9b4+7p31ceY6M=";
   };
 
@@ -32,9 +32,9 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Display images in your terminal";
     homepage = "https://github.com/nabijaczleweli/termimage";
-    changelog = "https://github.com/nabijaczleweli/termimage/releases/tag/v${version}";
+    changelog = "https://github.com/nabijaczleweli/termimage/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.mit;
     maintainers = [ ];
     mainProgram = "termimage";
   };
-}
+})

--- a/pkgs/by-name/te/textplots/package.nix
+++ b/pkgs/by-name/te/textplots/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "textplots";
   version = "0.8.5";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-83EAe6O8ETsuGJ5MK6kt68OnJL+r+BAYkFzvzlxHyp4=";
   };
 
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ ];
     mainProgram = "textplots";
   };
-}
+})

--- a/pkgs/by-name/to/toipe/package.nix
+++ b/pkgs/by-name/to/toipe/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "toipe";
   version = "0.5.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-L4JemOxpynGYsA8FgHnMv/hrogLSRaaiIzDjxzZDqjM=";
   };
 
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
       samyak
     ];
   };
-}
+})

--- a/pkgs/by-name/to/toml2json/package.nix
+++ b/pkgs/by-name/to/toml2json/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "toml2json";
   version = "1.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-ZqHXtk6bPYm/20DjFhVmrc9+wYAmSEBLxqNgyzPGO2c=";
   };
 
@@ -22,4 +22,4 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ rvarago ];
   };
-}
+})

--- a/pkgs/by-name/tr/trashy/package.nix
+++ b/pkgs/by-name/tr/trashy/package.nix
@@ -6,12 +6,12 @@
   stdenv,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "trashy";
   version = "2.0.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-1xHyhAV8hpgMngQdamRzEliyG60t+I3KfsDJi0+180o=";
   };
 
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Simple, fast, and featureful alternative to rm and trash-cli";
     homepage = "https://github.com/oberblastmeister/trashy";
-    changelog = "https://github.com/oberblastmeister/trashy/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/oberblastmeister/trashy/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20 # or
       mit
@@ -41,4 +41,4 @@ rustPlatform.buildRustPackage rec {
     # darwin is unsupported due to https://github.com/Byron/trash-rs/issues/8
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/tr/treedome/package.nix
+++ b/pkgs/by-name/tr/treedome/package.nix
@@ -17,13 +17,13 @@
   sqlite,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "treedome";
   version = "0.6.1";
 
   src = fetchgit {
     url = "https://codeberg.org/solver-orgz/treedome";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-qa87pgNHGRhP1G4TEFHYrkiJ9AHWG7PUdgxEF4X9EM8=";
     fetchLFS = true;
   };
@@ -31,7 +31,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-Rg65BiHQF7bBBCtc5F+gY31yhcuI0+IDfxr3pFmxT+w=";
 
   offlineCache = fetchYarnDeps {
-    yarnLock = "${src}/yarn.lock";
+    yarnLock = "${finalAttrs.src}/yarn.lock";
     hash = "sha256-Q0xsi1xymQne6qN0oxm4YkaDLnGL17iuj70CTdQlxzM=";
   };
 
@@ -59,10 +59,10 @@ rustPlatform.buildRustPackage rec {
   ];
 
   cargoRoot = "src-tauri";
-  buildAndTestSubdir = cargoRoot;
+  buildAndTestSubdir = finalAttrs.cargoRoot;
 
   env = {
-    VERGEN_GIT_DESCRIBE = version;
+    VERGEN_GIT_DESCRIBE = finalAttrs.version;
   };
 
   # WEBKIT_DISABLE_COMPOSITING_MODE essential in NVIDIA + compositor https://github.com/NixOS/nixpkgs/issues/212064#issuecomment-1400202079
@@ -78,6 +78,6 @@ rustPlatform.buildRustPackage rec {
     platforms = [ "x86_64-linux" ];
     mainProgram = "treedome";
     maintainers = with lib.maintainers; [ tengkuizdihar ];
-    changelog = "https://codeberg.org/solver-orgz/treedome/releases/tag/${version}";
+    changelog = "https://codeberg.org/solver-orgz/treedome/releases/tag/${finalAttrs.version}";
   };
-}
+})

--- a/pkgs/by-name/tt/ttfb/package.nix
+++ b/pkgs/by-name/tt/ttfb/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "ttfb";
   version = "1.15.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-OOVqCWeF5cHMweEGWYIiWWWsw1QlNDFgnia05Qxo7uo=";
   };
 
@@ -28,8 +28,8 @@ rustPlatform.buildRustPackage rec {
       connect, and TLS handshake.
     '';
     homepage = "https://github.com/phip1611/ttfb";
-    changelog = "https://github.com/phip1611/ttfb/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/phip1611/ttfb/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ phip1611 ];
   };
-}
+})

--- a/pkgs/by-name/tu/tuifeed/package.nix
+++ b/pkgs/by-name/tu/tuifeed/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "tuifeed";
   version = "0.4.2";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-CL6cd9OfvnA5N4W3rGl7XLcnlSrh3kcqA7idxexkjA4=";
   };
 
@@ -24,4 +24,4 @@ rustPlatform.buildRustPackage rec {
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ devhell ];
   };
-}
+})

--- a/pkgs/by-name/tw/twiggy/package.nix
+++ b/pkgs/by-name/tw/twiggy/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "twiggy";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-FguDuah3MlC0wgz8VnXV5xepIVhTwYmQzijgX0sbdNY=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     ];
     maintainers = with lib.maintainers; [ lucperkins ];
   };
-}
+})

--- a/pkgs/by-name/ty/typst-live/package.nix
+++ b/pkgs/by-name/ty/typst-live/package.nix
@@ -6,12 +6,12 @@
   typst,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "typst-live";
   version = "0.8.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-bR4Rhhs6rAC6C1nfPFj/3rCtfEziuTGn5m33CR0qZkU=";
   };
 
@@ -33,4 +33,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ lib.maintainers.matthiasbeyer ];
     mainProgram = "typst-live";
   };
-}
+})

--- a/pkgs/by-name/un/unpfs/package.nix
+++ b/pkgs/by-name/un/unpfs/package.nix
@@ -22,8 +22,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
   env.RUSTC_BOOTSTRAP = 1;
 
   postInstall = ''
-    install -D -m 0444 ../../README* -t "$out/share/doc/${finalAttrs.pname}"
-    install -D -m 0444 ../../LICEN* -t "$out/share/doc/${finalAttrs.pname}"
+    install -D -m 0444 ../../README* -t "$out/share/doc/unpfs"
+    install -D -m 0444 ../../LICEN* -t "$out/share/doc/unpfs"
   '';
 
   meta = {

--- a/pkgs/by-name/un/unpfs/package.nix
+++ b/pkgs/by-name/un/unpfs/package.nix
@@ -4,7 +4,7 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "unpfs";
   version = "0-unstable-2021-04-23";
 
@@ -15,15 +15,15 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-zyDkUb+bFsVnxAE4UODbnRtDim7gqUNuY22vuxMsLZM=";
   };
 
-  sourceRoot = "${src.name}/example/unpfs";
+  sourceRoot = "${finalAttrs.src.name}/example/unpfs";
 
   cargoHash = "sha256-jRe1lgzfhzBUsS6wwwlqxxomap2TIDOyF3YBv20GJ14=";
 
   env.RUSTC_BOOTSTRAP = 1;
 
   postInstall = ''
-    install -D -m 0444 ../../README* -t "$out/share/doc/${pname}"
-    install -D -m 0444 ../../LICEN* -t "$out/share/doc/${pname}"
+    install -D -m 0444 ../../README* -t "$out/share/doc/${finalAttrs.pname}"
+    install -D -m 0444 ../../LICEN* -t "$out/share/doc/${finalAttrs.pname}"
   '';
 
   meta = {
@@ -36,4 +36,4 @@ rustPlatform.buildRustPackage rec {
     platforms = with lib.platforms; linux;
     mainProgram = "unpfs";
   };
-}
+})

--- a/pkgs/by-name/vo/vopono/package.nix
+++ b/pkgs/by-name/vo/vopono/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "vopono";
   version = "0.10.15";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-78G0Dm0WAEjjud+vrl7n3Uh6NnMQhs3uY4DIeSTKTJs=";
   };
 
@@ -23,4 +23,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ lib.maintainers.romildo ];
     mainProgram = "vopono";
   };
-}
+})

--- a/pkgs/by-name/vr/vrc-get/package.nix
+++ b/pkgs/by-name/vr/vrc-get/package.nix
@@ -8,12 +8,12 @@
   buildPackages,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "vrc-get";
   version = "1.9.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-b/rlHfm+AfrluCqoTyBqx86xVaNV3QBGollk5HyD4xk=";
   };
 
@@ -44,4 +44,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ bddvlpr ];
     mainProgram = "vrc-get";
   };
-}
+})

--- a/pkgs/by-name/wa/wambo/package.nix
+++ b/pkgs/by-name/wa/wambo/package.nix
@@ -4,12 +4,12 @@
   rustPlatform,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wambo";
   version = "0.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-3EwNC78DhSXbVFSg6q+66yge4S1m5icJ5nOhoy9qsRI=";
   };
 
@@ -25,8 +25,8 @@ rustPlatform.buildRustPackage rec {
       and so on.
     '';
     homepage = "https://github.com/phip1611/wambo";
-    changelog = "https://github.com/phip1611/wambo/blob/v${version}/CHANGELOG.md";
+    changelog = "https://github.com/phip1611/wambo/blob/v${finalAttrs.version}/CHANGELOG.md";
     license = with lib.licenses; [ mit ];
     maintainers = with lib.maintainers; [ phip1611 ];
   };
-}
+})

--- a/pkgs/by-name/wc/wchisp/package.nix
+++ b/pkgs/by-name/wc/wchisp/package.nix
@@ -9,12 +9,12 @@
   versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wchisp";
   version = "0.3.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-6WNXsRvbldEjAykMn1DCiuKctBrsTHGv1fJuRXBblu0=";
   };
 
@@ -36,11 +36,11 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Command-line implementation of WCHISPTool, for flashing ch32 MCUs";
     homepage = "https://ch32-rs.github.io/wchisp/";
-    changelog = "https://github.com/ch32-rs/wchisp/releases/tag/v${version}";
+    changelog = "https://github.com/ch32-rs/wchisp/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [ gpl2Only ];
     platforms = with lib.platforms; linux ++ darwin ++ windows;
     broken = !stdenv.hostPlatform.isLinux;
     maintainers = with lib.maintainers; [ jwillikers ];
     mainProgram = "wchisp";
   };
-}
+})

--- a/pkgs/by-name/we/wezterm/package.nix
+++ b/pkgs/by-name/we/wezterm/package.nix
@@ -26,7 +26,7 @@
   zlib,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wezterm";
   version = "0-unstable-2026-01-17";
 
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   postPatch = ''
-    echo ${version} > .tag
+    echo ${finalAttrs.version} > .tag
 
     # hash does not work well with NixOS
     substituteInPlace assets/shell-integration/wezterm.sh \
@@ -88,7 +88,7 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     mkdir -p $out/nix-support
-    echo "${passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
+    echo "${finalAttrs.passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
 
     install -Dm644 assets/icon/terminal.png $out/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
     install -Dm644 assets/wezterm.desktop $out/share/applications/org.wezfurlong.wezterm.desktop
@@ -142,7 +142,7 @@ rustPlatform.buildRustPackage rec {
         }
         ''
           mkdir -p $out/share/terminfo $out/nix-support
-          tic -x -o $out/share/terminfo ${src}/termwiz/data/wezterm.terminfo
+          tic -x -o $out/share/terminfo ${finalAttrs.src}/termwiz/data/wezterm.terminfo
         '';
 
     tests = {
@@ -163,4 +163,4 @@ rustPlatform.buildRustPackage rec {
       SuperSandro2000
     ];
   };
-}
+})

--- a/pkgs/by-name/wh/when-cli/package.nix
+++ b/pkgs/by-name/wh/when-cli/package.nix
@@ -3,12 +3,12 @@
   fetchCrate,
   rustPlatform,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "when-cli";
   version = "0.4.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-LWssrLl2HKul24N3bJdf2ePqeR4PCROrTiVY5sqzB2M=";
   };
 
@@ -21,4 +21,4 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ loicreynier ];
   };
-}
+})

--- a/pkgs/by-name/wi/wiremix/package.nix
+++ b/pkgs/by-name/wi/wiremix/package.nix
@@ -6,12 +6,12 @@
   pipewire,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wiremix";
   version = "0.9.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-gs6KqluASHTf4fURZKEmNvERguQEH5UDc4044uJddrU=";
   };
 
@@ -34,4 +34,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ tsowell ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/wl/wleave/package.nix
+++ b/pkgs/by-name/wl/wleave/package.nix
@@ -17,14 +17,14 @@
   librsvg,
   libxml2,
 }:
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wleave";
   version = "0.6.2";
 
   src = fetchFromGitHub {
     owner = "AMNatty";
     repo = "wleave";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-+0EKnaxRaHRxRvhASuvfpUijEZJFimR4zSzOyC3FOkQ=";
   };
 
@@ -49,10 +49,10 @@ rustPlatform.buildRustPackage rec {
 
   postPatch = ''
     substituteInPlace src/config.rs \
-      --replace-fail "/etc/wleave" "$out/etc/${pname}"
+      --replace-fail "/etc/wleave" "$out/etc/${finalAttrs.pname}"
 
     substituteInPlace layout.json \
-      --replace-fail "/usr/share/wleave" "$out/share/${pname}"
+      --replace-fail "/usr/share/wleave" "$out/share/${finalAttrs.pname}"
   '';
 
   postInstall = ''
@@ -81,4 +81,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ ludovicopiero ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/wl/wleave/package.nix
+++ b/pkgs/by-name/wl/wleave/package.nix
@@ -49,10 +49,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   postPatch = ''
     substituteInPlace src/config.rs \
-      --replace-fail "/etc/wleave" "$out/etc/${finalAttrs.pname}"
+      --replace-fail "/etc/wleave" "$out/etc/wleave"
 
     substituteInPlace layout.json \
-      --replace-fail "/usr/share/wleave" "$out/share/${finalAttrs.pname}"
+      --replace-fail "/usr/share/wleave" "$out/share/wleave"
   '';
 
   postInstall = ''

--- a/pkgs/by-name/wl/wlink/package.nix
+++ b/pkgs/by-name/wl/wlink/package.nix
@@ -10,12 +10,12 @@
   versionCheckHook,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wlink";
   version = "0.1.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-YxozhEJh/KBirlA6ymIEbJY3r7wYSeTL40W2xQLyue0=";
   };
 
@@ -38,7 +38,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "WCH-Link flash tool for WCH's RISC-V MCUs(CH32V, CH56X, CH57X, CH58X, CH59X, CH32L103, CH32X035, CH641, CH643)";
     homepage = "https://github.com/ch32-rs/wlink";
-    changelog = "https://github.com/ch32-rs/wlink/releases/tag/v${version}";
+    changelog = "https://github.com/ch32-rs/wlink/releases/tag/v${finalAttrs.version}";
     license = with lib.licenses; [
       mit # or
       asl20
@@ -48,4 +48,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ jwillikers ];
     mainProgram = "wlink";
   };
-}
+})

--- a/pkgs/by-name/wy/wyvern/package.nix
+++ b/pkgs/by-name/wy/wyvern/package.nix
@@ -7,12 +7,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wyvern";
   version = "1.4.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-OjL3wEoh4fT2nKqb7lMefP5B0vYyUaTRj09OXPEVfW4=";
   };
 
@@ -34,4 +34,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ _0x4A6F ];
     platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/xq/xq/package.nix
+++ b/pkgs/by-name/xq/xq/package.nix
@@ -4,12 +4,12 @@
   fetchCrate,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "xq";
   version = "0.4.1";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-Qe+crretlKJRoNPO2+aHxCmMO9MecqGjOuvdhr4a0NU=";
   };
 
@@ -25,4 +25,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ matthewcroughan ];
     mainProgram = "xq";
   };
-}
+})

--- a/pkgs/by-name/zb/zbus-xmlgen/package.nix
+++ b/pkgs/by-name/zb/zbus-xmlgen/package.nix
@@ -6,12 +6,12 @@
   rustfmt,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zbus_xmlgen";
   version = "5.2.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-CFXOPUWjbzNkE8mb+AC4ZtdvV0MSb/eBr1C0WyreAoU=";
   };
 
@@ -32,4 +32,4 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ qyliss ];
     license = lib.licenses.mit;
   };
-}
+})

--- a/pkgs/by-name/zi/zine/package.nix
+++ b/pkgs/by-name/zi/zine/package.nix
@@ -6,12 +6,12 @@
   openssl,
 }:
 
-rustPlatform.buildRustPackage rec {
+rustPlatform.buildRustPackage (finalAttrs: {
   pname = "zine";
   version = "0.16.0";
 
   src = fetchCrate {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-pUoMMgZQ+oDs9Yhc1rQuy9cUWiR800DlIe8wxQjnIis=";
   };
 
@@ -33,11 +33,11 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Simple and opinionated tool to build your own magazine";
     homepage = "https://github.com/zineland/zine";
-    changelog = "https://github.com/zineland/zine/releases/tag/v${version}";
+    changelog = "https://github.com/zineland/zine/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       dit7ya
     ];
     mainProgram = "zine";
   };
-}
+})


### PR DESCRIPTION
part of #293452

also fixing up some pname misuse in these packages

this shouldn't create any rebuilds

<details>
<summary>
the move was done with the following script
</summary>

```fish
#!/usr/bin/env fish

# nix shell .#nixfmt nixpkgs#{nixf-diagnose,ripgrep,sd}

set base (git rev-parse HEAD)

set scope pkgs/by-name
set builder buildRustPackage

set files (rg --files-with-matches -F "$builder rec {" $scope | sort -u)

for file in $files
    echo $file
    sd -F "$builder rec {" "$builder (finalAttrs: {" $file
    # version
    sd -F 'version}' 'finalAttrs.version}' $file
    sd -F '${version' '${finalAttrs.version' $file
    sd -F '= version' '= finalAttrs.version' $file
    sd -F 'inherit version;' 'inherit (finalAttrs) version;' $file
    sd -F ' + version;' ' + finalAttrs.version;' $file
    sd 'replaceStrings (.*) version' 'replaceStrings $1 finalAttrs.version' $file
    sd -F 'splitVersion version' 'splitVersion finalAttrs.version' $file
    sd -F 'versionAtLeast version' 'versionAtLeast finalAttrs.version' $file
    sd 'versions\.([a-z]+) version' 'versions.$1 finalAttrs.version' $file
    # src
    sd -F 'src}' 'finalAttrs.src}' $file
    sd -F '${src' '${finalAttrs.src' $file
    sd -F '= src' '= finalAttrs.src' $file
    sd -F 'inherit src;' 'inherit (finalAttrs) src;' $file
    sd -F 'inherit (src' 'inherit (finalAttrs.src' $file
    # pname
    sd -F 'pname}' 'finalAttrs.pname}' $file
    sd -F '${pname' '${finalAttrs.pname' $file
    sd -F '= pname' '= finalAttrs.pname' $file
    sd -F 'inherit pname;' 'inherit (finalAttrs) pname;' $file
    # combinations
    sd -F 'inherit version src;' 'inherit (finalAttrs) version src;' $file
    sd -F 'inherit src version;' 'inherit (finalAttrs) src version;' $file
    sd -F 'inherit version pname;' 'inherit (finalAttrs) version pname;' $file
    sd -F 'inherit pname version;' 'inherit (finalAttrs) pname version;' $file
    sd -F 'inherit pname src version;' 'inherit (finalAttrs) pname src version;' $file
    sd -F 'inherit pname version src;' 'inherit (finalAttrs) pname version src;' $file
    sd -F 'inherit src pname version;' 'inherit (finalAttrs) src pname version;' $file
    sd -F 'inherit src version pname;' 'inherit (finalAttrs) src version pname;' $file
    sd -F 'inherit version pname src;' 'inherit (finalAttrs) version pname src;' $file
    sd -F 'inherit version src pname;' 'inherit (finalAttrs) version src pname;' $file
    # meta
    sd -F '${meta' '${finalAttrs.meta' $file
    sd -F '= meta' '= finalAttrs.meta' $file
    sd -F 'inherit (meta' 'inherit (finalAttrs.meta' $file
    # cargo
    sd -F 'cargoRoot}' 'finalAttrs.cargoRoot}' $file
    sd -F '${cargoRoot' '${finalAttrs.cargoRoot' $file
    sd -F '= cargoRoot' '= finalAttrs.cargoRoot' $file
    sd -F 'cargoBuildFlags}' 'finalAttrs.cargoBuildFlags}' $file
    sd -F '${cargoBuildFlags' '${finalAttrs.cargoBuildFlags' $file
    sd -F '= cargoBuildFlags' '= finalAttrs.cargoBuildFlags' $file
    # patches
    sd -F 'patches}' 'finalAttrs.patches}' $file
    sd -F '${patches' '${finalAttrs.patches' $file
    sd -F '= patches' '= finalAttrs.patches' $file
    # passthru
    sd -F 'passthru}' 'finalAttrs.passthru}' $file
    sd -F '${passthru' '${finalAttrs.passthru' $file
    sd -F '= passthru' '= finalAttrs.passthru' $file
    # *buildInputs
    sd -F 'buildInputs}' 'finalAttrs.buildInputs}' $file
    sd -F 'makeLibraryPath buildInputs' 'makeLibraryPath finalAttrs.buildInputs' $file
    sd -F 'nativeBuildInputs}' 'finalAttrs.nativeBuildInputs}' $file
    sd -F 'propagatedBuildInputs}' 'finalAttrs.propagatedBuildInputs}' $file
    # other
    sd -F 'desktopItem}' 'finalAttrs.desktopItem}' $file
    sd -F 'runtimeLibs}' 'finalAttrs.runtimeLibs}' $file
    sd -F 'libPath}' 'finalAttrs.libPath}' $file
    sd -F 'runtimeDependencies}' 'finalAttrs.runtimeDependencies}' $file
    sd -F 'nativeRuntimeInputs}' 'finalAttrs.nativeRuntimeInputs}' $file
    sd -F '(!doCheck)' '(!finalAttrs.doCheck)' $file
    sd -F 'optional doCheck' 'optional finalAttrs.doCheck' $file
    sd -F 'optionals doCheck' 'optionals finalAttrs.doCheck' $file
    sd -F '++ runtimeDependencies' '++ finalAttrs.runtimeDependencies' $file
    # close finalAttrs lambda
    echo ')' >>$file
    # catch some errors early
    if ! nixfmt $file
        git restore $file
        continue
    end
    if ! nixf-diagnose -i sema-primop-overridden $file
        git restore $file
        continue
    end
end

set torestore (rg -F .finalAttrs --files-with-matches $scope)
if test (count $torestore) -gt 0
    git restore $torestore
end
# set torestore (rg -F finalAttrs.pname --files-with-matches $scope)
# if test (count $torestore) -gt 0
#     git restore $torestore
# end

# commit for faster eval times
git add pkgs
git commit --no-gpg-sign -m temp
set torestore

for file in $files
    # file hasn't changed
    if git diff --quiet $base $file
        continue
    end
    # try to eval the package to definitely catch all errors
    echo $file
    set pname (string split / $file -f 4)
    if ! nix eval .#$pname
        set torestore $torestore $file
    end
end

# restore files that don't eval
git reset --soft $base
git restore --staged .
if test (count $torestore) -gt 0
    git restore $torestore
end
```
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] no rebuilds
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] changes do not require release notes
- [x] merges cleanly with staging (as of 84cdb83a026d)
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
