### PR TITLE
nixos/initrd: refactor `secrets` option into `secretPaths` and `extraSecretsHook`

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -193,6 +193,8 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
 
 - `services.caddy` now supports setting `httpPort` and `httpsPort` and opening them in the firewall via `openFirewall`.
 
+- `boot.initrd.secrets` is now deprecated in favour of `boot.initrd.secretPaths` and `boot.initrd.extraSecretsHook`.
+
 - The latest available version of Nextcloud is v33 (available as `pkgs.nextcloud33`). The installation logic is as follows:
   - If [`services.nextcloud.package`](#opt-services.nextcloud.package) is specified explicitly, this package will be installed (**recommended**)
   - If [`system.stateVersion`](#opt-system.stateVersion) is >=26.05, `pkgs.nextcloud33` will be installed by default.

--- a/nixos/modules/services/networking/iscsi/root-initiator.nix
+++ b/nixos/modules/services/networking/iscsi/root-initiator.nix
@@ -86,7 +86,7 @@ in
       description = ''
         Append an additional file's contents to `/etc/iscsid.conf`. Use a non-store path
         and store passwords in this file. Note: the file specified here must be available
-        in the initrd, see: `boot.initrd.secrets`.
+        in the initrd, see: `boot.initrd.secretPaths`.
       '';
       default = null;
       type = nullOr str;

--- a/nixos/modules/system/activation/bootspec.nix
+++ b/nixos/modules/system/activation/bootspec.nix
@@ -14,7 +14,9 @@ let
   children = lib.mapAttrs (
     childName: childConfig: childConfig.configuration.system.build.toplevel
   ) config.specialisation;
-  hasAtLeastOneInitrdSecret = lib.length (lib.attrNames config.boot.initrd.secrets) > 0;
+  hasInitrdSecrets =
+    (lib.length (lib.attrNames config.boot.initrd.secretPaths) > 0)
+    || (config.boot.initrd.extraSecretsHook != "");
   schemas = {
     v1 = rec {
       filename = "boot.json";
@@ -33,7 +35,7 @@ let
               // lib.optionalAttrs config.boot.initrd.enable {
                 initrd = "${config.system.build.initialRamdisk}/${config.system.boot.loader.initrdFile}";
               }
-              // lib.optionalAttrs hasAtLeastOneInitrdSecret {
+              // lib.optionalAttrs hasInitrdSecrets {
                 initrdSecrets = "${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets";
               };
             }

--- a/nixos/modules/system/boot/clevis.nix
+++ b/nixos/modules/system/boot/clevis.nix
@@ -99,8 +99,8 @@ in
         sed -i $out/bin/clevis-decrypt-tpm2 -e 's,tpm2_,tpm2 ,'
       '';
 
-      secrets = lib.mapAttrs' (
-        name: value: lib.nameValuePair "/etc/clevis/${name}.jwe" value.secretFile
+      secretPaths = lib.mapAttrs' (
+        name: value: lib.nameValuePair "/etc/clevis/${name}.jwe" { source = value.secretFile; }
       ) cfg.devices;
 
       systemd = {

--- a/nixos/modules/system/boot/initrd-openvpn.nix
+++ b/nixos/modules/system/boot/initrd-openvpn.nix
@@ -29,7 +29,7 @@ in
     };
 
     boot.initrd.network.openvpn.configuration = mkOption {
-      type = types.path; # Same type as boot.initrd.secrets
+      type = types.path; # Same type as boot.initrd.secretPaths.*.source
       description = ''
         The configuration file for OpenVPN.
 
@@ -74,8 +74,8 @@ in
       "${pkgs.glibc}/lib/libnss_dns.so.2"
     ];
 
-    boot.initrd.secrets = {
-      "/etc/initrd.ovpn" = cfg.configuration;
+    boot.initrd.secretPaths = {
+      "/etc/initrd.ovpn".source = cfg.configuration;
     };
 
     # openvpn --version would exit with 1 instead of 0

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -302,8 +302,8 @@ in
         fi
       '';
 
-      boot.initrd.secrets = listToAttrs (
-        map (path: nameValuePair (initrdKeyPath path) path) cfg.hostKeys
+      boot.initrd.secretPaths = listToAttrs (
+        map (path: nameValuePair (initrdKeyPath path) { source = path; }) cfg.hostKeys
       );
 
       # Systemd initrd stuff

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -414,7 +414,7 @@ in
 
           ln -s ${initrdPath} $out/initrd
 
-          ${optionalString (config.boot.initrd.secrets != { }) ''
+          ${optionalString (config.boot.initrd.secretPaths != { }) ''
             ln -s ${config.system.build.initialRamdiskSecretAppender}/bin/append-initrd-secrets $out
           ''}
 

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -935,21 +935,21 @@ in
     '')
     (mkRemovedOptionModule [ "boot" "loader" "grub" "extraInitrd" ] ''
       This option has been replaced with the bootloader agnostic
-      boot.initrd.secrets option. To migrate to the initrd secrets system,
+      boot.initrd.secretPaths option. To migrate to the initrd secrets system,
       extract the extraInitrd archive into your main filesystem:
 
         # zcat /boot/extra_initramfs.gz | cpio -idvmD /etc/secrets/initrd
         /path/to/secret1
         /path/to/secret2
 
-      then replace boot.loader.grub.extraInitrd with boot.initrd.secrets:
+      then replace boot.loader.grub.extraInitrd with boot.initrd.secretPaths:
 
-        boot.initrd.secrets = {
-          "/path/to/secret1" = "/etc/secrets/initrd/path/to/secret1";
-          "/path/to/secret2" = "/etc/secrets/initrd/path/to/secret2";
+        boot.initrd.secretPaths = {
+          "/path/to/secret1".source = "/etc/secrets/initrd/path/to/secret1";
+          "/path/to/secret2".source = "/etc/secrets/initrd/path/to/secret2";
         };
 
-      See the boot.initrd.secrets option documentation for more information.
+      See the boot.initrd.secretPaths option documentation for more information.
     '')
   ];
 

--- a/nixos/modules/system/boot/loader/grub/install-grub.pl
+++ b/nixos/modules/system/boot/loader/grub/install-grub.pl
@@ -482,7 +482,7 @@ sub addEntry {
               die "failed to create initrd secrets $!\n";
           } else {
               say STDERR "warning: failed to create initrd secrets for \"$name\", an older generation";
-              say STDERR "note: this is normal after having removed or renamed a file in `boot.initrd.secrets`";
+              say STDERR "note: this is normal after having modified or removed an entry in `boot.initrd.secretPaths`";
           }
         }
         # Check whether any secrets were actually added

--- a/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
+++ b/nixos/modules/system/boot/loader/systemd-boot/systemd-boot-builder.py
@@ -202,7 +202,7 @@ def write_entry(profile: str | None, generation: int, specialisation: str | None
             print("warning: failed to create initrd secrets "
                   f'for "{title} - Configuration {generation}", an older generation', file=sys.stderr)
             print("note: this is normal after having removed "
-                  "or renamed a file in `boot.initrd.secrets`", file=sys.stderr)
+                  "or modified an entry in `boot.initrd.secretPaths`", file=sys.stderr)
     entry_file = BOOT_MOUNT_POINT / "loader/entries" / generation_conf_filename(profile, generation, specialisation)
     tmp_path = entry_file.with_suffix(".tmp")
     kernel_params = "init=%s " % bootspec.init

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -659,16 +659,10 @@ in
     boot.initrd.secrets = mkOption {
       default = { };
       type = types.attrsOf (types.nullOr types.path);
+      visible = false;
       description = ''
-        Secrets to append to the initrd. The attribute name is the
-        path the secret should have inside the initrd, the value
-        is the path it should be copied from (or null for the same
-        path inside and out).
-
-        Note that `nixos-rebuild switch` will generate the initrd
-        also for past generations, so if secrets are moved or deleted
-        you will also have to garbage collect the generations that
-        use those secrets.
+        Secrets to append to the initrd. This option has been deprecated in
+        favour of `boot.initrd.secretPaths`.
       '';
       example = literalExpression ''
         { "/etc/dropbear/dropbear_rsa_host_key" =
@@ -872,6 +866,10 @@ in
         '';
       }
     ];
+
+    warnings = lib.optional (config.boot.initrd.secrets != { }) ''
+      The option `boot.initrd.secrets` has been deprecated in favour of `boot.initrd.secretPaths`.
+    '';
 
     # Backwards compatibility to the legacy `boot.initrd.secrets` option.
     boot.initrd.secretPaths = lib.mapAttrs' (dest: source: {

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -148,23 +148,22 @@ let
         # Copy secrets if needed.
         #
         # TODO: move out to a separate script; see #85000.
-        ${optionalString (!config.boot.loader.supportsInitrdSecrets) (
-          concatStringsSep "\n" (
-            mapAttrsToList (
-              dest: source:
-              let
-                source' = if source == null then dest else source;
-              in
-              ''
-                mkdir -p $(dirname "$out/secrets/${dest}")
-                # Some programs (e.g. ssh) doesn't like secrets to be
-                # symlinks, so we use `cp -L` here to match the
-                # behaviour when secrets are natively supported.
-                cp -Lr ${source'} "$out/secrets/${dest}"
-              ''
-            ) config.boot.initrd.secrets
-          )
-        )}
+        ${optionalString (!config.boot.loader.supportsInitrdSecrets) ''
+          ${concatStringsSep "\n" (
+            mapAttrsToList (_: scfg: ''
+              mkdir -p $(dirname "$out/secrets${scfg.path}")
+              # Some programs (e.g. ssh) doesn't like secrets to be
+              # symlinks, so we use `cp -L` here to match the
+              # behaviour when secrets are natively supported.
+              # The assertion further up in this file (stage-1.nix)
+              # checks that all secretPaths are Nix store paths set via
+              # boot.initrd.secretPaths.*.source if the bootloader doesn't
+              # support initrd secrets.
+              cp -Lr ${scfg.source} "$out/secrets${scfg.path}"
+            '') config.boot.initrd.secretPaths
+          )}
+          ${config.boot.initrd.extraSecretsHook}
+        ''}
 
         ${config.boot.initrd.extraUtilsCommands}
 
@@ -436,7 +435,9 @@ let
         exit 0
       fi
 
-      ${lib.optionalString (config.boot.initrd.secrets == { }) "exit 0"}
+      ${lib.optionalString (
+        config.boot.initrd.secretPaths == { } && config.boot.initrd.extraSecretsHook == ""
+      ) "exit 0"}
 
       export PATH=${pkgs.coreutils}/bin:${pkgs.cpio}/bin:${pkgs.gzip}/bin:${pkgs.findutils}/bin
 
@@ -451,16 +452,24 @@ let
 
       ${lib.concatStringsSep "\n" (
         mapAttrsToList (
-          dest: source:
+          _: scfg:
           let
-            source' = if source == null then dest else toString source;
+            prefix = lib.optionalString scfg.intermediateSecretsDir "/.initrd-secrets";
           in
           ''
-            mkdir -p $(dirname "$tmp/.initrd-secrets/${dest}")
-            cp -a ${source'} "$tmp/.initrd-secrets/${dest}"
+            mkdir -p $(dirname "$tmp${prefix}${scfg.path}")
+            (
+              export out="$tmp${prefix}${scfg.path}"
+              ${scfg.generateSecretCommand}
+            )
           ''
-        ) config.boot.initrd.secrets
+        ) config.boot.initrd.secretPaths
       )}
+
+      (
+        cd "$tmp"
+        ${config.boot.initrd.extraSecretsHook}
+      )
 
       # mindepth 1 so that we don't change the mode of /
       (cd "$tmp" && find . -mindepth 1 | xargs touch -amt 197001010000 && find . -mindepth 1 -print0 | sort -z | cpio --quiet -o -H newc -R +0:+0 --reproducible --null) | \
@@ -668,6 +677,104 @@ in
       '';
     };
 
+    boot.initrd.secretPaths = mkOption {
+      default = { };
+      type = types.attrsOf (
+        types.submodule (
+          { config, name, ... }:
+          {
+            options = {
+              path = mkOption {
+                type = types.path;
+                default = name;
+                description = ''
+                  The path the secret should be placed at in the initrd. Defaults
+                  to the attribute name.
+                '';
+              };
+
+              intermediateSecretsDir = mkOption {
+                type = types.bool;
+                default = true;
+                description = ''
+                  By default, the secrets will be copied over to the
+                  `/.initrd-secrets` dir at initrd generation time, and then copied
+                  over to their final location at boot time. This is because initrd secrets
+                  that are supposed to be placed in `/run` would be overridden by
+                  the tmpfs mount over `/run` otherwise.
+
+                  Set this option to `false` to skip this intermediate step and
+                  place the secret at its final location straightaway.
+                '';
+              };
+
+              source = mkOption {
+                type = types.nullOr types.path;
+                default = null;
+                description = ''
+                  The absolute path on the filesystem to copy the secret from.
+                '';
+                example = "/var/lib/secrets/initrd/ssh_host_ed25519_key";
+              };
+
+              generateSecretCommand = mkOption {
+                type = types.path;
+                description = ''
+                  The command to run to generate the secret. It should write
+                  the secret to `$out`.
+
+                  This is useful if you have a more advanced secrets provisioning
+                  mechanism.
+                '';
+                example = ''
+                  pkgs.writeShellScript "generate-secret" '''
+                    ''${lib.getExe pkgs.age} -d -i /etc/ssh/ssh_host_ed25519_key -o "$out" ''${./secret.age}
+                  '''
+                '';
+              };
+            };
+
+            config = {
+              generateSecretCommand = lib.mkIf (config.source != null) (
+                pkgs.writeShellScript "copy-secret" ''
+                  cp -Lr ${config.source} "$out"
+                ''
+              );
+            };
+          }
+        )
+      );
+      description = ''
+        Secret paths to append to the initrd. The attribute name is the
+        path the secret should have inside the initrd.
+
+        Note that `nixos-rebuild switch` will generate the initrd
+        also for past generations, so if secrets are moved or deleted
+        you will also have to garbage collect the generations that
+        use those secrets.
+      '';
+      example = {
+        "/etc/ssh/ssh_host_ed25519_key".source = "/var/lib/secrets/initrd/ssh_host_ed25519_key";
+      };
+    };
+
+    boot.initrd.extraSecretsHook = mkOption {
+      default = "";
+      type = types.lines;
+      description = ''
+        Extra commands to be executed after the initrd secrets generation phase.
+
+        This script should place files into the current workdir. These files
+        will then be copied over to the initrd to the corresponding absolute
+        paths, e.g. `etc/ssh/ssh_host_ed25519_key` will be copied over to
+        `/etc/ssh/ssh_host_ed25519_key`.
+      '';
+      example = ''
+        # Generate a new SSH host key for every generation.
+        ssh-keygen -f etc/ssh/ssh_host_ed25519_key
+      '';
+    };
+
     boot.initrd.supportedFilesystems = mkOption {
       default = { };
       inherit (options.boot.supportedFilesystems) example type description;
@@ -746,15 +853,18 @@ in
         assertion =
           !config.boot.loader.supportsInitrdSecrets
           -> all (
-            source: builtins.isPath source || (builtins.isString source && hasPrefix builtins.storeDir source)
-          ) (attrValues config.boot.initrd.secrets);
+            scfg:
+            builtins.isPath scfg.source
+            || (builtins.isString scfg.source && hasPrefix builtins.storeDir scfg.source)
+          ) (attrValues config.boot.initrd.secretPaths);
         message = ''
-          boot.initrd.secrets values must be unquoted paths when
-          using a bootloader that doesn't natively support initrd
-          secrets, e.g.:
+          When using a bootloader that doesn't natively support initrd secrets,
+          all `boot.initrd.secretPaths` values must be defined via
+          `boot.initrd.secretsPaths.*.source`, and the `source` values must be
+          unquoted paths, e.g.
 
-            boot.initrd.secrets = {
-              "/etc/secret" = /path/to/secret;
+            boot.initrd.secretPaths = {
+              "/etc/secret".source = /path/to/secret;
             };
 
           Note that this will result in all secrets being stored
@@ -762,6 +872,14 @@ in
         '';
       }
     ];
+
+    # Backwards compatibility to the legacy `boot.initrd.secrets` option.
+    boot.initrd.secretPaths = lib.mapAttrs' (dest: source: {
+      # The legacy boot.initrd.secrets option didn't type-check the attr
+      # names, so we need to optionally prepend a slash.
+      name = "${lib.optionalString (!lib.hasPrefix "/" dest) "/"}${dest}";
+      value.source = if dest != null then source else dest;
+    }) config.boot.initrd.secrets;
 
     system.build = mkMerge [
       {

--- a/nixos/tests/bootspec.nix
+++ b/nixos/tests/bootspec.nix
@@ -128,7 +128,7 @@ in
       environment.systemPackages = [ pkgs.jq ];
       # It's probably the case, but we want to make it explicit here.
       boot.initrd.enable = true;
-      boot.initrd.secrets."/some/example" = pkgs.writeText "example-secret" "test";
+      boot.initrd.secretPaths."/some/example".source = pkgs.writeText "example-secret" "test";
     };
 
     testScript = ''

--- a/nixos/tests/initrd-luks-empty-passphrase.nix
+++ b/nixos/tests/initrd-luks-empty-passphrase.nix
@@ -47,7 +47,7 @@ in
           };
         };
         virtualisation.rootDevice = "/dev/mapper/cryptroot";
-        boot.initrd.secrets."/etc/cryptroot.key" = keyfile;
+        boot.initrd.secretPaths."/etc/cryptroot.key".source = keyfile;
       };
 
       specialisation.boot-luks-missing-keyfile.configuration = {

--- a/nixos/tests/initrd-secrets-changing.nix
+++ b/nixos/tests/initrd-secrets-changing.nix
@@ -21,16 +21,16 @@ testing.makeTest {
 
       boot.loader.grub.device = "/dev/vda";
 
-      boot.initrd.secrets = {
-        "/test" = secret1InStore;
-        "/run/keys/test" = secret1InStore;
+      boot.initrd.secretPaths = {
+        "/test".source = secret1InStore;
+        "/run/keys/test".source = secret1InStore;
       };
       boot.initrd.postMountCommands = "cp /test /mnt-root/secret-from-initramfs";
 
       specialisation.secrets2System.configuration = {
-        boot.initrd.secrets = lib.mkForce {
-          "/test" = secret2InStore;
-          "/run/keys/test" = secret2InStore;
+        boot.initrd.secretPaths = lib.mkForce {
+          "/test".source = secret2InStore;
+          "/run/keys/test".source = secret2InStore;
         };
       };
     };

--- a/nixos/tests/initrd-secrets.nix
+++ b/nixos/tests/initrd-secrets.nix
@@ -22,13 +22,25 @@ let
         {
           virtualisation.useBootLoader = true;
           boot.initrd.secretPaths = {
-            "/test".source = secretInStore;
+            "/test" = {
+              source = secretInStore;
+              intermediateSecretsDir = false;
+            };
 
             # This should *not* need to be copied in postMountCommands
-            "/run/keys/test".source = secretInStore;
+            "/run/keys/test1".source = secretInStore;
+
+            "/run/keys/test2".generateSecretCommand = pkgs.writeShellScript "copy-secret" ''
+              cp ${secretInStore} "$out"
+            '';
           };
+          boot.initrd.extraSecretsHook = ''
+            mkdir -p etc/secrets
+            cp ${secretInStore} etc/secrets/test2
+          '';
           boot.initrd.postMountCommands = ''
-            cp /test /mnt-root/secret-from-initramfs
+            cp /test /mnt-root/secret-from-initramfs-1
+            cp /etc/secrets/test2 /mnt-root/secret-from-initramfs-2
           '';
           boot.initrd.compressor = compressor;
           # zstd compression is only supported from 5.9 onwards. Remove when 5.10 becomes default.
@@ -39,8 +51,10 @@ let
         start_all()
         machine.wait_for_unit("multi-user.target")
         machine.succeed(
-            "cmp ${secretInStore} /secret-from-initramfs",
-            "cmp ${secretInStore} /run/keys/test",
+            "cmp ${secretInStore} /secret-from-initramfs-1",
+            "cmp ${secretInStore} /secret-from-initramfs-2",
+            "cmp ${secretInStore} /run/keys/test1",
+            "cmp ${secretInStore} /run/keys/test2",
         )
       '';
     };

--- a/nixos/tests/initrd-secrets.nix
+++ b/nixos/tests/initrd-secrets.nix
@@ -21,11 +21,11 @@ let
         { ... }:
         {
           virtualisation.useBootLoader = true;
-          boot.initrd.secrets = {
-            "/test" = secretInStore;
+          boot.initrd.secretPaths = {
+            "/test".source = secretInStore;
 
             # This should *not* need to be copied in postMountCommands
-            "/run/keys/test" = secretInStore;
+            "/run/keys/test".source = secretInStore;
           };
           boot.initrd.postMountCommands = ''
             cp /test /mnt-root/secret-from-initramfs

--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -67,7 +67,7 @@ let
           boot.loader.systemd-boot.enable = true;
         ''}
 
-        boot.initrd.secrets."/etc/secret" = "/etc/nixos/secret";
+        boot.initrd.secretPaths."/etc/secret".source = "/etc/nixos/secret";
 
         ${optionalString clevisTest ''
           boot.kernelParams = [ "console=tty0" "ip=192.168.1.1:::255.255.255.0::eth1:none" ];
@@ -1385,7 +1385,7 @@ in
   };
 
   # Full disk encryption (root, kernel and initrd encrypted) using GRUB, GPT/UEFI,
-  # LVM-on-LUKS and a keyfile in initrd.secrets to enter the passphrase once
+  # LVM-on-LUKS and a keyfile in initrd.secretPaths to enter the passphrase once
   fullDiskEncryption = makeInstallerTest "fullDiskEncryption" {
     createPartitions = ''
       installer.succeed(
@@ -1419,7 +1419,7 @@ in
       boot.loader.grub.enableCryptodisk = true;
       boot.loader.efi.efiSysMountPoint = "/boot/efi";
 
-      boot.initrd.secrets."/luks.key" = "/etc/nixos/luks.key";
+      boot.initrd.secretPaths."/luks.key" = "/etc/nixos/luks.key";
       boot.initrd.luks.devices.crypt =
         { device  = "/dev/vda2";
           keyFile = "/luks.key";

--- a/nixos/tests/systemd-initrd-luks-keyfile.nix
+++ b/nixos/tests/systemd-initrd-luks-keyfile.nix
@@ -38,7 +38,7 @@ in
           };
         };
         virtualisation.rootDevice = "/dev/mapper/cryptroot";
-        boot.initrd.secrets."/etc/cryptroot.key" = keyfile;
+        boot.initrd.secretPaths."/etc/cryptroot.key".source = keyfile;
       };
     };
 

--- a/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
+++ b/pkgs/by-name/ca/calamares-nixos-extensions/src/modules/nixos/main.py
@@ -60,8 +60,8 @@ cfgbootnone = """  # Disable bootloader.
 """
 
 cfgbootgrubcrypt = """  # Setup keyfile
-  boot.initrd.secrets = {
-    "/boot/crypto_keyfile.bin" = null;
+  boot.initrd.secretPaths = {
+    "/boot/crypto_keyfile.bin".source = null;
   };
 
   boot.loader.grub.enableCryptodisk = true;

--- a/pkgs/by-name/ni/nixos-install/nixos-install.sh
+++ b/pkgs/by-name/ni/nixos-install/nixos-install.sh
@@ -252,7 +252,7 @@ if [[ -z $noBootLoader ]]; then
       # system. This preserves the validity of their absolute paths after changing
       # the root with `nixos-enter`.
       # Without this the bootloader installation may fail due to options that
-      # contain paths referenced during evaluation, like initrd.secrets.
+      # contain paths referenced during evaluation, like initrd.secretPaths.
       # when not root, re-execute the script in an unshared namespace
       mount --rbind --mkdir / "$mountPoint"
       mount --make-rslave "$mountPoint"


### PR DESCRIPTION
The current `boot.initrd.secrets` option has two problems:

- It always places the secret paths in the intermediate directory `/.initrd-secrets` in the initrd, and then copies the secrets to their actual locations during boot. to allow the user to place secrets in the `/run` tmpfs. However, this makes this mechanism for systemd units or files generating system units (e.g. `/etc/veritytab`), since they appear too late and systemd doesn't notice them.

- It assumes that the secrets are present somewhere in the filesystem, and doesn't allow for other secrets provisioning mechanisms.

This PR introduces two new options to fix these problems:

- `boot.initrd.secretPaths.*`: an `attrsOf submodule` to specify individual secret paths. They can either be sourced from a filesystem path via `boot.initrd.secretPaths.*.source`, or be generated by some more sophisticated secrets provisioning mechanisms via `boot.initrd.secretPaths.*.generateSecretsCommand`, for instance:
  ```nix
  boot.initrd.secretPaths."/etc/secret-key".generateSecretsCommand = pkgs.writeShellScript "decrypt-secret-key" ''
    age --decrypt --identity /etc/ssh/ssh_host_ed25519_key --output "$1" ${./secret-key.age}
  '';
  ```
  This command is being run at `nixos-rebuild` time.
- `boot.initrd.extraSecretsHook`: A wildcard mechanism for writing additional secret files to the initrd, for instance:
  ```nix
  boot.initrd.extraSecretsHook = ''
    age --decrypt --identity /etc/ssh/ssh_host_ed25519_key --output etc/secret-key ${./secret-key.age}
  '';
  ```

We maintain backwards compatibility with pre-existing configs by keeping `boot.initrd.secrets`, adding a deprecation warning, and generating `boot.initrd.secretPath` definitions from it.

cc @adisbladis @Mic92 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
