### PR TITLE
h3_4: 4.3.0 -> 4.4.1, python3Packages.h3: 4.4.1 -> 4.4.2

### DIFF
--- a/pkgs/development/misc/h3/default.nix
+++ b/pkgs/development/misc/h3/default.nix
@@ -56,7 +56,7 @@ in
   };
 
   h3_4 = generic {
-    version = "4.3.0";
-    hash = "sha256-DUILKZ1QvML6qg+WdOxir6zRsgTvk+En6yjeFf6MQBg=";
+    version = "4.4.1";
+    hash = "sha256-tKonXauTJiOb5DV56tOmnvba7eNYcWTnOvCSokheVsY=";
   };
 }

--- a/pkgs/development/python-modules/h3/default.nix
+++ b/pkgs/development/python-modules/h3/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "h3";
-  version = "4.4.1";
+  version = "4.4.2";
   pyproject = true;
 
   # pypi version does not include tests
@@ -24,7 +24,7 @@ buildPythonPackage (finalAttrs: {
     owner = "uber";
     repo = "h3-py";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ugYx8FJUxfrJHfzRxyjaOlG/Z0KhKglRHTgKKBHzUGQ=";
+    hash = "sha256-+2cf/m+8BEEjNgIyuYmLDD7wsmc3Bg8QXaIjC0Px+Qk=";
   };
 
   dontConfigure = true;

--- a/pkgs/development/python-modules/h3/default.nix
+++ b/pkgs/development/python-modules/h3/default.nix
@@ -14,7 +14,7 @@
   stdenv,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "h3";
   version = "4.4.1";
   pyproject = true;
@@ -23,7 +23,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "uber";
     repo = "h3-py";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ugYx8FJUxfrJHfzRxyjaOlG/Z0KhKglRHTgKKBHzUGQ=";
   };
 
@@ -75,9 +75,10 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "h3" ];
 
   meta = {
+    changelog = "https://github.com/uber/h3-py/blob/${finalAttrs.src.rev}/CHANGELOG.md";
     homepage = "https://github.com/uber/h3-py";
     description = "Hierarchical hexagonal geospatial indexing system";
     license = lib.licenses.asl20;
     maintainers = [ lib.maintainers.kalbasit ];
   };
-}
+})


### PR DESCRIPTION
https://github.com/uber/h3/blob/refs/tags/v4.4.1/CHANGELOG.md
https://github.com/uber/h3/compare/refs/tags/v4.3.0...refs/tags/v4.4.1

https://github.com/uber/h3-py/compare/refs/tags/v4.4.1...refs/tags/v4.4.2
https://github.com/uber/h3-py/blob/refs/tags/v4.4.2/CHANGELOG.md

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`
Commit: `b4ab47cf34117854e4b0370bff441c9aff3b0b02`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 15 packages built:</summary>
  <ul>
    <li>h3_4</li>
    <li>h3_4.dev</li>
    <li>postgresql14Packages.h3-pg</li>
    <li>postgresql15Packages.h3-pg</li>
    <li>postgresql16Packages.h3-pg</li>
    <li>postgresql17Packages.h3-pg</li>
    <li>postgresql18Packages.h3-pg</li>
    <li>python313Packages.h3</li>
    <li>python313Packages.h3.dist</li>
    <li>python313Packages.timezonefinder</li>
    <li>python313Packages.timezonefinder.dist</li>
    <li>python314Packages.h3</li>
    <li>python314Packages.h3.dist</li>
    <li>python314Packages.timezonefinder</li>
    <li>python314Packages.timezonefinder.dist</li>
  </ul>
</details>

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test