### PR TITLE
fast-cli-zig: init at 0.3.5

### DIFF
--- a/pkgs/by-name/fa/fast-cli-zig/package.nix
+++ b/pkgs/by-name/fa/fast-cli-zig/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  zig,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  # fast-cli existed, was removed as noted in aliasses.nix on 2025-11-17. Consider to rename this package after 1 to 2 releases of nixos
+  pname = "fast-cli-zig";
+  version = "0.3.5";
+
+  src = fetchFromGitHub {
+    owner = "mikkelam";
+    repo = "fast-cli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KKjxKQHiSYMaGCfX1+h6DQ809xHh9Yfv8B4PXvr3CwQ=";
+  };
+
+  zigDeps = zig.fetchDeps {
+    inherit (finalAttrs) src pname version;
+    hash = "sha256-89ig8lO5Yb9qFlJ1yL3NDDfKeZDl/CeM6qFxT40eOf8=";
+  };
+
+  nativeBuildInputs = [ zig.hook ];
+
+  postConfigure = ''
+    ln -s ${finalAttrs.zigDeps} "$ZIG_GLOBAL_CACHE_DIR/p"
+  '';
+
+  doCheck = true;
+  # Tests create a local http server to check the latency functionality
+  __darwinAllowLocalNetworking = true;
+
+  meta = {
+    description = "Command line version of fast.com in ~1.2 MB";
+    homepage = "https://github.com/mikkelam/fast-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dwt ];
+    mainProgram = "fast-cli";
+    inherit (zig.meta) platforms;
+  };
+})


### PR DESCRIPTION
## Things done

This is a different package to what was in Nixpkgs in 24.11, so I am not yet sure how to handle this.

Should this package get a fresh name, so we can maintain the deprecation notice? Or is it fine to get a different package as long as it does mostly the same thing?

I would really like to learn how nixpkgs handle this, but haven't yet found documentation on this

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
