### PR TITLE
bagels: 0.3.9 -> 0.3.12

### DIFF
--- a/pkgs/by-name/ba/bagels/package.nix
+++ b/pkgs/by-name/ba/bagels/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "bagels";
-  version = "0.3.9";
+  version = "0.3.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "EnhancedJax";
     repo = "bagels";
     tag = finalAttrs.version;
-    hash = "sha256-LlEQ0by6Si37e8FvC4agjLy8eanizSA1iq44BaQ8D5o=";
+    hash = "sha256-w7Q7yCKffya2SyuHUaTWOugkeyTZbL9JNj/Ir3tnafE=";
   };
 
   build-system = with python3Packages; [
@@ -80,13 +80,23 @@ python3Packages.buildPythonApplication (finalAttrs: {
     # AttributeError: 'NoneType' object has no attribute 'defaults'
     "test_basic_balance_calculation"
     "test_combined_balance_calculation"
+    "test_create_template"
+    "test_create_multiple_templates"
+    "test_delete_template"
+    "test_get_adjacent_template"
+    "test_get_all_templates"
     "test_get_days_in_period"
     "test_get_period_average"
     "test_get_period_figures"
     "test_get_start_end_of_period"
     "test_get_start_end_of_week"
+    "test_get_template_by_id"
     "test_split_balance_calculation"
+    "test_swap_template_order"
+    "test_swap_template_order_edge_cases"
+    "test_template_validation"
     "test_transfer_balance_calculation"
+    "test_update_template"
   ];
 
   meta = {


### PR DESCRIPTION
Updated the `bagels` package to its latest version, 0.3.12 ([changelog](https://github.com/EnhancedJax/Bagels/blob/HEAD/CHANGELOG.md#0312)).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
