### PR TITLE
python3Packages.pyorc: unpin protobuf

### DIFF
--- a/pkgs/development/python-modules/pyorc/default.nix
+++ b/pkgs/development/python-modules/pyorc/default.nix
@@ -40,7 +40,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     pkgs.lz4
-    pkgs.protobuf_31
+    pkgs.protobuf
     pkgs.snappy
     pkgs.zlib
     pkgs.zstd


### PR DESCRIPTION
## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `0a076b0ef884f9e30cb2579ae72f023bc11a884f`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 7 packages built:</summary>
  <ul>
    <li>python313Packages.pyorc</li>
    <li>python313Packages.pyorc.dist</li>
    <li>python313Packages.swh-export</li>
    <li>python313Packages.swh-export.dist</li>
    <li>python314Packages.pyorc</li>
    <li>python314Packages.pyorc.dist</li>
    <li>swh</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test