### PR TITLE
vscode-extensions.vadimcn.vscode-lldb: 1.11.4 -> 1.12.1

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/codelldb-launch.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/codelldb-launch.nix
@@ -1,0 +1,22 @@
+{
+  makeBinaryWrapper,
+  rustPlatform,
+  pname,
+  src,
+  version,
+
+  cargoHash,
+}:
+rustPlatform.buildRustPackage {
+  pname = "${pname}-codelldb-launch";
+  inherit version src cargoHash;
+
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  cargoBuildFlags = [
+    "--package=codelldb-launch"
+  ];
+
+  # Tests fail to build (as of version 1.12.0).
+  doCheck = false;
+}

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/codelldb-types.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/codelldb-types.nix
@@ -1,0 +1,22 @@
+{
+  makeWrapper,
+  rustPlatform,
+  pname,
+  src,
+  version,
+
+  cargoHash,
+}:
+rustPlatform.buildRustPackage {
+  pname = "${pname}-codelldb-types";
+  inherit version src cargoHash;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  cargoBuildFlags = [
+    "--package=codelldb-types"
+  ];
+
+  # Tests fail to build (as of version 1.12.0).
+  doCheck = false;
+}

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/node_deps.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/node_deps.nix
@@ -16,7 +16,7 @@ buildNpmPackage {
   pname = "${pname}-node-deps";
   inherit version src;
 
-  npmDepsHash = "sha256-Efeun7AFMAnoNXLbTGH7OWHaBHT2tO9CodfjKrIYw40=";
+  npmDepsHash = "sha256-TCeIBrlsNuphW2gVsX97+Wu1lOG5gDwS7559YA1d10M=";
 
   nativeBuildInputs = [
     python3

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/patches/cmake-build-extension-only.patch
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/patches/cmake-build-extension-only.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 5cab8b1..0b500d5 100644
+index 3e4f955..2ca59d0 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -16,13 +16,6 @@ endif()
@@ -13,27 +13,32 @@ index 5cab8b1..0b500d5 100644
 -    message(FATAL_ERROR "LLDB_PACKAGE not set." )
 -endif()
 -
- if (CMAKE_SYSROOT)
-     set(CMAKE_C_FLAGS "--sysroot=${CMAKE_SYSROOT} ${CMAKE_C_FLAGS}")
-     set(CMAKE_CXX_FLAGS "--sysroot=${CMAKE_SYSROOT} ${CMAKE_CXX_FLAGS}")
-@@ -116,16 +109,6 @@ configure_file(package.json ${CMAKE_CURRENT_BINARY_DIR}/package.json @ONLY)
- configure_file(webpack.config.js ${CMAKE_CURRENT_BINARY_DIR}/webpack.config.js)
- file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+ set(CMAKE_CTEST_ARGUMENTS "--output-on-failure" CACHE INTERNAL "CTest arguments")
  
+ set(TEST_TIMEOUT 5000 CACHE STRING "Test timeout [ms]")
+@@ -120,12 +113,6 @@ configure_file(package.json ${CMAKE_CURRENT_BINARY_DIR}/package.json @ONLY)
+ # We still need to resolve codelldb schema $ref's in it, but we'll do this during the build.
+ file(COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/package.json ${CMAKE_CURRENT_BINARY_DIR}/package.pre.json)
+ file(COPY_FILE ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json ${CMAKE_CURRENT_BINARY_DIR}/package-lock.json)
 -# Install node_modules
 -execute_process(
--    COMMAND ${NPM} --loglevel verbose ci # like install, but actually respects package-lock file.
+-    COMMAND ${NPM} install
 -    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
--    RESULT_VARIABLE Result
+-    COMMAND_ERROR_IS_FATAL ANY
 -)
--if (NOT ${Result} EQUAL 0)
--    message(FATAL_ERROR "npm install failed: ${Result}")
--endif()
--
- # Resolve $refs
- execute_process(
-     COMMAND ${WithEnv} NODE_PATH=${CMAKE_CURRENT_BINARY_DIR}/node_modules node ${CMAKE_CURRENT_SOURCE_DIR}/tools/prep-package.js ${CMAKE_CURRENT_BINARY_DIR}/package.json ${CMAKE_CURRENT_BINARY_DIR}/package.json
-@@ -183,6 +166,7 @@ add_custom_target(adapter_tests
+ # So we can commit any changes
+ file(COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/package-lock.json ${CMAKE_CURRENT_SOURCE_DIR}/package-lock.json)
+ 
+@@ -133,7 +120,7 @@ file(COPY_FILE ${CMAKE_CURRENT_BINARY_DIR}/package-lock.json ${CMAKE_CURRENT_SOU
+ add_custom_command(
+     OUTPUT ${CMAKE_BINARY_DIR}/package.json ${CMAKE_BINARY_DIR}/generated/codelldb.ts
+     DEPENDS ${CMAKE_SOURCE_DIR}/package.json ${CMAKE_SOURCE_DIR}/src/codelldb-types/src/lib.rs
+-    COMMAND cargo run --package codelldb-types -- ${CMAKE_BINARY_DIR}/codelldb.schema.json
++    COMMAND codelldb-types ${CMAKE_BINARY_DIR}/codelldb.schema.json
+     COMMAND ${WithEnv} NODE_PATH=${CMAKE_CURRENT_BINARY_DIR}/node_modules node ${CMAKE_CURRENT_SOURCE_DIR}/tools/prep-package.js
+             ${CMAKE_CURRENT_BINARY_DIR}/package.pre.json ${CMAKE_CURRENT_BINARY_DIR}/package.json
+     COMMAND ${NPM} run json2ts -- ${CMAKE_BINARY_DIR}/codelldb.schema.json ${CMAKE_BINARY_DIR}/generated/codelldb.ts
+@@ -158,6 +145,7 @@ add_custom_target(update_lockfiles
  
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_BINARY_DIR}/README.md)
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md ${CMAKE_CURRENT_BINARY_DIR}/CHANGELOG.md)
@@ -41,7 +46,7 @@ index 5cab8b1..0b500d5 100644
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/lldb.png ${CMAKE_CURRENT_BINARY_DIR}/images/lldb.png)
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/user.svg ${CMAKE_CURRENT_BINARY_DIR}/images/user.svg)
  add_copy_file(PackageFiles ${CMAKE_CURRENT_SOURCE_DIR}/images/users.svg ${CMAKE_CURRENT_BINARY_DIR}/images/users.svg)
-@@ -199,6 +183,7 @@ add_custom_target(dev_debugging
+@@ -174,6 +162,7 @@ add_custom_target(dev_debugging
  set(PackagedFilesBootstrap
      README.md
      CHANGELOG.md


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/vadimcn/codelldb/releases/tag/v1.12.1
based on https://github.com/NixOS/nixpkgs/pull/468237; Resolves https://github.com/NixOS/nixpkgs/issues/467872
- added a fix for `vscode-extensions.vadimcn.vscode-lldb.adapter` not having `codelldb-launch`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

