### PR TITLE
kanban: update homepage URL to landing page

### DIFF
--- a/pkgs/by-name/ka/kanban/package.nix
+++ b/pkgs/by-name/ka/kanban/package.nix
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
       built with Rust. Features include file persistence, keyboard-driven
       navigation, multi-select capabilities, and sprint management.
     '';
-    homepage = "https://github.com/fulsomenko/kanban";
+    homepage = "https://kanban.yoon.se";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ fulsomenko ];
     mainProgram = "kanban";


### PR DESCRIPTION
## Summary
- Updated homepage URL from GitHub repository link to the official landing page (https://kanban.yoon.se)

## Test plan
- Verified the URL is accessible