### PR TITLE
vcpkg: 2025.10.17 -> 2026.01.16

### DIFF
--- a/pkgs/by-name/vc/vcpkg-tool/change-lock-location.patch
+++ b/pkgs/by-name/vc/vcpkg-tool/change-lock-location.patch
@@ -1,14 +1,14 @@
 diff --git a/src/vcpkg/vcpkgpaths.cpp b/src/vcpkg/vcpkgpaths.cpp
-index 3f588c21..e6f2bbed 100644
+index bb07a8fe..7dcf9c9b 100644
 --- a/src/vcpkg/vcpkgpaths.cpp
 +++ b/src/vcpkg/vcpkgpaths.cpp
-@@ -579,7 +579,8 @@ namespace vcpkg
-                 if (!args.do_not_take_lock)
-                 {
-                     std::error_code ec;
+@@ -607,7 +607,8 @@ namespace vcpkg
+                         lock_taking_context = &wdc;
+                     }
+ 
 -                    const auto vcpkg_root_file = root / ".vcpkg-root";
 +                    fs.create_directories(Path{"/tmp/vcpkg"}, VCPKG_LINE_INFO);
 +                    const auto vcpkg_root_file = Path{"/tmp/vcpkg"} / Hash::get_string_sha256(root.c_str());
                      if (args.wait_for_lock.value_or(false))
                      {
-                         file_lock_handle = fs.take_exclusive_file_lock(vcpkg_root_file, ec);
+                         file_lock_handle = fs.take_exclusive_file_lock(*lock_taking_context, vcpkg_root_file);

--- a/pkgs/by-name/vc/vcpkg-tool/package.nix
+++ b/pkgs/by-name/vc/vcpkg-tool/package.nix
@@ -24,13 +24,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "vcpkg-tool";
-  version = "2025-12-05";
+  version = "2025-12-16";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vcpkg-tool";
     rev = finalAttrs.version;
-    hash = "sha256-Sl9xs4WkydcRd5NGFGEoQEx2o+g+KAGn4UPtQ1dPpoY=";
+    hash = "sha256-EnKfeWRiqWVFbGc2QNT9YQHs+dlXvvri9FPVxpxpphM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vc/vcpkg/package.nix
+++ b/pkgs/by-name/vc/vcpkg/package.nix
@@ -9,13 +9,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "vcpkg";
-  version = "2025.10.17";
+  version = "2026.01.16";
 
   src = fetchFromGitHub {
     owner = "microsoft";
     repo = "vcpkg";
     tag = finalAttrs.version;
-    hash = "sha256-prWpMtvXWZ53y2gzr7IIqL/5kQZRfErnynEHMqi15/A=";
+    hash = "sha256-fT1EADy3wXm1JIpAbOmS2LWCJCK/kbsiaN9ILgQuZek=";
     leaveDotGit = true;
     postFetch = ''
       cd "$out"
@@ -39,12 +39,8 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   postPatch = ''
     substituteInPlace scripts/toolchains/linux.cmake \
-      --replace-fail "aarch64-linux-gnu-as"  "aarch64-unknown-linux-gnu-as" \
-      --replace-fail "aarch64-linux-gnu-gcc" "aarch64-unknown-linux-gnu-gcc" \
-      --replace-fail "aarch64-linux-gnu-g++" "aarch64-unknown-linux-gnu-g++" \
-      --replace-fail "arm-linux-gnueabihf-as"  "armv7l-unknown-linux-gnueabihf-as" \
-      --replace-fail "arm-linux-gnueabihf-gcc" "armv7l-unknown-linux-gnueabihf-gcc" \
-      --replace-fail "arm-linux-gnueabihf-g++" "armv7l-unknown-linux-gnueabihf-g++"
+      --replace-fail "\''${CMAKE_SYSTEM_PROCESSOR}-linux-gnu" "\''${CMAKE_SYSTEM_PROCESSOR}-unknown-linux-gnu" \
+      --replace-fail "arm-linux-gnueabihf" "armv7l-unknown-linux-gnueabihf"
     # If we don’t turn this off, then you won’t be able to run binaries that
     # are installed by vcpkg.
     find triplets -name '*linux*.cmake' -exec bash -c 'echo "set(X_VCPKG_RPATH_KEEP_SYSTEM_PATHS ON)" >> "$1"' -- {} \;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Updated vcpkg-tool, the build was broken since a patch failed to apply because of [an upstream refactor](https://github.com/microsoft/vcpkg-tool/commit/c86172d360bd375efe0813aa76568e1408ffa2e6)
- Updated postPatch script since the [upstream file change](https://github.com/microsoft/vcpkg/commit/c70c929e4854f1add688dab6abd5e0f466864767) significantly enough for the script to not substitute strings properly.

------

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
