### PR TITLE
python3Packages.timm: 1.0.24 -> 1.0.25

### DIFF
--- a/pkgs/development/python-modules/gradio/client.nix
+++ b/pkgs/development/python-modules/gradio/client.nix
@@ -30,9 +30,9 @@
   writableTmpDirAsHomeHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gradio-client";
-  version = "2.0.1";
+  version = "2.2.0";
   pyproject = true;
 
   # no tests on pypi
@@ -40,31 +40,24 @@ buildPythonPackage rec {
     owner = "gradio-app";
     repo = "gradio";
     # not to be confused with @gradio/client@${version}
-    # tag = "gradio_client@${version}";
+    # tag = "gradio_client@${finalAttrs.version}";
     # TODO: switch back to a tag next release, if they tag it.
-    rev = "7a8894d7249ee20c2f7a896237e290e99661fd43"; # 2.0.1
+    rev = "8b03393a51e1e03fb04cb0a41b9a5dc3266a58aa"; # 2.2.0
     sparseCheckout = [
       "client/python"
       "gradio/media_assets"
     ];
-    hash = "sha256-p3okK48DJjjyvUzedNR60r5P8aKUxjE+ocb3EplZ6Uk=";
+    hash = "sha256-LkTZwPyHe1w8D5unEMW7dBGKNHxM7gWJ7I+4HwiexKk=";
   };
 
-  sourceRoot = "${src.name}/client/python";
+  sourceRoot = "${finalAttrs.src.name}/client/python";
 
+  # Because we set sourceRoot above, the folders "client/python"
+  # don't exist, as far as this is concerned.
   postPatch = ''
-    # Because we set sourceRoot above, the folders "client/python"
-    # don't exist, as far as this is concerned.
     substituteInPlace test/conftest.py \
       --replace-fail 'from client.python.test import media_data' 'import media_data'
   '';
-
-  # upstream adds upper constraints because they can, not because the need to
-  # https://github.com/gradio-app/gradio/pull/4885
-  pythonRelaxDeps = [
-    # only backward incompat is dropping py3.7 support
-    "websockets"
-  ];
 
   build-system = [
     hatchling
@@ -105,10 +98,6 @@ buildPythonPackage rec {
     cat ${./conftest-skip-network-errors.py} >> test/conftest.py
   '';
 
-  pytestFlags = [
-    #"-x" "-Wignore" # uncomment for debugging help
-  ];
-
   enabledTestPaths = [
     "test/"
   ];
@@ -135,10 +124,11 @@ buildPythonPackage rec {
   };
 
   meta = {
-    homepage = "https://www.gradio.app/";
-    changelog = "https://github.com/gradio-app/gradio/releases/tag/gradio_client@${version}";
     description = "Lightweight library to use any Gradio app as an API";
+    homepage = "https://www.gradio.app/";
+    downloadPage = "https://github.com/gradio-app/gradio/tree/main/client/python";
+    # changelog = "https://github.com/gradio-app/gradio/releases/tag/${finalAttrs.src.tag}"; TODO: uncomment if the tag exists
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pbsds ];
   };
-}
+})

--- a/pkgs/development/python-modules/gradio/default.nix
+++ b/pkgs/development/python-modules/gradio/default.nix
@@ -79,40 +79,32 @@ let
   nodejs = nodejs_24;
   pnpm = pnpm_10.override { inherit nodejs; };
 in
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gradio";
-  version = "6.5.1";
+  version = "6.8.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "gradio-app";
     repo = "gradio";
-    tag = "gradio@${version}";
-    hash = "sha256-pIcliKcb1eVVMk0ARzWcZGXc6pmI8mGVAvCJZ0JHXUw=";
+    tag = "gradio@${finalAttrs.version}";
+    hash = "sha256-ZHglnRs0AXCu9HlVoSO0h5p6SE4al/OLPn0jwZgKVR8=";
   };
 
+  patches = [
+    ./fix-transformers-pipelines-imports.patch
+  ];
+
   pnpmDeps = fetchPnpmDeps {
-    inherit
+    inherit (finalAttrs)
       pname
-      pnpm
       version
       src
       ;
+    inherit pnpm;
     fetcherVersion = 3;
     hash = "sha256-6Cx0hdVd0srhArvck2Kn9U2fT7aKtTZjgV5b/Usrnoo=";
   };
-
-  pythonRelaxDeps = [
-    "aiofiles"
-    "gradio-client"
-    "markupsafe"
-    "pydantic" # Requests >=2.11.10,<=2.12.4. Staging has it, master doesn't.
-  ];
-
-  pythonRemoveDeps = [
-    # this isn't a real runtime dependency
-    "ruff"
-  ];
 
   nativeBuildInputs = [
     zip
@@ -128,6 +120,10 @@ buildPythonPackage rec {
     hatch-fancy-pypi-readme
   ];
 
+  pythonRelaxDeps = [
+    "aiofiles"
+    "tomlkit"
+  ];
   dependencies = [
     aiofiles
     anyio
@@ -191,7 +187,7 @@ buildPythonPackage rec {
     # mock calls to `shutil.which(...)`
     (writeShellScriptBin "npm" "false")
   ]
-  ++ optional-dependencies.oauth
+  ++ finalAttrs.passthru.optional-dependencies.oauth
   ++ pydantic.optional-dependencies.email;
 
   preBuild = ''
@@ -216,6 +212,7 @@ buildPythonPackage rec {
 
     # requires network, it caught our xfail exception
     "test_error_analytics_successful"
+    "TestSnippetExecution"
 
     # Flaky, tries to pin dependency behaviour. Sensitive to dep versions
     # These error only affect downstream use of the check dependencies.
@@ -441,9 +438,9 @@ buildPythonPackage rec {
 
   meta = {
     homepage = "https://www.gradio.app/";
-    changelog = "https://github.com/gradio-app/gradio/releases/tag/gradio@${version}";
+    changelog = "https://github.com/gradio-app/gradio/releases/tag/${finalAttrs.src.tag}";
     description = "Python library for easily interacting with trained machine learning models";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ pbsds ];
   };
-}
+})

--- a/pkgs/development/python-modules/gradio/fix-transformers-pipelines-imports.patch
+++ b/pkgs/development/python-modules/gradio/fix-transformers-pipelines-imports.patch
@@ -1,0 +1,162 @@
+diff --git a/test/test_pipelines.py b/test/test_pipelines.py
+index 1903f758f..c40e6d3b1 100644
+--- a/test/test_pipelines.py
++++ b/test/test_pipelines.py
+@@ -3,20 +3,6 @@ from unittest.mock import MagicMock
+ 
+ import pytest
+ import transformers
+-from transformers import (
+-    AudioClassificationPipeline,
+-    AutomaticSpeechRecognitionPipeline,
+-    DocumentQuestionAnsweringPipeline,
+-    FeatureExtractionPipeline,
+-    FillMaskPipeline,
+-    ImageClassificationPipeline,
+-    ObjectDetectionPipeline,
+-    QuestionAnsweringPipeline,
+-    TextClassificationPipeline,
+-    TextGenerationPipeline,
+-    VisualQuestionAnsweringPipeline,
+-    ZeroShotClassificationPipeline,
+-)
+ 
+ import gradio as gr
+ from gradio.pipelines_utils import (
+@@ -24,6 +10,14 @@ from gradio.pipelines_utils import (
+ )
+ 
+ 
++def _get_pipeline_cls(name: str):
++    """Resolve a pipeline class by name from transformers, returning None if it
++    was removed in the installed version."""
++    return getattr(transformers, name, None) or getattr(
++        transformers.pipelines, name, None
++    )
++
++
+ @pytest.mark.flaky
+ def test_interface_in_blocks():
+     pipe1 = transformers.pipeline(model="deepset/roberta-base-squad2")  # type: ignore
+@@ -50,50 +44,66 @@ def test_transformers_load_from_pipeline():
+ 
+ 
+ class TestHandleTransformersPipelines(unittest.TestCase):
++    def _require(self, name: str):
++        """Return the pipeline class or skip the test if it was removed."""
++        cls = _get_pipeline_cls(name)
++        if cls is None:
++            self.skipTest(
++                f"{name} not available in transformers {transformers.__version__}"
++            )
++        return cls
++
+     def test_audio_classification_pipeline(self):
+-        pipe = MagicMock(spec=AudioClassificationPipeline)
++        cls = self._require("AudioClassificationPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input"
+         assert pipeline_info["outputs"].label == "Class"
+ 
+     def test_automatic_speech_recognition_pipeline(self):
+-        pipe = MagicMock(spec=AutomaticSpeechRecognitionPipeline)
++        cls = self._require("AutomaticSpeechRecognitionPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input"
+         assert pipeline_info["outputs"].label == "Output"
+ 
+     def test_object_detection_pipeline(self):
+-        pipe = MagicMock(spec=ObjectDetectionPipeline)
++        cls = self._require("ObjectDetectionPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input Image"
+         assert pipeline_info["outputs"].label == "Objects Detected"
+ 
+     def test_feature_extraction_pipeline(self):
+-        pipe = MagicMock(spec=FeatureExtractionPipeline)
++        cls = self._require("FeatureExtractionPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input"
+         assert pipeline_info["outputs"].label == "Output"
+ 
+     def test_fill_mask_pipeline(self):
+-        pipe = MagicMock(spec=FillMaskPipeline)
++        cls = self._require("FillMaskPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input"
+         assert pipeline_info["outputs"].label == "Classification"
+ 
+     def test_image_classification_pipeline(self):
+-        pipe = MagicMock(spec=ImageClassificationPipeline)
++        cls = self._require("ImageClassificationPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input Image"
+         assert pipeline_info["outputs"].label == "Classification"
+ 
+     def test_question_answering_pipeline(self):
+-        pipe = MagicMock(spec=QuestionAnsweringPipeline)
++        cls = self._require("QuestionAnsweringPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"][0].label == "Context"
+@@ -102,21 +112,24 @@ class TestHandleTransformersPipelines(unittest.TestCase):
+         assert pipeline_info["outputs"][1].label == "Score"
+ 
+     def test_text_classification_pipeline(self):
+-        pipe = MagicMock(spec=TextClassificationPipeline)
++        cls = self._require("TextClassificationPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input"
+         assert pipeline_info["outputs"].label == "Classification"
+ 
+     def test_text_generation_pipeline(self):
+-        pipe = MagicMock(spec=TextGenerationPipeline)
++        cls = self._require("TextGenerationPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"].label == "Input"
+         assert pipeline_info["outputs"].label == "Output"
+ 
+     def test_zero_shot_classification_pipeline(self):
+-        pipe = MagicMock(spec=ZeroShotClassificationPipeline)
++        cls = self._require("ZeroShotClassificationPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"][0].label == "Input"
+@@ -127,7 +140,8 @@ class TestHandleTransformersPipelines(unittest.TestCase):
+         assert pipeline_info["outputs"].label == "Classification"
+ 
+     def test_document_question_answering_pipeline(self):
+-        pipe = MagicMock(spec=DocumentQuestionAnsweringPipeline)
++        cls = self._require("DocumentQuestionAnsweringPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"][0].label == "Input Document"
+@@ -135,7 +149,8 @@ class TestHandleTransformersPipelines(unittest.TestCase):
+         assert pipeline_info["outputs"].label == "Label"
+ 
+     def test_visual_question_answering_pipeline(self):
+-        pipe = MagicMock(spec=VisualQuestionAnsweringPipeline)
++        cls = self._require("VisualQuestionAnsweringPipeline")
++        pipe = MagicMock(spec=cls)
+         pipeline_info = handle_transformers_pipeline(pipe)
+         assert pipeline_info is not None
+         assert pipeline_info["inputs"][0].label == "Input Image"

--- a/pkgs/development/python-modules/skops/default.nix
+++ b/pkgs/development/python-modules/skops/default.nix
@@ -3,23 +3,28 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+
+  # build-system
   hatchling,
-  huggingface-hub,
-  matplotlib,
+
+  # dependencies
   numpy,
   packaging,
-  pandas,
   prettytable,
+  scikit-learn,
+  tabulate,
+
+  # tests
+  matplotlib,
+  pandas,
   pytest-cov-stub,
   pytestCheckHook,
   pyyaml,
   rich,
-  scikit-learn,
   streamlit,
-  tabulate,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "skops";
   version = "0.13.0";
   pyproject = true;
@@ -27,7 +32,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "skops-dev";
     repo = "skops";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-1550LIVyChqP5q4VZmflCXPyXXg4eHJU5AlVQJD2M8c=";
   };
 
@@ -59,8 +64,14 @@ buildPythonPackage rec {
   disabledTests = [
     # flaky
     "test_base_case_works_as_expected"
+
     # fairlearn is not available in nixpkgs
     "TestAddFairlearnMetricFrame"
+
+    # numpy.linalg.LinAlgError: The covariance matrix of class 0 is not full rank.
+    # Increase the value of `reg_param` to reduce the collinearity.
+    "test_can_persist_fitted"
+
   ];
 
   disabledTestPaths = [
@@ -76,6 +87,10 @@ buildPythonPackage rec {
     # Warning from scipy.optimize in skops/io/tests/test_persist.py::test_dump_and_load_with_file_wrapper
     # https://github.com/skops-dev/skops/issues/479
     "-Wignore::DeprecationWarning"
+
+    # FutureWarning: Class PassiveAggressiveClassifier is deprecated; this is deprecated in version
+    # 1.8 and will be removed in 1.10. Use `SGDClassifier(...)` instead.
+    "-Wignore::FutureWarning"
   ];
 
   pythonImportsCheck = [ "skops" ];
@@ -83,9 +98,9 @@ buildPythonPackage rec {
   meta = {
     description = "Library for saving/loading, sharing, and deploying scikit-learn based models";
     homepage = "https://skops.readthedocs.io/en/stable";
-    changelog = "https://github.com/skops-dev/skops/releases/tag/${src.tag}";
+    changelog = "https://github.com/skops-dev/skops/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = [ lib.maintainers.bcdarwin ];
     mainProgram = "skops";
   };
-}
+})

--- a/pkgs/development/python-modules/smolagents/default.nix
+++ b/pkgs/development/python-modules/smolagents/default.nix
@@ -66,6 +66,9 @@ buildPythonPackage (finalAttrs: {
 
   build-system = [ setuptools ];
 
+  pythonRelaxDeps = [
+    "huggingface-hub"
+  ];
   dependencies = [
     huggingface-hub
     jinja2
@@ -146,18 +149,23 @@ buildPythonPackage (finalAttrs: {
   disabledTestPaths = [
     # ImportError: cannot import name 'require_soundfile' from 'transformers.testing_utils'
     "tests/test_types.py"
+
+    # Requires unpackaged 'helium'
+    "tests/test_vision_web_browser.py"
   ];
 
   disabledTests = [
     # Missing dependencies
+    "TestBlaxelExecutorUnit"
+    "TestModalExecutorUnit"
+    "mcp"
     "test_cleanup"
     "test_ddgs_with_kwargs"
     "test_e2b_executor_instantiation"
     "test_flatten_messages_as_text_for_all_models"
-    "mcp"
     "test_import_smolagents_without_extras"
-    "test_vision_web_browser_main"
     "test_multiple_servers"
+    "test_vision_web_browser_main"
     # Tests require network access
     "test_agent_type_output"
     "test_call_different_providers_without_key"
@@ -184,6 +192,9 @@ buildPythonPackage (finalAttrs: {
     "test_multiagents_save"
     "test_new_instance"
 
+    # Flaky: assert 0.9858949184417725 <= 0.73
+    "test_retry_on_rate_limit_error"
+
     # Requires optional "blaxel" dependencies
     "test_blaxel_executor_instantiation_with_blaxel_sdk"
     "test_blaxel_executor_custom_parameters"
@@ -192,7 +203,6 @@ buildPythonPackage (finalAttrs: {
     "test_sandbox_lifecycle"
     # TypeError: 'function' object is not subscriptable
     "test_stream_to_gradio_memory_step"
-
   ];
 
   __darwinAllowLocalNetworking = true;

--- a/pkgs/development/python-modules/timm/default.nix
+++ b/pkgs/development/python-modules/timm/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage (finalAttrs: {
   pname = "timm";
-  version = "1.0.24";
+  version = "1.0.25";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "huggingface";
     repo = "pytorch-image-models";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-uimOYftxX3zRvrLlT8Y23g3LdlGUDVs3AMMyKNFbsPg=";
+    hash = "sha256-ulF94vSc4DQjVH6kZ+wFsrdmGRK+zpRk2ImWuF46xwE=";
   };
 
   build-system = [ pdm-backend ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Diff: https://github.com/huggingface/pytorch-image-models/compare/v1.0.24...v1.0.25
Changelog: https://github.com/huggingface/pytorch-image-models/blob/v1.0.25/README.md#whats-new

cc @bcdarwin

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test