### PR TITLE
nixos/systemd: convert `sleep.extraConfig` to RFC42-style settings

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -181,6 +181,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - [services.resolved](#opt-services.resolved.enable) module was converted to RFC42-style settings. The moved options have also been renamed to match the upstream names. Aliases mean current configs will continue to function, but users should move to the new options as convenient.
 
+- `systemd.sleep.extraConfig` was replaced by [RFC 0042](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md)-compliant `systemd.sleep.settings.Sleep`, which is used to generate the `sleep.conf` configuration file. See {manpage}`sleep.conf.d(5)` for available options.
+
 - Support for Bluetooth audio based on `bluez-alsa` has been added to the `hardware.alsa` module. It can be enabled with the new [enableBluetooth](#opt-hardware.alsa.enableBluetooth) option.
 
 - `services.openssh` now supports generating host SSH keys by setting `services.openssh.generateHostKeys = true` while leaving `services.openssh.enable` disabled.  This is particularly useful for systems that have no need of an SSH daemon but want SSH host keys for other purposes such as using agenix or sops-nix.

--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -470,13 +470,17 @@ in
       '';
     };
 
-    sleep.extraConfig = mkOption {
-      default = "";
-      type = types.lines;
-      example = "HibernateDelaySec=1h";
+    sleep.settings.Sleep = mkOption {
+      default = { };
+      type = lib.types.submodule {
+        freeformType = types.attrsOf unitOption;
+      };
+      example = {
+        HibernateDelaySec = "1h";
+      };
       description = ''
-        Extra config options for systemd sleep state logic.
-        See {manpage}`sleep.conf.d(5)` man page for available options.
+        Options for systemd sleep state logic. See {manpage}`sleep.conf.d(5)` man page
+        for available options.
       '';
     };
 
@@ -637,10 +641,7 @@ in
 
         "systemd/system.conf".text = settingsToSections cfg.settings;
 
-        "systemd/sleep.conf".text = ''
-          [Sleep]
-          ${cfg.sleep.extraConfig}
-        '';
+        "systemd/sleep.conf".text = settingsToSections cfg.sleep.settings;
 
         "systemd/user-generators" = {
           source = hooks "user-generators" cfg.user.generators;
@@ -853,6 +854,11 @@ in
       NixOS does not officially support this configuration and might cause your system to be unbootable in future versions. You are on your own.
     '')
     (mkRemovedOptionModule [ "systemd" "extraConfig" ] "Use systemd.settings.Manager instead.")
+    (mkRemovedOptionModule [
+      "systemd"
+      "sleep"
+      "extraConfig"
+    ] "Use systemd.sleep.settings.Sleep instead.")
     (lib.mkRenamedOptionModule
       [ "systemd" "watchdog" "device" ]
       [ "systemd" "settings" "Manager" "WatchdogDevice" ]


### PR DESCRIPTION
This converts `systemd.sleep.extraConfig` from a `types.lines` option to a structured `systemd.sleep.settings.Sleep` submodule, per [RFC42](https://github.com/NixOS/rfcs/blob/master/rfcs/0042-config-option.md).

### Before

```nix
systemd.sleep.extraConfig = ''
  HibernateDelaySec=1h
  AllowSuspendThenHibernate=no
'';
```

### After

```nix
systemd.sleep.settings.Sleep = {
  HibernateDelaySec = "1h";
  AllowSuspendThenHibernate = false;
};
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
