### PR TITLE
tetrio-desktop: add darwin support

### DIFF
--- a/pkgs/by-name/te/tetrio-desktop/package.nix
+++ b/pkgs/by-name/te/tetrio-desktop/package.nix
@@ -2,48 +2,85 @@
   stdenv,
   lib,
   fetchzip,
+  fetchurl,
   dpkg,
   makeWrapper,
   addDriverRunpath,
   electron,
+  _7zz,
   withTetrioPlus ? false,
   tetrio-plus,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "tetrio-desktop";
+let
+  inherit (stdenv.hostPlatform) isDarwin system;
+
   version = "10";
 
-  src = fetchzip {
-    url = "https://tetr.io/about/desktop/builds/${finalAttrs.version}/TETR.IO%20Setup.deb";
-    hash = "sha256-2FtFCajNEj7O8DGangDecs2yeKbufYLx1aZb3ShnYvw=";
-    nativeBuildInputs = [ dpkg ];
+  srcs = {
+    x86_64-linux = fetchzip {
+      url = "https://tetr.io/about/desktop/builds/${version}/TETR.IO%20Setup.deb";
+      hash = "sha256-2FtFCajNEj7O8DGangDecs2yeKbufYLx1aZb3ShnYvw=";
+      nativeBuildInputs = [ dpkg ];
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://tetr.io/about/desktop/builds/${version}/TETR.IO%20Setup%20arm64.dmg";
+      hash = "sha256-PbK9XEynpii35p6DQYiPbaRM4guPazWd5N4Dr2O4H24=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://tetr.io/about/desktop/builds/${version}/TETR.IO%20Setup%20x86.dmg";
+      hash = "sha256-I4Mj6YY7KwpLk2tZ02EdqUxnxSW/3vCM4J7YFzCLEuM=";
+    };
   };
+in
+stdenv.mkDerivation {
+  pname = "tetrio-desktop";
+  inherit version;
 
-  nativeBuildInputs = [
-    makeWrapper
-  ];
+  src = srcs.${system} or (throw "Unsupported system: ${system}");
+
+  nativeBuildInputs = lib.optionals (!isDarwin) [ makeWrapper ] ++ lib.optionals isDarwin [ _7zz ];
+
+  sourceRoot = lib.optionalString isDarwin "TETR.IO.app";
+
+  unpackPhase = lib.optionalString isDarwin ''
+    7zz x $src
+  '';
 
   installPhase =
-    let
-      asarPath = if withTetrioPlus then tetrio-plus else "opt/TETR.IO/resources/app.asar";
-    in
-    ''
-      runHook preInstall
+    if isDarwin then
+      ''
+        runHook preInstall
 
-      mkdir -p $out
-      cp -r usr/share/ $out
+        mkdir -p "$out/Applications/TETR.IO.app"
+        cp -R . "$out/Applications/TETR.IO.app"
 
-      mkdir -p $out/share/TETR.IO/
-      cp ${asarPath} $out/share/TETR.IO/app.asar
+        ${lib.optionalString withTetrioPlus ''
+          cp ${tetrio-plus} "$out/Applications/TETR.IO.app/Contents/Resources/app.asar"
+        ''}
 
-      substituteInPlace $out/share/applications/TETR.IO.desktop \
-        --replace-fail "Exec=/opt/TETR.IO/TETR.IO" "Exec=$out/bin/tetrio"
+        runHook postInstall
+      ''
+    else
+      let
+        asarPath = if withTetrioPlus then tetrio-plus else "opt/TETR.IO/resources/app.asar";
+      in
+      ''
+        runHook preInstall
 
-      runHook postInstall
-    '';
+        mkdir -p $out
+        cp -r usr/share/ $out
 
-  postFixup = ''
+        mkdir -p $out/share/TETR.IO/
+        cp ${asarPath} $out/share/TETR.IO/app.asar
+
+        substituteInPlace $out/share/applications/TETR.IO.desktop \
+          --replace-fail "Exec=/opt/TETR.IO/TETR.IO" "Exec=$out/bin/tetrio"
+
+        runHook postInstall
+      '';
+
+  postFixup = lib.optionalString (!isDarwin) ''
     makeShellWrapper '${lib.getExe electron}' $out/bin/tetrio \
       --prefix LD_LIBRARY_PATH : ${addDriverRunpath.driverLink}/lib \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
@@ -61,8 +98,11 @@ stdenv.mkDerivation (finalAttrs: {
       Play multiplayer games against friends and foes all over the world, or claim a spot on the leaderboards - the stacker future is yours!
     '';
     mainProgram = "tetrio";
-    maintainers = with lib.maintainers; [ huantian ];
-    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [
+      huantian
+      anish
+    ];
+    platforms = [ "x86_64-linux" ] ++ lib.platforms.darwin;
     sourceProvenance = [ lib.sourceTypes.binaryBytecode ];
   };
-})
+}


### PR DESCRIPTION
Add macOS support for `tetrio-desktop` (x86_64-darwin and aarch64-darwin).

TETR.IO provides separate `.dmg` downloads for Intel and Apple Silicon Macs. Uses `_7zz` to unpack the APFS-based DMGs and installs the `.app` bundle to `$out/Applications/`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
