### PR TITLE
xfce4-whiskermenu-plugin: 2.10.0 -> 2.10.1

### DIFF
--- a/pkgs/by-name/xf/xfce4-whiskermenu-plugin/package.nix
+++ b/pkgs/by-name/xf/xfce4-whiskermenu-plugin/package.nix
@@ -22,14 +22,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xfce4-whiskermenu-plugin";
-  version = "2.10.0";
+  version = "2.10.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.xfce.org";
     owner = "panel-plugins";
     repo = "xfce4-whiskermenu-plugin";
     tag = "xfce4-whiskermenu-plugin-${finalAttrs.version}";
-    hash = "sha256-2FACsP6mKx0k91xG3DaVS6hdvdLrjLu9Y9rVOW6PZ3M=";
+    hash = "sha256-mSACaLwC7G2NBg7JbK59hwpkaSnQE4nsfSH1oABdOso=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
https://gitlab.xfce.org/panel-plugins/xfce4-whiskermenu-plugin/-/compare/xfce4-whiskermenu-plugin-2.10.0...xfce4-whiskermenu-plugin-2.10.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
