### PR TITLE
various: migrate from pcre to pcre2

### DIFF
--- a/ci/eval/outpaths.nix
+++ b/ci/eval/outpaths.nix
@@ -33,6 +33,9 @@ let
             allowVariants = !attrNamesOnly;
             checkMeta = true;
 
+            # Silence the `x86_64-darwin` deprecation warning.
+            allowDeprecatedx86_64Darwin = true;
+
             handleEvalIssue =
               reason: errormsg:
               let

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -15143,6 +15143,11 @@
     githubId = 101508537;
     name = "Yuchen He";
   };
+  lilahummel = {
+    github = "LilaHummel";
+    githubId = 263230236;
+    name = "Lila Hummel";
+  };
   lilioid = {
     name = "Lilly";
     email = "li@lly.sh";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17342,6 +17342,12 @@
     githubId = 43088426;
     name = "Mihnea Stoian";
   };
+  mikaeladev = {
+    email = "mikaeladev@icloud.com";
+    github = "mikaeladev";
+    githubId = 100416544;
+    name = "mikaeladev";
+  };
   mikaelfangel = {
     email = "nixpkgs.bottle597@passfwd.com";
     github = "MikaelFangel";

--- a/nixos/modules/security/tpm2.nix
+++ b/nixos/modules/security/tpm2.nix
@@ -276,11 +276,11 @@ in
         services.udev.extraRules = lib.mkIf cfg.applyUdevRules (udevRules cfg.tssUser cfg.tssGroup);
 
         # Create the tss user and group only if the default value is used
-        users.users.${cfg.tssUser} = lib.mkIf (cfg.tssUser == "tss") {
+        users.users.tss = lib.mkIf (cfg.tssUser == "tss" || cfg.tssGroup == "tss") {
           isSystemUser = true;
           group = "tss";
         };
-        users.groups.${cfg.tssGroup} = lib.mkIf (cfg.tssGroup == "tss") { };
+        users.groups.tss = lib.mkIf (cfg.tssUser == "tss" || cfg.tssGroup == "tss") { };
 
         environment.variables = lib.mkIf cfg.tctiEnvironment.enable (
           lib.attrsets.genAttrs

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1633,7 +1633,7 @@ in
   tomcat = runTest ./tomcat.nix;
   tor = runTest ./tor.nix;
   tpm-ek = handleTest ./tpm-ek { };
-  tpm2 = runTest ./tpm2.nix;
+  tpm2 = import ./tpm2 { inherit runTest; };
   traccar = runTest ./traccar.nix;
   # tracee requires bpf
   tracee = handleTestOn [ "x86_64-linux" ] ./tracee.nix { };

--- a/nixos/tests/tpm2/default.nix
+++ b/nixos/tests/tpm2/default.nix
@@ -1,4 +1,5 @@
 { runTest }:
 {
   abrmd = runTest ./tpm2-abrmd.nix;
+  tpmrm = runTest ./tpm2-tpmrm.nix;
 }

--- a/nixos/tests/tpm2/default.nix
+++ b/nixos/tests/tpm2/default.nix
@@ -1,0 +1,4 @@
+{ runTest }:
+{
+  abrmd = runTest ./tpm2-abrmd.nix;
+}

--- a/nixos/tests/tpm2/tpm2-abrmd.nix
+++ b/nixos/tests/tpm2/tpm2-abrmd.nix
@@ -39,6 +39,10 @@
     machine.start()
     machine.wait_for_unit("multi-user.target")
 
+    with subtest("/dev/tpmrm0 has correct ownership"):
+        machine.succeed('[ `stat -c "%U" /dev/tpmrm0` = "tss" ]')
+        machine.succeed('[ `stat -c "%G" /dev/tpmrm0` = "tss" ]')
+
     with subtest("tabrmd service started properly"):
         machine.succeed('[ `systemctl show tpm2-abrmd.service --property=Result` = "Result=success" ]')
         machine.succeed('[ `journalctl -b -u tpm2-abrmd.service | grep -c "Starting"` = "1" ]')

--- a/nixos/tests/tpm2/tpm2-tpmrm.nix
+++ b/nixos/tests/tpm2/tpm2-tpmrm.nix
@@ -1,0 +1,72 @@
+{ lib, pkgs, ... }:
+{
+  name = "tpm2-tpmrm";
+
+  nodes.machine =
+    { config, pkgs, ... }:
+    {
+      virtualisation = {
+        mountHostNixStore = true;
+        useEFIBoot = true;
+        tpm.enable = true;
+      };
+
+      users.users = {
+        tss-user = {
+          isNormalUser = true;
+          extraGroups = [ "tss" ];
+        };
+      };
+
+      security.sudo.wheelNeedsPassword = false;
+
+      security.tpm2 = {
+        enable = true;
+        pkcs11.enable = true;
+        tctiEnvironment.enable = true;
+        fapi.ekCertLess = true;
+      };
+
+      environment.systemPackages = [
+        pkgs.tpm2-tools
+        pkgs.openssl
+      ];
+    };
+
+  testScript = ''
+    machine.start()
+    machine.wait_for_unit("multi-user.target")
+
+    with subtest("/dev/tpmrm0 has correct ownership"):
+        machine.succeed('[ `stat -c "%U" /dev/tpmrm0` = "root" ]')
+        machine.succeed('[ `stat -c "%G" /dev/tpmrm0` = "tss" ]')
+
+    with subtest("tpm2 cli works"):
+        machine.succeed('tpm2 createprimary --hierarchy=o --key-algorithm=aes256 --attributes="fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|decrypt" --key-context=owner_root_key.ctx')
+        machine.succeed('tpm2 create --parent-context=owner_root_key.ctx --key-algorithm=ecc256:ecdsa-sha256:null --attributes="fixedtpm|fixedparent|sensitivedataorigin|userwithauth|restricted|sign" --key-context=ecc_sign_key.ctx --creation-ticket=ecc_sign_key-creation_ticket.bin -f pem --output=ecc_sign_key_public.pem')
+        machine.succeed('echo "A very important message." > message.txt')
+        machine.succeed('tpm2 sign --key-context=ecc_sign_key.ctx --hash-algorithm=sha256 -f plain --signature message_signature.bin message.txt')
+        machine.succeed('openssl dgst -verify ecc_sign_key_public.pem -signature message_signature.bin message.txt')
+        machine.succeed('echo "evil addition!" >> message.txt')
+        machine.fail('openssl dgst -verify ecc_sign_key_public.pem -signature message_signature.bin message.txt')
+
+    def format_command(command, user):
+        return f"runuser -u {user} -- bash -c '{command}'"
+    def succeedu(command,user):
+        return machine.succeed(format_command(command,user))
+    def failu(command,user):
+        return machine.fail(format_command(command,user))
+
+    with subtest("tss2 cli works"):
+        machine.succeed('tss2 provision')
+        succeedu('tss2 createkey --path=HS/SRK/sign --type=sign --authValue=""',"tss-user")
+        succeedu('tss2 gettpmblobs --path=HS/SRK/sign --tpm2bPublic=$HOME/sign_key_public.bin',"tss-user")
+        succeedu('tpm2 print -t TPM2B_PUBLIC -f pem $HOME/sign_key_public.bin > $HOME/sign_key_public.pem',"tss-user")
+        succeedu('echo "A very important message." > $HOME/message.txt',"tss-user")
+        succeedu('tpm2 hash --hash-algorithm=sha256 --output=$HOME/message_hash.bin $HOME/message.txt',"tss-user")
+        succeedu('tss2 sign --keyPath=HS/SRK/sign --digest=$HOME/message_hash.bin --signature=$HOME/message_signature.bin',"tss-user")
+        succeedu('openssl dgst -verify $HOME/sign_key_public.pem -signature $HOME/message_signature.bin $HOME/message.txt',"tss-user")
+        succeedu('echo "evil addition!" >> $HOME/message.txt',"tss-user")
+        failu('openssl dgst -verify $HOME/sign_key_public.pem -signature $HOME/message_signature.bin $HOME/message.txt',"tss-user")
+  '';
+}

--- a/pkgs/applications/audio/mpg123/default.nix
+++ b/pkgs/applications/audio/mpg123/default.nix
@@ -81,13 +81,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-mpg123" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<a href="download/mpg123-1.32.6.tar.bz2">'
       new_version="$(curl -s https://mpg123.org/download.shtml |
-          pcregrep -o1 '<a href="download/mpg123-([0-9.]+).tar.bz2">')"
+          pcre2grep -o1 '<a href="download/mpg123-([0-9.]+).tar.bz2">')"
       update-source-version ${finalAttrs.pname} "$new_version"
     '';
   };

--- a/pkgs/applications/emulators/libretro/cores/freeintv.nix
+++ b/pkgs/applications/emulators/libretro/cores/freeintv.nix
@@ -5,13 +5,13 @@
 }:
 mkLibretroCore {
   core = "freeintv";
-  version = "0-unstable-2025-12-26";
+  version = "0-unstable-2026-02-24";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "freeintv";
-    rev = "df5a5312985b66b1ec71b496868641e40b7ad1c9";
-    hash = "sha256-xpcDAvxHvnuiQiWBYSwPKGE+Zg1lcs/6L4hMhpb1G1g=";
+    rev = "0e0e58503386304c5e7ac860c135583bc52e2e49";
+    hash = "sha256-uRkLF3LSiAMV/k8R8PuE0QZUnc1YEYe0rmccQz6H43A=";
   };
 
   makefile = "Makefile";

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -806,13 +806,13 @@
     "vendorHash": "sha256-UuLHaOEG6jmOAgfdNOtLyUimlAr3g6K8n3Ehu64sKqk="
   },
   "keycloak_keycloak": {
-    "hash": "sha256-u9gIh3iM9mpBJbO0Vgyt8YZNsRHvewJTY6vNm+KVxwY=",
+    "hash": "sha256-55/a3lJCJEOIDsnFckx5BsUClphPZ9BSBvWxQBq1D9Y=",
     "homepage": "https://registry.terraform.io/providers/keycloak/keycloak",
     "owner": "keycloak",
     "repo": "terraform-provider-keycloak",
-    "rev": "v5.6.0",
+    "rev": "v5.7.0",
     "spdx": "Apache-2.0",
-    "vendorHash": "sha256-va9B1CPLLT0NH4VP+1Fjr8O/I2K8xVO9aVjM3fZ9jVE="
+    "vendorHash": "sha256-JgQqOm+cAMLACp/rVz3ek1C4uuTAs8vqDcwRkpFssYc="
   },
   "kislerdm_neon": {
     "hash": "sha256-1o5EnAI9X8Q+dXxh1/jZwimy1MmPDF3X2aRc+HO7HpQ=",

--- a/pkgs/applications/networking/cluster/terraform-providers/providers.json
+++ b/pkgs/applications/networking/cluster/terraform-providers/providers.json
@@ -571,11 +571,11 @@
     "vendorHash": "sha256-xIagZvWtlNpz5SQfxbA7r9ojAeS3CW2pwV337ObKOwU="
   },
   "hashicorp_google": {
-    "hash": "sha256-SeShEZVFMn/f/ATUY08Jl1wwXBJFmyTpRh7U46ftM60=",
+    "hash": "sha256-HXHeCA3h5h9pyC9WZ+3EnySWmIsxGMskHbW+SjvZel4=",
     "homepage": "https://registry.terraform.io/providers/hashicorp/google",
     "owner": "hashicorp",
     "repo": "terraform-provider-google",
-    "rev": "v7.19.0",
+    "rev": "v7.20.0",
     "spdx": "MPL-2.0",
     "vendorHash": "sha256-lhTdDrTwTbRuWngQ+NGuh+x5Z5HZfVTtNi+mZqIENbg="
   },

--- a/pkgs/by-name/am/amneziawg-tools/package.nix
+++ b/pkgs/by-name/am/amneziawg-tools/package.nix
@@ -14,13 +14,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "amneziawg-tools";
-  version = "1.0.20250903";
+  version = "1.0.20260223";
 
   src = fetchFromGitHub {
     owner = "amnezia-vpn";
     repo = "amneziawg-tools";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-a5o49hx0HwB0PwlY1orp3ZI5zb5mpzHoRIhv9OdGSbU=";
+    hash = "sha256-pHmuxlrbTqjwRrB7BShdC4ENw3iVQRRLH+Z2w8x+KeE=";
   };
 
   sourceRoot = "${finalAttrs.src.name}/src";

--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -171,13 +171,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-argyllcms" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'Current Version 3.0.1 (19th October 2023)'
       new_version="$(curl -s https://www.argyllcms.com/ |
-          pcregrep -o1 '>Current Version ([0-9.]+) ')"
+          pcre2grep -o1 '>Current Version ([0-9.]+) ')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "argyllcms";
-  version = "3.4.1";
+  version = "3.5.0";
 
   src = fetchzip {
     # Kind of flacky URL, it was reaturning 406 and inconsistent binaries for a
     # while on me. It might be good to find a mirror
     url = "https://www.argyllcms.com/Argyll_V${version}_src.zip";
-    hash = "sha256-QVugWtAk8xBn+/fRFqCoi072Q2q8OlB0LRhavrHC5MI=";
+    hash = "sha256-5xBNM0H+hJcXc9heckLHQxXQDFXHpfrkuoQzHCrGW9U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/co/cosmic-applets/package.nix
+++ b/pkgs/by-name/co/cosmic-applets/package.nix
@@ -20,17 +20,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-applets";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-applets";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-ZL7Rt0UeWiMaALCIy/eDY5ROTm83xqRymiCupyvx9yI=";
+    hash = "sha256-ONDfvyIy7sqgMpf2IrVUjLPkXUEOiN3OGK57P/4KVZQ=";
   };
 
-  cargoHash = "sha256-n83JK/pOEMLTBlh0bbFqyW10usEthrSiXoozqmkUa58=";
+  cargoHash = "sha256-FWpfgqPqjbzzv6yaBKx9eq+PHCCQ/TErx+TGWqmXqXA=";
 
   nativeBuildInputs = [
     just

--- a/pkgs/by-name/co/cosmic-applibrary/package.nix
+++ b/pkgs/by-name/co/cosmic-applibrary/package.nix
@@ -11,14 +11,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-applibrary";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-applibrary";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-nxTsshFF7xRbd06q7YiMjXYmt94CRm8nSofcyrzulSQ=";
+    hash = "sha256-OxHfrtUrcVC5rdh3W56zNhNRNzYrX+VRJIiW19lAJPM=";
   };
 
   cargoHash = "sha256-apLIpb1VUuQRgOJ2mQioPyucbETzyh5wOeatMCLGrc4=";

--- a/pkgs/by-name/co/cosmic-bg/package.nix
+++ b/pkgs/by-name/co/cosmic-bg/package.nix
@@ -13,14 +13,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-bg";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-bg";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-lD5lTYXBy+keee+VArtNHgCS9n737YKaW8Kg3tu+8o0=";
+    hash = "sha256-/6VYiZ02y/UAA3fZ+CHb18BZAWBnm/3HAf7IdEhaeD0=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/co/cosmic-comp/package.nix
+++ b/pkgs/by-name/co/cosmic-comp/package.nix
@@ -20,17 +20,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-comp";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-comp";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-TQBHXXF8hZrdgqQLtQQHsallAfxAUGxGa3becbddPqc=";
+    hash = "sha256-AxMhcWBYN6q6IDKXXBWFi+WvSnSgF/lg5Ch9Obs+7uc=";
   };
 
-  cargoHash = "sha256-58qUzJDzwwMB5hmOl9XHmbTRZE/ep5fWKPj5u2onvRM=";
+  cargoHash = "sha256-hcQ6u4Aj5Av9T9uX0oDSbJG82g6E8IXcJc4Z2CfoRtg=";
 
   separateDebugInfo = true;
 

--- a/pkgs/by-name/co/cosmic-edit/package.nix
+++ b/pkgs/by-name/co/cosmic-edit/package.nix
@@ -16,17 +16,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-edit";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-edit";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-MaWRzTLJlc7883BVKCegyAT3GXf3OqgZhFWteVI+P6o=";
+    hash = "sha256-yaDFlnORaPwh/2Zb3Nh1Hr/jA1Z/kQT6Y1zic0eVvwA=";
   };
 
-  cargoHash = "sha256-EdKx+ynQBthJp4f3COmYRYp9pTq7/TkxuheyxcDuwV0=";
+  cargoHash = "sha256-1Q+jdr7uSQTp+3z2fgQIyH33v/Ld9MPER3/WRJ34Mdg=";
 
   postPatch = ''
     substituteInPlace justfile --replace-fail '#!/usr/bin/env' "#!$(command -v env)"

--- a/pkgs/by-name/co/cosmic-files/package.nix
+++ b/pkgs/by-name/co/cosmic-files/package.nix
@@ -12,17 +12,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-files";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-files";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-oSCGJAjfCSM9hSr/bsEzFY+E/JjFVrvPAlKlU/Zw57g=";
+    hash = "sha256-kTPPYfga0to19ZC66bGj/ROsMceG8LuELl1OkwKSirU=";
   };
 
-  cargoHash = "sha256-+Z7ICOBnxhS+I9gAZTnpq6guLzlqXlMAk9+awCIzNCk=";
+  cargoHash = "sha256-tkH9BIeTukdVJhN9yUgFdUUhyfqnx3tTqwu+LAAULog=";
 
   nativeBuildInputs = [
     just

--- a/pkgs/by-name/co/cosmic-greeter/package.nix
+++ b/pkgs/by-name/co/cosmic-greeter/package.nix
@@ -19,14 +19,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-greeter";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-greeter";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-mtq8xz70zAXrKW/18nUOvO3UjxC6qoYznhWyUWJ5NBc=";
+    hash = "sha256-U0JrxvMWzISSA0tP8moasN7iN7TfZreEwbvWZGHRn8E=";
   };
 
   cargoHash = "sha256-sNJTXBInr/h8w5dhOOP9ceBYWBcJW3qGjDuaG6UTV90=";

--- a/pkgs/by-name/co/cosmic-icons/package.nix
+++ b/pkgs/by-name/co/cosmic-icons/package.nix
@@ -9,14 +9,14 @@
 }:
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cosmic-icons";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-icons";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-lbj64wH180UGO3jYW9HhuHIwy/tU2Ka86wXz+Wjde8g=";
+    hash = "sha256-dLiBao8jvtxxSlENceVkPJNChwEK1Wtf3k5hY97WZoI=";
   };
 
   nativeBuildInputs = [ just ];

--- a/pkgs/by-name/co/cosmic-idle/package.nix
+++ b/pkgs/by-name/co/cosmic-idle/package.nix
@@ -16,14 +16,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-idle";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-idle";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-mQnWGYHlY1zKGynCwJSxjMSeHd0iBFYWsY3b1wZEGTs=";
+    hash = "sha256-0tcrOfVT5b57ev3b5F2U78F2QPGFwp94bqFVNyKH0Yk=";
   };
 
   cargoHash = "sha256-wAjFC6qAC3nllbnZf0KVaZTEztNYo6GTvwcp5FYmXLw=";

--- a/pkgs/by-name/co/cosmic-initial-setup/package.nix
+++ b/pkgs/by-name/co/cosmic-initial-setup/package.nix
@@ -14,14 +14,14 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-initial-setup";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-initial-setup";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-6pa4ZSH1NzVqq65d5MQucCLNr4c4PURNE0mLvrfWlug=";
+    hash = "sha256-+yl3MIBNO3G0O4o4Iu1vMkcLW4UMj8mPv9IWCCcqG6s=";
   };
 
   cargoHash = "sha256-Kj+eaTMHMQQHN0X3prIuZm1wvfnaV7BUlUKem6JLtc8=";

--- a/pkgs/by-name/co/cosmic-launcher/package.nix
+++ b/pkgs/by-name/co/cosmic-launcher/package.nix
@@ -11,14 +11,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-launcher";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-launcher";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-j65JSGBeRiDvZQgrPuaBBsQGfoowjkZLfW7lfdxXIh0=";
+    hash = "sha256-zrU5wn/DaIJiIri5u40t4etqkyn8ZO9ITTyJQGyqziw=";
   };
 
   cargoHash = "sha256-o2CyAjUp0E4m5G4SG8vm4RhQzvFsmbgfJDQRRxoyGEg=";

--- a/pkgs/by-name/co/cosmic-notifications/package.nix
+++ b/pkgs/by-name/co/cosmic-notifications/package.nix
@@ -12,14 +12,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-notifications";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-notifications";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-We2N6lyN75loTOSP2GRv/6S73QgLa7B/bjLftoZIviA=";
+    hash = "sha256-uBnKwl1yZh/QPV6pastve2UBLwG/VjYVQmGJ3kZt8c8=";
   };
 
   cargoHash = "sha256-zyM4iMJs2wPIKIEdji1uJF3WYpPGihFswIK5Wyf6Mns=";

--- a/pkgs/by-name/co/cosmic-osd/package.nix
+++ b/pkgs/by-name/co/cosmic-osd/package.nix
@@ -15,14 +15,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-osd";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-osd";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-i0fGEwLBpbqmz808Z6uqQlykSsi6hAFUsShMBXtRpl8=";
+    hash = "sha256-HhE8/N+tD12MLWQwqsoQSQFtFMj2LZkUTPkOijmEBaM=";
   };
 
   cargoHash = "sha256-DNQvmE/2swrDybjcQfCAjMRkAttjl+ibbLG0HSlcZwU=";

--- a/pkgs/by-name/co/cosmic-panel/package.nix
+++ b/pkgs/by-name/co/cosmic-panel/package.nix
@@ -11,14 +11,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-panel";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-panel";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-1Xwe1uONJbl4wq6QBbTI1suLiSlTzU4e/5WBccvghHE=";
+    hash = "sha256-ZNbX9Xs84TQmoke+xEolpkGqgJkC/lIuMKWRJjgZ+nE=";
   };
 
   cargoHash = "sha256-ZkjXZrcA4qKHSjEOxj7+j10PxJw/du8B2Mee2fxPJxs=";

--- a/pkgs/by-name/co/cosmic-player/package.nix
+++ b/pkgs/by-name/co/cosmic-player/package.nix
@@ -18,17 +18,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-player";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-player";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-zBSSJHn+onMj5HIEgGXKmsFAvKVewCk1BqkfeBE0KC0=";
+    hash = "sha256-ddwYgyyAaQr+0ULdCm7ZDLBfmXi014OR/G2KauYsI10=";
   };
 
-  cargoHash = "sha256-KjGP1iEAuAEb4Ab343aPx22u3h8tFCG7yW6Op6DwTik=";
+  cargoHash = "sha256-8w66CbGoonmJ3cb5G4G7pPjjk1OVbdZFp9smuKchvRY=";
 
   nativeBuildInputs = [
     just

--- a/pkgs/by-name/co/cosmic-randr/package.nix
+++ b/pkgs/by-name/co/cosmic-randr/package.nix
@@ -12,14 +12,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-randr";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-randr";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-7jkHaCE1IUE3GuRUeDMvbxomBp3gTzauK1EP1MAbqf0=";
+    hash = "sha256-Jimw6YCRouG9FDlLBp15OOCRlywBIaP/K/bXLR7trQM=";
   };
 
   cargoHash = "sha256-QWSPj7bxxWh5/KeNEtUsfDKg+JMONLjomrMcn57j6fw=";

--- a/pkgs/by-name/co/cosmic-reader/package.nix
+++ b/pkgs/by-name/co/cosmic-reader/package.nix
@@ -19,13 +19,13 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-reader";
-  version = "0-unstable-2026-02-11";
+  version = "0-unstable-2026-02-17";
 
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-reader";
-    rev = "3fbecec478a7988f218c16d54fb7470e5f50a83f";
-    hash = "sha256-Dg9XUWNz+sgh9QqhA3OwAffV7p9lh8FSuGs2aWnVWCw=";
+    rev = "cbf4fa1e28ad807b60ad3555d250f0611a6a59fc";
+    hash = "sha256-19Bp1EeMq1C1JP3xMfiFVDF8rqYJX4I2CzayJpqGxFM=";
   };
 
   cargoHash = "sha256-p0dg5RNXkzbi+/RB5k+jr34RNOp+Irahj0BiFUddfnk=";

--- a/pkgs/by-name/co/cosmic-screenshot/package.nix
+++ b/pkgs/by-name/co/cosmic-screenshot/package.nix
@@ -11,14 +11,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-screenshot";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-screenshot";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-IyjrXj9UElfWKU7t9JpJi4WvOpgteg/Y3tvj3ZukQYI=";
+    hash = "sha256-w80z/mKr+kYLeg5MMR0GfS/XkX5EU+unvmlRCUZvp6A=";
   };
 
   cargoHash = "sha256-O8fFeg1TkKCg+QbTnNjsH52xln4+ophh/BW/b4zQs9o=";

--- a/pkgs/by-name/co/cosmic-session/package.nix
+++ b/pkgs/by-name/co/cosmic-session/package.nix
@@ -12,14 +12,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-session";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-session";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-LZN+7hN3rBpVk7UWvG9D4gH2UOrfwMmSisdIsOT4vmA=";
+    hash = "sha256-dMx7ZSl+ZDZGwAbo3tWwSH8Tg00ZVTJsXNZrBHY4Xj4=";
   };
 
   cargoHash = "sha256-wFh9AYQRZB9qK0vCrhW9Zk61Yg+VY3VPAqJRD47NbK4=";

--- a/pkgs/by-name/co/cosmic-settings-daemon/package.nix
+++ b/pkgs/by-name/co/cosmic-settings-daemon/package.nix
@@ -16,14 +16,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-settings-daemon";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-settings-daemon";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-4YozCuj6lF9GmsV9eRD4HEb3G8tYKjQc3+ghYHxKrhE=";
+    hash = "sha256-nivViFs0swS5MUH+hfpBl5sFGBZ6XPo3E0PGONVmzxo=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/co/cosmic-settings/package.nix
+++ b/pkgs/by-name/co/cosmic-settings/package.nix
@@ -27,17 +27,17 @@ let
 in
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-settings";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-settings";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-255HkAWq9q7Fxx/YCTYqcsRE7g6Hnuqc6rJWBW+7MYA=";
+    hash = "sha256-IkWH8V5M8k3BB8UpnNMxM5z5uzKRatu/tbACywiqezg=";
   };
 
-  cargoHash = "sha256-T9fbhrYrQrc7TjyumhfT5vyElRKnDzxVBsJtcGA3f7I=";
+  cargoHash = "sha256-1T/Wd59AD8HVeTCeKb8BIdzw3n+nK5otevFmwn3YJRs=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/co/cosmic-store/package.nix
+++ b/pkgs/by-name/co/cosmic-store/package.nix
@@ -15,17 +15,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-store";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-store";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-0QcgFEyMlAK5QxZK9CmXBSJoFymmw4yru3VdK9TcXws=";
+    hash = "sha256-nFquLO/qMANbQRbOfjegZeMb2vCSKUK5/Y/U4ghuW64=";
   };
 
-  cargoHash = "sha256-0cn7/Mow9uAOAQZEUh7CZXNk9r4tvOeqjyCyJGtE2m4=";
+  cargoHash = "sha256-rrIIQ5bx4HMrxoUDH63qFJN7J+eyohSSewFZB5xMNjs=";
 
   nativeBuildInputs = [
     just

--- a/pkgs/by-name/co/cosmic-term/package.nix
+++ b/pkgs/by-name/co/cosmic-term/package.nix
@@ -15,17 +15,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-term";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-term";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-bfl8mi32EWdRJfnSkv672rQvHpYyArrDzCOsNShdqXU=";
+    hash = "sha256-Woko89mT0jBx1YhzO4yXyMfxAMDxPiMn1m51Cm1e7hQ=";
   };
 
-  cargoHash = "sha256-uKPRRfjhx1Yc+6hFTjac3333Do92+GFY36DEhw9F91U=";
+  cargoHash = "sha256-KXhjNBpTOk96+86PbDjeKtQ/VynRVV4a9SYbYGz4A6c=";
 
   nativeBuildInputs = [
     just

--- a/pkgs/by-name/co/cosmic-wallpapers/package.nix
+++ b/pkgs/by-name/co/cosmic-wallpapers/package.nix
@@ -7,7 +7,7 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "cosmic-wallpapers";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
@@ -16,7 +16,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     tag = "epoch-${finalAttrs.version}";
     forceFetchGit = true;
     fetchLFS = true;
-    hash = "sha256-XtNmV6fxKFlirXQvxxgAYSQveQs8RCTfcFd8SVdEXtE=";
+    hash = "sha256-m2cYppfitpBDKK8CC9i/lUrC9rfSYTuqUSZSyIKKGyg=";
   };
 
   makeFlags = [ "prefix=${placeholder "out"}" ];

--- a/pkgs/by-name/co/cosmic-workspaces-epoch/package.nix
+++ b/pkgs/by-name/co/cosmic-workspaces-epoch/package.nix
@@ -14,17 +14,17 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "cosmic-workspaces-epoch";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "cosmic-workspaces-epoch";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-MWQhDFCn10ONm3SuT+vcXkliCvm3xPJHHYVytufCq2g=";
+    hash = "sha256-HrW02lM1uSiI2UBC46Jjgv7r3urVcgS3Mrvfoig/EjI=";
   };
 
-  cargoHash = "sha256-ZVl09YgeH+V4X3H88rdeiBgua1IpVcfKe0y8A78wzl4=";
+  cargoHash = "sha256-r5Do3eRBcwjA4IysyKgkHLz8Wo1WwdEl596ZENiQbEM=";
 
   separateDebugInfo = true;
 

--- a/pkgs/by-name/di/diffoscope/package.nix
+++ b/pkgs/by-name/di/diffoscope/package.nix
@@ -317,12 +317,12 @@ python.pkgs.buildPythonApplication rec {
   passthru = {
     updateScript = writeScript "update-diffoscope" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of "Latest release: 198 (31 Dec 2021)"'.
-      newVersion="$(curl -s https://diffoscope.org/ | pcregrep -o1 'Latest release: ([0-9]+)')"
+      newVersion="$(curl -s https://diffoscope.org/ | pcre2grep -o1 'Latest release: ([0-9]+)')"
       update-source-version ${pname} "$newVersion"
     '';
   };

--- a/pkgs/by-name/do/docfd/package.nix
+++ b/pkgs/by-name/do/docfd/package.nix
@@ -14,7 +14,7 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "docfd";
-  version = "12.3.0";
+  version = "12.3.1";
 
   minimalOCamlVersion = "5.1";
 
@@ -22,7 +22,7 @@ ocamlPackages.buildDunePackage rec {
     owner = "darrenldl";
     repo = "docfd";
     rev = version;
-    hash = "sha256-PEeZcSlXkWLo0hZHOsmuvcQoxeAXxqNfTR9sUJQG40g=";
+    hash = "sha256-PiA3nN/NTz+4yLYgr2uN7SGcGJhO2VZ3QHF3jlDeUbc=";
   };
 
   # Compatibility with nottui ≥ 0.4

--- a/pkgs/by-name/es/esphome/package.nix
+++ b/pkgs/by-name/es/esphome/package.nix
@@ -33,14 +33,14 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "esphome";
-  version = "2026.2.0";
+  version = "2026.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "esphome";
     repo = "esphome";
     tag = version;
-    hash = "sha256-VcfQsDx3u7GTndF5GE0XCplPXVo9ClLJwqWLJFKzWEk=";
+    hash = "sha256-7gCUSR2jLhCre84JggSPvNHIRzAA6ZSVGTe1pQ+D8ok=";
   };
 
   patches = [

--- a/pkgs/by-name/et/ethtool/package.nix
+++ b/pkgs/by-name/et/ethtool/package.nix
@@ -29,14 +29,14 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-ethtool" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<a href="ethtool-VER.tar.xz">...</a>'
       # The page always lists versions newest to oldest. Pick the first one.
       new_version="$(curl -s https://mirrors.edge.kernel.org/pub/software/network/ethtool/ |
-          pcregrep -o1 '<a href="ethtool-([0-9.]+)[.]tar[.]xz">' |
+          pcre2grep -o1 '<a href="ethtool-([0-9.]+)[.]tar[.]xz">' |
           head -n1)"
       update-source-version ethtool "$new_version"
     '';

--- a/pkgs/by-name/fi/firefly-iii/package.nix
+++ b/pkgs/by-name/fi/firefly-iii/package.nix
@@ -13,13 +13,13 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "firefly-iii";
-  version = "6.4.14";
+  version = "6.4.22";
 
   src = fetchFromGitHub {
     owner = "firefly-iii";
     repo = "firefly-iii";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-hXqLy0i1q2RRx0yg67zOPZPxEQ2c+VsFp90LFIXOE2w=";
+    hash = "sha256-i20D0/z6GA7pZYrWvRJ8tUlptNI5Cl/e9UY0hKg9SP8=";
   };
 
   buildInputs = [ php84 ];
@@ -36,13 +36,13 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname src version;
     composerStrictValidation = true;
     strictDeps = true;
-    vendorHash = "sha256-fLL0FAhd8r2igiZZ+wb1gse+vembHS6rzUnKe9LXXmI=";
+    vendorHash = "sha256-m+esW/yQs/GSwnw2iqVfSMXCf6/5M4634GUbt4Nnvbg=";
   };
 
   npmDeps = fetchNpmDeps {
     inherit (finalAttrs) src;
     name = "${finalAttrs.pname}-npm-deps";
-    hash = "sha256-kmYxC5+Vi/wCP/mT4n7JtxbzW4nVHOsA4xFpNMn0Li8=";
+    hash = "sha256-pu8dxL0NRB1cyqlQEf2zT2wdVp2fbe+Vp85qMs7f6s0=";
   };
 
   preInstall = ''

--- a/pkgs/by-name/fr/framework-tool-tui/package.nix
+++ b/pkgs/by-name/fr/framework-tool-tui/package.nix
@@ -7,16 +7,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "framework-tool-tui";
-  version = "0.7.6";
+  version = "0.7.7";
 
   src = fetchFromGitHub {
     owner = "grouzen";
     repo = "framework-tool-tui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-reIsJK2bGuMf83SmjCVu9PdUrd4zilCxpvbZllnU6vo=";
+    hash = "sha256-XzOwShPMTyQjuoJ6fGW39kOF0Cnf3n8IEOQql0cEBvc=";
   };
 
-  cargoHash = "sha256-E2lVpu+sI/Bf1YwqCbwg3pr15kfo4DUddwI+5/Dwh40=";
+  cargoHash = "sha256-geLxSMtSucJ5SO5u9yvbV6lT+O2a/JVbq3HxTZGYhQE=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ udev ];

--- a/pkgs/by-name/gd/gdb/package.nix
+++ b/pkgs/by-name/gd/gdb/package.nix
@@ -199,13 +199,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-gdb" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<h3>GDB version 12.1</h3>'
       new_version="$(curl -s https://www.sourceware.org/gdb/ |
-          pcregrep -o1 '<h3>GDB version ([0-9.]+)</h3>')"
+          pcre2grep -o1 '<h3>GDB version ([0-9.]+)</h3>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/gd/gdevelop/darwin.nix
+++ b/pkgs/by-name/gd/gdevelop/darwin.nix
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://github.com/4ian/GDevelop/releases/download/v${version}/GDevelop-5-${version}-universal-mac.zip";
-    hash = "sha256-qukv1lD17FW0IOjOcJeh8kt4O9cwK/wzNEH0+vdr6NA=";
+    hash = "sha256-3C++qdbngBdIVyyFV7VaOzH+rQBDEYp9wDcBVBjsrSc=";
   };
 
   sourceRoot = ".";

--- a/pkgs/by-name/gd/gdevelop/linux.nix
+++ b/pkgs/by-name/gd/gdevelop/linux.nix
@@ -13,7 +13,7 @@ let
     if stdenv.hostPlatform.system == "x86_64-linux" then
       fetchurl {
         url = "https://github.com/4ian/GDevelop/releases/download/v${version}/GDevelop-5-${version}.AppImage";
-        hash = "sha256-hElD8VUC17Q/1sMy+ASidhoY9svGNncDf7IUfKkFfZU=";
+        hash = "sha256-9apZXwVF8MV0ZK7/FsoQf+30lTg4P42aTtqedBCnSls=";
       }
     else
       throw "${pname}-${version} is not supported on ${stdenv.hostPlatform.system}";

--- a/pkgs/by-name/gd/gdevelop/package.nix
+++ b/pkgs/by-name/gd/gdevelop/package.nix
@@ -4,7 +4,7 @@
   callPackage,
 }:
 let
-  version = "5.6.257";
+  version = "5.6.258";
   pname = "gdevelop";
   meta = {
     description = "Graphical Game Development Studio";

--- a/pkgs/by-name/gi/github-mcp-server/package.nix
+++ b/pkgs/by-name/gi/github-mcp-server/package.nix
@@ -8,16 +8,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "github-mcp-server";
-  version = "0.30.3";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "github";
     repo = "github-mcp-server";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-RqTwii79h7Kk1bpJT1uGG2ODZE5DtROZZyMDKvH3jmo=";
+    hash = "sha256-7vcDkN0q/bNr2dHQgM4YzmQjDjMyLLtkbdBjhmUM1/4=";
   };
 
-  vendorHash = "sha256-rv7mZQ2/j4R9s3p+Psq5E2I99zFtnieGc3eaMT3ykqQ=";
+  vendorHash = "sha256-zxisK5o2zqeAkQEPKd1w8rFXoJsDB4VNEdD27uos250=";
 
   ldflags = [
     "-s"

--- a/pkgs/by-name/gr/grimblast/package.nix
+++ b/pkgs/by-name/gr/grimblast/package.nix
@@ -13,6 +13,7 @@
   slurp,
   wl-clipboard,
   unixtools,
+  glib,
   bash,
   nix-update-script,
 }:
@@ -56,6 +57,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           slurp
           wl-clipboard
           unixtools.getopt
+          glib
         ]
       }"
   '';

--- a/pkgs/by-name/in/inja/package.nix
+++ b/pkgs/by-name/in/inja/package.nix
@@ -6,6 +6,7 @@
   nlohmann_json,
   doctest,
   callPackage,
+  fetchpatch,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -18,6 +19,15 @@ stdenv.mkDerivation (finalAttrs: {
     rev = "v${finalAttrs.version}";
     hash = "sha256-P4XKz2FcMfP0HRMoEC2+RKE/ljZSpusUTDmF9Ao5txo=";
   };
+
+  patches = [
+    # https://github.com/pantor/inja/pull/317
+    (fetchpatch {
+      name = "cmake-install-pc.patch";
+      url = "https://github.com/pantor/inja/commit/ebb7aeb3ae49ccb49a642aaecb0d41483078b8bd.patch";
+      hash = "sha256-Cz0EbYwGwFcfhKd8lJzXDy2DpMAcHkz7EC/vVFV60c0=";
+    })
+  ];
 
   nativeBuildInputs = [ cmake ];
   propagatedBuildInputs = [ nlohmann_json ];

--- a/pkgs/by-name/jo/jotta-cli/package.nix
+++ b/pkgs/by-name/jo/jotta-cli/package.nix
@@ -8,11 +8,11 @@
 
 stdenv.mkDerivation rec {
   pname = "jotta-cli";
-  version = "0.17.148769";
+  version = "0.17.158308";
 
   src = fetchzip {
     url = "https://repo.jotta.us/archives/linux/amd64/jotta-cli-${version}_linux_amd64.tar.gz";
-    hash = "sha256-uI5yYpyLa7gGg9eL1nG5MMwHZ2j2yH5/8n5sB/WgoQI=";
+    hash = "sha256-KSm4SGK/NeBwixEzcu8mh1Ssr2tx1vBHT5QtvtwfMBE=";
     stripRoot = false;
   };
 

--- a/pkgs/by-name/la/laravel/composer.lock
+++ b/pkgs/by-name/la/laravel/composer.lock
@@ -167,16 +167,16 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v12.51.0",
+            "version": "v12.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "1fd7db2203ce5a935fffd2ad40955248fb9f581c"
+                "reference": "f35c084f0d9bc57895515cb4d0665797c66285fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/1fd7db2203ce5a935fffd2ad40955248fb9f581c",
-                "reference": "1fd7db2203ce5a935fffd2ad40955248fb9f581c",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/f35c084f0d9bc57895515cb4d0665797c66285fd",
+                "reference": "f35c084f0d9bc57895515cb4d0665797c66285fd",
                 "shasum": ""
             },
             "require": {
@@ -223,11 +223,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-09T13:43:38+00:00"
+            "time": "2026-02-16T14:10:38+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v12.51.0",
+            "version": "v12.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
@@ -273,16 +273,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.51.0",
+            "version": "v12.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "3d4eeab332c04a9eaea90968c19a66f78745e47a"
+                "reference": "620d82bad07f55fcb7f5125f44c9d9b93335fb8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/3d4eeab332c04a9eaea90968c19a66f78745e47a",
-                "reference": "3d4eeab332c04a9eaea90968c19a66f78745e47a",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/620d82bad07f55fcb7f5125f44c9d9b93335fb8c",
+                "reference": "620d82bad07f55fcb7f5125f44c9d9b93335fb8c",
                 "shasum": ""
             },
             "require": {
@@ -317,20 +317,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-01-28T15:26:27+00:00"
+            "time": "2026-02-10T18:16:44+00:00"
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.51.0",
+            "version": "v12.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "62c225e046a4c469779c0855dce7abd8c0b1fa1e"
+                "reference": "c4c3f8612f218afcf09f3c7f5c7dc9e282626800"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/62c225e046a4c469779c0855dce7abd8c0b1fa1e",
-                "reference": "62c225e046a4c469779c0855dce7abd8c0b1fa1e",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/c4c3f8612f218afcf09f3c7f5c7dc9e282626800",
+                "reference": "c4c3f8612f218afcf09f3c7f5c7dc9e282626800",
                 "shasum": ""
             },
             "require": {
@@ -384,11 +384,11 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-09T20:42:48+00:00"
+            "time": "2026-02-13T20:26:32+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v12.51.0",
+            "version": "v12.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
@@ -434,7 +434,7 @@
         },
         {
             "name": "illuminate/reflection",
-            "version": "v12.51.0",
+            "version": "v12.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/reflection.git",
@@ -485,16 +485,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v12.51.0",
+            "version": "v12.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "fcc84cf4fba138f1835d6a5978ac4434f11a55aa"
+                "reference": "6e9de455bcb232372db11531b72a01d4eca83ef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/fcc84cf4fba138f1835d6a5978ac4434f11a55aa",
-                "reference": "fcc84cf4fba138f1835d6a5978ac4434f11a55aa",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/6e9de455bcb232372db11531b72a01d4eca83ef2",
+                "reference": "6e9de455bcb232372db11531b72a01d4eca83ef2",
                 "shasum": ""
             },
             "require": {
@@ -561,7 +561,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-10T16:02:09+00:00"
+            "time": "2026-02-14T23:03:41+00:00"
         },
         {
             "name": "laravel/prompts",

--- a/pkgs/by-name/la/laravel/package.nix
+++ b/pkgs/by-name/la/laravel/package.nix
@@ -7,19 +7,19 @@
 }:
 php.buildComposerProject2 (finalAttrs: {
   pname = "laravel";
-  version = "5.24.5";
+  version = "5.24.6";
 
   src = fetchFromGitHub {
     owner = "laravel";
     repo = "installer";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-wFyXg92bW7hZBKubj4Gf6nXnFpEpD3aUXv7mF7XbYQw=";
+    hash = "sha256-zXgLIp2tTPwGvZTT0rJqbbsO0Od/8sf6NQIgx/xhfJE=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
 
   composerLock = ./composer.lock;
-  vendorHash = "sha256-hEr7VX4ZwuS7HUSNOvWCy+FOufTE1fMpJih37ZReoro=";
+  vendorHash = "sha256-pegatl+tktcTSFV5GuxiyXvmZGVC+57DzWAIsOoZJWE=";
 
   # Adding npm (nodejs) and php composer to path
   postInstall = ''

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -17,13 +17,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "legcord";
-  version = "1.2.1";
+  version = "1.2.2";
 
   src = fetchFromGitHub {
     owner = "Legcord";
     repo = "Legcord";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-196AE244jEZNfhkC+vouNq9M7DOd3kk/1JLW1XRLOHA=";
+    hash = "sha256-i4Pw1jvkRYCQg1+9eZVi30Qblpttz9V+k//zehBZGDM=";
   };
 
   nativeBuildInputs = [
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     fetcherVersion = 1;
-    hash = "sha256-ksClxW8dIV72Hky5RFJ6cpPAteL29Cx8Me0aG5V/Y4k=";
+    hash = "sha256-9sdN5tbCCe/euTo8zRkU0C3yQ8sAufPyN8a4GeJW/Us=";
   };
 
   buildPhase = ''

--- a/pkgs/by-name/li/libcomps/package.nix
+++ b/pkgs/by-name/li/libcomps/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libcomps";
-  version = "0.1.23";
+  version = "0.1.24";
 
   outputs = [
     "out"
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "rpm-software-management";
     repo = "libcomps";
     rev = finalAttrs.version;
-    hash = "sha256-6nX6Oa2ACVALOtXDxjowIGKaziZkGZbtkgZzDfuP4PE=";
+    hash = "sha256-O60+k3ZnSfP+wFI55s/WfgrPbvu52uXZh88Ebg3Nf+c=";
   };
 
   patches = [

--- a/pkgs/by-name/ll/llmfit/package.nix
+++ b/pkgs/by-name/ll/llmfit/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "llmfit";
-  version = "0.2.1";
+  version = "0.4.3";
 
   src = fetchFromGitHub {
     owner = "AlexsJones";
     repo = "llmfit";
     tag = "v${finalAttrs.version}";
-    sha256 = "sha256-XmbxJlchBhXrAK8Yjn1dTBxrg+90B9/0HXgEhmZz6+4=";
+    sha256 = "sha256-m3JV7lF/YuxtPMsUvGNQd4VjLw4KFuBM5jQYjnC+2Hs=";
   };
 
-  cargoHash = "sha256-VTFZ592eZZToj5MeC2mdpugMazWmqyO5VrKLJbweI/E=";
+  cargoHash = "sha256-Ue09DBvcqyvQDQ23yAUa6Fo56AWn5pxAl2XYiVLrUYI=";
 
   meta = {
     description = "Find what runs on your hardware";

--- a/pkgs/by-name/lu/lunatask/package.nix
+++ b/pkgs/by-name/lu/lunatask/package.nix
@@ -6,12 +6,12 @@
 }:
 
 let
-  version = "2.1.21";
+  version = "2.1.23";
   pname = "lunatask";
 
   src = fetchurl {
     url = "https://github.com/lunatask/lunatask/releases/download/v${version}/Lunatask-${version}.AppImage";
-    hash = "sha256-q+GnztAetorwEywBYmjEjFl4PLqTj+v0igQB3toFRTg=";
+    hash = "sha256-IvQNc52xd13zCyMnAXRvG/g2xAGYGqC2dk4EHu8w0Gg=";
   };
 
   appimageContents = appimageTools.extract {

--- a/pkgs/by-name/mc/mc/package.nix
+++ b/pkgs/by-name/mc/mc/package.nix
@@ -96,8 +96,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     set -eu -o pipefail
 
-    # Expect the text in format of "Current version is: 4.8.27; ...".
-    new_version="$(curl -s https://midnight-commander.org/ | pcre2grep -o1 'Current version is: (([0-9]+\.?)+);')"
+    # Expect the text in format of mc-4.8.27; ...".
+    new_version="$(curl -s https://ftp.osuosl.org/pub/midnightcommander/ | pcre2grep -o 'mc-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^mc-//' | sort -Vu | tail -n1)"
     update-source-version mc "$new_version"
   '';
 

--- a/pkgs/by-name/mc/mc/package.nix
+++ b/pkgs/by-name/mc/mc/package.nix
@@ -92,12 +92,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru.updateScript = writeScript "update-mc" ''
     #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl pcre common-updater-scripts
+    #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
     set -eu -o pipefail
 
     # Expect the text in format of "Current version is: 4.8.27; ...".
-    new_version="$(curl -s https://midnight-commander.org/ | pcregrep -o1 'Current version is: (([0-9]+\.?)+);')"
+    new_version="$(curl -s https://midnight-commander.org/ | pcre2grep -o1 'Current version is: (([0-9]+\.?)+);')"
     update-source-version mc "$new_version"
   '';
 

--- a/pkgs/by-name/mi/mini-calc/package.nix
+++ b/pkgs/by-name/mi/mini-calc/package.nix
@@ -9,16 +9,16 @@
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "mini-calc";
-  version = "4.0.2";
+  version = "4.0.3";
 
   src = fetchFromGitHub {
     owner = "vanilla-extracts";
     repo = "calc";
     tag = finalAttrs.version;
-    hash = "sha256-eyWRDuECMV/jfxq+Ki2uouiYqp4PmQJa+D3QORewj+Y=";
+    hash = "sha256-NR5SJpJW7L6VGu6tCyzt0hhQ5Wnvx3TKlq3MAK4EcLM=";
   };
 
-  cargoHash = "sha256-7hBtu6mJ+wQF4apU0SAuVKFE7LdajjZdMyk3Ov6xxlQ=";
+  cargoHash = "sha256-LejKPnp4GvGykMTFZM9WVQIa0EMueeit5XfSuE1uiPQ=";
 
   nativeBuildInputs = [ makeWrapper ];
   postFixup = ''

--- a/pkgs/by-name/mp/mpfr/package.nix
+++ b/pkgs/by-name/mp/mpfr/package.nix
@@ -60,13 +60,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-mpfr" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<title>GNU MPFR version 4.1.1</title>'
       new_version="$(curl -s https://www.mpfr.org/mpfr-current/ |
-          pcregrep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
+          pcre2grep -o1 '<title>GNU MPFR version ([0-9.]+)</title>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/mu/mullvad-browser/package.nix
+++ b/pkgs/by-name/mu/mullvad-browser/package.nix
@@ -97,7 +97,7 @@ let
     ++ lib.optionals mediaSupport [ ffmpeg_7 ]
   );
 
-  version = "15.0.6";
+  version = "15.0.7";
 
   sources = {
     x86_64-linux = fetchurl {
@@ -109,7 +109,7 @@ let
         "https://tor.eff.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
         "https://tor.calyxinstitute.org/dist/mullvadbrowser/${version}/mullvad-browser-linux-x86_64-${version}.tar.xz"
       ];
-      hash = "sha256-7FqNvt6Uyl00sxiScDA4EhBT2a8BYStIxfzCOanWx7M=";
+      hash = "sha256-Uj2H6ONVpn3EtzMNl8xqOAf6UeO6FGAKtyH9DKh976U=";
     };
   };
 

--- a/pkgs/by-name/mu/music-discord-rpc/package.nix
+++ b/pkgs/by-name/mu/music-discord-rpc/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "music-discord-rpc";
-  version = "0.6.2";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "patryk-ku";
     repo = "music-discord-rpc";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-Sc7K9xD+l48w5xXLWjSsw1eq+x0xP8QHMioPaulPP2E=";
+    hash = "sha256-HZh7rwZR/9dccNyQV2BEyQF2vtoH+L/lW4L4hu9RJTI=";
   };
 
-  cargoHash = "sha256-nHG6W6WbMNVmsnG1f5o0obp5SEUI4UIyyJDvgS6sUzA=";
+  cargoHash = "sha256-vCqjeY07R/AuNruBYS3sc7n9kN/Y4IwvvpSooWTu7Oc=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/mu/mutt/package.nix
+++ b/pkgs/by-name/mu/mutt/package.nix
@@ -115,13 +115,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-mutt" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -euo pipefail
 
       # Expect the text in format of "The current stable public release version is 2.2.6."
       new_version="$(curl -s http://www.mutt.org/download.html |
-          pcregrep -o1 'The current stable public release version is ([0-9.]+).')"
+          pcre2grep -o1 'The current stable public release version is ([0-9.]+).')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/na/naja/package.nix
+++ b/pkgs/by-name/na/naja/package.nix
@@ -17,13 +17,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "naja";
-  version = "0.4.0";
+  version = "0.4.1";
 
   src = fetchFromGitHub {
     owner = "najaeda";
     repo = "naja";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-q0k8uk2QGEkwBr2PXOvJadNbx0vCpS56BgMQPlAVW/E=";
+    hash = "sha256-QKKV1+xhodA66404ez7w+V0gYatsCoAYq3IuvB3QPnA=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/ne/netbird-dashboard/package.nix
+++ b/pkgs/by-name/ne/netbird-dashboard/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "netbird-dashboard";
-  version = "2.31.0";
+  version = "2.32.5";
 
   src = fetchFromGitHub {
     owner = "netbirdio";
     repo = "dashboard";
     rev = "v${version}";
-    hash = "sha256-vpxMPoF0xn5UzY1Yo5Y2NAfmwC21Z6Ogv+C30JKyj0E=";
+    hash = "sha256-DNIibCGeC4dzJ8xKQPLkWJZ2YfW2igLse+321SrSmhE=";
   };
 
-  npmDepsHash = "sha256-IyNVeoEusQlxOYzYe9xIwtHepDRyjUfKHGNNR8LoOSA=";
+  npmDepsHash = "sha256-shN+XdS5Z2MxEFy453YqqovDUXbde3L9Y7+cPZW53/Y=";
   npmFlags = [ "--legacy-peer-deps" ];
 
   installPhase = ''

--- a/pkgs/by-name/nv/nvibrant/package.nix
+++ b/pkgs/by-name/nv/nvibrant/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nvibrant";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "Tremeschin";
+    repo = "nvibrant";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-RZIi1V3hcwZdaI84Nd0YSQOjDng9/ZDg7aqfTL7GJIU=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  mesonBuildType = "release";
+
+  meta = with lib; {
+    description = "Configure NVIDIA's Digital Vibrance on Wayland";
+    homepage = "https://github.com/Tremeschin/nvibrant";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.mikaeladev ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "nvibrant";
+  };
+})

--- a/pkgs/by-name/op/openbao/package.nix
+++ b/pkgs/by-name/op/openbao/package.nix
@@ -14,16 +14,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "openbao";
-  version = "2.5.0";
+  version = "2.5.1";
 
   src = fetchFromGitHub {
     owner = "openbao";
     repo = "openbao";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-4w+CkYhFS/P9ZeHiR2daK+DujqCKzF/aUAZbMcHqvyk=";
+    hash = "sha256-pVFsyNg9ccSFAdHb/fjeVoMBh1nKcjwcFfVBBqFalIo=";
   };
 
-  vendorHash = "sha256-3QNiw3q0dhgWeGFBq4a5GCE3bIIa4YiJRKMU+Hakvx0=";
+  vendorHash = "sha256-lfabvwO+p54SREvpCZdw5z/QMLDZqaf1UZTXWGm6sdg=";
 
   proxyVendor = true;
 

--- a/pkgs/by-name/ph/phpstan/package.nix
+++ b/pkgs/by-name/ph/phpstan/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "phpstan";
-  version = "2.1.39";
+  version = "2.1.40";
 
   src = fetchFromGitHub {
     owner = "phpstan";
     repo = "phpstan";
     tag = finalAttrs.version;
-    hash = "sha256-aOAD4ZDjsm47tn44qgHnQEx9D04qAI5ErRG/oP/h1Nk=";
+    hash = "sha256-AlM5lJPHlO0BAkav1PluP/bIkZBzaWTsm4HA72y59iI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pl/playball/package.nix
+++ b/pkgs/by-name/pl/playball/package.nix
@@ -6,16 +6,16 @@
 
 buildNpmPackage rec {
   pname = "playball";
-  version = "3.2.0";
+  version = "3.3.0";
 
   src = fetchFromGitHub {
     owner = "paaatrick";
     repo = "playball";
     tag = "v${version}";
-    hash = "sha256-xgAhzNWCLNmbrwaYAGmXMercoRgXWPjjV5dcnXunmeA=";
+    hash = "sha256-Kg1ooxtXwP2q9qa7uuzUtl2R8/jqG9wryaKWYnWXIjw=";
   };
 
-  npmDepsHash = "sha256-s0JKBJnVYkeXOE62F6BZRKwd0Hg3IOuMai6rmKUi6TI=";
+  npmDepsHash = "sha256-waaC5AcsEWMOLyXSmMbRuRS5Ozq5ERrmONQZhP05Kes=";
 
   env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 

--- a/pkgs/by-name/po/poke/package.nix
+++ b/pkgs/by-name/po/poke/package.nix
@@ -80,13 +80,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-poke" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '<a href="...">poke 2.0</a>'
       new_version="$(curl -s https://www.jemarch.net/poke |
-          pcregrep -o1 '>poke ([0-9.]+)</a>')"
+          pcre2grep -o1 '>poke ([0-9.]+)</a>')"
       update-source-version poke "$new_version"
     '';
   };

--- a/pkgs/by-name/po/postfix/update.sh
+++ b/pkgs/by-name/po/postfix/update.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl pcre common-updater-scripts
+#!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
 set -eu -o pipefail
 
 # Expect the text in format of '<a href="official/postfix-3.7.4.tar.gz">Source code</a> |'
 # Stable release goes first.
 new_version="$(curl -s https://postfix-mirror.horus-it.com/postfix-release/index.html |
-    pcregrep -o1 '"official/postfix-([0-9.]+)[.]tar[.]gz">' | head -n1)"
+    pcre2grep -o1 '"official/postfix-([0-9.]+)[.]tar[.]gz">' | head -n1)"
 update-source-version postfix "$new_version"

--- a/pkgs/by-name/pr/pretix/package.nix
+++ b/pkgs/by-name/pr/pretix/package.nix
@@ -45,13 +45,13 @@ let
   };
 
   pname = "pretix";
-  version = "2026.1.1";
+  version = "2026.2.0";
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix";
     tag = "v${version}";
-    hash = "sha256-iH8S7+2SMw4LJjHjJvHAQgNSWU/zuk0nOUY/YI96T3E=";
+    hash = "sha256-S8HcCtTBTU9oU7X+XD6avSZVtlRkXeF7pIqnggqJRPs=";
   };
 
   npmDeps = buildNpmPackage {
@@ -59,7 +59,7 @@ let
     inherit version src;
 
     sourceRoot = "${src.name}/src/pretix/static/npm_dir";
-    npmDepsHash = "sha256-GaUPVSHRZg5Aihk4WAjmF8M6zIL99DU9Z3F3dym78bs=";
+    npmDepsHash = "sha256-n4Gd4DKdP4b6LT34uy9aJDWcTz9okk4imq6vtw1cC+k=";
 
     dontBuild = true;
 

--- a/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
+++ b/pkgs/by-name/pr/pretix/plugins/mollie/package.nix
@@ -8,14 +8,14 @@
 
 buildPythonPackage rec {
   pname = "pretix-mollie";
-  version = "2.5.1";
+  version = "2.5.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pretix";
     repo = "pretix-mollie";
     tag = "v${version}";
-    hash = "sha256-SpSXHPPxwI36iz5b8naD60vTomc52U84LjeeV8OnJXo=";
+    hash = "sha256-Q9cofG4etT8Lb/RZbOVkSYlN1ONS3vPGkE53ph92cLg=";
   };
 
   build-system = [

--- a/pkgs/by-name/qm/qmapshack/package.nix
+++ b/pkgs/by-name/qm/qmapshack/package.nix
@@ -13,13 +13,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "qmapshack";
-  version = "1.20.0";
+  version = "1.20.1";
 
   src = fetchFromGitHub {
     owner = "Maproom";
     repo = "qmapshack";
     tag = "V_${finalAttrs.version}";
-    hash = "sha256-OazG5BkgofNXWKoTpKEoyZ+Ew1u2w2i1Y/ovTYNrl+w=";
+    hash = "sha256-NqyouJGagVvyJGGetF8csA1byATaigBtGJIt5U3in+0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/qo/qovery-cli/package.nix
+++ b/pkgs/by-name/qo/qovery-cli/package.nix
@@ -10,16 +10,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "qovery-cli";
-  version = "1.57.2";
+  version = "1.57.3";
 
   src = fetchFromGitHub {
     owner = "Qovery";
     repo = "qovery-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6a4vkzY2IuiPzYisqgH/H9nxwCLRIOhD6F0Ht5qeN+k=";
+    hash = "sha256-RjSpojVDmUIBYTKPiiFzbkUeena45nFNi/GhD14FbYY=";
   };
 
-  vendorHash = "sha256-fea6M+zq9/pBFWY/X18fDjga1StgOHCbk0AVGNiO8HE=";
+  vendorHash = "sha256-i0QWcRF8PKDQmZMzI0mHWY6pDbnjAOoXKxg9onavTjw=";
 
   env.CGO_ENABLED = 0;
 

--- a/pkgs/by-name/qu/qui/package.nix
+++ b/pkgs/by-name/qu/qui/package.nix
@@ -14,12 +14,12 @@
 }:
 buildGoModule (finalAttrs: {
   pname = "qui";
-  version = "1.13.1";
+  version = "1.14.1";
   src = fetchFromGitHub {
     owner = "autobrr";
     repo = "qui";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-zpOz5X3Okig5PNdzwa1nS6HaldSXEFIQ/Aj0dQczabs=";
+    hash = "sha256-DfIqjYcRdE0ZlhB+wvgyYvwxInqH40VIQ9s/efGepdI=";
   };
 
   qui-web = stdenvNoCC.mkDerivation (finalAttrs': {
@@ -44,7 +44,7 @@ buildGoModule (finalAttrs: {
         ;
       pnpm = pnpm_9;
       fetcherVersion = 2;
-      hash = "sha256-3TAB5StrKBmgit02J7GiMfk6EDl8oiLvcOAnCJ9ian4=";
+      hash = "sha256-HzbwKFZaXQEjE7ELiqjHqLbkfM9YkyWqPNwXGUqW550=";
     };
 
     postBuild = ''
@@ -56,7 +56,7 @@ buildGoModule (finalAttrs: {
     '';
   });
 
-  vendorHash = "sha256-F4P+hpbAFWCrk+lSleOQFTsR3kfZoWkMbybeKPzMv20=";
+  vendorHash = "sha256-PeGWnnIxcxXzZdOaRUzUD7pG3CJTDDgjvXXJeSo9+hc=";
 
   preBuild = ''
     cp -r ${finalAttrs.qui-web}/* web/dist

--- a/pkgs/by-name/re/redlist/package.nix
+++ b/pkgs/by-name/re/redlist/package.nix
@@ -1,0 +1,48 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "redlist";
+  version = "0-unstable-2026-01-30";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Laharah";
+    repo = "redlist";
+    rev = "3d465a12d79331eefde52351b441d8e0875f93e3";
+    hash = "sha256-eROvTs4WCVeXE2+4FICC9Rl5bjIkf0E5sYvqCaskXEw=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      aiohttp
+      beets
+      humanize
+      confuse
+      pynentry
+      deluge-client
+      cryptography
+    ]
+    ++ aiohttp.optional-dependencies.speedups;
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"pytest-runner"' ""
+  '';
+
+  meta = {
+    description = "Convert Spotify playlists to local m3u's and fill the gaps";
+    mainProgram = "redlist";
+    homepage = "https://github.com/Laharah/redlist";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+})

--- a/pkgs/by-name/re/regclient/package.nix
+++ b/pkgs/by-name/re/regclient/package.nix
@@ -18,16 +18,16 @@ in
 
 buildGoModule rec {
   pname = "regclient";
-  version = "0.11.1";
+  version = "0.11.2";
   tag = "v${version}";
 
   src = fetchFromGitHub {
     owner = "regclient";
     repo = "regclient";
     rev = tag;
-    sha256 = "sha256-7HfcwDb4BgpOxkjOau/QVs9x/U6Da5eh5rHB6W1NhwE=";
+    sha256 = "sha256-q3dsIQgUyLQXiiBgz//ttT1leGaUROd1GFxXIbbvV2U=";
   };
-  vendorHash = "sha256-cNbHgb/yHF/ubhnWkyEQOjOz5qmircJJR8jDYj+d8bM=";
+  vendorHash = "sha256-J0kY5tltiicZPdQeq9uHAwqKR7SpFzwgLSryXtxL+9U=";
 
   outputs = [ "out" ] ++ bins;
 

--- a/pkgs/by-name/ru/rumdl/package.nix
+++ b/pkgs/by-name/ru/rumdl/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rumdl";
-  version = "0.1.22";
+  version = "0.1.26";
 
   src = fetchFromGitHub {
     owner = "rvben";
     repo = "rumdl";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-pOSsd/U/KdvhK/NTprFRzv0jROEeAjbboXr5ik1KFJA=";
+    hash = "sha256-+GWsVsDhHTWYP3JkNkEfYp9qU53TCKAjkvsZXpGeB8k=";
   };
 
-  cargoHash = "sha256-t/71aCc1lXIdYjP0g0nvjkMfHtoygAlpBEqfebLes7c=";
+  cargoHash = "sha256-8XsHhXutb+W39OxVgKtFaE+34YTsj+DXNElnFS3DqAU=";
 
   cargoBuildFlags = [
     "--bin=rumdl"

--- a/pkgs/by-name/ru/rustical/package.nix
+++ b/pkgs/by-name/ru/rustical/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "rustical";
-  version = "0.12.8";
+  version = "0.12.9";
 
   src = fetchFromGitHub {
     owner = "lennart-k";
     repo = "rustical";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-JYWm4/Fkya5NcBlf+lxpNTea2S64v2Dl/RNwipdpm64=";
+    hash = "sha256-1dGpYvsdrSngeZkSjtm0dgZBcZonlToDWvkb8rpmoMQ=";
   };
 
-  cargoHash = "sha256-553DKENM8RvofiYL/W31dg+JtlNvKjnbj+qZbKM4S5k=";
+  cargoHash = "sha256-3V6enIbZAErSk4+nZN3x03I+TyOisS3adBbnjbBXBFc=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];

--- a/pkgs/by-name/se/serd/package.nix
+++ b/pkgs/by-name/se/serd/package.nix
@@ -47,13 +47,13 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-poke" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'download.drobilla.net/serd-0.30.16.tar.xz">'
       new_version="$(curl -s https://drobilla.net/category/serd/ |
-          pcregrep -o1 'download.drobilla.net/serd-([0-9.]+).tar.xz' |
+          pcre2grep -o1 'download.drobilla.net/serd-([0-9.]+).tar.xz' |
           head -n1)"
       update-source-version ${finalAttrs.pname} "$new_version"
     '';

--- a/pkgs/by-name/sg/sgt-puzzles/package.nix
+++ b/pkgs/by-name/sg/sgt-puzzles/package.nix
@@ -79,11 +79,11 @@ stdenv.mkDerivation (finalAttrs: {
     tests.sgt-puzzles = nixosTests.sgt-puzzles;
     updateScript = writeScript "update-sgt-puzzles" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
-      version="$(curl -sI 'https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles.tar.gz' | grep -Fi Location: | pcregrep -o1 'puzzles-([0-9a-f.]*).tar.gz')"
+      version="$(curl -sI 'https://www.chiark.greenend.org.uk/~sgtatham/puzzles/puzzles.tar.gz' | grep -Fi Location: | pcre2grep -o1 'puzzles-([0-9a-f.]*).tar.gz')"
       update-source-version sgt-puzzles "$version"
     '';
   };

--- a/pkgs/by-name/sl/slang/package.nix
+++ b/pkgs/by-name/sl/slang/package.nix
@@ -67,13 +67,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-slang" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'Version 2.3.3</td>'
       new_version="$(curl -s https://www.jedsoft.org/slang/ |
-          pcregrep -o1 'Version ([0-9.]+)</td>')"
+          pcre2grep -o1 'Version ([0-9.]+)</td>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/sl/slipshow/package.nix
+++ b/pkgs/by-name/sl/slipshow/package.nix
@@ -9,13 +9,13 @@
 
 ocamlPackages.buildDunePackage rec {
   pname = "slipshow";
-  version = "0.8.1";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "panglesd";
     repo = "slipshow";
     tag = "v${version}";
-    hash = "sha256-13LoIvmSYGycuJpAqylyVmVnyttuyaQF1Dk/3BgikkE=";
+    hash = "sha256-6i7zbfk0uBgwoXlg5fLvC+onZMYKBJwUd74FUakt3jc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/sl/slurm/package.nix
+++ b/pkgs/by-name/sl/slurm/package.nix
@@ -42,7 +42,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "slurm";
-  version = "25.11.2.1";
+  version = "25-11-3-1";
 
   # N.B. We use github release tags instead of https://www.schedmd.com/downloads.php
   # because the latter does not keep older releases.
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     repo = "slurm";
     # The release tags use - instead of .
     rev = "slurm-${builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
-    hash = "sha256-ukQlxKD+XhvL/sh15g3Tk5drsgXkK3hV+PFa1d2y9mk=";
+    hash = "sha256-wG94g5fb39A/JqJgdKn8EuXTg1xtGNQw9vJn4jAF3z0=";
   };
 
   outputs = [

--- a/pkgs/by-name/so/sops/package.nix
+++ b/pkgs/by-name/so/sops/package.nix
@@ -61,7 +61,7 @@ buildGoModule (finalAttrs: {
   meta = {
     homepage = "https://getsops.io/";
     description = "Simple and flexible tool for managing secrets";
-    changelog = "https://github.com/getsops/sops/blob/v${finalAttrs.version}/CHANGELOG.rst";
+    changelog = "https://github.com/getsops/sops/blob/v${finalAttrs.version}/CHANGELOG.md";
     mainProgram = "sops";
     maintainers = with lib.maintainers; [
       Scrumplex

--- a/pkgs/by-name/so/sops/package.nix
+++ b/pkgs/by-name/so/sops/package.nix
@@ -12,13 +12,13 @@
 
 buildGoModule (finalAttrs: {
   pname = "sops";
-  version = "3.12.0";
+  version = "3.12.1";
 
   src = fetchFromGitHub {
     owner = "getsops";
     repo = finalAttrs.pname;
     tag = "v${finalAttrs.version}";
-    hash = "sha256-fmOBEu/WnDyk6Nd4vwAs9Qdr4XlXNGJPX9bX9JymEWA=";
+    hash = "sha256-65M6rv4dE2edm+k0mPDZkrOb/LY1Cyi4y1D7xaoOdfw=";
   };
 
   vendorHash = "sha256-dniVUk/PsF111UCujFY6zIKR1cp8c8ZawH2ywMef9hE=";

--- a/pkgs/by-name/sr/sratom/package.nix
+++ b/pkgs/by-name/sr/sratom/package.nix
@@ -13,7 +13,7 @@
 
 stdenv.mkDerivation rec {
   pname = "sratom";
-  version = "0.6.20";
+  version = "0.6.22";
 
   outputs = [
     "out"
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://download.drobilla.net/${pname}-${version}.tar.xz";
-    hash = "sha256-OCbpGGyrxDyl41n8w9gjgGAjL1+KIJC+XcmrOQ5bZHc=";
+    hash = "sha256-Agm30PIslqu0FnIu1zWwkzvkeTHs/0qksm3td2C08lI=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/sr/sratom/package.nix
+++ b/pkgs/by-name/sr/sratom/package.nix
@@ -50,13 +50,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-sratom" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'download.drobilla.net/sratom-0.30.16.tar.xz">'
       new_version="$(curl -s https://drobilla.net/category/sratom/ |
-          pcregrep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
+          pcre2grep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
           head -n1)"
       update-source-version ${pname} "$new_version"
     '';

--- a/pkgs/by-name/sr/sratom/package.nix
+++ b/pkgs/by-name/sr/sratom/package.nix
@@ -55,9 +55,7 @@ stdenv.mkDerivation rec {
       set -eu -o pipefail
 
       # Expect the text in format of 'download.drobilla.net/sratom-0.30.16.tar.xz">'
-      new_version="$(curl -s https://drobilla.net/category/sratom/ |
-          pcre2grep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
-          head -n1)"
+      new_version="$(curl -s https://drobilla.net/category/sratom/ | pcre2grep -o1 'Sratom ([0-9]+\.[0-9]+\.[0-9]+)' | sort -V | tail -n1)"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/su/sub-store-frontend/package.nix
+++ b/pkgs/by-name/su/sub-store-frontend/package.nix
@@ -13,13 +13,13 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "sub-store-frontend";
-  version = "2.16.15";
+  version = "2.16.16";
 
   src = fetchFromGitHub {
     owner = "sub-store-org";
     repo = "Sub-Store-Front-End";
     tag = finalAttrs.version;
-    hash = "sha256-YlN3nv/wbHMUocQbt77iq5vD8FTJAdysDEmRRZSbQkE=";
+    hash = "sha256-DezjtsNUYbhgfyLdy0PgOpUPL8ttjCDEaxoSrgcqjrQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/tr/trunk-io/update.sh
+++ b/pkgs/by-name/tr/trunk-io/update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl pcre common-updater-scripts
+#!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
 set -eu -o pipefail
 
-version="$(curl -fsSL https://trunk.io/releases/trunk | grep -Fi 'readonly TRUNK_LAUNCHER_VERSION=' | pcregrep -o1 '"(\d+(?:\.\d+)+)"')"
+version="$(curl -fsSL https://trunk.io/releases/trunk | grep -Fi 'readonly TRUNK_LAUNCHER_VERSION=' | pcre2grep -o1 '"(\d+(?:\.\d+)+)"')"
 update-source-version trunk-io "$version"

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -6,14 +6,14 @@
   uasm,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation(finalAttrs: {
   pname = "uasm";
   version = "2.57";
 
   src = fetchFromGitHub {
     owner = "Terraspace";
     repo = "uasm";
-    tag = "v${version}r";
+    tag = "v${finalAttrs.version}r";
     hash = "sha256-HaiK2ogE71zwgfhWL7fesMrNZYnh8TV/kE3ZIS0l85w=";
   };
 
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     runHook preInstall
 
     install -Dt "$out/bin" -m0755 GccUnixR/uasm
-    install -Dt "$out/share/doc/${pname}" -m0644 {Readme,History}.txt Doc/*
+    install -Dt "$out/share/doc/uasm" -m0644 {Readme,History}.txt Doc/*
 
     runHook postInstall
   '';
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
   passthru.tests.version = testers.testVersion {
     package = uasm;
     command = "uasm -h";
-    version = "v${version}";
+    version = "v${finalAttrs.version}";
   };
 
   meta = {
@@ -54,4 +54,4 @@ stdenv.mkDerivation rec {
     license = lib.licenses.watcom;
     broken = stdenv.hostPlatform.isDarwin;
   };
-}
+})

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation(finalAttrs: {
     description = "Free MASM-compatible assembler based on JWasm";
     mainProgram = "uasm";
     platforms = lib.platforms.unix;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.zane ];
     license = lib.licenses.watcom;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -6,7 +6,7 @@
   uasm,
 }:
 
-stdenv.mkDerivation(finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "uasm";
   version = "2.57";
 
@@ -20,10 +20,7 @@ stdenv.mkDerivation(finalAttrs: {
   enableParallelBuilding = true;
 
   makefile =
-    if stdenv.hostPlatform.isDarwin then
-      "Makefile-OSX-Clang-64.mak"
-    else
-      "Makefile-Linux-GCC-64.mak";
+    if stdenv.hostPlatform.isDarwin then "Makefile-OSX-Clang-64.mak" else "Makefile-Linux-GCC-64.mak";
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
 

--- a/pkgs/by-name/ua/uasm/package.nix
+++ b/pkgs/by-name/ua/uasm/package.nix
@@ -1,14 +1,11 @@
 {
   lib,
-  gcc13Stdenv,
+  stdenv,
   fetchFromGitHub,
   testers,
   uasm,
 }:
 
-let
-  stdenv = gcc13Stdenv;
-in
 stdenv.mkDerivation rec {
   pname = "uasm";
   version = "2.57";
@@ -23,12 +20,15 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
 
   makefile =
-    if gcc13Stdenv.hostPlatform.isDarwin then
+    if stdenv.hostPlatform.isDarwin then
       "Makefile-OSX-Clang-64.mak"
     else
       "Makefile-Linux-GCC-64.mak";
 
   makeFlags = [ "CC=${stdenv.cc.targetPrefix}cc" ];
+
+  # Needed for compiling with GCC > 13
+  env.CFLAGS = "-std=c99 -Wno-incompatible-pointer-types -Wno-implicit-function-declaration -Wno-int-conversion";
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/va/valgrind/package.nix
+++ b/pkgs/by-name/va/valgrind/package.nix
@@ -86,14 +86,14 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-valgrind" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of:
       #  'Current release: <a href="/downloads/current.html#current">valgrind-3.19.0</a>'
       new_version="$(curl -s https://valgrind.org/ |
-          pcregrep -o1 'Current release: .*>valgrind-([0-9.]+)</a>')"
+          pcre2grep -o1 'Current release: .*>valgrind-([0-9.]+)</a>')"
       update-source-version ${pname} "$new_version"
     '';
   };

--- a/pkgs/by-name/wh/wheelwizard/package.nix
+++ b/pkgs/by-name/wh/wheelwizard/package.nix
@@ -14,13 +14,13 @@
 }:
 buildDotnetModule rec {
   pname = "wheelwizard";
-  version = "2.3.5";
+  version = "2.4.0";
 
   src = fetchFromGitHub {
     owner = "TeamWheelWizard";
     repo = "WheelWizard";
     tag = version;
-    hash = "sha256-VEoj0h+YTEPWmYz2jtFnLzcMbMNeSt8yTuOwbfNt9t0=";
+    hash = "sha256-3qFJ08v9JI7VDSG9Nm0EuWJG8WHVLfpkk8TLYezWV5Y=";
   };
   postPatch = ''
     rm .config/dotnet-tools.json

--- a/pkgs/by-name/xd/xdg-desktop-portal-cosmic/package.nix
+++ b/pkgs/by-name/xd/xdg-desktop-portal-cosmic/package.nix
@@ -17,14 +17,14 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "xdg-desktop-portal-cosmic";
-  version = "1.0.6";
+  version = "1.0.7";
 
   # nixpkgs-update: no auto update
   src = fetchFromGitHub {
     owner = "pop-os";
     repo = "xdg-desktop-portal-cosmic";
     tag = "epoch-${finalAttrs.version}";
-    hash = "sha256-aFS9At51o4OYLggXscgFo22VViwd6skB63iNPSPoWro=";
+    hash = "sha256-gsX2J6dae33uclXTnIw7mB2kPdVFXWn94XOvfu0/qUc=";
   };
 
   cargoHash = "sha256-99MGWfZrDOav77SRI7c5V21JTfkq7ejC7x+ZiQ5J0Yw=";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1046,6 +1046,11 @@ with haskellLib;
   rethinkdb = dontCheck super.rethinkdb;
   Rlang-QQ = dontCheck super.Rlang-QQ;
   sai-shape-syb = dontCheck super.sai-shape-syb;
+  # https://github.com/LeventErkok/sbv/pull/772#issuecomment-3930657736
+  # SBV requires a multitude of external tools, some not packaged with nixpkgs
+  # for tests to pass, users may only want to use one or two of tools.
+  # maintainer recomends disabling tests
+  sbv = dontCheck super.sbv;
   scp-streams = dontCheck super.scp-streams;
   sdl2 = dontCheck super.sdl2; # the test suite needs an x server
   separated = dontCheck super.separated;

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5503,7 +5503,6 @@ broken-packages:
   - satyros # failure in job https://hydra.nixos.org/build/233199726 at 2023-09-02
   - savage # failure in job https://hydra.nixos.org/build/233213243 at 2023-09-02
   - sax # failure in job https://hydra.nixos.org/build/233218617 at 2023-09-02
-  - sbv # failure in job https://hydra.nixos.org/build/233210414 at 2023-09-02
   - sc2-proto # failure in job https://hydra.nixos.org/build/252730301 at 2024-03-16
   - scale # failure in job https://hydra.nixos.org/build/233222189 at 2023-09-02
   - scaleimage # failure in job https://hydra.nixos.org/build/233240688 at 2023-09-02

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -168,13 +168,13 @@ builder rec {
 
     updateScript = writeScript "update-guile-3" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '"https://ftp.gnu.org/gnu/guile/guile-3.0.8.tar.gz"'
       new_version="$(curl -s https://www.gnu.org/software/guile/download/ |
-          pcregrep -o1 '"https://ftp.gnu.org/gnu/guile/guile-(3[.0-9]+).tar.gz"')"
+          pcre2grep -o1 '"https://ftp.gnu.org/gnu/guile/guile-(3[.0-9]+).tar.gz"')"
       update-source-version guile_3_0 "$new_version"
     '';
   };

--- a/pkgs/development/octave-modules/interval/default.nix
+++ b/pkgs/development/octave-modules/interval/default.nix
@@ -7,11 +7,11 @@
 
 buildOctavePackage rec {
   pname = "interval";
-  version = "3.2.1";
+  version = "3.2.2";
 
   src = fetchurl {
     url = "mirror://sourceforge/octave/${pname}-${version}.tar.gz";
-    sha256 = "sha256-OOUmQnN1cTIpqz2Gpf4/WghVB0fYQgVBcG/eqQk/3Og=";
+    sha256 = "sha256-wBMbet0UveqpB8Fo68yYe2RA9ny1YGmEmyS8rSwK0XY=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/development/python-modules/css-inline/Cargo.lock
+++ b/pkgs/development/python-modules/css-inline/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "built"
@@ -53,15 +53,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cargo-lock"
@@ -77,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -99,9 +99,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -141,11 +141,12 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "css-inline"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "cssparser",
  "html5ever",
  "lru",
+ "memchr",
  "precomputed-hash",
  "reqwest",
  "rustc-hash",
@@ -156,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "css-inline-python"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "built",
  "css-inline",
@@ -256,9 +257,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -276,20 +277,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -297,33 +288,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -331,15 +322,14 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -381,9 +371,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
  "markup5ever",
@@ -468,14 +458,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -492,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -618,21 +607,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -659,9 +639,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "f4eacb0641a310445a4c513f2a5e23e19952e269c6a38887254d5f837a305506"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -669,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "litemap"
@@ -696,9 +676,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown",
 ]
@@ -710,16 +690,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
  "tendril",
@@ -728,18 +702,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
@@ -869,9 +834,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -899,35 +864,32 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.104"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
 dependencies = [
  "target-lexicon",
 ]
@@ -940,9 +902,9 @@ checksum = "4bf83fcee540452241ba030140f50418b973e840a64727c967b9266660f0a690"
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -950,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -962,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1030,9 +992,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1065,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -1149,7 +1111,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1172,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
  "ring",
@@ -1186,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -1196,9 +1158,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1213,9 +1175,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scopeguard"
@@ -1225,9 +1187,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "selectors"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
 dependencies = [
  "bitflags",
  "cssparser",
@@ -1284,9 +1246,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.148"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
@@ -1333,15 +1295,15 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1351,9 +1313,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -1375,7 +1337,6 @@ dependencies = [
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
@@ -1398,9 +1359,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1429,35 +1390,34 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
- "futf",
- "mac",
+ "new_debug_unreachable",
  "utf-8",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1491,9 +1451,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -1556,9 +1516,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1626,15 +1586,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "untrusted"
@@ -1644,9 +1598,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1692,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "05d7d0fce354c88b7982aec4400b3e7fcf723c32737cef571bd165f7613557ee"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1705,11 +1659,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "ee85afca410ac4abba5b584b12e77ea225db6ee5471d0aebaae0861166f9378a"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -1718,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "55839b71ba921e4f75b674cb16f843f4b1f3b26ddfcb3454de1cf65cc021ec0f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1728,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "caf2e969c2d60ff52e7e98b7392ff1588bffdd1ccd4769eba27222fd3d621571"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1741,18 +1696,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "0861f0dcdf46ea819407495634953cdcc8a8c7215ab799a7a7ce366be71c7b30"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "10053fbf9a374174094915bbce141e87a6bf32ecd9a002980db4b638405e8962"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1770,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd0c322f146d0f8aad130ce6c187953889359584497dac6561204c8e17bb43d"
+checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -1782,9 +1737,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2050,18 +2005,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2130,6 +2085,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.2"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/pkgs/development/python-modules/css-inline/default.nix
+++ b/pkgs/development/python-modules/css-inline/default.nix
@@ -17,14 +17,14 @@
 
 buildPythonPackage rec {
   pname = "css-inline";
-  version = "0.19.0";
+  version = "0.20.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Stranger6667";
     repo = "css-inline";
     rev = "python-v${version}";
-    hash = "sha256-IIZmSshcXC3H6kaH0iEiJEhDrZQtN0i5KNQ8H5aCGf4=";
+    hash = "sha256-T/oNrRZjW8GMzdf1I00y2nylaCrl6oVdSv2bEVADKsY=";
   };
 
   postPatch = ''
@@ -43,7 +43,7 @@ buildPythonPackage rec {
       cd bindings/python
       ln -s ${./Cargo.lock} Cargo.lock
     '';
-    hash = "sha256-cLBF3Teb2vcYUoE6Et6XgC5SAqV4MEpjTbpgb/TkMG0=";
+    hash = "sha256-XX4R+HRXw2sGJwZPW+qaaE2eGLkFFaaWjZfAYvHs9qQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/deebot-client/default.nix
+++ b/pkgs/development/python-modules/deebot-client/default.nix
@@ -22,7 +22,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "deebot-client";
-  version = "17.1.0";
+  version = "18.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.13";
@@ -31,12 +31,12 @@ buildPythonPackage (finalAttrs: {
     owner = "DeebotUniverse";
     repo = "client.py";
     tag = finalAttrs.version;
-    hash = "sha256-0gKjps5KqbicYYyN3VTO9diF11zR1UYsTyIwZG34doI=";
+    hash = "sha256-ZKLA8RbYsysY+pAT9K6z2yThWo2YeM6TLqLBMuo+/GQ=";
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-h1iSXoVv9J6u30VCudIhGBuJsWCKUJyXhVaM/5f5NqI=";
+    hash = "sha256-UcgQKv8YhsWdOzKQ7K3HTX/FmopQen7HQ/Jyuj+hePI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/mcstatus/default.nix
+++ b/pkgs/development/python-modules/mcstatus/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "mcstatus";
-  version = "12.2.0";
+  version = "12.2.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "py-mine";
     repo = "mcstatus";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-dBnUf4Hu2FgUI8CNr+cGIE7iAsM+FoRX5xRl2C6E9Mg=";
+    hash = "sha256-twgFGeJfeKZSWbBui/zmtF/7aZ5Kw8k1K81Bj3Nm2ZY=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/picosvg/default.nix
+++ b/pkgs/development/python-modules/picosvg/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
   setuptools-scm,
   absl-py,
   lxml,
@@ -20,6 +21,15 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-ocdHF0kYnfllpvul32itu1QtlDrqVeq5sT8Ecb5V1yk=";
   };
+
+  patches = [
+    # Fix test failures with skia-pathops 0.9.x (m143)
+    # https://github.com/googlefonts/picosvg/pull/331
+    (fetchpatch {
+      url = "https://github.com/googlefonts/picosvg/commit/885ee64b75f526e938eb76e09fab7d93e946a355.patch";
+      hash = "sha256-fR3FfnEPHwSO1rMtmQEr1pyvByTx8T53FxSpuAKWIjw=";
+    })
+  ];
 
   nativeBuildInputs = [ setuptools-scm ];
 

--- a/pkgs/development/python-modules/pynentry/default.nix
+++ b/pkgs/development/python-modules/pynentry/default.nix
@@ -1,0 +1,36 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pinentry-curses,
+  setuptools,
+}:
+
+buildPythonPackage {
+  pname = "pynentry";
+  version = "0.1.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Laharah";
+    repo = "pynentry";
+    rev = "54a484b36b8ac16c0ae51fe436844d5a056ec3c9";
+    hash = "sha256-bbuAI0IB3cTIfaCCrq0g93geRLUsxaahHWuU3bBtHII";
+  };
+
+  build-system = [ setuptools ];
+
+  postPatch = ''
+    substituteInPlace pynentry.py \
+      --replace-fail 'executable="pinentry"' 'executable="${lib.getExe pinentry-curses}"'
+  '';
+
+  pythonImportsCheck = [ "pynentry" ];
+
+  meta = {
+    description = "Wrapper for pinentry for python";
+    homepage = "https://github.com/Laharah/pynentry";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+}

--- a/pkgs/kde/frameworks/knewstuff/default.nix
+++ b/pkgs/kde/frameworks/knewstuff/default.nix
@@ -16,5 +16,8 @@ mkKdeDerivation {
     qttools
   ];
   extraPropagatedBuildInputs = [ kcmutils ];
+
+  dontQmlLint = true; # weird namespace setup
+
   meta.mainProgram = "knewstuff-dialog6";
 }

--- a/pkgs/kde/frameworks/kquickcharts/default.nix
+++ b/pkgs/kde/frameworks/kquickcharts/default.nix
@@ -1,9 +1,11 @@
 {
   mkKdeDerivation,
   qtdeclarative,
+  kirigami,
 }:
 mkKdeDerivation {
   pname = "kquickcharts";
 
   extraBuildInputs = [ qtdeclarative ];
+  extraPropagatedBuildInputs = [ kirigami ];
 }

--- a/pkgs/kde/gear/audiocd-kio/default.nix
+++ b/pkgs/kde/gear/audiocd-kio/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   mkKdeDerivation,
+  libkcompactdisc,
   cdparanoia,
   flac,
   libogg,
@@ -20,6 +21,8 @@ mkKdeDerivation {
   ];
 
   extraBuildInputs = [
+    libkcompactdisc
+
     cdparanoia
     flac
     libogg

--- a/pkgs/kde/gear/merkuro/default.nix
+++ b/pkgs/kde/gear/merkuro/default.nix
@@ -12,4 +12,7 @@ mkKdeDerivation {
     qtsvg
     libplasma
   ];
+
+  # FIXME: not sure why this is failing
+  dontQmlLint = true;
 }

--- a/pkgs/kde/gear/mimetreeparser/default.nix
+++ b/pkgs/kde/gear/mimetreeparser/default.nix
@@ -3,6 +3,8 @@
   qt5compat,
   qtdeclarative,
   qgpgme,
+  kirigami,
+  qtwebengine,
 }:
 mkKdeDerivation {
   pname = "mimetreeparser";
@@ -11,5 +13,10 @@ mkKdeDerivation {
     qt5compat
     qtdeclarative
     qgpgme
+  ];
+
+  extraPropagatedBuildInputs = [
+    kirigami
+    qtwebengine
   ];
 }

--- a/pkgs/kde/generated/sources/plasma.json
+++ b/pkgs/kde/generated/sources/plasma.json
@@ -1,367 +1,367 @@
 {
   "aurorae": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/aurorae-6.6.0.tar.xz",
-    "hash": "sha256-or62Kn3J75xCbC+1RgN6O91qjyT7vhExNcW+23l9bXo="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/aurorae-6.6.1.tar.xz",
+    "hash": "sha256-jX/DD0PPjZqjNvQJNf/7+9sjOe9jB/R0IiyxEBQH1N4="
   },
   "bluedevil": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/bluedevil-6.6.0.tar.xz",
-    "hash": "sha256-2ZKMkFjivcHB/+HOkUd5j21VLnjBUTBWldM+O06tDuY="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/bluedevil-6.6.1.tar.xz",
+    "hash": "sha256-wWBwfSa/58ZmH6WT1096WAQXeCw2TOxOFMoLxPVC/hs="
   },
   "breeze": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/breeze-6.6.0.tar.xz",
-    "hash": "sha256-FiWUy3TS5sAz0ItF/FKQS0iPIyCXx6oCXYN78ef6OOg="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/breeze-6.6.1.tar.xz",
+    "hash": "sha256-S8s5YqugdUDO+EYGPBZSqM5GOoh7R317rWZ+GLR7y8w="
   },
   "breeze-grub": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/breeze-grub-6.6.0.tar.xz",
-    "hash": "sha256-iGdl7Gr525Fnm813nAPCeInosorHBDwTD7uIurLCFYI="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/breeze-grub-6.6.1.tar.xz",
+    "hash": "sha256-w4sukPrLO39IcCI+shr2aeb4foPuVD1YMFkCBe+V+6M="
   },
   "breeze-gtk": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/breeze-gtk-6.6.0.tar.xz",
-    "hash": "sha256-3mTRrebetEAiAQbTlG/pn9RAS8WYsLtGazU6ZorZvbg="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/breeze-gtk-6.6.1.tar.xz",
+    "hash": "sha256-Vw/4+Turr3byGS5tCxXVeFuCIVXCb0JrhAUDrC85OgM="
   },
   "breeze-plymouth": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/breeze-plymouth-6.6.0.tar.xz",
-    "hash": "sha256-G8BnbhsqKlQxI3iBX1MAXiRKtOogFU8H46XwG7KUDR4="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/breeze-plymouth-6.6.1.tar.xz",
+    "hash": "sha256-SdfNmRAUTBs/ImCxOpsP+01jSsqXC8N7TgXIFrpmYZ0="
   },
   "discover": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/discover-6.6.0.tar.xz",
-    "hash": "sha256-0b36RrUQTebawt3acu+sfB1SYdwxjR5KfozaxunY5kU="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/discover-6.6.1.tar.xz",
+    "hash": "sha256-VPu76KY+IgTs3g3zmpzFAMwPwgLh4xdFL5caLRMpWDY="
   },
   "drkonqi": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/drkonqi-6.6.0.tar.xz",
-    "hash": "sha256-ujpzb+YC/7Eswkb0prZie2sFIuIgQAS108PsLk8ehXA="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/drkonqi-6.6.1.tar.xz",
+    "hash": "sha256-AZvv6hnGqNMf863KiGuVR7HBJVPzcCoj1XubX6Qf0zI="
   },
   "flatpak-kcm": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/flatpak-kcm-6.6.0.tar.xz",
-    "hash": "sha256-0VeDeWQPYwWOu1pCQRlYIjwqobJrvxS48asc1cTgZnE="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/flatpak-kcm-6.6.1.tar.xz",
+    "hash": "sha256-R2Qv+mLmn33HlSnyY02zjbJoLKICiT6h6FrCHjRKZIY="
   },
   "kactivitymanagerd": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kactivitymanagerd-6.6.0.tar.xz",
-    "hash": "sha256-mAISeDGo/vbC1EadqrslqFNjCbh7O61rsZMxSJ1mhWw="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kactivitymanagerd-6.6.1.tar.xz",
+    "hash": "sha256-vvaLS76zaw2o87W1kx177Fp/V/yJ6iH0bqCZyi/BRwU="
   },
   "kde-cli-tools": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kde-cli-tools-6.6.0.tar.xz",
-    "hash": "sha256-tFGzuAyH5+ZWLPmpxmn0LzdvgiZmYpLpIdr6/TRRHa0="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kde-cli-tools-6.6.1.tar.xz",
+    "hash": "sha256-KIENC0QH0Kx1L5Qg7NhDry9VaHUfwccNEUYg8Flv3uw="
   },
   "kde-gtk-config": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kde-gtk-config-6.6.0.tar.xz",
-    "hash": "sha256-9+ZYUmXpbaQlueVLU2BQqHVfSOgqOKJKg3/3Yrkjcjw="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kde-gtk-config-6.6.1.tar.xz",
+    "hash": "sha256-miMpCk7MVq167Ad35q0lQNAtZ05lGUtYI0T8irciv4c="
   },
   "kdecoration": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kdecoration-6.6.0.tar.xz",
-    "hash": "sha256-aoan47qz3C4/ZIZojoUCpcGs7BN5uwhfhTsOgprmSjs="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kdecoration-6.6.1.tar.xz",
+    "hash": "sha256-Rrh0nAlIjV3cFksjdH4mYHkJLu+UXTACs0TwfDECbm8="
   },
   "kdeplasma-addons": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kdeplasma-addons-6.6.0.tar.xz",
-    "hash": "sha256-31hRkDj4+gLzmcPr0G1oYIgGQfK9aFZrIgchL5ujQjU="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kdeplasma-addons-6.6.1.tar.xz",
+    "hash": "sha256-y+rXnwkN8azhT+k8wwuvMypZLbz44mDvIPglxsS8J34="
   },
   "kgamma": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kgamma-6.6.0.tar.xz",
-    "hash": "sha256-bwsj4bvvhBsNb8W3Cq/RyokVKdbbb2EtFaACpHTpYi8="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kgamma-6.6.1.tar.xz",
+    "hash": "sha256-ojiFdbarkHaKczTP3gTxfxGwNvZTB0qTa0EpiFJnVMk="
   },
   "kglobalacceld": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kglobalacceld-6.6.0.tar.xz",
-    "hash": "sha256-XdX1gmMMg4sbu/FjiUsbSFpGHz6EO4T/qmUhZkVp22w="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kglobalacceld-6.6.1.tar.xz",
+    "hash": "sha256-qoex0m2hlHwnBv+q3bIdTGC7XwXoIE2jRUEaE1WMdWs="
   },
   "kinfocenter": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kinfocenter-6.6.0.tar.xz",
-    "hash": "sha256-a9uLarSrwZl+qE18iuThfBe1NhGAK7hOx00JUHKk10U="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kinfocenter-6.6.1.tar.xz",
+    "hash": "sha256-Lc1X8jAO9kYQuHXXIARfIEhz3Kb/fDIXhXdjnkujR2M="
   },
   "kmenuedit": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kmenuedit-6.6.0.tar.xz",
-    "hash": "sha256-Nsnk59PHnxyO/ly6P6eUlzqxpVW8yl0JxpVQdv3Um+E="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kmenuedit-6.6.1.tar.xz",
+    "hash": "sha256-ZzzKLK9ip5gt6Y/L0Q6Hn5/ruURNlBmPY4jfeK6p9fE="
   },
   "knighttime": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/knighttime-6.6.0.tar.xz",
-    "hash": "sha256-bzKOHo1ubiJijzZL8EmlNYlfCMtWX7FVG3XX3mF46Lc="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/knighttime-6.6.1.tar.xz",
+    "hash": "sha256-46ZRVde9LXEwnB5U6QR/FetAcDDhvU25E0BrjFmGPTk="
   },
   "kpipewire": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kpipewire-6.6.0.tar.xz",
-    "hash": "sha256-g3PJQkGzgzHxWmkROQERSiXnJyyFUhrSMwseYPBtGiY="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kpipewire-6.6.1.tar.xz",
+    "hash": "sha256-3vKbsyiMKoALGC6OS1CMNKvP+P8iImusu1al6sVRqrk="
   },
   "krdp": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/krdp-6.6.0.tar.xz",
-    "hash": "sha256-XDwXxXUg8fLpdGKeqp3XtFfU7VBebwbLtpPbF0Ui3tk="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/krdp-6.6.1.tar.xz",
+    "hash": "sha256-Z7qhpK9eMLfOG5xwZFIUor8L87g1GtyolPsSH1l6dVM="
   },
   "kscreen": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kscreen-6.6.0.tar.xz",
-    "hash": "sha256-pWq+tUfkM0c1cRV/4xPILyfxFAleFErkNHUSdGWD2SQ="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kscreen-6.6.1.tar.xz",
+    "hash": "sha256-DoprGz22zK31si44udBgerdPkxaxCSDN/NmVBT4Zhds="
   },
   "kscreenlocker": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kscreenlocker-6.6.0.tar.xz",
-    "hash": "sha256-9dYP7+WA4dgy9a8bdMolNX0OBOZtrtdTMAa31WL8vVg="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kscreenlocker-6.6.1.tar.xz",
+    "hash": "sha256-/sq+uxQHLOb9bWfoKyfy2TtP8vETUkID52Volvk9KTw="
   },
   "ksshaskpass": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/ksshaskpass-6.6.0.tar.xz",
-    "hash": "sha256-KKd1pSvi+2fEQEr9+BkTIVIYNUHL3b4LFXU+ewxjQfY="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/ksshaskpass-6.6.1.tar.xz",
+    "hash": "sha256-OdljnWw8xorOqkA+1b7o2g76sXzTRSzbL2/vJbJmZ4c="
   },
   "ksystemstats": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/ksystemstats-6.6.0.tar.xz",
-    "hash": "sha256-W9t+gmYIvhSacJ0QhalpIMeQqtbgaVw/jbDOvEyDvuE="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/ksystemstats-6.6.1.tar.xz",
+    "hash": "sha256-sI20ksG3/5hMRfEr2qc5WZlpI5WNhcjp7dTJslVH/XM="
   },
   "kwallet-pam": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kwallet-pam-6.6.0.tar.xz",
-    "hash": "sha256-WrYCaXV4XiFhBf1YNisoMqsHW2jB0kK3MqVWF5zEygU="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kwallet-pam-6.6.1.tar.xz",
+    "hash": "sha256-MQ4PdoWSLSxa1OgR9dHwXOWDNOHsFyCbk5y0KftdSyc="
   },
   "kwayland": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kwayland-6.6.0.tar.xz",
-    "hash": "sha256-bhgKQjU5CirnKW5qdgoOeleXHgB5Cu0NmNcQNPEnSAE="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kwayland-6.6.1.tar.xz",
+    "hash": "sha256-zCbgIqMJC6us0K6OwUbRvULfkeuMt2pAewcunN2DYBc="
   },
   "kwayland-integration": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kwayland-integration-6.6.0.tar.xz",
-    "hash": "sha256-kyhCUrjPFTXLRoS5CvWrPVXUUU1jJvZBtN6ZqzRcJE0="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kwayland-integration-6.6.1.tar.xz",
+    "hash": "sha256-tzVkX+so+8jV9ScEapBJnnChsDGusaW+TFWpGXX8f3U="
   },
   "kwin": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kwin-6.6.0.tar.xz",
-    "hash": "sha256-NRNPz7ZNAZBM3NJa6o6Qxow3lzoIiXHk1nis/cUCCRQ="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kwin-6.6.1.tar.xz",
+    "hash": "sha256-zDwqgl3xpv5ApSlNwaX7C51h5CVciTVv3Wm2yzNGcOs="
   },
   "kwin-x11": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kwin-x11-6.6.0.tar.xz",
-    "hash": "sha256-k8OqWBwvFtm/5oR9FXIffKZrg8fhAd/0UGluEchlyGY="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kwin-x11-6.6.1.tar.xz",
+    "hash": "sha256-MwTTMnfyDbHa7kqQ16/pXRMBwQNvjQSKdcYmEcPgHXI="
   },
   "kwrited": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/kwrited-6.6.0.tar.xz",
-    "hash": "sha256-sBG1SJdLPVtm5qjRfggVPvH/ySKeDsJtIoT3ZWHne98="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/kwrited-6.6.1.tar.xz",
+    "hash": "sha256-pCcZpDR4VUjn/4b1I9667CjnORn+MpUbb/pCzg8xRZM="
   },
   "layer-shell-qt": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/layer-shell-qt-6.6.0.tar.xz",
-    "hash": "sha256-RVFSanRqGfjkexQZ5kXuWVuuciumuO7ciMBrkX/t6so="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/layer-shell-qt-6.6.1.tar.xz",
+    "hash": "sha256-YaQTwRP/gIpBZKd8B3udhDLW2Z+AmjCK8AF3LpsPiKc="
   },
   "libkscreen": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/libkscreen-6.6.0.tar.xz",
-    "hash": "sha256-A5b+OzGtZjYv0aM2JkYYf0008RFJDNsQWUqJwIjFNGc="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/libkscreen-6.6.1.tar.xz",
+    "hash": "sha256-MIzn7NrYdgef9nhBfeKbjE4ug+HkBOREQhQdY/5encU="
   },
   "libksysguard": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/libksysguard-6.6.0.tar.xz",
-    "hash": "sha256-1FvhUbGLRp27thkUNePwqeZ10Hvx218I8cfcSlenHWI="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/libksysguard-6.6.1.tar.xz",
+    "hash": "sha256-Yz23KSLSx/ioblM87ewmlSEuYZgaiF8d8Hwu63L0MSw="
   },
   "libplasma": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/libplasma-6.6.0.tar.xz",
-    "hash": "sha256-hmAQmBa7uQo2d8e6hZBzQi0muxGADYzir6MIcZQ8Feg="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/libplasma-6.6.1.tar.xz",
+    "hash": "sha256-KbZLAQfMkriOz/D0niskRbT3cJAwYUF8HJugXV9NIEg="
   },
   "milou": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/milou-6.6.0.tar.xz",
-    "hash": "sha256-9IyixnNMKt8lB4Y3nc05HZQX7dTWYgIJRBbppH3HcQ4="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/milou-6.6.1.tar.xz",
+    "hash": "sha256-M5tNIhaxB6EbCbYjxO1h27XpITWQeVtAK5HEjbWX3lE="
   },
   "ocean-sound-theme": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/ocean-sound-theme-6.6.0.tar.xz",
-    "hash": "sha256-k0H1TNZW+KttwhZH00fixbnwmybMjGk1lJBBz7EIBHM="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/ocean-sound-theme-6.6.1.tar.xz",
+    "hash": "sha256-r9Z7sS1h1gZkVGkAI/9WkuOZCvZV4nABZN81cb/oUKw="
   },
   "oxygen": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/oxygen-6.6.0.tar.xz",
-    "hash": "sha256-e797nKufLTJTgrd30b2BoVNAfHTfFhCiPpG0qgyvFaM="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/oxygen-6.6.1.tar.xz",
+    "hash": "sha256-VBHfHa2dPAumbWScLudE++YvdvM88ghZyMbiMkZfNvM="
   },
   "oxygen-sounds": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/oxygen-sounds-6.6.0.tar.xz",
-    "hash": "sha256-dn3tj7QXv6tQjweOhoSsMwTQCDQIx+AVRFIooOg0Bi4="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/oxygen-sounds-6.6.1.tar.xz",
+    "hash": "sha256-Q5sZSeNHfqXvl27w7h/oo6wTNleoLuao3P9fJg30Uso="
   },
   "plasma-activities": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-activities-6.6.0.tar.xz",
-    "hash": "sha256-MISO/5WVi9DaCTpNAAan3UVQ6h9wg48JqV65vV54T6E="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-activities-6.6.1.tar.xz",
+    "hash": "sha256-Z63DquMRPtPxU7DdynID9h6Q1fgFA4cclCwDj+su/yA="
   },
   "plasma-activities-stats": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-activities-stats-6.6.0.tar.xz",
-    "hash": "sha256-A/572n2y3TDLJsu4fSgpllUyQ5qNZTK+CJ4xdinqm1o="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-activities-stats-6.6.1.tar.xz",
+    "hash": "sha256-ANEUg5UhklV3ARYwzHrYxtXaMVzBSYuS37RZcrYdQbQ="
   },
   "plasma-browser-integration": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-browser-integration-6.6.0.tar.xz",
-    "hash": "sha256-8Jwufc3KU9AoTa2dFyte9bnyNoz6u+ZENIyncFeE59w="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-browser-integration-6.6.1.tar.xz",
+    "hash": "sha256-TfoLWN5s92nIzx1mTPyyqwU9FU7fsLrFsCyn0uLVTVY="
   },
   "plasma-desktop": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-desktop-6.6.0.tar.xz",
-    "hash": "sha256-2R5N0nbqGtdD4xrOhZo27E37QxSVyB6xqOsypJxz80I="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-desktop-6.6.1.tar.xz",
+    "hash": "sha256-kPdPz612TtvUMlsF1UJWPd4qu8P9F/bRb+n7yaY5B2U="
   },
   "plasma-dialer": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-dialer-6.6.0.tar.xz",
-    "hash": "sha256-ie+Y0g52CZtvEX9f5JywamRt++EARNIIP5WcXOtIcFo="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-dialer-6.6.1.tar.xz",
+    "hash": "sha256-R8gjdHpITvZmeAgFWSy+dAg1UaKBoa9R8FBoNrgD2Ng="
   },
   "plasma-disks": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-disks-6.6.0.tar.xz",
-    "hash": "sha256-Sk4QOOjw/0NHUYaNUDc/seI6DywF/BiqwT+NJ0KwuCM="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-disks-6.6.1.tar.xz",
+    "hash": "sha256-lmOyisCH34oBSNg8vhU0X5z68A2Qd1h3ZWWzcSREles="
   },
   "plasma-firewall": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-firewall-6.6.0.tar.xz",
-    "hash": "sha256-b2Q3QOdlfKPx1jWdx9lpSisCX9AeW4350xwy3T+9pG8="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-firewall-6.6.1.tar.xz",
+    "hash": "sha256-M8/V3WnmjjhuLXNFT8d+HuaDAS/p1CITPi0QW9+b0pk="
   },
   "plasma-integration": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-integration-6.6.0.tar.xz",
-    "hash": "sha256-WmnQEtosv8bU2Rd1MfGmjGDLAj+94RTV1elWN7YYnfs="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-integration-6.6.1.tar.xz",
+    "hash": "sha256-a7Lp33s7ux3txCgUBknUAmlMK1aVcV98yasxszymyjg="
   },
   "plasma-keyboard": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-keyboard-6.6.0.tar.xz",
-    "hash": "sha256-zC7pFU5V4aSck0qostQUanIJhZ3lgFfZbSl1YWUrdtw="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-keyboard-6.6.1.tar.xz",
+    "hash": "sha256-whNcGgf7a5qUxSZWBnoJoLpst0X2rABRS/E5SxlmbQI="
   },
   "plasma-login-manager": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-login-manager-6.6.0.tar.xz",
-    "hash": "sha256-dJjelWswi3H9QmdgKCCSNeK3+/eT7uAp5lSEl54u8NQ="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-login-manager-6.6.1.tar.xz",
+    "hash": "sha256-r3+RETmorkzV4ygA+stBLz3dptvZ0Pono/TGpvmNbzk="
   },
   "plasma-mobile": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-mobile-6.6.0.tar.xz",
-    "hash": "sha256-RUL/2sxtjuodaQz1PAxa19xaVh622oHHccYyzkZ2RhM="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-mobile-6.6.1.tar.xz",
+    "hash": "sha256-KlAK8DKXWP7XSvwbE5OnKQp7N0fDnmQBqgMoa6KAW0w="
   },
   "plasma-nano": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-nano-6.6.0.tar.xz",
-    "hash": "sha256-PoiBgnhpB9kXJanPGM8VuFC409C48T/HAW5HpcITv7Y="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-nano-6.6.1.tar.xz",
+    "hash": "sha256-2BXWQF5qCBwi3W8MMmU7cNqMl8WryljsCwnwMUrBV3Y="
   },
   "plasma-nm": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-nm-6.6.0.tar.xz",
-    "hash": "sha256-AeVD1cbxAfsuAc7v19Qzi34u0LLWdUbXIn7TqnjdXVA="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-nm-6.6.1.tar.xz",
+    "hash": "sha256-cikb1wTaPJHd61i0NMsxMBOMofsg7uQhDiYxh3HghFc="
   },
   "plasma-pa": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-pa-6.6.0.tar.xz",
-    "hash": "sha256-zQOK72PaXjew8XDmP+GCuTwqNitnVt0mwtUEFgUnBfo="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-pa-6.6.1.tar.xz",
+    "hash": "sha256-KBh6P296ZUhqmT3l1IaYOj0eOrTPmP+b/hH+zzCsHyE="
   },
   "plasma-sdk": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-sdk-6.6.0.tar.xz",
-    "hash": "sha256-yFInW8YkL8RnklgW1IvvpzICUNrACX1jNxwn6vfBeAw="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-sdk-6.6.1.tar.xz",
+    "hash": "sha256-7Idn3aBLCnjfLsbhzU17vCCmhH4pa+hh1FRkHThEyXc="
   },
   "plasma-setup": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-setup-6.6.0.tar.xz",
-    "hash": "sha256-+DfQyLymYRn4x+2TXj3MA91uxysydtbBbplyi7nMEE4="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-setup-6.6.1.tar.xz",
+    "hash": "sha256-EUurgZWA1OLwt8C+w4w85miBTT4A0sFG5LdwOnOdymE="
   },
   "plasma-systemmonitor": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-systemmonitor-6.6.0.tar.xz",
-    "hash": "sha256-wQXtaGrQeZqJv5aCE6tKcZgg2OsmCb12Az1laAeu+Vg="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-systemmonitor-6.6.1.tar.xz",
+    "hash": "sha256-xahLr3+po2gXWGW39YQayGByOZV83ZS3yeh0iU9F7A0="
   },
   "plasma-thunderbolt": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-thunderbolt-6.6.0.tar.xz",
-    "hash": "sha256-JBCG63aweff6iG92ARmqNjG6jHZoAx868O/pojzYYT4="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-thunderbolt-6.6.1.tar.xz",
+    "hash": "sha256-VhAzoRJo0hn/6o3K9LdHYjLUWeMC9aTllSM1UASILYE="
   },
   "plasma-vault": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-vault-6.6.0.tar.xz",
-    "hash": "sha256-VP++tYAzqLnup1zU2SgtOxSmOJDFk+QEkClUESWi7zA="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-vault-6.6.1.tar.xz",
+    "hash": "sha256-fATLYM/qk3waj5s5xYgTa1DFe3XyLAbr+L+6LSXcGdA="
   },
   "plasma-welcome": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-welcome-6.6.0.tar.xz",
-    "hash": "sha256-ILm7Pw3osmLH5aDdqJ0jV12TLxXjFiMzN1DEq8XM9ac="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-welcome-6.6.1.tar.xz",
+    "hash": "sha256-c5WVd9dO+HNYE5ZneUuEZzp8SVq31AVF9U4evy9XYII="
   },
   "plasma-workspace": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-workspace-6.6.0.tar.xz",
-    "hash": "sha256-CY4f3bMGAIVSSL6jbgEsD1/xLRujOBoc5CAF5NIwTW4="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-workspace-6.6.1.tar.xz",
+    "hash": "sha256-yMNEvTyEJzHP1d8ccX225FEyndMrmDcX1/+avf80NO0="
   },
   "plasma-workspace-wallpapers": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma-workspace-wallpapers-6.6.0.tar.xz",
-    "hash": "sha256-Z7HUhWkU19iMCnfCtS6DqnP65ju2TSup4zmTfAh8GRw="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma-workspace-wallpapers-6.6.1.tar.xz",
+    "hash": "sha256-YPuRUi6jJJ+yhVWcQAO8zvPQHlYbl3v6le5rpAvEJps="
   },
   "plasma5support": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plasma5support-6.6.0.tar.xz",
-    "hash": "sha256-5ucVeVDBKrMwmVZ88oudlWnS4mVXFboSOGTRj2BxJis="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plasma5support-6.6.1.tar.xz",
+    "hash": "sha256-r5Iph67gpsG9Am6LNDDR6xUK74MG5MpofhO4vNXiXO8="
   },
   "plymouth-kcm": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/plymouth-kcm-6.6.0.tar.xz",
-    "hash": "sha256-2dKax0X8Y6rzlSbMtPYCuGk+uCqMmjlMqc9+01kIVOc="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/plymouth-kcm-6.6.1.tar.xz",
+    "hash": "sha256-QuO3NX2kT48vYq1W/GN1//ovVG6MA8ke3xIj8VW2qJ8="
   },
   "polkit-kde-agent-1": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/polkit-kde-agent-1-6.6.0.tar.xz",
-    "hash": "sha256-qdzvAS9uG7VOoa7jlxCNaDzMt3oPLHYgENdUdoS0aSs="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/polkit-kde-agent-1-6.6.1.tar.xz",
+    "hash": "sha256-oDzVsTB3+es2Y2Tbnk9sD4Kr49GQU7XmTN5J5qjidfo="
   },
   "powerdevil": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/powerdevil-6.6.0.tar.xz",
-    "hash": "sha256-UpDbhrpUbZ/HrEaNTX5odZpHa8e5vod1zg3eovTC204="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/powerdevil-6.6.1.tar.xz",
+    "hash": "sha256-GHKWCWEpVvtR9BwTyor9RvoeRq3hGEQz0x5XaGZjBAM="
   },
   "print-manager": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/print-manager-6.6.0.tar.xz",
-    "hash": "sha256-m0UGnY5hv6XSz5WP1WLRj+Dcy2dwCNmazutVmbgIte0="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/print-manager-6.6.1.tar.xz",
+    "hash": "sha256-LMS+MwFYg7GK7zHqozqFj4Yn+2m9SRjZd8vBZYDFA9A="
   },
   "qqc2-breeze-style": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/qqc2-breeze-style-6.6.0.tar.xz",
-    "hash": "sha256-cMQHYnFE1ZxYXC9DDpg0oBSANnjxbKUU5fv3pcuDr+w="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/qqc2-breeze-style-6.6.1.tar.xz",
+    "hash": "sha256-FeJY14SReqJ8fcEVXadfuqlMmjRXBbyTT83w5eBFahM="
   },
   "sddm-kcm": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/sddm-kcm-6.6.0.tar.xz",
-    "hash": "sha256-FepTheJ5dzmLlwAWg4ugwF2y/4CtOdtfrOys8B78+Vc="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/sddm-kcm-6.6.1.tar.xz",
+    "hash": "sha256-3nisFmz1o0eEzR1HTXgEK/TnajxXnIfqDIMatc/Rm7g="
   },
   "spacebar": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/spacebar-6.6.0.tar.xz",
-    "hash": "sha256-faBiuQOyFf8gyh7sHwS33EsrY+81iNRs1xwtSefyRoE="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/spacebar-6.6.1.tar.xz",
+    "hash": "sha256-nyC1vKHRDWAmG9zEUJvUHHBDbKGoKoTWP3E9XeR9LH8="
   },
   "spectacle": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/spectacle-6.6.0.tar.xz",
-    "hash": "sha256-qhSn/aoMRDEfDEHzUCrzk3TGUFfFFbd5aC1dvZT8v+M="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/spectacle-6.6.1.tar.xz",
+    "hash": "sha256-auAzSC8g/oR2EO9OK++B6rK0g9f18jDFzfhzJzaV668="
   },
   "systemsettings": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/systemsettings-6.6.0.tar.xz",
-    "hash": "sha256-0Mi/monOpfHXRjsRUFTABg36jvueJyC3J8qAz2v/Ykk="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/systemsettings-6.6.1.tar.xz",
+    "hash": "sha256-Yf2Fd1Xb2v6Axq+6q5iXT2QBwjRu0K/jhVAJ5d5ADig="
   },
   "wacomtablet": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/wacomtablet-6.6.0.tar.xz",
-    "hash": "sha256-u4Zb35LGmcQkXu7ENQVcfEUz8q01qCMi8lxMJ+yg6RY="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/wacomtablet-6.6.1.tar.xz",
+    "hash": "sha256-WotpF9R/Jc8blW1tKNXupwn7Tll+TnWmVdsO8oo6CEc="
   },
   "xdg-desktop-portal-kde": {
-    "version": "6.6.0",
-    "url": "mirror://kde/stable/plasma/6.6.0/xdg-desktop-portal-kde-6.6.0.tar.xz",
-    "hash": "sha256-htpZ7238nfEyyzMixlEKtWRW9T4/F3I1fUU9o+oe/kI="
+    "version": "6.6.1",
+    "url": "mirror://kde/stable/plasma/6.6.1/xdg-desktop-portal-kde-6.6.1.tar.xz",
+    "hash": "sha256-UxjWPddIoIYvjdmPPWbKGwsQ4+uYlrAANCMd/QpBryo="
   }
 }

--- a/pkgs/kde/lib/mk-kde-derivation.nix
+++ b/pkgs/kde/lib/mk-kde-derivation.nix
@@ -8,6 +8,7 @@ self:
   qt6,
   python3,
   python3Packages,
+  jq,
 }:
 let
   dependencies = (lib.importJSON ../generated/dependencies.json).dependencies;
@@ -77,6 +78,14 @@ let
     };
 
   moveOutputsHook = makeSetupHook { name = "kf6-move-outputs-hook"; } ./move-outputs-hook.sh;
+
+  qmllintHook = makeSetupHook {
+    name = "qmllint-validate-hook";
+    substitutions = {
+      qmllint = "${qt6.qtdeclarative}/bin/qmllint";
+      jq = lib.getExe jq;
+    };
+  } ./qmllint-hook.sh;
 in
 {
   pname,
@@ -131,6 +140,7 @@ let
       ninja
       qt6.wrapQtAppsHook
       moveOutputsHook
+      qmllintHook
     ]
     ++ lib.optionals hasPythonBindings [
       python3Packages.shiboken6
@@ -154,6 +164,8 @@ let
     strictDeps = true;
 
     cmakeFlags = [ "-DQT_MAJOR_VERSION=6" ] ++ extraCmakeFlags;
+
+    doInstallCheck = true;
 
     separateDebugInfo = true;
 

--- a/pkgs/kde/lib/qmllint-hook.sh
+++ b/pkgs/kde/lib/qmllint-hook.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+if [[ -z "${__nix_qmllintHook-}" ]]; then
+  __nix_qmllintHook=1 # Don't run this hook more than once.
+
+  qmlHostPathSeen=()
+  qmlIncludeDirs=()
+
+  qmlUnseenHostPath() {
+      for pkg in "${qmlHostPathSeen[@]}"; do
+          if [ "${pkg:?}" == "$1" ]; then
+              return 1
+          fi
+      done
+
+      qtHostPathSeen+=("$1")
+      return 0
+  }
+
+  qmlHostPathHook() {
+      qmlUnseenHostPath "$1" || return 0
+
+      if ! [ -v qtQmlPrefix ]; then
+          echo "qmlLintHook: qtQmlPrefix is unset. hint: add qt6.qtbase to buildInputs"
+      fi
+
+      local qmlDir="$1/${qtQmlPrefix:?}"
+      if [ -d "$qmlDir" ]; then
+          qmlIncludeDirs+=("-I" "$qmlDir")
+      fi
+  }
+  addEnvHooks "$targetOffset" qmlHostPathHook
+
+  doQmlLint() {
+      LANG=C.UTF-8 @qmllint@ --bare "${qmlIncludeDirs[@]}" -I "${out}/${qtQmlPrefix}" "$@"
+  }
+
+  qmlLintCheck() {
+      echo "Running qmlLintCheck"
+
+      # intentionally scoped to the default QML prefix, as things in $out/share etc
+      # can be used in random weird contexts and will cause spurious errors
+      if [ -d "$out/$qtQmlPrefix" ]; then
+        find "$out/$qtQmlPrefix" -name '*.qml' | while IFS= read -r i; do
+            if [ -n "$(doQmlLint "$i" --json - | @jq@ '.files[] | .warnings[] | select(.id == "import") | select(.message | startswith("Failed to import"))')" ]; then
+                echo "qmllint failed for file $i:"
+
+                doQmlLint "$i"
+                exit 1
+            fi
+        done
+      fi
+  }
+
+  if [ -z "${dontQmlLint-}" ]; then
+      postInstallCheckHooks+=('qmlLintCheck')
+  fi
+fi

--- a/pkgs/kde/misc/kirigami-addons/default.nix
+++ b/pkgs/kde/misc/kirigami-addons/default.nix
@@ -3,8 +3,10 @@
   mkKdeDerivation,
   fetchurl,
   qtdeclarative,
+  qtmultimedia,
   qt5compat,
   qttools,
+  kitemmodels,
 }:
 mkKdeDerivation rec {
   pname = "kirigami-addons";
@@ -17,7 +19,11 @@ mkKdeDerivation rec {
 
   extraNativeBuildInputs = [ qttools ];
   extraBuildInputs = [ qtdeclarative ];
-  extraPropagatedBuildInputs = [ qt5compat ];
+  extraPropagatedBuildInputs = [
+    qt5compat
+    qtmultimedia
+    kitemmodels
+  ];
 
   meta.license = with lib.licenses; [
     bsd2

--- a/pkgs/kde/plasma/kwin-x11/default.nix
+++ b/pkgs/kde/plasma/kwin-x11/default.nix
@@ -41,4 +41,7 @@ mkKdeDerivation {
 
     libxcvt
   ];
+
+  # plugin QML relies on non-global imports
+  dontQmlLint = true;
 }

--- a/pkgs/kde/plasma/kwin/default.nix
+++ b/pkgs/kde/plasma/kwin/default.nix
@@ -64,4 +64,7 @@ mkKdeDerivation {
     # we need to provide this so it knows our xwayland supports new features
     xwayland
   ];
+
+  # plugin QML relies on non-global imports
+  dontQmlLint = true;
 }

--- a/pkgs/kde/plasma/libksysguard/default.nix
+++ b/pkgs/kde/plasma/libksysguard/default.nix
@@ -3,6 +3,8 @@
   qtwebchannel,
   qtwebengine,
   qttools,
+  kitemmodels,
+  kquickcharts,
   libpcap,
   libnl,
   lm_sensors,
@@ -21,5 +23,10 @@ mkKdeDerivation {
     libpcap
     libnl
     lm_sensors
+  ];
+
+  extraPropagatedBuildInputs = [
+    kitemmodels
+    kquickcharts
   ];
 }

--- a/pkgs/kde/plasma/plasma-keyboard/default.nix
+++ b/pkgs/kde/plasma/plasma-keyboard/default.nix
@@ -20,4 +20,7 @@ mkKdeDerivation {
     # FIXME: fix this upstream? This should probably be XDG_DATA_DIRS
     "--set QT_VIRTUALKEYBOARD_HUNSPELL_DATA_PATH /run/current-system/sw/share/hunspell/"
   ];
+
+  # themes rely on non-global imports
+  dontQmlLint = true;
 }

--- a/pkgs/kde/plasma/plasma-nm/default.nix
+++ b/pkgs/kde/plasma/plasma-nm/default.nix
@@ -3,6 +3,7 @@
   replaceVars,
   pkg-config,
   qtwebengine,
+  kirigami-addons,
   mobile-broadband-provider-info,
   openconnect,
   openvpn,
@@ -22,4 +23,6 @@ mkKdeDerivation {
     mobile-broadband-provider-info
     openconnect
   ];
+
+  extraPropagatedBuildInputs = [ kirigami-addons ];
 }

--- a/pkgs/kde/plasma/plasma-systemmonitor/default.nix
+++ b/pkgs/kde/plasma/plasma-systemmonitor/default.nix
@@ -1,5 +1,11 @@
-{ mkKdeDerivation }:
+{
+  mkKdeDerivation,
+  kquickcharts,
+}:
 mkKdeDerivation {
   pname = "plasma-systemmonitor";
+
+  extraPropagatedBuildInputs = [ kquickcharts ];
+
   meta.mainProgram = "plasma-systemmonitor";
 }

--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -15,6 +15,7 @@
   qtlocation,
   qtpositioning,
   qtsvg,
+  qtvirtualkeyboard,
   qtwayland,
   libcanberra,
   libqalculate,
@@ -70,6 +71,10 @@ mkKdeDerivation {
     libxft
 
     gpsd
+  ];
+
+  extraPropagatedBuildInputs = [
+    qtvirtualkeyboard
   ];
 
   qtWrapperArgs = [ "--inherit-argv0" ];

--- a/pkgs/os-specific/linux/rtl8852bu/default.nix
+++ b/pkgs/os-specific/linux/rtl8852bu/default.nix
@@ -66,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/morrownr/rtl8852bu-20240418";
     license = lib.licenses.gpl2Only;
     platforms = [ "x86_64-linux" ];
-    broken = kernel.kernelOlder "6" && kernel.isHardened; # Similar to 79c1cf6
+    broken = (kernel.kernelOlder "6" && kernel.isHardened) || kernel.kernelAtLeast "6.18"; # Similar to 79c1cf6
     maintainers = with lib.maintainers; [
       lonyelon
       thtrf

--- a/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
+++ b/pkgs/servers/sql/postgresql/ext/plpgsql_check.nix
@@ -8,13 +8,13 @@
 
 postgresqlBuildExtension (finalAttrs: {
   pname = "plpgsql-check";
-  version = "2.8.9";
+  version = "2.8.11";
 
   src = fetchFromGitHub {
     owner = "okbob";
     repo = "plpgsql_check";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-SqL+Rw1ICeTj2b5bfW+awOf0Kk4SrsvfC6HF6XNe6+I=";
+    hash = "sha256-qeCC/rmd+qhAlpq7y5UhqDkFVGsDbBUAFWPizciPVaI=";
   };
 
   passthru.tests.extension = postgresqlTestExtension {

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -61,14 +61,14 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     updateScript = writeScript "update-xz" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of '>xz-5.2.6.tar.xz</a>'
       # We pick first match where a stable release goes first.
       new_version="$(curl -s https://tukaani.org/xz/ |
-          pcregrep -o1 '>xz-([0-9.]+)[.]tar[.]xz</a>' |
+          pcre2grep -o1 '>xz-([0-9.]+)[.]tar[.]xz</a>' |
           head -n1)"
       update-source-version ${finalAttrs.pname} "$new_version"
     '';

--- a/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
+++ b/pkgs/tools/typesetting/tex/texlive/tlpdb-overrides.nix
@@ -109,6 +109,9 @@ lib.recursiveUpdate orig rec {
     ))
   ];
   exceltex.extraBuildInputs = [ (perl.withPackages (ps: with ps; [ SpreadsheetParseExcel ])) ];
+  latexdiff.extraBuildInputs = [
+    (perl.withPackages (ps: with ps; [ EncodeLocale ]))
+  ];
   latex-git-log.extraBuildInputs = [ (perl.withPackages (ps: with ps; [ IPCSystemSimple ])) ];
   latexindent.extraBuildInputs = [
     (perl.withPackages (

--- a/pkgs/top-level/config.nix
+++ b/pkgs/top-level/config.nix
@@ -431,6 +431,23 @@ let
         Please read https://www.visualstudio.com/license-terms/mt644918/ and enable this config if you accept.
       '';
     };
+
+    allowDeprecatedx86_64Darwin = mkOption {
+      # `force` does nothing; it’s reserved for forward compatibility
+      # with 26.11. We hide it from the documentation to avoid a
+      # footgun, as it will make the error in 26.11 less useful.
+      type = types.either types.bool (types.enum [ "force" ]) // {
+        inherit (types.bool) description descriptionClass;
+      };
+      default = false;
+      description = ''
+        Silence the warning for the upcoming deprecation of the
+        `x86_64-darwin` platform in Nixpkgs 26.11.
+
+        This does nothing in 25.11, and is provided there for forward
+        compatibility of configurations with 26.05.
+      '';
+    };
   };
 
 in

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14125,6 +14125,8 @@ self: super: with self; {
 
   pynello = callPackage ../development/python-modules/pynello { };
 
+  pynentry = callPackage ../development/python-modules/pynentry { };
+
   pynest2d = callPackage ../development/python-modules/pynest2d { };
 
   pynetbox = callPackage ../development/python-modules/pynetbox { };


### PR DESCRIPTION
This pull request updates multiple package update scripts across the codebase to use `pcre2` and `pcre2grep` instead of the older `pcre` and `pcregrep` utilities. This change ensures compatibility with newer systems and aligns with current best practices, as `pcre2` is the actively maintained version of the Perl Compatible Regular Expressions library.

**Migration from pcre/pcregrep to pcre2/pcre2grep:**

* Updated the shebang lines and package lists in update scripts across numerous package definitions (e.g., `mpg123`, `argyllcms`, `diffoscope`, `ethtool`, `gdb`, `mc`, `mpfr`, `mutt`, `poke`, `serd`, `sgt-puzzles`, `slang`, `sratom`, `valgrind`, `guile`, `xz`, and more) to use `pcre2` and `pcre2grep` instead of `pcre` and `pcregrep`.

* Replaced all instances of `pcregrep` with `pcre2grep` in the commands that extract the latest version numbers from upstream sources in the update scripts.

No other functional or logic changes were made—this is a straightforward dependency and tool migration.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
