### PR TITLE
pony-corral: Tells hydra to use base arch instead of native

### DIFF
--- a/pkgs/by-name/po/pony-corral/package.nix
+++ b/pkgs/by-name/po/pony-corral/package.nix
@@ -17,6 +17,17 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-pJ6/+PYxMpJcj1e9v2Al8vIWFizJnLMIw7LlVU9ogS0=";
   };
 
+  env.arch =
+    if stdenv.hostPlatform.isx86_64 then
+      "x86-64"
+    else if stdenv.hostPlatform.isAarch64 then
+      "armv8-a"
+    else
+      lib.warn ''
+        architecture '${stdenv.hostPlatform.system}' compiles with native optimizations,
+        this may result in crashes on incompatible CPUs!
+      '' "native";
+
   strictDeps = true;
 
   nativeBuildInputs = [ ponyc ];


### PR DESCRIPTION
The current ponyc defaults to generative code using "native" unless you specify --cpu on the command line. This causes this hydra-built package to SIGILL on systems with lowlier CPUs (many cloud VMs).

This PR ensures that corral is built in a way that the typical stdenv use of using NIX_ENFORCE_NO_NATIVE=1.

This will hopefully fully resolve Issue #414174.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
