### PR TITLE
waypoint: init at 0-unstable-2025-06-10

### DIFF
--- a/pkgs/by-name/wa/waypoint/package.nix
+++ b/pkgs/by-name/wa/waypoint/package.nix
@@ -1,0 +1,30 @@
+{
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "waypoint";
+  version = "0-unstable-2025-06-10";
+
+  src = fetchFromGitHub {
+    owner = "tadeokondrak";
+    repo = "waypoint";
+    rev = "bfd3a4ddf75b0be933ea8954f7db0fdb6fd22fab";
+    hash = "sha256-WUsJlZAmIhKMNuQI74fyiUCLvQ321bz2vkSHJ8YVLbg=";
+  };
+
+  cargoHash = "sha256-U2xHFII0FMG9Zc+2W3JguBIXIgtfWIHWsUUDxnjoF5U=";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Move and click the mouse pointer with keyboard controls";
+    homepage = "https://github.com/tadeokondrak/waypoint";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ yiyu ];
+    mainProgram = "waypoint";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
