### PR TITLE
lager: 0.1.0 -> 0.1.2

### DIFF
--- a/pkgs/by-name/la/lager/package.nix
+++ b/pkgs/by-name/la/lager/package.nix
@@ -4,38 +4,49 @@
   fetchFromGitHub,
   cmake,
   boost,
+  cereal,
   immer,
   zug,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lager";
-  version = "0.1.0";
+  version = "0.1.2";
 
   src = fetchFromGitHub {
     owner = "arximboldi";
     repo = "lager";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-KTHrVV/186l4klwlcfDwFsKVoOVqWCUPzHnIbWuatbg=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-ssGBQu8ba798MSTtJeCBE3WQ7AFfvSGLhZ7WBYHEgfw=";
   };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ cmake ];
 
   buildInputs = [
     boost
+    cereal
     immer
     zug
   ];
-  nativeBuildInputs = [
-    cmake
-  ];
+
   cmakeFlags = [
-    "-Dlager_BUILD_EXAMPLES=OFF"
+    (lib.cmakeBool "lager_BUILD_DEBUGGER_EXAMPLES" false)
+    (lib.cmakeBool "lager_BUILD_DOCS" false)
+    (lib.cmakeBool "lager_BUILD_EXAMPLES" false)
+    (lib.cmakeBool "lager_BUILD_TESTS" false)
   ];
+
+  # remove BUILD file to avoid conflicts with the build directory
   preConfigure = ''
     rm BUILD
   '';
+
   meta = {
-    homepage = "https://github.com/arximboldi/lager";
+    changelog = "https://github.com/arximboldi/lager/releases/tag/${finalAttrs.src.tag}";
     description = "C++ library for value-oriented design using the unidirectional data-flow architecture — Redux for C++";
+    homepage = "https://sinusoid.es/lager/";
     license = lib.licenses.mit;
     maintainers = [ ];
   };


### PR DESCRIPTION
https://github.com/arximboldi/lager/compare/refs/tags/v0.1.0...refs/tags/v0.1.2

enables checks

fixes #493431

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 493363`
Commit: `070b8d095f3404ab1bd283451dcf38f078a4d912`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 2 packages marked as broken and skipped:</summary>
  <ul>
    <li>kazv</li>
    <li>libkazv</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>krita</li>
    <li>krita-plugin-gmic</li>
    <li>krita-unwrapped</li>
    <li>lager</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test