### PR TITLE
beamPackages.buildRebar3: update to use extendMkDerivation and hooks

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -105,6 +105,8 @@ let
         mixBuildDirHook
         mixCompileHook
         mixAppConfigPatchHook
+        rebar3CompileHook
+        rebarDevendorPatchHook
         ;
     };
 in

--- a/pkgs/development/beam-modules/hooks/beam-module-install-hook.sh
+++ b/pkgs/development/beam-modules/hooks/beam-module-install-hook.sh
@@ -9,7 +9,15 @@ beamModuleInstallHook() {
 
   mkdir -p "$out/lib/erlang/lib/${beamModuleName}-${version}"
 
-  for reldir in _build/{$MIX_BUILD_PREFIX,shared}/lib/${beamModuleName}/{src,ebin,priv,include}; do
+  # default to rebar3
+  local fromDir=(./{ebin,priv,include})
+
+  # replace if mix project
+  if [ -n "$MIX_BUILD_PREFIX" ]; then
+    fromDir=(_build/{$MIX_BUILD_PREFIX,shared}/lib/"${beamModuleName}"/{src,ebin,priv,include})
+  fi
+
+  for reldir in "${fromDir[@]}"; do
     if test -d "$reldir"; then
       # Some builds produce symlinks (eg: phoenix priv directory). They must
       # be followed with -H flag.

--- a/pkgs/development/beam-modules/hooks/default.nix
+++ b/pkgs/development/beam-modules/hooks/default.nix
@@ -19,4 +19,12 @@
   mixAppConfigPatchHook = makeSetupHook {
     name = "mix-config-patch-hook.sh";
   } ./mix-app-config-patch-hook.sh;
+
+  rebar3CompileHook = makeSetupHook {
+    name = "rebar3-compile-hook.sh";
+  } ./rebar3-compile-hook.sh;
+
+  rebarDevendorPatchHook = makeSetupHook {
+    name = "rebar-devendor-patch-hook.sh";
+  } ./rebar-devendor-patch-hook.sh;
 }

--- a/pkgs/development/beam-modules/hooks/rebar-devendor-patch-hook.sh
+++ b/pkgs/development/beam-modules/hooks/rebar-devendor-patch-hook.sh
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+#
+# It's common to vendor a copy of rebar/rebar3 in repos, but we want to remove those
+
+rebarDevendorPatchHook() {
+  echo "Executing rebarDevendorPatchHook"
+
+  rm -f rebar rebar
+
+  echo "Finished rebarDevendorPatchHook"
+}
+
+prePatchHooks+=(rebarDevendorPatchHook)

--- a/pkgs/development/beam-modules/hooks/rebar3-compile-hook.sh
+++ b/pkgs/development/beam-modules/hooks/rebar3-compile-hook.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+
+rebar3CompileHook() {
+  echo "Executing rebar3CompileHook"
+
+  runHook preBuild
+
+  HOME=. rebar3 bare compile --paths "."
+
+  runHook postBuild
+
+  echo "Finished rebar3CompileHook"
+}
+
+if [ -z "${dontRebar3Compile-}" ] && [ -z "${buildPhase-}" ]; then
+  buildPhase=rebar3CompileHook
+fi


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
