### PR TITLE
linux_rpi: 6.12.47-stable_20250916 -> 6.12.62-1+rpt1

### DIFF
--- a/pkgs/os-specific/linux/kernel/linux-rpi.nix
+++ b/pkgs/os-specific/linux/kernel/linux-rpi.nix
@@ -9,22 +9,23 @@
 
 let
   # NOTE: raspberrypifw & raspberryPiWirelessFirmware should be updated with this
-  modDirVersion = "6.12.47";
-  tag = "stable_20250916";
-  hash = "sha256-HG8Oc04V2t54l0SOn4gKmNJWQUrZfjWusgKcWvx74H0==";
+  modDirVersion = "6.12.62";
+  hash = "sha256-jcSzPoCCnmZU1GDBUWAljIUjZRzbfdh2aQB9/GOc5mQ=";
 in
 lib.overrideDerivation
   (buildLinux (
     args
     // {
-      version = "${modDirVersion}-${tag}";
+      version = "${modDirVersion}-1+rpt1";
       inherit modDirVersion;
       pname = "linux-rpi";
 
       src = fetchFromGitHub {
         owner = "raspberrypi";
         repo = "linux";
-        inherit tag hash;
+        # https://github.com/RPi-Distro/linux-packaging/raw/refs/tags/pios/1%256.12.62-1+rpt1/debian/changelog
+        rev = "a1073743767f9e7fdc7017ababd2a07ea0c97c1c";
+        inherit hash;
       };
 
       defconfig =


### PR DESCRIPTION
Yeah... Raspberry Pi folks stop tagging raspberrypi/linux GitHub repo again. And this time they don't tag raspberrypi/firmware either. So, I switched my reference point to Raspberry Pi OS, which publishes their packaging for Linux kernel in RPi-Distro/linux-packaging.

The version is set to Debian packaging's version, and the commit comes from the changelog entry for that version.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Tested on Raspberry Pi 4 8 GB.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
