### PR TITLE
mpv: use sysconfdir /etc

### DIFF
--- a/nixos/tests/mpv.nix
+++ b/nixos/tests/mpv.nix
@@ -16,9 +16,14 @@ in
           scripts = [ pkgs.mpvScripts.simple-mpv-webui ];
         })
       ];
+
+      environment.etc."mpv/mpv.conf".text = ''
+        [nixos-test-profile]
+      '';
     };
 
   testScript = ''
+    machine.succeed("mpv --profile=help | grep -F nixos-test-profile")
     machine.execute("set -m; mpv --script-opts=webui-port=${port} --idle=yes >&2 &")
     machine.wait_for_open_port(${port})
     assert "<title>simple-mpv-webui" in machine.succeed("curl -s localhost:${port}")

--- a/pkgs/by-name/mp/mpv-unwrapped/package.nix
+++ b/pkgs/by-name/mp/mpv-unwrapped/package.nix
@@ -138,6 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   mesonFlags = [
     (lib.mesonOption "default_library" "shared")
+    (lib.mesonOption "sysconfdir" "/etc")
     (lib.mesonBool "libmpv" true)
     (lib.mesonEnable "manpage-build" true)
     (lib.mesonEnable "cdda" cddaSupport)


### PR DESCRIPTION
closes #397333
supersedes #397410

As of [mpv 0.41](https://github.com/mpv-player/mpv/commit/41f6a645068483470267271e1d09966ca3b9f413#diff-47f65c6ffc9837b14c82867d688ae7f7f0729173f6f9d92b29da3dee44ebdae2R97-R98) nothing is installed to `$out/etc` anymore and mpv can be configured to use config files in `/etc`.

> * `encoding-profiles.conf` is no longer installed by default into the system configuration directory and is instead installed in the data directory 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
