### PR TITLE
hash_extender: fix `gcc-15` build

### DIFF
--- a/pkgs/by-name/ha/hash_extender/package.nix
+++ b/pkgs/by-name/ha/hash_extender/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   openssl,
 }:
 
@@ -16,10 +17,27 @@ stdenv.mkDerivation {
     sha256 = "1fj118566hr1wv03az2w0iqknazsqqkak0mvlcvwpgr6midjqi9b";
   };
 
+  patches = [
+    # gcc-15 build fix:
+    #   https://github.com/iagox86/hash_extender/pull/15
+    (fetchpatch {
+      name = "gcc-15.patch";
+      url = "https://github.com/iagox86/hash_extender/commit/84d8d70eb10bcbe4dea2cf5a41d246d59a389e61.patch";
+      hash = "sha256-LCzv4FK+4WoJBYYUYB+zsC6358ZpTOxbE91W/1pFe6U=";
+    })
+  ];
+
   buildInputs = [ openssl ];
 
+  enableParallelBuilding = true;
   doCheck = true;
-  checkPhase = "./hash_extender --test";
+  checkPhase = ''
+    runHook preCheck
+
+    ./hash_extender --test
+
+    runHook postCheck
+  '';
 
   # https://github.com/iagox86/hash_extender/issues/26
   hardeningDisable = [ "fortify3" ];
@@ -27,8 +45,12 @@ stdenv.mkDerivation {
   env.NIX_CFLAGS_COMPILE = "-Wno-error=deprecated-declarations";
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin
     cp hash_extender $out/bin
+
+    runHook postInstall
   '';
 
   meta = {


### PR DESCRIPTION
Without the change the build fails on `master` as
https://hydra.nixos.org/build/319912473:

```
In file included from hash_extender_engine.c:33:
tiger.h:1: error: header guard '__TIGER_H_' followed by '#define' of a different macro [-Werror=header-guard]
    1 | #ifndef __TIGER_H_
tiger.h:2: note: '__TIGER_H__' is defined here; did you mean '__TIGER_H_'?
    2 | #define __TIGER_H__
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
