### PR TITLE
python3Packages.modal: init at 1.3.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13956,6 +13956,12 @@
     githubId = 1778670;
     name = "Austin Horstman";
   };
+  Kharacternyk = {
+    email = "nazar@vinnich.uk";
+    github = "Kharacternyk";
+    githubId = 43315801;
+    name = "Nazar Vinnichuk";
+  };
   khaser = {
     email = "a-horohorin@mail.ru";
     github = "khaser";

--- a/pkgs/development/python-modules/modal/default.nix
+++ b/pkgs/development/python-modules/modal/default.nix
@@ -1,0 +1,144 @@
+{
+  lib,
+  aiohttp,
+  buildPythonPackage,
+  cbor2,
+  certifi,
+  click,
+  fastapi,
+  fetchFromGitHub,
+  flaky,
+  grpcio-tools,
+  grpclib,
+  httpx,
+  invoke,
+  ipython,
+  mypy,
+  mypy-protobuf,
+  protobuf,
+  pyjwt,
+  pytest-asyncio,
+  pytest-env,
+  pytest-markdown-docs,
+  pytest-timeout,
+  pytestCheckHook,
+  python-dotenv,
+  rich,
+  ruff,
+  setuptools,
+  six,
+  synchronicity,
+  toml,
+  typer,
+  types-certifi,
+  types-toml,
+  typing-extensions,
+  watchfiles,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "modal";
+  version = "1.3.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "modal-labs";
+    repo = "modal-client";
+    tag = "py/v${finalAttrs.version}";
+    hash = "sha256-DjCEnQ+H03Ga0My2qHGEEF4Ae5HnmlWNvwL+jLdo0pg=";
+  };
+  sourceRoot = "${finalAttrs.src.name}/py";
+
+  postPatch = ''
+    substituteInPlace pyproject.toml --replace-fail 'setuptools~=77.0.3' setuptools
+    patchShebangs protoc_plugin/plugin.py
+    inv protoc
+    inv type-stubs
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    invoke
+    ipython
+    grpcio-tools
+    grpclib
+    synchronicity
+    mypy-protobuf
+    ruff
+  ]
+  ++ synchronicity.optional-dependencies.compile;
+
+  pythonRelaxDeps = [
+    "protobuf"
+  ];
+
+  dependencies = [
+    aiohttp
+    cbor2
+    certifi
+    click
+    grpclib
+    protobuf
+    rich
+    synchronicity
+    toml
+    typer
+    types-certifi
+    types-toml
+    typing-extensions
+    watchfiles
+  ];
+
+  nativeCheckInputs = [
+    fastapi
+    flaky
+    httpx
+    mypy
+    pyjwt
+    pytest-asyncio
+    pytest-env
+    pytest-markdown-docs
+    pytest-timeout
+    pytestCheckHook
+    python-dotenv
+    six
+  ];
+
+  disabledTestPaths = [
+    # Fail due to not finding /bin/bash
+    "test/app_composition_test.py"
+    "test/cli_shell_test.py"
+    "test/cli_test.py"
+    "test/container_test.py"
+    "test/mounted_files_test.py"
+
+    # Needs unpackaged pythonjsonlogger
+    "test/logging_test.py"
+
+    # Matches against error messages of a specific mypy version
+    "test/static_types_test.py"
+
+    # Fails due to "Jupyter is migrating its paths to use standard platformdirs"
+    "test/notebook_test.py"
+  ];
+  disabledTests = [
+    # Non-deterministic
+    "test_queue_blocking_put"
+  ];
+
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "modal" ];
+
+  meta = {
+    description = "Python client library for Modal (serverless compute provider)";
+    homepage = "https://github.com/modal-labs/modal-client";
+    changelog = "https://github.com/modal-labs/modal-client/blob/${finalAttrs.src.tag}/py/CHANGELOG.md";
+    mainProgram = "modal";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ Kharacternyk ];
+  };
+})

--- a/pkgs/development/python-modules/synchronicity/default.nix
+++ b/pkgs/development/python-modules/synchronicity/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  fetchFromGitHub,
+  gevent,
+  hatchling,
+  mypy,
+  pytest-asyncio,
+  pytest-markdown-docs,
+  pytestCheckHook,
+  pythonOlder,
+  sigtools,
+  typing-extensions,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "synchronicity";
+  version = "0.11.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "modal-labs";
+    repo = "synchronicity";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Uyn4apHILBwjHoMkr52IkcFlaX7jx3WzuzZfvdxcDFo=";
+  };
+
+  build-system = [ hatchling ];
+  dependencies = [ typing-extensions ];
+  optional-dependencies.compile = [ sigtools ];
+
+  nativeCheckInputs = [
+    mypy
+    pytestCheckHook
+    pytest-asyncio
+    pytest-markdown-docs
+    sigtools
+  ]
+  ++ lib.optionals (pythonOlder "3.13") [
+    gevent
+  ];
+
+  disabledTests = [
+    # Assert execution time, non-deterministic
+    "test_blocking"
+    "test_multithreaded"
+    "test_nowrap"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # Assertion error
+    "test_async"
+  ];
+
+  pythonImportsCheck = [ "synchronicity" ];
+
+  meta = {
+    description = "Export blocking and async library versions from a single async implementation";
+    homepage = "https://github.com/modal-labs/synchronicity";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ Kharacternyk ];
+  };
+})

--- a/pkgs/development/python-modules/types-certifi/default.nix
+++ b/pkgs/development/python-modules/types-certifi/default.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "types-certifi";
+  version = "2021.10.8.3";
+  pyproject = true;
+
+  # Building typeshed subpackages from the GitHub repository requires packaging
+  # https://github.com/typeshed-internal/stub_uploader
+  # The switch to fetchFromGitHub can be made at once for all applicable types-*
+  # packages once stub_uploader is packaged
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-cs93mNFlvAt24cEN0eowl8cGPELCHWZFI7ko6ItVSk8=";
+  };
+
+  build-system = [ setuptools ];
+
+  # No tests
+  doCheck = false;
+
+  meta = {
+    description = "Typing stubs for certifi";
+    homepage = "https://github.com/python/typeshed";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ Kharacternyk ];
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20221,6 +20221,8 @@ self: super: with self; {
 
   types-beautifulsoup4 = callPackage ../development/python-modules/types-beautifulsoup4 { };
 
+  types-certifi = callPackage ../development/python-modules/types-certifi { };
+
   types-click = callPackage ../development/python-modules/types-click { };
 
   types-colorama = callPackage ../development/python-modules/types-colorama { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18825,6 +18825,8 @@ self: super: with self; {
 
   syncer = callPackage ../development/python-modules/syncer { };
 
+  synchronicity = callPackage ../development/python-modules/synchronicity { };
+
   syndication-domination = toPythonModule (
     pkgs.syndication-domination.override {
       enablePython = true;

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10086,6 +10086,8 @@ self: super: with self; {
 
   mockupdb = callPackage ../development/python-modules/mockupdb { };
 
+  modal = callPackage ../development/python-modules/modal { };
+
   modbus-tk = callPackage ../development/python-modules/modbus-tk { };
 
   moddb = callPackage ../development/python-modules/moddb { };


### PR DESCRIPTION
[Modal](https://modal.com/docs/guide) is a serverless compute provider, GPUs included. The primary interface to their compute is a [Python package](https://github.com/modal-labs/modal-client). A simple example from their docs:
```python
import modal

image = modal.Image.debian_slim().pip_install("torch")
app = modal.App(image=image)


@app.function(gpu="A100")
def run():
    import torch

    assert torch.cuda.is_available()
```

I haven't been able to run `nixpkgs-review` because it's going OOM for me.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test