### PR TITLE
snes9x: fix snes9x-gtk build with GCC 15

### DIFF
--- a/pkgs/by-name/sn/snes9x/glslang-include-cstdint.patch
+++ b/pkgs/by-name/sn/snes9x/glslang-include-cstdint.patch
@@ -1,0 +1,10 @@
+--- a/external/glslang/SPIRV/SpvBuilder.h
++++ b/external/glslang/SPIRV/SpvBuilder.h
+@@ -61,6 +61,7 @@
+ #include "spirv.hpp"
+ #include "spvIR.h"
+
++#include <cstdint>
+ #include <algorithm>
+ #include <map>
+ #include <stack>

--- a/pkgs/by-name/sn/snes9x/package.nix
+++ b/pkgs/by-name/sn/snes9x/package.nix
@@ -42,6 +42,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-INMVyB3alwmsApO7ToAaUWgh7jlg2MeLxqHCEnUO88U=";
   };
 
+  patches = [
+    ./glslang-include-cstdint.patch
+  ];
+
   nativeBuildInputs = [
     pkg-config
     python3


### PR DESCRIPTION
This PR fixes a build failure in snes9x-gtk caused by the transition to GCC 15.

The issue lies in the glslang subcomponent. In newer GCC versions, \<cstdint\> is no longer implicitly included in certain headers, leading to a 'uint32_t' has not been declared error in external/glslang/SPIRV/SpvBuilder.h.

The base snes9x (CLI version) builds successfully without this patch because it does not trigger the compilation of the SPIRV-related shader tools. However, snes9x-gtk enables these features by default, which causes the build to fail. This patch ensures both versions remain buildable with the latest nixpkgs.

Note: This fix is already present upstream in glslang: https://github.com/KhronosGroup/glslang/commit/e40c14a3e007fac0e4f2e4164fdf14d1712355bd

So I believe it is only necessary for 1.63 and earlier. Any new releases should render this unnecessary.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
