### PR TITLE
shortcut-mcp-server: init at 0.22.0

### DIFF
--- a/pkgs/by-name/sh/shortcut-mcp-server/package.nix
+++ b/pkgs/by-name/sh/shortcut-mcp-server/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "shortcut-mcp-server";
+  version = "0.22.0";
+
+  src = fetchFromGitHub {
+    owner = "useshortcut";
+    repo = "mcp-server-shortcut";
+    tag = "v0.22.0";
+    hash = "sha256-ixIll7lYJcYVRSUhoil+Qx7yULxBaNzhDI71afuF/bs=";
+  };
+
+  npmDepsHash = "sha256-xhfbx9hWv5UKzUryJG0g7m3tpOSW4wxX4uNoiC23EhQ=";
+
+  # Dependency resolution issue occur during install phase using bun as a dev Dependency
+  patches = [ ./remove-bun-dep.patch ];
+
+  meta = {
+    description = "MCP server for Shortcut";
+    homepage = "https://github.com/useshortcut/mcp-server-shortcut";
+    changelog = "https://github.com/useshortcut/mcp-server-shortcut/releases/tag/v${finalAttrs.version}";
+    license = [ lib.licenses.mit ];
+    maintainers = [ lib.maintainers.kashw2 ];
+    mainProgram = "mcp-server-shortcut";
+  };
+})

--- a/pkgs/by-name/sh/shortcut-mcp-server/remove-bun-dep.patch
+++ b/pkgs/by-name/sh/shortcut-mcp-server/remove-bun-dep.patch
@@ -1,0 +1,15 @@
+diff --git a/package.json b/package.json
+index 44d3f1f..b1a72a2 100644
+--- a/package.json
++++ b/package.json
+@@ -42,9 +42,7 @@
+ 	},
+ 	"devDependencies": {
+ 		"@biomejs/biome": "2.3.14",
+-		"@types/bun": "latest",
+ 		"@types/express": "^4.17.21",
+-		"bun": "1.3.9",
+ 		"husky": "9.1.7",
+ 		"pino-pretty": "^13.0.0",
+ 		"tsdown": "0.20.3"
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://help.shortcut.com/hc/en-us/articles/36443434285844-MCP-Server

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
