### PR TITLE
librewolf: add hythera as maintainer

### DIFF
--- a/pkgs/by-name/li/librewolf-unwrapped/package.nix
+++ b/pkgs/by-name/li/librewolf-unwrapped/package.nix
@@ -31,6 +31,7 @@ in
     maintainers = with lib.maintainers; [
       dwrege
       fpletz
+      hythera
     ];
     platforms = lib.platforms.unix;
     broken = stdenv.buildPlatform.is32bit;


### PR DESCRIPTION
Usually I'd do such things in a package update but I don't want to block any security updates in this case. My main motivation is that I would be able to use the merge bot on some PRs, so it would be great if this could be backported to `25.11`, allowing me to manually merge backport PRs.