### PR TITLE
chezmoi-modify-manager: init at 3.7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4560,6 +4560,12 @@
     githubId = 32384814;
     name = "Nikita Mitasov";
   };
+  chadnorvell = {
+    email = "chadnorvell@pm.me";
+    github = "chadnorvell";
+    githubId = 29340381;
+    name = "Chad Norvell";
+  };
   chaduffy = {
     email = "charles@dyfis.net";
     github = "charles-dyfis-net";

--- a/pkgs/by-name/ch/chezmoi-modify-manager/package.nix
+++ b/pkgs/by-name/ch/chezmoi-modify-manager/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  dbus,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "chezmoi-modify-manager";
+  version = "3.7.0";
+
+  src = fetchFromGitHub {
+    owner = "VorpalBlade";
+    repo = "chezmoi_modify_manager";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-S/KyyCHYytm/v6Bmld+JxcfmCrLaSgLBhJrz6nQlpVo=";
+  };
+
+  cargoHash = "sha256-MT/RxJS46mQBR84gwXl6SdKF3PgZ5CmyYWiX+dROBg8=";
+
+  nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
+
+  buildInputs = [ dbus ];
+
+  buildNoDefaultFeatures = true;
+  buildFeatures = [ "keyring" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Chezmoi addon to patch ini files with mixed settings and state";
+    homepage = "https://github.com/VorpalBlade/chezmoi_modify_manager";
+    changelog = "https://github.com/VorpalBlade/chezmoi_modify_manager/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ chadnorvell ];
+    mainProgram = "chezmoi_modify_manager";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Added [`chezmoi_modify_manager`](https://github.com/VorpalBlade/chezmoi_modify_manager/), an extension to `chezmoi`, which is already in `nixpkgs`. Also added myself to the maintainers list.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
