### PR TITLE
release: stop building for `x86_64-darwin`

### DIFF
--- a/doc/preface.chapter.md
+++ b/doc/preface.chapter.md
@@ -42,7 +42,7 @@ shows the status of tests for the `nixpkgs-unstable` channel.
 
 The tests are conducted by a cluster called [Hydra](https://nixos.org/hydra/),
 which also builds binary packages from the Nix expressions in Nixpkgs for
-`x86_64-linux`, `aarch64-linux`, `x86_64-darwin` and `aarch64-darwin`.
+`x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
 The binaries are made available via a [binary cache](https://cache.nixos.org).
 
 The current Nix expressions of the channels are available in the

--- a/doc/using/platform-support.chapter.md
+++ b/doc/using/platform-support.chapter.md
@@ -29,8 +29,7 @@ Platform Tiers [4 through 7](https://github.com/NixOS/rfcs/blob/master/rfcs/0046
 | `x86_64-unknown-linux-musl`           | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | Limited        | ❌             | ✔️                 | ✔️                      |
 | `aarch64-unknown-linux-musl`          | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | Limited        | ❌             | ✔️                 | ✔️                      |
 | `x86_64-unknown-unknown-freebsd`      | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-| `arm64-apple-darwin`                  | [Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) | Some | ✔️            | ✔️            | ✔️                 | ❌\*                     |
-| `x86_64-apple-darwin`                 | [Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) | Some | ✔️            | ✔️            | ✔️                 | ❌\*                     |
+| `arm64-apple-darwin`                  | [Tier 2](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-2) | Some | ✔️            | ✔️            | ✔️                 | ❌                       |
 | `i686-unknown-linux-gnu`              | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | Limited        | ❌             | ✔️                 | ✔️                      |
 | `riscv32-unknown-linux-gnu`           | [Tier 4](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-4) | None | ❌             | ❌             | ❌                  | ✔️                      |
 | `riscv64-unknown-linux-gnu`           | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
@@ -45,5 +44,3 @@ Platform Tiers [4 through 7](https://github.com/NixOS/rfcs/blob/master/rfcs/0046
 | `powerpc64-unknown-linux-gnuabielfv2` | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
 | `powerpc64le-unknown-linux-gnu`       | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
 | `s390x-unknown-linux-gnu`             | [Tier 3](https://github.com/NixOS/rfcs/blob/master/rfcs/0046-platform-support-tiers.md#tier-3) | None | ❌             | ❌             | ✔️                 | ✔️                      |
-
-\* - Cross compiling is only supported on Darwin hosts.

--- a/flake.nix
+++ b/flake.nix
@@ -220,17 +220,25 @@
         evaluation. Evaluating the attribute value tends to require a significant
         amount of computation, even considering lazy evaluation.
       */
-      legacyPackages = forAllSystems (
-        system:
-        (import ./. {
-          inherit system;
-          overlays = import ./pkgs/top-level/impure-overlays.nix ++ [
-            (final: prev: {
-              lib = prev.lib.extend libVersionInfoOverlay;
-            })
-          ];
-        })
-      );
+      legacyPackages =
+        let
+          # We include `x86_64-darwin` here to ensure that users get a
+          # good error message for the 26.11 deprecation of the platform,
+          # while excluding it from `lib.systems.flakeExposed` so that we
+          # don’t break `nix flake check` for downstream users.
+          forAllSystems' = lib.genAttrs (lib.systems.flakeExposed ++ [ "x86_64-darwin" ]);
+        in
+        forAllSystems' (
+          system:
+          (import ./. {
+            inherit system;
+            overlays = import ./pkgs/top-level/impure-overlays.nix ++ [
+              (final: prev: {
+                lib = prev.lib.extend libVersionInfoOverlay;
+              })
+            ];
+          })
+        );
 
       /**
         Optional modules that can be imported into a NixOS configuration.

--- a/lib/systems/flake-systems.nix
+++ b/lib/systems/flake-systems.nix
@@ -11,7 +11,6 @@
   "x86_64-linux"
   # Tier 2
   "aarch64-linux"
-  "x86_64-darwin"
   # Tier 3
   "armv6l-linux"
   "armv7l-linux"

--- a/pkgs/top-level/nixpkgs-basic-release-checks.nix
+++ b/pkgs/top-level/nixpkgs-basic-release-checks.nix
@@ -56,7 +56,7 @@ pkgs.runCommand "nixpkgs-release-checks"
           set -x
           nix-env -f $src \
               --show-trace --argstr system "$platform" \
-              --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
+              --arg config '{ allowAliases = false; }' \
               --option lint-url-literals fatal \
               -qa --drv-path --system-filter \* --system \
               "''${opts[@]}" 2> eval-warnings.log > packages1
@@ -72,7 +72,7 @@ pkgs.runCommand "nixpkgs-release-checks"
 
         nix-env -f $src2 \
             --show-trace --argstr system "$platform" \
-            --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
+            --arg config '{ allowAliases = false; }' \
             --option lint-url-literals fatal \
             -qa --drv-path --system-filter \* --system \
             "''${opts[@]}" > packages2
@@ -95,7 +95,7 @@ pkgs.runCommand "nixpkgs-release-checks"
 
         nix-env -f $src \
             --show-trace --argstr system "$platform" \
-            --arg config '{ allowAliases = false; allowDeprecatedx86_64Darwin = true; }' \
+            --arg config '{ allowAliases = false; }' \
             --option lint-url-literals fatal \
             -qa --drv-path --system-filter \* --system --meta --xml \
             "''${opts[@]}" > /dev/null

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -192,7 +192,7 @@ let
   #   -> [a]  -- list of elements from which to remove
   #   -> [a]
   #
-  # > removeMany ["aarch64-linux" "x86_64-darwin"] ["aarch64-linux" "x86_64-darwin" "x86_64-linux"]
+  # > removeMany ["aarch64-linux" "aarch64-darwin"] ["aarch64-linux" "aarch64-darwin" "x86_64-linux"]
   # ["x86_64-linux"]
   removeMany = itemsToRemove: list: lib.foldr lib.remove list itemsToRemove;
 
@@ -373,7 +373,6 @@ let
             "aarch64-linux"
 
             # musl only supports linux, not darwin.
-            "x86_64-darwin"
             "aarch64-darwin"
           ]
           {
@@ -401,7 +400,6 @@ let
             "aarch64-linux" # times out on Hydra
 
             # Static doesn't work on darwin
-            "x86_64-darwin"
             "aarch64-darwin"
           ]
           {
@@ -500,7 +498,6 @@ let
               # Testing cross from x86_64-linux
               "aarch64-darwin"
               "aarch64-linux"
-              "x86_64-darwin"
             ]
             {
               haskellPackages = {

--- a/pkgs/top-level/release-supported-systems.json
+++ b/pkgs/top-level/release-supported-systems.json
@@ -1,6 +1,5 @@
 [
   "aarch64-linux",
   "aarch64-darwin",
-  "x86_64-linux",
-  "x86_64-darwin"
+  "x86_64-linux"
 ]

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -26,7 +26,6 @@
     "aarch64-unknown-linux-gnu"
     "aarch64-unknown-linux-musl"
     "i686-unknown-linux-gnu"
-    "x86_64-apple-darwin"
     "x86_64-unknown-linux-gnu"
     "x86_64-unknown-linux-musl"
     # we can uncomment that once our bootstrap tarballs are fixed
@@ -90,10 +89,7 @@ let
 
   inherit (release-lib.lib.attrsets) unionOfDisjoint;
 
-  supportDarwin = genAttrs [
-    "x86_64"
-    "aarch64"
-  ] (arch: elem "${arch}-darwin" supportedSystems);
+  supportDarwin = elem "aarch64-darwin" supportedSystems;
 
   nonPackageJobs = {
     tarball = import ./make-tarball.nix {
@@ -112,7 +108,7 @@ let
     metrics = import ./metrics.nix { inherit pkgs nixpkgs; };
 
     darwin-tested =
-      if supportDarwin.x86_64 || supportDarwin.aarch64 then
+      if supportDarwin then
         pkgs.releaseTools.aggregate {
           name = "nixpkgs-darwin-${jobs.tarball.version}";
           meta.description = "Release-critical builds for the Nixpkgs darwin channel";
@@ -120,49 +116,7 @@ let
             jobs.tarball
             jobs.release-checks
           ]
-          ++ optionals supportDarwin.x86_64 [
-            jobs.cabal2nix.x86_64-darwin
-            jobs.ghc.x86_64-darwin
-            jobs.git.x86_64-darwin
-            jobs.go.x86_64-darwin
-            jobs.mariadb.x86_64-darwin
-            jobs.nix.x86_64-darwin
-            jobs.nixpkgs-review.x86_64-darwin
-            jobs.nix-info.x86_64-darwin
-            jobs.nix-info-tested.x86_64-darwin
-            jobs.openssh.x86_64-darwin
-            jobs.openssl.x86_64-darwin
-            jobs.pandoc.x86_64-darwin
-            jobs.postgresql.x86_64-darwin
-            jobs.python3.x86_64-darwin
-            jobs.ruby.x86_64-darwin
-            jobs.rustc.x86_64-darwin
-            # blocking ofBorg CI 2020-02-28
-            # jobs.stack.x86_64-darwin
-            jobs.stdenv.x86_64-darwin
-            jobs.vim.x86_64-darwin
-            jobs.cachix.x86_64-darwin
-            jobs.darwin.linux-builder.x86_64-darwin
-
-            # UI apps
-            # jobs.firefox-unwrapped.x86_64-darwin
-            jobs.qt5.qtmultimedia.x86_64-darwin
-            jobs.inkscape.x86_64-darwin
-            jobs.gimp2.x86_64-darwin # FIXME replace with gimp once https://github.com/NixOS/nixpkgs/issues/411189 is resoved
-            jobs.emacs.x86_64-darwin
-            jobs.wireshark.x86_64-darwin
-
-            # Tests
-            /*
-              jobs.tests.cc-wrapper.default.x86_64-darwin
-              jobs.tests.cc-wrapper.llvmPackages.clang.x86_64-darwin
-              jobs.tests.cc-wrapper.llvmPackages.libcxx.x86_64-darwin
-              jobs.tests.stdenv-inputs.x86_64-darwin
-              jobs.tests.macOSSierraShared.x86_64-darwin
-              jobs.tests.stdenv.hooks.patch-shebangs.x86_64-darwin
-            */
-          ]
-          ++ optionals supportDarwin.aarch64 [
+          ++ optionals supportDarwin [
             jobs.cabal2nix.aarch64-darwin
             jobs.ghc.aarch64-darwin
             jobs.git.aarch64-darwin
@@ -251,33 +205,7 @@ let
         */
       ]
       ++ collect isDerivation jobs.stdenvBootstrapTools
-      ++ optionals supportDarwin.x86_64 [
-        jobs.stdenv.x86_64-darwin
-        jobs.cargo.x86_64-darwin
-        jobs.cachix.x86_64-darwin
-        jobs.devenv.x86_64-darwin
-        jobs.go.x86_64-darwin
-        jobs.python3.x86_64-darwin
-        jobs.nixpkgs-review.x86_64-darwin
-        jobs.nix.x86_64-darwin
-        jobs.nix-info.x86_64-darwin
-        jobs.nix-info-tested.x86_64-darwin
-        jobs.git.x86_64-darwin
-        jobs.mariadb.x86_64-darwin
-        jobs.vim.x86_64-darwin
-        jobs.inkscape.x86_64-darwin
-        jobs.qt5.qtmultimedia.x86_64-darwin
-        jobs.darwin.linux-builder.x86_64-darwin
-        /*
-          jobs.tests.cc-wrapper.default.x86_64-darwin
-          jobs.tests.cc-wrapper.llvmPackages.clang.x86_64-darwin
-          jobs.tests.cc-wrapper.llvmPackages.libcxx.x86_64-darwin
-          jobs.tests.stdenv-inputs.x86_64-darwin
-          jobs.tests.macOSSierraShared.x86_64-darwin
-          jobs.tests.stdenv.hooks.patch-shebangs.x86_64-darwin
-        */
-      ]
-      ++ optionals supportDarwin.aarch64 [
+      ++ optionals supportDarwin [
         jobs.stdenv.aarch64-darwin
         jobs.cargo.aarch64-darwin
         jobs.cachix.aarch64-darwin
@@ -294,7 +222,13 @@ let
         jobs.inkscape.aarch64-darwin
         jobs.qt5.qtmultimedia.aarch64-darwin
         jobs.darwin.linux-builder.aarch64-darwin
-        # consider adding tests, as suggested above for x86_64-darwin
+        /*
+          jobs.tests.cc-wrapper.default.aarch64-darwin
+          jobs.tests.cc-wrapper.llvmPackages.clang.aarch64-darwin
+          jobs.tests.cc-wrapper.llvmPackages.libcxx.aarch64-darwin
+          jobs.tests.stdenv-inputs.aarch64-darwin
+          jobs.tests.stdenv.hooks.patch-shebangs.aarch64-darwin
+        */
       ];
     };
 


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/pull/492160.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
