### PR TITLE
buildstream/buildstream-plugins: ignore Git tags containing `dev` substring

### DIFF
--- a/pkgs/by-name/bu/buildstream/package.nix
+++ b/pkgs/by-name/bu/buildstream/package.nix
@@ -2,7 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  nix-update-script,
+  gitUpdater,
 
   # buildInputs
   buildbox,
@@ -119,7 +119,9 @@ python3Packages.buildPythonApplication (finalAttrs: {
 
   versionCheckProgram = "${placeholder "out"}/bin/bst";
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = gitUpdater {
+    ignoredVersions = "dev";
+  };
 
   meta = {
     description = "Powerful software integration tool";

--- a/pkgs/development/python-modules/buildstream-plugins/default.nix
+++ b/pkgs/development/python-modules/buildstream-plugins/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  gitUpdater,
   setuptools,
   cython,
 }:
@@ -28,6 +29,10 @@ buildPythonPackage rec {
   # May be fixable by skipping certain tests? TODO.
 
   pythonImportsCheck = [ "buildstream_plugins" ];
+
+  passthru.updateScript = gitUpdater {
+    ignoredVersions = "dev";
+  };
 
   meta = {
     description = "BuildStream plugins";


### PR DESCRIPTION
Tags containing `*dev*` on official BuildStream projects are for pre-releases, and should not be included in the passthru updateScript.

This is needed after https://github.com/NixOS/nixpkgs/pull/493236 showed a issue with the updateScript.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
