### PR TITLE
fastdds: init at 3.4.2

### DIFF
--- a/pkgs/by-name/fa/fastdds/package.nix
+++ b/pkgs/by-name/fa/fastdds/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  openssl,
+  asio,
+  tinyxml-2,
+  openjdk11,
+  python3,
+  foonathan-memory,
+  fastcdr,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fastdds";
+  version = "3.4.2";
+
+  src = fetchFromGitHub {
+    owner = "eProsima";
+    repo = "Fast-DDS";
+    rev = "v${finalAttrs.version}";
+    fetchSubmodules = true;
+    hash = "sha256-NTdkGRbE4yVMMZ/PqLC2nZYD0uIcmo1tr+ieOBSijCM=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    openjdk11
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    asio
+    tinyxml-2
+    foonathan-memory
+    fastcdr
+    python3
+  ];
+
+  cmakeFlags = [
+    "-DCMAKE_BUILD_TYPE=Release"
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DSECURITY=ON"
+    "-DCOMPILE_EXAMPLES=OFF"
+    "-DCMAKE_PREFIX_PATH=${foonathan-memory}"
+  ];
+
+  meta = {
+    description = "C++ implementation of the DDS (Data Distribution Service) standard";
+    homepage = "https://github.com/eProsima/Fast-DDS";
+    license = lib.licenses.asl20;
+    longDescription = ''
+      eProsima Fast DDS is a C++ implementation of the DDS (Data Distribution Service) standard
+      of the OMG (Object Management Group). It implements the RTPS (Real Time Publish Subscribe)
+      protocol, which provides publisher-subscriber communications over unreliable transports
+      such as UDP, as defined and maintained by the Object Management Group (OMG) consortium.
+    '';
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Add the [Fast DDS](https://fast-dds.docs.eprosima.com/en/stable/) package which implements transport for [Data Distribution Service (DDS)](https://community.rti.com/)-compliant data

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
