### PR TITLE
[staging-next] python3Packages.mysql-connector: fix build

### DIFF
--- a/pkgs/development/python-modules/mysql-connector/0001-Revert-Fix-MacOS-wheels-platform-tag.patch
+++ b/pkgs/development/python-modules/mysql-connector/0001-Revert-Fix-MacOS-wheels-platform-tag.patch
@@ -2,16 +2,16 @@ diff --git a/cpydist/__init__.py b/cpydist/__init__.py
 index 7fdbaf2..3c427da 100644
 --- a/cpydist/__init__.py
 +++ b/cpydist/__init__.py
-@@ -38,7 +38,7 @@ import tempfile
+@@ -37,7 +37,7 @@ import tempfile
  from glob import glob
  from pathlib import Path
- from subprocess import PIPE, Popen, check_call
+ from subprocess import PIPE, Popen
 -from sysconfig import get_config_vars, get_python_version
 +from sysconfig import get_python_version
 
  from setuptools import Command
  from setuptools.command.build_ext import build_ext
-@@ -68,8 +68,6 @@ version_py = os.path.join("lib", "mysql", "connector", "version.py")
+@@ -67,8 +67,6 @@ version_py = os.path.join("lib", "mysql", "connector", "version.py")
  with open(version_py, "rb") as fp:
      exec(compile(fp.read(), version_py, "exec"))
 

--- a/pkgs/development/python-modules/mysql-connector/default.nix
+++ b/pkgs/development/python-modules/mysql-connector/default.nix
@@ -29,6 +29,8 @@ buildPythonPackage rec {
     hash = "sha256-EwdJpiyplck26Tc9SiczxGieJ3GcTGMQva/fDzhzWn4=";
   };
 
+  sourceRoot = "${src.name}/mysql-connector-python";
+
   patches = [
     # mysql-connector overrides MACOSX_DEPLOYMENT_TARGET to 11.
     # This makes the installation with nixpkgs fail. I suspect, that's


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
