### PR TITLE
steelix: init at 25.07-unstable-2026-03-01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21992,6 +21992,12 @@
     githubId = 30029970;
     keys = [ { fingerprint = "66AE 3F93 364C 6AB8 18F9  F35D 8D1E 0726 2DFD BD00"; } ];
   };
+  Ra77a3l3-jar = {
+    email = "raffaelemeo77@gmail.com";
+    name = "Raffaele Meo";
+    github = "Ra77a3l3-jar";
+    githubId = 175424218;
+  };
   raboof = {
     email = "arnout@bzzt.net";
     matrix = "@raboof:matrix.org";

--- a/pkgs/by-name/st/steelix/package.nix
+++ b/pkgs/by-name/st/steelix/package.nix
@@ -1,0 +1,61 @@
+{
+  fetchFromGitHub,
+  helix,
+  installShellFiles,
+  lib,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "steelix";
+  version = "25.07-unstable-2026-03-01";
+
+  src = fetchFromGitHub {
+    owner = "mattwparas";
+    repo = "helix";
+    rev = "69d8222d17d42be19d4610f74c756d9e172cef68";
+    hash = "sha256-QQuflhLeN+1tH2g7ob1N+DSnQaWDsRk0YzyX69QIX1k=";
+  };
+
+  cargoHash = "sha256-Dx+82EutywNJohvfTgoIQ3B6f2wQS9MkFyOBzXqngXM=";
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  # Don't use cargo xtask steel since it needs network access
+  cargoBuildFlags = [
+    "--package"
+    "helix-term"
+    "--features"
+    "steel,git"
+  ];
+
+  env = {
+    # Disable fetching and building of tree-sitter grammars in the helix-term build.rs
+    HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+    # Use tree-sitter grammars and runtime from the helix package
+    HELIX_DEFAULT_RUNTIME = helix.runtime;
+  };
+
+  postInstall = ''
+    installShellCompletion contrib/completion/hx.{bash,fish,zsh}
+    mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
+    cp contrib/Helix.desktop $out/share/applications
+    cp contrib/helix.png $out/share/icons/hicolor/256x256/apps
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Helix editor with Steel (Scheme) scripting support";
+    longDescription = ''
+      Steelix is a fork of the Helix text editor with Steel (Scheme) scripting support.
+    '';
+    homepage = "https://github.com/mattwparas/helix";
+    changelog = "https://github.com/mattwparas/helix/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mpl20;
+    mainProgram = "hx";
+    maintainers = with lib.maintainers; [
+      Ra77a3l3-jar
+    ];
+  };
+})

--- a/pkgs/by-name/st/steelix/update.sh
+++ b/pkgs/by-name/st/steelix/update.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p nix-update
+
+set -euo pipefail
+
+echo "Updating steelix source to the latest commit from steel-event-system branch..."
+nix-update steelix --version=branch=steel-event-system
+
+echo "Done!"


### PR DESCRIPTION
Steelix is a fork of the Helix text editor that adds Steel (Scheme) scripting support. This package provides an easy installation method for users wanting to try Steel scripting in Helix without needing a Rust toolchain or building from source.
.
# Things done
- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] NixOS tests in nixos/tests.
  - [ ] Package tests at passthru.tests.
  - [ ] Tests in lib/tests or pkgs/test for functions and "core" functionality.
- [x] Ran nixpkgs-review on this PR. See nixpkgs-review usage.
- [x] Tested basic functionality of all binary files, usually in ./result/bin/.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits CONTRIBUTING.md, pkgs/README.md, maintainers/README.md and other READMEs.