### PR TITLE
difit: init at 3.1.10

### DIFF
--- a/pkgs/by-name/di/difit/package.nix
+++ b/pkgs/by-name/di/difit/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  stdenv,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  jq,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  nix-update-script,
+  versionCheckHook,
+  git,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "difit";
+  version = "3.1.10";
+
+  src = fetchFromGitHub {
+    owner = "yoshiko-pg";
+    repo = "difit";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Yr7x8NJJP3X8YP5tGNMmn4mUxrmz3RMvnx9MPz4jj7o=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    pnpm = pnpm_10;
+    fetcherVersion = 3;
+    hash = "sha256-IRCr/Fo0lgv+JSMIYrTpyWgGA6EORCNL+igK88dkJNg=";
+  };
+
+  nativeBuildInputs = [
+    nodejs
+    pnpmConfigHook
+    pnpm_10
+    jq
+    makeWrapper
+  ];
+
+  postPatch = ''
+    # Remove prepare script (lefthook install) since we don't need git hooks
+    jq 'del(.scripts.prepare)' package.json > package.json.tmp
+    mv package.json.tmp package.json
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    pnpm build
+    pnpm prune --prod
+    # Clean up broken symlinks left behind by pnpm prune
+    find node_modules -xtype l -delete
+    # Remove non-deterministic files
+    rm -f node_modules/.modules.yaml
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    appdir="$out/lib/difit"
+    mkdir -p "$appdir" "$out/bin"
+
+    cp -r dist node_modules package.json "$appdir"/
+
+    makeWrapper ${nodejs}/bin/node "$out/bin/difit" \
+      --add-flags "$appdir/dist/cli/index.js" \
+      --set NODE_PATH "$appdir/node_modules" \
+      --prefix PATH : ${lib.makeBinPath [ git ]}
+
+    # Install agent skill file for AI coding assistants
+    install -Dm644 SKILL.md "$out/share/difit/SKILL.md"
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI tool to view local git diffs in a GitHub-style web viewer";
+    homepage = "https://github.com/yoshiko-pg/difit";
+    changelog = "https://github.com/yoshiko-pg/difit/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "difit";
+    maintainers = with lib.maintainers; [ poelzi ];
+  };
+})


### PR DESCRIPTION
[difit](https://github.com/yoshiko-pg/difit) is a CLI tool to view local git diffs in a GitHub-style web viewer.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test