### PR TITLE
soundfont-generaluser: 2.0.2-unstable-2025-04-21 -> 2.0.3, rename and modernize

### DIFF
--- a/pkgs/by-name/so/soundfont-generaluser-gs/package.nix
+++ b/pkgs/by-name/so/soundfont-generaluser-gs/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  stdenv,
+  stdenvNoCC,
   fetchFromGitHub,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "soundfont-generaluser-gs";
   version = "2.0.2-unstable-2025-04-21";
 
@@ -17,11 +17,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   installPhase = ''
     runHook preInstall
-    install -Dm644 $src/GeneralUser-GS.sf2 $out/share/soundfonts/GeneralUser-GS.sf2
+
+    install -Dm444 GeneralUser-GS.sf2 $out/share/soundfonts/GeneralUser-GS.sf2
+
     runHook postInstall
   '';
 
   meta = {
+    changelog = "https://github.com/mrbumpy409/GeneralUser-GS/blob/main/documentation/CHANGELOG.md";
     description = "General MIDI SoundFont with a low memory footprint";
     homepage = "https://www.schristiancollins.com/generaluser.php";
     license = lib.licenses.generaluser;

--- a/pkgs/by-name/so/soundfont-generaluser-gs/package.nix
+++ b/pkgs/by-name/so/soundfont-generaluser-gs/package.nix
@@ -5,7 +5,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  pname = "generaluser";
+  pname = "soundfont-generaluser-gs";
   version = "2.0.2-unstable-2025-04-21";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/so/soundfont-generaluser-gs/package.nix
+++ b/pkgs/by-name/so/soundfont-generaluser-gs/package.nix
@@ -6,13 +6,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "soundfont-generaluser-gs";
-  version = "2.0.2-unstable-2025-04-21";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "mrbumpy409";
     repo = "GeneralUser-GS";
-    rev = "74d4cfe4042a61ddab17d4f86dbccd9d2570eb2a";
-    hash = "sha256-I27l8F/BFAo6YSNbtAV14AKVsPIJTHFG2eGudseWmjo=";
+    rev = "6f2014e815237de02e26e793f8c66c796ba66db5";
+    hash = "sha256-/nWcvaAcXDSd/6HapDEa7rDmQD2Q1w6iYsbckh2vnek=";
   };
 
   installPhase = ''

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1771,6 +1771,7 @@ mapAliases {
   somatic-sniper = throw "somatic-sniper has been removed as it was archived in 2020 and fails to build."; # Added 2025-10-14
   sonusmix = throw "'sonusmix' has been removed due to lack of maintenance"; # Added 2025-08-27
   soulseekqt = throw "'soulseekqt' has been removed due to lack of maintenance in Nixpkgs in a long time. Consider using 'nicotine-plus' or 'slskd' instead."; # Added 2025-06-07
+  soundfont-generaluser = warnAlias "'soundfont-generaluser' has been renamed to 'soundfont-generaluser-gs'" soundfont-generaluser-gs; # Added 2026-02-26
   soundkonverter = throw "'soundkonverter' has been dropped as it depends on KDE Gear 5, and is unmaintained"; # Added 2025-08-20
   soundmodem = throw "'soundmodem' was removed due to lack of maintenance and relying on gtk2"; # Added 2025-12-02
   soundOfSorting = throw "'soundOfSorting' has been renamed to/replaced by 'sound-of-sorting'"; # Converted to throw 2025-10-27


### PR DESCRIPTION
Changelog: https://github.com/mrbumpy409/GeneralUser-GS/blob/main/documentation/CHANGELOG.md

- Rename package to proper name (generaluser -> generaluser-gs) and add alias
- Bump to latest version
- Clean up derivation. Fix soundfont permissions, swap to stdEnvNoCC, remove `$src`, add changelog link

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
