### PR TITLE
redlist: init at 0-unstable-2026-01-30

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15143,6 +15143,11 @@
     githubId = 101508537;
     name = "Yuchen He";
   };
+  lilahummel = {
+    github = "LilaHummel";
+    githubId = 263230236;
+    name = "Lila Hummel";
+  };
   lilioid = {
     name = "Lilly";
     email = "li@lly.sh";

--- a/pkgs/by-name/re/redlist/package.nix
+++ b/pkgs/by-name/re/redlist/package.nix
@@ -1,0 +1,48 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "redlist";
+  version = "0-unstable-2026-01-30";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Laharah";
+    repo = "redlist";
+    rev = "3d465a12d79331eefde52351b441d8e0875f93e3";
+    hash = "sha256-eROvTs4WCVeXE2+4FICC9Rl5bjIkf0E5sYvqCaskXEw=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      aiohttp
+      beets
+      humanize
+      confuse
+      pynentry
+      deluge-client
+      cryptography
+    ]
+    ++ aiohttp.optional-dependencies.speedups;
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"pytest-runner"' ""
+  '';
+
+  meta = {
+    description = "Convert Spotify playlists to local m3u's and fill the gaps";
+    mainProgram = "redlist";
+    homepage = "https://github.com/Laharah/redlist";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+})

--- a/pkgs/development/python-modules/pynentry/default.nix
+++ b/pkgs/development/python-modules/pynentry/default.nix
@@ -1,0 +1,36 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pinentry-curses,
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "pynentry";
+  version = "0.1.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Laharah";
+    repo = "pynentry";
+    rev = "54a484b36b8ac16c0ae51fe436844d5a056ec3c9";
+    hash = "sha256-bbuAI0IB3cTIfaCCrq0g93geRLUsxaahHWuU3bBtHII";
+  };
+
+  build-system = [ setuptools ];
+
+  postPatch = ''
+    substituteInPlace pynentry.py \
+      --replace-fail 'executable="pinentry"' 'executable="${lib.getExe pinentry-curses}"'
+  '';
+
+  pythonImportsCheck = [ "pynentry" ];
+
+  meta = {
+    description = "Wrapper for pinentry for python";
+    homepage = "https://github.com/Laharah/pynentry";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14125,6 +14125,8 @@ self: super: with self; {
 
   pynello = callPackage ../development/python-modules/pynello { };
 
+  pynentry = callPackage ../development/python-modules/pynentry { };
+
   pynest2d = callPackage ../development/python-modules/pynest2d { };
 
   pynetbox = callPackage ../development/python-modules/pynetbox { };


### PR DESCRIPTION
Add redlist tool.

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
