### PR TITLE
python3Packages.plotly: fix build with pytest 9 and numpy 2.4

### DIFF
--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -48,6 +48,16 @@ buildPythonPackage rec {
     hash = "sha256-7rMatpaZvHuNPpiXR5eUHultqNnLER1iW+GR3dwgkyo=";
   };
 
+  patches = [
+    # https://numpy.org/devdocs/release/2.4.0-notes.html#removed-interpolation-parameter-from-quantile-and-percentile-functions
+    # Upstream PR: https://github.com/plotly/plotly.py/pull/5505
+    ./numpy-2.4-percentile-interpolation.patch
+
+    # https://numpy.org/devdocs/release/2.4.0-notes.html#removed-numpy-in1d
+    # Upstream PR: https://github.com/plotly/plotly.py/pull/5522
+    ./numpy-2.4-in1d.patch
+  ];
+
   postPatch = ''
     substituteInPlace pyproject.toml \
       --replace-fail '"hatch", ' "" \

--- a/pkgs/development/python-modules/plotly/default.nix
+++ b/pkgs/development/python-modules/plotly/default.nix
@@ -52,6 +52,14 @@ buildPythonPackage rec {
     substituteInPlace pyproject.toml \
       --replace-fail '"hatch", ' "" \
       --replace-fail "jupyter_packaging~=0.10.0" jupyter_packaging
+
+    # `pytest_ignore_collect` takes only `collection_path` starting with
+    # pytest 9. Most of the paths referenced in `plotly/conftest.py`
+    # don't exist anymore and wouldn't be collected anyway, so we can just
+    # remove the file.
+    # https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
+    # Upstream PR: https://github.com/plotly/plotly.py/pull/5521
+    rm plotly/conftest.py
   '';
 
   env.SKIP_NPM = true;

--- a/pkgs/development/python-modules/plotly/numpy-2.4-in1d.patch
+++ b/pkgs/development/python-modules/plotly/numpy-2.4-in1d.patch
@@ -1,0 +1,38 @@
+From 9531e7ff00be577560f2cebf6739343646d3c770 Mon Sep 17 00:00:00 2001
+From: Tom Hunze <dev@thunze.de>
+Date: Mon, 23 Feb 2026 19:21:45 +0100
+Subject: [PATCH] Use `np.isin` instead of `np.in1d` to fix numpy 2.4 test
+ compatibility
+
+https://numpy.org/devdocs/release/2.4.0-notes.html#removed-numpy-in1d
+---
+ tests/test_optional/test_px/test_px.py           | 2 +-
+ tests/test_optional/test_px/test_px_functions.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tests/test_optional/test_px/test_px.py b/tests/test_optional/test_px/test_px.py
+index 6c65925a727..a74c4680540 100644
+--- a/tests/test_optional/test_px/test_px.py
++++ b/tests/test_optional/test_px/test_px.py
+@@ -36,7 +36,7 @@ def test_custom_data_scatter(backend):
+     )
+     for data in fig.data:
+         assert np.all(
+-            np.in1d(data.customdata[:, 1], iris.get_column("petal_width").to_numpy())
++            np.isin(data.customdata[:, 1], iris.get_column("petal_width").to_numpy())
+         )
+     # Hover and custom data, no repeated arguments
+     fig = px.scatter(
+diff --git a/tests/test_optional/test_px/test_px_functions.py b/tests/test_optional/test_px/test_px_functions.py
+index 0814898f89d..8220ec7a33a 100644
+--- a/tests/test_optional/test_px/test_px_functions.py
++++ b/tests/test_optional/test_px/test_px_functions.py
+@@ -307,7 +307,7 @@ def test_sunburst_treemap_with_path_color(constructor):
+     fig = px.sunburst(
+         df.to_native(), path=path, color="sectors", color_discrete_map=cmap
+     )
+-    assert np.all(np.in1d(fig.data[0].marker.colors, list(cmap.values())))
++    assert np.all(np.isin(fig.data[0].marker.colors, list(cmap.values())))
+ 
+     # Numerical column in path
+     df = (

--- a/pkgs/development/python-modules/plotly/numpy-2.4-percentile-interpolation.patch
+++ b/pkgs/development/python-modules/plotly/numpy-2.4-percentile-interpolation.patch
@@ -1,0 +1,17 @@
+diff --git a/plotly/figure_factory/_violin.py b/plotly/figure_factory/_violin.py
+index 55924e692..e89db0e11 100644
+--- a/plotly/figure_factory/_violin.py
++++ b/plotly/figure_factory/_violin.py
+@@ -17,9 +17,9 @@ def calc_stats(data):
+     x = np.asarray(data, float)
+     vals_min = np.min(x)
+     vals_max = np.max(x)
+-    q2 = np.percentile(x, 50, interpolation="linear")
+-    q1 = np.percentile(x, 25, interpolation="lower")
+-    q3 = np.percentile(x, 75, interpolation="higher")
++    q2 = np.percentile(x, 50, method="linear")
++    q1 = np.percentile(x, 25, method="lower")
++    q3 = np.percentile(x, 75, method="higher")
+     iqr = q3 - q1
+     whisker_dist = 1.5 * iqr
+ 


### PR DESCRIPTION
Hydra: https://hydra.nixos.org/build/322261587/nixlog/4

pytest 9 and numpy 2.4 introduced a bunch of backward-incompatible changes that broke plotly in a few ways.

- https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
  - Upstream PR: https://github.com/plotly/plotly.py/pull/5521
- https://numpy.org/devdocs/release/2.4.0-notes.html#removed-interpolation-parameter-from-quantile-and-percentile-functions
  - Upstream PR: https://github.com/plotly/plotly.py/pull/5505
- https://numpy.org/devdocs/release/2.4.0-notes.html#removed-numpy-in1d
  - Upstream PR: https://github.com/plotly/plotly.py/pull/5522

Fixes https://github.com/NixOS/nixpkgs/issues/493605

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{13,14}Packages.plotly`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
