### PR TITLE
CONTRIBUTING: add style guide rule for Mad Lib code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -682,6 +682,60 @@ If you have any problems with formatting, please ping the [formatting team](http
   As an exception, an explicit conditional expression with null can be used when fixing an important bug without triggering a mass rebuild.
   If this is done a follow up pull request _should_ be created to change the code to `lib.optional(s)`.
 
+- In some situations, you may want to write Mad Lib code. Mad Lib code is code that takes a value and embeds it in a new piece of data that will be parsed again later (for example, a Nix expression might embed the value of a variable in a Bash script, a Python script might calculate values and then embed them in a JSON file or a Bash script might dynamically generate a URL). When writing Mad Lib code, always include safe guards to ensure that values are properly escaped (unless doing so would break something):
+
+  ```nix
+  { lib, writeShellScript }:
+  let
+    authors = "Alice and Bob";
+  in
+  writeShellScript "show-author-names" ''
+    printf 'This script was created by %s.\n' ${lib.strings.escapeShellArg authors}
+  ''
+  ```
+
+  instead of
+
+  ```nix
+  { writeShellScript }:
+  let
+    authors = "Alice and Bob";
+  in
+  writeShellScript "show-author-names" ''
+    printf 'This script was created by %s.\n' ${authors}
+  ''
+  ```
+
+  Safe guards should be included even if you believe that a value will never contain anything that needs to be escaped (you might be mistaken, and the situation might change with future code changes).
+
+  Don’t use safe guards if doing so would break something:
+
+  ```nix
+  { writeShellScript }:
+  let
+    bashStrictMode = "set -o errexit -o nounset -o pipefail";
+  in
+  writeShellScript "strict-hello-world" ''
+    ${bashStrictMode}
+
+    echo 'Hello, world!'
+  ''
+  ```
+
+  instead of
+
+  ```nix
+  { lib, writeShellScript }:
+  let
+    bashStrictMode = "set -o errexit -o nounset -o pipefail";
+  in
+  writeShellScript "strict-hello-world" ''
+    ${lib.strings.escapeShellArg bashStrictMode}
+
+    echo 'Hello, world!'
+  ''
+  ```
+
 - Any style choices not covered here but that can be expressed as general rules should be left at the discretion of the authors of changes and _not_ commented in reviews.
   The purpose of this is:
    - to avoid churn as contributors with different style preferences undo each other's changes,


### PR DESCRIPTION
This pull request adds rules to the style guide in `CONTRIBUTING.md`. The rules tell contributors to always use functions like `lib.strings.escapeShellArg` when applicable. See the commit message for more information.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built (code examples) on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files (from code examples), usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
