### PR TITLE
x2goserver: refactor

### DIFF
--- a/pkgs/by-name/x2/x2goserver/package.nix
+++ b/pkgs/by-name/x2/x2goserver/package.nix
@@ -34,80 +34,17 @@
   bash,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "x2goserver";
   version = "4.1.0.5";
 
   src = fetchurl {
-    url = "https://code.x2go.org/releases/source/${pname}/${pname}-${version}.tar.gz";
+    url = "https://code.x2go.org/releases/source/x2goserver/x2goserver-${finalAttrs.version}.tar.gz";
     hash = "sha256-Q1vbB84iQZ2eRWDf+Kyn+utrNgkdVayrwXZCm5Ia65Y=";
   };
 
-  x2go-perl = perlPackages.buildPerlPackage {
-    pname = "X2Go";
-    inherit version src;
-    makeFlags = [
-      "-f"
-      "Makefile.perl"
-    ];
-    patchPhase = ''
-      substituteInPlace X2Go/Config.pm --replace '/etc/x2go' '/var/lib/x2go/conf'
-      substituteInPlace X2Go/Server/DB.pm \
-        --replace '$x2go_lib_path/libx2go-server-db-sqlite3-wrapper' \
-                  '/run/wrappers/bin/x2gosqliteWrapper'
-      substituteInPlace X2Go/Server/DB/SQLite3.pm --replace "user='x2gouser'" "user='x2go'"
-    '';
-  };
-
-  perlEnv = perl.withPackages (
-    p: with p; [
-      x2go-perl
-      DBI
-      DBDSQLite
-      FileBaseDir
-      TryTiny
-      CaptureTiny
-      ConfigSimple
-      Switch
-      FileWhich
-    ]
-  );
-
-  binaryDeps = [
-    perlEnv
-    which
-    nx-libs
-    util-linux
-    coreutils
-    glibc.bin
-    gawk
-    gnused
-    gnugrep
-    findutils
-    net-tools
-    iproute2
-    bc
-    procps
-    psmisc
-    lsof
-    pwgen
-    openssh
-    sshfs
-    xauth
-    xinit
-    xrandr
-    xmodmap
-    xwininfo
-    font-util
-    xkbcomp
-    setxkbmap
-  ];
-in
-stdenv.mkDerivation {
-  inherit pname version src;
-
   buildInputs = [
-    perlEnv
+    finalAttrs.passthru.perlEnv
     bash
   ];
 
@@ -116,22 +53,22 @@ stdenv.mkDerivation {
   prePatch = ''
     patchShebangs .
     sed -i '/Makefile.PL\|Makefile.perl/d' Makefile
-    for i in */Makefile; do
-      substituteInPlace "$i" --replace "-o root -g root " ""
-    done
-    substituteInPlace libx2go-server-db-perl/Makefile --replace "chmod 2755" "chmod 755"
-    for i in x2goserver/sbin/x2godbadmin x2goserver/bin/x2go*
-    do
-      substituteInPlace $i --replace '/etc/x2go' '/var/lib/x2go/conf'
-    done
+    substituteInPlace */Makefile \
+      --replace-fail '-o root -g root ' ""
+    substituteInPlace libx2go-server-db-perl/Makefile \
+      --replace-fail 'chmod 2755' 'chmod 755'
+    # --replace without fail because not all x2go binaries use '/etc/x2go'
+    substituteInPlace x2goserver/{s,}bin/x2go* \
+      --replace '/etc/x2go' '/var/lib/x2go/conf'
     substituteInPlace x2goserver/Makefile \
       --replace-fail "\$(DESTDIR)/etc" "\$(DESTDIR)/\$(ETCDIR)"
     substituteInPlace x2goserver/sbin/x2gocleansessions \
-      --replace '/var/run/x2goserver.pid' '/var/run/x2go/x2goserver.pid'
-    substituteInPlace x2goserver/sbin/x2godbadmin --replace 'user="x2gouser"' 'user="x2go"'
+      --replace-fail '/var/run/x2goserver.pid' '/var/run/x2go/x2goserver.pid'
+    substituteInPlace x2goserver/sbin/x2godbadmin \
+      --replace-fail 'user="x2gouser"' 'user="x2go"'
     substituteInPlace x2goserver-xsession/etc/Xsession \
-      --replace "SSH_AGENT /bin/bash -c" "SSH_AGENT ${bash}/bin/bash -c" \
-      --replace "[ -f /etc/redhat-release ]" "[ -d /etc/nix ] || [ -f /etc/redhat-release ]"
+      --replace-fail 'SSH_AGENT /bin/bash -c' 'SSH_AGENT ${bash}/bin/bash -c' \
+      --replace-fail '[ -f /etc/redhat-release ]' '[ -d /etc/nix ] || [ -f /etc/redhat-release ]'
   '';
 
   makeFlags = [
@@ -148,15 +85,87 @@ stdenv.mkDerivation {
     for i in $out/sbin/x2go* $(find $out/bin -type f) \
       $(ls $out/lib/x2go/x2go* | grep -v x2gocheckport)
     do
-      wrapProgram $i --prefix PATH : ${lib.makeBinPath binaryDeps}:$out
+      wrapProgram $i --prefix PATH : ${
+        lib.makeBinPath [
+          finalAttrs.passthru.perlEnv
+          which
+          nx-libs
+          util-linux
+          coreutils
+          glibc.bin
+          gawk
+          gnused
+          gnugrep
+          findutils
+          net-tools
+          iproute2
+          bc
+          procps
+          psmisc
+          lsof
+          pwgen
+          openssh
+          sshfs
+          xauth
+          xinit
+          xrandr
+          xmodmap
+          xwininfo
+          font-util
+          xkbcomp
+          setxkbmap
+        ]
+      }:$out
     done
     # We're patching @INC of the setgid wrapper, because we can't mix
     # the perl wrapper (for PERL5LIB) with security.wrappers (for setgid)
-    sed -i -e "s,.\+bin/perl,#!${perl}/bin/perl -I ${perlEnv}/lib/perl5/site_perl," \
+    sed -i -e "s,.\+bin/perl,#!${perl}/bin/perl -I ${finalAttrs.passthru.perlEnv}/lib/perl5/site_perl," \
       $out/lib/x2go/libx2go-server-db-sqlite3-wrapper.pl
   '';
 
   enableParallelBuilding = true;
+
+  passthru = {
+    # x2go-perl in passthru, so it can depend on finalAttrs (thus overriding works)
+    x2go-perl = perlPackages.buildPerlPackage {
+      pname = "x2go-perl";
+      inherit (finalAttrs) version src;
+
+      patchPhase = ''
+        runHook prePatch
+
+        substituteInPlace X2Go/Config.pm \
+          --replace-fail '/etc/x2go' '/var/lib/x2go/conf'
+        substituteInPlace X2Go/Server/DB.pm \
+          --replace-fail '$x2go_lib_path/libx2go-server-db-sqlite3-wrapper' '/run/wrappers/bin/x2gosqliteWrapper'
+        substituteInPlace X2Go/Server/DB/SQLite3.pm \
+          --replace-fail "user='x2gouser'" "user='x2go'"
+
+        runHook postPatch
+      '';
+
+      makeFlags = [
+        "-f"
+        "Makefile.perl"
+      ];
+
+      inherit (finalAttrs) meta;
+    };
+
+    perlEnv = perl.withPackages (
+      p: with p; [
+        finalAttrs.passthru.x2go-perl
+        DBI
+        DBDSQLite
+        FileBaseDir
+        TryTiny
+        CaptureTiny
+        ConfigSimple
+        Switch
+        FileWhich
+      ]
+    );
+  };
 
   meta = {
     description = "Remote desktop application, server component";
@@ -165,4 +174,4 @@ stdenv.mkDerivation {
     license = lib.licenses.gpl2;
     maintainers = with lib.maintainers; [ averelld ];
   };
-}
+})


### PR DESCRIPTION
the output doesn't change other than the output path

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
