### PR TITLE
np2kai: 0.86rev22-unstable-2025-09-13 -> 0.86rev22-unstable-2026-02-08

### DIFF
--- a/pkgs/by-name/np/np2kai/1001-CMakeLists.txt-Fix-CMAKE_CXX_FLAGS_-RELEASE-DEBUG.patch
+++ b/pkgs/by-name/np/np2kai/1001-CMakeLists.txt-Fix-CMAKE_CXX_FLAGS_-RELEASE-DEBUG.patch
@@ -1,0 +1,33 @@
+From 3d23274eefcf9c494358662539c29eebd8996cbf Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 23 Feb 2026 17:00:24 +0100
+Subject: [PATCH 1/3] CMakeLists.txt: Fix CMAKE_CXX_FLAGS_{RELEASE,DEBUG} being
+ lists of strings
+
+g++ /* ... */ -O2 -Wall -DNDEBUG;-Wno-implicit-function-declaration -Wno-incompatible-pointer-types /* ... */ -o CMakeFiles/sdlnp2kai_sdl2.dir/sound/fmgen/fmgen_file.cpp.o -c /build/source/sound/fmgen/fmgen_file.cpp
+ld: <glibc>/lib/Scrt1.o: in function `_start':
+(.text+0x1b): undefined reference to `main'
+collect2: error: ld returned 1 exit status
+bash: line 1: -Wno-implicit-function-declaration: command not found
+---
+ CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5a9884f..9c14d94 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -323,8 +323,8 @@ if(NOT CMAKE_BUILD_TYPE)
+ endif()
+ if(NOT EMSCRIPTEN)
+ set(COMMON_C_CXX_FLAGS "-Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-incompatible-function-pointer-types -Wno-int-conversion -fno-sized-deallocation")
+-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -Wall -DDEBUG -DTRACE" ${COMMON_C_CXX_FLAGS})
+-set(CMAKE_CXX_FLAGS_RELEASE "-O2 -Wall -DNDEBUG" ${COMMON_C_CXX_FLAGS})
++set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -Wall -DDEBUG -DTRACE ${COMMON_C_CXX_FLAGS}")
++set(CMAKE_CXX_FLAGS_RELEASE "-O2 -Wall -DNDEBUG ${COMMON_C_CXX_FLAGS}")
+ set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os -Wall")
+ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-Og -g -Wall -DNDEBUG")
+ endif()
+-- 
+2.52.0
+

--- a/pkgs/by-name/np/np2kai/1002-sdl-x-fontmng.c-Fix-GlyphMetrics-calls.patch
+++ b/pkgs/by-name/np/np2kai/1002-sdl-x-fontmng.c-Fix-GlyphMetrics-calls.patch
@@ -1,0 +1,72 @@
+From a6b3a5d71c9c31b690f8045ba2fd6d9c529da92c Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 23 Feb 2026 17:18:58 +0100
+Subject: [PATCH 2/3] {sdl,x}/fontmng.c: Fix GlyphMetrics calls
+
+/build/source/sdl/fontmng.c:503:58: error: passing argument 2 of 'TTF_GlyphMetrics' makes integer from pointer without a cast [-Wint-conversion]
+In file included from /build/source/sdl/fontmng.c:20:
+<SDL2_ttf>/include/SDL2/SDL_ttf.h:800:69: note: expected 'Uint16' {aka 'short unsigned int'} but argument is of type 'SDL_Surface *'
+---
+ sdl/fontmng.c | 8 ++++----
+ x/fontmng.c   | 8 ++++----
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/sdl/fontmng.c b/sdl/fontmng.c
+index 487e563..27b7a47 100644
+--- a/sdl/fontmng.c
++++ b/sdl/fontmng.c
+@@ -498,9 +498,9 @@ static void TTFGetFont1(FNTMNG _this, FNTDAT fdat, UINT16 c)
+ 		{
+ #if !defined(_WINDOWS)
+ #if USE_SDL_VERSION >= 3
+-			TTF_GetGlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GetGlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #else
+-			TTF_GlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #endif
+ #endif
+ 			for (y = 0; y < fdat->height; y++)
+@@ -532,9 +532,9 @@ static void TTFGetFont1(FNTMNG _this, FNTDAT fdat, UINT16 c)
+ 		{
+ #if !defined(_WINDOWS)
+ #if USE_SDL_VERSION >= 3
+-			TTF_GetGlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GetGlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #else
+-			TTF_GlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #endif
+ #endif
+ 			for (y = 0; y < fdat->height; y++)
+diff --git a/x/fontmng.c b/x/fontmng.c
+index a284ba6..01ed817 100755
+--- a/x/fontmng.c
++++ b/x/fontmng.c
+@@ -484,9 +484,9 @@ static void TTFGetFont1(FNTMNG _this, FNTDAT fdat, UINT16 c)
+ 		if (_this->fonttype & FDAT_ALIAS)
+ 		{
+ #if USE_SDL_VERSION >= 3
+-			TTF_GetGlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GetGlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #else
+-			TTF_GlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #endif
+ 			for (y = 0; y < fdat->height; y++)
+ 			{
+@@ -510,9 +510,9 @@ static void TTFGetFont1(FNTMNG _this, FNTDAT fdat, UINT16 c)
+ 		else
+ 		{
+ #if USE_SDL_VERSION >= 3
+-			TTF_GetGlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GetGlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #else
+-			TTF_GlyphMetrics(_this->ttf_font,s,&minx,NULL,NULL,&maxy,&advance);
++			TTF_GlyphMetrics(_this->ttf_font,c,&minx,NULL,NULL,&maxy,&advance);
+ #endif
+ 			for (y = 0; y < fdat->height; y++)
+ 			{
+-- 
+2.52.0
+

--- a/pkgs/by-name/np/np2kai/1003-sdl-np2.c-Fix-wrong-order-of-arguments-to-fgets-call.patch
+++ b/pkgs/by-name/np/np2kai/1003-sdl-np2.c-Fix-wrong-order-of-arguments-to-fgets-call.patch
@@ -1,0 +1,27 @@
+From 697fac371b414212526aae25e7c9774f167f4ef3 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 23 Feb 2026 17:26:26 +0100
+Subject: [PATCH 3/3] sdl/np2.c: Fix wrong order of arguments to fgets call
+
+/build/source/sdl/np2.c:373:19: error: passing argument 2 of 'fgets' makes integer from pointer without a cast [-Wint-conversion]
+/build/source/sdl/np2.c:373:25: error: passing argument 3 of 'fgets' makes pointer from integer without a cast [-Wint-conversion]
+---
+ sdl/np2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sdl/np2.c b/sdl/np2.c
+index 6712ac1..002ee33 100755
+--- a/sdl/np2.c
++++ b/sdl/np2.c
+@@ -370,7 +370,7 @@ char np2_main_read_m3u(const char *file)
+ #if defined(__LIBRETRO__)
+   while (filestream_gets(f, line, sizeof(line)) && np2_main_disk_images_count < sizeof(np2_main_disk_images_paths) / MAX_PATH)
+ #else
+-  while (fgets(f, line, sizeof(line)) && np2_main_disk_images_count < sizeof(np2_main_disk_images_paths) / MAX_PATH)
++  while (fgets(f, sizeof(line), line) && np2_main_disk_images_count < sizeof(np2_main_disk_images_paths) / MAX_PATH)
+ #endif
+   {
+     if (line[0] == '#')
+-- 
+2.52.0
+


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
