### PR TITLE
[staging-next] python3Packages.{sqlglot: 28.6.0 -> 28.9.0,sqlframe: 3.45.0 -> 3.46.2,narwhals: 2.15.0 -> 2.16.0}

### DIFF
--- a/pkgs/development/python-modules/narwhals/default.nix
+++ b/pkgs/development/python-modules/narwhals/default.nix
@@ -22,14 +22,14 @@
 
 buildPythonPackage rec {
   pname = "narwhals";
-  version = "2.15.0";
+  version = "2.16.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "narwhals-dev";
     repo = "narwhals";
     tag = "v${version}";
-    hash = "sha256-7tLxMtFWpk0ZpR9UYtKdk6L2UXb/ah1ZA6XZ4RbnvsI=";
+    hash = "sha256-k7CeM8Q4JgKbkLisAaVrljro4diOf0K0immek6AI0vM=";
   };
 
   build-system = [ hatchling ];
@@ -81,6 +81,10 @@ buildPythonPackage rec {
     # ibis improvements cause strict XPASS failures (tests expected to fail now pass)
     "test_empty_scalar_reduction_with_columns"
     "test_collect_empty"
+    "test_first_last_expr_over_order_by"
+    "test_first_expr_broadcasting"
+    # sqlframe improvements cause strict XPASS failures (tests expected to fail now pass)
+    "test_unique_expr"
   ];
 
   disabledTestPaths = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [

--- a/pkgs/development/python-modules/sqlframe/default.nix
+++ b/pkgs/development/python-modules/sqlframe/default.nix
@@ -38,14 +38,14 @@
 
 buildPythonPackage rec {
   pname = "sqlframe";
-  version = "3.45.0";
+  version = "3.46.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "eakmanrq";
     repo = "sqlframe";
     tag = "v${version}";
-    hash = "sha256-S0tcdmdA9SptmaFT/G3efO3yPLWrBOJVDLCK3Zu2r9w=";
+    hash = "sha256-WTeJXiIkyj9FgO1w3P6JsCTtpGzezWnsiz/boB9PdIU=";
   };
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/sqlglot/default.nix
+++ b/pkgs/development/python-modules/sqlglot/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "sqlglot";
-  version = "28.6.0";
+  version = "28.9.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     repo = "sqlglot";
     owner = "tobymao";
     tag = "v${version}";
-    hash = "sha256-1RAjGqu2D/wrec/sryPGZlPnaBGkyhYpzdaZu9KYh2Q=";
+    hash = "sha256-2AmHKGAoDF8w9k8VN9d25Js3UiSh8YNqdGRHN7VqRpw=";
   };
 
   build-system = [


### PR DESCRIPTION
Fixes [python3Packages.narwhals](https://hydra.nixos.org/build/322071348) build.

sqlglot 28.10.1 is actually current, but it seems incompatible with sqlframe.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
