### PR TITLE
kripton-gtk-theme: init at 0-unstable-2026-02-16

### DIFF
--- a/pkgs/by-name/kr/kripton-gtk-theme/package.nix
+++ b/pkgs/by-name/kr/kripton-gtk-theme/package.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "kripton";
+  version = "0-unstable-2026-02-16";
+
+  src = fetchFromGitHub {
+    owner = "EliverLara";
+    repo = "Kripton";
+    rev = "5e0f2e79ea9cc44c01da49457b26ea92924207c6";
+    hash = "sha256-QC3ZgDmqoKiltJ02wP9KdOHmMb6mfGLRW0+YB4e0mms=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/themes/Kripton
+    cp -a ./* $out/share/themes/Kripton
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "A dark theme with flat style for GNOME";
+    homepage = "https://github.com/EliverLara/Kripton";
+    license = lib.licenses.gpl3Only;
+    maintainers = [ ];
+    mainProgram = "kripton";
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION

kripton-gtk-theme: init at 0-unstable-2026-02-16
This PR adds the [Kripton GTK theme](https://github.com/EliverLara/Kripton) by EliverLara. It is a dark, flat theme for GNOME and other GTK-based desktop environments.
I have verified the build locally on x86_64-linux. I confirmed that the index.theme metadata is correct.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
