### PR TITLE
python3Packages.magic-wormhole-mailbox-server: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   setuptools,
   attrs,
   twisted,
@@ -17,9 +17,11 @@ buildPythonPackage (finalAttrs: {
   version = "0.5.1";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit (finalAttrs) pname version;
-    hash = "sha256-oAegNnIpMgRldoHb9QIEXW1YF8V/mq4vIibm6hoAjKE=";
+  src = fetchFromGitHub {
+    owner = "magic-wormhole";
+    repo = "magic-wormhole-mailbox-server";
+    tag = finalAttrs.version;
+    hash = "sha256-z0iJDUE0LL/PbAYGAHnNJ4wizuB4qA4nFk3uLNuTNWg=";
   };
 
   build-system = [ setuptools ];
@@ -52,7 +54,7 @@ buildPythonPackage (finalAttrs: {
   meta = {
     description = "Securely transfer data between computers";
     homepage = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server";
-    changelog = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/refs/tags/${finalAttrs.version}/NEWS.md";
+    changelog = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/${finalAttrs.src.rev}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
   };

--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "magic-wormhole-mailbox-server";
-  version = "0.5.1";
+  version = "0.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "magic-wormhole";
     repo = "magic-wormhole-mailbox-server";
     tag = finalAttrs.version;
-    hash = "sha256-z0iJDUE0LL/PbAYGAHnNJ4wizuB4qA4nFk3uLNuTNWg=";
+    hash = "sha256-Ckwkvw4pMEGUTarfzg1GOodHMwM5hVix2bPCZTI6hxU=";
   };
 
   build-system = [ setuptools ];
@@ -29,7 +29,6 @@ buildPythonPackage (finalAttrs: {
   dependencies = [
     attrs
     autobahn
-    setuptools # pkg_resources is referenced at runtime
     twisted
   ]
   ++ autobahn.optional-dependencies.twisted

--- a/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
+++ b/pkgs/development/python-modules/magic-wormhole-mailbox-server/default.nix
@@ -12,13 +12,13 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "magic-wormhole-mailbox-server";
   version = "0.5.1";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
+    inherit (finalAttrs) pname version;
     hash = "sha256-oAegNnIpMgRldoHb9QIEXW1YF8V/mq4vIibm6hoAjKE=";
   };
 
@@ -52,8 +52,8 @@ buildPythonPackage rec {
   meta = {
     description = "Securely transfer data between computers";
     homepage = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server";
-    changelog = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/${version}/NEWS.md";
+    changelog = "https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/refs/tags/${finalAttrs.version}/NEWS.md";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.mjoerg ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/magic-wormhole/magic-wormhole-mailbox-server/compare/refs/tags/0.5.1...refs/tags/0.6.0
https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/refs/tags/0.6.0/NEWS.md

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 493049`
Commit: `78099582b69e72a09ec00bb46facbe1b278e9f7c`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 15 packages built:</summary>
  <ul>
    <li>gnome-keysign</li>
    <li>gnome-keysign.dist</li>
    <li>magic-wormhole (python313Packages.magic-wormhole)</li>
    <li>magic-wormhole.dist (python313Packages.magic-wormhole.dist)</li>
    <li>python313Packages.magic-wormhole-mailbox-server</li>
    <li>python313Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python314Packages.magic-wormhole</li>
    <li>python314Packages.magic-wormhole-mailbox-server</li>
    <li>python314Packages.magic-wormhole-mailbox-server.dist</li>
    <li>python314Packages.magic-wormhole.dist</li>
    <li>tahoe-lafs</li>
    <li>tahoe-lafs.dist</li>
    <li>tahoe-lafs.doc</li>
    <li>tahoe-lafs.info</li>
    <li>tahoe-lafs.man</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test