### PR TITLE
netpbm: fix build for non-Glibc

### DIFF
--- a/pkgs/by-name/ne/netpbm/c23.patch
+++ b/pkgs/by-name/ne/netpbm/c23.patch
@@ -1,0 +1,63 @@
+From cde10364f1b59098fa2fbcacbdba88c7bbab4848 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Sun, 22 Feb 2026 12:06:15 +0100
+Subject: [PATCH] Remove function declarators without prototypes
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+These are no longer valid in C23 — they prototype the function as
+taking no arguments, and now cause compilation errors when building
+for non-Glibc systems.
+
+getenv is part of the C standard, so should be universally present,
+and getopt is part of POSIX, so conflicting prototypes should be a
+thing of the past.  Similar changes have been made in upstream gnulib.
+---
+ converter/other/fiasco/getopt.c | 3 +--
+ converter/other/fiasco/getopt.h | 7 -------
+ 2 files changed, 1 insertion(+), 9 deletions(-)
+
+diff --git a/converter/other/fiasco/getopt.c b/converter/other/fiasco/getopt.c
+index 65c206c3..565fac28 100644
+--- a/converter/other/fiasco/getopt.c
++++ b/converter/other/fiasco/getopt.c
+@@ -44,6 +44,7 @@
+ 
+ #include <string.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ 
+ /* Comment out all this code if we are using the GNU C Library, and are not
+    actually compiling the library itself.  This code is part of the GNU C
+@@ -203,8 +204,6 @@ static char *posixly_correct;
+ /* Avoid depending on library functions or files
+    whose names are inconsistent.  */
+ 
+-char *getenv ();
+-
+ static char *
+ my_index (str, chr)
+      const char *str;
+diff --git a/converter/other/fiasco/getopt.h b/converter/other/fiasco/getopt.h
+index 3c735e3d..08138da4 100644
+--- a/converter/other/fiasco/getopt.h
++++ b/converter/other/fiasco/getopt.h
+@@ -95,14 +95,7 @@ struct option
+ #define optional_argument       2
+ 
+ #if defined (__STDC__) && __STDC__
+-#ifdef __GNU_LIBRARY__
+-/* Many other libraries have conflicting prototypes for getopt, with
+-   differences in the consts, in stdlib.h.  To avoid compilation
+-   errors, only prototype getopt for the GNU C library.  */
+ extern int getopt (int argc, char *const *argv, const char *shortopts);
+-#else /* not __GNU_LIBRARY__ */
+-extern int getopt ();
+-#endif /* __GNU_LIBRARY__ */
+ extern int getopt_long (int argc, char *const *argv, const char *shortopts,
+                         const struct option *longopts, int *longind);
+ extern int getopt_long_only (int argc, char *const *argv,
+-- 
+2.52.0
+

--- a/pkgs/by-name/ne/netpbm/package.nix
+++ b/pkgs/by-name/ne/netpbm/package.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-WfmUfP/uc2k8qPki5Gh7WrTH6nIeyhACcn+F5GaFJCE=";
   };
 
+  patches = [
+    # Sent to maintainer 2026-02-22.
+    ./c23.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     flex


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/issues/479198

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
