### PR TITLE
lomiri: Fix builds after staging-next merge

### DIFF
--- a/pkgs/by-name/pe/persistent-cache-cpp/package.nix
+++ b/pkgs/by-name/pe/persistent-cache-cpp/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   testers,
   boost,
@@ -30,6 +31,15 @@ stdenv.mkDerivation (finalAttrs: {
     "out"
     "dev"
     "doc"
+  ];
+
+  patches = [
+    # Remove when version > 1.0.9
+    (fetchpatch {
+      name = "0001-persistent-cache-cpp-Fix-compatibility-with-Boost-1.89.patch";
+      url = "https://gitlab.com/ubports/development/core/lib-cpp/persistent-cache-cpp/-/commit/121397b58bdb2d6750a41bec0cf1676e4e9b8cf5.patch";
+      hash = "sha256-QKPf5E49NNZ+rzCCknJNQjcd/bEgHuh23RBM892Xz1o=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -2,10 +2,10 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   testers,
-  # https://gitlab.com/ubports/development/core/biometryd/-/issues/8
-  boost186,
+  boost,
   cmake,
   cmake-extras,
   dbus,
@@ -39,6 +39,15 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
+  patches = [
+    # Remove when version > 0.4.0
+    (fetchpatch {
+      name = "0001-biometryd-Fix-compatibility-with-Boost-1.87.patch";
+      url = "https://gitlab.com/ubports/development/core/biometryd/-/commit/8def6dfb18ee56971f0f64e3622af2a5a39ab0f6.patch";
+      hash = "sha256-PddZRML4Gc+s4aNeOyZwJJjmPSixMGFVFNcrO9dNDSI=";
+    })
+  ];
+
   postPatch = ''
     # Substitute systemd's prefix in pkg-config call
     substituteInPlace data/CMakeLists.txt \
@@ -66,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost186
+    boost
     cmake-extras
     dbus
     dbus-cpp

--- a/pkgs/desktops/lomiri/services/lomiri-polkit-agent/1001-Fix-compat-with-libnotify-0.8.8.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-polkit-agent/1001-Fix-compat-with-libnotify-0.8.8.patch
@@ -1,0 +1,36 @@
+From df28165c0955ab963aeda41ffda86651115f4efb Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Tue, 24 Feb 2026 21:04:37 +0100
+Subject: [PATCH] tests/authentication-test.cpp: Fix compat with libnotify
+ 0.8.8
+
+---
+ tests/authentication-test.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/tests/authentication-test.cpp b/tests/authentication-test.cpp
+index 8c74867..2fee42d 100644
+--- a/tests/authentication-test.cpp
++++ b/tests/authentication-test.cpp
+@@ -245,12 +245,16 @@ TEST_F(AuthenticationTest, BasicRequest)
+     EXPECT_EQ("Cancel", dialogs[0].actions[3]);
+ 
+     /* Hints */
+-#if (NOTIFY_VERSION_MAJOR >= 0) && (NOTIFY_VERSION_MINOR >= 8)
++#if NOTIFY_CHECK_VERSION(0, 8, 0)
++#if NOTIFY_CHECK_VERSION(0, 8, 8)
++    EXPECT_EQ(4, dialogs[0].hints.size());
++#else
+     EXPECT_EQ(3, dialogs[0].hints.size());
++#endif // NOTIFY_CHECK_VERSION(0, 8, 8)
+     EXPECT_NE(dialogs[0].hints.end(), dialogs[0].hints.find("sender-pid"));
+ #else
+     EXPECT_EQ(2, dialogs[0].hints.size());
+-#endif
++#endif // NOTIFY_CHECK_VERSION(0, 8, 0)
+     EXPECT_NE(dialogs[0].hints.end(), dialogs[0].hints.find("x-lomiri-snap-decisions"));
+     EXPECT_NE(dialogs[0].hints.end(), dialogs[0].hints.find("x-lomiri-private-menu-model"));
+ 
+-- 
+2.51.2
+

--- a/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-polkit-agent/default.nix
@@ -27,6 +27,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-JKU2lm5wco9aC2cu3lgJ9OfGAzKQO/wQXFPEdb9Uz3Y=";
   };
 
+  patches = [
+    # Remove when https://gitlab.com/ubports/development/core/lomiri-polkit-agent/-/merge_requests/17 merged & in release
+    ./1001-Fix-compat-with-libnotify-0.8.8.patch
+  ];
+
   strictDeps = true;
 
   nativeBuildInputs = [

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -76,6 +76,14 @@ stdenv.mkDerivation (finalAttrs: {
     # Tests run in parallel to other builds, don't suck up cores
     substituteInPlace tests/headers/compile_headers.py \
       --replace-fail 'max_workers=multiprocessing.cpu_count()' "max_workers=1"
+  ''
+  # https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/31
+  # Too simple to bother with fetchpatch
+  + ''
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+        'find_package(Boost COMPONENTS filesystem iostreams regex system REQUIRED)' \
+        'find_package(Boost COMPONENTS filesystem iostreams regex REQUIRED)'
   '';
 
   strictDeps = true;

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -96,6 +96,14 @@ stdenv.mkDerivation (
       substituteInPlace src/platform/graphics/CMakeLists.txt \
         --replace-fail "/usr/include/drm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h" \
         --replace-fail "/usr/include/libdrm/drm_fourcc.h" "${lib.getDev libdrm}/include/libdrm/drm_fourcc.h"
+    ''
+    # Boost.System was deprecated & dropped
+    + lib.optionalString (lib.strings.versionOlder version "2.23.0") ''
+      substituteInPlace \
+        tests/CMakeLists.txt \
+        tests/unit-tests/CMakeLists.txt \
+        tests/mir_test_framework/CMakeLists.txt \
+        --replace-fail 'Boost::system' ""
     '';
 
     strictDeps = true;

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -110,6 +110,23 @@ in
         ];
         hash = "sha256-gzLVQW9Z6y+s2D7pKtp0ondQrjkzZ5iUYhGDPqFXD5M=";
       })
+
+      # Drop deprecated & removed Boost.System
+      # Remove when version > 2.22.2
+      (fetchpatch {
+        name = "0301-mir-Disable-boost_system.patch";
+        url = "https://github.com/canonical/mir/commit/0261aa6ce700311ee2b8723294451cdade1bc219.patch";
+        excludes = [
+          # hunk errors
+          "tests/CMakeLists.txt"
+          "tests/mir_test_framework/CMakeLists.txt"
+          "tests/unit-tests/CMakeLists.txt"
+
+          # doesn't exist
+          "tests/window_management_tests/CMakeLists.txt"
+        ];
+        hash = "sha256-UqClQFHzA1th2P7NH67dMJtncw8n/ey9RlPD5Z3VPk0=";
+      })
     ];
   };
 }


### PR DESCRIPTION
- Boost 1.89 compatibility fixes (#485826)
- `lomiri.lomiri-telephony-service` fails, libnotify 0.8.8 throws an assertion error in tests:
  ```
  lomiri-telephony-service> libnotify:ERROR:../libnotify/notify.c:53:_notify_check_spec_version: assertion failed: (_spec_version_major > 0)
  lomiri-telephony-service> lomiri-telephony-service-approver: Bail out! libnotify:ERROR:../libnotify/notify.c:53:_notify_check_spec_version: assertion failed: (_spec_version_major > 0)
  lomiri-telephony-service> lomiri-telephony-service-approver: Exited with status 134
  ```
  Reported to lomiri-telephony-service upstream, hope that this isn't a serious failure…

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
