### PR TITLE
[25.11] antigravity: 1.11.14 -> 1.18.4

### DIFF
--- a/pkgs/by-name/an/antigravity/information.json
+++ b/pkgs/by-name/an/antigravity/information.json
@@ -1,22 +1,22 @@
 {
-  "version": "1.11.14",
-  "vscodeVersion": "1.104.0",
-  "sources": {
-    "x86_64-linux": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.11.14-5763785964257280/linux-x64/Antigravity.tar.gz",
-      "sha256": "983c478f4def33a68623dc07a04156404c2fe2accdd492bb2f067e3d91239e20"
-    },
-    "aarch64-linux": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.11.14-5763785964257280/linux-arm/Antigravity.tar.gz",
-      "sha256": "df7f9e3888d001d34e1a9550c4cdc26a158d538646720fad7e2abe404e50e9fa"
-    },
-    "x86_64-darwin": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.11.14-5763785964257280/darwin-x64/Antigravity.zip",
-      "sha256": "5ab684a28a7802cb8df565061438f87d0cbd69eddbdffd0040f0eb18c8962653"
-    },
-    "aarch64-darwin": {
-      "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.11.14-5763785964257280/darwin-arm/Antigravity.zip",
-      "sha256": "82312771175f9892096a9d393aaff7adede2a2f681b14b4c705b022dcb81c56a"
+    "version": "1.18.4",
+    "vscodeVersion": "1.107.0",
+    "sources": {
+          "x86_64-linux": {
+                  "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.4-5780041996042240/linux-x64/Antigravity.tar.gz",
+                  "sha256": "f97d790d1fb74e8ccb9ddb6af301a2b60391aed22f633f1a2baf86862aa65826"
+          },
+          "aarch64-linux": {
+                  "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.4-5780041996042240/linux-arm/Antigravity.tar.gz",
+                  "sha256": "eee54e88290cf4b0b8feb56283a04ab31ce4746465ca0bd1afd3e4505b2f95ea"
+          },
+          "x86_64-darwin": {
+                  "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.4-5780041996042240/darwin-x64/Antigravity.zip",
+                  "sha256": "fdff8b6fdfda9a28ac5a147f174337c3cf515b10cddc8466af5a32c6deaaca87"
+          },
+          "aarch64-darwin": {
+                  "url": "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.18.4-5780041996042240/darwin-arm/Antigravity.zip",
+                  "sha256": "f1ccd9e3f051431b54b95b905afed8ec1b8b1a3f1bc841b3617b143553fd6f51"
+          }
     }
-  }
 }


### PR DESCRIPTION
Backporting 1.18.4 to release-25.11 to fix compatibility with 3.1 models. Cherry-picked from commit 6455a476e843476ba90866c046b75d7e680ac10a in PR #492660.