### PR TITLE
lib.systems: Internally translate -gnuabielfv<1,2> to -gnu + gcc.abi

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -490,13 +490,6 @@ let
                 }
                 .${cpu.name} or cpu.name;
               vendor_ = final.rust.platform.vendor;
-              abi_ =
-                # We're very explicit about the POWER ELF ABI w/ glibc in our parsing, while Rust is not.
-                # TODO: Somehow ensure that Rust actually *uses* the correct ABI, and not just a libc-based default.
-                if (lib.strings.hasPrefix "powerpc" cpu.name) && (lib.strings.hasPrefix "gnuabielfv" abi.name) then
-                  "gnu"
-                else
-                  abi.name;
             in
             # TODO: deprecate args.rustc in favour of args.rust after 23.05 is EOL.
             args.rust.rustcTarget or args.rustc.config or (
@@ -507,7 +500,7 @@ let
               if final.isWasi then
                 "${cpu_}-wasip1"
               else
-                "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi_}"}"
+                "${cpu_}-${vendor_}-${kernel.name}${optionalString (abi.name != "unknown") "-${abi.name}"}"
             );
 
           # The name of the rust target if it is standard, or the json file

--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -22,10 +22,12 @@ rec {
   };
 
   ppc64-elfv1 = {
-    config = "powerpc64-unknown-linux-gnuabielfv1";
+    # system instead of config, need environment to get parsed during pkgsCross
+    system = "powerpc64-unknown-linux-gnuabielfv1";
   };
   ppc64-elfv2 = {
-    config = "powerpc64-unknown-linux-gnuabielfv2";
+    # system instead of config, need environment to get parsed during pkgsCross
+    system = "powerpc64-unknown-linux-gnuabielfv2";
   };
   ppc64 = ppc64-elfv2;
   ppc64-musl = {

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -69,8 +69,8 @@ rec {
         abi = "elfv1";
       };
     };
-    # This ABI is the default in NixOS PowerPC64 BE, but not on mainline GCC,
-    # so it sometimes causes issues in certain packages that makes the wrong
+    # This ABI is not the default when building mainline GCC against glibc,
+    # so it sometimes causes issues in certain packages that make the wrong
     # assumption on the used ABI.
     isAbiElfv2 = [
       {

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -727,10 +727,13 @@ rec {
       abi = "n32";
     };
 
+    # Clang does not understand these, ABI set via <platform>.gcc.abi & cc-wrapper
     gnuabielfv2 = {
+      name = "gnu";
       abi = "elfv2";
     };
     gnuabielfv1 = {
+      name = "gnu";
       abi = "elfv1";
     };
 

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -6,6 +6,21 @@
 # optional fields; currently these are: linux-kernel, gcc, and rustc.
 
 { lib }:
+let
+  ppc64ForAbi = abi: {
+    linux-kernel = {
+      name = "powerpc64";
+
+      baseConfig = "ppc64_defconfig";
+      target = "vmlinux";
+      autoModules = true;
+    };
+
+    gcc = {
+      inherit abi;
+    };
+  };
+in
 rec {
   pc = {
     linux-kernel = {
@@ -36,15 +51,8 @@ rec {
     };
   };
 
-  ppc64 = {
-    linux-kernel = {
-      name = "powerpc64";
-
-      baseConfig = "ppc64_defconfig";
-      target = "vmlinux";
-      autoModules = true;
-    };
-  };
+  ppc64-elfv1 = ppc64ForAbi "elfv1";
+  ppc64-elfv2 = ppc64ForAbi "elfv2";
 
   ##
   ## ARM
@@ -630,7 +638,12 @@ rec {
       (import ./examples.nix { inherit lib; }).mipsel-linux-gnu
 
     else if platform.isPower64 then
-      if platform.isLittleEndian then powernv else ppc64
+      if platform.isLittleEndian then
+        powernv
+      else if platform.isAbiElfv2 then
+        ppc64-elfv2
+      else
+        ppc64-elfv1
 
     else if platform.isLoongArch64 then
       loongarch64-multiplatform

--- a/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
+++ b/pkgs/build-support/cc-wrapper/add-clang-cc-cflags-before.sh
@@ -30,10 +30,6 @@ if $targetPassed && [[ "$targetValue" != "@defaultTarget@" ]] && (( "${NIX_CC_WR
     echo "Warning: supplying the --target $targetValue != @defaultTarget@ argument to a nix-wrapped compiler may not work correctly - cc-wrapper is currently not designed with multi-target compilers in mind. You may want to use an un-wrapped compiler instead." >&2
 elif [[ $0 != *cpp ]]; then
     extraBefore+=(-target @defaultTarget@ @machineFlags@)
-
-    if [[ "@explicitAbiValue@" != "" ]]; then
-        extraBefore+=(-mabi=@explicitAbiValue@)
-    fi
 fi
 
 if [[ "@darwinMinVersion@" ]]; then

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -331,6 +331,7 @@ let
       optional (
         targetPlatform ? gcc.cpu && !(targetPlatform.isDarwin && targetPlatform.isAarch64)
       ) "-mcpu=${targetPlatform.gcc.cpu}"
+    ++ optional (targetPlatform ? gcc.abi) "-mabi=${targetPlatform.gcc.abi}"
     ++
       # -mfloat-abi only matters on arm32 but we set it here
       # unconditionally just in case. If the abi specifically sets hard

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -93,14 +93,12 @@ let
     getLib
     getName
     getVersion
-    hasPrefix
     mapAttrsToList
     optional
     optionalAttrs
     optionals
     optionalString
     removePrefix
-    removeSuffix
     replaceStrings
     toList
     versionAtLeast
@@ -943,24 +941,12 @@ stdenvNoCC.mkDerivation {
     ## General Clang support
     ## Needs to go after ^ because the for loop eats \n and makes this file an invalid script
     ##
-    + optionalString isClang (
-      let
-        hasUnsupportedGnuSuffix = hasPrefix "gnuabielfv" targetPlatform.parsed.abi.name;
-        clangCompatibleConfig =
-          if hasUnsupportedGnuSuffix then
-            removeSuffix (removePrefix "gnu" targetPlatform.parsed.abi.name) targetPlatform.config
-          else
-            targetPlatform.config;
-        explicitAbiValue = if hasUnsupportedGnuSuffix then targetPlatform.parsed.abi.abi else "";
-      in
-      ''
-        # Escape twice: once for this script, once for the one it gets substituted into.
-        export machineFlags=${escapeShellArg (escapeShellArgs machineFlags)}
-        export defaultTarget=${clangCompatibleConfig}
-        export explicitAbiValue=${explicitAbiValue}
-        substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
-      ''
-    )
+    + optionalString isClang ''
+      # Escape twice: once for this script, once for the one it gets substituted into.
+      export machineFlags=${escapeShellArg (escapeShellArgs machineFlags)}
+      export defaultTarget=${targetPlatform.config}
+      substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
+    ''
 
     ##
     ## Extra custom steps


### PR DESCRIPTION
While GCC supports the powerpc64-unknown-linux-gnuabielfv1 & powerpc64-unknown-linux-gnuabielfv2 triplets, Clang does not.
So using these triplets while configuring compilers and other tools that build upon them leads to issues and hacks.

Instead, set the name that should be used for -gnuabielfv<1,2> to just -gnu, with an annotation of the actual ABI for
GCC / the cc-wrapper. This still allows isAbiElfv<1,2> inspections to work without resulting in triplets that are
unknown to Clang & rustc.

---

I don't know if this is a *good* idea, I feel like it kinda just replaces hacks in one location with hacks in another… But it fixes some things ig… I don't feel like merging this as-is is fine without someone with a better understanding of & opinion on the `lib.systems` stuff having a look. Turning to draft once pings go out.

- `powerpc64-unknown-linux-gnu` triplet is still rejected by `lib.systems.parse.abis.gnu.assertions` - we want the user to be precise about which ABI they want. Maybe abit confusing cus the used triplet will be shown as `powerpc64-unknown-linux-gnu`, but passing that in will trigger an assertion failure.
- Change in `lib/systems/examples.nix` is because while passing those triplets as a string in `crossSystem` gets them parsed as expected, using `pkgsCross.ppc64-elfv<1,2>` just used the triplet as-is without any parsing of the components. Which lead to neither of the `isAbiElfv<1,2>` inspections working, amongst other issues.
- Untested natively on hardware, but cross doesn't seem to be going catastrophically wrong at least, and `file` of cross results reports the expected ABI version.
- Examples of issues / hacks that were necessitated by these triplets being given to compilers:
  - https://github.com/NixOS/nixpkgs/pull/297425
  - https://github.com/NixOS/nixpkgs/pull/451087
  - https://github.com/NixOS/nixpkgs/issues/473862
  - https://github.com/NixOS/nixpkgs/issues/490944
  - #546264
- Fixes `pkgsCross.ppc64-elfv<1,2>.capnproto`, and anything else cross that uses `clangStdenv`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
