### PR TITLE
maintainers: drop dezgeg

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6583,12 +6583,6 @@
     githubId = 4951663;
     name = "Morgan Helton";
   };
-  dezgeg = {
-    email = "tuomas.tynkkynen@iki.fi";
-    github = "dezgeg";
-    githubId = 579369;
-    name = "Tuomas Tynkkynen";
-  };
   dezren39 = {
     email = "drewrypope@gmail.com";
     github = "dezren39";

--- a/pkgs/by-name/am/amoeba-data/package.nix
+++ b/pkgs/by-name/am/amoeba-data/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Fast-paced, polished OpenGL demonstration by Excess (data files)";
     homepage = "https://packages.qa.debian.org/a/amoeba-data.html";
     license = lib.licenses.unfree;
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/am/amoeba/package.nix
+++ b/pkgs/by-name/am/amoeba/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Fast-paced, polished OpenGL demonstration by Excess";
     homepage = "https://packages.qa.debian.org/a/amoeba.html";
     license = lib.licenses.gpl2Only; # Engine is GPLv2, data files in amoeba-data nonfree
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ba/bastet/package.nix
+++ b/pkgs/by-name/ba/bastet/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "bastet";
     homepage = "http://fph.altervista.org/prog/bastet.html";
     license = lib.licenses.gpl3;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/bm/bmaptool/package.nix
+++ b/pkgs/by-name/bm/bmaptool/package.nix
@@ -29,7 +29,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
     description = "BMAP Tools";
     homepage = "https://github.com/yoctoproject/bmaptool";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "bmaptool";
   };

--- a/pkgs/by-name/ck/ckbcomp/package.nix
+++ b/pkgs/by-name/ck/ckbcomp/package.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Compiles a XKB keyboard description to a keymap suitable for loadkeys";
     homepage = "https://salsa.debian.org/installer-team/console-setup";
     license = lib.licenses.gpl2Plus;
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "ckbcomp";
   };

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -343,7 +343,6 @@ python.pkgs.buildPythonApplication rec {
     changelog = "https://diffoscope.org/news/diffoscope-${version}-released/";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
-      dezgeg
       danielfullmer
       raitobezarius
     ];

--- a/pkgs/by-name/dt/dtc/package.nix
+++ b/pkgs/by-name/dt/dtc/package.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Device Tree Compiler";
     homepage = "https://git.kernel.org/pub/scm/utils/dtc/dtc.git";
     license = lib.licenses.gpl2Plus; # dtc itself is GPLv2, libfdt is dual GPL/BSD
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "dtc";
   };

--- a/pkgs/by-name/es/esptool-ck/package.nix
+++ b/pkgs/by-name/es/esptool-ck/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "ESP8266/ESP32 build helper tool";
     homepage = "https://github.com/igrr/esptool-ck";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "esptool";
   };

--- a/pkgs/by-name/es/esptool/package.nix
+++ b/pkgs/by-name/es/esptool/package.nix
@@ -116,7 +116,6 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/espressif/esptool";
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [
-      dezgeg
       dotlambda
     ];
     platforms = with lib.platforms; linux ++ darwin;

--- a/pkgs/by-name/et/eternal-terminal/package.nix
+++ b/pkgs/by-name/et/eternal-terminal/package.nix
@@ -57,7 +57,6 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/MisterTea/EternalTerminal/releases/tag/et-v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      dezgeg
       jshort
     ];
     platforms = lib.platforms.linux ++ lib.platforms.darwin;

--- a/pkgs/by-name/fi/filebench/package.nix
+++ b/pkgs/by-name/fi/filebench/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "File system and storage benchmark that can generate both micro and macro workloads";
     homepage = "https://sourceforge.net/projects/filebench/";
     license = lib.licenses.cddl;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "filebench";
   };

--- a/pkgs/by-name/fs/fsmark/package.nix
+++ b/pkgs/by-name/fs/fsmark/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Synchronous write workload file system benchmark";
     homepage = "https://sourceforge.net/projects/fsmark/";
     license = lib.licenses.gpl2Plus;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "fs_mark";
   };

--- a/pkgs/by-name/fs/fsmon/package.nix
+++ b/pkgs/by-name/fs/fsmon/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/nowsecure/fsmon";
     changelog = "https://github.com/nowsecure/fsmon/releases/tag/${finalAttrs.version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "fsmon";
   };

--- a/pkgs/by-name/gn/gnu-config/package.nix
+++ b/pkgs/by-name/gn/gnu-config/package.nix
@@ -64,7 +64,6 @@ stdenv.mkDerivation {
     #   the same distribution terms that you use for the rest of that
     #   program.
     maintainers = with lib.maintainers; [
-      dezgeg
       emilytrau
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/i2/i2c-tools/package.nix
+++ b/pkgs/by-name/i2/i2c-tools/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
       lgpl21Plus
       gpl2Plus
     ];
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/km/kmscube/package.nix
+++ b/pkgs/by-name/km/kmscube/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation {
     description = "Example OpenGL app using KMS/GBM";
     homepage = "https://gitlab.freedesktop.org/mesa/kmscube";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 }

--- a/pkgs/by-name/lc/lcov/package.nix
+++ b/pkgs/by-name/lc/lcov/package.nix
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/linux-test-project/lcov/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.gpl2Plus;
 
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
   };
 })

--- a/pkgs/by-name/li/libnsl/package.nix
+++ b/pkgs/by-name/li/libnsl/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Client interface library for NIS(YP) and NIS+";
     homepage = "https://github.com/thkukuk/libnsl";
     license = lib.licenses.lgpl21;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/li/libraspberrypi/package.nix
+++ b/pkgs/by-name/li/libraspberrypi/package.nix
@@ -43,7 +43,6 @@ stdenv.mkDerivation {
       "x86_64-linux"
     ];
     maintainers = with lib.maintainers; [
-      dezgeg
       tkerber
     ];
   };

--- a/pkgs/by-name/li/linuxquota/package.nix
+++ b/pkgs/by-name/li/linuxquota/package.nix
@@ -40,6 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://sourceforge.net/projects/linuxquota/";
     license = lib.licenses.gpl2Plus; # With some files being BSD as an exception
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
   };
 })

--- a/pkgs/by-name/ls/lsof/package.nix
+++ b/pkgs/by-name/ls/lsof/package.nix
@@ -88,7 +88,7 @@ stdenv.mkDerivation rec {
       from it).
     '';
     license = lib.licenses.lsof;
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/me/memtester/package.nix
+++ b/pkgs/by-name/me/memtester/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Userspace utility for testing the memory subsystem for faults";
     homepage = "http://pyropus.ca/software/memtester/";
     license = lib.licenses.gpl2Only;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "memtester";
   };

--- a/pkgs/by-name/mi/ministat/package.nix
+++ b/pkgs/by-name/mi/ministat/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Simple tool for statistical comparison of data sets";
     homepage = "https://git.decadent.org.uk/gitweb/?p=ministat.git";
     license = lib.licenses.beerware;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.all;
     mainProgram = "ministat";
   };

--- a/pkgs/by-name/mm/mmc-utils/package.nix
+++ b/pkgs/by-name/mm/mmc-utils/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "mmc";
     homepage = "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/";
     license = lib.licenses.gpl2Only;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/nt/ntfs3g/package.nix
+++ b/pkgs/by-name/nt/ntfs3g/package.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "https://github.com/tuxera/ntfs-3g";
     description = "FUSE-based NTFS driver with full write support";
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     mainProgram = "ntfs-3g";
     platforms = with lib.platforms; darwin ++ linux;
     license = with lib.licenses; [

--- a/pkgs/by-name/re/read-edid/package.nix
+++ b/pkgs/by-name/re/read-edid/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Tool for reading and parsing EDID data from monitors";
     homepage = "http://www.polypux.org/projects/read-edid/";
     license = lib.licenses.bsd2; # Quoted: "This is an unofficial license. Let's call it BSD-like."
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/si/sidplayfp/package.nix
+++ b/pkgs/by-name/si/sidplayfp/package.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with lib.licenses; [ gpl2Plus ];
     mainProgram = "sidplayfp";
     maintainers = with lib.maintainers; [
-      dezgeg
       OPNA2608
     ];
     platforms = lib.platforms.all;

--- a/pkgs/by-name/si/simg2img/package.nix
+++ b/pkgs/by-name/si/simg2img/package.nix
@@ -40,7 +40,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.asl20;
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
-      dezgeg
       arkivm
     ];
   };

--- a/pkgs/by-name/sn/sng/package.nix
+++ b/pkgs/by-name/sn/sng/package.nix
@@ -38,8 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Minilanguage designed to represent the entire contents of a PNG file in an editable form";
     license = lib.licenses.zlib;
     mainProgram = "sng";
-    maintainers = with lib.maintainers; [
-      dezgeg
+    maintainers = [
     ];
     platforms = lib.platforms.unix;
   };

--- a/pkgs/by-name/st/streamlink/package.nix
+++ b/pkgs/by-name/st/streamlink/package.nix
@@ -78,7 +78,6 @@ python3Packages.buildPythonApplication rec {
     license = lib.licenses.bsd2;
     mainProgram = "streamlink";
     maintainers = with lib.maintainers; [
-      dezgeg
       zraexy
       DeeUnderscore
     ];

--- a/pkgs/by-name/tr/trinity/package.nix
+++ b/pkgs/by-name/tr/trinity/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "trinity";
     homepage = "https://github.com/kernelslacker/trinity";
     license = lib.licenses.gpl2Only;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/xf/xfsprogs/package.nix
+++ b/pkgs/by-name/xf/xfsprogs/package.nix
@@ -104,7 +104,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]; # see https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/debian/copyright
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
-      dezgeg
       ajs124
     ];
   };

--- a/pkgs/by-name/xf/xfstests/package.nix
+++ b/pkgs/by-name/xf/xfstests/package.nix
@@ -159,7 +159,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Torture test suite for filesystems";
     homepage = "https://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git/";
     license = lib.licenses.gpl2Only;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.linux;
     mainProgram = "xfstests-check";
   };

--- a/pkgs/by-name/yl/yle-dl/package.nix
+++ b/pkgs/by-name/yl/yle-dl/package.nix
@@ -46,7 +46,7 @@ python3Packages.buildPythonApplication {
     homepage = "https://aajanki.github.io/yle-dl/";
     changelog = "https://github.com/aajanki/yle-dl/blob/${src.tag}/ChangeLog";
     license = lib.licenses.gpl3Plus;
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     mainProgram = "yle-dl";
   };

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -152,7 +152,6 @@ let
             description = "Boot loader for embedded systems";
             license = lib.licenses.gpl2Plus;
             maintainers = with lib.maintainers; [
-              dezgeg
               lopsided98
             ];
           }

--- a/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
+++ b/pkgs/os-specific/linux/firmware/raspberrypi/default.nix
@@ -29,7 +29,7 @@ stdenvNoCC.mkDerivation rec {
     description = "Firmware for the Raspberry Pi board";
     homepage = "https://github.com/raspberrypi/firmware";
     license = lib.licenses.unfreeRedistributableFirmware; # See https://github.com/raspberrypi/firmware/blob/master/boot/LICENCE.broadcom
-    maintainers = with lib.maintainers; [ dezgeg ];
+    maintainers = [ ];
     # Hash mismatch on source, mystery.
     # Maybe due to https://github.com/NixOS/nix/issues/847
     broken = stdenvNoCC.hostPlatform.isDarwin;

--- a/pkgs/tools/graphics/rocket/default.nix
+++ b/pkgs/tools/graphics/rocket/default.nix
@@ -37,6 +37,6 @@ stdenv.mkDerivation {
     homepage = "https://github.com/rocket/rocket";
     license = lib.licenses.zlib;
     platforms = lib.platforms.linux;
-    maintainers = [ lib.maintainers.dezgeg ];
+    maintainers = [ ];
   };
 }

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -301,7 +301,7 @@ in
       linuxTools = import ../stdenv/linux/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
       freebsdTools = import ../stdenv/freebsd/make-bootstrap-tools-cross.nix { system = "x86_64-linux"; };
       linuxMeta = {
-        maintainers = [ maintainers.dezgeg ];
+        maintainers = [ ];
       };
       freebsdMeta = {
         maintainers = [ maintainers.rhelmot ];


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Adezgeg) since 2018 despite over 700 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2019-01-01+user-review-requested%3Adezgeg). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@dezgeg if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
