### PR TITLE
config: add stub `allowDeprecatedx86_64Darwin` option

### DIFF
--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -33,6 +33,9 @@ let
             allowVariants = !attrNamesOnly;
             checkMeta = true;
 
+            # Silence the `x86_64-darwin` deprecation warning.
+            allowDeprecatedx86_64Darwin = true;
+
             handleEvalIssue =
               reason: errormsg:
               let

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -431,6 +431,23 @@ let
         Please read https://www.visualstudio.com/license-terms/mt644918/ and enable this config if you accept.
       '';
     };
+
+    allowDeprecatedx86_64Darwin = mkOption {
+      # `force` does nothing; it’s reserved for forward compatibility
+      # with 26.11. We hide it from the documentation to avoid a
+      # footgun, as it will make the error in 26.11 less useful.
+      type = types.either types.bool (types.enum [ "force" ]) // {
+        inherit (types.bool) description descriptionClass;
+      };
+      default = false;
+      description = ''
+        Silence the warning for the upcoming deprecation of the
+        `x86_64-darwin` platform in Nixpkgs 26.11.
+
+        This does nothing in 25.11, and is provided there for forward
+        compatibility of configurations with 26.05.
+      '';
+    };
   };
 
 in


### PR DESCRIPTION
Split out from https://github.com/NixOS/nixpkgs/pull/492100 for backporting.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
