### PR TITLE
Revert "yamlscript: 0.2.8 -> 0.2.9"

### DIFF
--- a/pkgs/by-name/ya/yamlscript/package.nix
+++ b/pkgs/by-name/ya/yamlscript/package.nix
@@ -6,11 +6,11 @@
 
 buildGraalvmNativeImage (finalAttrs: {
   pname = "yamlscript";
-  version = "0.2.9";
+  version = "0.2.8";
 
   src = fetchurl {
     url = "https://github.com/yaml/yamlscript/releases/download/${finalAttrs.version}/yamlscript.cli-${finalAttrs.version}-standalone.jar";
-    hash = "sha256-N3F2lZ81hcs2ul4AndSxSPic4hmeGAPXDS/K8iDihtw=";
+    hash = "sha256-qA8j14xUWtg2988ahklawnRZl9u3pvogjjXXs8byE2g=";
   };
 
   extraNativeImageBuildArgs = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#487496

Upstream deleted the tag.