### PR TITLE
keepass-*: set pname and version

### DIFF
--- a/pkgs/by-name/ke/keepass-charactercopy/package.nix
+++ b/pkgs/by-name/ke/keepass-charactercopy/package.nix
@@ -45,7 +45,7 @@ let
 in
 # Mono is required to compile plugin at runtime, after loading.
 buildEnv {
-  name = drv.name;
+  inherit (drv) pname version;
   paths = [
     mono
     drv

--- a/pkgs/by-name/ke/keepass-keeagent/package.nix
+++ b/pkgs/by-name/ke/keepass-keeagent/package.nix
@@ -36,7 +36,7 @@ let
 in
 # Mono is required to compile plugin at runtime, after loading.
 buildEnv {
-  name = drv.name;
+  inherit (drv) pname version;
   paths = [
     mono
     drv

--- a/pkgs/by-name/ke/keepass-keepasshttp/package.nix
+++ b/pkgs/by-name/ke/keepass-keepasshttp/package.nix
@@ -38,7 +38,7 @@ let
 in
 # Mono is required to compile plugin at runtime, after loading.
 buildEnv {
-  name = drv.name;
+  inherit (drv) pname version;
   paths = [
     mono
     drv

--- a/pkgs/by-name/ke/keepass-keepassrpc/package.nix
+++ b/pkgs/by-name/ke/keepass-keepassrpc/package.nix
@@ -36,7 +36,7 @@ let
 in
 # Mono is required to compile plugin at runtime, after loading.
 buildEnv {
-  name = drv.name;
+  inherit (drv) pname version;
   paths = [
     mono
     drv

--- a/pkgs/by-name/ke/keepass-keetraytotp/package.nix
+++ b/pkgs/by-name/ke/keepass-keetraytotp/package.nix
@@ -44,7 +44,7 @@ let
 in
 # Mono is required to compile plugin at runtime, after loading.
 buildEnv {
-  name = drv.name;
+  inherit (drv) pname version;
   paths = [
     mono
     drv

--- a/pkgs/by-name/ke/keepass-otpkeyprov/package.nix
+++ b/pkgs/by-name/ke/keepass-otpkeyprov/package.nix
@@ -36,7 +36,7 @@ let
 in
 # Mono is required to compile plugin at runtime, after loading.
 buildEnv {
-  name = drv.name;
+  inherit (drv) pname version;
   paths = [
     mono
     drv

--- a/pkgs/by-name/ke/keepass-qrcodeview/package.nix
+++ b/pkgs/by-name/ke/keepass-qrcodeview/package.nix
@@ -43,7 +43,7 @@ let
 in
 # Mono is required to compile plugin at runtime, after loading.
 buildEnv {
-  name = drv.name;
+  inherit (drv) pname version;
   paths = [
     mono
     drv


### PR DESCRIPTION
Part of #485742

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
