### PR TITLE
highfive: 2.10.1 -> 3.3.0

### DIFF
--- a/pkgs/by-name/hi/highfive/package.nix
+++ b/pkgs/by-name/hi/highfive/package.nix
@@ -3,8 +3,6 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  boost,
-  eigen,
   hdf5,
   mpiSupport ? hdf5.mpiSupport,
   mpi ? hdf5.mpi,
@@ -14,20 +12,18 @@ assert mpiSupport -> mpi != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "highfive${lib.optionalString mpiSupport "-mpi"}";
-  version = "2.10.1";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
-    owner = "BlueBrain";
-    repo = "HighFive";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-Nv+nbel/xGlGTB8sKF0EM1xwz/ZEri5uGB7ma6Ba6fo=";
+    owner = "highfive-devs";
+    repo = "highfive";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-BuDvoQgMdZIDHYwXqigM78DQ+WtT+K0FdXERMUjmXc0=";
   };
 
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    boost
-    eigen
     hdf5
   ];
 
@@ -36,19 +32,16 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cmakeFlags = [
-    "-DHIGHFIVE_USE_BOOST=ON"
-    "-DHIGHFIVE_USE_EIGEN=ON"
     "-DHIGHFIVE_EXAMPLES=OFF"
     "-DHIGHFIVE_UNIT_TESTS=OFF"
-    "-DHIGHFIVE_USE_INSTALL_DEPS=ON"
-    (lib.cmakeFeature "CMAKE_POLICY_VERSION_MINIMUM" "3.5")
   ]
-  ++ (lib.optionals mpiSupport [ "-DHIGHFIVE_PARALLEL_HDF5=ON" ]);
+  ++ (lib.optionals mpiSupport [ "-DHDF5_IS_PARALLEL=ON" ]);
 
   meta = {
     description = "Header-only C++ HDF5 interface";
+    homepage = "https://github.com/highfive-devs/highfive";
+    changelog = "https://github.com/highfive-devs/highfive/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     license = lib.licenses.boost;
-    homepage = "https://bluebrain.github.io/HighFive/";
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [ robertodr ];
   };


### PR DESCRIPTION
This fixes the build of highfive on staging-next.

- The removed cmake flags don't exist anymore.
- Repo moved to https://github.com/highfive-devs/highfive, see the notice in the [original repo](https://github.com/BlueBrain/HighFive)

Hydra: https://hydra.nixos.org/build/321339317/nixlog/5

Changelog: https://github.com/highfive-devs/highfive/blob/v3.3.0/CHANGELOG.md
Diff: https://github.com/highfive-devs/highfive/compare/v2.10.1...v3.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `highfive{,-mpi}`, `rivet` (although I suspect highfive isn't even used by rivet)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
