### PR TITLE
burpsuite: additional CLI Flags, added license config

### DIFF
--- a/pkgs/by-name/bu/burpsuite/package.nix
+++ b/pkgs/by-name/bu/burpsuite/package.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   buildFHSEnv,
   fetchurl,
@@ -8,6 +9,7 @@
 
   # Either "community" or "pro"
   iconName ? "community",
+  licenseAccepted ? config.burpsuite.accept_license or false,
 }:
 assert lib.assertMsg (
   iconName == "pro" || iconName == "community"
@@ -45,7 +47,9 @@ in
 buildFHSEnv {
   inherit pname version;
 
-  runScript = "${lib.getExe jdk} -jar ${src}";
+  runScript =
+    "${lib.getExe jdk} -jar ${src} --suppress-jre-check --disable-check-for-updates-dialog --disable-auto-update"
+    + lib.optionalString licenseAccepted " --i-accept-the-license-agreement";
 
   targetPkgs =
     pkgs: with pkgs; [


### PR DESCRIPTION
This PR adds several undocumented cli flags to the runScript command:

- `--suppress-jre-check`: This disables the false-positive JRE Version warnings at startup
- `-disable-auto-update`: This disables any built-in auto-updates mechanisms, these will fail on nix anyway
- `--disable-check-for-updates-dialog`: This disables the update dialog on startup, which is irrelevant because burp is updated via nix
- `--i-accept-the-license-agreement`: This flag auto-accepts the eula

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [X] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
