### PR TITLE
sunshine: add darwin support

### DIFF
--- a/pkgs/by-name/su/sunshine/package.nix
+++ b/pkgs/by-name/su/sunshine/package.nix
@@ -121,6 +121,8 @@ stdenv'.mkDerivation (finalAttrs: {
     pkg-config
     python3
     makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     wayland-scanner
     # Avoid fighting upstream's usage of vendored ffmpeg libraries
     autoPatchelfHook
@@ -133,6 +135,20 @@ stdenv'.mkDerivation (finalAttrs: {
 
   buildInputs = [
     avahi
+    openssl
+    libopus
+    boost
+    curl
+    pcre
+    pcre2
+    libuuid
+    libthai
+    libdatrie
+    libnotify
+    miniupnpc
+    nlohmann_json
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
     libevdev
     libpulseaudio
     libx11
@@ -141,23 +157,14 @@ stdenv'.mkDerivation (finalAttrs: {
     libxrandr
     libxtst
     libxi
-    openssl
-    libopus
-    boost
     libdrm
     wayland
     libffi
     libevdev
     libcap
     libdrm
-    curl
-    pcre
-    pcre2
-    libuuid
     libselinux
     libsepol
-    libthai
-    libdatrie
     libxdmcp
     libxkbcommon
     libepoxy
@@ -168,16 +175,13 @@ stdenv'.mkDerivation (finalAttrs: {
     amf-headers
     svt-av1
     libappindicator
-    libnotify
-    miniupnpc
-    nlohmann_json
   ]
   ++ lib.optionals cudaSupport [
     cudaPackages.cudatoolkit
     cudaPackages.cuda_cudart
   ];
 
-  runtimeDependencies = [
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
     avahi
     libgbm
     libxrandr
@@ -253,6 +257,6 @@ stdenv'.mkDerivation (finalAttrs: {
     license = lib.licenses.gpl3Only;
     mainProgram = "sunshine";
     maintainers = with lib.maintainers; [ devusb ];
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
   };
 })


### PR DESCRIPTION
Tested on macOS Sequoia

<img width="1580" height="937" alt="Moonlight on Linux connecting to Sunshine on macOS" src="https://github.com/user-attachments/assets/8179f708-cc0a-4e16-93a1-11cedb681f51" />

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
