### PR TITLE
iortcw: set pname and version, fix build

### DIFF
--- a/pkgs/by-name/io/iortcw/package.nix
+++ b/pkgs/by-name/io/iortcw/package.nix
@@ -11,7 +11,8 @@ let
   });
 in
 buildEnv {
-  name = "iortcw";
+  inherit (sp) version;
+  pname = "iortcw";
 
   paths = [
     sp

--- a/pkgs/by-name/io/iortcw/sp.nix
+++ b/pkgs/by-name/io/iortcw/sp.nix
@@ -19,9 +19,16 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "iortcw";
     repo = "iortcw";
-    rev = finalAttrs.version;
-    sha256 = "0g5wgqb1gm34pd05dj2i8nj3qhsz0831p3m7bsgxpjcg9c00jpyw";
+    tag = finalAttrs.version;
+    hash = "sha256-3F8JAEuPydufXqeOGwYCX0M8pEVRyFZAu2TUFxZ+vDw=";
   };
+
+  # Constexpr is a reserved keyword since C++11 that can't be overwritten. Replacing constexpr with
+  # const_expr is necessary in this case for the build to function.
+  postPatch = ''
+    substituteInPlace code/tools/lcc/src/{c.h,init.c,simp.c,stmt.c} \
+      --replace-fail 'constexpr' 'const_expr'
+  '';
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Part of #485742

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
