### PR TITLE
flood: add dataDir

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -27696,6 +27696,12 @@
     githubId = 20206121;
     name = "umlx5h";
   };
+  unazikx = {
+    name = "Aziz Kurbonov";
+    github = "unazikx";
+    githubId = 189107707;
+    email = "xfalwa@gmail.com";
+  };
   uncenter = {
     name = "uncenter";
     email = "uncenter@uncenter.dev";

--- a/nixos/modules/services/torrent/flood.nix
+++ b/nixos/modules/services/torrent/flood.nix
@@ -10,8 +10,6 @@ let
   cfg = config.services.flood;
 in
 {
-  meta.maintainers = with lib.maintainers; [ thiagokokada ];
-
   options.services.flood = {
     enable = lib.mkEnableOption "flood";
     package = lib.mkPackageOption pkgs "flood" { };
@@ -29,6 +27,11 @@ in
       description = "Host to bind webserver.";
       default = "localhost";
       example = "::";
+    };
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      description = "Directory for `flood` config and db.";
+      default = "/var/lib/flood";
     };
     extraArgs = lib.mkOption {
       type = with lib.types; listOf str;
@@ -56,7 +59,8 @@ in
             cfg.host
             "--port"
             (toString cfg.port)
-            "--rundir=/var/lib/flood"
+            "--rundir"
+            cfg.dataDir
           ]
           ++ cfg.extraArgs
         );
@@ -84,7 +88,8 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
-        StateDirectory = "flood";
+        StateDirectory = baseNameOf cfg.dataDir;
+        StateDirectoryMode = lib.mkDefault 775;
         SystemCallArchitectures = "native";
         SystemCallFilter = [
           "@system-service"
@@ -98,4 +103,9 @@ in
       cfg.port
     ];
   };
+
+  meta.maintainers = with lib.maintainers; [
+    thiagokokada
+    unazikx
+  ];
 }


### PR DESCRIPTION
Added services.flood.dataDir option for special state directory

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
