### PR TITLE
crossmacro{,-daemon}, nixos/crossmacro: sync 0.9.7 packaging and canonical polkit IDs

### DIFF
--- a/nixos/modules/services/desktops/crossmacro.nix
+++ b/nixos/modules/services/desktops/crossmacro.nix
@@ -44,8 +44,8 @@ in
       ACTION=="add|change", KERNEL=="event*", ATTRS{name}=="CrossMacro Virtual Input Device", ENV{LIBINPUT_ATTR_POINTER_ACCEL}="0"
     '';
 
-    environment.etc."polkit-1/actions/org.crossmacro.policy".source =
-      "${cfg.daemonPackage}/share/polkit-1/actions/org.crossmacro.policy";
+    environment.etc."polkit-1/actions/io.github.alper_han.crossmacro.policy".source =
+      "${cfg.daemonPackage}/share/polkit-1/actions/io.github.alper_han.crossmacro.policy";
 
     environment.etc."polkit-1/rules.d/50-crossmacro.rules".source =
       "${cfg.daemonPackage}/share/polkit-1/rules.d/50-crossmacro.rules";

--- a/pkgs/by-name/cr/crossmacro-daemon/deps.json
+++ b/pkgs/by-name/cr/crossmacro-daemon/deps.json
@@ -1,5 +1,10 @@
 [
   {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "10.0.3",
+    "hash": "sha256-ShB94jEtsq5X5r6xDZQ+wotZYG3OPKOCHNGy4B7NVFs="
+  },
+  {
     "pname": "Serilog",
     "version": "4.0.0",
     "hash": "sha256-j8hQ5TdL1TjfdGiBO9PyHJFMMPvATHWN1dtrrUZZlNw="
@@ -16,8 +21,8 @@
   },
   {
     "pname": "Serilog",
-    "version": "4.3.0",
-    "hash": "sha256-jyIy4BjsyFXge3aO4GRFAdnX4/rz1MHfBkBDIpCDsTw="
+    "version": "4.3.1",
+    "hash": "sha256-TY+GaQYnyDfOGl0gi67xDyUMOuV/mjz8BU66/UsmStI="
   },
   {
     "pname": "Serilog.Sinks.Async",
@@ -36,7 +41,7 @@
   },
   {
     "pname": "Tmds.DBus",
-    "version": "0.23.0",
-    "hash": "sha256-BwWQSqOOMS+Cf2fM8MIuiHey8QnGH4WvYjOn9haq5e0="
+    "version": "0.90.3",
+    "hash": "sha256-/yBQpjsIqbY4JFBxxVKXPR2S/N1TMLG5QPXvScSCdEk="
   }
 ]

--- a/pkgs/by-name/cr/crossmacro-daemon/package.nix
+++ b/pkgs/by-name/cr/crossmacro-daemon/package.nix
@@ -20,7 +20,7 @@ buildDotnetModule rec {
     owner = "alper-han";
     repo = "CrossMacro";
     tag = "v${version}";
-    hash = "sha256-qVKlch9GxEfB9thqXdiwWgF25ljX+b5on+bZmcAjAzw=";
+    hash = "sha256-CRP3u3ChP587yHgoi49yPiozcPB6juVNZLVVknkqvKo=";
   };
 
   projectFile = "src/CrossMacro.Daemon/CrossMacro.Daemon.csproj";
@@ -47,8 +47,8 @@ buildDotnetModule rec {
   dotnetFlags = [ "-p:Version=${version}" ];
 
   postInstall = ''
-    install -Dm644 scripts/assets/org.crossmacro.policy \
-      $out/share/polkit-1/actions/org.crossmacro.policy
+    install -Dm644 scripts/assets/io.github.alper_han.crossmacro.policy \
+      $out/share/polkit-1/actions/io.github.alper_han.crossmacro.policy
 
     install -Dm644 scripts/assets/50-crossmacro.rules \
       $out/share/polkit-1/rules.d/50-crossmacro.rules

--- a/pkgs/by-name/cr/crossmacro/deps.json
+++ b/pkgs/by-name/cr/crossmacro/deps.json
@@ -1,13 +1,8 @@
 [
   {
     "pname": "Avalonia",
-    "version": "11.3.11",
-    "hash": "sha256-FSMuXVA5q5L5evwos5bIsuT81suO8FbCjEF3OvAL9p0="
-  },
-  {
-    "pname": "Avalonia.Angle.Windows.Natives",
-    "version": "2.1.25547.20250602",
-    "hash": "sha256-LE/lENAHptmz6t3T/AoJwnhpda+xs7PqriNGzdcfg8M="
+    "version": "11.3.12",
+    "hash": "sha256-T2y8aoKUSfXqmV2RL1QStytzJkc/SZYfIdJihB5UWR0="
   },
   {
     "pname": "Avalonia.BuildServices",
@@ -16,63 +11,48 @@
   },
   {
     "pname": "Avalonia.Controls.ColorPicker",
-    "version": "11.3.11",
-    "hash": "sha256-Ki6O9HYbseQPV3DsvwmJ+ERimi/WmvzelNJDKP6loo0="
-  },
-  {
-    "pname": "Avalonia.Desktop",
-    "version": "11.3.11",
-    "hash": "sha256-oFivO8/0rir4BwQsTeWs3bSnb7RmldwxYmI77j5pt8k="
+    "version": "11.3.12",
+    "hash": "sha256-zNpmfOTfw+gKZp8VPpfHe2hjqhrRmExf7lxqLf5OvDg="
   },
   {
     "pname": "Avalonia.Diagnostics",
-    "version": "11.3.11",
-    "hash": "sha256-p38+O0VDqZ8u5VOzImP21/U5wyP1BUp2UrLLc9HSfwE="
+    "version": "11.3.12",
+    "hash": "sha256-iDH6DjRKqm4YLXBq2JGg9IkkEGm3Rq1FQWyr/L+VaVA="
   },
   {
     "pname": "Avalonia.Fonts.Inter",
-    "version": "11.3.11",
-    "hash": "sha256-S0DWwcZHulVUIckiv2HM1Vbqno64c/Xt+mPhZp1tfsA="
+    "version": "11.3.12",
+    "hash": "sha256-yr4/zpUbmQuVzdupV5v87qNO24sPOVhnnJ1SeiLxMx8="
   },
   {
     "pname": "Avalonia.FreeDesktop",
-    "version": "11.3.11",
-    "hash": "sha256-UE2/w9cw3YDzsw3HuhI2sTPy8reH9C71ufmHOpzvlSQ="
-  },
-  {
-    "pname": "Avalonia.Native",
-    "version": "11.3.11",
-    "hash": "sha256-vw67lp/oOt+2lqdJ5PK2FY93jqPTcgZqOAXLtSXlJ8s="
+    "version": "11.3.12",
+    "hash": "sha256-NTcYVHn13lFQjTNezmpmPGjxsBzryXorK0K6hl4ZZto="
   },
   {
     "pname": "Avalonia.Remote.Protocol",
-    "version": "11.3.11",
-    "hash": "sha256-l1f3rVygtI268llwbN0NvTDSfXwZE3CyRw8w5tbHBC4="
+    "version": "11.3.12",
+    "hash": "sha256-dF93nP1Cd7ZdzrO7ScGHchxYxCjWN45AjiqiO1J+cmU="
   },
   {
     "pname": "Avalonia.Skia",
-    "version": "11.3.11",
-    "hash": "sha256-89TGu50JfEVFo+QZgyOR0uOagC/xoJvqfnrHep3W/cc="
+    "version": "11.3.12",
+    "hash": "sha256-gRMjH7igRIm22zQV0WxtwFHe8AiMTcaPlR0sC5lJy+w="
   },
   {
     "pname": "Avalonia.Themes.Fluent",
-    "version": "11.3.11",
-    "hash": "sha256-tiJ0xAFf0UVSH7LASPtg/7ils7+vZjw2UKBMydyUR3Q="
+    "version": "11.3.12",
+    "hash": "sha256-4TTsW7zLF0Z9C1lzPsPfekHpHrSx7RB7I63j/cKUX8U="
   },
   {
     "pname": "Avalonia.Themes.Simple",
-    "version": "11.3.11",
-    "hash": "sha256-AJS5Ls0tJ6PCr2mnr1PpxGWX4sII8mpe2R+VCFYRg44="
-  },
-  {
-    "pname": "Avalonia.Win32",
-    "version": "11.3.11",
-    "hash": "sha256-6/NG4OrB/4YisXzJ51GPuq3uDn8oEUWyJRAqejyMCQw="
+    "version": "11.3.12",
+    "hash": "sha256-EIuAcUmoL7/y4lUfdSg120/l/v3zQytC2rfr0b6jKiM="
   },
   {
     "pname": "Avalonia.X11",
-    "version": "11.3.11",
-    "hash": "sha256-2fiQvKxU/r71UOAQgy0zwSHVCM2uG2sdEUhObd5TrQQ="
+    "version": "11.3.12",
+    "hash": "sha256-SEc0GaZTh1eGNFWHT6lGiN6LD0qE+ubTK7Efl0H/Q2w="
   },
   {
     "pname": "CommunityToolkit.Mvvm",
@@ -111,13 +91,13 @@
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
-    "version": "10.0.2",
-    "hash": "sha256-/9UWQRAI2eoocnJWWf1ktnAx/1Gt65c16fc0Xqr9+CQ="
+    "version": "10.0.3",
+    "hash": "sha256-h/wiSaVtRCIGdkv6/soA41Dhdlmu2I9hjv/swP8OjDk="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "10.0.2",
-    "hash": "sha256-UF9T13V5SQxJy2msfLmyovLmitZrjJayf8gHH+uK2eg="
+    "version": "10.0.3",
+    "hash": "sha256-ShB94jEtsq5X5r6xDZQ+wotZYG3OPKOCHNGy4B7NVFs="
   },
   {
     "pname": "Serilog",
@@ -136,8 +116,8 @@
   },
   {
     "pname": "Serilog",
-    "version": "4.3.0",
-    "hash": "sha256-jyIy4BjsyFXge3aO4GRFAdnX4/rz1MHfBkBDIpCDsTw="
+    "version": "4.3.1",
+    "hash": "sha256-TY+GaQYnyDfOGl0gi67xDyUMOuV/mjz8BU66/UsmStI="
   },
   {
     "pname": "Serilog.Sinks.Async",
@@ -165,11 +145,6 @@
     "hash": "sha256-mQ/oBaqRR71WfS66mJCvcc3uKW7CNEHoPN2JilDbw/A="
   },
   {
-    "pname": "SkiaSharp.NativeAssets.Linux.NoDependencies",
-    "version": "2.88.9",
-    "hash": "sha256-WjpcM78Q6kaW0eU5iqDR5+fGcF+06/tawWHsJRK57Es="
-  },
-  {
     "pname": "SkiaSharp.NativeAssets.macOS",
     "version": "2.88.9",
     "hash": "sha256-qvGuAmjXGjGKMzOPBvP9VWRVOICSGb7aNVejU0lLe/g="
@@ -186,8 +161,8 @@
   },
   {
     "pname": "Tmds.DBus",
-    "version": "0.23.0",
-    "hash": "sha256-BwWQSqOOMS+Cf2fM8MIuiHey8QnGH4WvYjOn9haq5e0="
+    "version": "0.90.3",
+    "hash": "sha256-/yBQpjsIqbY4JFBxxVKXPR2S/N1TMLG5QPXvScSCdEk="
   },
   {
     "pname": "Tmds.DBus.Protocol",

--- a/pkgs/by-name/cr/crossmacro/package.nix
+++ b/pkgs/by-name/cr/crossmacro/package.nix
@@ -35,10 +35,10 @@ buildDotnetModule rec {
     owner = "alper-han";
     repo = "CrossMacro";
     tag = "v${version}";
-    hash = "sha256-qVKlch9GxEfB9thqXdiwWgF25ljX+b5on+bZmcAjAzw=";
+    hash = "sha256-CRP3u3ChP587yHgoi49yPiozcPB6juVNZLVVknkqvKo=";
   };
 
-  projectFile = "src/CrossMacro.UI/CrossMacro.UI.csproj";
+  projectFile = "src/CrossMacro.UI.Linux/CrossMacro.UI.Linux.csproj";
   nugetDeps = ./deps.json;
 
   dotnet-sdk = dotnetCorePackages.sdk_10_0;


### PR DESCRIPTION
• This PR syncs CrossMacro packaging with upstream `v0.9.7` and aligns NixOS module/polkit naming with the canonical namespace introduced between `0.9.6` and `0.9.7`.

  ## What changed

  - `pkgs/by-name/cr/crossmacro/package.nix`
    - update `src.hash` to current `v0.9.7` tarball hash
    - switch `projectFile` to Linux host entrypoint:
      `src/CrossMacro.UI.Linux/CrossMacro.UI.Linux.csproj`
  - `pkgs/by-name/cr/crossmacro/deps.json`
    - regenerate NuGet lockfile for the updated source/project graph
  - `pkgs/by-name/cr/crossmacro-daemon/package.nix`
    - update `src.hash`
    - install canonical policy file only:
      `io.github.alper_han.crossmacro.policy`
  - `pkgs/by-name/cr/crossmacro-daemon/deps.json`
    - regenerate NuGet lockfile
  - `nixos/modules/services/desktops/crossmacro.nix`
    - switch policy source path to canonical filename:
      `io.github.alper_han.crossmacro.policy`

  ## Why this is needed

  - Existing `0.9.7` packaging used an outdated source hash and pre-host-split UI project path.
  - Upstream `0.9.6 -> 0.9.7` moved policy/action naming from `org.crossmacro.*` to `io.github.alper_han.crossmacro.*`; nixpkgs now matches that canonical naming.

  ## Upstream references

  - Release: https://github.com/alper-han/CrossMacro/releases/tag/v0.9.7
  - Changelog diff: https://github.com/alper-han/CrossMacro/compare/v0.9.6...v0.9.7

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

  [NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
  [Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
  [nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

  [CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
  [lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
  [maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
  [nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
  [pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
  [pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test