### PR TITLE
paradise-gtk: init at 0-unstable-2022-06-13

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -343,6 +343,12 @@
     githubId = 65275785;
     name = "Alexander Kenji Berthold";
   };
+  asteriau = {
+    email = "dorahaladita@gmail.com";
+    github = "asteriau";
+    githubId = 131019152;
+    name = "Laura";
+  };
   A1ca7raz = {
     email = "aya@wtm.moe";
     github = "A1ca7raz";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -343,12 +343,6 @@
     githubId = 65275785;
     name = "Alexander Kenji Berthold";
   };
-  asteriau = {
-    email = "dorahaladita@gmail.com";
-    github = "asteriau";
-    githubId = 131019152;
-    name = "Laura";
-  };
   A1ca7raz = {
     email = "aya@wtm.moe";
     github = "A1ca7raz";
@@ -2469,6 +2463,12 @@
     github = "Astavie";
     githubId = 7745457;
     name = "Astavie";
+  };
+  asteriau = {
+    email = "dorahaladita@gmail.com";
+    github = "asteriau";
+    githubId = 131019152;
+    name = "Laura";
   };
   asterismono = {
     email = "cmiki@amono.me";

--- a/pkgs/by-name/pa/paradise-gtk/package.nix
+++ b/pkgs/by-name/pa/paradise-gtk/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildNpmPackage,
+}:
+
+buildNpmPackage rec {
+  pname = "paradise-gtk";
+  version = "0-unstable-2022-06-13"; # No release, use commit's date
+
+  src = fetchFromGitHub {
+    owner = "paradise-theme";
+    repo = "gtk";
+    rev = "19afc8d54a96a2be5b5cf878ad988a0e0afba284";
+    hash = "sha256-NXP2h/qXqLy9tQ+TQ+zuXFP4syywIj34k+Fts/mUqps="; # This should be fine since repo is basically abandoned
+  };
+
+  npmDepsHash = "sha256-PEXClnWZHmO3pdES6QcAGXBUhBklsdFqz1LjnFMtcs4=";
+
+  npmBuildScript = "build";
+
+  installPhase = ''
+    runHook preInstall
+
+    themeDir=$out/share/themes/paradise
+    mkdir -p "$themeDir"
+
+    install -m 0644 index.theme "$themeDir"
+    cp -r assets gtk-3.0 "$themeDir"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Paradise GTK theme";
+    homepage = "https://github.com/paradise-theme/gtk";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.asteriau ];
+  };
+}

--- a/pkgs/by-name/pa/paradise-gtk/package.nix
+++ b/pkgs/by-name/pa/paradise-gtk/package.nix
@@ -4,7 +4,7 @@
   buildNpmPackage,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage {
   pname = "paradise-gtk";
   version = "0-unstable-2022-06-13"; # No release, use commit's date
 


### PR DESCRIPTION
<!--
This PR adds the Paradise GTK theme.

Homepage: https://github.com/paradise-theme/gtk

The theme provides styling for GTK3. That's about it.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
