### PR TITLE
python3Packages.homelink-integration-api: init at 0.0.1

### DIFF
--- a/pkgs/development/python-modules/homelink-integration-api/default.nix
+++ b/pkgs/development/python-modules/homelink-integration-api/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiofiles,
+  aiohttp,
+  boto3,
+  paho-mqtt,
+  pyopenssl,
+  python-decouple,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "homelink-integration-api";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Gentex-Corporation";
+    repo = "homelink-integration-api";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ELEqx41JSAmXBEowwJ1tYPZV40hMjswaHQonD+1IG5E=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiofiles
+    aiohttp
+    boto3
+    paho-mqtt
+    pyopenssl
+    python-decouple
+  ];
+
+  # upstream tests require network access and AWS credentials
+  doCheck = false;
+
+  pythonImportsCheck = [ "homelink" ];
+
+  meta = {
+    description = "API to interact with Homelink cloud for MQTT-enabled smart home platforms";
+    homepage = "https://github.com/Gentex-Corporation/homelink-integration-api";
+    changelog = "https://github.com/Gentex-Corporation/homelink-integration-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2060,7 +2060,8 @@
       ];
     "gentex_homelink" =
       ps: with ps; [
-      ]; # missing inputs: homelink-integration-api
+        homelink-integration-api
+      ];
     "geo_json_events" =
       ps: with ps; [
         aio-geojson-generic-client
@@ -7449,6 +7450,7 @@
     "generic_hygrostat"
     "generic_thermostat"
     "geniushub"
+    "gentex_homelink"
     "geo_json_events"
     "geo_location"
     "geo_rss_events"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7011,6 +7011,8 @@ self: super: with self; {
 
   homeconnect = callPackage ../development/python-modules/homeconnect { };
 
+  homelink-integration-api = callPackage ../development/python-modules/homelink-integration-api { };
+
   homematicip = callPackage ../development/python-modules/homematicip { };
 
   homepluscontrol = callPackage ../development/python-modules/homepluscontrol { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/homelink-integration-api/
- https://github.com/Gentex-Corporation/homelink-integration-api
- https://www.home-assistant.io/integrations/gentex_homelink/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
