### PR TITLE
firefox_decrypt: 1.1.1 -> 1.1.3

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -574,6 +574,7 @@ in
     _module.args.firefoxPackage = pkgs.firefox-esr-140;
   };
   firefox-syncserver = runTest ./firefox-syncserver.nix;
+  firefox_decrypt = runTest ./firefox_decrypt.nix;
   firefoxpwa = runTest ./firefoxpwa.nix;
   firejail = runTest ./firejail.nix;
   firewall = runTest {

--- a/nixos/tests/firefox_decrypt.nix
+++ b/nixos/tests/firefox_decrypt.nix
@@ -1,0 +1,73 @@
+{ lib, ... }:
+{
+  name = "firefox_decrypt";
+
+  meta = {
+    maintainers = with lib.maintainers; [ schnusch ];
+  };
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      imports = [ ./common/x11.nix ];
+      programs.firefox.enable = true;
+      environment.systemPackages = [ pkgs.firefox_decrypt ];
+    };
+
+  enableOCR = true;
+
+  testScript = ''
+    import csv
+    import io
+    import random
+    import string
+
+    machine.wait_for_x()
+
+    expected: dict[str, str] = {
+        "url": "http://localhost",
+        "user": "user",
+        "password": "".join(random.choices(string.ascii_letters + string.digits, k=32)),
+    }
+
+    machine.execute("firefox about:logins >&2 &")
+
+    # press "Add password" button
+    # "Search Passwords" is not found by OCR, probably due to too low contrast.
+    machine.wait_for_text("No passwords saved")
+    for c in ("tab", "\n"):
+        machine.send_key(c)
+
+    # add a new password entry
+    machine.wait_for_text("Add password")
+    for text, control in [
+        (expected["url"], "tab"),
+        (expected["user"], "tab"),
+        (expected["password"], "\n"),
+    ]:
+        with machine.nested(f"typing {repr(text)}"):
+            for c in text:
+                machine.send_key(c, log=False)
+        machine.send_key(control)
+
+    # "Remove" button for our new entry appeared
+    machine.wait_for_text("Remove")
+
+    # close Firefox
+    machine.send_key("ctrl-q")
+    machine.wait_for_text(r"Quit Firefox or close current tab\?")
+    machine.send_key("\n")
+
+    # extract Firefox logins
+    credentials = list(
+        csv.DictReader(
+            io.StringIO(
+                machine.succeed("firefox_decrypt -f csv ~/.config/mozilla/firefox"),
+                newline="",
+            ),
+            delimiter=";",
+        )
+    )
+    assert expected in credentials, f"expected {expected!r} in {credentials!r}"
+  '';
+}

--- a/nixos/tests/firefox_decrypt.nix
+++ b/nixos/tests/firefox_decrypt.nix
@@ -62,7 +62,7 @@
     credentials = list(
         csv.DictReader(
             io.StringIO(
-                machine.succeed("firefox_decrypt -f csv ~/.config/mozilla/firefox"),
+                machine.succeed("firefox-decrypt -f csv ~/.config/mozilla/firefox"),
                 newline="",
             ),
             delimiter=";",

--- a/pkgs/by-name/fi/firefox_decrypt/package.nix
+++ b/pkgs/by-name/fi/firefox_decrypt/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   nss,
+  nixosTests,
   nix-update-script,
   stdenv,
   python3Packages,
@@ -32,7 +33,12 @@ python3Packages.buildPythonApplication (finalAttrs: {
     (lib.makeLibraryPath [ nss ])
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    tests = {
+      inherit (nixosTests) firefox_decrypt;
+    };
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     homepage = "https://github.com/unode/firefox_decrypt";

--- a/pkgs/by-name/fi/firefox_decrypt/package.nix
+++ b/pkgs/by-name/fi/firefox_decrypt/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "firefox_decrypt";
-  version = "1.1.2";
+  version = "1.1.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "unode";
     repo = "firefox_decrypt";
     tag = finalAttrs.version;
-    hash = "sha256-ohCQcIn++eFlY9Kzmc5VkYt1pCO97qtmWG5JRyE8Y6I=";
+    hash = "sha256-Y958qXGpkNgMBYiM80OKQYkO7EdqH7T5FfINELAB9CY=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/by-name/fi/firefox_decrypt/package.nix
+++ b/pkgs/by-name/fi/firefox_decrypt/package.nix
@@ -33,6 +33,17 @@ python3Packages.buildPythonApplication (finalAttrs: {
     (lib.makeLibraryPath [ nss ])
   ];
 
+  checkPhase = ''
+    runHook preCheck
+
+    patchShebangs tests
+    (cd tests && ${
+      if stdenv.hostPlatform.isDarwin then "DYLD_LIBRARY_PATH" else "LD_LIBRARY_PATH"
+    }=${lib.makeLibraryPath [ nss ]} ./run_all)
+
+    runHook postCheck
+  '';
+
   passthru = {
     tests = {
       inherit (nixosTests) firefox_decrypt;

--- a/pkgs/by-name/fi/firefox_decrypt/package.nix
+++ b/pkgs/by-name/fi/firefox_decrypt/package.nix
@@ -43,7 +43,7 @@ python3Packages.buildPythonApplication (finalAttrs: {
   meta = {
     homepage = "https://github.com/unode/firefox_decrypt";
     description = "Tool to extract passwords from profiles of Mozilla Firefox and derivates";
-    mainProgram = "firefox_decrypt";
+    mainProgram = "firefox-decrypt";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       schnusch

--- a/pkgs/by-name/fi/firefox_decrypt/package.nix
+++ b/pkgs/by-name/fi/firefox_decrypt/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "firefox_decrypt";
-  version = "1.1.1";
+  version = "1.1.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "unode";
     repo = "firefox_decrypt";
     tag = finalAttrs.version;
-    hash = "sha256-HPjOUWusPXoSwwDvW32Uad4gFERvn79ee/WxeX6h3jY=";
+    hash = "sha256-ohCQcIn++eFlY9Kzmc5VkYt1pCO97qtmWG5JRyE8Y6I=";
   };
 
   build-system = with python3Packages; [

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -6460,6 +6460,8 @@ with pkgs;
     fmt_12
     ;
 
+  firefox_decrypt = callPackage ../by-name/fi/firefox_decrypt/package.nix { nss = nss_latest; };
+
   fmt = fmt_12;
 
   freeipa = callPackage ../os-specific/linux/freeipa {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

supersedes #486232

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test