### PR TITLE
cutecosmic: init at 0.1-unstable-2026-01-21

### DIFF
--- a/pkgs/by-name/cu/cutecosmic/package.nix
+++ b/pkgs/by-name/cu/cutecosmic/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  stdenv,
+  cargo,
+  cmake,
+  common-updater-scripts,
+  fetchFromGitHub,
+  nix-update,
+  qt6,
+  ripgrep,
+  rustPlatform,
+  rustc,
+  writeShellScript,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cutecosmic";
+  version = "0.1-unstable-2026-01-21";
+
+  src = fetchFromGitHub {
+    owner = "IgKh";
+    repo = "cutecosmic";
+    rev = "8e584418f69eeeaee8574c4a48cc92ef27fd610e";
+    hash = "sha256-jKiO+WlNHM1xavKdB6PrGd3HmTgnyL1vjh0Ps1HcWx4=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs) src;
+    name = "${finalAttrs.pname}-${finalAttrs.version}";
+    sourceRoot = "${finalAttrs.src.name}/bindings";
+    hash = "sha256-+1z0VoxDeOYSmb7BoFSdrwrfo1mmwkxeuEGP+CGFc8Y=";
+  };
+
+  cargoRoot = "bindings";
+
+  nativeBuildInputs = [
+    cmake
+    qt6.wrapQtAppsHook
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_CORROSION" "${finalAttrs.passthru.sources.corrosion}")
+  ];
+
+  postPatch = ''
+    substituteInPlace platformtheme/CMakeLists.txt \
+      --replace-fail "\''${QT_INSTALL_PLUGINS}/platformthemes" \
+      "${qt6.qtbase.qtPluginPrefix}/platformthemes"
+  '';
+
+  passthru = {
+    sources = {
+      # rev from source/bindings/CMakeLists.txt
+      corrosion = fetchFromGitHub {
+        owner = "corrosion-rs";
+        repo = "corrosion";
+        rev = "v0.5.2";
+        hash = "sha256-sO2U0llrDOWYYjnfoRZE+/ofg3kb+ajFmqvaweRvT7c=";
+      };
+    };
+
+    updateScript = writeShellScript "update-cutecosmic" ''
+      set -euo pipefail
+
+      ${lib.getExe nix-update} cutecosmic --version branch=HEAD
+      src=$(nix-build -A cutecosmic.src --no-out-link)
+
+      # Corrosion-rs dependency
+      tag=$(${lib.getExe ripgrep} --multiline --pcre2 --only-matching \
+        'FetchContent_Declare\(\s*Corrosion[^)]*GIT_TAG\s+(v[\d.]+)' \
+        --replace '$1' \
+        "$src/bindings/CMakeLists.txt")
+
+      ${lib.getExe' common-updater-scripts "update-source-version"} \
+        cutecosmic.sources.corrosion \
+        "$tag" \
+        --source-key=out \
+        --version-key=rev \
+        --file=${lib.escapeShellArg (toString ./.) + "/package.nix"}
+    '';
+  };
+
+  meta = {
+    homepage = "https://github.com/IgKh/cutecosmic";
+    description = "Qt platform theme for COSMIC Desktop environment";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [
+      amozeo
+      thefossguy
+    ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
cutecosmic is a Qt platform theme for the COSMIC™ Desktop environment

source: https://github.com/IgKh/cutecosmic

CC: @NixOS/cosmic as I think they will find this contribution interesting, especially after [cosmic-session's `start-cosmic` script looking for it](<https://github.com/pop-os/cosmic-session/commit/618624bcc0d06fe223f9c71727826d73a9b61d03>) in next epoch release

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
