### PR TITLE
frigate: various fixes

### DIFF
--- a/pkgs/by-name/fr/frigate/onnxruntime-compat.patch
+++ b/pkgs/by-name/fr/frigate/onnxruntime-compat.patch
@@ -1,0 +1,19 @@
+Disable the SimplifedLayerNormFusion optimization for onnxruntime embedding
+models to prevent a crash when using FP16 models (like jinna-clip-v1) with newer
+onnxruntime versions.
+
+https://github.com/microsoft/onnxruntime/issues/26717#issuecomment-3800462654
+
+
+diff --git a/frigate/embeddings/onnx/runner.py b/frigate/embeddings/onnx/runner.py
+index c34c97a8d..dca91daae 100644
+--- a/frigate/embeddings/onnx/runner.py
++++ b/frigate/embeddings/onnx/runner.py
+@@ -52,6 +52,7 @@ class ONNXModelRunner:
+                 model_path,
+                 providers=providers,
+                 provider_options=options,
++                disabled_optimizers=["SimplifiedLayerNormFusion"],
+             )
+ 
+     def get_input_names(self) -> list[str]:

--- a/pkgs/by-name/fr/frigate/package.nix
+++ b/pkgs/by-name/fr/frigate/package.nix
@@ -98,6 +98,8 @@ python3Packages.buildPythonApplication rec {
     })
     # https://github.com/microsoft/onnxruntime/issues/26717
     ./onnxruntime-compat.patch
+    # https://github.com/blakeblackshear/frigate/pull/22089
+    ./proc-cmdline-strip.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/fr/frigate/package.nix
+++ b/pkgs/by-name/fr/frigate/package.nix
@@ -84,6 +84,7 @@ python3Packages.buildPythonApplication rec {
       hash = "sha256-1+n0n0yCtjfAHkXzsZdIF0iCVdPGmsG7l8/VTqBVEjU=";
     })
     ./ffmpeg.patch
+    # https://github.com/blakeblackshear/frigate/pull/21876
     ./ai-edge-litert.patch
     (fetchpatch {
       # peewee-migrate 0.14.x compat
@@ -95,6 +96,8 @@ python3Packages.buildPythonApplication rec {
       ];
       hash = "sha256-RrmwjE4SHJIUOYfqcCtMy9Pht7UXhHcoAZlFQv9aQFw=";
     })
+    # https://github.com/microsoft/onnxruntime/issues/26717
+    ./onnxruntime-compat.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/fr/frigate/proc-cmdline-strip.patch
+++ b/pkgs/by-name/fr/frigate/proc-cmdline-strip.patch
@@ -1,0 +1,27 @@
+Strip trailing whitespace from process commandlines. This is annoying for exact
+process matches against Prometheus labels.
+
+https://github.com/blakeblackshear/frigate/pull/22089
+
+diff --git a/frigate/util/services.py b/frigate/util/services.py
+index b31a7eea3..f1e8f0f5f 100644
+--- a/frigate/util/services.py
++++ b/frigate/util/services.py
+@@ -118,7 +118,7 @@ def get_cpu_stats() -> dict[str, dict]:
+         pid = str(process.info["pid"])
+         try:
+             cpu_percent = process.info["cpu_percent"]
+-            cmdline = process.info["cmdline"]
++            cmdline = " ".join(process.info["cmdline"]).rstrip()
+ 
+             with open(f"/proc/{pid}/stat", "r") as f:
+                 stats = f.readline().split()
+@@ -152,7 +152,7 @@ def get_cpu_stats() -> dict[str, dict]:
+                 "cpu": str(cpu_percent),
+                 "cpu_average": str(round(cpu_average_usage, 2)),
+                 "mem": f"{mem_pct}",
+-                "cmdline": clean_camera_user_pass(" ".join(cmdline)),
++                "cmdline": clean_camera_user_pass(cmdline),
+             }
+         except Exception:
+             continue


### PR DESCRIPTION
Based on staging-next to resolve merge conflicts early.

Fixes:
- onnxruntime compat with jinna-clip-v1 fp16 embedding models
- fixes trailing whitespace in process commandline leaking into prometheus labels

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
