### PR TITLE
opencode-desktop: let it find zed-editor

### DIFF
--- a/pkgs/by-name/op/opencode-desktop/package.nix
+++ b/pkgs/by-name/op/opencode-desktop/package.nix
@@ -29,6 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     src
     node_modules
     patches
+    postPatch
     ;
 
   cargoRoot = "packages/desktop/src-tauri";

--- a/pkgs/by-name/op/opencode/package.nix
+++ b/pkgs/by-name/op/opencode/package.nix
@@ -11,6 +11,7 @@
   installShellFiles,
   versionCheckHook,
   writableTmpDirAsHomeHook,
+  zed-editor,
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "opencode";
@@ -86,6 +87,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     substituteInPlace packages/script/src/index.ts \
       --replace-fail 'throw new Error(`This script requires bun@''${expectedBunVersionRange}' \
                      'console.warn(`Warning: This script requires bun@''${expectedBunVersionRange}'
+
+    # HACK https://github.com/anomalyco/opencode/issues/14444
+    substituteInPlace packages/app/src/components/session/session-header.tsx \
+      --replace-fail  '{ id: "zed", label: "Zed", icon: "zed", openWith: "zed" },' \
+                      '{ id: "zed", label: "Zed", icon: "zed", openWith: ${builtins.toJSON zed-editor.meta.mainProgram} },'
   '';
 
   configurePhase = ''


### PR DESCRIPTION
Workaround https://github.com/anomalyco/opencode/issues/14444.

With this change, OpenCode Desktop should be able to open the project in Zed for NixOS users.

@moduon MT-10900


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
