### PR TITLE
reef: 0.2.0 -> 0.3.0

### DIFF
--- a/pkgs/by-name/re/reef/package.nix
+++ b/pkgs/by-name/re/reef/package.nix
@@ -14,10 +14,10 @@ rustPlatform.buildRustPackage (finalAttrs: {
     owner = "ZStud";
     repo = "reef";
     tag = "v${finalAttrs.version}";
-    hash = lib.fakeHash;
+    hash = "sha256-ytQ/nLfqdVkdpyVVOzQuVd8Ina0DUQJjLAtMgkn1KLU=";
   };
 
-  cargoHash = lib.fakeHash;
+  cargoHash = "sha256-v/UCabpSt5weUH1+spbQFC4MCOozLXhmN/pEUZCVH84=";
 
   postInstall = ''
     install -Dm644 fish/functions/*.fish -t $out/share/fish/vendor_functions.d/

--- a/pkgs/by-name/re/reef/package.nix
+++ b/pkgs/by-name/re/reef/package.nix
@@ -8,16 +8,16 @@
 
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "reef";
-  version = "0.2.0";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "ZStud";
     repo = "reef";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FP7cnqYIICb4JCYk9ytvSp4yxW+xW2SUVqhELdTGLZQ=";
+    hash = lib.fakeHash;
   };
 
-  cargoHash = "sha256-UmazwJqsWXQK3bniDLyNCLXHrgrF3iHRPugOAkRzhv8=";
+  cargoHash = lib.fakeHash;
 
   postInstall = ''
     install -Dm644 fish/functions/*.fish -t $out/share/fish/vendor_functions.d/


### PR DESCRIPTION
## Description

Update reef from 0.2.0 to 0.3.0.

[reef](https://github.com/ZStud/reef) is a bash compatibility layer for fish shell.

### What's new in v0.3.0

- **Persistence modes** — `reef persist state` (exported vars persist via state file) and `reef persist full` (persistent bash coprocess, everything persists)
- **Confirm mode** — `reef confirm on` previews translations before executing
- **Library crate** — reef is now both a binary and a Rust library (`cargo add reef-shell`)
- 498 unit tests + 5 doc tests, zero clippy warnings

### Note

`hash` and `cargoHash` are set to `lib.fakeHash` — I don't have nix installed locally to compute the NAR hashes. Could a reviewer or ofborg fill these in from the build error? Happy to update the PR once the correct hashes are known.

## Checklist

- [x] Package version updated
- [ ] Hashes updated (need nix to compute)
- [x] Builds and tests pass upstream