### PR TITLE
act3: init at 2.0.0

### DIFF
--- a/pkgs/by-name/ac/act3/package.nix
+++ b/pkgs/by-name/ac/act3/package.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "act3";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "dhth";
+    repo = "act3";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-GE9f4hm+R4G4NCqdPN6h5MTZqMVLkrdMnc20bOZGcu4=";
+  };
+
+  vendorHash = "sha256-+WSWlmxQTryLrpeloYdupyMibsgFYpjSuDvW+if3IHE=";
+
+  meta = {
+    description = "Glance at the last 3 runs of your GitHub Actions workflows";
+    homepage = "https://tools.dhruvs.space/act3/";
+    downloadPage = "https://github.com/dhth/act3";
+    changelog = "https://github.com/dhth/act3/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ artur-sannikov ];
+  };
+})


### PR DESCRIPTION
## Things done

act3: Glance at the last 3 runs of your GitHub Actions workflows 
Homepage: https://tools.dhruvs.space/act3/
Github: https://github.com/dhth/act3

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test