### PR TITLE
nextpnr, trellis: update to fix Boost 1.87+ compatibility

### DIFF
--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -23,7 +23,9 @@ let
   };
 
   pname = "nextpnr";
-  version = "0.9";
+
+  # Version 0.9 was patched (c7cfb) for Boost 1.87+ compatibility (boost system)
+  version = "0.9-unstable-2026-02-08";
 
   prjbeyond_src = fetchFromGitHub {
     owner = "YosysHQ-GmbH";
@@ -39,8 +41,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "nextpnr";
-    tag = "${pname}-${version}";
-    hash = "sha256-rpg99k7rSNU4p5D0iXipLgNNOA2j0PdDsz8JTxyYNPM=";
+    rev = "35f14336c042a9aa86cc66221434262fbb02034e";
+    hash = "sha256-5Fn/Y+pjhnGFcZsCN7XZN0nPB9u/BIr+lxgrCC5pnpE=";
     fetchSubmodules = true;
   };
 
@@ -49,6 +51,7 @@ stdenv.mkDerivation rec {
     python3
   ]
   ++ (lib.optional enableGui wrapQtAppsHook);
+
   buildInputs = [
     boostPython
     eigen
@@ -59,13 +62,12 @@ stdenv.mkDerivation rec {
 
   cmakeFlags =
     let
-      # the specified version must always start with "nextpnr-", so add it if
-      # missing (e.g. if the user overrides with a git hash)
+      # Use the commit hash for the internal versioning
       rev = src.rev;
-      version = if (lib.hasPrefix "nextpnr-" rev) then rev else "nextpnr-${rev}";
+      versionStr = if (lib.hasPrefix "nextpnr-" rev) then rev else "nextpnr-${lib.substring 0 7 rev}";
     in
     [
-      "-DCURRENT_GIT_VERSION=${version}"
+      "-DCURRENT_GIT_VERSION=${versionStr}"
       "-DARCH=generic;ice40;ecp5;himbaechel"
       "-DBUILD_TESTS=ON"
       "-DICESTORM_INSTALL_PREFIX=${icestorm}"

--- a/pkgs/by-name/tr/trellis/package.nix
+++ b/pkgs/by-name/tr/trellis/package.nix
@@ -8,30 +8,30 @@
 }:
 
 let
-  rev = "488f4e71073062de314c55a037ede7cf03a3324c";
+  rev = "e821bcbecdc997d71766836a200e16b27535a835";
   # git describe --tags
-  realVersion = "1.2.1-14-g${builtins.substring 0 7 rev}";
+  realVersion = "1.4-12-g${builtins.substring 0 7 rev}";
 
   main_src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "prjtrellis";
     inherit rev;
-    hash = "sha256-Blbu+0rlM/3izbF0XCvkNpSAND0IclWEwK7anzyrpvw=";
+    hash = "sha256-RyCZTdiF8kFBNGWJnwALjF0fXrZm3OvSM0sdL6ljlYU=";
     name = "trellis";
   };
 
   database_src = fetchFromGitHub {
     owner = "YosysHQ";
     repo = "prjtrellis-db";
-    rev = "35d900a94ff0db152679a67bf6e4fbf40ebc34aa";
-    hash = "sha256-r6viR8y9ZjURGNbsa0/YY8lzy9kGzjuu408ntxwpqm0=";
+    rev = "015e0330630d7c238c0e4f2cdd9c8157eb78c54a";
+    hash = "sha256-1VpxI0RHZSiWdQPCgsEWQ3hqzy5F1YV7ZOGL3kK18XM=";
     name = "trellis-database";
   };
 
 in
 stdenv.mkDerivation {
   pname = "trellis";
-  version = "unstable-2022-09-14";
+  version = "unstable-2025-01-30";
 
   srcs = [
     main_src
@@ -52,7 +52,6 @@ stdenv.mkDerivation {
 
   preConfigure = ''
     rmdir database && ln -sfv ${database_src} ./database
-
     cd libtrellis
   '';
 


### PR DESCRIPTION
- Update prjtrellis to e821bcbecdc997d71766836a200e16b27535a835
- Update prjtrellis-db to 015e0330630d7c238c0e4f2cdd9c8157eb78c54a
- Fixes build failure with Boost 1.87+ by removing dependency on boost_system.

## Things done

- Built on platform:
  - [x] x86_64-linux
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
