### PR TITLE
proton-vpn: init darwin at 6.4.0

### DIFF
--- a/pkgs/by-name/pr/proton-vpn/darwin.nix
+++ b/pkgs/by-name/pr/proton-vpn/darwin.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  meta,
+  stdenvNoCC,
+  _7zz,
+  fetchurl,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "proton-vpn";
+  version = "6.4.0";
+
+  src = fetchurl {
+    url = "https://github.com/ProtonVPN/ios-mac-app/releases/download/mac%2F${finalAttrs.version}/ProtonVPN_mac_v${finalAttrs.version}.dmg";
+    hash = "sha256-F5NS7NNqxNJcl7gFaqWtWxBxBbV6Btp7cyyDpegEGLQ=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [ _7zz ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -R ./ProtonVPN/ProtonVPN.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "mac/(.*)"
+    ];
+  };
+
+  meta = meta // {
+    changelog = "https://github.com/ProtonVPN/ios-mac-app/releases/tag/mac%2F${finalAttrs.version}";
+    platforms = [
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/pr/proton-vpn/linux.nix
+++ b/pkgs/by-name/pr/proton-vpn/linux.nix
@@ -1,0 +1,96 @@
+{
+  lib,
+  meta,
+  python3Packages,
+  fetchFromGitHub,
+  gobject-introspection,
+  libappindicator-gtk3,
+  libayatana-appindicator,
+  libnotify,
+  wrapGAppsHook4,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  withIndicator ? true,
+}:
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "proton-vpn";
+  version = "4.15.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ProtonVPN";
+    repo = "proton-vpn-gtk-app";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-bKUhrbfOLVjknljwW9UPo3Ros1Ayzb+be5KTUjPnIW0=";
+  };
+
+  nativeBuildInputs = [
+    # Needed for the NM namespace
+    gobject-introspection
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libnotify # gir typelib is used
+  ]
+  ++ lib.optionals withIndicator [
+    # Adds AppIndicator3 namespace
+    libappindicator-gtk3
+    # Adds AyatanaAppIndicator3 namespace
+    libayatana-appindicator
+  ];
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies = with python3Packages; [
+    dbus-python
+    packaging
+    proton-core
+    proton-keyring-linux
+    proton-vpn-api-core
+    proton-vpn-local-agent
+    pycairo
+    pygobject3
+  ];
+
+  dontWrapGApps = true;
+
+  preFixup = ''
+    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/{applications,pixmaps}
+
+    # Fix the desktop file to correctly identify the wrapped app and show the icon during runtime
+    substitute ${finalAttrs.src}/rpmbuild/SOURCES/proton.vpn.app.gtk.desktop $out/share/applications/proton.vpn.app.gtk.desktop \
+      --replace-fail "StartupWMClass=protonvpn-app" "StartupWMClass=.protonvpn-app-wrapped"
+    install -Dm 644 ${finalAttrs.src}/rpmbuild/SOURCES/proton-vpn-logo.svg $out/share/pixmaps
+  '';
+
+  preCheck = ''
+    export XDG_RUNTIME_DIR=$(mktemp -d)
+  '';
+
+  nativeCheckInputs = [
+    writableTmpDirAsHomeHook
+  ]
+  ++ (with python3Packages; [
+    pytestCheckHook
+    pytest-cov-stub
+  ]);
+
+  disabledTestPaths = [
+    # Segmentation fault during widgets tests
+    "tests/unit/widgets"
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = meta // {
+    platforms = lib.platforms.linux;
+    mainProgram = "protonvpn-app";
+  };
+})

--- a/pkgs/by-name/pr/proton-vpn/package.nix
+++ b/pkgs/by-name/pr/proton-vpn/package.nix
@@ -1,99 +1,22 @@
 {
   lib,
-  python3Packages,
-  fetchFromGitHub,
-  gobject-introspection,
-  libappindicator-gtk3,
-  libayatana-appindicator,
-  libnotify,
-  wrapGAppsHook4,
-  withIndicator ? true,
+  stdenv,
+  callPackage,
 }:
-
-python3Packages.buildPythonApplication (finalAttrs: {
-  pname = "proton-vpn";
-  version = "4.15.0";
-  pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "ProtonVPN";
-    repo = "proton-vpn-gtk-app";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-bKUhrbfOLVjknljwW9UPo3Ros1Ayzb+be5KTUjPnIW0=";
-  };
-
-  nativeBuildInputs = [
-    # Needed for the NM namespace
-    gobject-introspection
-    wrapGAppsHook4
-  ];
-
-  buildInputs = [
-    libnotify # gir typelib is used
-  ]
-  ++ lib.optionals withIndicator [
-    # Adds AppIndicator3 namespace
-    libappindicator-gtk3
-    # Adds AyatanaAppIndicator3 namespace
-    libayatana-appindicator
-  ];
-
-  build-system = with python3Packages; [
-    setuptools
-  ];
-
-  dependencies = with python3Packages; [
-    dbus-python
-    packaging
-    proton-core
-    proton-keyring-linux
-    proton-vpn-api-core
-    proton-vpn-local-agent
-    pycairo
-    pygobject3
-  ];
-
-  dontWrapGApps = true;
-
-  preFixup = ''
-    makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
-  '';
-
-  postInstall = ''
-    mkdir -p $out/share/{applications,pixmaps}
-
-    # Fix the desktop file to correctly identify the wrapped app and show the icon during runtime
-    substitute ${finalAttrs.src}/rpmbuild/SOURCES/proton.vpn.app.gtk.desktop $out/share/applications/proton.vpn.app.gtk.desktop \
-      --replace-fail "StartupWMClass=protonvpn-app" "StartupWMClass=.protonvpn-app-wrapped"
-    install -Dm 644 ${finalAttrs.src}/rpmbuild/SOURCES/proton-vpn-logo.svg $out/share/pixmaps
-  '';
-
-  preCheck = ''
-    # Needed for Permission denied: '/homeless-shelter'
-    export HOME=$(mktemp -d)
-    export XDG_RUNTIME_DIR=$(mktemp -d)
-  '';
-
-  nativeCheckInputs = with python3Packages; [
-    pytestCheckHook
-    pytest-cov-stub
-  ];
-
-  disabledTestPaths = [
-    # Segmentation fault during widgets tests
-    "tests/unit/widgets"
-  ];
-
+let
   meta = {
-    description = "Proton VPN GTK app for Linux";
-    homepage = "https://github.com/ProtonVPN/proton-vpn-gtk-app";
-    license = lib.licenses.gpl3Plus;
-    platforms = lib.platforms.linux;
-    mainProgram = "protonvpn-app";
+    description = "Official Proton VPN client";
+    homepage = "https://protonvpn.com/";
+    license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [
       anthonyroussel
-      sebtm
+      delafthi
       rapiteanu
+      sebtm
     ];
   };
-})
+in
+if stdenv.hostPlatform.isDarwin then
+  callPackage ./darwin.nix { inherit meta; }
+else
+  callPackage ./linux.nix { inherit meta; }

--- a/pkgs/by-name/pr/proton-vpn/package.nix
+++ b/pkgs/by-name/pr/proton-vpn/package.nix
@@ -11,7 +11,7 @@
 }:
 
 python3Packages.buildPythonApplication (finalAttrs: {
-  pname = "protonvpn-gui";
+  pname = "proton-vpn";
   version = "4.15.0";
   pyproject = true;
 

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1635,6 +1635,7 @@ mapAliases {
   protonup = throw "'protonup' has been renamed to/replaced by 'protonup-ng'"; # Converted to throw 2025-10-27
   protonvpn-cli = throw "protonvpn-cli source code was removed from upstream. Use proton-vpn-cli instead."; # Added 2025-10-16
   protonvpn-cli_2 = throw "protonvpn-cli_2 has been removed due to being deprecated. Use proton-vpn-cli instead."; # Added 2025-10-16
+  protonvpn-gui = warnAlias "'protonvpn-gui' has been renamed to/replaced by 'proton-vpn'" proton-vpn; # Added 2026-02-23
   proxmark3-rrg = throw "'proxmark3-rrg' has been renamed to/replaced by 'proxmark3'"; # Converted to throw 2025-10-27
   pscid = throw "'pscid' has been removed because it was unmaintained upstream"; # Added 2025-12-12
   pulp = throw "'pulp' has been removed because it was unmaintained upstream"; # Added 2025-12-12


### PR DESCRIPTION
This PR packages the binary version of [ProtonVPN for macOS](https://github.com/ProtonVPN/ios-mac-app).

- Renamed `protonvpn-gui` → `proton-vpn` to align naming conventions with other `proton-*` packages
- Separated platform-specific configurations into dedicated files:
  - `linux.nix` for Linux-specific package declaration
  - `darwin.nix` for macOS-specific package declaration
  - `package.nix` as the main orchestrator
- Added `nix-update-script` to the `proton-vpn` Linux package
- Use `writableTmpDirAsHomeHook` in Linux package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
