### PR TITLE
mdbook-pagecrypt: init at 0.1.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12406,6 +12406,13 @@
     githubId = 2881268;
     name = "John Hollowell";
   };
+  jhult = {
+    email = "Jonathan@JonathanHult.com";
+    github = "jhult";
+    githubId = 9849069;
+    name = "Jonathan Hult";
+    keys = [ { fingerprint = "DEE7 054C 5D43 ABEA C0F9  8BE4 3512 C8F8 2E2F 2A16"; } ];
+  };
   jiegec = {
     name = "Jiajie Chen";
     email = "c@jia.je";

--- a/pkgs/by-name/md/mdbook-pagecrypt/package.nix
+++ b/pkgs/by-name/md/mdbook-pagecrypt/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  openssl,
+  pkg-config,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "mdbook-pagecrypt";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "Wybxc";
+    repo = "mdbook-pagecrypt";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-pwEiqLJM4EXqt32j5h7aaJdcdauRtkvxSSu1wbtWr5E=";
+  };
+
+  cargoHash = "sha256-muhLJfOh5riSuymmu1NSemM+c+7Y1Ya/YG9TjFQgPkk=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ openssl ];
+
+  meta = {
+    description = "Encrypt your mdBook-built site with password protection";
+    mainProgram = "mdbook-pagecrypt";
+    homepage = "https://github.com/Wybxc/mdbook-pagecrypt";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ jhult ];
+  };
+})


### PR DESCRIPTION
[`mdbook-pagecrypt`](https://github.com/Wybxc/)

> Encrypt your [`mdbook`](https://github.com/rust-lang/mdBook)-built site with password protection.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [x] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test