### PR TITLE
zoneminder: 1.36.36 -> 1.36.38, fixes CVE-2026-27470

### DIFF
--- a/pkgs/by-name/zo/zoneminder/package.nix
+++ b/pkgs/by-name/zo/zoneminder/package.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  fetchpatch,
   fetchurl,
   cmake,
   makeWrapper,
@@ -84,24 +83,17 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "zoneminder";
-  version = "1.36.36";
+  version = "1.36.38";
 
   src = fetchFromGitHub {
     owner = "ZoneMinder";
     repo = "zoneminder";
     tag = version;
-    hash = "sha256-q+LpM8JSjcroGa04CqQ7PUU/WvZ9YCVhGOhwBAhOFY0=";
+    hash = "sha256-c/Q+h0ntJ4XUuvgrLSlWfue4GL4nGARgmXt0En334Y4=";
     fetchSubmodules = true;
   };
 
   patches = [
-    # Fix building against FFmpeg 8.0
-    # https://github.com/ZoneMinder/zoneminder/pull/4466
-    (fetchpatch {
-      url = "https://github.com/peat-psuwit/zoneminder/commit/15241687e9ccd97d7866cc7245324472ff6c7f0e.patch";
-      hash = "sha256-DXeoYOMI3Hcpwshg6wiBxaoTPOswLVV3Weq3Mh5Vaw0=";
-    })
-
     ./default-to-http-1dot1.patch
     ./0001-Don-t-use-file-timestamp-in-cache-filename.patch
   ];


### PR DESCRIPTION
Changelog:
- https://github.com/ZoneMinder/zoneminder/releases/tag/1.36.37
- https://github.com/ZoneMinder/zoneminder/releases/tag/1.36.38

Supersedes https://github.com/NixOS/nixpkgs/pull/476910

See also: GHSA-r6gm-478g-f2c4

Note: we'll soon want to update to the next major version, 1.38.x (currently 1.38.1). However I don't quite have time for that at the moment (the [changes](https://github.com/ZoneMinder/zoneminder/releases/tag/1.38.0) seems significant). And 1.36.38 contains a security fix, so for now, this.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
