### PR TITLE
[Backport release-25.11] jabref: fix for gradle 9.3.0

### DIFF
--- a/pkgs/by-name/ja/jabref/deps.json
+++ b/pkgs/by-name/ja/jabref/deps.json
@@ -652,13 +652,13 @@
    "jar": "sha256-bNkZkTI917L7KMqT16wSr1qGovUyeeKzWCezAxP9C58=",
    "pom": "sha256-rECp8tDB7mMfw7CO+OLwvRS6IgEcp2/xvPZftWnq3zU="
   },
-  "org/gradle/kotlin#gradle-kotlin-dsl-plugins/6.4.1": {
-   "jar": "sha256-JolZk48cG8O1VeIihdIEVdoPOrCAaEuSfBvK5VTZFNM=",
-   "module": "sha256-QfjCNSMXc2dWDubRXMC9a8GqRP6x2BjXihzt2+IMC40=",
-   "pom": "sha256-G9F/hR9bve0OCz16YZzBdxKrmEXqpFu8ypBxX86jEF8="
+  "org/gradle/kotlin#gradle-kotlin-dsl-plugins/6.4.2": {
+   "jar": "sha256-MwhkX0Z7Jm5YhMJkUIIktnKejtwWbm1DX1tibBTg/Rk=",
+   "module": "sha256-kxqze7wDwJHt/8RtlqYLXk+isLTV2UWLkscm4FpR0NM=",
+   "pom": "sha256-VGkK7nfKVycLvqXnhrnTPiOvYIzuIVuIDvcq45v5aU8="
   },
-  "org/gradle/kotlin/kotlin-dsl#org.gradle.kotlin.kotlin-dsl.gradle.plugin/6.4.1": {
-   "pom": "sha256-9FhdUWKX7VtEyA0nq82/XKA0aCx1B4E+8UAHLhDYts4="
+  "org/gradle/kotlin/kotlin-dsl#org.gradle.kotlin.kotlin-dsl.gradle.plugin/6.4.2": {
+   "pom": "sha256-Xi2xvrvUHGTWc1VEsphssmofxmiX0ZCXnJC1C4fIXfo="
   },
   "org/gradle/toolchains#foojay-resolver/1.0.0": {
    "jar": "sha256-eLhqR9/fdpfJvRXaeJg/2A2nJH1uAvwQa98H4DiLYKg=",
@@ -762,146 +762,146 @@
    "jar": "sha256-rOKhDcji1f00kl7KwD5JiLLA+FFlDJS4zvSbob0RFHg=",
    "pom": "sha256-llrrK+3/NpgZvd4b96CzuJuCR91pyIuGN112Fju4w5c="
   },
-  "org/jetbrains/kotlin#abi-tools-api/2.2.20": {
-   "jar": "sha256-8chm6sXcCI8/0IEQCENAm/TxYSu7mY+6ofaFMlyuDVU=",
-   "pom": "sha256-HOL7NczYP8vJCuXFmN/bsilS0IVHgElEpbIfLEbKwL0="
+  "org/jetbrains/kotlin#abi-tools-api/2.2.21": {
+   "jar": "sha256-I5kB8xfBibS0zIvF6WaUPcGeOSWVOeZouqXX7xjrkWo=",
+   "pom": "sha256-kkkKzKD0UFgdVs4FeWHY/6mDVYfmn2bpbQpxdbrOzYU="
   },
-  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.2.20": {
-   "module": "sha256-n+aVWzf+KQtlFiXPnGgea6IKjxLEZYzOUCblk1BaMSk=",
-   "pom": "sha256-P6gmRiy9hG0YAgLyLFGTQYy5zan2lcmUEjWpsbXBQdk="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.2.21": {
+   "module": "sha256-SVZZs54wVUHstxLmm2IuE+OK2SQPmoJ8oFhDS9mfIR0=",
+   "pom": "sha256-JQzsmn5XTCwRF+7PBCHjIAHqDzSwqQHH+k6tb+jd7aQ="
   },
-  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.2.20/gradle813": {
-   "jar": "sha256-OmlZW2x1+/ktMgFodFxpj/cRS4YHhBBQ1ISYgjAG6HE="
+  "org/jetbrains/kotlin#fus-statistics-gradle-plugin/2.2.21/gradle813": {
+   "jar": "sha256-J9z0rqpbu2TYYb0p7WDUgvD/2WJEyB4kJrnaxef9xj8="
   },
-  "org/jetbrains/kotlin#kotlin-assignment-compiler-plugin-embeddable/2.2.20": {
-   "jar": "sha256-07TapcbMI1Zfj7k2NI84xCGgRhFjdF02rt9E096UJQo=",
-   "pom": "sha256-L/XBHfd+t6JZdmzdqed47WW6SFxYxhO7ppAoauzi3H0="
+  "org/jetbrains/kotlin#kotlin-assignment-compiler-plugin-embeddable/2.2.21": {
+   "jar": "sha256-JmFrjhshTWLwLRUzHK/3JcToI3ziCtFPXMznJKop588=",
+   "pom": "sha256-Bhpvb0xNvpCtDeOeUeeKuvtmf+jJsJXODA3qM1aPQh8="
   },
-  "org/jetbrains/kotlin#kotlin-assignment/2.2.20": {
-   "module": "sha256-xbfmG95gHQM75qCyXhkxfc9u434wVC/XRsRr/3gBj1o=",
-   "pom": "sha256-fh3mglHYFXQXuKIXn2YlW8m5zzFTPdkDukFVZlwwXGs="
+  "org/jetbrains/kotlin#kotlin-assignment/2.2.21": {
+   "module": "sha256-GNfXYm3tHJiZC9JhNVjUmrJfY7eGx360iKmdirZaxhM=",
+   "pom": "sha256-rzH4fPfA2i55da7DPjYB0T/HeWaE0VVTaX3uJJtt7tQ="
   },
-  "org/jetbrains/kotlin#kotlin-assignment/2.2.20/gradle813": {
-   "jar": "sha256-MYCcvl5312WyQRFT6huuR2cQQGoXfjmhC/ZKYSOgRfI="
+  "org/jetbrains/kotlin#kotlin-assignment/2.2.21/gradle813": {
+   "jar": "sha256-hxwwVHmuFrFE1AwgTr3/AZEwBejpjasXs2XFRaJZ9R0="
   },
   "org/jetbrains/kotlin#kotlin-bom/2.0.21": {
    "pom": "sha256-1Ufg3iVCLZY+IsepRPO13pQ8akmClbUtv/49KJXNm+g="
   },
-  "org/jetbrains/kotlin#kotlin-build-statistics/2.2.20": {
-   "jar": "sha256-+2VKT1vFY2h1kXMSnfSRB60J3FtBcrAXda+z+nJXndU=",
-   "pom": "sha256-tdU2T1fSH/FBgiBei2lf1oZNnYqleApu3EIJWEBHwRU="
+  "org/jetbrains/kotlin#kotlin-build-statistics/2.2.21": {
+   "jar": "sha256-jf37K49n/NzEzuPvkKJa9GfKKVhTsOoBnQAQrOvW8Yo=",
+   "pom": "sha256-yL9i9tym159DbECxrwnbQvRuv0vNcrMHnfjHJbXAY1g="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-api/2.2.20": {
-   "jar": "sha256-/ZlHs6F2Iahvq9lTr4fzS9K7f4sm2uksHte+dHL0TDs=",
-   "pom": "sha256-AtR9SHfsMktJbZMTMkXNTTSLZSMDzyfvpj44ry+zzyo="
+  "org/jetbrains/kotlin#kotlin-build-tools-api/2.2.21": {
+   "jar": "sha256-MWRcpSI5siHr0GCgD/+NhRb/3Ii72fTkzX3bQacGjHA=",
+   "pom": "sha256-Y/3PHe0qtFrXfASZefqkTxkPe7jurE+B+Yd+nfqf2fk="
   },
-  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.2.20": {
-   "jar": "sha256-ZHiafwBWWSfy8/LRCfIwV009kwjtXW6Gv8qEPaZIfPc=",
-   "pom": "sha256-4vQ157rwHeL/kNCoc3r4+b+X/BUuWVuGp2C6ZOjmnfY="
+  "org/jetbrains/kotlin#kotlin-build-tools-impl/2.2.21": {
+   "jar": "sha256-RYtj74/FCgoxgP5ojsG5lXRZkqBcSV2sYeWNEIiSeoA=",
+   "pom": "sha256-Ln/cogFlzxDnO2L4NfZ+7PQnyCPtYPGdXwButnQ0Wv4="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.2.20": {
-   "jar": "sha256-HGw/gQv+akGry8NLOi72OfHj9K7tOpU6Swl07qT0GIk=",
-   "pom": "sha256-Bf8CX3+wky+xH6HhzK71KPdgJ9lWaA+INdQ4VCdi4go="
+  "org/jetbrains/kotlin#kotlin-compiler-embeddable/2.2.21": {
+   "jar": "sha256-lYj6aWrFUHr3ZP1WYN9olBheEnBOwbw/XLdyr0mH8pU=",
+   "pom": "sha256-CzPGTyYiujvIKDN4vbdQXyvjMKInWAcDitVDWbM935s="
   },
-  "org/jetbrains/kotlin#kotlin-compiler-runner/2.2.20": {
-   "jar": "sha256-+vloNPogBNeL2ORCD1go3j1CckJ9ZHR5gCTqbpz4XN0=",
-   "pom": "sha256-kbsVJI9OqUS2Mw8xA/HrVF0TvditSuxDe3R6WG57F6k="
+  "org/jetbrains/kotlin#kotlin-compiler-runner/2.2.21": {
+   "jar": "sha256-o6Qi4GvNNaMqeY0ZHvbrs16ms5w1U+lB05wB5jH8XHc=",
+   "pom": "sha256-HxA9i94I3dYUvZg6vfy3lJE5xgasYM2KaJQf0Pse4SQ="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-client/2.2.20": {
-   "jar": "sha256-cO983NwwEHe5s7ohqp6cVadq+z/73+9KtWKmd9GN+kw=",
-   "pom": "sha256-ihNtDxPrmDpr40/x4WPJznmFXkuiF09Fy0KqpnVT91Q="
+  "org/jetbrains/kotlin#kotlin-daemon-client/2.2.21": {
+   "jar": "sha256-POLKPF17x8h8QUmsLFk9IaeR1ndiKa4SPbZFowF96BQ=",
+   "pom": "sha256-T2/dvBDZshZ4meNPoRP8mtdcxNbOWKuE+WFLY8BfjaM="
   },
-  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.2.20": {
-   "jar": "sha256-fFyM0vi+rdMoMjm7nKIZoMr6GvAmgrQHsYHhF5cY8vc=",
-   "pom": "sha256-9Yhmv7yYZ8bWR1ec/3DUKHeZctvd2N5MJXh5y0N0FIk="
+  "org/jetbrains/kotlin#kotlin-daemon-embeddable/2.2.21": {
+   "jar": "sha256-kcBnPCLkSwVK4DFNMjhg6+Hzr/Pw68dP/4LEcz3eCb4=",
+   "pom": "sha256-Fwvb7LpX/wCiuNF+8seeCLhfZ99p2FO6CiWaQYO/uSM="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.2.20": {
-   "jar": "sha256-T8MqG+ZFynQE4hskRSCI+T6OmT6v/Sbza9Ndv3XGB1I=",
-   "pom": "sha256-sbbgEXktfKkv7K+/+sSlCPdvA5yfeuijI9GJKIgl9P4="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-annotations/2.2.21": {
+   "jar": "sha256-NZTEDHAF0ESVL4D3BBcrtv0YRCQQJRlPsWvubUXaLls=",
+   "pom": "sha256-VErpKrN3QI/B7TBOxBou7EKT4PLhObPS9v0nIF8UY38="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.20": {
-   "jar": "sha256-dgfuXHoMpT+lku58VA7oCJYqe62P7p7Xj+Z0hBRj2V0=",
-   "module": "sha256-T8vx/H5Uzr/pC5peD7RpYv7Vwi03I52iNfXi37xtUog=",
-   "pom": "sha256-C5E9oNIYhCAmOpBLtApkD9s1pTWnLwWC/llkHjoMSi4="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.21": {
+   "jar": "sha256-t7/Qf18eCkSvYS60hHTfYyjuD286anNkLORz8wZF4aU=",
+   "module": "sha256-HnS0hvlEq54Rb5pKriDFL8L5rFI6VS25fdZYFID+lAs=",
+   "pom": "sha256-m9RXg5guF17un6rUX1/3QVyWrrau8ufPjjUIr7Y51hc="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.20/gradle813": {
-   "jar": "sha256-dgfuXHoMpT+lku58VA7oCJYqe62P7p7Xj+Z0hBRj2V0="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-api/2.2.21/gradle813": {
+   "jar": "sha256-t7/Qf18eCkSvYS60hHTfYyjuD286anNkLORz8wZF4aU="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.2.20": {
-   "jar": "sha256-dtFu5ZzeHmpwVWtdQEhu+fEcFkOodJPBnE3zMWU4N9k=",
-   "pom": "sha256-xRuhScfyk1nSWk7RIS4otpNOGkdW9VLAAHvxFE0onB0="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea-proto/2.2.21": {
+   "jar": "sha256-S0vndO+5WFrw/aGA0zkD2CcuSX33uBuwkfqTOezaRb0=",
+   "pom": "sha256-uhvOJI5HRY7tRmheuiEreT/7fTfkKd/2cKIT3dEC0MA="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.2.20": {
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-idea/2.2.21": {
    "jar": "sha256-7JacXwsJn4I4RiMiOPm9ZPPTdB5i6pBQrS5DL6150KA=",
-   "module": "sha256-/IW7KUlsw/X5DHjHonejkw7xFg8IQ/iu1ke3TGejtJQ=",
-   "pom": "sha256-NkQjJURfF7rCH1OGu0k4+D53K4NOWGBT1BRbGnXZ4oU="
+   "module": "sha256-kVGuIjeH8cILcLJKEXeJtNFNDMSE5GJzLLIwp5f3W88=",
+   "pom": "sha256-KKWiq7pbWCk+JKngbmqskmJr4YLGXfyLLbaUlE5wraU="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin-model/2.2.20": {
-   "jar": "sha256-U6MhUoJjIGAYUgSaC291OMqLtX/QnYeszRGLxo1D+OQ=",
-   "module": "sha256-EZdKVPSOCCXpdxML9u9qyZp/216yr53iZa9iTHY2g+U=",
-   "pom": "sha256-3uDjB7pub1GQPH5DPehSZ10eMOfyLPJGWxglVSZR7fs="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin-model/2.2.21": {
+   "jar": "sha256-kI5uXIkLtJ28kmbczyi9sMJYxIZHA5rtcC/p1YZkAYY=",
+   "module": "sha256-/kRucdWLn1verY7wW2i0mGFzF+G5LUe5qztnTWTydmQ=",
+   "pom": "sha256-IIRTo2pr5JsHGhwQ6bRAQQZjbJO65b8wxtrFdMQM9bE="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.2.20": {
-   "module": "sha256-3CS/pH4EQigykOIfBpoFYUHR8IjWy57Kouqs4bR7a4w=",
-   "pom": "sha256-ucP9Lr1UhNYMX+DbeqEIeDA+7d/JP5Qvc1wHupmBh8w="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.2.21": {
+   "module": "sha256-TiOAKj1TACSsRlrNJkh9ajpwLugEzWEzScUQjeq/S6I=",
+   "pom": "sha256-5bWdPJpGu38Pe0nPyI1pjaVBpL0JClwX2aAKtHIQc4w="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.2.20/gradle813": {
-   "jar": "sha256-XTJbXCxdS8i/RBRdJOtNS+sGDRPRHr5IiYk27VzRVk4="
+  "org/jetbrains/kotlin#kotlin-gradle-plugin/2.2.21/gradle813": {
+   "jar": "sha256-t6UoZcal4WDSz2Hk1CPORKaiDeCmsj0DQEttAaKBFzc="
   },
-  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.2.20": {
-   "module": "sha256-P7tFda43xKd2rrhtj/k8aqEbDPLadXScUyDiWFCwIp4=",
-   "pom": "sha256-PG1GnpFfuzCWrEy4wvRsedAnw8WQ5lihBoihVx61eNg="
+  "org/jetbrains/kotlin#kotlin-gradle-plugins-bom/2.2.21": {
+   "module": "sha256-3E/A81pVMqU6Qy7k/iJDEyVIVV8nX2PuaZDVAzP4zio=",
+   "pom": "sha256-JfRGZjOd7uAQanbqXvzPqzSvz9uWCnZy+4h/cboNqL0="
   },
-  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.2.20": {
-   "jar": "sha256-OYK+RbEpMOIYGbWJ2zcHyOhM4le/Ks5/xi/I3zaPWz4=",
-   "pom": "sha256-CzAJtJQmv6F3qtlLSBCbjKVMck6i5sUGgmo6lc9ZEOE="
+  "org/jetbrains/kotlin#kotlin-klib-commonizer-api/2.2.21": {
+   "jar": "sha256-WLxFHOYu1r79B3rBB+pfEzRD503XjPOkpI+GjmGDfos=",
+   "pom": "sha256-yJkqd6ltK5+NgTdMQL1x0y4h2f8c23mdFdSXGLEqEuE="
   },
   "org/jetbrains/kotlin#kotlin-metadata-jvm/2.2.20": {
    "jar": "sha256-hSTqyQ9+jg8TZog/LGyCDJO/ph3z12hXyNPoA89nMV0=",
    "pom": "sha256-e2qAtqLSZ2oEIvaWg4EyMVQlUfYbMgxochz7nh9ZCdA="
   },
-  "org/jetbrains/kotlin#kotlin-native-utils/2.2.20": {
-   "jar": "sha256-UBd3SirqQf+HEhNxFs1NgAP+mroSAMEG5lcw/rW7dEI=",
-   "pom": "sha256-U+++4FpxIhiQYPXuXspodjnOr+KfXlmW3phiopxnJyU="
+  "org/jetbrains/kotlin#kotlin-native-utils/2.2.21": {
+   "jar": "sha256-50sUQG2uCgI4gYfGLBcxGDun0NjmBnVoLeURqQr6bFY=",
+   "pom": "sha256-1SJqfIYGn6mnIavJeuTaFaQO0WicirVQXhoa0tsg3F8="
   },
   "org/jetbrains/kotlin#kotlin-reflect/1.6.10": {
    "jar": "sha256-MnesECrheq0QpVq+x1/1aWyNEJeQOWQ0tJbnUIeFQgM=",
    "pom": "sha256-V5BVJCdKAK4CiqzMJyg/a8WSWpNKBGwcxdBsjuTW1ak="
   },
-  "org/jetbrains/kotlin#kotlin-reflect/2.2.20": {
-   "jar": "sha256-ggkIOkp8TkdtmEKweDCPqWqW8Hpr2Z8F81hu4TKJqyY=",
-   "pom": "sha256-TidHQGbbg/uixZB0KJunEr6MhRV83guQUCmkRcJ19bo="
+  "org/jetbrains/kotlin#kotlin-reflect/2.2.21": {
+   "jar": "sha256-RDgKvzfSRc5cDylPQ1EtHDmllkK/pGOSLHTpaHfPSfg=",
+   "pom": "sha256-5atrEFYKWlJWLDXNvnHdvkJ9Uetb/HAdzU9rlJvZ4D8="
   },
-  "org/jetbrains/kotlin#kotlin-sam-with-receiver-compiler-plugin-embeddable/2.2.20": {
-   "jar": "sha256-WRNzsEtDtom0HgvIYqlslEx+DDHSMIH0aooe48a6Edc=",
-   "pom": "sha256-iSompWD3bch9NVEw9Akk2ZtL1gB212R0Ff6YkYjSLA4="
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver-compiler-plugin-embeddable/2.2.21": {
+   "jar": "sha256-yweF5qeHDS9eqW9kcCDigS3snXAjAzMZu9sc5+XmVUg=",
+   "pom": "sha256-CcOMhkgRKRfUMPoji0Nxz4DbE86Dgu6KK6g0EPmd0yY="
   },
-  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.2.20": {
-   "module": "sha256-c7Eee8xPZZeWcN8Vx1aADHOiHaH9EJL56sWfON+cVjE=",
-   "pom": "sha256-LhNnvGXeGLQPpn2H9+JGXj4dYUviuLCdOQZRZ8JwK+M="
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.2.21": {
+   "module": "sha256-2iXbk8+OvwbGM1L4PnIK14e8cD/Q54DxGRjQii7JgE4=",
+   "pom": "sha256-IU7uupPxsDquZnoJfbq/6z2XRel5zU0LJGLzj+vHd2Q="
   },
-  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.2.20/gradle813": {
-   "jar": "sha256-YZ6b4NCK9+W0TRIkJQ0jXiLvimiKzISPO4kC+mZAQws="
+  "org/jetbrains/kotlin#kotlin-sam-with-receiver/2.2.21/gradle813": {
+   "jar": "sha256-tHyUm4u4DOaAcj+Lw8hw8ifDZHel6wLCtz1hEY1GMKY="
   },
-  "org/jetbrains/kotlin#kotlin-script-runtime/2.2.20": {
-   "jar": "sha256-XIvV3Xrh6i7rJ3j9vqoZpWIYSXX2yrigu2d55BkHMa4=",
-   "pom": "sha256-IpOhQenagKfpjYXtKkkuldsMAWW86rC3Klzp4tkrCAc="
+  "org/jetbrains/kotlin#kotlin-script-runtime/2.2.21": {
+   "jar": "sha256-KxUZtCe1FNFTbBtCVnSwP+kUr2N5JAKOmVnGYlRC31E=",
+   "pom": "sha256-h2elQPxdviC34Sg6lfUQKX5sDJiy6sLtxNBhKi0PLq8="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-common/2.2.20": {
-   "jar": "sha256-+5n/fwzZUtpo1UjT89ZErlB4sLlvybrwZewUZqKTuAU=",
-   "pom": "sha256-iTjGIFKXW7uW3OotqaeNS2sk2vLwnTWMGnqEHxaMtzo="
+  "org/jetbrains/kotlin#kotlin-scripting-common/2.2.21": {
+   "jar": "sha256-QU7ZHD9eRJKyPLlTeEK0ZRA44l2thBB5OfQ0wiA/KpI=",
+   "pom": "sha256-7CWpeZRRdbrSFlRqSEsLj0SoZwVZGV4kCzR/H9oXcN8="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.2.20": {
-   "jar": "sha256-2GJhDAAzQuUIjKIcRAQix9ijcA4ZnWA/ehAnjESIR2E=",
-   "pom": "sha256-PW9vFZH6P3r14jFlxowu4BclFYZFQ09eMBdF5kfHVhE="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-embeddable/2.2.21": {
+   "jar": "sha256-2TS50MJGvAliS3Bor1itV87xHb4q3bx7GdJQzOQt4ck=",
+   "pom": "sha256-EUhmLJXzbgCYEXj7LYldBrLs59BX7YRTLdNTu9bDVlA="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.2.20": {
-   "jar": "sha256-e3kSNZL//r81xhag/xBDMscc3mN6ZX4JrbXfbD+cA84=",
-   "pom": "sha256-+l+wJ+4qSbPb/zh3VBtC+3CuzMN7oC4dOthipcZyVLc="
+  "org/jetbrains/kotlin#kotlin-scripting-compiler-impl-embeddable/2.2.21": {
+   "jar": "sha256-eIowYMjnmX+K4WulwCgNBQBa8KQgKfGMsQxWJbl5+sM=",
+   "pom": "sha256-DKT5XDLUrpVOF06kHlutYseNvJOmTEUHb96czISrNgk="
   },
-  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.2.20": {
-   "jar": "sha256-qR+5BJY0oyum09LpGgy5mD4KpOccDC4bKDg4qOBhYx8=",
-   "pom": "sha256-0df8RWSBne6v6OvdcfbyGBf/xVjr0U9HpW6NyTaW3Rk="
+  "org/jetbrains/kotlin#kotlin-scripting-jvm/2.2.21": {
+   "jar": "sha256-g4IMX8xdKPBF+RTs1ZALu8+BFbDXAHM03gaf5scGaeY=",
+   "pom": "sha256-nR1Dsi27irmp3yJ6bVRYNB2v/sFQ73WV12XMXsvxeQg="
   },
   "org/jetbrains/kotlin#kotlin-stdlib-jdk7/1.8.21": {
    "jar": "sha256-M9FI2w4R3r0NkGd9KCQrztkH+cd3MAAP1ZeGcIkDnYY=",
@@ -919,26 +919,26 @@
    "jar": "sha256-FcjArLMRSDwGjRaXUBllR0tw39gKx5WA7KOgPPUeSh0=",
    "pom": "sha256-MQ1tXGVBPjEQuUAr2AdfyuP0vlGdH9kHMTahj+cnvFc="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib/2.2.20": {
-   "jar": "sha256-iDbM/9NYX63amQEkSyDUKQHS881YEFjYQ04v+rzzo+c=",
-   "module": "sha256-yRj1IU0CGnLjdn8nVul9EDpSbgTxQj2jZj79+1hH25U=",
-   "pom": "sha256-SosIbmQxvPYjY39Ssv8ZLhrbkTg4dC5cDupwqN7kKcQ="
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.21": {
+   "jar": "sha256-ZVij0jPaVqIJNLMhWfnbX4btWBbvCY94osIj3Gq7ed0=",
+   "module": "sha256-v7xlfd06jjfkyK1BeWjV6wsLFxyfzkj5YsKtMu5DTCE=",
+   "pom": "sha256-zzH5IxlsY67ezQpXwkJpvTcCpOR8C/C9ZLWtpd5SInI="
   },
-  "org/jetbrains/kotlin#kotlin-tooling-core/2.2.20": {
+  "org/jetbrains/kotlin#kotlin-tooling-core/2.2.21": {
    "jar": "sha256-dAFOxPPveM59p+Pmlk8sUmoxIdXFj++MopeeXzRFgvQ=",
-   "pom": "sha256-jvep2QYs59w/xlVxXdAoqZRLeElhPgEYR8XWs7mSgXE="
+   "pom": "sha256-3TPmGTLBut893oXyBPY0yABL6WQnw6HKiGbMAR1xHfo="
   },
-  "org/jetbrains/kotlin#kotlin-util-io/2.2.20": {
-   "jar": "sha256-1DGva+puLcmInE/iawc84VfxEchgj+laGL/gi4F8/3Q=",
-   "pom": "sha256-xqXQGEjNBAz8j3uuYjLXktcFwpOi2nJmrmJszbNdagM="
+  "org/jetbrains/kotlin#kotlin-util-io/2.2.21": {
+   "jar": "sha256-JmqkAmoQb1n878PxUXaIcK+RzvFeQBH6wKofH1Z9SfQ=",
+   "pom": "sha256-67UM9Bx0RJdvAsL5FbQXMlcsXzmUplgciOZN4LmY970="
   },
-  "org/jetbrains/kotlin#kotlin-util-klib-metadata/2.2.20": {
-   "jar": "sha256-vuSQHKU6WiHA22RZAdKwcK/2gkAkF91XiODjWTZFcTs=",
-   "pom": "sha256-vtAGUSIGX65328DEb/xBRqaFy7GLijApq9XaO/qhECc="
+  "org/jetbrains/kotlin#kotlin-util-klib-metadata/2.2.21": {
+   "jar": "sha256-AiuVo9/tlJ18LkeCC82YNu4Fe3IVE/dzNh5DM/bHb4w=",
+   "pom": "sha256-87Mj0f6eM9x+nF7XfzBSg//WN4FdiMUHlFQRvXqiow8="
   },
-  "org/jetbrains/kotlin#kotlin-util-klib/2.2.20": {
-   "jar": "sha256-7XyAlrK75HetF8MXjeuoyDr1MourNr/iEJEL1bQZI0w=",
-   "pom": "sha256-2mwiR3qvQt2hbYWa2unj7Yq8khzLp/9RYTTMi9NZqpI="
+  "org/jetbrains/kotlin#kotlin-util-klib/2.2.21": {
+   "jar": "sha256-VUAKkX5rmEphl+rni1tS7b3yzW4KfDhD95VEgbr7JD8=",
+   "pom": "sha256-o1Lf02Uns67w98DsZJDeydX8m+xPM02ETK6U+BdD3zA="
   },
   "org/jetbrains/kotlinx#kotlinx-coroutines-bom/1.8.0": {
    "pom": "sha256-Ejnp2+E5fNWXE0KVayURvDrOe2QYQuQ3KgiNz6i5rVU="
@@ -1203,10 +1203,18 @@
   "com/fasterxml/jackson#jackson-parent/2.20": {
    "pom": "sha256-tDt/XGLoaxZPrnCuF9aRHF22B5mvAQVzYK/aguSEW+U="
   },
+  "com/fasterxml/jackson/core#jackson-annotations/2.17.2": {
+   "module": "sha256-KMxD6Y54gYA+HoKFIeOKt67S+XejbCVR3ReQ9DDz688=",
+   "pom": "sha256-Q3gYTWCK3Nu7BKd4vGRmhj8HpFUqcgREZckQQD+ewLs="
+  },
   "com/fasterxml/jackson/core#jackson-annotations/2.20": {
    "jar": "sha256-lZov+y1ZFDb1Hxg8alIfyJNHkS9xG/DK4AjN8EXZUxk=",
    "module": "sha256-wHDxTsg1jQlcAurootZcsAzLoOXFqnOwASlDM/5GiXE=",
    "pom": "sha256-TXQMRHjdCNCJ7NxtBjIopVoRp+jkl9pDOPhy+BFXlKQ="
+  },
+  "com/fasterxml/jackson/core#jackson-core/2.17.2": {
+   "module": "sha256-OCgvt1xzPSOV3TTcC1nsy7Q6p8wxohomFrqqivy38jY=",
+   "pom": "sha256-F4IeGYjoMnB6tHGvGjBvSl7lATTyLY0nF7WNqFnrNbs="
   },
   "com/fasterxml/jackson/core#jackson-core/2.19.2": {
    "jar": "sha256-qnfq8pKTqGjEc3IZT3xSh9d9k3CwTqJdP//B5JBLWIA=",
@@ -1896,9 +1904,6 @@
   },
   "net/java/dev/jna#jna/5.13.0": {
    "pom": "sha256-9RXCV4F49FJH7Mp6nh2xCVMbHELyQk4lPO6w9rjUI3Q="
-  },
-  "net/java/dev/jna#jna/5.17.0": {
-   "pom": "sha256-UBoP8F2EpK0Q9t4lvpT0k5i3CjG+jzoO2fTGtE++/uQ="
   },
   "net/java/dev/jna#jna/5.18.1": {
    "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",

--- a/pkgs/by-name/ja/jabref/deps.json
+++ b/pkgs/by-name/ja/jabref/deps.json
@@ -6,29 +6,9 @@
    "jar": "sha256-lCG/tJqgorl3a7E7I0tU2uJ54twh5GW26r/l4SgUzwQ=",
    "pom": "sha256-wy8tTwK/IzXbLQH9Gwz/teUyhGO0lDZmvqwaH/ijpRs="
   },
-  "koppor#wiremock-slf4j-shim/main-4c871b2e09-1/SNAPSHOT": {
-   "jar": "sha256-hYimLyaTZemhJDtmEe7bXPgd6NyKqTlEmUNmppuGRMQ=",
-   "module": "sha256-0hRsMRKmvd7NpykFlfy09yR+mB1dRC1BJ9ZXJMHT3mg=",
-   "pom": "sha256-8zEeXekVsvcVpndak1CfKytwdn66tWZ1P/LMn7AghiM="
-  },
-  "koppor#wiremock-slf4j-spi-shim/main-baf2359720-1/SNAPSHOT": {
-   "jar": "sha256-pMFZcWqiV+eoEWvos2DcosgjcISVkIRJd/frIot7wtY=",
-   "module": "sha256-X/cJ7GFDbk5yxaoKRBL+2WNQaou3AtGjdJ3guAZ5e+I=",
-   "pom": "sha256-eN40hwyeJ7TzUBS5QkTROKe8dU47/PKV5MWGKFgV2pM="
-  },
   "koppor/jbang-gradle-plugin#build/8a85836163": {
    "jar": "sha256-EV18C7JMsORCV1SsIU0OAN0RGXwNSxVqHvUUagoFibM=",
    "pom": "sha256-/UAMODCKxj6CvtciTIXCQDvzZlYH4L3iPe+aI2csWMg="
-  },
-  "koppor/wiremock-slf4j-shim/main-SNAPSHOT/maven-metadata": {
-   "xml": {
-    "groupId": "com.github.koppor"
-   }
-  },
-  "koppor/wiremock-slf4j-spi-shim/main-SNAPSHOT/maven-metadata": {
-   "xml": {
-    "groupId": "com.github.koppor"
-   }
   },
   "sialcasa/mvvmFX#mvvmfx-parent/f195849ca9": {
    "pom": "sha256-5nTE66pGjgRswUpwK3guGpZb5iI4/2kmYy+wtGIsSz0="
@@ -36,27 +16,6 @@
   "sialcasa/mvvmFX#mvvmfx-validation/f195849ca9": {
    "jar": "sha256-Q3dcLohYshPQP3jWb0/Wh6IENg4CGn9Tl8tVvRHVhO0=",
    "pom": "sha256-MplYnkdrZQ8ptd0PuUqUcWe6SwKaoM4VdOOV1KMAPvs="
-  }
- },
- "https://maven-central.storage-download.googleapis.com": {
-  "repos/central/data/com/google/code/gson/gson/maven-metadata": {
-   "xml": {
-    "groupId": "com.google.code.gson",
-    "lastUpdated": "20191004190047",
-    "release": "2.8.6"
-   }
-  }
- },
- "https://oss.sonatype.org/content/groups/public/com/google/code": {
-  "gson#gson/2.13.1": {
-   "pom": "sha256-wPZXItdcDljNGDWzBGBG9ga12mmZBBYfjba3j+ubQBo="
-  },
-  "gson/gson/maven-metadata": {
-   "xml": {
-    "groupId": "com.google.code.gson",
-    "lastUpdated": "20250424011321",
-    "release": "2.13.1"
-   }
   }
  },
  "https://plugins.gradle.org/m2": {
@@ -79,10 +38,10 @@
    "module": "sha256-49Y3GBZP75e4crP94UvWCedF5nN3CRI5B2dD71Umino=",
    "pom": "sha256-/+1G4g7Y+U21B6Am4PcD3GYEiA9bDhwmq7flVq7mFSM="
   },
-  "com/autonomousapps#dependency-analysis-gradle-plugin/3.3.0": {
-   "jar": "sha256-czStTpOfjq99QgOYUgcKiCi80Vz5qTSvCRpIrosUb4g=",
-   "module": "sha256-a7FFF9qhCdcqgO9yeOE5+KaIBs6Ee6Ors7HfJ+pdoo4=",
-   "pom": "sha256-YKDf6jxhBxClvOTaQ/0llWWjwHSWdZBUfveZ36jOU+w="
+  "com/autonomousapps#dependency-analysis-gradle-plugin/3.5.1": {
+   "jar": "sha256-jlXMuCOCKMkeeSCCYjmrjsI38llXokViln2oeyQetFo=",
+   "module": "sha256-fQoho8g9jqe9+07AT77Dm4fZvEQgkY0oLcgfXvBU85k=",
+   "pom": "sha256-FTlnlpXM5EdIs9U1FumQktMkui9Zs/cFmWYzEBZ5oC8="
   },
   "com/autonomousapps#graph-support/0.9.0": {
    "jar": "sha256-1ec9azC/6AT3g1FWOusgRFBPGYTe+0lAE6d8kbxGkwA=",
@@ -106,9 +65,6 @@
   "com/fasterxml#oss-parent/55": {
    "pom": "sha256-D14Y8rNev22Dn3/VSZcog/aWwhD5rjIwr9LCC6iGwE0="
   },
-  "com/fasterxml#oss-parent/58": {
-   "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
-  },
   "com/fasterxml#oss-parent/61": {
    "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
   },
@@ -118,26 +74,20 @@
   "com/fasterxml#oss-parent/70": {
    "pom": "sha256-JsqO1vgsnS7XzTIpgQW7ZcD52JnbYXV6CXQVhvqTpjk="
   },
-  "com/fasterxml/jackson#jackson-base/2.17.1": {
-   "pom": "sha256-4K78YdOPzd2VX/7sAbt1EE8bv/+jpuy1jb50r7cV4yI="
+  "com/fasterxml#oss-parent/73": {
+   "pom": "sha256-SG2NomL0LJwA8+fP/xRxRzNHz8ae3X8GT8lxlN4p1m4="
   },
   "com/fasterxml/jackson#jackson-base/2.18.3": {
    "pom": "sha256-1bv9PIRFIw5Ji2CS3oCa/WXPUE0BOTLat7Pf1unzpP0="
   },
-  "com/fasterxml/jackson#jackson-base/2.20.0": {
-   "pom": "sha256-/IgCjRnuqjftpZbmuY03SfIs/IrdGeoZdFq+g2iDzmY="
-  },
-  "com/fasterxml/jackson#jackson-bom/2.17.1": {
-   "pom": "sha256-n0RhIo4SkQPu16MC3BABqy5Mgt086pFcKn27jMYe/SU="
+  "com/fasterxml/jackson#jackson-base/2.20.1": {
+   "pom": "sha256-C3SKsMx/KH21tgGMYUz+Z+fh9NgJQc4vQdMXzMO1tcU="
   },
   "com/fasterxml/jackson#jackson-bom/2.18.3": {
    "pom": "sha256-8dTGrrMhGGUMgF/pu8XulA+o8s19DwT6Q2BVHponspA="
   },
-  "com/fasterxml/jackson#jackson-bom/2.20.0": {
-   "pom": "sha256-9ig2R+cB/aHNMS3MIcsTKkD3mPGejkL6/D/jR8WlG7s="
-  },
-  "com/fasterxml/jackson#jackson-parent/2.17": {
-   "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
+  "com/fasterxml/jackson#jackson-bom/2.20.1": {
+   "pom": "sha256-DGRn7UyMc5JSTOcDymzj7YhZbuw5DxOwwmTy+WEwilQ="
   },
   "com/fasterxml/jackson#jackson-parent/2.18.1": {
    "pom": "sha256-0IIvrBoCJoRLitRFySDEmk9hkWnQmxAQp9/u0ZkQmYw="
@@ -145,55 +95,40 @@
   "com/fasterxml/jackson#jackson-parent/2.20": {
    "pom": "sha256-tDt/XGLoaxZPrnCuF9aRHF22B5mvAQVzYK/aguSEW+U="
   },
-  "com/fasterxml/jackson/core#jackson-annotations/2.17.1": {
-   "jar": "sha256-/MrYLhMXLA5DhNtxV3IZybhjHAgg9LGNqqVwFvtmHHY=",
-   "module": "sha256-VNTVHaATppa+CeH0gDH39At3cYB4qpNuZMAjpP2blZM=",
-   "pom": "sha256-c1XzdEX12vUPUMdfLrzXG6LE+86ktiVBSAWexjVkTnc="
-  },
   "com/fasterxml/jackson/core#jackson-annotations/2.20": {
    "jar": "sha256-lZov+y1ZFDb1Hxg8alIfyJNHkS9xG/DK4AjN8EXZUxk=",
    "module": "sha256-wHDxTsg1jQlcAurootZcsAzLoOXFqnOwASlDM/5GiXE=",
    "pom": "sha256-TXQMRHjdCNCJ7NxtBjIopVoRp+jkl9pDOPhy+BFXlKQ="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.17.1": {
-   "jar": "sha256-3bJsih8ahFNeghPEizWyUzcENOMoezzxV3eFb8TljOY=",
-   "module": "sha256-iowJZP38Js7bso2CXfRiGBf7jNIrnnpZ2cdKOl8b3R0=",
-   "pom": "sha256-2UiDEgmgTAE5G5Oq7nrTShyelIY/nnaFwvW2FJoqs50="
+  "com/fasterxml/jackson/core#jackson-core/2.20.1": {
+   "jar": "sha256-/6tNlX2qJ5bPJMtm0LeKcJDxvL4Xw6RXjwmv+q8TcIk=",
+   "module": "sha256-GalAQ0Ic2ahuFUkSnDjBjgs1exQUWuT3Ns2gL4Bch8k=",
+   "pom": "sha256-FuBJqySPgqpssEjwTVLvPuH1TIDaHSY68k++UM9ueX4="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.20.0": {
-   "jar": "sha256-vAz0YHWHcgH4QG7n3idBrn32wGb18EV72AYypxjAbnI=",
-   "module": "sha256-2oWNOW9/pritA4zVzLkDj7ORq3o2rmKWI+N6UyR537w=",
-   "pom": "sha256-XxZVisIjBzpvJHRA8wX1nwXv9QqvHurguq1BKAABb2g="
+  "com/fasterxml/jackson/core#jackson-databind/2.20.1": {
+   "jar": "sha256-NLvrRSb/9PhWWxIQa/haavy66FiWbUibVCFKxGsuJug=",
+   "module": "sha256-S1M7Mu5wZfVaSnsNbuTYn9WDdxSr83YUyJkRT7EhWHo=",
+   "pom": "sha256-vP3yeCUyMraDq1HeLcvI+Y8g9Hc4wRHs/SyFxBsTHOw="
   },
-  "com/fasterxml/jackson/core#jackson-databind/2.17.1": {
-   "jar": "sha256-tsovfVsaskXOxUlewzl3PS2QVUxIWSWQZz+xj0QAqUg=",
-   "module": "sha256-C6vGRqBi8NnTWEQCpQJxiE7cPhekGULB4x4OENcdvuY=",
-   "pom": "sha256-YKCKmGrDE60+MmiKTjJ6YSg6ioAa1vphV5+MS+bcj2w="
-  },
-  "com/fasterxml/jackson/core#jackson-databind/2.20.0": {
-   "jar": "sha256-pw4Uamvyy6T5zTZxaXh/UK3Pu1cSK8LpyDkM0LOXrDA=",
-   "module": "sha256-oSgvNhZKyQG66p7bULqYE3L/7hjCz7F75CW5s/dYeuI=",
-   "pom": "sha256-zv7+0B3SwNlqiOEBuz4GX8FQBjtJjjAak4xpCwK8884="
-  },
-  "com/fasterxml/jackson/dataformat#jackson-dataformat-xml/2.20.0": {
-   "jar": "sha256-DU67TVg92pGAHTfHVl1GKiX+kp8NdsNHZ+xLgEExEMA=",
-   "module": "sha256-+Vo/xxi+i/IaLVkpokZpblRMLigfA9yPrPaQhiusUCI=",
-   "pom": "sha256-SSZxpqcwB8Xq7YZ9luLJfKVtGzfSpYx0Zx99V4Aav6w="
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-xml/2.20.1": {
+   "jar": "sha256-GQrU66NdidujUX2ieeBpBoHEdFF0uUsJ6nj4HOrhQPA=",
+   "module": "sha256-hUEEQQ13F89ArnJvmWoK2aACxiaV23QHvjm+NlNJmW8=",
+   "pom": "sha256-QTj0W/qeyxDsefm/3JLfYos5yLpScTk2tq9eBioP9ck="
   },
   "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.18.3": {
    "module": "sha256-v2AjrStgVyCsbaJ6K16Y7bGjJs0L9jfDpAtiH+jgk80=",
    "pom": "sha256-a056nStXQq6hOMFcDJ3gRjLxotjebnYe3vizYJK0hko="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.20.0": {
-   "jar": "sha256-zD3sn7i1ZXR5e/72JkEyVQjw5byWi9JoVoQCgY1Vuq4=",
-   "module": "sha256-ZA8QhiTO8o1t6jJ+KC6eyC9lEhVY5gkcqPuJlfkUpac=",
-   "pom": "sha256-rpwz0EFZBkwZsuq0FIiU+jHxVjW7/lMYzjIp+OFHCcU="
+  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.20.1": {
+   "jar": "sha256-Aw8dkfffJ46G4bo+Ep+1IIcawWzlMBfHNfcIgjvpcNs=",
+   "module": "sha256-At0WoElpdLY7sgrszAK2fpeuQ6Uc5H1JSbyAUiLHQxI=",
+   "pom": "sha256-JrotoAFsKiNbPccCc5xm3O6xjKBURirhVE2srfnguSU="
   },
   "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.18.3": {
    "pom": "sha256-VnParMboVZdt7O3rRtxjOVprGsmkg+Zy8IMc9G/gbiU="
   },
-  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.20.0": {
-   "pom": "sha256-RH4cfT+o2Skn3L2DjSRGOAXohi9yPM7VENUNrrhPgLQ="
+  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.20.1": {
+   "pom": "sha256-bIZ3yvUcuerYfbYmiPNR3MxDrPkAqONHcuQQ0TOPaqs="
   },
   "com/fasterxml/woodstox#woodstox-core/7.1.1": {
    "jar": "sha256-ArnQIunUdwT/inqFmg2/07KIKoMR63/x4YD3YMzaJxI=",
@@ -204,10 +139,10 @@
    "module": "sha256-HJZopxNuP0KJnDB4Gj/BlEwmOt+JxD/9Wjq4CyLJWys=",
    "pom": "sha256-BWin12bwYR/dbcGzCa+cFTQdt60LwDDeymXm7OTeWQo="
   },
-  "com/github/ben-manes/caffeine#caffeine/3.2.2": {
-   "jar": "sha256-x0psciId+3brkvK7QBCOpWGn2i8xXcOx5kr6jwd/IQw=",
-   "module": "sha256-oD7s/Xs/XQSmZSw4yT1xFDCnSfx/+OwKpN7janRJwDE=",
-   "pom": "sha256-OQTfB3fF2aYILhfKOiaSseoGGtTpOjomkAIRbrGsq2I="
+  "com/github/ben-manes/caffeine#caffeine/3.2.3": {
+   "jar": "sha256-ynDJCl0c4VEYgM6ck9StIhCPYREdPa+R61J2K1cb0Xk=",
+   "module": "sha256-jZo7mA6b1wQS7jObJFYxNhezuK4uhon5s8vwZAzVjzw=",
+   "pom": "sha256-n3BPkIN5e099DB1chV00zSaNVEzwa0KD1c5CiKz8nuA="
   },
   "com/github/package-url#packageurl-java/1.5.0": {
    "jar": "sha256-5FVRcncHrMDFasYtVpZDMuoPE41sw2VtmIuTaRUPUkc=",
@@ -227,21 +162,21 @@
    "jar": "sha256-JMkjNyxY410LnxagKJKbua7cd1IYZ8J08r0HNd9bofU=",
    "pom": "sha256-TKWjXWEjXhZUmsNG0eNFUc3w/ifoSqV+A8vrJV6k5do="
   },
-  "com/google/errorprone#error_prone_annotations/2.36.0": {
-   "pom": "sha256-15z9N8hfdta3VMdQHuHchEe3smQsI4LXeCUhZr0zHpw="
+  "com/google/errorprone#error_prone_annotations/2.41.0": {
+   "pom": "sha256-oVHfHi4LSGGNiwahgHSKKbOrs5sbI5b2och5pydIjG4="
   },
-  "com/google/errorprone#error_prone_annotations/2.40.0": {
-   "jar": "sha256-v6d+SSJum9KsesG8SjxwQwB48ubNMMjgYV1sJdiugY0=",
-   "pom": "sha256-GI+AyOrAS0CvdrRdA90dCjk5IOP6DEglL05u8YcojK4="
+  "com/google/errorprone#error_prone_annotations/2.43.0": {
+   "jar": "sha256-SCcudcFuH3vce9GVKcys1e4XBARwHX9aI0QbtYR5V/U=",
+   "pom": "sha256-T2uIia+o3r2+Hj/ipfjmbiIWygtWPya05UE4cw7s3IA="
   },
   "com/google/errorprone#error_prone_parent/2.27.0": {
    "pom": "sha256-+oGCnQSVWd9pJ/nJpv1rvQn4tQ5tRzaucsgwC2w9dlQ="
   },
-  "com/google/errorprone#error_prone_parent/2.36.0": {
-   "pom": "sha256-Okz8imvtYetI6Wl5b8MeoNJwtj5nBZmUamGIOttwlNw="
+  "com/google/errorprone#error_prone_parent/2.41.0": {
+   "pom": "sha256-xTg4jXYKXByY3PBvbtPP5fEaZRgn21y9LtgojHlcrUI="
   },
-  "com/google/errorprone#error_prone_parent/2.40.0": {
-   "pom": "sha256-HGt0MRxgFPj9aMjdHl9h3bVEz/LHQ8JyTbf4LXLd5Is="
+  "com/google/errorprone#error_prone_parent/2.43.0": {
+   "pom": "sha256-u5LEWE0CEb1ZvspPsnYXD13FD+NGFG6TV40tqyYDPhA="
   },
   "com/google/guava#failureaccess/1.0.3": {
    "jar": "sha256-y/w5BrGbj1XdfP1t/gqkUy6DQlDX8IC9jSEaPiRrWcs=",
@@ -256,10 +191,18 @@
   "com/google/guava#guava-parent/33.4.8-jre": {
    "pom": "sha256-oDxRmaG+FEQ99/1AuoZzscaq4E3u9miM59Vz6kieOiA="
   },
+  "com/google/guava#guava-parent/33.5.0-jre": {
+   "pom": "sha256-aHGeaHxuTJ/z4P7L73vSCJbw9PezFHQ+0zxy+WJWghU="
+  },
   "com/google/guava#guava/33.4.8-jre": {
    "jar": "sha256-89f1f2f9Yi9NRo391pKzpeOQkkbCgBesMmNAXw/mF+0=",
    "module": "sha256-WKM1cwMGmiGTDnuf6bhk3ov7i9RgdDPb5IJjRZYgz/w=",
    "pom": "sha256-BDZdS27yLIz5NJ/mKAafw+gaLIODUUAu9OlfnnV77rw="
+  },
+  "com/google/guava#guava/33.5.0-jre": {
+   "jar": "sha256-HjAfDFKsJIsLFP3D0SKDx3JS1Nb0hSHVcufYxMLMSsc=",
+   "module": "sha256-d+1CyMiyzru5OsngdUP/ZBiqJL24UXWAz1Mk6aZRCVY=",
+   "pom": "sha256-BHj6eKkIs8Mf5td76ZeKqmIeKhgduEAH49OzdCSirGE="
   },
   "com/google/guava#listenablefuture/9999.0-empty-to-avoid-conflict-with-guava": {
    "jar": "sha256-s3KgN9QjCqV/vv/e8w/WEj+cDC24XQrO0AyRuXTzP5k=",
@@ -274,13 +217,13 @@
   "com/google/inject#guice/5.1.0/classes": {
    "jar": "sha256-FCrUR14ZUk0v46yZWz98vJYvxyby7bnb3Mxh/qubK/k="
   },
-  "com/google/j2objc#j2objc-annotations/3.0.0": {
-   "jar": "sha256-iCQVc0Z93KRP/U10qgTCu/0Rv3wX4MNCyUyd56cKfGQ=",
-   "pom": "sha256-I7PQOeForYndEUaY5t1744P0osV3uId9gsc6ZRXnShc="
+  "com/google/j2objc#j2objc-annotations/3.1": {
+   "jar": "sha256-hNOhUFGEhfgUDqmbiphWVnSWKfZDPJK4DHWzaro7CZs=",
+   "pom": "sha256-FFcIOFAANPwbR8ggXOHJ1rJVwczdLRr9zcv3XomySjM="
   },
-  "com/h2database#h2/2.2.224": {
-   "jar": "sha256-udjxk1itqCpPbrWxdMbP4yCjdbWpy1pP5FbWI+blVJc=",
-   "pom": "sha256-DUUDoBpMemL5GuGmJxM5z4BvKkYt7+C+/17/1aYR45g="
+  "com/h2database#h2/2.4.240": {
+   "jar": "sha256-KbcOQnzBxAzcN2KDrbsMxihTBzeXu1/ldh+B/nPVfOA=",
+   "pom": "sha256-J69LeAWFazFw1YfgoCyqyT1CH4dc/JSX2/X/1/Mkeko="
   },
   "com/networknt#json-schema-validator/1.5.9": {
    "jar": "sha256-4Li663j9G6AnRU7jl02KAvVER+qlENMFKCCn0hYNmuQ=",
@@ -310,59 +253,62 @@
    "module": "sha256-2VLG3ZGntCbD8KUe3D986zSQrAH/GDAVJ63+x6eDfdk=",
    "pom": "sha256-MXodP7cFQDG/6QzKibECSQH9m5/MqZFmws54U7X8e9k="
   },
-  "com/squareup/okhttp3#okhttp-jvm/5.1.0": {
-   "jar": "sha256-pqrH8V08LDy9Kvfs9W+XQHFkpgSy24eVKZUOMc6mmbI=",
-   "module": "sha256-sulz7WEYTDMNpU5+YuW6STQLZkh1x8PiLfjvSWB8TXA=",
-   "pom": "sha256-aNCp1oSYz/jQM+gJUKihDamZiE6Y07RMiNDpsAUd4nA="
+  "com/squareup/okhttp3#okhttp/3.14.9": {
+   "jar": "sha256-JXD6tVUVy/iB16TO70n8UVSQvAJwV+Zmd2ooMkZa7KA=",
+   "pom": "sha256-Ye3zxHZOqV8SEsot+8bqXUEzxxxOjEC9JH7IPnxrfOc="
   },
-  "com/squareup/okhttp3#okhttp/5.1.0": {
-   "module": "sha256-9Lg+E7Rr8Q9cccDL82M54X4ttXZwDaNElfulX063g24=",
-   "pom": "sha256-hwO2W8qKgsj6H3DHt4FTtAx5FrKQUS/PmA5/IaZQpzc="
+  "com/squareup/okhttp3#parent/3.14.9": {
+   "pom": "sha256-tfEB3PLMfzLsPXtovcB4536sGXm7hmTo+H92IojD3OU="
   },
-  "com/squareup/okio#okio-bom/3.15.0": {
-   "module": "sha256-x3W4IzK61AlhIt5sVUqd2PlLgvJUxwr7Cnw9lkxN8GY=",
-   "pom": "sha256-d91HMYPYt/8tpJVLSsYCBj7mMnhk/nYpxYgwj18l4Eo="
+  "com/squareup/okio#okio-bom/3.16.4": {
+   "module": "sha256-dJ52meyyZXzaGsemojjaSsTbCBXPJL38gOXMnxB/jos=",
+   "pom": "sha256-Z1oFMqkhyPOLkw2SMOYhLFqtaNiDUED2ouLluudzbyE="
   },
-  "com/squareup/okio#okio-jvm/3.15.0": {
-   "jar": "sha256-SD3Dg7EEnSIIkjIqDWpDCEJfCbsFtIxD1Oqp/4KxzRY=",
-   "module": "sha256-mJRUqUrvvClwMoiPE1rNoUqf+0aWDn2EYDkl0mkkHuc=",
-   "pom": "sha256-B45C9oykYT/yWX+8VUHFzleM3MSIOdqJ2nynYFGL+3k="
+  "com/squareup/okio#okio-jvm/3.16.4": {
+   "jar": "sha256-IZa5k800272Rnn4B9XpHgbWL7oD4YQYWPih8IDQ6lqc=",
+   "module": "sha256-kAjVopVKBoxoSCdPbuvf9IsUpw28aT0zAuCMVwzKAy8=",
+   "pom": "sha256-ZnePTQWXvOY/kewADFdcwCmzIB990JLLgIh1FVs+hqE="
   },
   "com/squareup/okio#okio-jvm/3.7.0": {
    "jar": "sha256-2LNa3Ch2j0OuWv5qfRqiqHi6UeC5ak8wiBHzsfWxPlU=",
    "module": "sha256-b64CAbCuSKGWBt4Ab/6YQtjQ/CoeQ04Hhc7Ni3Wr5HQ=",
    "pom": "sha256-d07LnSsHlLT7J+eeCHYMpWC39U+qlRm5GDxn/rRfLJc="
   },
-  "com/squareup/okio#okio/3.15.0": {
-   "module": "sha256-EWgmBmzrTTM2p05xcqM3UWF+w0S8UKNPmbDSSVmko50=",
-   "pom": "sha256-LXN4VBFATurDLwRzouB6sVFrmFCpKAzGGgi0eXkMzPg="
+  "com/squareup/okio#okio/3.16.4": {
+   "module": "sha256-yEQahybbGk+dTzngaOu0LfalnWR+MqnGHBW1OQ7VklI=",
+   "pom": "sha256-CPvpfh4ugVoUyvFv9ayHCFEb713ec51gwHE5UYdtomM="
   },
   "com/squareup/okio#okio/3.7.0": {
    "module": "sha256-88rgCfC2yEL7vFLOd1QsGdGdVu6ZpeVVZH8Lr8nVDPo=",
    "pom": "sha256-H2KMRSg726uM4DwHps+3akeLjdrhgL2PNKusJz5Id24="
   },
-  "com/squareup/retrofit2#converter-scalars/3.0.0": {
-   "jar": "sha256-uXzwaSmoDUm8Yy5E8hnPCnGF/Ezuhh7JCtHQ5IIIQCM=",
-   "module": "sha256-gECNEiZVQbMCRDuw++YUb0BqglP+fDdudWulhAujnKQ=",
-   "pom": "sha256-B42x+Kgsb48K0vzzn7ia4bfUf1XQIlGEksToSN1QL8c="
+  "com/squareup/retrofit2#converter-moshi/2.12.0": {
+   "jar": "sha256-GbejX6FkCTYH+aY+2BC0scH76cfUXjGWJ3wea+Exfy4=",
+   "module": "sha256-1FNRun8nTshOXqsvdrPOfGPduLpL+KzTHiix0D3Jmu0=",
+   "pom": "sha256-FHYD65pzlqUrotJq/brZw8i0kR9B1MKMV782mtDwYYU="
   },
-  "com/squareup/retrofit2#retrofit/3.0.0": {
-   "jar": "sha256-acai00UbbflUmpP6t0QJTr8HpLDOT0U9bI9XXvD+yaE=",
-   "module": "sha256-PeUoKbiYIVU06G7aJo2kSf/L+VsYcD2lKdmYgyd0hPc=",
-   "pom": "sha256-/BaPqJcZiIc331OurA9JgLP07z5hIeMww2YGHJlrBoA="
+  "com/squareup/retrofit2#converter-scalars/2.12.0": {
+   "jar": "sha256-EV60l+rtabOFSyeico6fDzAB/xU0DxXEackw/1lhDHM=",
+   "module": "sha256-vXPboF8M9vxG6Tbq205zOKpgDNs8UDW6k6NypSrk3Hs=",
+   "pom": "sha256-P0n83lXvfTADVn2UYOZ8yjtm3TlSdCbBuUROq4dQJOI="
   },
-  "com/vanniktech#central-portal/0.34.0": {
-   "jar": "sha256-9HyW3152+uQ1H46O8qAFTtTKvvfzNzJgwPVv7yY9ITY=",
-   "module": "sha256-ff8P01naUujxJk8f49eVPQD9LrwCSq+a6rvdfnULjj8=",
-   "pom": "sha256-BNzoESg1rimFmZ1hLZ0YfKfBqj0z1Noqx4KBnFie+ow="
+  "com/squareup/retrofit2#retrofit/2.12.0": {
+   "jar": "sha256-Oy37gruZzTPfldkq1vzXi6fxesgeZ5BOuZH+QEAV0dg=",
+   "module": "sha256-Og+cjvwUlYqFoThkgj+UBCc41gF72euPvGH3EXTM2B8=",
+   "pom": "sha256-pPj7y8g4IBNWfzPnDLCJ7wxl7TJ+DV4EIx99hDTQ8wA="
   },
-  "com/vanniktech#gradle-maven-publish-plugin/0.34.0": {
-   "jar": "sha256-GzBK4yfXA03hlRH3etInulnXNY6LUdGLCdp6JT/sTAU=",
-   "module": "sha256-3b3ll8lZPBTqNerTPKC1nMP9W50241Q1j/ZvYwSYHHE=",
-   "pom": "sha256-yBLl8DxlILOqJxkOEn8SXCubWDWVWLfPPf09daGQnYE="
+  "com/vanniktech#central-portal/0.35.0": {
+   "jar": "sha256-mJ3cc+/lNAB+Be/yx8MU3ru9OLEgfTOwdBoNmMrcoFA=",
+   "module": "sha256-3ICG1mWG0LrcSgP85vv0IMyZJnz0QZ/Wwwe++UIEvXM=",
+   "pom": "sha256-YVVZa2TixqHcpFMfJMBrqCzsrfF/HNG/iIg9DOYqYYw="
   },
-  "com/vanniktech/maven/publish#com.vanniktech.maven.publish.gradle.plugin/0.34.0": {
-   "pom": "sha256-yvlwLHCOE0teBeL1lb16yBsMYdEGC0Kat3Y5aLa5epY="
+  "com/vanniktech#gradle-maven-publish-plugin/0.35.0": {
+   "jar": "sha256-9TrJP++0RWm06G+XlW5ggFj9VSIrCuXUS82tFHThF+A=",
+   "module": "sha256-R6IkODDchPwQ9/ZWbb3+7zqpvDWgMIBGpBEFs/5sdp0=",
+   "pom": "sha256-Bqupfg8WGjoZN2P78jvEb/MYQ0ejYKtMqlcUPbyeFIM="
+  },
+  "com/vanniktech/maven/publish#com.vanniktech.maven.publish.gradle.plugin/0.35.0": {
+   "pom": "sha256-iAGpAS3B+PqnKUcEDWYVpQFg6ftXoHwA9JspwjQ1gZ4="
   },
   "commons-codec#commons-codec/1.16.0": {
    "pom": "sha256-bLWVeBnfOTlW/TEaOgw/XuwevEm6Wy0J8/ROYWf6PnQ="
@@ -371,17 +317,13 @@
    "jar": "sha256-+fbLED8t3DyZqdgK2irnvwaFER/Wv/zLcgM9HaTm/yM=",
    "pom": "sha256-f6DbTYFQ2vkylYuK6onuJKu00Y4jFqXeU1J4/BMVEqA="
   },
-  "commons-codec#commons-codec/1.18.0": {
-   "jar": "sha256-ugBfMEzvkqPe3iSjitWsm4r8zw2PdYOdbBM4Y0z39uQ=",
-   "pom": "sha256-dLkW2ksDhMYZ5t1MGN7+iqQ4f3lSBSU8+0u7L0WM3c4="
-  },
   "commons-codec#commons-codec/1.19.0": {
    "jar": "sha256-XDiB5PVWhV6cUykn7gyd/elMxmdg1YBcAxpZiHBwr18=",
    "pom": "sha256-4PMmn6I94MgxMMVln1+VFMxUIsC830Xy6uAEp4ufyjQ="
   },
-  "commons-io#commons-io/2.18.0": {
-   "jar": "sha256-88oPjWPEDiOlbVQQHGDV7e4Ta0LYS/uFvHljCTEJz4s=",
-   "pom": "sha256-Y9lpQetE35yQ0q2yrYw/aZwuBl5wcEXF2vcT/KUrz8o="
+  "commons-codec#commons-codec/1.20.0": {
+   "jar": "sha256-avZllfn2p7tYzmZRjWiI1AtUfDZtImLwZnbu4ZUo/2Y=",
+   "pom": "sha256-r/ZFxYzUGsUYTZds6O443laU2Zq4dk1u5/FPcOrV+Ys="
   },
   "commons-io#commons-io/2.19.0": {
    "jar": "sha256-gkJokZtLYvn0DwjFQ4HeWZOwePWGZ+My0XNIrgGdcrk=",
@@ -390,6 +332,10 @@
   "commons-io#commons-io/2.20.0": {
    "jar": "sha256-35C7oP48tYa38WTnj+j49No/LdXCf6ZF+IgQDMwl3XI=",
    "pom": "sha256-vb34EHLBkO6aixgaXFj1vZF6dQ+xOiVt679T9dvTOio="
+  },
+  "commons-io#commons-io/2.21.0": {
+   "jar": "sha256-fWQ6Kv6osFi3YqpvuQ5bJW9scpc5+LN4TDNw3cYJ6I0=",
+   "pom": "sha256-rkd5XnIYA+yP8d7tdL4oqBGgJxO9WjqwrGfCtYy2Nas="
   },
   "dev/zacsweers/moshix#moshi-sealed-reflect/0.30.0": {
    "jar": "sha256-vP2qMkmcYojqi201i2ZknAXaif9mHENj1D0z1n5gp7k=",
@@ -474,9 +420,9 @@
    "jar": "sha256-KT2A9UtTa3QJXc1+o88KKbv8NAJRkoEzJJX0Qg03DRY=",
    "pom": "sha256-34zBqDh9TOhCNjtyCf3G0135djg5/T/KtVig+D+dhBw="
   },
-  "org/apache/commons#commons-csv/1.14.0": {
-   "jar": "sha256-LzTWn4nclNYG4lDV6yYgWSPl28LDiR01dfhshJ9/hyY=",
-   "pom": "sha256-k7VTRtiuqBQAS5x8wq7ZWwidOLMTiTZkNCuOA2mRJWU="
+  "org/apache/commons#commons-csv/1.14.1": {
+   "jar": "sha256-Mr4OHnZnMJL10Sy3kL0qy2wqsExOpu/GnqXuF5EcJP4=",
+   "pom": "sha256-ld9zUwLAq5LOwForUeInB1jhXwpkGG3mVmLrFI69l/0="
   },
   "org/apache/commons#commons-lang3/3.16.0": {
    "jar": "sha256-CHCd101gK3Bc5AF9JlRCEAVqS6WD1bIMCTc0Bv56APg=",
@@ -502,12 +448,6 @@
   "org/apache/commons#commons-parent/72": {
    "pom": "sha256-Q0Xev8dnsa6saKvdcvxn0YtSHUs5A3KhG2P/DFhrIyA="
   },
-  "org/apache/commons#commons-parent/78": {
-   "pom": "sha256-Ai0gLmVe3QTyoQ7L5FPZKXeSTTg4Ckyow1nxgXqAMg4="
-  },
-  "org/apache/commons#commons-parent/79": {
-   "pom": "sha256-Yo3zAUis08SRz8trc8euS1mJ5VJqsTovQo3qXUrRDXo="
-  },
   "org/apache/commons#commons-parent/81": {
    "pom": "sha256-NI1OfBMb5hFMhUpxnOekQwenw5vTZghJd7JP0prQ7bQ="
   },
@@ -516,6 +456,9 @@
   },
   "org/apache/commons#commons-parent/88": {
    "pom": "sha256-i/cmFQ0dakO6CqkgYOVSkzyvKHOqGTlS2dSWRw+p+9g="
+  },
+  "org/apache/commons#commons-parent/91": {
+   "pom": "sha256-0vi2/UgAtqrxIPWjgibV+dX8bbg3r5ni+bMwZ4aLmHI="
   },
   "org/apache/maven#maven-artifact/3.8.8": {
    "jar": "sha256-gTIzqEhcuvl7H5osF873I7Bo9yYKQxnPSVjyIdBLmTc=",
@@ -672,17 +615,17 @@
    "jar": "sha256-phxI1VPvrXi8Af/8SsUovruuZMuuwXCypeOc9h61Gr4=",
    "pom": "sha256-TpAuxVb8ZZi0HClS7BVz7cgVA35zMOxJIuq2GUImhuI="
   },
-  "org/cyclonedx#cyclonedx-core-java/11.0.0": {
-   "jar": "sha256-3oQazoSm6GTV0FaNgX7B5NEZcyWHKGr14aL9VmW5S4Y=",
-   "pom": "sha256-2GHp/nFKoPukYKNkp5tkKm8ZWrAdVuttzFf3pBEGT+8="
+  "org/cyclonedx#cyclonedx-core-java/11.0.1": {
+   "jar": "sha256-mJNIzG04VimjzLc11FCw8PAiFny3AsL8sObyvdmJ3ec=",
+   "pom": "sha256-7CoPqkYkAWvfNEvI4fItXgv793Q8DxWnUhMUBhLQw7E="
   },
-  "org/cyclonedx#cyclonedx-gradle-plugin/3.0.1": {
-   "jar": "sha256-NykXVNJpBdoPeyf5I107ir4WazI4wuzqTjIjjRvMjks=",
-   "module": "sha256-ERVsrays+tt40MWkgB7TwmImovG3uTiDJ7xPUra3Gj8=",
-   "pom": "sha256-ZUi5/PCURQCRtZnJ85fCbjm3ZFTBku0oDOxjYFDE+Rs="
+  "org/cyclonedx#cyclonedx-gradle-plugin/3.1.0": {
+   "jar": "sha256-OTJUHCikD2bqsO/zc0GFVsn1+cSeUx/FPq3p1omxUzs=",
+   "module": "sha256-cwK7mMFmJIdyH2JUWThMsSwY9sQlg2Lr+G+XqNTfcpI=",
+   "pom": "sha256-JxJ5LudnqlkYFEuKnzuZCig3v5h9oAZj1tmi8yWApns="
   },
-  "org/cyclonedx/bom#org.cyclonedx.bom.gradle.plugin/3.0.1": {
-   "pom": "sha256-M3mVlmdlvhj6qnYnIC23PibiYE7kBZAFEFsC5j2XBMo="
+  "org/cyclonedx/bom#org.cyclonedx.bom.gradle.plugin/3.1.0": {
+   "pom": "sha256-gS6ychNdCtFa6/ehS3ydwMYD+kxnLR+C62Mq/olOcvk="
   },
   "org/eclipse/sisu#org.eclipse.sisu.inject/0.3.5": {
    "jar": "sha256-xZlAELzc4dK9YDpNUMRxkd29eHXRFXsjqqJtM8gv2hM=",
@@ -732,20 +675,20 @@
    "module": "sha256-fhNlSHgJgj3QsW1doKyZf9PmtrTephg58fHm8x/4D7A=",
    "pom": "sha256-N/yzpQhcQ/1cjVNvUU1LPju4WQtv0HNKcUL4i4NpWOA="
   },
-  "org/gradlex#java-module-packaging/1.1": {
-   "jar": "sha256-tG4desVuo/RmoviGeVclIuaFoV/mblWlKhSlDL1ZG/4=",
-   "module": "sha256-CilLazbgRJ4PllkhFCxED+ZW6OiWk0xdpYeDM3J0284=",
-   "pom": "sha256-NJEVgtmX9kIcxlBzUReESqL4SND5UPZCLscdp1Hg9Wo="
+  "org/gradlex#java-module-packaging/1.2": {
+   "jar": "sha256-OYhi3QQLcnd1LnptEgug8mHIG2gQ352+wiSQLsyJABs=",
+   "module": "sha256-shcObdBLh6Jc2FPHPbMUPknQWsTxsNwXj/AIc+1qfyo=",
+   "pom": "sha256-oIxyBX9Jmj68iOVJaCcC430yJZpcuQM8EbTrLebfr00="
   },
-  "org/gradlex#java-module-testing/1.7": {
-   "jar": "sha256-SuAfIlj54DFcfEqHVxpN73LUZHfDO/HnZwpnSGCgMMM=",
-   "module": "sha256-fF35H4l02PrGF8J5/V6SlaN/Xqq4RRc6F7PCFoqDuJo=",
-   "pom": "sha256-2xMRTEoSN6SknNX5a2N99tfDxQeIwc3F9rU+qWXfvuY="
+  "org/gradlex#java-module-testing/1.8": {
+   "jar": "sha256-VGnTdoQTLIykKPjhCa0cyuKFqRe+7VtIBqO7zyQxHh8=",
+   "module": "sha256-YzjMz5Q6yRPtywfwD6LBCmb/0dTjBFI9TK52iA3sUO4=",
+   "pom": "sha256-oQB1HIxCz13s7vaVQ/rNEY7eC3O/zf1kydIvPuJoPMA="
   },
-  "org/gradlex#jvm-dependency-conflict-resolution/2.4": {
-   "jar": "sha256-07ysXNC5ZGAo2eT4s1iP+r9UGwPmEzgAQQZ/g/QlRCY=",
-   "module": "sha256-9rh4lX2yRAgFK8q0lyZiVlznCC2hiD5C8fsU24GIlRo=",
-   "pom": "sha256-uacve85Giz5v2SwEXDdN6mMskIRE6tdzc0vfdDBMjnU="
+  "org/gradlex#jvm-dependency-conflict-resolution/2.5": {
+   "jar": "sha256-ZTyhRdbI9h4nbrIw3yr3htxWZaCqyXOi3tdd4gw6170=",
+   "module": "sha256-wbliVk8tJ7IJc4FOQbiw8FT9nJ02tDZRaEHjLGYQuog=",
+   "pom": "sha256-x/+x9Yt+AWImYiG5T75j1jb1NciBIO8QnjOMgWJ/0uA="
   },
   "org/itsallcode#openfasttrace-gradle/3.1.0": {
    "jar": "sha256-+HhFKm0fhNF7qz+Kw7tlqTcsICHWIqvFneXWLdSgtYM=",
@@ -1005,9 +948,9 @@
    "module": "sha256-/2oi2kAECTh1HbCuIRd+dlF9vxJqdnlvVCZye/dsEig=",
    "pom": "sha256-pWM6vVNGfOuRYi2B8umCCAh3FF4LduG3V4hxVDSIXQs="
   },
-  "org/jooq#jool/0.9.14": {
-   "jar": "sha256-EO13VqAFaYQJsWqteXqnZgCaZhD29r7GZ7NbFwl7o0s=",
-   "pom": "sha256-L4ndA8dhMAqVuGSecX63t1j1SOz8q8hHkb0kVzslv/c="
+  "org/jooq#jool/0.9.15": {
+   "jar": "sha256-ow2WcZCZ603oewgVL5etsLo8/vmX2tys6LLk3NwZf4Q=",
+   "pom": "sha256-/mCqsovG1YbUq0u/zSPc9KFXa/gzK2lEwhxaehS8x4M="
   },
   "org/jspecify#jspecify/1.0.0": {
    "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",
@@ -1029,10 +972,6 @@
   "org/junit#junit-bom/5.11.1": {
    "module": "sha256-42L7gWcgLW8NSlsWcHxTJFEP0pA9U2SYiMRJasgcM34=",
    "pom": "sha256-xyEkqcmnmRDBhYdmtyw1Dho5JEy/tLB2NI+/4HgoGWU="
-  },
-  "org/junit#junit-bom/5.11.2": {
-   "module": "sha256-iDoFuJLxGFnzg23nm3IH4kfhQSVYPMuKO+9Ni8D1jyw=",
-   "pom": "sha256-9I6IU4qsFF6zrgNFqevQVbKPMpo13OjR6SgTJcqbDqI="
   },
   "org/junit#junit-bom/5.11.4": {
    "module": "sha256-qaTye+lOmbnVcBYtJGqA9obSd9XTGutUgQR89R2vRuQ=",
@@ -1072,16 +1011,16 @@
   "org/openjfx#javafx/25": {
    "pom": "sha256-55IzCPyt1/LGiwcgQfR9jnNVIj2EZVnutceA3EuivxM="
   },
-  "org/openrewrite#plugin/7.19.0": {
-   "jar": "sha256-0Q7hjPsBdtkJPK1XOudOT71gdrnRlLdUFx/Hz55svEQ=",
-   "module": "sha256-O34NiVkjs7Kkluv2/TjvNRLruzaUJ8aqWtH28zxoeW0=",
-   "pom": "sha256-ZoGHq63frzP4dlvYpmb2ZFWefpPS6+l2pGjLXAjIjoE="
+  "org/openrewrite#plugin/7.23.0": {
+   "jar": "sha256-FVTJaML4Qf/TyPQSYzueRB3hsIcUt1lKr7O6VsK3y8o=",
+   "module": "sha256-zMwRRR/4rKPfwRVYPfbUtN6n7hrOkMKL1BC/Uw18GRk=",
+   "pom": "sha256-1iJirMbYonNt/uYcEsdLRophOntSLZC1KZDT7INDCq8="
   },
-  "org/openrewrite#rewrite-bom/8.64.0": {
-   "pom": "sha256-TUbuSNSXKl011/ufBiQhwFVY0Z2+KtuoRso5rb45OWs="
+  "org/openrewrite#rewrite-bom/8.69.0": {
+   "pom": "sha256-qB0qP51WQTq/xDVb7rWgmX0HbsCiwktZqWNy6ZG1/YM="
   },
-  "org/openrewrite/rewrite#org.openrewrite.rewrite.gradle.plugin/7.19.0": {
-   "pom": "sha256-IhGb4mgJ1Ht6ijckmt2mm0q6kDJ/pgyKUuE24UAaHso="
+  "org/openrewrite/rewrite#org.openrewrite.rewrite.gradle.plugin/7.23.0": {
+   "pom": "sha256-DPyIx0N8YHljfQckzwRhwEorLJ2ouhBsbXBnvN4y2Z8="
   },
   "org/ow2#ow2/1.5.1": {
    "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
@@ -1094,42 +1033,26 @@
    "jar": "sha256-A9madK0e5ccTNO9nQ39O9P40iMqnyW2GRavHPI4gF9Q=",
    "pom": "sha256-z4Ye8edF1XFUr3muFN80DtU0Hl3NAVfO/NLrfxqgXFc="
   },
-  "org/slf4j#slf4j-api/1.7.2": {
-   "jar": "sha256-O654m0ATM7Kh0WA7f6Vz4ZkIYoGRcHID9utwjN7iwFI=",
-   "pom": "sha256-LqynGv4KFRb0q9jp/5B4ONJo84yBw6VCzOjX87h8XUw="
-  },
   "org/slf4j#slf4j-api/1.7.36": {
+   "jar": "sha256-0+9XXj5JeWeNwBvx3M5RAhSTtNEft/G+itmCh3wWocA=",
    "pom": "sha256-+wRqnCKUN5KLsRwtJ8i113PriiXmDL0lPZhSEN7cJoQ="
-  },
-  "org/slf4j#slf4j-api/2.0.13": {
-   "jar": "sha256-58KkjoUVuh9J+mN9V7Ti9ZCz9b2XQHrGmcOqXvsSBKk=",
-   "pom": "sha256-UYBc/agMoqyCBBuQbZhl056YI+NYoO62I3nf7UdcFXE="
   },
   "org/slf4j#slf4j-api/2.0.17": {
    "jar": "sha256-e3UdlSBhlU1av+1xgcH2RdM2CRtnmJFZHWMynGIuuDI=",
    "pom": "sha256-FQxAKH987NwhuTgMqsmOkoxPM8Aj22s0jfHFrJdwJr8="
   },
-  "org/slf4j#slf4j-bom/2.0.13": {
-   "pom": "sha256-evJy16c44rmHY3kf/diWBA6L6ymKiP1gYhRAeXbNMQo="
-  },
   "org/slf4j#slf4j-bom/2.0.17": {
    "pom": "sha256-940ntkK0uIbrg5/BArXNn+fzDzdZn/5oGFvk4WCQMek="
-  },
-  "org/slf4j#slf4j-parent/1.7.2": {
-   "pom": "sha256-HY4ISm8jhK3kJoUzK1Kg7OCQR4ZB3BTA+oxS4eKYRCU="
   },
   "org/slf4j#slf4j-parent/1.7.36": {
    "pom": "sha256-uziNN/vN083mTDzt4hg4aTIY3EUfBAQMXfNgp47X6BI="
   },
-  "org/slf4j#slf4j-parent/2.0.13": {
-   "pom": "sha256-Z/rP1R8Gk1zqhWFaBHddcNgL/QOtDzdnA1H5IO0LtYo="
-  },
   "org/slf4j#slf4j-parent/2.0.17": {
    "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
   },
-  "org/slf4j#slf4j-simple/2.0.13": {
-   "jar": "sha256-MVP+HWic/7lPFTC1hHDDBmhbpohE3ohXEW47bruB2fc=",
-   "pom": "sha256-Sk1Lskz4q+LLh0qDb150PTSFt9sE/P9vwHFJUlO1z6g="
+  "org/slf4j#slf4j-simple/2.0.17": {
+   "jar": "sha256-3f6lmsB0xtPiSsLDhiLS2WOJXhf3CzjtS9rk14C+aWQ=",
+   "pom": "sha256-+zDo4vauotKYQnmGd+1FQbmyJVcVwVg1DKLF9ce4ZLA="
   },
   "org/sonatype/oss#oss-parent/7": {
    "pom": "sha256-tR+IZ8kranIkmVV/w6H96ne9+e9XRyL+kM5DailVlFQ="
@@ -1144,31 +1067,51 @@
   "org/zeroturnaround#zt-exec/1.12": {
    "jar": "sha256-9ROvOZj9QCT5k+iyWe/TazSgzxx5PpO0olrcNJjQEf0=",
    "pom": "sha256-aYxGAAk6FF9lEYVGJfSVKPBOFqLESAiFKP2Oi0JsTFQ="
+  },
+  "tools/jackson#jackson-base/3.0.3": {
+   "pom": "sha256-kvfF8WaH7WtSwOgm76sON5s3rkkYFc8tQ3ySPUJodbQ="
+  },
+  "tools/jackson#jackson-bom/3.0.3": {
+   "pom": "sha256-hOPOTqXFbXvqiGH+HEOayaGd1UqaPem4oIhL8LvHUPI="
+  },
+  "tools/jackson/core#jackson-core/3.0.3": {
+   "jar": "sha256-QUm7Kzu/+1M5CJF04m9FQIHmoBoQTSSyL3iha5SHmes=",
+   "module": "sha256-tJO1FTrvaKzJwyEsOa3fbYi7yDO4h1LhVjLgwoEAdjU=",
+   "pom": "sha256-Z4lSP9lndVN7lriKwAyQ5CQ+lkYVXLE1/OjzE6GiH9g="
+  },
+  "tools/jackson/core#jackson-databind/3.0.3": {
+   "jar": "sha256-37t5EwkQ3s8GMSXB5pOjnF7I+4tHjX85ZxkB1Hzn9qI=",
+   "module": "sha256-tpz6mbeuIssVcLSJ7RUprnUluaGrP57zXR9PPT5HGHs=",
+   "pom": "sha256-9EpMrUeqwuQkLk31NoJ7WP7fKCkFbJUX9E51raYHF2g="
   }
  },
  "https://repo.maven.apache.org/maven2": {
-  "ai/djl#api/0.34.0": {
-   "jar": "sha256-fTJPadhpvbRg0n0PegUu0LxVFNq4gBTYmk4BKa2ZYM4=",
-   "pom": "sha256-8aXphfBTdbhovv8377sA4eemn7LKjFff8QnXAGAkXCo="
+  "ai/djl#api/0.35.1": {
+   "jar": "sha256-EpXJunxbDil0pjiVPtEjFUvMCsoNvEEGkR3GyaXYzPU=",
+   "pom": "sha256-vuzCtZfq/v79VQOau6bjrKEhxvO6+kpO79hLn8DqrJc="
   },
-  "ai/djl#bom/0.34.0": {
-   "pom": "sha256-/mUHucQxaWENPHsxS9NBD8koaBn8iz/94fJpzBfqM3E="
+  "ai/djl#bom/0.35.1": {
+   "pom": "sha256-T8VC15hK8PPvGwIPd9+v3ZCYWDzGN7BVz8fznimOQHs="
   },
-  "ai/djl/huggingface#tokenizers/0.34.0": {
-   "jar": "sha256-zDVisUKNQIDqjEQ+xG844XjfYafvtr7c1coeM1CmflI=",
-   "pom": "sha256-ODxC90MPpmbgG932pPdt1d1XHGkDhOn24SqyH6xaWZs="
+  "ai/djl/huggingface#tokenizers/0.35.1": {
+   "jar": "sha256-7R2M9g8BhuQpO2wKVR6R+DSxjfeyNmoWuA6sJFWutUI=",
+   "pom": "sha256-ZA0rZaYZFnbWHvbk5WDojA583fl3sGsRNN5lGx9tVHA="
   },
-  "ai/djl/pytorch#pytorch-engine/0.34.0": {
-   "jar": "sha256-Y498d7lSd0TEbxz5IvdrviicSdM58B1LuTKcRen7ZsM=",
-   "pom": "sha256-JEGTooNdo/aI8pNl+qgxa5ra0TLFK/1bfA7h0PkuBqo="
+  "ai/djl/pytorch#pytorch-engine/0.35.1": {
+   "jar": "sha256-n4s4o4IPrLve8JtOaRkA2lhgu3178uBo2b4gXEca4C8=",
+   "pom": "sha256-KNmLmRj+KFMUVNstmg6x6gcFI5eVeWJokNWYGctykjc="
   },
-  "ai/djl/pytorch#pytorch-model-zoo/0.34.0": {
-   "jar": "sha256-gqb4Xdubnzgmj63lEM5G5YhPB57CzkN8ezur2+VhySg=",
-   "pom": "sha256-8bXJCIW2cS0Xnk3bQPIutJczhWJ59KcFI0UmzlwqCpI="
+  "ai/djl/pytorch#pytorch-model-zoo/0.35.1": {
+   "jar": "sha256-xF+2zouU+bT5gn80EkEe1oPWg3emv2KJEcd1SmMGato=",
+   "pom": "sha256-m6bKSOEbokXqHCGVrK1NlBjjCm+XjW3tfnusVo2PCn8="
   },
   "at/favre/lib#hkdf/1.1.0": {
    "jar": "sha256-gexMVudA1EC8lCb6YAyu5Ku26fTO/1dunOznw4F8WgY=",
    "pom": "sha256-HCRX381QzRlXEdO38sd7YLFf+8YukrOvxTujzKawfHg="
+  },
+  "cc/jilt#jilt/1.9": {
+   "module": "sha256-gGgkCvNxRtdHYhuiKcHpl1Ac6+t5UrK58KMj1oglvKc=",
+   "pom": "sha256-bfLSAjd4+Rljn71PVxUEPFc9oiyzh6Wmf/jg49BZwDk="
   },
   "com/dlsc#dlsc-maven-parent/1.0.0": {
    "pom": "sha256-6aQJT1Kt8lihN2bcHAh0Xk3D0hkL60SvIMalCLeg28w="
@@ -1179,19 +1122,19 @@
   "com/dlsc#dlsc-maven-parent/1.6.0": {
    "pom": "sha256-4ZbQC5GiVEwBEy/ZZXg5MWci0OzPYKn7tqFQbBxr4lE="
   },
-  "com/dlsc/gemsfx#gemsfx/3.5.7": {
-   "jar": "sha256-Y+dETxXXBI8h/0esdUtXFR+Vk3fw7rIltmU6bZNQvRs=",
-   "pom": "sha256-4Cb6VQcdX6hIkxDVgRBgGr+NGjlTM8xNSatkkH0RNwI="
+  "com/dlsc/gemsfx#gemsfx/3.6.2": {
+   "jar": "sha256-1U/XOBMiFpDnyDiaAV5cpk45QAJzFxwyMmDQwA0GuxM=",
+   "pom": "sha256-unp6nKC/WVT/J8qtR2kUtwGEWr615SfKXweAFOL4DQk="
   },
-  "com/dlsc/gemsfx#parent/3.5.7": {
-   "pom": "sha256-ORawbydR4eGFsBL7XJkwe+OFRtlTI2/N515p01GIvH8="
+  "com/dlsc/gemsfx#parent/3.6.2": {
+   "pom": "sha256-cqDCKTd0AXAiLe4KquYeC0ZIzzeR3mMZHekt94KZR1Y="
   },
-  "com/dlsc/pdfviewfx#parent/3.3.2": {
-   "pom": "sha256-o6yhZ7+ceSphXd39Q4pr+OnTfM1WyARtsgfNCb6gVaQ="
+  "com/dlsc/pdfviewfx#parent/3.4.1": {
+   "pom": "sha256-x2WzdVKrEG81YjepLD+gldo/wPD4+casNMsBtFwgqHA="
   },
-  "com/dlsc/pdfviewfx#pdfviewfx/3.3.2": {
-   "jar": "sha256-HmWihBRyah4PHs4xE574h7ubCmi1xEs48BzIjpLEoA4=",
-   "pom": "sha256-DDn3/qcYMDIhxeoVoOrXcxJbmH+k/IF+V/1zlj+5kkI="
+  "com/dlsc/pdfviewfx#pdfviewfx/3.4.1": {
+   "jar": "sha256-0K6aX7Ej1rvwQR9nWJN28aaqBoPB9dJB5uX+4ouRE1g=",
+   "pom": "sha256-StvaJfplK4cTwkMRqKQVP7UvC1pf6SiJOSrefdcCshs="
   },
   "com/dlsc/pickerfx#parent/1.3.1": {
    "pom": "sha256-aUrDFyy6O9PUh4XN3UBHsi++Qk9Kd3G+bK9RwP2/3Wc="
@@ -1207,28 +1150,19 @@
    "jar": "sha256-Sxhrmeu47j3uesKeevLS+/dkeQQ8cj+q1Zaad+WhnBg=",
    "pom": "sha256-6v50YYv2uOH3NAVfC75ayZ7hfLkWxfW8AJppE0uCOb8="
   },
-  "com/ethlo/time#itu/1.10.3": {
-   "pom": "sha256-shihqWmXfQEerG6Ttzo6uwuIQGMK0aHxbr//JOWIbXQ="
+  "com/fasterxml#aalto-xml/1.3.4": {
+   "jar": "sha256-9Kxo2RGEootCBM72sSS4qvQ5sj0/E/WCG1znpnVPXyA=",
+   "pom": "sha256-klKG9TV8CCLMl5lWME+Ly8pvvTE7V3j+4m38BBmIL9c="
   },
-  "com/fasterxml#aalto-xml/1.3.3": {
-   "jar": "sha256-KIKe67NoY7BYEI+hubi1z7lMGHE0bkpPc+aeH+Cl8PY=",
-   "pom": "sha256-lXWPfdZUKR9D0cEJvBwm4lQYe61NyAAuhje/fiMUr9c="
-  },
-  "com/fasterxml#classmate/1.7.0": {
-   "jar": "sha256-y4aPIxxczrideV6gDm4bepO49Kwc4di+dt3jIt/0oEY=",
-   "pom": "sha256-ZHEa3vDskvH2zap7LqwGsuVmekppkez7i/rEZoHVuTE="
+  "com/fasterxml#classmate/1.7.1": {
+   "jar": "sha256-zDKZ5d9PwkGA5pR3yJDQfTjbed0t7MDvIOdKmGiXwKE=",
+   "pom": "sha256-z4m9p/hn2IUOK5Ma8VEcCXX2obhVB6oL/0F5ZQHHpkI="
   },
   "com/fasterxml#oss-parent/55": {
    "pom": "sha256-D14Y8rNev22Dn3/VSZcog/aWwhD5rjIwr9LCC6iGwE0="
   },
-  "com/fasterxml#oss-parent/56": {
-   "pom": "sha256-/UkfeIV0JBBtLj1gW815m1PTGlZc3IaEY8p+h120WlA="
-  },
   "com/fasterxml#oss-parent/58": {
    "pom": "sha256-VnDmrBxN3MnUE8+HmXpdou+qTSq+Q5Njr57xAqCgnkA="
-  },
-  "com/fasterxml#oss-parent/61": {
-   "pom": "sha256-NklRPPWX6RhtoIVZhqjFQ+Er29gF7e75wSTbVt0DZUQ="
   },
   "com/fasterxml#oss-parent/68": {
    "pom": "sha256-Jer9ltriQra1pxCPVbLBQBW4KNqlq+I0KJ/W53Shzlc="
@@ -1239,20 +1173,17 @@
   "com/fasterxml#oss-parent/70": {
    "pom": "sha256-JsqO1vgsnS7XzTIpgQW7ZcD52JnbYXV6CXQVhvqTpjk="
   },
+  "com/fasterxml#oss-parent/73": {
+   "pom": "sha256-SG2NomL0LJwA8+fP/xRxRzNHz8ae3X8GT8lxlN4p1m4="
+  },
   "com/fasterxml/jackson#jackson-base/2.17.2": {
    "pom": "sha256-fPnFn70UyQVnRxN7kNcKleh3YN/huCRWufAjF9W1b68="
   },
   "com/fasterxml/jackson#jackson-base/2.19.2": {
    "pom": "sha256-/779Z5U5lKd12QJsscFvkrqB0cHBMX7oorma4AnSYUM="
   },
-  "com/fasterxml/jackson#jackson-base/2.20.0": {
-   "pom": "sha256-/IgCjRnuqjftpZbmuY03SfIs/IrdGeoZdFq+g2iDzmY="
-  },
   "com/fasterxml/jackson#jackson-bom/2.17.2": {
    "pom": "sha256-H0crC8IATVz0IaxIhxQX+EGJ5481wElxg4f9i0T7nzI="
-  },
-  "com/fasterxml/jackson#jackson-bom/2.18.3": {
-   "pom": "sha256-8dTGrrMhGGUMgF/pu8XulA+o8s19DwT6Q2BVHponspA="
   },
   "com/fasterxml/jackson#jackson-bom/2.19.1": {
    "pom": "sha256-um1o7qs6HME6d6it4hl/+aMqoc/+rHKEfUm63YLhuc4="
@@ -1260,14 +1191,8 @@
   "com/fasterxml/jackson#jackson-bom/2.19.2": {
    "pom": "sha256-IgBr5w/QGAmemcbCesCYIyDzoPPCzgU8VXA1eaXuowM="
   },
-  "com/fasterxml/jackson#jackson-bom/2.20.0": {
-   "pom": "sha256-9ig2R+cB/aHNMS3MIcsTKkD3mPGejkL6/D/jR8WlG7s="
-  },
   "com/fasterxml/jackson#jackson-parent/2.17": {
    "pom": "sha256-rubeSpcoOwQOQ/Ta1XXnt0eWzZhNiSdvfsdWc4DIop0="
-  },
-  "com/fasterxml/jackson#jackson-parent/2.18.1": {
-   "pom": "sha256-0IIvrBoCJoRLitRFySDEmk9hkWnQmxAQp9/u0ZkQmYw="
   },
   "com/fasterxml/jackson#jackson-parent/2.19.2": {
    "pom": "sha256-Y5orY90F2k44EIEwOYXKrfu3rZ+FsdIyBjj2sR8gg2U="
@@ -1277,11 +1202,6 @@
   },
   "com/fasterxml/jackson#jackson-parent/2.20": {
    "pom": "sha256-tDt/XGLoaxZPrnCuF9aRHF22B5mvAQVzYK/aguSEW+U="
-  },
-  "com/fasterxml/jackson/core#jackson-annotations/2.19.2": {
-   "jar": "sha256-5RZ0OjFtz4PFcv/Jy26MXowTSIDIxRVbAvezTpxdw88=",
-   "module": "sha256-MZtf0wd2wFk8yNxajX4ITkuQcJpDUGQYQqu9WfyByBU=",
-   "pom": "sha256-SVAWGuCtZsaze8Ku0S0hxleeF3ltv86Yixm40MIjpck="
   },
   "com/fasterxml/jackson/core#jackson-annotations/2.20": {
    "jar": "sha256-lZov+y1ZFDb1Hxg8alIfyJNHkS9xG/DK4AjN8EXZUxk=",
@@ -1293,53 +1213,34 @@
    "module": "sha256-Ua8uZ3g6XXJETeajB8jj7ZMAklbNJ+ghkVVZohZcCUI=",
    "pom": "sha256-gfatIwlG88U9gYwZ/l7hEcH6MxuRXEvajQGC5rT/1lA="
   },
-  "com/fasterxml/jackson/core#jackson-core/2.20.0": {
-   "jar": "sha256-vAz0YHWHcgH4QG7n3idBrn32wGb18EV72AYypxjAbnI=",
-   "module": "sha256-2oWNOW9/pritA4zVzLkDj7ORq3o2rmKWI+N6UyR537w=",
-   "pom": "sha256-XxZVisIjBzpvJHRA8wX1nwXv9QqvHurguq1BKAABb2g="
+  "com/fasterxml/jackson/core#jackson-databind/2.17.2": {
+   "module": "sha256-9HC96JRNV9axUMqov1O7mCqZ6x1lkecxr8uXKrPddx8=",
+   "pom": "sha256-0kUGmLrpC+M48rmfrtppTNRQrbUhJCE+elO0Ehm1QGI="
   },
   "com/fasterxml/jackson/core#jackson-databind/2.19.2": {
    "jar": "sha256-ChvU6bDWcOYy1A7oxiWtN2IzUC8DwvWIm66pXQJbR6c=",
    "module": "sha256-xgFVg0SRj0CDS7bVg4EepsiDvwaigXmkx04voYswbGg=",
    "pom": "sha256-2KebdQK2m/JQaEwZCpiCOJImaG1dlikGdW2BzVskO4I="
   },
-  "com/fasterxml/jackson/core#jackson-databind/2.20.0": {
-   "jar": "sha256-pw4Uamvyy6T5zTZxaXh/UK3Pu1cSK8LpyDkM0LOXrDA=",
-   "module": "sha256-oSgvNhZKyQG66p7bULqYE3L/7hjCz7F75CW5s/dYeuI=",
-   "pom": "sha256-zv7+0B3SwNlqiOEBuz4GX8FQBjtJjjAak4xpCwK8884="
-  },
-  "com/fasterxml/jackson/dataformat#jackson-dataformat-yaml/2.20.0": {
-   "jar": "sha256-zD3sn7i1ZXR5e/72JkEyVQjw5byWi9JoVoQCgY1Vuq4=",
-   "module": "sha256-ZA8QhiTO8o1t6jJ+KC6eyC9lEhVY5gkcqPuJlfkUpac=",
-   "pom": "sha256-rpwz0EFZBkwZsuq0FIiU+jHxVjW7/lMYzjIp+OFHCcU="
-  },
-  "com/fasterxml/jackson/dataformat#jackson-dataformats-text/2.20.0": {
-   "pom": "sha256-RH4cfT+o2Skn3L2DjSRGOAXohi9yPM7VENUNrrhPgLQ="
-  },
   "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.17.2": {
    "module": "sha256-eG+CJvp0Tkyw3/M7pt+MLv8kd2PixpwhkP1SesSrrmw=",
    "pom": "sha256-3fwpGHlF2jpkLCK4cP1keg30smJYIK/DXLeldGkWjsQ="
   },
-  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.20.0": {
-   "jar": "sha256-Pq6dtKTruBwzBnq2aDobEpZzF5V/QzxdzsKoWSN8SHc=",
-   "module": "sha256-2gH0D0MTgHgHN4crpPKPY9nySFLjLWXg+kJPtY2KFgI=",
-   "pom": "sha256-n2YSsgn9bSeizmJPneGWtK/jQuakfx1OeXDG23fwmXk="
-  },
-  "com/fasterxml/jackson/datatype#jackson-datatype-jsr310/2.20.0": {
-   "jar": "sha256-jDIVWXWpNbH3v9Z3ZHvVyM3uErFEuE5EkqRHteoulNU=",
-   "module": "sha256-GLsOOniabs0DmHNhBUEU3jf6hrB98wzeKuEO2L3LFgw=",
-   "pom": "sha256-DPgn58+QwbLF/C2PIXWgKO5ylG1rWN4YL7/ZDlTO1Zk="
+  "com/fasterxml/jackson/datatype#jackson-datatype-jdk8/2.19.2": {
+   "jar": "sha256-YFX+8QdW6L0bDogHqh2IEzjGPKldWSceHaSSK5oXWB4=",
+   "module": "sha256-cJMXXvltnjxoFL59n5uQeZzGsd/JDqi8ZUVP9byleEo=",
+   "pom": "sha256-u2kaYgtZPgNo7zrOifnc1dY3VtXlvAXdyay3ih/Ny+c="
   },
   "com/fasterxml/jackson/module#jackson-modules-java8/2.17.2": {
    "pom": "sha256-PznFUQn1GiKIF7SxheQ1G57wUBwJ/B4aMHWulUfMLQM="
   },
-  "com/fasterxml/jackson/module#jackson-modules-java8/2.20.0": {
-   "pom": "sha256-jhXY4aWgLsdHIj8j4OSkmv5vZVUERDysO47pkvqWxSU="
+  "com/fasterxml/jackson/module#jackson-modules-java8/2.19.2": {
+   "pom": "sha256-o8wywUW5Yr45UE+FNsrGISTry1rVAy2TC8ck/flOgqQ="
   },
-  "com/github/ben-manes/caffeine#caffeine/3.0.5": {
-   "jar": "sha256-iptU01BqO5LuRrIXvO55GWshym1S3ClnxoaiBfsvnBU=",
-   "module": "sha256-MNqUAgRzgsSZ0djzcgH8Ead8mTTSxYa8WkKvrEr6wrI=",
-   "pom": "sha256-vM/bJH7Xa1K7sUMMIoLEO61BjtPGl7TiqVrQmbvyXPg="
+  "com/github/ben-manes/caffeine#caffeine/3.2.3": {
+   "jar": "sha256-ynDJCl0c4VEYgM6ck9StIhCPYREdPa+R61J2K1cb0Xk=",
+   "module": "sha256-jZo7mA6b1wQS7jObJFYxNhezuK4uhon5s8vwZAzVjzw=",
+   "pom": "sha256-n3BPkIN5e099DB1chV00zSaNVEzwa0KD1c5CiKz8nuA="
   },
   "com/github/hypfvieh#dbus-java-core/4.2.1": {
    "jar": "sha256-Onuf1UOhvpTemQCcNqwYA/CNbRI1dwbI9QQIVTFUadE=",
@@ -1367,17 +1268,6 @@
   },
   "com/github/javaparser#javaparser-symbol-solver-core/3.27.1": {
    "pom": "sha256-pc/rihPH9G7kilI87mX+9KJHrG2ivpnoFKC42ooovVg="
-  },
-  "com/github/jknack#handlebars-helpers/4.3.1": {
-   "jar": "sha256-VvCtTe+0RLA4pwio4NADaS3xuRK5EhlzanZN6I/3hnw=",
-   "pom": "sha256-AYv9plPb9sQZG3sF/k7+2KPY1w495wp77RsYim3ibNI="
-  },
-  "com/github/jknack#handlebars.java/4.3.1": {
-   "pom": "sha256-UECkDYFTRzveednE1O+4cSChaQ+uWFtYKAcH1DdCCZk="
-  },
-  "com/github/jknack#handlebars/4.3.1": {
-   "jar": "sha256-VCT9EukRzxW+/RY0G0bg4bxoGqYePLHAcMV+aNzNW70=",
-   "pom": "sha256-/DAp8kYk6YvWC1pGmSEPP1YKOUiTQpzQbMrYROj41BU="
   },
   "com/github/kevinstern#software-and-algorithms/1.0": {
    "jar": "sha256-YauCQ5zvNzQ7FPUxVMRhYZN1NzpWuTOOiVcJ+1Tghkw=",
@@ -1413,22 +1303,8 @@
   "com/google/auto/value#auto-value-parent/1.9": {
    "pom": "sha256-Lj2d/2OWAcq4gdfhcIBry9jgMffr/yWcu0W+V7TL14c="
   },
-  "com/google/code/gson#gson-parent/2.13.0": {
-   "pom": "sha256-bNRgu0Rf977gqbtmJwJkh0RXgCxUGJlFY4IYSvNNFqI="
-  },
-  "com/google/code/gson#gson-parent/2.13.1": {
-   "pom": "sha256-+IEKzlDd/j/ag9ESbeZdmdXSUVoUo2uIvrG5mkdpeDY="
-  },
   "com/google/code/gson#gson-parent/2.13.2": {
    "pom": "sha256-g6tSip1Q/XauuK1vcns+6ct2ZYYlV3TtFsqMTHbZ2s0="
-  },
-  "com/google/code/gson#gson/2.13.0": {
-   "jar": "sha256-jGp0K3T4aaefOfXHjMCZmfmfO2r/YwT87db1Q+J++ng=",
-   "pom": "sha256-AuRJJF3rSlZG8BXOzxEk7lvTe1Ue7YHf0JAVG0Vu/0w="
-  },
-  "com/google/code/gson#gson/2.13.1": {
-   "jar": "sha256-lIVZQtSZLxEpRtPeHDNOcJI3uBJtgTC/B4B8AYpKISA=",
-   "pom": "sha256-wPZXItdcDljNGDWzBGBG9ga12mmZBBYfjba3j+ubQBo="
   },
   "com/google/code/gson#gson/2.13.2": {
    "jar": "sha256-3QzhtVo+0ggMtw+cZVhQzahsIGhiMQAJ3LXlyVJlpeA=",
@@ -1441,13 +1317,9 @@
     "release": "2.13.2"
    }
   },
-  "com/google/errorprone#error_prone_annotation/2.42.0": {
-   "jar": "sha256-6O9uAxS9CrVZXkJ0t894lkxSVoWCeuX089D+/7TaXxE=",
-   "pom": "sha256-MEn5AqmV9qu6xJm5Q4wv0lS99A7QpzPSqvBEIh3agCA="
-  },
-  "com/google/errorprone#error_prone_annotations/2.37.0": {
-   "jar": "sha256-0ppiY7SNRtTHwotkcXptEFs+Kj5kJWCS+EXo53T8pro=",
-   "pom": "sha256-nBm0OV6yKL6yEJXdMdVa2V+bcnKYNpuShL0jMOi2LaI="
+  "com/google/errorprone#error_prone_annotation/2.44.0": {
+   "jar": "sha256-zWlNRVWHQMkFSQAs/z6PjP+q//Ai9TigS7jQook+EV8=",
+   "pom": "sha256-GPtw0vTOH/dgIV2HIXe4OvqaALTIYPCiMKaMVP55Y6g="
   },
   "com/google/errorprone#error_prone_annotations/2.38.0": {
    "jar": "sha256-ZmHVM1CQpfxh3YadIJW8bB4hVuOqR6bkq6vfZMmaeIk=",
@@ -1457,20 +1329,21 @@
    "jar": "sha256-pW54K1tQgRrCBAc6NVoh2RWiEH/OE+xxEzGtA29mD8w=",
    "pom": "sha256-oVHfHi4LSGGNiwahgHSKKbOrs5sbI5b2och5pydIjG4="
   },
-  "com/google/errorprone#error_prone_annotations/2.42.0": {
-   "jar": "sha256-8oKmSIg4mGuAM71RiIkoz/alnBBQQmR2VT7SYiuJ5RA=",
-   "pom": "sha256-r9/wIhQuSJ7lRS6KSgiOLdPndkBWSyMj6e+EeHLwbP0="
+  "com/google/errorprone#error_prone_annotations/2.43.0": {
+   "jar": "sha256-SCcudcFuH3vce9GVKcys1e4XBARwHX9aI0QbtYR5V/U=",
+   "pom": "sha256-T2uIia+o3r2+Hj/ipfjmbiIWygtWPya05UE4cw7s3IA="
   },
-  "com/google/errorprone#error_prone_check_api/2.42.0": {
-   "jar": "sha256-d9z8e4mqHwlBREJ9Mw1SAo6Fc/V038kYHBOsmtjRqTU=",
-   "pom": "sha256-E4cgJOTwd9ZEAu6vuZk+auW9GGPDhDJ3MyLj3teUSX8="
+  "com/google/errorprone#error_prone_annotations/2.44.0": {
+   "jar": "sha256-vPc4pSXlRskmojPQoWnPfq/PcD/oGsnWmU9yRO2ikFI=",
+   "pom": "sha256-fmGVkFEuhKKOAjWK3qvn3kureQr2FOhAtAQTlRbeFlc="
   },
-  "com/google/errorprone#error_prone_core/2.42.0": {
-   "jar": "sha256-Ofv13fwqr88MnEfgZNS0MmqZU/PtGX/N1SD3e01k7TE=",
-   "pom": "sha256-B+TX1Nuy8gvyK+ZFOy/aVETo9RQaBTkj7rkcTlEN/rU="
+  "com/google/errorprone#error_prone_check_api/2.44.0": {
+   "jar": "sha256-rFRNsezoAFm1NJU93Ipa/PZUfCCrnBtQC5kHGQOQDL8=",
+   "pom": "sha256-Nl9VFHNSFSwr9syl+uNdspsxDqR4A/neWuRL/k1d+jo="
   },
-  "com/google/errorprone#error_prone_parent/2.37.0": {
-   "pom": "sha256-SmWUVg9cwGyJ2vzEn4spHxJ83bon1CYFliKhmrjWzkc="
+  "com/google/errorprone#error_prone_core/2.44.0": {
+   "jar": "sha256-3K8Higb7HPuj5dRkRIrTDwERB6OdaSQg2YetU8jlnew=",
+   "pom": "sha256-GSe9Wd9Xlv2pXW2z/4rT/y2ioGUmYSGtgLG0mjyS3+0="
   },
   "com/google/errorprone#error_prone_parent/2.38.0": {
    "pom": "sha256-5iRYpqPmMIG8fFezwPrJ8E92zjL2BlMttp/is9R7k0w="
@@ -1478,11 +1351,11 @@
   "com/google/errorprone#error_prone_parent/2.41.0": {
    "pom": "sha256-xTg4jXYKXByY3PBvbtPP5fEaZRgn21y9LtgojHlcrUI="
   },
-  "com/google/errorprone#error_prone_parent/2.42.0": {
-   "pom": "sha256-YolCpNYTZBj92nOUhBcOY4B250E/zJ6E9xutJUvWICA="
+  "com/google/errorprone#error_prone_parent/2.43.0": {
+   "pom": "sha256-u5LEWE0CEb1ZvspPsnYXD13FD+NGFG6TV40tqyYDPhA="
   },
-  "com/google/errorprone#error_prone_type_annotations/2.37.0": {
-   "pom": "sha256-69Fv9A5HxZg71f1iL0ym71cWPowYU+OilsOtKUYnUdY="
+  "com/google/errorprone#error_prone_parent/2.44.0": {
+   "pom": "sha256-9v3+0f+Ubr0B9HgCSux5CBz16XbMDY6MmL+GMXOxY10="
   },
   "com/google/googlejavaformat#google-java-format-parent/1.27.0": {
    "pom": "sha256-rOuKJTTBnTBcBY8iq0ffOaDhm3QIWx5MWwfTukXYQlA="
@@ -1532,25 +1405,21 @@
    "jar": "sha256-LIIlzXOyOUOCudABbZJ4oAKRViIkpZTu8AwApqxQvAQ=",
    "pom": "sha256-fqc4xbuppSWxP3KDW9aBOFPZgHMf9Kuiy4uo4OWA7Zg="
   },
-  "com/jayway/jsonpath#json-path/2.9.0": {
-   "module": "sha256-5ikAQ9rpOnDZqz+hvrh56M9e1ajgqQGD+5bCUVqXCD4=",
-   "pom": "sha256-DCU33em/ncKix5ZzAPwTvFIp0ZJnf8uItv2Jlmk2ZD8="
-  },
   "com/knuddels#jtokkit/1.1.0": {
    "jar": "sha256-FQHOAlmriXxnRsz6+h0gis1AT7F+GsYuFXFy8meLEYM=",
    "module": "sha256-QxxAPs80ROw72ZNJIvNpOf1vCClXmpolySdBmSzVjC8=",
    "pom": "sha256-cfjoMOMzqx9I5NAy7FSiu4J6Zk+crtGlo8h815W+8eA="
   },
-  "com/konghq#unirest-java-core/4.5.1": {
-   "jar": "sha256-hzS58uio16ATB/9TLutw7rPwRFvPimeY2u6fRSjF9uM=",
-   "pom": "sha256-G8IxK1eWPVaavo0VZdyYmXkvsWGaiahuLncZTfBegc0="
+  "com/konghq#unirest-java-core/4.7.0": {
+   "jar": "sha256-vrG2r47OzMOXs83OhvWcLIeSzQmO7mllaYY6bl10l8Q=",
+   "pom": "sha256-HMU/jIc5+Wgzi9DOQU++WbDGc6fB06JQfY+CQizHW+M="
   },
-  "com/konghq#unirest-java-parent/4.5.1": {
-   "pom": "sha256-Op85yzb/PrKGx4BNG2tAW9QdBTlA3mcL6LQuEPfLGIE="
+  "com/konghq#unirest-java-parent/4.7.0": {
+   "pom": "sha256-hflUAkAOOKwySYOxi/sQtwuZQt1V6SpONXiUx4tbw3s="
   },
-  "com/konghq#unirest-modules-gson/4.5.1": {
-   "jar": "sha256-vCLl5VY1vvywEjMmOCqao27fw5+Y2smBloskQ8Myy3E=",
-   "pom": "sha256-2oBvnNCenHShoeLh1IJ9qItegtH8BPzvS1VpU/6oHdE="
+  "com/konghq#unirest-modules-gson/4.7.0": {
+   "jar": "sha256-Vkqs1zMxmn0BtQ/Pg5cvAdhFCFU3JwzX91agvVpOpzY=",
+   "pom": "sha256-5Lh7puKpRzeyuJi+yk9RFgES7LyVRZpLzeXgH8BIzmM="
   },
   "com/lihaoyi#fastparse_2.13/2.3.3": {
    "jar": "sha256-dXipnwkfW7pdj+2IFhn8rZraeU0/N4dWBwrViUPxBVE=",
@@ -1563,9 +1432,6 @@
   "com/lihaoyi#sourcecode_2.13/0.2.3": {
    "jar": "sha256-B5T8EGEH001xEB6tCzGyxIJzc32JGXu/mxusb/MqtXY=",
    "pom": "sha256-oiq0AqkyzobUAcU3A01FPzeuq1nlJMKIalwgeVB92jU="
-  },
-  "com/networknt#json-schema-validator/1.5.6": {
-   "pom": "sha256-e/wlpTWWxa1g1qLRQ+BPC1weA9u2IGjnpl9q3YiCl5w="
   },
   "com/pixelduke#fxthemes/1.6.0": {
    "jar": "sha256-Lw53pVtUPDjUlpYEFr40sRZzLeNYvG7mtg6ANY9MD9s=",
@@ -1589,10 +1455,10 @@
    "module": "sha256-9Lg+E7Rr8Q9cccDL82M54X4ttXZwDaNElfulX063g24=",
    "pom": "sha256-hwO2W8qKgsj6H3DHt4FTtAx5FrKQUS/PmA5/IaZQpzc="
   },
-  "com/squareup/okio#okio-jvm/3.16.0": {
-   "jar": "sha256-xzfANcpnUYe/EaZ925WBlUvw1cqfPgSOg4syZ88ytcM=",
-   "module": "sha256-h5N9uN2s/m54G1UOVcRgEvRtuvEggD2phbshf0eXWJA=",
-   "pom": "sha256-UZpRemxp4bmF6BsNm3XT3kWjg4aI46CUjnpTYeVHOPM="
+  "com/squareup/okio#okio-jvm/3.16.4": {
+   "jar": "sha256-IZa5k800272Rnn4B9XpHgbWL7oD4YQYWPih8IDQ6lqc=",
+   "module": "sha256-kAjVopVKBoxoSCdPbuvf9IsUpw28aT0zAuCMVwzKAy8=",
+   "pom": "sha256-ZnePTQWXvOY/kewADFdcwCmzIB990JLLgIh1FVs+hqE="
   },
   "com/squareup/okio#okio/3.15.0": {
    "module": "sha256-EWgmBmzrTTM2p05xcqM3UWF+w0S8UKNPmbDSSVmko50=",
@@ -1741,8 +1607,11 @@
    "pom": "sha256-f6DbTYFQ2vkylYuK6onuJKu00Y4jFqXeU1J4/BMVEqA="
   },
   "commons-codec#commons-codec/1.18.0": {
-   "jar": "sha256-ugBfMEzvkqPe3iSjitWsm4r8zw2PdYOdbBM4Y0z39uQ=",
    "pom": "sha256-dLkW2ksDhMYZ5t1MGN7+iqQ4f3lSBSU8+0u7L0WM3c4="
+  },
+  "commons-codec#commons-codec/1.20.0": {
+   "jar": "sha256-avZllfn2p7tYzmZRjWiI1AtUfDZtImLwZnbu4ZUo/2Y=",
+   "pom": "sha256-r/ZFxYzUGsUYTZds6O443laU2Zq4dk1u5/FPcOrV+Ys="
   },
   "commons-collections#commons-collections/3.2.2": {
    "jar": "sha256-7urpF5FxRKaKdB1MDf9mqlxcX9hVk/8he87T/Iyng7g=",
@@ -1752,12 +1621,9 @@
    "jar": "sha256-4LK5gKhPxlM8XOKR8ZF7MsUH9ivK1kGY//RDaMIZaj0=",
    "pom": "sha256-FaWcDnV8bAfD0baJ1zXI46nsVpXWzrapQdQGKrIpAbc="
   },
-  "commons-fileupload#commons-fileupload/1.5": {
-   "pom": "sha256-zHIPHgWDV52f5Tk8iE7kbQ10+Z0fm6AXsXKzHqGJ4rE="
-  },
-  "commons-io#commons-io/2.20.0": {
-   "jar": "sha256-35C7oP48tYa38WTnj+j49No/LdXCf6ZF+IgQDMwl3XI=",
-   "pom": "sha256-vb34EHLBkO6aixgaXFj1vZF6dQ+xOiVt679T9dvTOio="
+  "commons-io#commons-io/2.21.0": {
+   "jar": "sha256-fWQ6Kv6osFi3YqpvuQ5bJW9scpc5+LN4TDNw3cYJ6I0=",
+   "pom": "sha256-rkd5XnIYA+yP8d7tdL4oqBGgJxO9WjqwrGfCtYy2Nas="
   },
   "commons-logging#commons-logging/1.3.5": {
    "jar": "sha256-bXp0TkAnZJ+7UIld+Ul9EJ+Yx2amNwYv6NLqu7MUC6Q=",
@@ -1857,81 +1723,85 @@
    "module": "sha256-hYXA4tg94OvQdHoIYgHVFkocGMac7CNkOzKInK+nplc=",
    "pom": "sha256-usoMboDZwvbgb1ZjNVPJL+gECIGhPJ1jCdOtCbHFQAI="
   },
-  "io/github/classgraph#classgraph/4.8.181": {
-   "pom": "sha256-kj4br0msZAeQ30WHuMz0AfYG8L/HBZZh9xhVG2Jw8Ug="
+  "io/github/classgraph#classgraph/4.8.184": {
+   "pom": "sha256-N7I1NJqAx1rokS+gCO3unouINL52mortCLp0xbCvgeA="
   },
-  "io/github/darvil82#terminal-text-formatter/2.2.0": {
-   "jar": "sha256-MfiZaC/y+NgogMWn41JR2fxoLJ5ZDbJcJyD/U0sTz1Q=",
-   "module": "sha256-283Z1+Tg06hSf1y3YdrCOyoQsdyf9gjUVFSSW/t2mk4=",
-   "pom": "sha256-f0eR6KhW9qojX3wmNptBqcAqOQUWBmsc9jF+wqH6L1o="
+  "io/github/darvil82#terminal-text-formatter/2.3.0c": {
+   "jar": "sha256-fmV4AIRX4Ztj+ovcIdMX+KNjTawswCGqVWgYr/zWjqg=",
+   "module": "sha256-QQEFGQh1NP7lkfhnQsF9n68nrICcbAPTE8qC8vTsAy8=",
+   "pom": "sha256-CGo8cNJRD5xXify/nwO9t9VclCv54BfuLrbSp8d5Dnc="
   },
-  "io/github/darvil82#utils/0.7.1": {
-   "jar": "sha256-ifcK6Ss6PJLm27m+PJHCjJSfSjmhfEvmbMJmPMl2GHM=",
-   "module": "sha256-Xv+x8FagR3nDzKTzrDi+rGqugjUyK+IF5nE44j0ccsQ=",
-   "pom": "sha256-/fFozhF1Mtmmu/IbpLr6kUuCc3Yhs/ACfdsIrDrXPR0="
+  "io/github/darvil82#utils/0.8.0b": {
+   "jar": "sha256-fjFIIzSX3MQMq/r+/NbWS9OQQQTQ74PwfIXMZiqmJHA=",
+   "module": "sha256-yQ3Zxs48wjBo4u23xXMR2wEZMOn/kDWABuf5cXHBAzw=",
+   "pom": "sha256-6T3YGIOl4gLoGhBjyGTrUBVajl6tT6a295eorLSR7wg="
   },
   "io/github/eisop#dataflow-errorprone/3.41.0-eisop1": {
    "jar": "sha256-EENPuk5T9V+px2kEzeQUuRiTJUjJ38Ti1jSsBf96fRA=",
    "pom": "sha256-I/HN+kYTwAzG6lyfU2DhRxtEn4JjPxPPX/bNs0+jHr0="
   },
-  "io/github/java-diff-utils#java-diff-utils-parent/4.15": {
-   "pom": "sha256-CefUSnz6GbxrI8rRTsCkHzKuC1l/Dias6RkW/cK7XII="
+  "io/github/java-diff-utils#java-diff-utils-parent/4.16": {
+   "pom": "sha256-pDRNpY5TqOjFe+Gekjut8ksn3UKwfebURtKmWaRWUJo="
   },
-  "io/github/java-diff-utils#java-diff-utils/4.15": {
-   "jar": "sha256-lkxp46I6iS2yd4rmgGqh1C+BIwAyvY5JgtyGIFgu5rc=",
-   "pom": "sha256-Gt8qYOhitxqmlKPo5qiIqjU/r/UFlHfrv9yrzTo/+S4="
+  "io/github/java-diff-utils#java-diff-utils/4.16": {
+   "jar": "sha256-YgQDAw1nakon94CjrOx0ON7hsWUaHIBPprsRuwc5mm8=",
+   "pom": "sha256-Q01Zih4YExEThSNRYWJ6TE69YhNPcFRCjT4gKzLPOd4="
   },
   "io/github/stefanbratanov#jvm-openai/0.11.0": {
    "jar": "sha256-xPzxC/BQ198fJ6UNBE+H3nDEmbt7MTDJeoWkuhAPDy4=",
    "module": "sha256-ZGQms3XvHPIxNpJDGVsdgcBV5OKcG+BDMGjYAZ1RLAc=",
    "pom": "sha256-NU6HjGIom9LFsjtidmUGBJESMU+mFS7J+XpTuzOb1n0="
   },
-  "io/github/thibaultmeyer#cuid/2.0.3": {
-   "jar": "sha256-qk6RPsJ+ucuZkXcx/LeZ57WueMDcPz6QOPBwf1pasrY=",
-   "pom": "sha256-AF9eKRgpy68hc7p2BUcJWRMo4uhHGES+6oayyu8DDwI="
+  "io/github/thibaultmeyer#cuid/2.0.4": {
+   "jar": "sha256-ThsaAKO3aVlMjY9dp61WmqhnqBuHWo54b6wEqBnriAc=",
+   "pom": "sha256-PLCprpRMOMgu60mgVm+2lxpBWnmaOgjUKeACNxoAdH8="
   },
   "io/zonky/test#embedded-postgres/2.1.1": {
    "jar": "sha256-txrgUlEpZ+o6CuOJgIkvgFdza67C96nrhRaQrUlAzis=",
    "pom": "sha256-utspdh18ivb3Gkl0tpY9mgocG51daf3oFjfGsfZGjGs="
   },
-  "io/zonky/test/postgres#embedded-postgres-binaries-bom/17.6.0": {
-   "pom": "sha256-n0HACqk5C+WZYlGnbZ9XwV5ZqY0ETc9XUNdjfm3105Q="
+  "io/zonky/test/postgres#embedded-postgres-binaries-bom/18.1.0": {
+   "pom": "sha256-rM8WPQuBWwALzewhj8l/OTN4RS+Xcyfwcr1BQ2CYmeE="
   },
   "io/zonky/test/postgres#embedded-postgres-binaries-darwin-amd64/14.19.0": {
    "pom": "sha256-FLhurgoE1tG4h5+5GjsmGGM7HiwfDBwapJq/RZijHX4="
   },
-  "io/zonky/test/postgres#embedded-postgres-binaries-darwin-amd64/17.6.0": {
-   "jar": "sha256-8dbTmJbKSOZdbby0ktgJ3w1JUsZSmd6K9uCNIgjq4+A=",
-   "pom": "sha256-7gS39XfUDVoOTtm3sANATtRSX3TKCszZT7gRS5O4i5U="
+  "io/zonky/test/postgres#embedded-postgres-binaries-darwin-amd64/18.1.0": {
+   "jar": "sha256-O08W3PVyUNj5xeknCn38OSG2bWZTTQD482boJj6GLRE=",
+   "pom": "sha256-rBkS1B68++ESgiKFkkG7ELadGDhPfgBPaLTILr+mHxY="
   },
-  "io/zonky/test/postgres#embedded-postgres-binaries-darwin-arm64v8/17.6.0": {
-   "jar": "sha256-6H7jZ2fe5PAPgp16UuSiFuL96+WTTFaDcwlAqr5XByE=",
-   "pom": "sha256-ATLl5guk2rgiPRTwMx81pCjI/w+iJCGUBCqtE55zpQE="
+  "io/zonky/test/postgres#embedded-postgres-binaries-darwin-arm64v8/18.1.0": {
+   "jar": "sha256-c5jGwZ0RWUqUTcDdx5/bthEWQxLh9QmoyGsJckAnQB4=",
+   "pom": "sha256-ser0IOUIpYaYvlHyg49iL9tTi/n8t1HAkFFbosX7K8s="
   },
   "io/zonky/test/postgres#embedded-postgres-binaries-linux-amd64-alpine/14.19.0": {
    "pom": "sha256-iljFNphFYXpVHn0f2erjjceSL6agTBunS7j7m2SafjM="
   },
-  "io/zonky/test/postgres#embedded-postgres-binaries-linux-amd64-alpine/17.6.0": {
-   "jar": "sha256-hYS8angY6WNE0pFzNGCh/suY8TPf1766lfxX5LAvBGI=",
-   "pom": "sha256-O2TRvK6S2WwNHULK+x+GtpLPaHx6GTRQKzT3PJQAmG0="
+  "io/zonky/test/postgres#embedded-postgres-binaries-linux-amd64-alpine/18.1.0": {
+   "jar": "sha256-hF5IIlr+QE1RVhCCM/7qdGJTIy8cLiF/7RYoYmgCEgk=",
+   "pom": "sha256-ZQaVEGjghW12eNoDjSw3FTeUBSpqYH9mF9Yy6r3XINs="
   },
   "io/zonky/test/postgres#embedded-postgres-binaries-linux-amd64/14.19.0": {
    "pom": "sha256-JNywnlVuwoQ7x7bTR7U11r3Q80xqu8Rjq9fu9cIeJP0="
   },
-  "io/zonky/test/postgres#embedded-postgres-binaries-linux-amd64/17.6.0": {
-   "jar": "sha256-I9paBEtPt6WggaRQCMlXSchzMFMo1z+Grv1Wkizh0p0=",
-   "pom": "sha256-DLyVzA+fPMGdkjprqaHcN9RKcRl4nzaeBlYdyb3K2dU="
+  "io/zonky/test/postgres#embedded-postgres-binaries-linux-amd64/18.1.0": {
+   "jar": "sha256-ZdByPgJ0rT7GIw3L3+A0r27glvzhWnew+bi+cdJwKTQ=",
+   "pom": "sha256-md4tr9pbBzQ5vbmv6tSUyGaFDBAsYNBxsmXsNJymCVk="
   },
-  "io/zonky/test/postgres#embedded-postgres-binaries-linux-arm64v8/17.6.0": {
-   "jar": "sha256-hEJ+pUpSOCR5JO87D5QOfQJ+WHYPGdcyUkLlDSL6AUo=",
-   "pom": "sha256-pI2qmGIcvwgtc+61g0GRW73K8g/m92m1qzGo6QCsecc="
+  "io/zonky/test/postgres#embedded-postgres-binaries-linux-arm64v8/18.1.0": {
+   "jar": "sha256-6g8Wt1T8ChDZ2Jk7vUJsIPjHCbMYso5JtC2crByVi48=",
+   "pom": "sha256-5GI/jei/YOFy1FXK3cMcEeaCI/KAQWoctUCQoApBsJE="
   },
   "io/zonky/test/postgres#embedded-postgres-binaries-windows-amd64/14.19.0": {
    "pom": "sha256-MeCJzI5PDPreCd3t6paoqbUi1wuGudsEzs3iAy504To="
   },
-  "io/zonky/test/postgres#embedded-postgres-binaries-windows-amd64/17.6.0": {
-   "jar": "sha256-yR05ttuRz4gR47INlB50oDluJ3Nghzgh2qtHzbTBKCw=",
-   "pom": "sha256-rdf2XFadF1hvicGy2AbRpU0Ma0agSxWNEW+gvrpOirI="
+  "io/zonky/test/postgres#embedded-postgres-binaries-windows-amd64/18.1.0": {
+   "jar": "sha256-Cn6VFmDLvuPzgvi0Syw64mxKF4F8Opct7jN4yA/Jsjs=",
+   "pom": "sha256-3N1luh4SY3a714teD9HrmjETd0M32Xcm1R+xUHnABiA="
+  },
+  "jakarta/activation#jakarta.activation-api/2.1.3": {
+   "jar": "sha256-AbF21xihaSY+eCkGkfxHmXcYa8xrMzSHMlCE1lhvRic=",
+   "pom": "sha256-slSZQMF7aGWjT2E1t3Iu2Mv+9tC2wNs3LDDwNGvIzVg="
   },
   "jakarta/activation#jakarta.activation-api/2.1.4": {
    "jar": "sha256-ydtSEAzmyKrJXMOQdflXINLlYbEfgFG4HBIa1O/9cAQ=",
@@ -1951,8 +1821,9 @@
   "jakarta/platform#jakartaee-api-parent/9.1.0": {
    "pom": "sha256-p3AsSHAmgCeEtXl7YjMKi41lkr8PRzeyXGel6sgmWcA="
   },
-  "jakarta/servlet#jakarta.servlet-api/6.0.0": {
-   "pom": "sha256-PVolnfvSuUDklcMFy6K2BhWSPcgXjgMrfvYMuyQThDk="
+  "jakarta/servlet#jakarta.servlet-api/6.1.0": {
+   "jar": "sha256-ijH0ZfNZO/I1FTGlyVIBTrg52pamBbWCW5PdVHFMSMQ=",
+   "pom": "sha256-G6+Lb6bQIYAwINCXDqQ/sH32beZskNKZohZ3Dwsz5K4="
   },
   "jakarta/validation#jakarta.validation-api/3.1.1": {
    "jar": "sha256-Y84AFWOIw2XzrBvnH8+vEUaC/AxFICC1325+wjbhQqs=",
@@ -1972,6 +1843,7 @@
    "pom": "sha256-T2Jvmnj4adPssUuUOjXlmas8psJZx1SxDwbfvKXWwGk="
   },
   "jakarta/xml/bind#jakarta.xml.bind-api/4.0.2": {
+   "jar": "sha256-DWvP5Hdj6FBHrPfDmDNtyE/4XrytCny287nT6YEkVAY=",
    "pom": "sha256-q3Jz4mpUgks7czPUlW5uzSbeE6XrPZDuYwIxk6ktcr4="
   },
   "jakarta/xml/bind#jakarta.xml.bind-api/4.0.4": {
@@ -1997,22 +1869,19 @@
    "jar": "sha256-qbqIfcolKtYbfVFTKU805vO99LJzawQ3PRNhWmlfwP8=",
    "pom": "sha256-gU7kLWsBF/S40etrHWLBbbTAtZfYOzrY2qV4HrFF19w="
   },
-  "net/bytebuddy#byte-buddy-parent/1.17.6": {
-   "pom": "sha256-3RX5X9VgUmPwZdncuOzuzEjr5NZmw3KY/0RgAUlCQL0="
-  },
   "net/bytebuddy#byte-buddy-parent/1.17.7": {
    "pom": "sha256-ilfiDczgDaccM+8+GdndhY/p0gQsouK8onhxcA1SaYw="
   },
-  "net/bytebuddy#byte-buddy/1.17.6": {
-   "pom": "sha256-UExH3b8VsOc8ymO52woBwSp83n+LM6DF2dW1BtGUaz4="
+  "net/bytebuddy#byte-buddy-parent/1.18.2": {
+   "pom": "sha256-1Ar3bB/A//KEcLWpG9FXIq0zBre6H525Z6ZfkEgBmXM="
   },
-  "net/bytebuddy#byte-buddy/1.17.7": {
-   "jar": "sha256-NXXcuKmPr5Q9PBWVxHoWBHxPzoqD67smJi8aL2dUY1c=",
-   "pom": "sha256-7n+6hWnDu1wekeWBL9n0oPMb4n5WjVNU4a39GRGfl7M="
+  "net/bytebuddy#byte-buddy/1.18.2": {
+   "jar": "sha256-9VsUX0yq2pspQ+SXYuoxcbAlmcTH4jD7qK/GakpRNd4=",
+   "pom": "sha256-jdLkoXMfilQMRQsvHpHMKJ3SDHL7BYvcI77Gk6i3Ao0="
   },
-  "net/harawata#appdirs/1.4.0": {
-   "jar": "sha256-5ImfxeiiZ9P4LUl+4BtIEKSxUCPnqBrwqlR5HFe8bBE=",
-   "pom": "sha256-CRqldjaf1HheU2S2BqFS3Mp4x/e3hMuMxwyWwzDk44s="
+  "net/harawata#appdirs/1.5.0": {
+   "jar": "sha256-Zf7OLgUQObfTnWpQmq3LE2qahtmH3YRHN5Eog7NXeOs=",
+   "pom": "sha256-2Yn1w5+5rAGUFVYdGkIIfHpeL3dY7gHm4S0YJ6FaRWk="
   },
   "net/java#jvnet-parent/4": {
    "pom": "sha256-RxOVc1VJSVKXyP+Tm5oy4IuRMCAg/3c1htJ+SXq7j7s="
@@ -2035,12 +1904,6 @@
    "jar": "sha256-JgxLHiKx254RDuRBxPE84RX4QfpIxB14dQmGIUs5VVc=",
    "pom": "sha256-mLYq5v8oDXR/s1n8QuSP7RE9Rbw3Kagj3DC4MIqAZkU="
   },
-  "net/javacrumbs/json-unit#json-unit-core/2.40.1": {
-   "pom": "sha256-fQRVja+97tYnCxaDBh2k+nj76qhlAgQ9IeRldagofhE="
-  },
-  "net/javacrumbs/json-unit#json-unit-parent/2.40.1": {
-   "pom": "sha256-GgCNCnykEDwm/lGk3ott86W5KGQZHNGLGfEBumF3yZQ="
-  },
   "net/jcip#jcip-annotations/1.0": {
    "jar": "sha256-vlgFOSBgxxR0v2yaZ6CZRxJ00wuD7vhL/E4IiaTx3MA=",
    "pom": "sha256-XBnmhIzFUKlWZPsIIwS8X5/Pe2cvrwOvFjXw6TwmgXc="
@@ -2048,12 +1911,6 @@
   "net/jodah#typetools/0.6.1": {
    "jar": "sha256-7+iqots4OhUeMYgQQAgEw5kr3lQ+dKTXLeon7VR0yvo=",
    "pom": "sha256-HxvbdkwDDZ3Q3MGAxHfDKgtwRuK6GDmAsSJXVeLegZ8="
-  },
-  "net/minidev#accessors-smart/2.5.0": {
-   "pom": "sha256-VJelxIYeWCxm5xyHzFppgtauiz4hSUersbl7l70+HAc="
-  },
-  "net/minidev#json-smart/2.5.0": {
-   "pom": "sha256-wyo2YQmypaNuoA4SGqolfa5W7jqbl9JEI+YzteIUVGY="
   },
   "net/sf/jopt-simple#jopt-simple/5.0.4": {
    "pom": "sha256-amd2O3avzZyAuV5cXiR4LRjMGw49m0VK0/h1THa3aBU="
@@ -2106,9 +1963,6 @@
   "org/apache#apache/27": {
    "pom": "sha256-srD8aeIqZQw4kvHDZtdwdvKVdcZzjfTHpwpEhESEzfk="
   },
-  "org/apache#apache/29": {
-   "pom": "sha256-PkkDcXSCC70N9jQgqXclWIY5iVTCoGKR+mH3J6w1s3c="
-  },
   "org/apache#apache/31": {
    "pom": "sha256-VV0MnqppwEKv+SSSe5OB6PgXQTbTVe6tRFIkRS5ikcw="
   },
@@ -2157,9 +2011,6 @@
   "org/apache/commons#commons-parent/47": {
    "pom": "sha256-io7LVwVTv58f+uIRqNTKnuYwwXr+WSkzaPunvZtC/Lc="
   },
-  "org/apache/commons#commons-parent/56": {
-   "pom": "sha256-VgxwUd3HaOE3LkCHlwdk5MATkDxdxutSwph3Nw2uJpQ="
-  },
   "org/apache/commons#commons-parent/65": {
    "pom": "sha256-bPNJX8LmrJE6K38uA/tZCPs/Ip+wbTNY3EVnjVrz424="
   },
@@ -2183,6 +2034,9 @@
   },
   "org/apache/commons#commons-parent/88": {
    "pom": "sha256-i/cmFQ0dakO6CqkgYOVSkzyvKHOqGTlS2dSWRw+p+9g="
+  },
+  "org/apache/commons#commons-parent/91": {
+   "pom": "sha256-0vi2/UgAtqrxIPWjgibV+dX8bbg3r5ni+bMwZ4aLmHI="
   },
   "org/apache/commons#commons-text/1.14.0": {
    "jar": "sha256-Eh/OIoKRDI8MO6eTpUNrMb63EEI8vi1XSj+3pzxQjpI=",
@@ -2232,37 +2086,37 @@
   "org/apache/logging/log4j#log4j/2.25.2": {
    "pom": "sha256-HYBXBY0LBcj3clyhrbpoc5y+rHWJjsoGpIymEVRsA+w="
   },
-  "org/apache/lucene#lucene-analysis-common/10.3.1": {
-   "jar": "sha256-NrXrYms/FsUG407H0UNjuEF9Jjm+XArrtZD7F1guihw=",
-   "pom": "sha256-hQC5/Dm/I3gfomccaDWh63wbz+cn4KsE68wVnExYDYY="
+  "org/apache/lucene#lucene-analysis-common/10.3.2": {
+   "jar": "sha256-FAPg3yA6kDdigBW82cpGz6iZQwvfuTk3TM7MNM3N9Gs=",
+   "pom": "sha256-RFxi6t+4yBF2WvOJW10AjOHEGV8A0k14fb5rBAmUXQI="
   },
-  "org/apache/lucene#lucene-core/10.3.1": {
-   "jar": "sha256-z2tig+D5vZL55NSapzr7cNvQd0L0U6lalk10XGtbJF8=",
-   "pom": "sha256-VTfn4AA0Bv+5TeeDrlPsm3tuMDrPL0uTrsR99zewnYE="
+  "org/apache/lucene#lucene-core/10.3.2": {
+   "jar": "sha256-yDWjzCfNVywsjZN3HFOt/pe8EeGrzDU7h6XSkPigGgg=",
+   "pom": "sha256-td+QeIHDN+zTDEne3DXsQKbhFB9vxXZj40xTZltRHC0="
   },
-  "org/apache/lucene#lucene-facet/10.3.1": {
-   "jar": "sha256-zzcjGJ04LUUVwh9XZAmLq9lz1gsOj1LTfUq7cUc+hlU=",
-   "pom": "sha256-n+hhDvAqWMllXfF2Ggpu2R5Ir2qr5aBr+WXEY3QGOsQ="
+  "org/apache/lucene#lucene-facet/10.3.2": {
+   "jar": "sha256-nOtAGQ517KUKJ9+AxdEG1/J/EfyfljMbGJO+AX0SPSA=",
+   "pom": "sha256-3cTnSs8dvN6VjuE2JpYmlPz5mp3sroB0hn+wDxgCQnc="
   },
-  "org/apache/lucene#lucene-highlighter/10.3.1": {
-   "jar": "sha256-vfimmf9u/v+uQ5OpmKw4swRCXQ2ADTCyUUXaeG7IyUs=",
-   "pom": "sha256-6SadgF00HhRa3ct7vehKeZanjdRAcsv/lQGhNpdCch0="
+  "org/apache/lucene#lucene-highlighter/10.3.2": {
+   "jar": "sha256-2cQ1TowJtGXl+eEbEF+ZvSdIHw2G7F4j4dMhS7KkPAk=",
+   "pom": "sha256-6ldRQrgiuKeH86mdBUt/LuGB1W/SnbkEU7xsfP95ee0="
   },
-  "org/apache/lucene#lucene-memory/10.3.1": {
-   "jar": "sha256-5D3dFNUJrAZGrRAzPoyKHz8FiBA+U02lL+B7tVS+1BQ=",
-   "pom": "sha256-b3eFyDk4wNjZZcr74rD2a7bzUDGNhFh2Bflk79JcLYQ="
+  "org/apache/lucene#lucene-memory/10.3.2": {
+   "jar": "sha256-Z9BTRXkdAS4dchiXM6dsl4hwKzVRBk4eqs5nU6olW6g=",
+   "pom": "sha256-9LnJkx+9O668bBANGZHnr4RG+CN5uxxpxYvZGZ9VW+M="
   },
-  "org/apache/lucene#lucene-queries/10.3.1": {
-   "jar": "sha256-K+r6yPjuQ7V2bc+tussZrS8UyKoqLgcq7RuaGCGcigc=",
-   "pom": "sha256-OYgGHbKmpAnKDF5tdOI20g4f0753G6nULyiym6K5ylg="
+  "org/apache/lucene#lucene-queries/10.3.2": {
+   "jar": "sha256-RfmJTSqj0UOnmpgPqUHXL3M7Tr1L5mwLGnnUKOag21c=",
+   "pom": "sha256-qzsGG2eHRGEvrp+NBv4Nkv8a82eQsxa6vnoZUkcwa8Y="
   },
-  "org/apache/lucene#lucene-queryparser/10.3.1": {
-   "jar": "sha256-YbJ79QsAqz8WvlKdEUIbgc/XxY1HVrHhMIxhpE0TynQ=",
-   "pom": "sha256-sNvV4DfnjLElQMV/LxlMZODm5yDb1bPRiVnHktCNVAc="
+  "org/apache/lucene#lucene-queryparser/10.3.2": {
+   "jar": "sha256-drlQ7T09TTlFYYoL5238XZ7pDiT483SK4Hdcjb3z1rg=",
+   "pom": "sha256-7ccAzTciiDsJdedvqmXEv15FmPG5xDUKbK7YEZrMKFA="
   },
-  "org/apache/lucene#lucene-sandbox/10.3.1": {
-   "jar": "sha256-CNvR32RMJaGoZ94GMQEKDV260bRyzTiRhNQ6diWF02E=",
-   "pom": "sha256-irB7zsHTwL9NfQU7yIS3+gupQPwqe8p+TqPuNNCMQ20="
+  "org/apache/lucene#lucene-sandbox/10.3.2": {
+   "jar": "sha256-ZwtxPSCWFemSBsQZ0Zu1pTMCXWf8tuQOJgBrKgnmIFE=",
+   "pom": "sha256-LCHL5A4z1/md9scSZepoqd+rO61+kjcxynggTmB+2xk="
   },
   "org/apache/opennlp#opennlp-tools/2.5.4": {
    "jar": "sha256-Xv7bJtDpflNweo0vDi4o8F/PZU/OKjP4v+EcLUwqT+k=",
@@ -2271,24 +2125,24 @@
   "org/apache/opennlp#opennlp/2.5.4": {
    "pom": "sha256-Qz0Ic+wnz+Gxog6mQ3c6LymkCh/eobtdGCiy81NQwps="
   },
-  "org/apache/pdfbox#fontbox/3.0.5": {
-   "jar": "sha256-6KYr4t8noNRBkbZmnAsY327+UnEjLbjcuHRdXZd0dVs=",
-   "pom": "sha256-I/bas9ldDvUDM8n3ZZp0ChCwYZ3eEXbqYtyLSTU4jr4="
+  "org/apache/pdfbox#fontbox/3.0.6": {
+   "jar": "sha256-egn8sMYw5HGsJrNHykWg2K71qWnMWa6/8cV/6SKT4rE=",
+   "pom": "sha256-RP18HBKL1r/1Kj9kvHiIcQD6zS5J8rJoGGMHfGdoFa4="
   },
-  "org/apache/pdfbox#pdfbox-io/3.0.5": {
-   "jar": "sha256-bfPztNtP1V71AoR+pOTrxY4okIgA6G6rAxNF7+IZtwU=",
-   "pom": "sha256-NVvL5DdA/CEouNwRUQsTutOrPcet1Cnjt0q72WA3iVc="
+  "org/apache/pdfbox#pdfbox-io/3.0.6": {
+   "jar": "sha256-GR6sY3Vv8NvIQeOX6Xz6DL39JRWXLWDvVjmgqohKfkc=",
+   "pom": "sha256-EClai3kj970whlODleHVo/XLQ/503tNMsHwy97P0X4U="
   },
-  "org/apache/pdfbox#pdfbox-parent/3.0.5": {
-   "pom": "sha256-HKnfIMk56uhgJQonn+oCoRzdK0DkJa2Q0M5Ma3d8gpY="
+  "org/apache/pdfbox#pdfbox-parent/3.0.6": {
+   "pom": "sha256-EdzNtSovFEpIui+89npGrcTaN5JZQ/xNkhLfiSMxqN4="
   },
-  "org/apache/pdfbox#pdfbox/3.0.5": {
-   "jar": "sha256-8OXToeVzxwfk+8wu6OQuqModUmG9yzoFoI0hGFU8Hlo=",
-   "pom": "sha256-oFmNxJdGm9W/HEjFubAmcqJlaQG435sfG6pJy3huZYM="
+  "org/apache/pdfbox#pdfbox/3.0.6": {
+   "jar": "sha256-h7kSK3j1If74PigG2Y5+SD4Enwh+piZ7ctMZ9nIBkQE=",
+   "pom": "sha256-PkOO4NLXVJ0IVPDy5LJnWK699Ocv1JMTSafHLzPI1S8="
   },
-  "org/apache/pdfbox#xmpbox/3.0.5": {
-   "jar": "sha256-AXiZsvtcKvcU0wxSzKks3o8SmZq/MUDU8NXxEzT2L90=",
-   "pom": "sha256-E6MTEo+lkzyjcj8gwYKO5oJUHRRqX7BK5JtXoqYFC4s="
+  "org/apache/pdfbox#xmpbox/3.0.6": {
+   "jar": "sha256-ATRBZTxgKBTu5Bo82DBeBlCHQN5/u/dRxTR/o8TSJ/g=",
+   "pom": "sha256-LwFS3KrhAotX9y88wYUreM/4KNMNEtwefwuh4cGi9XY="
   },
   "org/apache/velocity#velocity-engine-core/2.4.1": {
    "jar": "sha256-HBkVfRFx1WAIjkhb6XyTp6L36fVuUX8KMCc8XDnfYjE=",
@@ -2348,9 +2202,6 @@
    "jar": "sha256-pr01xTjPkP/5Qa1iWMQMCPygtcnD9TbGVxFPJ84FJ6c=",
    "pom": "sha256-NcnhYgmychJhNU6K6pcWJmSK2dQgHSIb2WkB2QA3LaA="
   },
-  "org/eclipse/ee4j#project/1.0.5": {
-   "pom": "sha256-kWtHlNjYIgpZo/32pk2+eUrrIzleiIuBrjaptaLFkaY="
-  },
   "org/eclipse/ee4j#project/1.0.6": {
    "pom": "sha256-Tn2DKdjafc8wd52CQkG+FF8nEIky9aWiTrkHZ3vI1y0="
   },
@@ -2363,84 +2214,12 @@
   "org/eclipse/ee4j#project/1.0.9": {
    "pom": "sha256-glN5k0oc8pJJ80ny0Yra95p7LLLb4jFRiXTh7nCUHBc="
   },
-  "org/eclipse/jetty#jetty-alpn-client/11.0.24": {
-   "pom": "sha256-4ChUPNXWBpMyzMepXiaeCUfgUWY62QK8CRmkbgxrfSk="
+  "org/eclipse/jgit#org.eclipse.jgit-parent/7.5.0.202512021534-r": {
+   "pom": "sha256-fjiAaoU2kaSdsW6sg2/mtiYnaUOxCLZ3VKPVx0D7vA4="
   },
-  "org/eclipse/jetty#jetty-alpn-java-client/11.0.24": {
-   "pom": "sha256-EXzXCLo3u6kMVwaD9v3LsY9IPiDkpOj0QhRT/JP47a0="
-  },
-  "org/eclipse/jetty#jetty-alpn-java-server/11.0.24": {
-   "pom": "sha256-jq2POCgEbXoevHVoT2OTaLdhQ51Ru19sgiCscdMJ33o="
-  },
-  "org/eclipse/jetty#jetty-alpn-parent/11.0.24": {
-   "pom": "sha256-OEfidTdZ+GkaIo2c8dddJPcwJG4J3FL/8b0r0PTbnVc="
-  },
-  "org/eclipse/jetty#jetty-alpn-server/11.0.24": {
-   "pom": "sha256-Kl+OKVd+qPdvkUmX9VOPjofcGYeJef4SC+UFRtsUoUg="
-  },
-  "org/eclipse/jetty#jetty-bom/11.0.24": {
-   "pom": "sha256-OzjVNA/7MaYiymePR8K2Bawg6lhVJZ84Xm0ujyfs1dk="
-  },
-  "org/eclipse/jetty#jetty-client/11.0.24": {
-   "pom": "sha256-u68OEXqGWPInb/qKEbdVywctM1NQWvsKPk7BpkzkbP4="
-  },
-  "org/eclipse/jetty#jetty-http/11.0.24": {
-   "pom": "sha256-/lve2cVDbsrkT438v4Rw0O96qj/U1nAe+oEuV4EOeP8="
-  },
-  "org/eclipse/jetty#jetty-io/11.0.24": {
-   "pom": "sha256-vTPGW6IaAznasQRHEZ9yPb23L7mSM0AHjtTT1ZVTkwc="
-  },
-  "org/eclipse/jetty#jetty-project/11.0.24": {
-   "pom": "sha256-9miJ0dIX26PbBfSwXOwksKIg1PHRbFLSA9m2+3HaYIY="
-  },
-  "org/eclipse/jetty#jetty-proxy/11.0.24": {
-   "pom": "sha256-NaAFoAOnCQTDSyp+GfgdI71U25KBjCEfYsTiInDyGys="
-  },
-  "org/eclipse/jetty#jetty-security/11.0.24": {
-   "pom": "sha256-NeCJ1jkTMrp34adpkgnU7j7zlq0pkmWDWt4tm/0Esp0="
-  },
-  "org/eclipse/jetty#jetty-server/11.0.24": {
-   "pom": "sha256-5yEko9Ho+3DaG1JY4VQrgB/+sDOqExYB2hH3lLQpj1Q="
-  },
-  "org/eclipse/jetty#jetty-servlet/11.0.24": {
-   "pom": "sha256-3uiUnisDmOn03P7p/2yS86l4qZd3aF1i6MheSx+7itg="
-  },
-  "org/eclipse/jetty#jetty-servlets/11.0.24": {
-   "pom": "sha256-gbRgsSDWSrntgs0oDfrdtb4om9P6V2M6D4/1e6R1HoQ="
-  },
-  "org/eclipse/jetty#jetty-util/11.0.24": {
-   "pom": "sha256-7ro8qZy7kyAEbuNm6V3wzr8vEQciaPRcouvj4iO2m8o="
-  },
-  "org/eclipse/jetty#jetty-webapp/11.0.24": {
-   "pom": "sha256-Y9pNCE6Eb9AtbJpCi8zGYK+hxb17wkfsIfFsN6cWaBs="
-  },
-  "org/eclipse/jetty#jetty-xml/11.0.24": {
-   "pom": "sha256-JXNlZfHw0Et42x+ZH449AZRmgAWbwqhXauRd7pJu8h8="
-  },
-  "org/eclipse/jetty/http2#http2-common/11.0.24": {
-   "pom": "sha256-aEwrliRzkYCfzaIEvCz/NqLyc7LgCLlDxs6QTrmkCsE="
-  },
-  "org/eclipse/jetty/http2#http2-hpack/11.0.24": {
-   "pom": "sha256-4N056ZrPI6FKjnFfmLf5Lxe6AgVMJuI4XOXEm85i4jU="
-  },
-  "org/eclipse/jetty/http2#http2-parent/11.0.24": {
-   "pom": "sha256-H/63MlEaizavZ8nPMV5XckiQjy/U8WLyxVezUjFsBis="
-  },
-  "org/eclipse/jetty/http2#http2-server/11.0.24": {
-   "pom": "sha256-e4PC3DueupOTnXmCIU9A++tU/iean6/NAb9Me0dVdE0="
-  },
-  "org/eclipse/jetty/toolchain#jetty-jakarta-servlet-api/5.0.2": {
-   "pom": "sha256-g+y5PmHWvZyMgfwlzcrUp3ONx7LAiCnRcihj7kaaSIo="
-  },
-  "org/eclipse/jetty/toolchain#jetty-toolchain/1.6": {
-   "pom": "sha256-RVY/EXXZhZwcBmoJgPvbn2u0xtPBLgXYlXm7F4P0e2w="
-  },
-  "org/eclipse/jgit#org.eclipse.jgit-parent/7.3.0.202506031305-r": {
-   "pom": "sha256-EuCm1BYOBfIGFJVPhMPmemiCdBhQJTysHHTj+5nXmjQ="
-  },
-  "org/eclipse/jgit#org.eclipse.jgit/7.3.0.202506031305-r": {
-   "jar": "sha256-xMTho+sa/p3Gqck7HIkG6qq5panNtcld5MyA7/TKDcE=",
-   "pom": "sha256-vWj77cwn8P6jA6dOS4JFmyRaL8IR0DZDrda/XpxYVyg="
+  "org/eclipse/jgit#org.eclipse.jgit/7.5.0.202512021534-r": {
+   "jar": "sha256-FZe8eKjYwBFpdtRqlIcqLMKGVnDrpNsLn1GBGzSTbXI=",
+   "pom": "sha256-bJVN/BDxwwG9uiXT1jCfd0eYBDY891VuUei7NxRVXGQ="
   },
   "org/eclipse/lsp4j#org.eclipse.lsp4j.jsonrpc/0.24.0": {
    "jar": "sha256-dyFXLoSdTzWbRu3lXVYEuYL/SY0NkuvHDhgCn1mCPAg=",
@@ -2459,10 +2238,10 @@
    "module": "sha256-R0PuegFqASpt8zzShzaiKv7nhN6qOoO5X8YWqNg+VBw=",
    "pom": "sha256-b3He3vgo4AGrCr+l2+15Adgd9Uzo58ea0kQ8fqkZR0E="
   },
-  "org/fxmisc/richtext#richtextfx/0.11.6": {
-   "jar": "sha256-LRL3kNssLeNdILgJDljhhPjTD9R2GwCO7l7yWODuD78=",
-   "module": "sha256-+KGPzb69jD/3+NUqg7/TE/H0LZRl33kDUKQgfIx7tWc=",
-   "pom": "sha256-jVYX1QxejiqosXXT8HDenZxOWn7jgJkSI9dJVyE5p60="
+  "org/fxmisc/richtext#richtextfx/0.11.7": {
+   "jar": "sha256-wmNVhtS6mjWou/X6N79afaNfsQ3Ylq78Z+u/hGCLmMw=",
+   "module": "sha256-hAX8CTISsp0PWhnk5JnRdca9bGoaW2lQH5xWRiCPRxo=",
+   "pom": "sha256-1mQ2pXSpvod9H3jLPWa5TLKXLGBynj4tSONRk4LT4Og="
   },
   "org/fxmisc/undo#undofx/2.1.1": {
    "jar": "sha256-25cIxYqOLbRX+9Z/BRXkqVlVygsLj06no9y7/L0Z0tc=",
@@ -2484,6 +2263,7 @@
    "pom": "sha256-5o1kXUXO91e5efhO+z/BMupcwMrGjITyoLu7E2SDfQk="
   },
   "org/glassfish/grizzly#grizzly-http-servlet/4.0.2": {
+   "jar": "sha256-OCI5UYe3scXFk6WM7MrI6DG//zEnqefH13GY+DZ5NrE=",
    "pom": "sha256-uRIINv8LSwQN83kziX5780xw4vcBqdVGYvos4izeo2w="
   },
   "org/glassfish/grizzly#grizzly-http/4.0.2": {
@@ -2496,28 +2276,49 @@
   "org/glassfish/hk2#external/3.1.1": {
    "pom": "sha256-Q1ET1J40IK3AYKMJqt75EHphOYgdgpRHhj7WWYygF48="
   },
+  "org/glassfish/hk2#external/4.0.0-M3": {
+   "pom": "sha256-h4t5Hl6qPIcE76MFUNGl5XF9yA0xS+a8szPMBWgC3WM="
+  },
   "org/glassfish/hk2#hk2-api/3.1.1": {
-   "jar": "sha256-rBTZKRCsU5UFtMDHKrbF91eqEqQ7yI0TpbyfI7GHBis=",
    "pom": "sha256-cZcycKIuCVh3fXK8+0SqW7wcpsoiIHm9XxfLlyEfbpg="
   },
+  "org/glassfish/hk2#hk2-api/4.0.0-M3": {
+   "jar": "sha256-ZvhZkW5qfeNiKXOs9/ZyqJXJusgWIggN+7laybAhsfg=",
+   "pom": "sha256-2ldYwcrGDJCVjWfLuaP++EZVE7gyTvQ/9si2VeHjJtc="
+  },
+  "org/glassfish/hk2#hk2-extra-parent/3.0.0": {
+   "pom": "sha256-7QQT8DTUZlo32xhiyiquiq9NjKuJTSrKTna7zN+qgFk="
+  },
   "org/glassfish/hk2#hk2-locator/3.1.1": {
-   "jar": "sha256-qx6GX1mGgJI1tlA0tc0i4AeqgdT35dFLb7TiKDOQt4g=",
    "pom": "sha256-Jx4a0fedi3l+kDJ1/BdNXui8Lod0MjC283fHLwxNBsY="
+  },
+  "org/glassfish/hk2#hk2-locator/4.0.0-M3": {
+   "jar": "sha256-KQAnOV2Vv8u19AyZI3am8hx1v2PJyNTfPPwDS6GoXe0=",
+   "pom": "sha256-UPXyftFr6i4tPdqL7CtLQIr6plzyi3ySP/KwK9cQkSY="
   },
   "org/glassfish/hk2#hk2-parent/3.1.1": {
    "pom": "sha256-u/kqbG0phpvXT9TOo8g0bgvQORe6kf8Rc6M4E9tdSRQ="
   },
+  "org/glassfish/hk2#hk2-parent/4.0.0-M3": {
+   "pom": "sha256-r2nz6US27idzz1BnoGR+pbNkKj60iZUTT2lPQFaO4jo="
+  },
   "org/glassfish/hk2#hk2-utils/3.1.1": {
-   "jar": "sha256-b16l/vUHVbog+7iTeCssY/mupGPBg9Y6V9zJ+msRcTk=",
    "pom": "sha256-9jp0ovDWaukmsU7dbk9W28NvctqQxZo/D/YCvNP3neU="
   },
-  "org/glassfish/hk2#osgi-resource-locator/1.0.3": {
-   "jar": "sha256-qrXXhJ98/Nosx8VBuhvTZRUdQidvFRyCU4ckXf3j3XQ=",
-   "pom": "sha256-i2Yi64HlVymfvZqoVLxax20wf3rl53BYZImli7Uziyo="
+  "org/glassfish/hk2#hk2-utils/4.0.0-M3": {
+   "jar": "sha256-unCHgn/omvPYJPwmVWyYXOmvoMww+qJOi2UUXKD+/PE=",
+   "pom": "sha256-YJoXFaqpUEu2K0tT6Ndf61iAfGtYdDrV88HYw9S4RIY="
+  },
+  "org/glassfish/hk2#osgi-resource-locator/3.0.0": {
+   "jar": "sha256-oYZsz92qKfGNpdOd9mKJSrLdmQKZSlAA52RPbMHjflU=",
+   "pom": "sha256-nxPzihfjMzJMF7uo68PDkvZq3rkVZAN3XN5V7HMe7Pw="
   },
   "org/glassfish/hk2/external#aopalliance-repackaged/3.1.1": {
-   "jar": "sha256-5AxkMBbUDdmsqjhCqYC5O3ltlFYh+CD8vYKyXJaWj6s=",
    "pom": "sha256-WEztva7OI/utMabFsHInu1xPx+NU0/fbGmBxJdZxcZo="
+  },
+  "org/glassfish/hk2/external#aopalliance-repackaged/4.0.0-M3": {
+   "jar": "sha256-ZcCruUbSqzoSN8YQ8kvxXwRpYVHpyvvhr6bO5S++1e0=",
+   "pom": "sha256-V9aw+yZOT3V7k1nvKC2cmXhG74JSSlA3Kj6GN8WKYe0="
   },
   "org/glassfish/jaxb#jaxb-bom/4.0.6": {
    "pom": "sha256-frfNg7krfC/QqK5mvLNQY1TxZqE/gtKmbB2WJZcy0qU="
@@ -2534,102 +2335,81 @@
    "jar": "sha256-/MdJeFQS7zgG/eHOcPk+9aAGXcxH/kSbyHHbB5XLEa8=",
    "pom": "sha256-avFKkbP56eMX96WOgNy+/T308vIFRINZ/zocWQFic3Q="
   },
-  "org/glassfish/jersey#jersey-bom/3.1.10": {
-   "pom": "sha256-KYl09Itfm23mIvJFApLexNuZs5vjJF9WVqbJpEtd67Q="
+  "org/glassfish/jersey#jersey-bom/4.0.0": {
+   "pom": "sha256-xUcMOr8/QtNyHQo137qtS6NkMJy36M8vyBBX+R1LFhs="
   },
-  "org/glassfish/jersey#jersey-bom/3.1.11": {
-   "pom": "sha256-3DdcE5WY+5VgZlWat70vwxGHlvVcMMT19LW8O0dEIrQ="
+  "org/glassfish/jersey#project/4.0.0": {
+   "pom": "sha256-AxgU8a/mE6OUS5+K/ekHabew9cTHZ665fFopnV+mvxU="
   },
-  "org/glassfish/jersey#project/3.1.10": {
-   "pom": "sha256-HwCrKqQxlS9Eb7DXajOYoWstCgzmAP/L/g8iKp9aRSU="
+  "org/glassfish/jersey/containers#jersey-container-grizzly2-http/4.0.0": {
+   "jar": "sha256-hwJuwE1+udvbAAIg1Uypkw9MTQSB/RhkTroHovBAyVU=",
+   "pom": "sha256-uvsXcNbWMs3d7c/97C4Sqmb7x9YkoAGSsUpu8QIwIPU="
   },
-  "org/glassfish/jersey#project/3.1.11": {
-   "pom": "sha256-0sAaDDv9lcCHl+FhePUlAWzPEudYUo6uG901UXrVDfs="
+  "org/glassfish/jersey/containers#jersey-container-grizzly2-servlet/4.0.0": {
+   "jar": "sha256-8vgixexSs7jnKuwQVIxDJMOJWJ0sYtdLJA81DCAnEP8=",
+   "pom": "sha256-l050jqVCcVWuC30u8CUdDviskTblit47C+afCmBLeAE="
   },
-  "org/glassfish/jersey/containers#jersey-container-grizzly2-http/3.1.10": {
-   "pom": "sha256-hLP/zKuuOE8Vx/0IucMSoW/AhcKOcxG+PM1ZuyTkC+s="
+  "org/glassfish/jersey/containers#jersey-container-servlet/4.0.0": {
+   "jar": "sha256-ckfY37DUlQmRaQWAYGxa2TO5F8an/oW1JW8j8oeCTA8=",
+   "pom": "sha256-V1zTMUcq1HkWWuVDODpFUoCJ8RVba/yI/WsgDkAq6T8="
   },
-  "org/glassfish/jersey/containers#jersey-container-grizzly2-http/3.1.11": {
-   "jar": "sha256-/zn2epqi6OHHtZUkxt2Xc/YHocMHVpwmh8Hkg4WhUY4=",
-   "pom": "sha256-GzqUkEc3Xl7M4fmTVVjrj86h6d12TrsrJpA3myk0pfk="
+  "org/glassfish/jersey/containers#project/4.0.0": {
+   "pom": "sha256-P0Q/lOWOho6LjY/aaLcLiSTgSXEao9PMM12z2Q4MwsE="
   },
-  "org/glassfish/jersey/containers#jersey-container-grizzly2-servlet/3.1.11": {
-   "pom": "sha256-1LiQFi+vCLjfBGPSohCa+8Tu+vwCyE6egndv2kWZVSA="
+  "org/glassfish/jersey/core#jersey-client/4.0.0": {
+   "jar": "sha256-ng3FA4bcY/jqaNkW3OVeogSmSAl4W/k1dp38Ew9maaM=",
+   "pom": "sha256-Em+B58WqDE5cQyjIBW2aTIiYzaLG1c/7yYDj6B3OUPE="
   },
-  "org/glassfish/jersey/containers#jersey-container-servlet-core/3.1.11": {
-   "pom": "sha256-X55C8+DtJ16eEiSqgrpdrn08IJCCb5G818lt3LJtbNE="
+  "org/glassfish/jersey/core#jersey-common/4.0.0": {
+   "jar": "sha256-H5/ES2basv+CkfTHCSqn4LObs+/hu/UM5poy+gl5ZhY=",
+   "pom": "sha256-LmkrASQngfxhm6CxdtWE2VAw267AfEDG1//FVb6xr5U="
   },
-  "org/glassfish/jersey/containers#jersey-container-servlet/3.1.11": {
-   "pom": "sha256-A7QnrQbxZbhH+95azcqHtVuOPptUxE0n0wiqj3Lfj5o="
+  "org/glassfish/jersey/core#jersey-server/4.0.0": {
+   "jar": "sha256-ZPQgKGYxe+xYDCtl5C5/I3HBC/cIWvYTwwyLQQI0Abg=",
+   "pom": "sha256-HwcEUUOi9xKWboWKwuU6T7lTeqWOZAy7a+A3ONP228M="
   },
-  "org/glassfish/jersey/containers#project/3.1.10": {
-   "pom": "sha256-srKeL9s0eph5sEbHW+rV6E9O/C0gQp9KVCoMsxkYRSM="
+  "org/glassfish/jersey/inject#jersey-hk2/4.0.0": {
+   "jar": "sha256-cZdRkWdrvjicm6EUrhlGyXFBmMrJnL3vVq2+s9Yip0E=",
+   "pom": "sha256-4DauIN1e9qyVr3h1K9jXVNqIwcKlbQwHrC7k+bha3nc="
   },
-  "org/glassfish/jersey/containers#project/3.1.11": {
-   "pom": "sha256-ZJwIEcmQf12y85FoimBT7AGS8F5oMiD8mII2CYgz5BQ="
+  "org/glassfish/jersey/inject#project/4.0.0": {
+   "pom": "sha256-KxCS7+A0OpDAuAeAUVD8HabmyIfNmw0gUqs+vZhJYeE="
   },
-  "org/glassfish/jersey/core#jersey-client/3.1.11": {
-   "jar": "sha256-nw9TKmurtTD0x9b8T0UrmWqXqnw0JIvySe6oos5jl1g=",
-   "pom": "sha256-l065XrwW5iL+YL9j3SIbCWaaO9NqAEXTdtLDIv3i4XM="
+  "org/glassfish/jersey/media#jersey-media-jaxb/4.0.0": {
+   "jar": "sha256-tM615k4UTN85DX6GxzmtHtwKoy8fSLDIXvgw/Kz7SwY=",
+   "pom": "sha256-R5qbwqpPN0qjDDZaQSAwli7cQQYq+1WqaHu+TwtR0Vk="
   },
-  "org/glassfish/jersey/core#jersey-common/3.1.10": {
-   "pom": "sha256-37Tr4q/ZEifpSSJXnGk6Wx6+UOupnI9HDFwZZjgipBY="
+  "org/glassfish/jersey/media#project/4.0.0": {
+   "pom": "sha256-e4ZcegGG5BiqMEipkySzRMxhM+WptxAnGOLvSFIHrX4="
   },
-  "org/glassfish/jersey/core#jersey-common/3.1.11": {
-   "jar": "sha256-7FFtfC/c/NfrdznqzzzWkU4XoVlf1FgmszyHZZZZgbI=",
-   "pom": "sha256-/shJQsC+skBPjbOWRrqMMPqM/elJPYO7FGUKl/kbDYk="
+  "org/glassfish/jersey/test-framework#jersey-test-framework-core/4.0.0": {
+   "jar": "sha256-nAniDTwafpg/QeHneWfVVrmtDzwE5NYiHcqTIhflK2M=",
+   "pom": "sha256-HOYqBvbWnmF1v0EFGTdiZBO2knwmrCryp6qD52NZQfo="
   },
-  "org/glassfish/jersey/core#jersey-server/3.1.11": {
-   "jar": "sha256-fd4q32YA8+j3I+N6jJbDGDimgvjbhU/c/PTwBpXW+QM=",
-   "pom": "sha256-y+VJe4ExCM0BGlMEa0T5akNQ5ozlz0T+eiG32RxOzu4="
+  "org/glassfish/jersey/test-framework#project/4.0.0": {
+   "pom": "sha256-qljN8WaFhfXzlBBNCRdBvOODFsS3Smt5IZZ9o8bMP2U="
   },
-  "org/glassfish/jersey/inject#jersey-hk2/3.1.11": {
-   "jar": "sha256-+u7phdcLgiOp6yK6q/V52fhgFBcW78r3SwolKmOVn8M=",
-   "pom": "sha256-667WoeVDo3q08uqt1wqEz3P24YffKd2nZaQS5vMEY2M="
+  "org/glassfish/jersey/test-framework/providers#jersey-test-framework-provider-grizzly2/4.0.0": {
+   "jar": "sha256-Zlu20Jxi44hLwWmVqkfVVqXPt/4pKzXip/nFqp8VTdU=",
+   "pom": "sha256-nqTMjn8SCGQ/qHPYpBk/tB6I7qlpVZSpHw0fkSE/iLY="
   },
-  "org/glassfish/jersey/inject#project/3.1.11": {
-   "pom": "sha256-2HawxNlN/CHWyem7mcxXmNmwT7MF/KPKIVXfn8A4Obg="
-  },
-  "org/glassfish/jersey/media#jersey-media-jaxb/3.1.11": {
-   "pom": "sha256-OJl3I+KYlhzoC1ThHpSKYGdDeV5BXJlbGpknliUiWTA="
-  },
-  "org/glassfish/jersey/media#project/3.1.11": {
-   "pom": "sha256-tQmzXrfR7wVA43bK+DvPUC949pI6yrNn7oXX0S6OM3w="
-  },
-  "org/glassfish/jersey/test-framework#jersey-test-framework-core/3.1.11": {
-   "pom": "sha256-KGnwIIig8xxsFCqbkudX/vCfxfrMADIHZP3p+4P0myE="
-  },
-  "org/glassfish/jersey/test-framework#project/3.1.11": {
-   "pom": "sha256-3OqcXyh28KciQ9MSMgrCfxLGwXElVMEkb7+h0aDs4Ag="
-  },
-  "org/glassfish/jersey/test-framework/providers#jersey-test-framework-provider-grizzly2/3.1.11": {
-   "pom": "sha256-IQazyx8NVZXetuIfp0A8MdW4tO+WhflFzC9IF262FzM="
-  },
-  "org/glassfish/jersey/test-framework/providers#project/3.1.11": {
-   "pom": "sha256-+Gd6F5VqTZ8wjT1QTcn7JdS2if9ERQ+HUn26AcO/7gk="
+  "org/glassfish/jersey/test-framework/providers#project/4.0.0": {
+   "pom": "sha256-BPXWhR3CI7huGPYMpHp/Kd++wr2UJqsDMdqSmLBxsxw="
   },
   "org/hamcrest#hamcrest-core/1.3": {
    "pom": "sha256-/eOGp5BRc6GxA95quCBydYS1DQ4yKC4nl3h8IKZP+pM="
-  },
-  "org/hamcrest#hamcrest-core/2.2": {
-   "pom": "sha256-9/3i//UQGl/Do54ogQuRHC2iAt3CvVB2X4nnxv+M590="
   },
   "org/hamcrest#hamcrest-parent/1.3": {
    "pom": "sha256-bVNflO+2Y722gsnyelAzU5RogAlkK6epZ3UEvBvkEps="
   },
   "org/hamcrest#hamcrest/3.0": {
+   "jar": "sha256-XWa2pKaAdVy27XyxBPp4Ne9kRmdYb/Bzet65d8Oezbw=",
    "module": "sha256-mhBVNzjTWME+a69Zeb8sGlSQ7uScLcas8xcPzKCSDd4=",
    "pom": "sha256-SgSmgTO/MkYfR7ilPI7p30zi9JoNrZeUvOhxe+5brDE="
   },
-  "org/hibernate/validator#hibernate-validator/9.0.1.Final": {
-   "jar": "sha256-JfQBGPpMUPhSLQkNJdUtWjiVOwzNElCDXwUue9MWTOA=",
-   "pom": "sha256-5w3BopQp/dTgh1E+tk70V1IMrwpRqxFFw7ilN8hC6gw="
-  },
-  "org/infinispan#infinispan-bom/11.0.19.Final": {
-   "pom": "sha256-OmBv0rX3f991rPM15brdRnxCQFsR8mjnPBfrkkM+WhE="
-  },
-  "org/infinispan#infinispan-build-configuration-parent/11.0.19.Final": {
-   "pom": "sha256-EghgxWpNd7zBIjy650Dusm8vk1XUmhfV8WWADuCvqno="
+  "org/hibernate/validator#hibernate-validator/9.1.0.Final": {
+   "jar": "sha256-Teogx4DRLorW4f59aVRgr3T4Zo3561iRCZGRkZRBIYg=",
+   "pom": "sha256-1XS291wE5USxv3YAcMLvuDnfufY0SNN19Z/dB+QM4JQ="
   },
   "org/jabref#afterburner.fx/2.0.0": {
    "jar": "sha256-PhxWSKv8xpaYIdi3BnPwxMV5qp8IBP/9/gwn1UTZDIM=",
@@ -2649,9 +2429,6 @@
    "jar": "sha256-sOqDZn2darH89q2EieF6pRsA18CGRUrsNQFuL7Ucm7U=",
    "pom": "sha256-ZMsdu8KSZgmcYTnVsq8NXKfUxgVV/gABoBePhGjfnCo="
   },
-  "org/jboss#jboss-parent/36": {
-   "pom": "sha256-AA3WFimK69IanVcxh03wg9cphCS5HgN7c8vdB+vIPg4="
-  },
   "org/jboss#jboss-parent/42": {
    "pom": "sha256-5BJ27+NQkFTLpBl7PWNgxR3Ve8ZA3eSM832vqkWgnDs="
   },
@@ -2667,30 +2444,39 @@
    "module": "sha256-n+hq62S4YyPo5XlQOxGgOKFAaUwTtoBDQ/ik3Jo6RrE=",
    "pom": "sha256-mn4e3huQFzBSwebtck+w8OvMiP9oLQI/DJs0PhN3p/8="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.0": {
-   "jar": "sha256-DRC8DUK4YF8jYpo/MeonwZzbyp3N9PU/bSLNY2aDbRg=",
-   "pom": "sha256-lcIYnDXve/xIlRwyrXCEeyHzgJ0m9dCnbiNXCHmYjDA="
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk7/2.2.21": {
+   "jar": "sha256-t4WSLxHm2Rpt0ddcsK7xzje4P43g46ITkTnfuCO7iiw=",
+   "pom": "sha256-I3xPNRZpV77Mwm7J8WxNjdTJtSNZ98cdAdznfYqwdmI="
   },
-  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.0": {
-   "jar": "sha256-rcFmSNu881sNEOfsMBw110bRwv5GDGBqulnxKxF8+bA=",
-   "pom": "sha256-I00G/b3CncvAdEfijEomq6uVmdXD2qPZKjTmrt6iNqY="
+  "org/jetbrains/kotlin#kotlin-stdlib-jdk8/2.2.21": {
+   "jar": "sha256-xiJ1xQ7lkcovgse6QmlreRYAwlhE9H6EvZRgMCoNUjg=",
+   "pom": "sha256-RN6GQYDP52PPB8EmjPJ5uYqVVaQjuyyBHe3bVawsyFk="
   },
   "org/jetbrains/kotlin#kotlin-stdlib/2.1.21": {
    "module": "sha256-DTc1BD1ot6WvtE0n3mX4Cp0rIIRicJwu27SP1bOVrYo=",
    "pom": "sha256-xVJAhso+SaZ5ht+P3M1mA3uvXzxaNYt2+d1gm+57tjg="
   },
   "org/jetbrains/kotlin#kotlin-stdlib/2.2.0": {
-   "jar": "sha256-ZdEthaO4ZcFg25FHhRcSpksQ2t1osi7qIqlb+KhnDco=",
    "module": "sha256-pbmP3NnbAX1ULhlyJdzuGNZYpW3h2yzEHhMZbWsXaaQ=",
    "pom": "sha256-jDyCEAfBNBFVhzm589U4LrgVUds4lc/7iVYeVsD03BY="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.20": {
+   "jar": "sha256-iDbM/9NYX63amQEkSyDUKQHS881YEFjYQ04v+rzzo+c=",
+   "module": "sha256-yRj1IU0CGnLjdn8nVul9EDpSbgTxQj2jZj79+1hH25U=",
+   "pom": "sha256-SosIbmQxvPYjY39Ssv8ZLhrbkTg4dC5cDupwqN7kKcQ="
+  },
+  "org/jetbrains/kotlin#kotlin-stdlib/2.2.21": {
+   "jar": "sha256-ZVij0jPaVqIJNLMhWfnbX4btWBbvCY94osIj3Gq7ed0=",
+   "module": "sha256-v7xlfd06jjfkyK1BeWjV6wsLFxyfzkj5YsKtMu5DTCE=",
+   "pom": "sha256-zzH5IxlsY67ezQpXwkJpvTcCpOR8C/C9ZLWtpd5SInI="
   },
   "org/jooq#jool/0.9.15": {
    "jar": "sha256-ow2WcZCZ603oewgVL5etsLo8/vmX2tys6LLk3NwZf4Q=",
    "pom": "sha256-/mCqsovG1YbUq0u/zSPc9KFXa/gzK2lEwhxaehS8x4M="
   },
-  "org/jsoup#jsoup/1.20.1": {
-   "jar": "sha256-ybt7LA9JVfx4WlXAVKPWpbFzuQ6krIhm17GmFuOEkc0=",
-   "pom": "sha256-oeGYRMAjusOTjPx5zGLPovp1SonWyooyxL+anx1IhIU="
+  "org/jsoup#jsoup/1.21.2": {
+   "jar": "sha256-8FSW4lVzR1nw1LVjLaeyT4ExMUfHjGnpCtBF0JYZE0Q=",
+   "pom": "sha256-S74tJSipD5l8QK7ztitRn9NzxWBXtU/7CGzCvvAe9EY="
   },
   "org/jspecify#jspecify/1.0.0": {
    "jar": "sha256-H61ua+dVd4Hk0zcp1Jrhzcj92m/kd7sMxozjUer9+6s=",
@@ -2704,10 +2490,6 @@
   "org/junit#junit-bom/5.10.2": {
    "module": "sha256-3iOxFLPkEZqP5usXvtWjhSgWaYus5nBxV51tkn67CAo=",
    "pom": "sha256-Fp3ZBKSw9lIM/+ZYzGIpK/6fPBSpifqSEgckzeQ6mWg="
-  },
-  "org/junit#junit-bom/5.10.3": {
-   "module": "sha256-qnlAydaDEuOdiaZShaqa9F8U2PQ02FDujZPbalbRZ7s=",
-   "pom": "sha256-EJN9RMQlmEy4c5Il00cS4aMUVkHKk6w/fvGG+iX2urw="
   },
   "org/junit#junit-bom/5.10.5": {
    "module": "sha256-hXsWv6Q5P1aoQJN8Z01TbeTiPFxjRpYgp3m1BcCowak=",
@@ -2748,64 +2530,60 @@
   "org/junit#junit-bom/5.5.1": {
    "pom": "sha256-eHThBkE5sx4sWkZrPcEClwk2IWK98B8PSqq3OKuTLTM="
   },
-  "org/junit#junit-bom/5.9.1": {
-   "module": "sha256-kCbBZWaQ+hRa117Og2dCEaoSrYkwqRsQfC9c3s4vGxw=",
-   "pom": "sha256-sWPBz8j8H9WLRXoA1YbATEbphtdZBOnKVMA6l9ZbSWw="
-  },
-  "org/junit#junit-bom/6.0.0": {
-   "module": "sha256-R98chw1F2mEXtKYNzAYhRmrD332s6I2aL5TXhAYkbkU=",
-   "pom": "sha256-s9mDL1wRu7aw5ihRuTqinSeMOfsadR63cbRtAEohYhk="
+  "org/junit#junit-bom/6.0.1": {
+   "module": "sha256-xI2Y9e3P2cVeefrLugEB98G6CIY0ib6EqRYrmaGG0cI=",
+   "pom": "sha256-4xXFzLsIchbc4ErnDDK/F2K+KguKQ++B47p4MXpM1cg="
   },
   "org/junit/jupiter#junit-jupiter-api/5.12.2": {
    "module": "sha256-VFfyRO3hjRFzbwfrnF8wklrrCW5Cw1m2oEqaDgOyKes=",
    "pom": "sha256-VmKCFmSJvUCxLDUHuZXkj44CXgmgXn0W3SuY3GQs994="
   },
-  "org/junit/jupiter#junit-jupiter-api/6.0.0": {
-   "jar": "sha256-iNaQ0tNzzWYXB3DDF5dxls6eRl8jiJMPS8lmXohzhfY=",
-   "module": "sha256-ulAS9rG1AydsxsokGUPC2bJuJFkCXowg3VjsMeumcXU=",
-   "pom": "sha256-rNeSzwaDpEvqadPP/uujfRm5kAwdnogijjKfJsRBNQM="
+  "org/junit/jupiter#junit-jupiter-api/6.0.1": {
+   "jar": "sha256-o8qMflZ0Ngk+SmcD1dSqwC2+o2EG6jL9E2e1beINTgI=",
+   "module": "sha256-zK14mBan6wSIQ0ad+9pkHonhhJ5juCSS8kvGCzBQu5s=",
+   "pom": "sha256-NjNXApnLjlv8KBYedmHSEfODqx4QndQNBWbGr6FDlxo="
   },
   "org/junit/jupiter#junit-jupiter-engine/5.12.2": {
    "module": "sha256-0W0wjmqiWjCz75JNnf5PiJqb/ybqvXLvMO6oH864SBU=",
    "pom": "sha256-PHGRdFCb6dsfqBesY7eLIfH2fQaL5HHaPQR4G9RAKqM="
   },
-  "org/junit/jupiter#junit-jupiter-engine/6.0.0": {
-   "jar": "sha256-j6HWw32ymm70cYO0mFHudnbwj9exwntozPOk5XzgL0g=",
-   "module": "sha256-/BOeA32ssQfRpQ6FVVg2h0+pwgKIwx17a86To9PoUEw=",
-   "pom": "sha256-qzyiIIkCJq8xuRVzeT+n8APHqBdSuskFZx3Krum5fXM="
+  "org/junit/jupiter#junit-jupiter-engine/6.0.1": {
+   "jar": "sha256-dHalb0qqtX/C9FmEfNa/txKzvQSprAuJ7ZVz963CxVA=",
+   "module": "sha256-DNBLxyt1p94NOMErkbE3PcQ3OgP+Iv/3oV6MvRyfXfk=",
+   "pom": "sha256-w0n6QNgPtJ/b+0TyYlR2zSa4vpWQQP+or4in/bHiSPY="
   },
   "org/junit/jupiter#junit-jupiter-params/5.12.2": {
    "module": "sha256-x3KP8z0SJgBzLq09DW+K3XRd4+lEFRmHE5WuiZymFHQ=",
    "pom": "sha256-pcfvF8refV90q2IHK7xrxxy9AWgGJGvOQl/LvBEISTw="
   },
-  "org/junit/jupiter#junit-jupiter-params/6.0.0": {
-   "jar": "sha256-IIR+RcVT1R45JEbgM1UGnxOP4MUekdfvG9v/wNOvBFQ=",
-   "module": "sha256-VfWJwqiUZt40HEAL8AzdGihwp+bc1oUL2tcyLbONc7c=",
-   "pom": "sha256-91zeM8lEa0XsSlqaKC3LWyv7dj1KMKshv8+EgqZg5UI="
+  "org/junit/jupiter#junit-jupiter-params/6.0.1": {
+   "jar": "sha256-lWbiSbTUx9U6bIkI9XeIXOLUxjE8kWvfv3/7xSa4o28=",
+   "module": "sha256-p9p+0ICwGl76I7bWB/qxxmMhEYc0EXoaVkde/DU7HMA=",
+   "pom": "sha256-sfUTKYkKt1oPR+kBQNZOJf6z57dM5KEHRZg9YViQbnM="
   },
   "org/junit/jupiter#junit-jupiter/5.12.2": {
    "module": "sha256-ioIpqKD4Se/BzD/9XPlN4W6sgAYcX5M5eoXAk8nX6nA=",
    "pom": "sha256-ka2OSkvzBCMslByQFKyRNnvroTHx21jVv+SZx5DUbxc="
   },
-  "org/junit/jupiter#junit-jupiter/6.0.0": {
-   "jar": "sha256-jb8LIX4usBPWU9kW/BBgkklrfMrI8IQyiYHlXjZzrnE=",
-   "module": "sha256-YdlnTuitkcdk2IbQzTFjO1up967ad6okIPglNaJVXOE=",
-   "pom": "sha256-9j4gTo0IDEzis05lnzGVzHHYpKZrcyqAW5pv0rjyVrs="
+  "org/junit/jupiter#junit-jupiter/6.0.1": {
+   "jar": "sha256-vXrygd/vjcwdCKUDzpMEWXtl4YUKDbgsmattjLEDGxQ=",
+   "module": "sha256-iuvBy0oYWd7uRjDJq3S2/KKMAdpl0h6Z7XgEp7ibGMo=",
+   "pom": "sha256-VICrz2YRG4YweP/+OFMKTcrtJoK9gCtO2VBdrzVleTM="
   },
-  "org/junit/platform#junit-platform-commons/6.0.0": {
-   "jar": "sha256-huj6+H8xUaPVRYUIUqDyzFXqiiQ07ungj4OIHFLVWZI=",
-   "module": "sha256-oNE82wfx2950q74HZmT/XcQEOtXRO/+UD3i55gTyElE=",
-   "pom": "sha256-lDFdk3FOzUB6kg2TOcj0S0DPCEBBMWMu1/m3dwzxCgU="
+  "org/junit/platform#junit-platform-commons/6.0.1": {
+   "jar": "sha256-+IU/RcEPOA3bFXz0KrupsHNHTwXMQDNbWFBV+FU43K0=",
+   "module": "sha256-mS8uNl3Y24i+YC+eXFwI+B/USwxbj6HPFzTzb8fh8f0=",
+   "pom": "sha256-E6l3Y7CJ0P0kyrrGE/d5pyEmm+5VHz5cHbr+mhzQ6tI="
   },
-  "org/junit/platform#junit-platform-engine/6.0.0": {
-   "jar": "sha256-b4GELpwT6ZfKxmtEYUUi82OUGeI4iuLQAMS8CmuS2T8=",
-   "module": "sha256-GcijGiINhY0hWr20mfYjuLxy/ig3jMBABI0ymTCliSE=",
-   "pom": "sha256-TD7A1PapQGLOgr3kLuvtHya5m7XLHWl24VmPzF+KSS0="
+  "org/junit/platform#junit-platform-engine/6.0.1": {
+   "jar": "sha256-9JV3Bzp64YTHGNm0OuDY7cuKv8Wsc4c17jM51GUukr8=",
+   "module": "sha256-2aXeq5puUhW79Aw5/+2pCwZXdPjNAY5Xuyod7OI0VKQ=",
+   "pom": "sha256-oiRe8nBlLAfVls5x2NZw0KipklHNzvRU85ZRmaycTpo="
   },
-  "org/junit/platform#junit-platform-launcher/6.0.0": {
-   "jar": "sha256-Xwl7AMZxS7cez7XexitZu0wveJdj+v0ezpbE7w5sKA8=",
-   "module": "sha256-/OwWMsXFlyf/nn6jCKmTh9ci/6iC2FzKUFKv7Iw47ug=",
-   "pom": "sha256-RwG8mhY9lbI1zhatdt4Z8qyFTFyjT689LsThAYsIzHQ="
+  "org/junit/platform#junit-platform-launcher/6.0.1": {
+   "jar": "sha256-7nWN2wb6sf0aiQwLrkqs+NwATE82fhONv/yxE80J66w=",
+   "module": "sha256-QGPjXSBE9xraiSUfrtFB8KWvnOwm1uO3znI889Vz29c=",
+   "pom": "sha256-TNsMG5Lxon57UucN6Buik1shlBgC2MqoiOnZ4V+s/ho="
   },
   "org/kordamp/ikonli#ikonli-bootstrapicons-pack/12.4.0": {
    "jar": "sha256-RbwgHLWfhluydZcOCI394XH01pxIwRYZS68xmSbFWAw=",
@@ -2842,9 +2620,9 @@
   "org/mockito#mockito-bom/4.11.0": {
    "pom": "sha256-2FMadGyYj39o7V8YjN6pRQBq6pk+xd+eUk4NJ9YUkdo="
   },
-  "org/mockito#mockito-core/5.20.0": {
-   "jar": "sha256-0altJSEo06QkfP2KLnZBLvo8wQOXe+F5M8lCEXok83Q=",
-   "pom": "sha256-mQPiB1XAxIh6q5xPEAYft/ERUdOp+t2WTp+6QnIm0TU="
+  "org/mockito#mockito-core/5.21.0": {
+   "jar": "sha256-A9sj3nQsvKQqo9YSf9rOVg+sN7A22TGHCAH4TCiL0oY=",
+   "pom": "sha256-AiGzH5bfAaFYxkU3Gq2BstP1vuD1icoNDC6qbo2gkvM="
   },
   "org/objenesis#objenesis-parent/3.3": {
    "pom": "sha256-MFw4SqLx4cf+U6ltpBw+w1JDuX1CjSSo93mBjMEL5P8="
@@ -2945,14 +2723,11 @@
   "org/ow2#ow2/1.5.1": {
    "pom": "sha256-Mh3bt+5v5PU96mtM1tt0FU1r+kI5HB92OzYbn0hazwU="
   },
-  "org/ow2/asm#asm-bom/9.7": {
-   "pom": "sha256-jIZR874EOzV43SihXAFhhhsV6wObf1JHZ5wMwNvwd4c="
+  "org/ow2/asm#asm-bom/9.9": {
+   "pom": "sha256-D6JzNvp7YpI8qb3GlSbr5xKjv7H37ov3bEoLP4XxnWI="
   },
-  "org/ow2/asm#asm-bom/9.8": {
-   "pom": "sha256-DaHcsibmzf2ttNrFkZFruRe1c3RnTZG9LxMAMTe0FSA="
-  },
-  "org/ow2/asm#asm/9.8": {
-   "pom": "sha256-wTZ8O7OD12Gef3l+ON91E4hfLu8ErntZCPaCImV7W6o="
+  "org/ow2/asm#asm/9.9": {
+   "pom": "sha256-z4Ye8edF1XFUr3muFN80DtU0Hl3NAVfO/NLrfxqgXFc="
   },
   "org/pcollections#pcollections/4.0.1": {
    "jar": "sha256-H4J2bXwyIZMIVAM76/9Qc+pGtD8nMmB0u+FdFIwYv7M=",
@@ -2985,6 +2760,10 @@
   "org/slf4j#slf4j-parent/2.0.17": {
    "pom": "sha256-lc1x6FLf2ykSbli3uTnVfsKy5gJDkYUuC1Rd7ggrvzs="
   },
+  "org/snakeyaml#snakeyaml-engine/2.10": {
+   "jar": "sha256-yZ2f1mx8JR2IGpzZUIm3yARMKaGwKYPXA2mBvUNU7Dc=",
+   "pom": "sha256-VhQsopiYjPZNplrivcGYNJIdc411qyN2Go+sS19YMUk="
+  },
   "org/sonatype/oss#oss-parent/5": {
    "pom": "sha256-FnjUEgpYXYpjATGu7ExSTZKDmFg7fqthbufVqH9SDT0="
   },
@@ -2997,9 +2776,6 @@
   "org/springframework#spring-framework-bom/5.3.39": {
    "module": "sha256-+ItA4qUDM7QLQvGB7uJyt17HXdhmbLFFvZCxW5fhg+M=",
    "pom": "sha256-9tSBCT51dny6Gsfh2zj49pLL4+OHRGkzcada6yHGFIs="
-  },
-  "org/testcontainers#testcontainers-bom/1.20.1": {
-   "pom": "sha256-CKrS6R3QXKeycG0t/Ap66AxLXFBHAweZyLzbcyfLL0A="
   },
   "org/testfx#testfx-core/4.0.18": {
    "pom": "sha256-+rVBhIAbFZm8WzBb8R0X3ACeT1lqUXwT3BxUb6jdOxo="
@@ -3023,27 +2799,14 @@
    "jar": "sha256-lcY8GlWyLdZFOJCkGcwaZA95C799iugtseMK7++wiIg=",
    "pom": "sha256-72CLg8O7bI4+azvqo4hCuhWWO0ZJXkr5GwdGyLdQ87k="
   },
-  "org/wiremock#wiremock/3.13.0": {
-   "module": "sha256-6UqHsje9650nqsFtS6+ujcPjsXblK3tBQSOKrhEsZgs=",
-   "pom": "sha256-8DaGoIr4nd2qb8RQ2/havBO4oKS99AXlSZo2vLhLjZ4="
-  },
   "org/xmlunit#xmlunit-core/2.10.4": {
    "pom": "sha256-QMVRcQPPFS8IejttyqpTDs5h8D1/KUSR/4gtk2utBl8="
-  },
-  "org/xmlunit#xmlunit-legacy/2.10.0": {
-   "pom": "sha256-B0sBekWQP79QoP3faxekM90lzFQDmMGvuG+tkOxxwmg="
   },
   "org/xmlunit#xmlunit-matchers/2.10.4": {
    "pom": "sha256-JH4kA3uLcvdMy7TUXzVPlJ1VUQTeyL7U6K/dVleCvww="
   },
-  "org/xmlunit#xmlunit-parent/2.10.0": {
-   "pom": "sha256-XOnCkW1QdlQJ78IKgQf5jvF3BAzr4LG4VwSI4h0JYcc="
-  },
   "org/xmlunit#xmlunit-parent/2.10.4": {
    "pom": "sha256-g9gzkrJTxbwHpRKgjYt5RiPn1MW7u6DE25H0zjeAkeI="
-  },
-  "org/xmlunit#xmlunit-placeholders/2.10.0": {
-   "pom": "sha256-41+qK1zuBc03FaViqCOoA4/PQyp97WWZny0lBaGMSes="
   },
   "org/yaml#snakeyaml/2.5": {
    "jar": "sha256-5mgqzxrOd1CO8TZJy/T40J0s9UV722HSX/tqwCM9eN0=",
@@ -3070,6 +2833,30 @@
   },
   "tech/uom/lib#uom-lib/2.2": {
    "pom": "sha256-EUCfWa/BJ74iyO5VCUNHZPSB5mX3FMBz5HGciB0oM8k="
+  },
+  "tools/jackson#jackson-base/3.0.2": {
+   "pom": "sha256-bNfjpxD7/9oYOZzlZe//tviCVICZC7Yxj4Ps8Z28k7I="
+  },
+  "tools/jackson#jackson-bom/3.0.2": {
+   "pom": "sha256-j/nmDa1VX3MadR8hSPVo36hhFpZPnofSOOK6m1fI0fQ="
+  },
+  "tools/jackson/core#jackson-core/3.0.2": {
+   "jar": "sha256-+nRRW6X8ASgs7Kt+WXD6EqD0/yO9bCBh6cd4MzjQtDY=",
+   "module": "sha256-ahqDE3aR5sMwIzIHsENnSsV+gohKRgT9erpnPsv4Dok=",
+   "pom": "sha256-M0PoYpgxJsUq1LGVhV/fKYlwcAFTRWHR5cH3DbrM5SM="
+  },
+  "tools/jackson/core#jackson-databind/3.0.2": {
+   "jar": "sha256-9U9pv8eAOAo/TeQvssPoKyLI702EupGM/4HSLGqhBp8=",
+   "module": "sha256-r8lO4gcAP1TxfepZ1em1DdSPSGl6aDD2XWKtwfJ35Lw=",
+   "pom": "sha256-Mk6hllrSTyPQU/zkQJ0lBaxZckJGcp1QLpct6f0fxIw="
+  },
+  "tools/jackson/dataformat#jackson-dataformat-yaml/3.0.2": {
+   "jar": "sha256-9Of2pLjGDePEiuIQe+eQo/1wUYg7P3tWfo2cAmG37sk=",
+   "module": "sha256-WhXr7vNPJ04OgA0ntENjjpEALsar8JhxUcjyxaLchBc=",
+   "pom": "sha256-WInJZdlIuikWXxpy2nGwVK3oL0RX3HREKwRvhcAUlTA="
+  },
+  "tools/jackson/dataformat#jackson-dataformats-text/3.0.2": {
+   "pom": "sha256-YV+jqbxqx0NoZZS1gJPmq8wW/zFypaxRErTrjzG6Too="
   }
  }
 }

--- a/pkgs/by-name/ja/jabref/package.nix
+++ b/pkgs/by-name/ja/jabref/package.nix
@@ -54,6 +54,7 @@ let
     url = ltwaUrl;
     hash = "sha256-jnS8Y9x8eg2L3L3RPnS6INTs19mEtwzfNIjJUw6HtIY=";
   };
+  kotlinDslVersion = "6.4.2";
 in
 stdenv.mkDerivation rec {
   version = "6.0-alpha.4";
@@ -92,6 +93,9 @@ stdenv.mkDerivation rec {
     sed -i -e 's/javafx = .*/javafx = "25"/' versions/build.gradle.kts
 
     sed -i -e '1a //REPOS file://${mitmCache}/https/repo.maven.apache.org/maven2,file://${mitmCache}/https/plugins.gradle.org/m2' build-support/src/main/java/*.java
+
+    substituteInPlace build-logic/build.gradle.kts \
+      --replace-fail '`kotlin-dsl`' 'id("org.gradle.kotlin.kotlin-dsl") version "${kotlinDslVersion}"'
 
     pushd jablib
 


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/482234/, as the automatic cherry-pick [failed](https://github.com/NixOS/nixpkgs/pull/482234#issuecomment-3779874937). Without this, JabRef (in 25.11) doesn't build at all.

<details>
<summary>build failure message</summary>


```
❯ nix run .#jabref
error: Cannot build '/nix/store/hahdaygrl3a33pykqagdrq0n9ysl2zzc-jabref-6.0-alpha.3.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/bmj2f0q2hxfqyc08izgwhyyqyagsmq6c-jabref-6.0-alpha.3
       Last 25 log lines:
       >
       > To honour the JVM settings for this build a single-use Daemon process will be forked. For more on this, please refer to https://docs.gradle.org/9.3.1/userguide/gradle_daemon.html#sec:disabling_the_daemon in the Gradle documentation.
       > Daemon will be stopped at the end of the build
       >
       > FAILURE: Build failed with an exception.
       >
       > * Where:
       > Build file '/build/source/build-logic/build.gradle.kts' line: 1
       >
       > * What went wrong:
       > Plugin [id: 'org.gradle.kotlin.kotlin-dsl', version: '6.4.2'] was not found in any of the following sources:
       >
       > - Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
       > - Included Builds (No included builds contain this plugin)
       > - Plugin Repositories (could not resolve plugin artifact 'org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:6.4.2')
       >   Searched in the following repositories:
       >     Gradle Central Plugin Repository
       >
       > * Try:
       > > Run with --stacktrace option to get the stack trace.
       > > Run with --info or --debug option to get more log output.
       > > Run with --scan to get full insights from a Build Scan (powered by Develocity).
       > > Get more help at https://help.gradle.org.
       >
       > BUILD FAILED in 31s
       For full logs, run:
         nix log /nix/store/hahdaygrl3a33pykqagdrq0n9ysl2zzc-jabref-6.0-alpha.3.drv
```


</details>

@linsui


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
