### PR TITLE
sourcegit: add libGL to runtimeDeps

### DIFF
--- a/pkgs/by-name/so/sourcegit/package.nix
+++ b/pkgs/by-name/so/sourcegit/package.nix
@@ -8,6 +8,7 @@
   makeDesktopItem,
   libicns,
 
+  libGL,
   libxcursor,
   libxext,
   libxi,
@@ -53,8 +54,10 @@ buildDotnetModule (finalAttrs: {
 
   # these are dlopen-ed at runtime
   # libxi is needed for right-click support
+  # libGL is needed for GPU-accelerated rendering (without it, Avalonia falls back to software rendering)
   # not sure about what the other ones are needed for, but I'll include them anyways
   runtimeDeps = [
+    libGL
     libxcursor
     libxext
     libxi


### PR DESCRIPTION
Without libglvnd, Avalonia can't load libGL.so/libGLX.so and falls back to
software Skia rendering, which causes a lot of UI lag that scales with window
size.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) in [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)
  - [ ] [Package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests) at `passthru.tests`
  - [ ] Tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test) for functions and "core" functionality
- [ ] Ran [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review#usage) on this PR
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module
  - [ ] Module update: when the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md), [pkgs/README.md](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md), [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md) and other READMEs