### PR TITLE
warp-terminal: 0.2025.12.17.17.17.stable_02 -> 0.2026.02.18.08.22.stable_02

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -18,6 +18,7 @@
   libxcursor,
   libx11,
   libxcb,
+  xz, # liblzma
   zlib,
   makeWrapper,
   waylandSupport ? false,
@@ -57,6 +58,7 @@ let
       fontconfig
       (lib.getLib stdenv.cc.cc) # libstdc++.so libgcc_s.so
       zlib
+      xz
     ];
 
     runtimeDependencies = [

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-C4NvlFEVIN3Qi//o7vPkpBGtkOBRCPOA8CUGc/3Rz0E=",
-    "version": "0.2025.12.17.17.17.stable_02"
+    "hash": "sha256-HiMDB8x72zL8XZJ36M2mVfF2CiPDCh//MnKC1ZJYWvU=",
+    "version": "0.2026.02.18.08.22.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-VGNIXVhrVu9Kqtg09E9MPPjvX87tNT6E7Ls6/+JkhO0=",
-    "version": "0.2025.12.17.17.17.stable_02"
+    "hash": "sha256-+CRcerac94LJjwamaEVVyl2GxHRbxydNe/xlIMQfcfU=",
+    "version": "0.2026.02.18.08.22.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-mTon/ue6QYTIGhG8jgA/jtTbAu5aA1xCE2yE3bdc5Pw=",
-    "version": "0.2025.12.17.17.17.stable_02"
+    "hash": "sha256-OQikiIpdegjQ7u3H6kRLc6s/4biN6l25KrHo01aEd6o=",
+    "version": "0.2026.02.18.08.22.stable_02"
   }
 }


### PR DESCRIPTION
Automatic updates are paused due to a new dependency (`liblzma.so`). This PR adds the dependency and updates to 0.2026.02.18.08.22.stable_02. I have tested basic functionalities (running UNIX commands and editing files with the local agent).

cc @imadnyc @FlameFlag @JohnRTitor @i-am-logger

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
