### PR TITLE
nrfutil: fix aarch64-linux; add darwin support; convenience 'withAllExtensions' passthru

### DIFF
--- a/pkgs/by-name/nr/nrfutil/package.nix
+++ b/pkgs/by-name/nr/nrfutil/package.nix
@@ -156,10 +156,21 @@ symlinkJoin {
         --zsh $(realpath "$out"/share/nrfutil-completion/scripts/zsh/_nrfutil)
     '';
 
-  passthru = {
-    updateScript = ./update.sh;
-    withExtensions = extensions: nrfutil.override { inherit extensions; };
-  };
+  passthru =
+    let
+      availableExtensions = lib.attrNames (
+        lib.removeAttrs platformSources.packages [
+          "nrfutil"
+          "nrfutil-completion"
+        ]
+      );
+    in
+    {
+      updateScript = ./update.sh;
+      allExtensions = availableExtensions;
+      withExtensions = extensions: nrfutil.override { inherit extensions; };
+      withAllExtensions = nrfutil.override { extensions = availableExtensions; };
+    };
 
   meta = sharedMeta // {
     mainProgram = "nrfutil";

--- a/pkgs/by-name/nr/nrfutil/package.nix
+++ b/pkgs/by-name/nr/nrfutil/package.nix
@@ -98,8 +98,8 @@ let
       (
         [
           "nrfutil"
-          "nrfutil-completion"
         ]
+        ++ lib.optional (platformSources.packages ? nrfutil-completion) "nrfutil-completion"
         ++ extensions
       );
 
@@ -151,9 +151,11 @@ symlinkJoin {
     ''
       wrapProgram "$out"/bin/nrfutil ${wrapProgramArgs}
 
-      installShellCompletion --cmd nrfutil \
-        --bash $(realpath "$out"/share/nrfutil-completion/scripts/bash/setup.bash) \
-        --zsh $(realpath "$out"/share/nrfutil-completion/scripts/zsh/_nrfutil)
+      ${lib.optionalString (platformSources.packages ? nrfutil-completion) ''
+        installShellCompletion --cmd nrfutil \
+          --bash $(realpath "$out"/share/nrfutil-completion/scripts/bash/setup.bash) \
+          --zsh $(realpath "$out"/share/nrfutil-completion/scripts/zsh/_nrfutil)
+      ''}
     '';
 
   passthru =

--- a/pkgs/by-name/nr/nrfutil/package.nix
+++ b/pkgs/by-name/nr/nrfutil/package.nix
@@ -53,16 +53,18 @@ let
             inherit (package) hash;
           };
 
-          nativeBuildInputs = [
+          nativeBuildInputs = lib.optionals (!stdenvNoCC.hostPlatform.isDarwin) [
             autoPatchelfHook
           ];
 
           buildInputs = [
+            libusb1
+            segger-jlink-headless
+          ]
+          ++ lib.optionals (!stdenvNoCC.hostPlatform.isDarwin) [
             xz
             zlib
-            libusb1
             gcc.cc.lib
-            segger-jlink-headless
           ];
 
           dontConfigure = true;
@@ -81,6 +83,12 @@ let
           nativeInstallCheckInputs = [
             versionCheckHook
           ];
+
+          # nrfutil tries to write a log file to $HOME/.nrfutil/logs/, which fails in sandbox
+          versionCheckKeepEnvironment = [ "HOME" ];
+          preVersionCheck = ''
+            export HOME=$(mktemp -d)
+          '';
 
           meta = sharedMeta // {
             mainProgram = name;
@@ -114,8 +122,18 @@ symlinkJoin {
           ''--prefix PATH : "$out/bin"''
           ''--prefix PATH : "$out"/lib/nrfutil-npm''
           ''--prefix PATH : "$out"/lib/nrfutil-nrf5sdk-tools''
-          "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libusb1 ]}"
-          "--set NRF_JLINK_DLL_PATH '${segger-jlink-headless}'/lib/libjlinkarm.so"
+          (
+            if stdenvNoCC.hostPlatform.isDarwin then
+              "--prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ libusb1 ]}"
+            else
+              "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libusb1 ]}"
+          )
+          (
+            if stdenvNoCC.hostPlatform.isDarwin then
+              "--set NRF_JLINK_DLL_PATH '${segger-jlink-headless}'/Applications/SEGGER/JLink/libjlinkarm.dylib"
+            else
+              "--set NRF_JLINK_DLL_PATH '${segger-jlink-headless}'/lib/libjlinkarm.so"
+          )
           ''--set NRFUTIL_BLE_SNIFFER_SHIM_BIN_ENV "$out"/lib/nrfutil-ble-sniffer/wireshark-shim''
           ''--set NRFUTIL_BLE_SNIFFER_HCI_SHIM_BIN_ENV "$out"/lib/nrfutil-ble-sniffer/wireshark-hci-shim''
         ]

--- a/pkgs/by-name/nr/nrfutil/package.nix
+++ b/pkgs/by-name/nr/nrfutil/package.nix
@@ -53,16 +53,18 @@ let
             inherit (package) hash;
           };
 
-          nativeBuildInputs = [
+          nativeBuildInputs = lib.optionals (!stdenvNoCC.hostPlatform.isDarwin) [
             autoPatchelfHook
           ];
 
           buildInputs = [
+            libusb1
+            segger-jlink-headless
+          ]
+          ++ lib.optionals (!stdenvNoCC.hostPlatform.isDarwin) [
             xz
             zlib
-            libusb1
             gcc.cc.lib
-            segger-jlink-headless
           ];
 
           dontConfigure = true;
@@ -81,6 +83,12 @@ let
           nativeInstallCheckInputs = [
             versionCheckHook
           ];
+
+          # nrfutil tries to write a log file to $HOME/.nrfutil/logs/, which fails in sandbox
+          versionCheckKeepEnvironment = [ "HOME" ];
+          preVersionCheck = ''
+            export HOME=$(mktemp -d)
+          '';
 
           meta = sharedMeta // {
             mainProgram = name;
@@ -114,8 +122,18 @@ symlinkJoin {
           ''--prefix PATH : "$out/bin"''
           ''--prefix PATH : "$out"/lib/nrfutil-npm''
           ''--prefix PATH : "$out"/lib/nrfutil-nrf5sdk-tools''
-          "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libusb1 ]}"
-          "--set NRF_JLINK_DLL_PATH '${segger-jlink-headless}'/lib/libjlinkarm.so"
+          (
+            if stdenvNoCC.hostPlatform.isDarwin then
+              "--prefix DYLD_LIBRARY_PATH : ${lib.makeLibraryPath [ libusb1 ]}"
+            else
+              "--prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ libusb1 ]}"
+          )
+          (
+            if stdenvNoCC.hostPlatform.isDarwin then
+              "--set NRF_JLINK_DLL_PATH ${segger-jlink-headless}/Applications/SEGGER/JLink/libjlinkarm.dylib"
+            else
+              "--set NRF_JLINK_DLL_PATH ${segger-jlink-headless}/lib/libjlinkarm.so"
+          )
           ''--set NRFUTIL_BLE_SNIFFER_SHIM_BIN_ENV "$out"/lib/nrfutil-ble-sniffer/wireshark-shim''
           ''--set NRFUTIL_BLE_SNIFFER_HCI_SHIM_BIN_ENV "$out"/lib/nrfutil-ble-sniffer/wireshark-hci-shim''
         ]

--- a/pkgs/by-name/nr/nrfutil/source.nix
+++ b/pkgs/by-name/nr/nrfutil/source.nix
@@ -1,4 +1,57 @@
 {
+  aarch64-darwin = {
+    triplet = "aarch64-apple-darwin";
+    packages = {
+      nrfutil = {
+        version = "8.1.1";
+        hash = "sha256-uUSviI9sPRA4geccGTEe89uBU4vnPSjP+3Y5RM1oieM=";
+      };
+      nrfutil-91 = {
+        version = "0.5.0";
+        hash = "sha256-eRYmwolAW/k0nggSDvbQhU3AfOdNlfs7pMDUQBYgWjQ=";
+      };
+      nrfutil-ble-sniffer = {
+        version = "0.16.2";
+        hash = "sha256-NRdEzjfBV5SSMxzc5LCaSSGTwp5Lyd8G7aI8OKTwlaA=";
+      };
+      nrfutil-completion = {
+        version = "1.5.0";
+        hash = "sha256-8+HJUSgmGIDPztlLM3BPLQROeurgKMxZ4iPtGQJtkUI=";
+      };
+      nrfutil-device = {
+        version = "2.15.1";
+        hash = "sha256-goLcorkaAYnHkUd5elLt0irLvDwnqFWUJR0nBkXGEFQ=";
+      };
+      nrfutil-mcu-manager = {
+        version = "0.8.0";
+        hash = "sha256-1mKoXw5i/++6aUexmLml+S/Qp5KbqO5GXuDbUFJcA+4=";
+      };
+      nrfutil-npm = {
+        version = "0.3.1";
+        hash = "sha256-tyUQkzCCho6Y5sulwdKGMEazuWxeS2nQid4aOolHbNE=";
+      };
+      nrfutil-nrf5sdk-tools = {
+        version = "1.1.0";
+        hash = "sha256-TbGmQ8Nu/n4YmikQ8ND7aWCEjWvD53jZqIFcEknKQFo=";
+      };
+      nrfutil-sdk-manager = {
+        version = "1.8.0";
+        hash = "sha256-sHAwJmtoISbmJmSnl3Am+10/ulIRw5x4aVIFYpBy734=";
+      };
+      nrfutil-suit = {
+        version = "0.9.0";
+        hash = "sha256-G7/WhtkxQgr1yzFVz+mlx+zwn8cgEepGRQZcJadAkOY=";
+      };
+      nrfutil-toolchain-manager = {
+        version = "0.15.0";
+        hash = "sha256-lVdvEj5Z2O5QhtRkbOSnVVP5dzJE9S34tMVE1O32sO0=";
+      };
+      nrfutil-trace = {
+        version = "4.0.1";
+        hash = "sha256-gAqBw/EsLu1JMuq2IRVhYYfDRw8byldFY6MxNfs29Gc=";
+      };
+    };
+  };
   aarch64-linux = {
     triplet = "aarch64-unknown-linux-gnu";
     packages = {
@@ -25,6 +78,59 @@
       nrfutil-trace = {
         version = "4.0.1";
         hash = "sha256-IR4P1tK/0P3d96Wnwciq7b3TJurENF2pYKaHu2yZIPk=";
+      };
+    };
+  };
+  x86_64-darwin = {
+    triplet = "x86_64-apple-darwin";
+    packages = {
+      nrfutil = {
+        version = "8.1.1";
+        hash = "sha256-EShnbgjMDAchKff52cXqoG2v1jurgCkya1QuWUgM6ug=";
+      };
+      nrfutil-91 = {
+        version = "0.5.0";
+        hash = "sha256-6DPcqusR5da47QqXGAafZJ5p2lN3Pb97ZdHEW9u9ZcU=";
+      };
+      nrfutil-ble-sniffer = {
+        version = "0.16.2";
+        hash = "sha256-xFSUrEejkAaCKNq7hDXjvOquFOpZlOY2Xg16uEw48zg=";
+      };
+      nrfutil-completion = {
+        version = "1.5.0";
+        hash = "sha256-sI4U5yz12Sf4dw//r9+uLhlS1objnUd/TmnVYbEBjvI=";
+      };
+      nrfutil-device = {
+        version = "2.15.1";
+        hash = "sha256-/db36wX0bImlJuSEvUJbYcWH+l9MTlrJ6vi2kc4Ll3g=";
+      };
+      nrfutil-mcu-manager = {
+        version = "0.8.0";
+        hash = "sha256-lHyFz3CR/N+CEmxpNkLPUyi5AuN1jFqTfsnkbxRYsVg=";
+      };
+      nrfutil-npm = {
+        version = "0.3.1";
+        hash = "sha256-fhWcNve4GxjiedEJQT3pCYJbNZHVayZQo2QASNXS6j8=";
+      };
+      nrfutil-nrf5sdk-tools = {
+        version = "1.1.0";
+        hash = "sha256-oJSzVZhxTlovDLUd5TVd3MOdCC9Ow6kIve5gA9kIeFM=";
+      };
+      nrfutil-sdk-manager = {
+        version = "1.8.0";
+        hash = "sha256-Ub/P0bW/Mfq6ffP0Kj9hYzH7Xi6gVlojx23CPajnZG8=";
+      };
+      nrfutil-suit = {
+        version = "0.9.0";
+        hash = "sha256-Xfx7gA5lcRV2zMdu5fsYySq07ncQ+FdBqLKyMM163Lg=";
+      };
+      nrfutil-toolchain-manager = {
+        version = "0.15.0";
+        hash = "sha256-wxlk73Up4jiPPdTyV51eootdgAQtcq9Tq1mUTEhUXVk=";
+      };
+      nrfutil-trace = {
+        version = "4.0.1";
+        hash = "sha256-/HtbZKFUVV7mGtWuFj6T1ATDghXIP+hsGM0HVCmyRdA=";
       };
     };
   };

--- a/pkgs/by-name/nr/nrfutil/source.nix
+++ b/pkgs/by-name/nr/nrfutil/source.nix
@@ -1,4 +1,57 @@
 {
+  aarch64-darwin = {
+    triplet = "aarch64-apple-darwin";
+    packages = {
+      nrfutil = {
+        version = "8.1.1";
+        hash = "sha256-uUSviI9sPRA4geccGTEe89uBU4vnPSjP+3Y5RM1oieM=";
+      };
+      nrfutil-91 = {
+        version = "0.5.0";
+        hash = "sha256-eRYmwolAW/k0nggSDvbQhU3AfOdNlfs7pMDUQBYgWjQ=";
+      };
+      nrfutil-ble-sniffer = {
+        version = "0.16.2";
+        hash = "sha256-NRdEzjfBV5SSMxzc5LCaSSGTwp5Lyd8G7aI8OKTwlaA=";
+      };
+      nrfutil-completion = {
+        version = "1.5.0";
+        hash = "sha256-8+HJUSgmGIDPztlLM3BPLQROeurgKMxZ4iPtGQJtkUI=";
+      };
+      nrfutil-device = {
+        version = "2.15.1";
+        hash = "sha256-goLcorkaAYnHkUd5elLt0irLvDwnqFWUJR0nBkXGEFQ=";
+      };
+      nrfutil-mcu-manager = {
+        version = "0.8.0";
+        hash = "sha256-1mKoXw5i/++6aUexmLml+S/Qp5KbqO5GXuDbUFJcA+4=";
+      };
+      nrfutil-npm = {
+        version = "0.3.1";
+        hash = "sha256-tyUQkzCCho6Y5sulwdKGMEazuWxeS2nQid4aOolHbNE=";
+      };
+      nrfutil-nrf5sdk-tools = {
+        version = "1.1.0";
+        hash = "sha256-TbGmQ8Nu/n4YmikQ8ND7aWCEjWvD53jZqIFcEknKQFo=";
+      };
+      nrfutil-sdk-manager = {
+        version = "1.8.0";
+        hash = "sha256-sHAwJmtoISbmJmSnl3Am+10/ulIRw5x4aVIFYpBy734=";
+      };
+      nrfutil-suit = {
+        version = "0.9.0";
+        hash = "sha256-G7/WhtkxQgr1yzFVz+mlx+zwn8cgEepGRQZcJadAkOY=";
+      };
+      nrfutil-toolchain-manager = {
+        version = "0.15.0";
+        hash = "sha256-lVdvEj5Z2O5QhtRkbOSnVVP5dzJE9S34tMVE1O32sO0=";
+      };
+      nrfutil-trace = {
+        version = "4.0.1";
+        hash = "sha256-gAqBw/EsLu1JMuq2IRVhYYfDRw8byldFY6MxNfs29Gc=";
+      };
+    };
+  };
   aarch64-linux = {
     triplet = "aarch64-unknown-linux-gnu";
     packages = {

--- a/pkgs/by-name/nr/nrfutil/source.nix
+++ b/pkgs/by-name/nr/nrfutil/source.nix
@@ -3,28 +3,28 @@
     triplet = "aarch64-apple-darwin";
     packages = {
       nrfutil = {
-        version = "8.1.1";
-        hash = "sha256-uUSviI9sPRA4geccGTEe89uBU4vnPSjP+3Y5RM1oieM=";
+        version = "8.2.0";
+        hash = "sha256-mU00xIFL2dp/0F4CMgqS4ScTf/SF4SyVs4FrETUhgLY=";
       };
       nrfutil-91 = {
         version = "0.5.0";
         hash = "sha256-eRYmwolAW/k0nggSDvbQhU3AfOdNlfs7pMDUQBYgWjQ=";
       };
       nrfutil-ble-sniffer = {
-        version = "0.16.2";
-        hash = "sha256-NRdEzjfBV5SSMxzc5LCaSSGTwp5Lyd8G7aI8OKTwlaA=";
+        version = "0.20.0";
+        hash = "sha256-4K8l9Oh0mp6Nee8taM3TsDrcZBxPhgCMf95Mm2FEzjE=";
       };
       nrfutil-completion = {
         version = "1.5.0";
         hash = "sha256-8+HJUSgmGIDPztlLM3BPLQROeurgKMxZ4iPtGQJtkUI=";
       };
       nrfutil-device = {
-        version = "2.15.1";
-        hash = "sha256-goLcorkaAYnHkUd5elLt0irLvDwnqFWUJR0nBkXGEFQ=";
+        version = "2.19.4";
+        hash = "sha256-ggU9VayYmZ3phyK70InMWxcquR4w9DCll0o93V7k0oc=";
       };
       nrfutil-mcu-manager = {
-        version = "0.8.0";
-        hash = "sha256-1mKoXw5i/++6aUexmLml+S/Qp5KbqO5GXuDbUFJcA+4=";
+        version = "0.10.2";
+        hash = "sha256-FgiIxR4c3qjlw9htX17xSqD/sM71iPE53yG1r9/6YY4=";
       };
       nrfutil-npm = {
         version = "0.3.1";
@@ -35,8 +35,8 @@
         hash = "sha256-TbGmQ8Nu/n4YmikQ8ND7aWCEjWvD53jZqIFcEknKQFo=";
       };
       nrfutil-sdk-manager = {
-        version = "1.8.0";
-        hash = "sha256-sHAwJmtoISbmJmSnl3Am+10/ulIRw5x4aVIFYpBy734=";
+        version = "1.15.0";
+        hash = "sha256-tXh/Z9IEqZt4g8tkdgPbZMGn2Ffzoa6ibD4AjWBY8hU=";
       };
       nrfutil-suit = {
         version = "0.9.0";
@@ -47,8 +47,8 @@
         hash = "sha256-lVdvEj5Z2O5QhtRkbOSnVVP5dzJE9S34tMVE1O32sO0=";
       };
       nrfutil-trace = {
-        version = "4.0.1";
-        hash = "sha256-gAqBw/EsLu1JMuq2IRVhYYfDRw8byldFY6MxNfs29Gc=";
+        version = "5.2.0";
+        hash = "sha256-dvf4YRAnkqBsnIkFFhv/FVp18wrjUkc8hMw4MuALUq8=";
       };
     };
   };
@@ -56,28 +56,28 @@
     triplet = "aarch64-unknown-linux-gnu";
     packages = {
       nrfutil = {
-        version = "8.1.1";
-        hash = "sha256-y7ywCr9Ze3Uz1JQh0hNg2BOPKW2yEftYDaD8WzHWSxY=";
+        version = "8.2.0";
+        hash = "sha256-4o+JK6Ditvjbr71k8kERZqRFIDVy8YcFgDZyKA3ToQ0=";
       };
       nrfutil-ble-sniffer = {
-        version = "0.16.2";
-        hash = "sha256-vCpSs9oUcqKPDKVoEtrqqY9Jy0AtbMwK8s398xvQ7Us=";
+        version = "0.20.0";
+        hash = "sha256-QB6KeJwafNNIeQP42IY9/tIXqdKxtXJ8owEmU6yKxTo=";
       };
       nrfutil-device = {
-        version = "2.15.1";
-        hash = "sha256-u8JlM7bxkR5x0fhTQRIkElpxot6jpKyL2SljFfoKj54=";
+        version = "2.19.4";
+        hash = "sha256-yMUroFG0VYrXtzsgUN3y2rh8MJaISmkwEHinaDCZHkI=";
       };
       nrfutil-mcu-manager = {
-        version = "0.8.0";
-        hash = "sha256-jLsLN/Ny5zL4MSaKS3cb2L4WBCKZHVLiR2RkPAL8JnY=";
+        version = "0.10.2";
+        hash = "sha256-65G/RPEbMvK1dZ5OFyab+x+1y2EuM6wx7stIfD3z2vM=";
       };
       nrfutil-sdk-manager = {
-        version = "1.8.0";
-        hash = "sha256-DsGuOQ6rzwit5oeG4ZLObCOaxMt8WB+YYnuXRYtqq4U=";
+        version = "1.15.0";
+        hash = "sha256-dTFiqFpZLOJ+Mhsx5z9Tzy+wP9tpyGBSCrb3mU7n1Rg=";
       };
       nrfutil-trace = {
-        version = "4.0.1";
-        hash = "sha256-IR4P1tK/0P3d96Wnwciq7b3TJurENF2pYKaHu2yZIPk=";
+        version = "5.2.0";
+        hash = "sha256-fqZF0ltseGYAfLqY7M9ejk3XrqXB5n3ULD6rg5T95XM=";
       };
     };
   };
@@ -85,28 +85,28 @@
     triplet = "x86_64-unknown-linux-gnu";
     packages = {
       nrfutil = {
-        version = "8.1.1";
-        hash = "sha256-asX1UbAE6X03lLC3l9e/9G2WgVRezfmRD6dyXJKb18Y=";
+        version = "8.2.0";
+        hash = "sha256-+r6EGY7+BFp83MnVEyZpwbwssWj2Hbk/ImGuT9mA5z8=";
       };
       nrfutil-91 = {
         version = "0.5.0";
         hash = "sha256-ACQ+csYVIoANKV+CyAAD+drXQSb7CVUdvDYe76LELqs=";
       };
       nrfutil-ble-sniffer = {
-        version = "0.16.2";
-        hash = "sha256-4TGbn0HdlER5k76Hc5rCSVvyx89VdLQ56fMiGgWUvrU=";
+        version = "0.20.0";
+        hash = "sha256-TbfUnGA/hychnRqnO+4KpPp+/ez5Vs28OSDO4Mh/Uv0=";
       };
       nrfutil-completion = {
         version = "1.5.0";
         hash = "sha256-KA5h9/hJA66nkAAW1Tui+m60E/Iv9wzVPdeQqIQWpxc=";
       };
       nrfutil-device = {
-        version = "2.15.1";
-        hash = "sha256-zH/QtM1vM6BIiZHPLM23TRt2LCRUdJvmYN9oveotsH0=";
+        version = "2.19.4";
+        hash = "sha256-1tnfQt7qCROqqGgx3yHViOvBKeb0cTxFiN3mg8h1wmE=";
       };
       nrfutil-mcu-manager = {
-        version = "0.8.0";
-        hash = "sha256-ItU3kys1HMd06srLTzPtRoAW1YxwOt39LqjIQPMvmaI=";
+        version = "0.10.2";
+        hash = "sha256-g+Jpp98OvKACIBoPk59fKBX0cULda5XzsWqgdPTLnRg=";
       };
       nrfutil-npm = {
         version = "0.3.1";
@@ -117,8 +117,8 @@
         hash = "sha256-hLQhTEa5F2lrFxppKmVrD5PnIA3JPcP/M/r9bYizHk8=";
       };
       nrfutil-sdk-manager = {
-        version = "1.8.0";
-        hash = "sha256-+Z1xfEdTAcvYj+hjsW0z/dHRoIzVGWXjD6lSqoQvOPg=";
+        version = "1.15.0";
+        hash = "sha256-qeegaIL1z7QlRyhbS/4szQXyw5587JHarea1gvKXwgY=";
       };
       nrfutil-suit = {
         version = "0.9.0";
@@ -129,8 +129,8 @@
         hash = "sha256-/bQx4yu1ybCO2TBd7MctxCANiYO5c1qCDYSjXm7hLcE=";
       };
       nrfutil-trace = {
-        version = "4.0.1";
-        hash = "sha256-YmsMQOD1vylaRwMWOhOA9xXePJR779P8im4Lcs7EcWk=";
+        version = "5.2.0";
+        hash = "sha256-3x7KH8Ou4eI9Vf1J588LtIEN7Xf0JT8Pj8CJDfGu89Q=";
       };
     };
   };

--- a/pkgs/by-name/nr/nrfutil/update.sh
+++ b/pkgs/by-name/nr/nrfutil/update.sh
@@ -14,11 +14,11 @@ declare -A versions
 declare -A hashes
 declare -a packages
 
-architectures["x86_64-linux"]="x86_64-unknown-linux-gnu"
+# same ordering as 'source.nix'
+architectures["aarch64-darwin"]="aarch64-apple-darwin"
 architectures["aarch64-linux"]="aarch64-unknown-linux-gnu"
-# NOTE: segger-jlink is not yet packaged for darwin
-# architectures["x86_64-darwin"]="x86_64-apple-darwin"
-# architectures["aarch64-darwin"]="aarch64-apple-darwin"
+architectures["x86_64-darwin"]="x86_64-apple-darwin"
+architectures["x86_64-linux"]="x86_64-unknown-linux-gnu"
 
 packages=(
     "nrfutil"
@@ -53,7 +53,7 @@ done
 
 {
     printf "{\n"
-    for a in "${!architectures[@]}"; do
+    for a in $(printf "%s\n" "${!architectures[@]}" | sort); do
         printf "  %s = {\n" "$a"
         printf "    triplet = \"%s\";\n" "${architectures["${a}"]}"
         printf "    packages = {\n"

--- a/pkgs/by-name/nr/nrfutil/update.sh
+++ b/pkgs/by-name/nr/nrfutil/update.sh
@@ -14,10 +14,10 @@ declare -A versions
 declare -A hashes
 declare -a packages
 
-architectures["x86_64-linux"]="x86_64-unknown-linux-gnu"
+# same ordering as 'source.nix'
+architectures["aarch64-darwin"]="aarch64-apple-darwin"
 architectures["aarch64-linux"]="aarch64-unknown-linux-gnu"
-# NOTE: segger-jlink is not yet packaged for darwin
-# architectures["aarch64-darwin"]="aarch64-apple-darwin"
+architectures["x86_64-linux"]="x86_64-unknown-linux-gnu"
 
 packages=(
     "nrfutil"
@@ -52,7 +52,7 @@ done
 
 {
     printf "{\n"
-    for a in "${!architectures[@]}"; do
+    for a in $(printf "%s\n" "${!architectures[@]}" | sort); do
         printf "  %s = {\n" "$a"
         printf "    triplet = \"%s\";\n" "${architectures["${a}"]}"
         printf "    packages = {\n"


### PR DESCRIPTION
Darwin support added, including the `update.sh` script.

Add a `withAllExtensions` passthru for convenience when desiring to build the complete package.

Fix broken aarch64-linux target

NOTE when testing you will need import options accepting the unfree licenses:

- if building with `nixpkgs-review` use `--extra-nixpkgs-config "{ config.allowUnfree = true; config.segger-jlink.acceptLicense = true; }"`
- if building locally use `nix-build -E 'with import ./default.nix { config.allowUnfree = true; config.segger-jlink.acceptLicense = true; }; nrfutil'`

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [N/A] [NixOS tests] in [nixos/tests].
  - [N/A] [Package tests] at `passthru.tests`.
  - [N/A] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [N/A] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [N/A] Module addition: when adding a new NixOS module.
  - [N/A] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @NixOS/darwin-maintainers 