### PR TITLE
python3Packages.jupysql: revert 0.38 -> 0.11.0; python3Packages.pyspark: fix dependencies, adopt

### DIFF
--- a/pkgs/development/python-modules/jupysql/default.nix
+++ b/pkgs/development/python-modules/jupysql/default.nix
@@ -38,15 +38,15 @@
 
 buildPythonPackage rec {
   pname = "jupysql";
-  version = "0.38";
+  version = "0.11.1";
 
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ploomber";
     repo = "jupysql";
-    tag = "v${version}";
-    hash = "sha256-Z132bGkjXUNPIscIfIM8FKRO0Uc/z4Sl932CVN8f3lc=";
+    tag = version;
+    hash = "sha256-7wfKvKqDf8LlUiLoevNRxmq8x5wLheOgIeWz72oFcuw=";
   };
 
   pythonRelaxDeps = [ "sqlalchemy" ];
@@ -131,7 +131,7 @@ buildPythonPackage rec {
   meta = {
     description = "Better SQL in Jupyter";
     homepage = "https://github.com/ploomber/jupysql";
-    changelog = "https://github.com/ploomber/jupysql/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/ploomber/jupysql/blob/${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ euxane ];
   };


### PR DESCRIPTION
`jupysql` 0.38 is an 11-year old build. 0.11.0 is a year old.
`pyspark` needed `optional-dependencies` updated for `jupysql`. Modernized, added finalAttrs, adopted.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
