### PR TITLE
ocamlPackages.eliom: 11.1.1 → 12.0.1

### DIFF
--- a/pkgs/development/ocaml-modules/eliom/default.nix
+++ b/pkgs/development/ocaml-modules/eliom/default.nix
@@ -19,13 +19,13 @@
 
 buildDunePackage (finalAttrs: {
   pname = "eliom";
-  version = "11.1.1";
+  version = "12.0.1";
 
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "eliom";
-    rev = finalAttrs.version;
-    hash = "sha256-ALuoyO6axNQEeBteBVIFwdoSrbLxxcaSTObAcLPGIvo=";
+    tag = finalAttrs.version;
+    hash = "sha256-Lja3Xe3FszzyILhpOXWTyA0ippaU6aW5CJ06WEKgbkA=";
   };
 
   nativeBuildInputs = [
@@ -69,7 +69,6 @@ buildDunePackage (finalAttrs: {
     '';
 
     license = lib.licenses.lgpl21;
-    broken = true;
     maintainers = [ lib.maintainers.gal_bolle ];
   };
 })

--- a/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-ppx-rpc/default.nix
@@ -3,27 +3,32 @@
   buildDunePackage,
   fetchFromGitHub,
   ppxlib,
+  version ? if lib.versionAtLeast ppxlib.version "0.36.0" then "1.1" else "1.0",
 }:
 
-buildDunePackage rec {
+buildDunePackage {
   pname = "ocsigen-ppx-rpc";
-  version = "1.0";
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "ocsigen";
-    repo = pname;
-    rev = version;
-    sha256 = "sha256:0qgasd89ayamgl2rfyxsipznmwa3pjllkyq9qg0g1f41h8ixpsfh";
+    repo = "ocsigen-ppx-rpc";
+    tag = version;
+    hash =
+      {
+        "1.0" = "sha256:0qgasd89ayamgl2rfyxsipznmwa3pjllkyq9qg0g1f41h8ixpsfh";
+        "1.1" = "sha256-YjRB0cem+iDnQIIQcHI6vo5crSxAGNGM65qyG3lTtkE=";
+      }
+      ."${version}";
   };
 
   propagatedBuildInputs = [ ppxlib ];
 
   meta = {
-    inherit (src.meta) homepage;
+    homepage = "https://github.com/ocsigen/ocsigen-ppx-rpc/";
     description = "Syntax for RPCs for Eliom and Ocsigen Start";
     license = lib.licenses.lgpl21Only;
     maintainers = [ lib.maintainers.vbgl ];
-    broken = lib.versionAtLeast ppxlib.version "0.36";
   };
 
 }

--- a/pkgs/development/ocaml-modules/ocsigen-start/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-start/default.nix
@@ -14,9 +14,9 @@
   ocsigen-ppx-rpc,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "ocaml${ocaml.version}-ocsigen-start";
-  version = "7.1.0";
+  version = "8.0.0";
 
   nativeBuildInputs = [
     ocaml
@@ -42,8 +42,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "ocsigen";
     repo = "ocsigen-start";
-    rev = version;
-    hash = "sha256-2DFFceUI7BYgGKvJ1sZphLWt/Rusa5Y86yc94Mi/quo=";
+    rev = "b64139e365ab1d244033133629431f7a73e3e054";
+    hash = "sha256-N6bPEibcN7WM23hSK4260+hZWo9PSRoSLjemF7m/9Ic=";
   };
 
   preInstall = ''

--- a/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-toolkit/default.nix
@@ -13,7 +13,7 @@
 stdenv.mkDerivation rec {
   pname = "ocsigen-toolkit";
   name = "ocaml${ocaml.version}-${pname}-${version}";
-  version = "4.1.0";
+  version = "4.2.0";
 
   propagatedBuildInputs = [
     calendar
@@ -40,9 +40,9 @@ stdenv.mkDerivation rec {
 
   src = fetchFromGitHub {
     owner = "ocsigen";
-    repo = pname;
-    rev = version;
-    hash = "sha256-1kw2HANajHDdMmjuYNB79ZDqy2Ml02nc5s+cJzIoxQ8=";
+    repo = "ocsigen-toolkit";
+    tag = version;
+    hash = "sha256-wken+5hUewE0Nktl2PY1xMmVveSs8X0ihWD+MK4pzRQ=";
   };
 
   meta = {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -548,19 +548,7 @@ let
           stdenv = pkgs.gcc13Stdenv;
         };
 
-        eliom =
-          let
-            js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
-            js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
-          in
-          callPackage ../development/ocaml-modules/eliom rec {
-            js_of_ocaml-ppx = self.js_of_ocaml-ppx.override { inherit js_of_ocaml; };
-            js_of_ocaml-ppx_deriving_json = self.js_of_ocaml-ppx_deriving_json.override {
-              inherit js_of_ocaml;
-            };
-            js_of_ocaml-lwt = self.js_of_ocaml-lwt.override { inherit js_of_ocaml js_of_ocaml-ppx; };
-            js_of_ocaml-tyxml = self.js_of_ocaml-tyxml.override { inherit js_of_ocaml js_of_ocaml-ppx; };
-          };
+        eliom = callPackage ../development/ocaml-modules/eliom { };
 
         elpi = callPackage ../development/ocaml-modules/elpi (
           let
@@ -1582,16 +1570,7 @@ let
 
         ocsigen-start = callPackage ../development/ocaml-modules/ocsigen-start { };
 
-        ocsigen-toolkit =
-          let
-            js_of_ocaml-compiler = self.js_of_ocaml-compiler.override { version = "5.9.1"; };
-            js_of_ocaml = self.js_of_ocaml.override { inherit js_of_ocaml-compiler; };
-          in
-          callPackage ../development/ocaml-modules/ocsigen-toolkit {
-            js_of_ocaml-ppx_deriving_json = self.js_of_ocaml-ppx_deriving_json.override {
-              inherit js_of_ocaml;
-            };
-          };
+        ocsigen-toolkit = callPackage ../development/ocaml-modules/ocsigen-toolkit { };
 
         ocsipersist = callPackage ../development/ocaml-modules/ocsipersist { };
 


### PR DESCRIPTION
## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
