### PR TITLE
NixOS: ArchiSteamFarm: Copy Bot Configs on Startup

### DIFF
--- a/nixos/modules/services/games/archisteamfarm.nix
+++ b/nixos/modules/services/games/archisteamfarm.nix
@@ -248,48 +248,36 @@ in
           }
         ];
 
-        preStart =
-          let
-            createBotsScript =
-              pkgs.runCommand "ASF-bots"
-                {
-                  preferLocalBuild = true;
-                }
-                ''
-                  mkdir -p $out
-                  # clean potential removed bots
-                  rm -rf $out/*.json
-                  for i in ${
-                    lib.concatStringsSep " " (map (x: "${lib.getName x},${x}") (lib.mapAttrsToList mkBot cfg.bots))
-                  }; do IFS=",";
-                    set -- $i
-                    ln -fs $2 $out/$1
-                  done
-                '';
-            replaceSecretBin = "${pkgs.replace-secret}/bin/replace-secret";
-          in
-          ''
-            mkdir -p config
+        preStart = ''
+          mkdir -p config
 
-            cp --no-preserve=mode ${configFile} config/ASF.json
+          cp --no-preserve=mode '${configFile}' config/ASF.json
 
-            ${lib.optionalString (cfg.ipcPasswordFile != null) ''
-              ${replaceSecretBin} '#ipcPassword#' '${cfg.ipcPasswordFile}' config/ASF.json
-            ''}
+          ${lib.optionalString (cfg.ipcPasswordFile != null) ''
+            ${lib.getExe pkgs.replace-secret} '#ipcPassword#' '${cfg.ipcPasswordFile}' config/ASF.json
+          ''}
 
-            ${lib.optionalString (cfg.ipcSettings != { }) ''
-              ln -fs ${ipc-config} config/IPC.config
-            ''}
+          ${lib.optionalString (cfg.ipcSettings != { }) ''
+            ln -fs ${ipc-config} config/IPC.config
+          ''}
 
-            ${lib.optionalString (cfg.bots != { }) ''
-              ln -fs ${createBotsScript}/* config/
-            ''}
+          for f in config/*.nixbot; do
+            [[ -f "$f" ]] || continue
+            rm "$f"
+            [[ -f "''${f%.nixbot}" ]] || continue
+            rm "''${f%.nixbot}"
+          done
 
-            rm -f www
-            ${lib.optionalString cfg.web-ui.enable ''
-              ln -s ${cfg.web-ui.package}/ www
-            ''}
-          '';
+          ${lib.concatMapStrings (x: ''
+            cp --no-preserve=mode '${x}' 'config/${lib.getName x}'
+            touch 'config/${lib.getName x}.nixbot'
+          '') (lib.mapAttrsToList mkBot cfg.bots)}
+
+          rm -f www
+          ${lib.optionalString cfg.web-ui.enable ''
+            ln -s '${cfg.web-ui.package}/' www
+          ''}
+        '';
       };
     };
   };


### PR DESCRIPTION
I previously noticed that, when you use declarative bots with the ASF service, the program would end up modifying the generated config files in the nix store. My understanding is that the nix store is intended to be read only (the data in it is described as [immutable](https://nix.dev/manual/nix/2.24/store/)), so I assume this is an error. #287674 attempted to address this issue by preventing ASF from performing config migrations, which is the main way these config files are modified by the program. However, in the review comments of that PR, issues with this solution were raised, preventing that solution from being viable. This proposes an alternative solution, which is distinct enough that I figured it was worth making it a separate PR.

In the comments of the other PR, it was pointed out that the main config file, `ASF.json`, was not affected by this issue since it's copied, unlike the bot configs which were symlinked. While this was done exclusively because  the setup script needs to be able to copy in the IPC password, it does indicate a viable solution for the bot configs as well. This PR changes the setup script to copy the bot configs, rather than symlinking them. This resolves the issue, as writes to the config files only affects the copies in the data directory, rather than affecting the symlinked files in the nix store. Unlike the previous PR, this keeps config migrations enabled, allowing users to read any modifications to the file to determine any potential config changes required before upgrading the ASF package. This *does* have the side-effect of causing any changes to the bot configs (eg. manually made in the web ui) will be reset when the service is restarted, rather than only when the config is rebuilt. However, this change means the behavior now matches that of `ASF.json`, so I think it's a warranted change.

With this PR, I also cleaned up the setup script config a little. I noticed there was a `createBotsScript` / ASF-Bots script that seemed to exclusively act as a middle-man between the generated config files and the data directory. From what I can tell, it doesn't seem to do anything meaningful (looking at the PR that introduced it, it seems like the intent was that removed bots would be handled in that script, but any changes to what bots are included changes the derivation of the script, meaning any old symlinks would still point to the old derivation), so I went ahead and just removed it. If there's a good reason to keep it around, let me know, and I'll update the PR.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
