### PR TITLE
nmstate: 2.2.57 -> 2.2.60

### DIFF
--- a/pkgs/by-name/nm/nmstate/package.nix
+++ b/pkgs/by-name/nm/nmstate/package.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  fetchFromGitHub,
   fetchurl,
   rustPlatform,
   libfaketime,
@@ -8,22 +7,21 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "nmstate";
-  version = "2.2.57";
+  version = "2.2.60";
 
   srcs = [
-    (fetchFromGitHub {
-      owner = "nmstate";
-      repo = "nmstate";
-      tag = "v${finalAttrs.version}";
-      hash = "sha256-7X51XmoSwlIrbsdJFfTQ23bhO3bitkHXOObL6JaGpvI=";
+    (fetchurl {
+      url = "https://github.com/nmstate/nmstate/releases/download/v${finalAttrs.version}/nmstate-${finalAttrs.version}.tar.gz";
+      hash = "sha256-k8FXwnuSKWjfxuj2SbrLAChzA+D9g7E88f8VqY+zWZw=";
     })
     (fetchurl {
       url = "https://github.com/nmstate/nmstate/releases/download/v${finalAttrs.version}/nmstate-vendor-${finalAttrs.version}.tar.xz";
-      hash = "sha256-stOHNezPLPjSrt/f3HmhqWMxSaSfOh/hYVGB2+l8Pb4=";
+      hash = "sha256-8NxAX3mPZ3z3u6vU/ddAotXmgLfLCRwukc6J3FzxhKY=";
     })
   ];
   sourceRoot = ".";
   postUnpack = ''
+    mv nmstate-* source
     mv vendor source/rust/
     cd source
   '';
@@ -45,6 +43,8 @@ rustPlatform.buildRustPackage (finalAttrs: {
     source_date=$(date --utc --date=@$SOURCE_DATE_EPOCH "+%F %T")
     PREFIX=$out LIBDIR=$out/lib RELEASE=1 SKIP_PYTHON_INSTALL=1 faketime -f "$source_date" make install
   '';
+
+  passthru.updateScript = ./update.py;
 
   meta = {
     description = "Nmstate: A Declarative Network API";

--- a/pkgs/by-name/nm/nmstate/update.py
+++ b/pkgs/by-name/nm/nmstate/update.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python3 -p python3
+
+from pathlib import Path
+import argparse
+import urllib.request
+import json
+import subprocess
+import sys
+import base64
+import os
+
+
+thisdir = Path(__file__).parent
+root = Path(__file__).parent.parent.parent.parent.parent
+_GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN', '')
+
+
+def fetch_json(url: str):
+    if _GITHUB_TOKEN and url.startswith('https://api.github.com/'):
+        request = urllib.request.Request(url, headers={'Authentication': f'Bearer {_GITHUB_TOKEN}'})
+    else:
+        request = urllib.request.Request(url)
+    with urllib.request.urlopen(request) as handle:
+        return json.load(handle)
+
+
+def last_version():
+    tag_name = fetch_json('https://api.github.com/repos/nmstate/nmstate/releases/latest')['tag_name']
+    assert tag_name.startswith('v')
+    return tag_name[1:]
+
+
+def github_release(version: str):
+    return fetch_json(f'https://api.github.com/repos/nmstate/nmstate/releases/tags/v{version}')
+
+
+def extract_version_and_hashes():
+    cmd = [
+        'nix-instantiate',
+        '--system',
+        'x86_64-linux',
+        '--eval',
+        '--strict',
+        '--json',
+        '-E',
+        'let pkg = ((import ./.) {}).pkgs.nmstate; in {inherit (pkg) version; srcs = builtins.map (x: {hash = x.hash; url = x.url; }) pkg.srcs;}',
+    ]
+    return json.loads(subprocess.run(cmd, check=True, stdout=subprocess.PIPE, cwd=root).stdout)
+
+
+def digest_to_sri(digest: str) -> str:
+    algo, hash = digest.split(':', 1)
+    b64_hash = base64.b64encode(bytes.fromhex(hash)).decode('ascii')
+    return f"{algo}-{b64_hash}"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", default=None, nargs='?')
+    args = parser.parse_args()
+    if args.version is None:
+        args.version = last_version()
+    pkg = extract_version_and_hashes()
+    old_version = pkg['version']
+    if old_version == args.version:
+        print('nmstate is up to date')
+        sys.exit(0)
+    print(f"Updating nmstate from {old_version} to {args.version}")
+    new_release = github_release(args.version)
+    old_hashes = {
+        src['url'].rsplit('/', 1)[-1]: src['hash']
+        for src in pkg['srcs']
+    }
+    new_hashes = {
+        asset['name'].replace(args.version, old_version): digest_to_sri(asset['digest'])
+        for asset in new_release['assets']
+    }
+    old_content = (thisdir / 'package.nix').read_text()
+    new_content = old_content.replace(f'version = "{old_version}"', f'version = "{args.version}"')
+    for name, old_hash in old_hashes.items():
+        new_content = new_content.replace(old_hash, new_hashes[name])
+    (thisdir / 'package.nix').write_text(new_content)


### PR DESCRIPTION
Updated the package, added an update script, changed to use the release tarball instead of the git source to simplify the update script.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
