### PR TITLE
maintainers: drop nixinator

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -19207,13 +19207,6 @@
     name = "nixbitcoindev";
     keys = [ { fingerprint = "577A 3452 7F3E 2A85 E80F  E164 DD11 F9AD 5308 B3BA"; } ];
   };
-  nixinator = {
-    email = "33lockdown33@protonmail.com";
-    matrix = "@nixinator:nixos.dev";
-    github = "nixinator";
-    githubId = 66913205;
-    name = "Rick Sanchez";
-  };
   nixy = {
     email = "nixy@nixy.moe";
     github = "nixy";

--- a/nixos/tests/mtp.nix
+++ b/nixos/tests/mtp.nix
@@ -4,7 +4,6 @@
   meta = with pkgs.lib.maintainers; {
     maintainers = [
       matthewcroughan
-      nixinator
     ];
   };
 

--- a/pkgs/by-name/cd/cdogs-sdl/package.nix
+++ b/pkgs/by-name/cd/cdogs-sdl/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://cxong.github.io/cdogs-sdl";
     description = "Open source classic overhead run-and-gun game";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ nixinator ];
+    maintainers = [ ];
     platforms = lib.platforms.unix;
     broken = stdenv.hostPlatform.isDarwin; # never built on Hydra https://hydra.nixos.org/job/nixpkgs/trunk/cdogs-sdl.x86_64-darwin
   };

--- a/pkgs/by-name/cl/clanlib/package.nix
+++ b/pkgs/by-name/cl/clanlib/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/sphair/ClanLib";
     description = "Cross platform toolkit library with a primary focus on game creation";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ nixinator ];
+    maintainers = [ ];
     platforms = with lib.platforms; lib.intersectLists linux (x86 ++ arm ++ aarch64 ++ riscv);
   };
 })

--- a/pkgs/by-name/fi/fioctl/package.nix
+++ b/pkgs/by-name/fi/fioctl/package.nix
@@ -47,7 +47,6 @@ buildGoModule (finalAttrs: {
     homepage = "https://github.com/foundriesio/fioctl";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
-      nixinator
       matthewcroughan
     ];
     mainProgram = "fioctl";

--- a/pkgs/by-name/me/methane/package.nix
+++ b/pkgs/by-name/me/methane/package.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Clone of Taito's Bubble Bobble arcade game released for Amiga in 1993 by Apache Software";
     mainProgram = "methane";
     license = lib.licenses.gpl2Only;
-    maintainers = with lib.maintainers; [ nixinator ];
+    maintainers = [ ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/by-name/se/seren/package.nix
+++ b/pkgs/by-name/se/seren/package.nix
@@ -41,7 +41,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [
       matthewcroughan
-      nixinator
     ];
     platforms = lib.platforms.linux;
   };

--- a/pkgs/by-name/xs/xsos/package.nix
+++ b/pkgs/by-name/xs/xsos/package.nix
@@ -55,6 +55,6 @@ stdenv.mkDerivation (finalAttrs: {
       "i686-linux"
       "x86_64-linux"
     ];
-    maintainers = [ lib.maintainers.nixinator ];
+    maintainers = [ ];
   };
 })


### PR DESCRIPTION
No [comments](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+commenter%3Anixinator) since 2023 despite 14 [review requests](https://github.com/NixOS/nixpkgs/pulls?q=is%3Apr+created%3A%3E%3D2024-01-01+user-review-requested%3Anixinator). Dropping per [maintainers/README.md](https://github.com/NixOS/nixpkgs/blob/33954594ec46166510795930ba8ebf0856249d4e/maintainers/README.md#losing-maintainer-status).

@nixinator if you object to being dropped please respond saying so within a week. Even if you don't make it, you are of course welcome back whenever you would like!



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
