### PR TITLE
Welsh / Cymraeg Hunspell dictionary

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8692,6 +8692,12 @@
     githubId = 40620903;
     name = "figsoda";
   };
+  fin-w = {
+    email = "fin-w@tutanota.com";
+    github = "fin-w";
+    githubId = 41450706;
+    name = "fin-w";
+  };
   fionera = {
     email = "nix@fionera.de";
     github = "fionera";

--- a/pkgs/by-name/hu/hunspell/dictionaries.nix
+++ b/pkgs/by-name/hu/hunspell/dictionaries.nix
@@ -1251,4 +1251,35 @@ rec {
       maintainers = with lib.maintainers; [ honnip ];
     };
   };
+
+  # According to https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+  # we should use `cy` for Cymraeg but it's cy_GB in Hunspell.
+  # WELSH / CYMRAEG
+  cy_GB = cy-gb;
+  cy-gb = mkDict rec {
+    pname = "hunspell-dict-cy-gb";
+    version = "25.03";
+
+    src = fetchFromGitHub {
+      owner = "techiaith";
+      repo = "hunspell-cy";
+      tag = version;
+      hash = "sha256-T1p0LbCUTKN7xfogbI2RqxdONgcMxDpjjFW+dN8IGa4=";
+    };
+
+    shortName = "cy-GB";
+    dictFileName = "cy_GB";
+    readmeFile = "README.md";
+
+    meta = {
+      description = "Hunspell dictionary for Welsh (Cymraeg)";
+      homepage = "https://github.com/techiaith/hunspell-cy";
+      license = with lib.licenses; [
+        lgpl3
+      ];
+      maintainers = with lib.maintainers; [
+        fin-w
+      ];
+    };
+  };
 }


### PR DESCRIPTION
New package: `hunspell-dict-cy-gb` based on [the Hunspell dictionary from Bangor University](https://github.com/techiaith/hunspell-cy).

Hash generated by `nurl https://github.com/techiaith/hunspell-cy 25.03`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
