### PR TITLE
minizip: install missing `ints.h` header

### DIFF
--- a/pkgs/by-name/mi/minizip/package.nix
+++ b/pkgs/by-name/mi/minizip/package.nix
@@ -3,11 +3,22 @@
   stdenv,
   zlib,
   autoreconfHook,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation {
   pname = "minizip";
   inherit (zlib) src version;
+
+  patches = [
+    # install missing header for qtwebengine:
+    #   https://github.com/madler/zlib/pull/1178
+    (fetchpatch {
+      name = "add-int.h.patch";
+      url = "https://github.com/madler/zlib/commit/cb14dc9ade3759352417a300e6c2ed73268f1d97.patch";
+      hash = "sha256-eX06nYLRPqpkbBAOso1ynGDYs9dcRAI14cG89qXuUzo=";
+    })
+  ];
 
   patchFlags = [ "-p3" ];
 


### PR DESCRIPTION
Without the change the `gtwebengine` fails to buil as:

    /nix/store/...-minizip-1.3.2/include/minizip/ioapi.h:74:10: fatal error: ints.h: No such file or directory
       74 | #include "ints.h"
          |          ^~~~~~~~


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
