### PR TITLE
box64: 0.3.8 -> 0.4.0

### DIFF
--- a/pkgs/applications/emulators/box64/default.nix
+++ b/pkgs/applications/emulators/box64/default.nix
@@ -21,13 +21,13 @@ assert
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "box64";
-  version = "0.3.8";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "ptitSeb";
     repo = "box64";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-PVzv1790UhWbqLmw/93+mU3Gw8lQek7NBls4LXks4wQ=";
+    hash = "sha256-ihg7sos2pyyZjXiYMct/gg/ianiu0yagNtXio+A7J3c=";
   };
 
   # Setting cpu doesn't seem to work (or maybe isn't enough / gets overwritten by the wrapper's arch flag?), errors about unsupported instructions for target
@@ -82,20 +82,16 @@ stdenv.mkDerivation (finalAttrs: {
     $out/bin/box64 -v
 
     echo Checking if Dynarec option was respected
-    $out/bin/box64 -v | grep ${lib.optionalString (!withDynarec) "-v"} Dynarec
+    $out/bin/box64 -v 2>&1 | grep ${lib.optionalString (!withDynarec) "-v"} Dynarec
 
     runHook postInstallCheck
   '';
 
   passthru = {
     updateScript = gitUpdater { rev-prefix = "v"; };
-    tests.hello =
-      runCommand "box64-test-hello" { nativeBuildInputs = [ finalAttrs.finalPackage ]; }
-        # There is no actual "Hello, world!" with any of the logging enabled, and with all logging disabled it's hard to
-        # tell what problems the emulator has run into.
-        ''
-          BOX64_NOBANNER=0 BOX64_LOG=1 box64 ${lib.getExe hello-x86_64} --version | tee $out
-        '';
+    tests.hello = runCommand "box64-test-hello" { nativeBuildInputs = [ finalAttrs.finalPackage ]; } ''
+      BOX64_LOG=1 box64 ${lib.getExe hello-x86_64} --version 2>&1 | tee $out
+    '';
   };
 
   meta = {


### PR DESCRIPTION
There is also now a [version 0.4.1-1 tagged](https://github.com/ptitSeb/box64/releases/tag/v0.4.1-1), but that has neither an announcement on the website, nor a release page on GitHub. It doesn't fit into the established version scheme either (increase by 0.0.2 every release)… I assume that's not a real release.

Needs to be checked on a platform where it's actually relevant, like aarch64 or loongarch64. Waiting for OfBorg to do a basic check for me via `box64.passthru.tests` on aarch64-linux…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
