### PR TITLE
Add libusb1 as a dependency to platformio's chroot

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -20533,6 +20533,12 @@
     githubId = 70602908;
     github = "nikolaizombie1";
   };
+  nikp123 = {
+    name = "nikp123";
+    email = "nikp123@e.email";
+    github = "nikp123";
+    githubId = 4696350;
+  };
   nikstur = {
     email = "nikstur@outlook.com";
     name = "nikstur";

--- a/pkgs/by-name/pl/platformio-chrootenv/package.nix
+++ b/pkgs/by-name/pl/platformio-chrootenv/package.nix
@@ -14,6 +14,7 @@ let
       platformio-core
       zlib
       git
+      libusb1
       xdg-user-dirs
       ncurses
       udev

--- a/pkgs/by-name/pl/platformio-chrootenv/package.nix
+++ b/pkgs/by-name/pl/platformio-chrootenv/package.nix
@@ -45,7 +45,10 @@ buildFHSEnv {
   meta = {
     description = "Open source ecosystem for IoT development";
     homepage = "https://platformio.org";
-    maintainers = with lib.maintainers; [ mog ];
+    maintainers = with lib.maintainers; [
+      mog
+      nikp123
+    ];
     license = lib.licenses.asl20;
     platforms = with lib.platforms; linux;
   };


### PR DESCRIPTION
This is needed for when platformio decides to use toolchains own tools like "minichlink" in case of the CH32v003 boards.

These chip flashing tools use libusb in order to communiate with the devices they support. Missing this breaks the flashing of said boards when using the pio commandline tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
