### PR TITLE
checkmate-capture: init at 1.3.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -999,6 +999,7 @@
   ./services/monitoring/bosun.nix
   ./services/monitoring/cadvisor.nix
   ./services/monitoring/certspotter.nix
+  ./services/monitoring/checkmate-capture.nix
   ./services/monitoring/cockpit.nix
   ./services/monitoring/collectd.nix
   ./services/monitoring/das_watchdog.nix

--- a/nixos/modules/services/monitoring/checkmate-capture.nix
+++ b/nixos/modules/services/monitoring/checkmate-capture.nix
@@ -1,0 +1,108 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.checkmate-capture;
+
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    mkOption
+    types
+    isPath
+    ;
+  inherit (builtins) toString;
+
+  assertStringPath =
+    optionName: value:
+    if isPath value then
+      throw ''
+        services.checkmate-capture.${optionName}:
+          ${toString value}
+          is a Nix path, but should be a string, since Nix
+          paths are copied into the world-readable Nix store.
+      ''
+    else
+      value;
+in
+{
+  options = {
+
+    services.checkmate-capture = {
+      enable = mkEnableOption "Checkmate capture agent";
+
+      package = mkPackageOption pkgs "checkmate-capture" { };
+
+      ginMode = mkOption {
+        type = types.enum [
+          "release"
+          "debug"
+        ];
+        default = "release";
+        description = ''
+          The mode of the Gin framework.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 59232;
+        description = ''
+          The port that the Checkmate capture listens on.
+        '';
+      };
+
+      openFirewall = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Open ports in the firewall for Checkmate capture.
+        '';
+      };
+
+      apiSecretFile = mkOption {
+        type = types.path;
+        apply = assertStringPath "apiSecretFile";
+        description = ''
+          The full path to a file containing the secret key for the API.
+        '';
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    systemd.services.checkmate-capture = {
+      description = "Checkmate capture.";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      startLimitIntervalSec = 60;
+      startLimitBurst = 3;
+      environment = {
+        GIN_MODE = cfg.ginMode;
+        PORT = toString cfg.port;
+      };
+      serviceConfig = {
+        LoadCredential = [ "API_SECRET:${cfg.apiSecretFile}" ];
+        LimitCORE = 0;
+        KillSignal = "SIGINT";
+        TimeoutStopSec = "30s";
+        Restart = "on-failure";
+        DynamicUser = true;
+      };
+      script = ''
+        set -eou pipefail
+        shopt -s inherit_errexit
+
+        API_SECRET="$(<"$CREDENTIALS_DIRECTORY/API_SECRET")" ${cfg.package}/bin/capture
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -354,6 +354,7 @@ in
   cfssl = runTestOn [ "aarch64-linux" "x86_64-linux" ] ./cfssl.nix;
   cgit = runTest ./cgit.nix;
   charliecloud = runTest ./charliecloud.nix;
+  checkmate-capture = runTest ./checkmate-capture.nix;
   chhoto-url = runTest ./chhoto-url.nix;
   chromadb = runTest ./chromadb.nix;
   chromium = (handleTestOn [ "aarch64-linux" "x86_64-linux" ] ./chromium.nix { }).stable or { };

--- a/nixos/tests/checkmate-capture.nix
+++ b/nixos/tests/checkmate-capture.nix
@@ -1,0 +1,29 @@
+{ lib, ... }:
+{
+  name = "checkmate-capture";
+  meta.maintainers = with lib.maintainers; [ robertjakub ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.checkmate-capture = {
+        enable = true;
+        apiSecretFile = "/run/checkmate-capture-api";
+      };
+    };
+
+  testScript = ''
+    machine.start()
+
+    machine.execute("echo \"APIPass\" > /run/checkmate-capture-api && chmod 400 /run/checkmate-capture-api")
+    machine.wait_for_unit("checkmate-capture.service")
+    machine.wait_for_open_port(59232)
+
+    machine.wait_until_succeeds("journalctl -o cat -u checkmate-capture.service | grep 'server started'")
+    machine.succeed("curl -sSfN http://127.0.0.1:59232/health | grep \"OK\"")
+    machine.succeed("curl -sSfN -H \"Authorization: Bearer APIPass\" http://127.0.0.1:59232/api/v1/metrics/host")
+
+    machine.shutdown()
+  '';
+
+}

--- a/pkgs/by-name/ch/checkmate-capture/package.nix
+++ b/pkgs/by-name/ch/checkmate-capture/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "checkmate-capture";
+  version = "1.3.2";
+
+  src = fetchFromGitHub {
+    owner = "bluewave-labs";
+    repo = "capture";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-2G/DHiNENjJPpiA7qVUcyjcGFHDbBR6ARc9FABHOVd4=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-XE011U2sI1kj7VnMjhZoxWakXMQGhIuFSCYUIjhefOQ=";
+
+  ldflags = [ "-X main.Version=${finalAttrs.version}" ];
+
+  doCheck = false;
+
+  meta = {
+    description = "A monitoring agent that collects and exposes hardware information through a RESTful API";
+    homepage = "https://github.com/bluewave-labs/capture";
+    changelog = "https://github.com/bluewave-labs/capture/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "capture";
+    maintainers = with lib.maintainers; [ robertjakub ];
+  };
+})


### PR DESCRIPTION
Capture is a hardware monitoring agent that collects hardware information from the host machine and exposes it through a RESTful API. The agent is designed to be lightweight and easy to use.

homepage: https://github.com/bluewave-labs/capture
documentation: https://docs.checkmate.so/uptime-manager/users-guide/server-monitoring-agent

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [X] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
