### PR TITLE
helix: fix build with extra tree-sitter grammars overrides

### DIFF
--- a/pkgs/by-name/he/helix/package.nix
+++ b/pkgs/by-name/he/helix/package.nix
@@ -13,11 +13,29 @@
   lockedGrammars ? lib.importJSON ./grammars.json,
   grammarsOverlay ? (
     final: prev: {
-      tree-sitter-sql = prev.tree-sitter-sql.override {
+      tree-sitter-beancount = prev.tree-sitter-beancount.override {
+        excludeBrokenTreeSitterJson = false;
+      };
+      tree-sitter-dart = prev.tree-sitter-dart.overrideAttrs {
+        patches = [ ];
+      };
+      tree-sitter-glimmer = prev.tree-sitter-glimmer.override {
+        excludeBrokenTreeSitterJson = false;
+      };
+      tree-sitter-janet-simple = prev.tree-sitter-janet-simple.override {
+        excludeBrokenTreeSitterJson = false;
+      };
+      tree-sitter-latex = prev.tree-sitter-latex.override {
         generate = false;
       };
       tree-sitter-qmljs = prev.tree-sitter-qmljs.overrideAttrs {
         dontCheckForBrokenSymlinks = true;
+      };
+      tree-sitter-sql = prev.tree-sitter-sql.override {
+        generate = false;
+      };
+      tree-sitter-tlaplus = prev.tree-sitter-tlaplus.overrideAttrs {
+        patches = [ ];
       };
     }
   ),


### PR DESCRIPTION
Closes #493016
`nix-build -A helix.tree-sitter-grammars` now builds all the grammars.
`nix-build -A helix` fails but it's not related to this PR, for some reason `coreutils` fails to build.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
