### PR TITLE
pure-prompt-bash: init at 0-unstable-2020-10-02

### DIFF
--- a/pkgs/by-name/pu/pure-prompt-bash/package.nix
+++ b/pkgs/by-name/pu/pure-prompt-bash/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "pure-prompt-bash";
+  version = "0-unstable-2020-10-02";
+
+  src = fetchFromGitHub {
+    owner = "krashikiworks";
+    repo = "pure-prompt-bash";
+    rev = "110dfe79628bcdcdd585a586e6410cee4c702dc3";
+    sha256 = "sha256-lTpD4sZd56pSMafhNhC4+zyyeldoJ3k8qEmTTdJkK9Y=";
+  };
+
+  strictDeps = true;
+  installPhase = ''
+    mkdir -p $out/share
+    cp pure.bash $out/share/pure.bash
+  '';
+
+  meta = {
+    description = "Pure, the minimal prompt for bash";
+    homepage = "https://github.com/krashikiworks/pure-prompt-bash";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      matthewcroughan
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This can then be used like this, in a user's config

```nix
{
  environment.interactiveShellInit = ''
    source "${pkgs.pure-prompt-bash}/share/pure.bash"
  '';
}
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
