### PR TITLE
wivrn: 26.2.2 -> 26.2.3

### DIFF
--- a/pkgs/by-name/wi/wivrn/package.nix
+++ b/pkgs/by-name/wi/wivrn/package.nix
@@ -53,13 +53,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "wivrn";
-  version = "26.2.2";
+  version = "26.2.3";
 
   src = fetchFromGitHub {
     owner = "wivrn";
     repo = "wivrn";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-DC+oHQLH9GlN/iDdk8XdPp1wENU5ZuZ+CC0x/wOlyYM=";
+    hash = "sha256-pU7FYPp5wa0MK0ut/BfFlnUai8yMcylpWC0CoAExAio=";
   };
 
   monado = applyPatches {


### PR DESCRIPTION
Updated WiVRn to most recent update to maintain compatibility with up-to-date VR headsets.

## Things done

- Built on platform:
  - [x] NixOS 26.05pre935279.bfc1b8a45741 (Yarara) x86_64

- Tested, as applicable:
  - [x] Ran 'nix run .#wivrn' successfully.

- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.


[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
