### PR TITLE
fokus: init at 2.3.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25649,6 +25649,11 @@
     githubId = 7543617;
     name = "Struan Robertson";
   };
+  structix = {
+    github = "STRUCTiX";
+    githubId = 15931333;
+    name = "Janek";
+  };
   stteague = {
     email = "stteague505@yahoo.com";
     github = "stteague";

--- a/pkgs/by-name/fo/fokus/package.nix
+++ b/pkgs/by-name/fo/fokus/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  kdePackages,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "fokus";
+  version = "2.3.3";
+
+  src = fetchFromGitLab {
+    owner = "divinae";
+    repo = "focus-plasmoid";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S/0hAAt9zzj8pP5juFDvT0Z2B+GKpFnBsIVdJjSEakI=";
+  };
+
+  dontWrapQtApps = true;
+
+  postPatch = ''
+    substituteInPlace package/contents/config/main.xml package/contents/ui/configNotifications.qml \
+         --replace-fail "/usr/share/sounds" "${kdePackages.ocean-sound-theme}/share/sounds"
+
+    substituteInPlace package/contents/ui/configNotifications.qml package/contents/ui/configScripts.qml package/contents/ui/main.qml package/contents/ui/NotificationManager.qml \
+         --replace-fail 'import QtMultimedia' 'import "file://${kdePackages.qtmultimedia}/lib/qt-6/qml/QtMultimedia"'
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/plasma/plasmoids/com.dv.fokus
+    cp -r package/* $out/share/plasma/plasmoids/com.dv.fokus/
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Simple pomodoro KDE Plasma plasmoid";
+    homepage = "https://gitlab.com/divinae/focus-plasmoid";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ structix ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds [Fokus](https://gitlab.com/divinae/focus-plasmoid), a Pomodoro timer applet for KDE Plasma.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
