### PR TITLE
[staging-next] dbus: fix darwin dynamic linking errors

### DIFF
--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -56,6 +56,13 @@ stdenv.mkDerivation (finalAttrs: {
     # We will also just remove installation of empty `${runstatedir}/dbus`
     # and `${localstatedir}/lib/dbus` since these are useless in the package.
     ./meson-install-dirs.patch
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Fixes Darwin issues like:
+    # dyld[29056]: Library not loaded: @rpath/libdbus-1.3.dylib
+    #   Referenced from: <...> /nix/store/.../bin/dbus-run-session
+    #   Reason: no LC_RPATH's found
+    ./set-install_rpath.patch
   ];
 
   strictDeps = true;

--- a/pkgs/by-name/db/dbus/set-install_rpath.patch
+++ b/pkgs/by-name/db/dbus/set-install_rpath.patch
@@ -1,0 +1,58 @@
+From 95a13025ec6fe4dd3c7a927732267e4abc4f4daf Mon Sep 17 00:00:00 2001
+From: Michael Daniels <mdaniels5757@gmail.com>
+Date: Sun, 22 Feb 2026 11:49:35 -0500
+Subject: [PATCH] set install_rpath for some executables
+
+Fixes Darwin issues like:
+
+dyld[29056]: Library not loaded: @rpath/libdbus-1.3.dylib
+  Referenced from: <3A452FD0-A471-30CB-A14F-FD0F818E4625> /nix/store/6ghcwk1zrkqkzvsh6i3b2dlagx7hs2d7-dbus-1.16.2/bin/dbus-run-session
+  Reason: no LC_RPATH's found
+---
+ bus/meson.build   | 2 ++
+ tools/meson.build | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/bus/meson.build b/bus/meson.build
+index 176894d6..bec64aa1 100644
+--- a/bus/meson.build
++++ b/bus/meson.build
+@@ -139,6 +139,7 @@ dbus_daemon = executable('dbus-daemon',
+     include_directories: root_include,
+     link_with: libdbus_daemon_internal,
+     install: true,
++    install_rpath: get_option('libdir'),
+ )
+ 
+ 
+@@ -180,6 +181,7 @@ if platform_unix and use_traditional_activation
+         link_with: liblaunch_helper_internal,
+         install: true,
+         install_dir: get_option('libexecdir'),
++        install_rpath: get_option('libdir'),
+     )
+ endif
+ 
+diff --git a/tools/meson.build b/tools/meson.build
+index 5d78d93a..def2a716 100644
+--- a/tools/meson.build
++++ b/tools/meson.build
+@@ -65,6 +65,7 @@ if message_bus
+         include_directories: root_include,
+         link_with: libdbus_internal,
+         install: true,
++        install_rpath: get_option('libdir'),
+     )
+ endif
+ 
+@@ -75,6 +76,7 @@ dbus_send = executable('dbus-send',
+     include_directories: root_include,
+     link_with: libdbus,
+     install: true,
++    install_rpath: get_option('libdir'),
+ )
+ 
+ dbus_test_tool = executable('dbus-test-tool',
+-- 
+2.51.2
+


### PR DESCRIPTION
Fixes darwin build of [python3Packages.dbus-python](https://hydra.nixos.org/build/321418696/nixlog/5/tail) (and likely others).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
