### PR TITLE
lirc: split outputs, and patch several FHS issues

### DIFF
--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -63,6 +63,9 @@ stdenv.mkDerivation (finalAttrs: {
     #   https://sourceforge.net/p/lirc/git/merge-requests/39/
     substituteInPlace python-pkg/lirc/database.py \
       --replace-fail 'yaml.load(' 'yaml.safe_load('
+
+    substituteInPlace systemd/*.service \
+      --replace-fail "ExecStart=/usr/" "ExecStart=''${!outputBin}/"
   '';
 
   preConfigure = ''

--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -59,8 +59,6 @@ stdenv.mkDerivation (finalAttrs: {
     # fix overriding PYTHONPATH
     sed -i 's,^PYTHONPATH *= *,PYTHONPATH := $(PYTHONPATH):,' \
       Makefile.in
-    sed -i 's,PYTHONPATH=,PYTHONPATH=$(PYTHONPATH):,' \
-      doc/Makefile.in
 
     # Pull fix for new pyyaml pending upstream inclusion
     #   https://sourceforge.net/p/lirc/git/merge-requests/39/

--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -51,14 +51,13 @@ stdenv.mkDerivation (finalAttrs: {
     # --with-systemdsystemunitdir
     # https://sourceforge.net/p/lirc/tickets/385/
     ./ubuntu.diff
+
+    # fix overriding PYTHONPATH
+    ./pythonpath.patch
   ];
 
   postPatch = ''
     patchShebangs .
-
-    # fix overriding PYTHONPATH
-    sed -i 's,^PYTHONPATH *= *,PYTHONPATH := $(PYTHONPATH):,' \
-      Makefile.in
 
     # Pull fix for new pyyaml pending upstream inclusion
     #   https://sourceforge.net/p/lirc/git/merge-requests/39/

--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -65,10 +65,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Pull fix for new pyyaml pending upstream inclusion
     #   https://sourceforge.net/p/lirc/git/merge-requests/39/
     substituteInPlace python-pkg/lirc/database.py --replace 'yaml.load(' 'yaml.safe_load('
-
-    # cant import '/build/lirc-0.10.1/python-pkg/lirc/_client.so' while cross-compiling to check the version
-    substituteInPlace python-pkg/setup.py \
-      --replace "VERSION='0.0.0'" "VERSION='${finalAttrs.version}'"
   '';
 
   preConfigure = ''

--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -64,7 +64,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     # Pull fix for new pyyaml pending upstream inclusion
     #   https://sourceforge.net/p/lirc/git/merge-requests/39/
-    substituteInPlace python-pkg/lirc/database.py --replace 'yaml.load(' 'yaml.safe_load('
+    substituteInPlace python-pkg/lirc/database.py \
+      --replace-fail 'yaml.load(' 'yaml.safe_load('
   '';
 
   preConfigure = ''

--- a/pkgs/by-name/li/lirc/package.nix
+++ b/pkgs/by-name/li/lirc/package.nix
@@ -109,6 +109,30 @@ stdenv.mkDerivation (finalAttrs: {
     "localstatedir=$TMPDIR"
   ];
 
+  outputs = [
+    "out"
+    "man"
+    "doc"
+    "dev"
+    # This is the output referenced by dependent packages most of the time.
+    # $out on the other hand contains files used by direct users of lirc -
+    # systemd units, binaries, shell scripts & lirc python package. Since
+    # Nixpkgs' stdenv puts by default python libraries in $lib, this causes a
+    # cyclic reference between $out and $lib. We solve this by moving the
+    # Python library to $out in postFixup below. Since the Python library is
+    # also strongly related to the direct usage of lirc (and not only linking
+    # to the libraries of it), this makes sense anyway.
+    "lib"
+  ];
+
+  postFixup = ''
+    moveToOutput "${python3.sitePackages}" "$out"
+    # $out/bin/lirc-setup is symlinked to $lib/''${python3.sitePackages}, so it
+    # has to be fixed due to the above.
+    rm $out/bin/lirc-setup
+    ln -s $out/${python3.sitePackages}/lirc-setup/lirc-setup $out/bin/lirc-setup
+  '';
+
   # Upstream ships broken symlinks in docs
   dontCheckForBrokenSymlinks = true;
 

--- a/pkgs/by-name/li/lirc/pythonpath.patch
+++ b/pkgs/by-name/li/lirc/pythonpath.patch
@@ -1,0 +1,13 @@
+diff --git i/Makefile.in w/Makefile.in
+index d039ed3e9d6a..c40e6eac56ae 100644
+--- i/Makefile.in
++++ w/Makefile.in
+@@ -493,7 +493,7 @@ AUTOMAKE_OPTIONS = 1.5 check-news dist-bzip2 -Wno-portability \
+ 
+ PYTHONPATH1 = $(abs_top_srcdir)/python-pkg/lirc:
+ PYTHONPATH2 = $(abs_top_srcdir)/python-pkg/lirc/lib/.libs
+-PYTHONPATH = $(PYTHONPATH1):$(PYTHONPATH2)
++PYTHONPATH := $(PYTHONPATH):$(PYTHONPATH1):$(PYTHONPATH2)
+ PYLINT = python3-pylint
+ pylint_template = {path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+ GIT_COMMIT = $(shell git log -1 --pretty=format:%h || echo UNKNOWN)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
    - [x] Direct dependency `pulseaudioFull`
    - [x] Direct dependency `rhythmbox`
  - [ ] aarch64-linux
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test