### PR TITLE
nixos/google-chrome: system-wide module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -230,6 +230,7 @@
   ./programs/gnome-disks.nix
   ./programs/gnome-terminal.nix
   ./programs/gnupg.nix
+  ./programs/google-chrome.nix
   ./programs/gpaste.nix
   ./programs/gphoto2.nix
   ./programs/gpu-screen-recorder.nix

--- a/nixos/modules/programs/google-chrome.nix
+++ b/nixos/modules/programs/google-chrome.nix
@@ -1,0 +1,68 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.google-chrome;
+in
+{
+  options.programs.google-chrome = {
+    enable = lib.mkEnableOption "Google Chrome browser";
+    package = lib.mkPackageOption pkgs "google-chrome" { };
+
+    extensions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "cjpalhdlnbpafiamejdnhcphjbkeiagm" # uBlock Origin
+        "nngceckbapebfimnlniiiahkandclblb" # Bitwarden
+      ];
+      description = "List of Chrome extension IDs to force install.";
+    };
+
+    commandLineArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "--disable-gpu"
+        "--enable-features=VaapiVideoDecoder"
+      ];
+      description = "Extra command line arguments passed to Google Chrome.";
+    };
+
+    policies = lib.mkOption {
+      type = lib.types.attrs;
+      default = { };
+      example = {
+        HomepageLocation = "https://nixos.org";
+        PasswordManagerEnabled = false;
+      };
+      description = "Chrome enterprise policies written to managed policies JSON.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [
+      (cfg.package.override {
+        commandLineArgs = cfg.commandLineArgs;
+      })
+    ];
+
+    environment.etc."opt/chrome/policies/managed/nixos.json".text =
+      let
+        extensionList = map (id: "${id};https://clients2.google.com/service/update2/crx") cfg.extensions;
+
+        finalPolicies = lib.recursiveUpdate cfg.policies (
+          lib.optionalAttrs (cfg.extensions != [ ]) {
+            ExtensionInstallForcelist = extensionList;
+          }
+        );
+      in
+      builtins.toJSON finalPolicies;
+
+    environment.sessionVariables.GOOGLE_CHROME_EXTRA_ARGS = lib.concatStringsSep " " cfg.commandLineArgs;
+  };
+}


### PR DESCRIPTION
This PR introduces the use of Google Chrome system-wide via module options.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
