### PR TITLE
nixos/nix-daemon: Fix unprivileged tmpfiles rules

### DIFF
--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -136,10 +136,11 @@ in
         };
 
         systemd.tmpfiles.rules = [
-          "d /nix/store                 0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - -"
-          "Z /nix/var                   0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - -"
-          "d /nix/var/nix/builds        0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - 7d"
-          "d /nix/var/nix/daemon-socket 0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - -"
+          "d /nix/store                   0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - -"
+          "Z /nix/var                     0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - -"
+          "d /nix/var/nix/builds          0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} 7d -"
+          "d /nix/var/nix/daemon-socket   0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - -"
+          "d /nix/var/nix/gc-roots-socket 0755 ${config.nix.daemonUser} ${config.nix.daemonGroup} - -"
         ];
 
         systemd.services.nix-roots-daemon = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

In #491809 I added support for running the nix daemon unprivileged, but did not include the correct path for the gc-roots-socket in tmpfiles and had a typo on another file. This was not caught in the tests.

I have tested this change with the nix functional tests, and plan to upstream that use in the future.

Fix those errors.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
