### PR TITLE
gemini-cli: build bundle, 0.30.0 -> 0.31.0

### DIFF
--- a/pkgs/by-name/ge/gemini-cli/package.nix
+++ b/pkgs/by-name/ge/gemini-cli/package.nix
@@ -73,39 +73,30 @@ buildNpmPackage (finalAttrs: {
     nodejs_22.python
   ];
 
+  npmBuildScript = "bundle";
+
   installPhase = ''
     runHook preInstall
-    mkdir -p $out/{bin,share/gemini-cli}
 
+    mkdir -p $out/{bin,share}
+    cp -r bundle $out/share/gemini-cli
+
+    # We only want to keep optionalDependencies (like @lydell/node-pty) to keep the closure size small,
+    # as regular dependencies are already bundled via esbuild into gemini.js.
+    jq '.dependencies = {} | del(.devDependencies) | del(.workspaces)' package.json > package.json.tmp && mv package.json.tmp package.json
     npm prune --omit=dev
+    rm -rf node_modules/.bin
 
-    # Remove python files to prevent python from getting into the closure
-    find node_modules -name "*.py" -delete
     # keytar/build has gyp-mac-tool with a Python shebang that gets patched,
     # creating a python3 reference in the closure
-    rm -rf node_modules/keytar/build
+    find node_modules -path "*/build/*" -type f -not -name "*.node" -delete
+    find node_modules -type d -empty -delete
 
     cp -r node_modules $out/share/gemini-cli/
 
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-core
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-a2a-server
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-sdk
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-test-utils
-    rm -f $out/share/gemini-cli/node_modules/gemini-cli-vscode-ide-companion
-    cp -r packages/cli $out/share/gemini-cli/node_modules/@google/gemini-cli
-    cp -r packages/core $out/share/gemini-cli/node_modules/@google/gemini-cli-core
-    cp -r packages/a2a-server $out/share/gemini-cli/node_modules/@google/gemini-cli-a2a-server
+    rm -f $out/share/gemini-cli/docs/CONTRIBUTING.md
 
-    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-core/dist/docs/CONTRIBUTING.md
-
-    ln -s $out/share/gemini-cli/node_modules/@google/gemini-cli/dist/index.js $out/bin/gemini
-    chmod +x "$out/bin/gemini"
-
-    # Clean up any remaining references to npmDeps in node_modules metadata
-    find $out/share/gemini-cli/node_modules -name "package-lock.json" -delete
-    find $out/share/gemini-cli/node_modules -name ".package-lock.json" -delete
-    find $out/share/gemini-cli/node_modules -name "config.gypi" -delete
+    ln -s $out/share/gemini-cli/gemini.js $out/bin/gemini
 
     runHook postInstall
   '';

--- a/pkgs/by-name/ge/gemini-cli/package.nix
+++ b/pkgs/by-name/ge/gemini-cli/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   jq,
   pkg-config,
+  makeWrapper,
   clang_20,
   libsecret,
   ripgrep,
@@ -14,24 +15,25 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "gemini-cli";
-  version = "0.30.0";
+  version = "0.31.0";
 
   src = fetchFromGitHub {
     owner = "google-gemini";
     repo = "gemini-cli";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-+w4w1cftPSj0gJ23Slw8Oexljmu0N/PZWH4IDjw75rs=";
+    hash = "sha256-huPd4W7Jf4/dZshWElicYpcHhktE83wPs/z5jVYwynM=";
   };
 
   nodejs = nodejs_22;
 
-  npmDepsHash = "sha256-Nkd5Q2ugRqsTqaFbCSniC3Obl++uEjVUmoa8MVT5++8=";
+  npmDepsHash = "sha256-iRlwCSGigRi/ilfXi8rI68vlfkeec3vB5nZWPmTLnK8=";
 
   dontPatchElf = stdenv.isDarwin;
 
   nativeBuildInputs = [
     jq
     pkg-config
+    makeWrapper
   ]
   ++ lib.optionals stdenv.isDarwin [ clang_20 ]; # clang_21 breaks @vscode/vsce's optionalDependencies keytar
 
@@ -70,7 +72,7 @@ buildNpmPackage (finalAttrs: {
   # Prevent npmDeps and python from getting into the closure
   disallowedReferences = [
     finalAttrs.npmDeps
-    nodejs_22.python
+    finalAttrs.nodejs.python
   ];
 
   npmBuildScript = "bundle";
@@ -96,7 +98,9 @@ buildNpmPackage (finalAttrs: {
 
     rm -f $out/share/gemini-cli/docs/CONTRIBUTING.md
 
-    ln -s $out/share/gemini-cli/gemini.js $out/bin/gemini
+    makeWrapper "${lib.getExe finalAttrs.nodejs}" "$out/bin/gemini" \
+      --add-flags "--no-warnings=DEP0040" \
+      --add-flags "$out/share/gemini-cli/gemini.js"
 
     runHook postInstall
   '';


### PR DESCRIPTION
This decreases output path size 15 times and makes package layout a lot closer to gemini-cli-bin.

Also includes update to 0.31.0, as it requires some changes in the build process as well:
* https://github.com/google-gemini/gemini-cli/blob/76f70d65ff64461eed5f0d286e1578bd9304252a/docs/changelogs/latest.md
* https://github.com/google-gemini/gemini-cli/releases/tag/v0.31.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
