### PR TITLE
keifu: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -29609,6 +29609,12 @@
     githubId = 22890520;
     matrix = "@yusufraji49:matrix.org";
   };
+  yutakobayashidev = {
+    name = "Yuta Kobayashi";
+    email = "hi@yutakobayashi.com";
+    github = "yutakobayashidev";
+    githubId = 91340399;
+  };
   yvan-sraka = {
     email = "yvan@sraka.xyz";
     github = "yvan-sraka";

--- a/pkgs/by-name/ke/keifu/package.nix
+++ b/pkgs/by-name/ke/keifu/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  pkg-config,
+  openssl,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "keifu";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "trasta298";
+    repo = "keifu";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8fjR204Wa9LJa9JGQ1CRHDoiHei6P3J81RGgA0G77EA=";
+  };
+
+  cargoHash = "sha256-OhNT+IbR1A7QD03/I+ju2h1LArVPL47BnVmit3tNSOA=";
+
+  env.OPENSSL_NO_VENDOR = 1;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "TUI tool for visualizing Git commit graphs";
+    homepage = "https://github.com/trasta298/keifu";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ yutakobayashidev ];
+    mainProgram = "keifu";
+  };
+})


### PR DESCRIPTION
Add [keifu](https://github.com/trasta298/keifu), a TUI tool for visualizing Git commit graphs with branch genealogy.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test