### PR TITLE
cinny-unwrapped: 4.10.3 -> 4.10.5

### DIFF
--- a/pkgs/by-name/ci/cinny-unwrapped/package.nix
+++ b/pkgs/by-name/ci/cinny-unwrapped/package.nix
@@ -14,18 +14,18 @@
 
 buildNpmPackage rec {
   pname = "cinny-unwrapped";
-  version = "4.10.3";
+  version = "4.10.5";
 
   src = fetchFromGitHub {
     owner = "cinnyapp";
     repo = "cinny";
     tag = "v${version}";
-    hash = "sha256-ZztZ/znJUwgYlvv5h9uxNZvQrkUMVbMG6R+HbRtSXHM=";
+    hash = "sha256-Napy3AcsLRDZPcBh3oq1U30FNtvoNtob0+AZtZSvcbM=";
   };
 
   nodejs = nodejs_22;
 
-  npmDepsHash = "sha256-Spt2+sQcoPwy1tU8ztqJHZS9ITX9avueYDVKE7BFYy4=";
+  npmDepsHash = "sha256-2Lrd0jAwAH6HkwLHyivqwaEhcpFAIALuno+MchSIfxo=";
 
   nativeBuildInputs = [
     python3


### PR DESCRIPTION
Changelog: https://github.com/cinnyapp/cinny/releases/tag/v4.10.5
This release contains [a security vulnerability mitigation](https://github.com/cinnyapp/cinny/releases/tag/v4.10.4) and should be backported.

@rebmit I could not get cinny-desktop to build using the new version (even with `NIXPKGS_ALLOW_BROKEN=1 NIXPKGS_ALLOW_INSECURE=1`), because of (new) dependencies on javascriptcore and libsoup-2.4. This was my diff: (now that I think of it libsoup_2_4 shouldn't even be in `buildInputs`, but rather in `nativeBuildInputs`, but I didn't follow through with fixing the builds because of all warnings because of multiple CVEs)

<details>
<summary>diff</summary>

```diff
diff --git a/pkgs/by-name/ci/cinny-desktop/package.nix b/pkgs/by-name/ci/cinny-desktop/package.nix
index d5c1082760ab..25fa334ed51d 100644
--- a/pkgs/by-name/ci/cinny-desktop/package.nix
+++ b/pkgs/by-name/ci/cinny-desktop/package.nix
@@ -13,23 +13,24 @@
   webkitgtk_4_1,
   jq,
   moreutils,
+  libsoup_2_4,
 }:
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cinny-desktop";
   # We have to be using the same version as cinny-web or this isn't going to work.
-  version = "4.10.2";
+  version = "4.10.5";
 
   src = fetchFromGitHub {
     owner = "cinnyapp";
     repo = "cinny-desktop";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-M1p8rwdNEsKvZ1ssxsFyfiIBS8tKrXhuz85CKM4dSRw=";
+    hash = "sha256-DRSafPNED9fpm3w5K4a9r8581xMpttfo7BEDBIJ87Kc=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src-tauri";
 
-  cargoHash = "sha256-Ie6xq21JoJ37j/BjdVrsiJ3JULVEV5ZwN3hf9NhfXVA=";
+  cargoHash = "sha256-q6YMAjK+BBYBpk8menA1sM3x/FCnAh40t70fs9knnRo=";
 
   postPatch =
     let
@@ -80,6 +81,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
     glib-networking
     openssl
     webkitgtk_4_1
+    libsoup_2_4
   ];
 
   meta = {
```
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  (x86_64-linux only, will use `nixpkgs-review-gha` for other platforms
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  (tested using `nix run .#python314 -- -m http.server`)
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
