### PR TITLE
python3Packages.langgraph-{checkpoint,-checkpoint-mongodb}: update and fix from python update script

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
@@ -13,7 +13,7 @@
   pymongo,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "langgraph-checkpoint-mongodb";
   version = "0.3.1";
   pyproject = true;
@@ -21,11 +21,11 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
-    tag = "libs/langgraph-checkpoint-mongodb/v${version}";
+    tag = "libs/langgraph-checkpoint-mongodb/v${finalAttrs.version}";
     hash = "sha256-vCiZ6Mp6aHmSEkLbeM6qTLJaxH0uoAdq80olTT5saX0=";
   };
 
-  sourceRoot = "${src.name}/libs/langgraph-checkpoint-mongodb";
+  sourceRoot = "${finalAttrs.src.name}/libs/langgraph-checkpoint-mongodb";
 
   build-system = [
     hatchling
@@ -60,8 +60,8 @@ buildPythonPackage rec {
   meta = {
     description = "Integrations between MongoDB, Atlas, LangChain, and LangGraph";
     homepage = "https://github.com/langchain-ai/langchain-mongodb/tree/main/libs/langgraph-checkpoint-mongodb";
-    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${src.tag}";
+    changelog = "https://github.com/langchain-ai/langchain-mongodb/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ sarahec ];
   };
-}
+})

--- a/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-mongodb/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
 
   # build-system
   hatchling,
@@ -14,20 +15,24 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-mongodb";
-  version = "0.11.0";
+  version = "0.3.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langchain-mongodb";
-    tag = "libs/langchain-mongodb/v${version}";
-    hash = "sha256-dO0dASjyNMxnbxZ/ry8lcJxedPdrv6coYiTjOcaT8/0=";
+    tag = "libs/langgraph-checkpoint-mongodb/v${version}";
+    hash = "sha256-vCiZ6Mp6aHmSEkLbeM6qTLJaxH0uoAdq80olTT5saX0=";
   };
 
   sourceRoot = "${src.name}/libs/langgraph-checkpoint-mongodb";
 
   build-system = [
     hatchling
+  ];
+
+  pythonRelaxDeps = [
+    "pymongo"
   ];
 
   dependencies = [
@@ -40,6 +45,14 @@ buildPythonPackage rec {
 
   # Connection refused (to localhost:27017) for all tests
   doCheck = false;
+
+  passthru = {
+    # python updater script sets the wrong tag
+    skipBulkUpdate = true;
+    updateScript = gitUpdater {
+      rev-prefix = "libs/langgraph-checkpoint-mongodb/v";
+    };
+  };
 
   # no pythonImportsCheck as this package does not provide any direct imports
   pythonImportsCheck = [ "langgraph.checkpoint.mongodb" ];

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "3.0.1";
+  version = "4.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpoint==${version}";
-    hash = "sha256-3hh1KyEIsp9JzhaJW1ycp179FGpggPYzg6OwnD/cTBM=";
+    hash = "sha256-IE9Y+kFkDN49SuwvTNwa2kK+Hig18sJPZmZCqHUP3DM=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";


### PR DESCRIPTION
## Important

Fixes [CVE-2026-27794](https://nvd.nist.gov/vuln/detail/CVE-2026-27794)


### langgraph-checkpoint

1. Version update to 4.0.0
2. Migrate to finalAttrs

### langgraph-checkpoint-mongodb

1. Repair source download
2. Disable bulk update
3. Configure updateScript appropriately
4. Migrate to finalAttrs

Fixes #494868

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
