### PR TITLE
keycloak.plugins.keycloak-discord: 0.6.1 -> 1.3.1, migrate to iForged fork

### DIFF
--- a/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
+++ b/pkgs/by-name/ke/keycloak/keycloak-discord/default.nix
@@ -6,26 +6,16 @@
 }:
 maven.buildMavenPackage rec {
   pname = "keycloak-discord";
-  version = "0.6.1";
+  version = "1.3.1";
 
   src = fetchFromGitHub {
-    owner = "wadahiro";
+    owner = "iForged";
     repo = "keycloak-discord";
     tag = "v${version}";
-    hash = "sha256-BA7x28k/aMI3VPQmEgNhKD9N34DdYqadAD/m4cxLSYg=";
+    hash = "sha256-xTGXETkE5Ct+h3mYbj3VUoQhi5Wx5oZqz3G1uN0pDns=";
   };
 
-  mvnHash =
-    let
-      mvnHashes = {
-        "aarch64-darwin" = "sha256-Or7VOZwz4NfDtb0kmHbbTYE/avAc+H8+Y6JPw+HGjxs=";
-        "x86_64-darwin" = "sha256-sX10vYlb2hWArTLZsPTcKYHHsPffQKtBxpcI42wcZZA=";
-        "aarch64-linux" = "sha256-I5qjhfAXPXMb+1SPG29t/IKH/zBQqdnu3U7dYSQhTL8=";
-        "x86_64-linux" = "sha256-uhm++MGgTN32/xbHNd+Z3Hes9Q5tl8ztIQ92LxMWKjg=";
-      };
-    in
-    mvnHashes.${stdenv.hostPlatform.system}
-      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+  mvnHash = "sha256-zFsVRFFGrHvTFW6+Y1o2OVFaf34JgqPVv+vMAfkSOJw=";
 
   installPhase = ''
     runHook preInstall
@@ -34,7 +24,7 @@ maven.buildMavenPackage rec {
   '';
 
   meta = {
-    homepage = "https://github.com/wadahiro/keycloak-discord";
+    homepage = "https://github.com/iForged/keycloak-discord";
     description = "Keycloak Identity Provider extension for Discord";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [


### PR DESCRIPTION
Based on the discussion in https://github.com/wadahiro/keycloak-discord/issues/65, migrates `keycloak-discord` to the actively maintained fork by iForged. This pulls in several major features from ignored PRs, includes security fixes, and re-establishes compatibility with the latest version of Keycloak.

Fixes https://github.com/NixOS/nixpkgs/issues/481137 (this package no longer needs to be marked broken)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
