### PR TITLE
nixos/cloudflared: add matchSNItoHost and http2Origin options

### DIFF
--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -179,6 +179,47 @@ let
       '';
     };
   };
+
+  configFiles = lib.mapAttrs (
+    name: tunnel:
+    let
+      filterConfig = lib.attrsets.filterAttrsRecursive (
+        _: v:
+        !builtins.elem v [
+          null
+          [ ]
+          { }
+        ]
+      );
+
+      filterIngressSet = lib.filterAttrs (_: v: builtins.typeOf v == "set");
+      filterIngressStr = lib.filterAttrs (_: v: builtins.typeOf v == "string");
+
+      ingressesSet = filterIngressSet tunnel.ingress;
+      ingressesStr = filterIngressStr tunnel.ingress;
+
+      fullConfig = filterConfig {
+        tunnel = name;
+        credentials-file = "/run/credentials/cloudflared-tunnel-${name}.service/credentials.json";
+        warp-routing = filterConfig tunnel.warp-routing;
+        originRequest = filterConfig tunnel.originRequest;
+        ingress =
+          (map (
+            key:
+            {
+              hostname = key;
+            }
+            // lib.getAttr key (filterConfig (filterConfig ingressesSet))
+          ) (lib.attrNames ingressesSet))
+          ++ (map (key: {
+            hostname = key;
+            service = lib.getAttr key ingressesStr;
+          }) (lib.attrNames ingressesStr))
+          ++ [ { service = tunnel.default; } ];
+      };
+    in
+    pkgs.writeText "cloudflared-${name}.yml" (builtins.toJSON fullConfig)
+  ) config.services.cloudflared.tunnels;
 in
 {
   imports = [
@@ -275,6 +316,12 @@ in
                 example = "http_status:404";
               };
 
+              configFile = lib.mkOption {
+                type = lib.types.path;
+                readOnly = true;
+                default = configFiles.${name};
+              };
+
               ingress = lib.mkOption {
                 type =
                   with lib.types;
@@ -358,42 +405,7 @@ in
     systemd.services = lib.mapAttrs' (
       name: tunnel:
       let
-        filterConfig = lib.attrsets.filterAttrsRecursive (
-          _: v:
-          !builtins.elem v [
-            null
-            [ ]
-            { }
-          ]
-        );
-
-        filterIngressSet = lib.filterAttrs (_: v: builtins.typeOf v == "set");
-        filterIngressStr = lib.filterAttrs (_: v: builtins.typeOf v == "string");
-
-        ingressesSet = filterIngressSet tunnel.ingress;
-        ingressesStr = filterIngressStr tunnel.ingress;
-
-        fullConfig = filterConfig {
-          tunnel = name;
-          credentials-file = "/run/credentials/cloudflared-tunnel-${name}.service/credentials.json";
-          warp-routing = filterConfig tunnel.warp-routing;
-          originRequest = filterConfig tunnel.originRequest;
-          ingress =
-            (map (
-              key:
-              {
-                hostname = key;
-              }
-              // lib.getAttr key (filterConfig (filterConfig ingressesSet))
-            ) (lib.attrNames ingressesSet))
-            ++ (map (key: {
-              hostname = key;
-              service = lib.getAttr key ingressesStr;
-            }) (lib.attrNames ingressesStr))
-            ++ [ { service = tunnel.default; } ];
-        };
-
-        mkConfigFile = pkgs.writeText "cloudflared.yml" (builtins.toJSON fullConfig);
+        configFile = configFiles.${name};
         certFile = if (tunnel.certificateFile != null) then tunnel.certificateFile else cfg.certificateFile;
       in
       lib.nameValuePair "cloudflared-tunnel-${name}" {
@@ -414,13 +426,14 @@ in
           ]
           ++ (lib.optional (certFile != null) "cert.pem:${certFile}");
 
-          ExecStart = "${cfg.package}/bin/cloudflared tunnel --config=${mkConfigFile} --no-autoupdate run";
+          ExecStartPre = "${cfg.package}/bin/cloudflared tunnel --config=${configFile} --no-autoupdate ingress validate";
+          ExecStart = "${cfg.package}/bin/cloudflared tunnel --config=${configFile} --no-autoupdate run";
           Restart = "on-failure";
           DynamicUser = true;
         };
 
         environment = {
-          TUNNEL_ORIGIN_CERT = lib.mkIf (certFile != null) ''%d/cert.pem'';
+          TUNNEL_ORIGIN_CERT = lib.mkIf (certFile != null) "%d/cert.pem";
           TUNNEL_EDGE_IP_VERSION = tunnel.edgeIPVersion;
         };
       }

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -92,6 +92,31 @@ let
       '';
     };
 
+    matchSNItoHost = lib.mkOption {
+      type = with lib.types; nullOr bool;
+      default = null;
+      example = "true";
+      description = ''
+        When true, cloudflared will automatically set the Server Name Indication (SNI) during the TLS handshake to the hostname of the incoming request.
+
+        This setting is useful when directing traffic to entry points that host multiple services and rely on SNI to route requests or present the correct certificate.
+        It eliminates the need to explicitly configure originServerName for individual services when using wildcard routing.
+      '';
+    };
+
+    http2Origin = lib.mkOption {
+      type = with lib.types; nullOr bool;
+      default = null;
+      example = "true";
+      description = ''
+        When false (default), cloudflared will connect to your origin with HTTP/1.1.
+
+        When true, cloudflared will attempt to connect to your origin server using HTTP/2.0 instead of HTTP/1.1.
+        HTTP/2.0 is a faster protocol for high traffic origins but requires you to deploy an SSL certificate on the origin.
+        We recommend using this setting in conjunction with noTLSVerify so that you can use a self-signed certificate.
+      '';
+    };
+
     caPool = lib.mkOption {
       type = with lib.types; nullOr (either str path);
       default = null;

--- a/nixos/modules/services/networking/cloudflared.nix
+++ b/nixos/modules/services/networking/cloudflared.nix
@@ -277,18 +277,6 @@ in
                 '';
               };
 
-              warp-routing = {
-                enabled = lib.mkOption {
-                  type = with lib.types; nullOr bool;
-                  default = null;
-                  description = ''
-                    Enable warp routing.
-
-                    See [Connect from WARP to a private network on Cloudflare using Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/tutorials/warp-to-tunnel/).
-                  '';
-                };
-              };
-
               edgeIPVersion = lib.mkOption {
                 type = lib.types.enum [
                   "auto"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -370,6 +370,7 @@ in
   };
   cloud-init = runTest ./cloud-init.nix;
   cloud-init-hostname = runTest ./cloud-init-hostname.nix;
+  cloudflared = runTest ./cloudflared.nix;
   cloudlog = runTest ./cloudlog.nix;
   cntr = import ./cntr.nix {
     inherit (pkgs) lib;

--- a/nixos/tests/cloudflared.nix
+++ b/nixos/tests/cloudflared.nix
@@ -1,0 +1,54 @@
+{ pkgs, ... }:
+{
+  name = "cloudflared";
+
+  nodes.machine = _: {
+    services.cloudflared = {
+      enable = true;
+      tunnels."00000000-0000-0000-0000-000000000000" = {
+        # set all available options, to make sure they exist and are properly formatted.
+        credentialsFile = "/tmp/test";
+        certificateFile = "/tmp/cert.pem";
+        default = "http_status:404";
+        originRequest = {
+          tlsTimeout = "30s";
+          tcpKeepAlive = "30s";
+          proxyType = "socks";
+          proxyPort = 1055;
+          proxyAddress = "127.0.0.1";
+          originServerName = "example.com";
+          noTLSVerify = false;
+          noHappyEyeballs = false;
+          keepAliveTimeout = "1m30s";
+          keepAliveConnections = 100;
+          httpHostHeader = "example.com";
+          disableChunkedEncoding = false;
+          connectTimeout = "30s";
+          caPool = "/tmp/ca.pem";
+          matchSNItoHost = true;
+          http2Origin = true;
+        };
+        ingress = {
+          "example.com" = "http://localhost:8080";
+        };
+      };
+    };
+  };
+
+  testScript =
+    {
+      nodes,
+      ...
+    }:
+    let
+      cloudflared = pkgs.lib.getExe pkgs.cloudflared;
+    in
+    ''
+      start_all()
+
+      # Verify the generated configs are valid.
+      machine.succeed("test -n \"$(${cloudflared} tunnel --config ${
+        nodes.machine.services.cloudflared.tunnels."00000000-0000-0000-0000-000000000000".configFile
+      } ingress validate | grep OK)\"")
+    '';
+}


### PR DESCRIPTION
Add `matchSNItoHost` and `http2Origin` options to `services.cloudflared`, as described here in the official docs: https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/cloudflared-parameters/origin-parameters/#matchsnitohost

I've tested this on my local setup.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
