### PR TITLE
cypress: make updateScript update all sources

### DIFF
--- a/pkgs/by-name/cy/cypress/update.sh
+++ b/pkgs/by-name/cy/cypress/update.sh
@@ -1,10 +1,45 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p common-updater-scripts curl jq
+#!nix-shell -i bash -p curl jq
 
 set -euo pipefail
 
 basedir="$(git rev-parse --show-toplevel)"
-version="$(curl -sL https://cdn.cypress.io/desktop/ | jq '.version' --raw-output)"
+package_nix="$basedir/pkgs/by-name/cy/cypress/package.nix"
 
-cd "$basedir"
-update-source-version cypress "$version"
+version="$(curl -sL https://cdn.cypress.io/desktop/ | jq '.version' --raw-output)"
+old_version=$(sed -nE 's/^  version = "(.*)";$/\1/p' "$package_nix")
+
+if [[ "$version" == "$old_version" ]]; then
+  echo "cypress is already up to date at version $version"
+  exit 0
+fi
+
+echo "Updating cypress from $old_version to $version"
+sed -i "s/version = \"$old_version\"/version = \"$version\"/" "$package_nix"
+
+update_hash() {
+  local nix_system="$1"
+  local platform="$2"
+  local url="https://cdn.cypress.io/desktop/${version}/${platform}/cypress.zip"
+
+  echo "Fetching hash for $nix_system ($platform)..."
+  local hash sri_hash old_hash
+  hash=$(nix-prefetch-url --unpack --type sha256 "$url" 2>/dev/null)
+  sri_hash=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+
+  old_hash=$(sed -n "/${nix_system}/,/hash/s/.*hash = \"\(.*\)\";/\1/p" "$package_nix")
+
+  if [[ -n "$old_hash" ]]; then
+    sed -i "s|${old_hash}|${sri_hash}|" "$package_nix"
+    echo "  $nix_system: $sri_hash"
+  else
+    echo "  ERROR: Could not find hash for $nix_system" >&2
+    exit 1
+  fi
+}
+
+update_hash "x86_64-linux" "linux-x64"
+update_hash "aarch64-linux" "linux-arm64"
+update_hash "aarch64-darwin" "darwin-arm64"
+
+echo "Done updating cypress to $version"


### PR DESCRIPTION
Currently cypress' updateScript only updates the x86_64-linux sources.
See #437895.

This pr makes sure that all 4 platforms are updated automatically.



## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
