### PR TITLE
warmup-s3-archives: init at 1.0.0

### DIFF
--- a/pkgs/by-name/wa/warmup-s3-archives/package.nix
+++ b/pkgs/by-name/wa/warmup-s3-archives/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  rustPlatform,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "warmup-s3-archives";
+  version = "1.0.0";
+
+  src = fetchFromGitLab {
+    owner = "philipmw";
+    repo = "warmup-s3-archives";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-TJluuylxxFc66NidXCHxZdQN2VNv2QjFodUDXIQolZQ=";
+  };
+
+  cargoHash = "sha256-cPjjSYDsMsZO3Wj9wbAhSACbJGDINrE70cj+Lj4QYQE=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://gitlab.com/philipmw/warmup-s3-archives";
+    changelog = "https://gitlab.com/philipmw/warmup-s3-archives/-/releases/v${finalAttrs.version}";
+    description = "A warmup program that facilitates restoring archived objects from Amazon S3 Glacier storage classes";
+    mainProgram = "warmup-s3-archives";
+    platforms = lib.platforms.all;
+    license = lib.licenses.isc;
+    maintainers = [ lib.maintainers.pmw ];
+  };
+})


### PR DESCRIPTION
This program is designed to plug into [rustic](https://rustic.cli.rs/) version 0.11.0+ (also [being added](https://github.com/NixOS/nixpkgs/pull/492665) to NixOS 26.05) to warm up data for restore when [using cold storage for rustic backups](https://rustic.cli.rs/docs/commands/init/cold_storage.html).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
