### PR TITLE
cmux: init at 0.60.0

### DIFF
--- a/pkgs/by-name/cm/cmux/package.nix
+++ b/pkgs/by-name/cm/cmux/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  undmg,
+  fetchurl,
+  lib,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "cmux";
+  version = "0.60.0";
+
+  src = fetchurl {
+    url = "https://github.com/manaflow-ai/cmux/releases/download/v${finalAttrs.version}/cmux-macos.dmg";
+    hash = "sha256-aIy/4dJSE7kl3VH1OpdtU1fqToac+LeLx/5qZF8CpbY=";
+  };
+
+  nativeBuildInputs = [ undmg ];
+
+  sourceRoot = ".";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    cp -r *.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents";
+    homepage = "https://www.cmux.dev";
+    license = lib.licenses.agpl3Plus;
+    maintainers = with lib.maintainers; [ shunueda ];
+    platforms = lib.platforms.darwin;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Adding [cmux](https://github.com/manaflow-ai/cmux) at 0.60.0. 

> Ghostty-based macOS terminal with vertical tabs and notifications for AI coding agents

1.6k+ stars and frequent updates. Listing myself as a maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
