### PR TITLE
eask-cli: 0.12.8 -> 0.12.9, versionCheckHook, finalAttrs

### DIFF
--- a/pkgs/by-name/ea/eask-cli/package.nix
+++ b/pkgs/by-name/ea/eask-cli/package.nix
@@ -2,25 +2,32 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
+  versionCheckHook,
 }:
 
-buildNpmPackage rec {
+buildNpmPackage (finalAttrs: {
   pname = "eask-cli";
-  version = "0.12.8";
+  version = "0.12.9";
 
   src = fetchFromGitHub {
     owner = "emacs-eask";
     repo = "cli";
-    rev = version;
-    hash = "sha256-eH46NlHQs+OVbc3WVUKHQGgXi9rvFMTrbd3UB8WCB6k=";
+    tag = finalAttrs.version;
+    hash = "sha256-jYdx+MYgUop01MzcKPxtm+ZW6lsy9eCqH00uQd8imRw=";
   };
 
-  npmDepsHash = "sha256-U/VKtefL31FNYUegt8+Qg2jM6fx4cX660UcNqGsWMOc=";
+  npmDepsHash = "sha256-Xj68un97I8xtAY3RXEq8PNC8ZOZ+NWg6SblnmKzHGMo=";
 
   dontBuild = true;
 
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
   meta = {
-    changelog = "https://github.com/emacs-eask/cli/blob/${src.rev}/CHANGELOG.md";
+    changelog = "https://github.com/emacs-eask/cli/blob/${finalAttrs.version}/CHANGELOG.md";
     description = "CLI for building, runing, testing, and managing your Emacs Lisp dependencies";
     homepage = "https://emacs-eask.github.io/";
     license = lib.licenses.gpl3Plus;
@@ -30,4 +37,4 @@ buildNpmPackage rec {
       piotrkwiecinski
     ];
   };
-}
+})


### PR DESCRIPTION
Tags 0.12.x has been removed except for 0.12.0, 0.12.9 (yesterday) and a new tag 0.12.10 (today, no github release yet so didn't bump to that).

I got problems building the package so I did a manual bump.

I also replaced rec with finalAttrs and added a versionCheckHook (as a smoke test).


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
