### PR TITLE
hashlink: remove obsolete workarounds

### DIFF
--- a/pkgs/by-name/ha/hashlink/package.nix
+++ b/pkgs/by-name/ha/hashlink/package.nix
@@ -10,7 +10,7 @@
   libjpeg_turbo,
   libuv,
   libvorbis,
-  mbedtls_2,
+  mbedtls,
   openal,
   pcre,
   SDL2,
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     libpng
     libuv
     libvorbis
-    mbedtls_2
+    mbedtls
     openal
     pcre
     SDL2

--- a/pkgs/by-name/ha/hashlink/package.nix
+++ b/pkgs/by-name/ha/hashlink/package.nix
@@ -28,14 +28,6 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-nVr+fDdna8EEHvIiXsccWFRTYzXfb4GG1zrfL+O6zLA=";
   };
 
-  # incompatible pointer type error: const char ** -> const void **
-  postPatch = ''
-    substituteInPlace libs/sqlite/sqlite.c \
-     --replace-warn \
-       "sqlite3_prepare16_v2(db->db, sql, -1, &r->r, &tl)" \
-       "sqlite3_prepare16_v2(db->db, sql, -1, &r->r, (const void**)&tl)"
-  '';
-
   buildInputs = [
     libGL
     libGLU

--- a/pkgs/by-name/ha/hashlink/package.nix
+++ b/pkgs/by-name/ha/hashlink/package.nix
@@ -28,6 +28,14 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-nVr+fDdna8EEHvIiXsccWFRTYzXfb4GG1zrfL+O6zLA=";
   };
 
+  # backport of https://github.com/HaxeFoundation/hashlink/pull/767
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+     --replace-warn \
+       "cmake_minimum_required(VERSION 3.1)" \
+       "cmake_minimum_required(VERSION 3.13)"
+  '';
+
   buildInputs = [
     libGL
     libGLU


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- hashlink 1.15 supports compiling with mbedtls 3, so there is no need to depend on mbedtls 2 anymore, see: https://github.com/HaxeFoundation/hashlink/pull/648
- hashlink 1.15 also fixes the compilation issue in sqlite.c, see: https://github.com/HaxeFoundation/hashlink/pull/686
- Backported a cmake fix due to incompatible versions: https://github.com/HaxeFoundation/hashlink/pull/767

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
