### PR TITLE
Zyn-fusion: fix mingw builds [DRAFT][ABANDONED]

### DIFF
--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -22,11 +22,11 @@
   dssiSupport ? false,
   dssi,
   ladspaH,
-  jackSupport ? true,
+  jackSupport ? (!stdenv.hostPlatform.isWindows),
   libjack2,
   lashSupport ? false,
   lash,
-  ossSupport ? true,
+  ossSupport ? (!stdenv.hostPlatform.isWindows),
   portaudioSupport ? true,
   portaudio,
   sndioSupport ? stdenv.hostPlatform.isOpenBSD,
@@ -45,6 +45,8 @@
   # Test dependencies
   cxxtest,
   ruby,
+  windows,
+  makeStaticLibraries,
 }:
 
 assert builtins.any (g: guiModule == g) [
@@ -55,6 +57,7 @@ assert builtins.any (g: guiModule == g) [
 ];
 
 let
+  makeStatic = p: p.override { isStatic = stdenv.hostPlatform.isWindows; };
   guiName =
     {
       "fltk" = "FLTK";
@@ -79,8 +82,9 @@ stdenv.mkDerivation rec {
 
   outputs = [
     "out"
-    "doc"
-  ];
+  ]
+    # mkDerivation bug? avoids: Not linking DLLs in the non-existent folder for doc
+  ++ lib.optional (!stdenv.hostPlatform.isWindows) "doc";
 
   patches = [
     # Lazily expand ZYN_DATADIR to fix builtin banks across updates
@@ -88,6 +92,7 @@ stdenv.mkDerivation rec {
       url = "https://github.com/zynaddsubfx/zynaddsubfx/commit/853aa03f4f92a180b870fa62a04685d12fca55a7.patch";
       hash = "sha256-4BsRZ9keeqKopr6lCQJznaZ3qWuMgD1/mCrdMiskusg=";
     })
+#    (./0001-Statically-link-core-gcc-libraries.patch)
   ];
 
   postPatch = ''
@@ -96,16 +101,16 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    makeWrapper
     pkg-config
-  ];
+  ] ++ lib.optional (!stdenv.hostPlatform.isWindows) makeWrapper;
 
   buildInputs =
     [
-      fftw
-      liblo
-      minixml
-      zlib
+      (makeStatic fftw)
+      (makeStatic liblo)
+      (makeStatic minixml)
+      (zlib.override { static = stdenv.hostPlatform.isWindows;
+                       shared = (!stdenv.hostPlatform.isWindows); })
     ]
     ++ lib.optionals alsaSupport [ alsa-lib ]
     ++ lib.optionals dssiSupport [
@@ -114,7 +119,7 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals jackSupport [ libjack2 ]
     ++ lib.optionals lashSupport [ lash ]
-    ++ lib.optionals portaudioSupport [ portaudio ]
+    ++ lib.optionals portaudioSupport [ (portaudio) ]
     ++ lib.optionals sndioSupport [ sndio ]
     ++ lib.optionals (guiModule == "fltk") [
       fltk
@@ -126,10 +131,11 @@ stdenv.mkDerivation rec {
       cairo
       libXpm
     ]
-    ++ lib.optionals (guiModule == "zest") [
+    ++ lib.optionals (guiModule == "zest" && (!stdenv.hostPlatform.isWindows)) [
       libGL
       libX11
-    ];
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isMinGW) [ windows.mingw_w64_pthreads ];
 
   cmakeFlags =
     [
@@ -140,11 +146,25 @@ stdenv.mkDerivation rec {
     # Must explicitly disable if support is not wanted.
     ++ lib.optional (!ossSupport) "-DOssEnable=OFF"
     # Find FLTK without requiring an OpenGL library in buildInputs
-    ++ lib.optional (guiModule == "fltk") "-DFLTK_SKIP_OPENGL=ON";
+    ++ lib.optional (guiModule == "fltk") "-DFLTK_SKIP_OPENGL=ON"
+    ++ lib.optional portaudioSupport "-DDefaultOutput=pa"
+
+    ++ lib.optionals stdenv.hostPlatform.isMinGW [
+#    "-DCMAKE_TOOLCHAIN_FILE=${./mingw.cmake}"
+      #(lib.cmakeFeature "CMAKE_C_FLAGS" "-static-libstdc++")
+      #(lib.cmakeFeature "CMAKE_CXX_FLAGS" "-static-libstdc++")
+ ];
 
   CXXFLAGS = [
     # GCC 13: error: 'uint8_t' does not name a type
     "-include cstdint"
+  ] ++ lib.optionals stdenv.hostPlatform.isMinGW [
+    "-static" "-static-libgcc" "-static-libstdc++"
+  ];
+
+  NIX_CFLAGS_LINK = [
+    "-static-libstdc++"
+    "-Wl,-Bstatic -lmcfgthread"
   ];
 
   doCheck = true;
@@ -174,6 +194,22 @@ stdenv.mkDerivation rec {
       runHook postCheck
     '';
 
+  installPhase = lib.optionalString (stdenv.hostPlatform.isWindows) ''
+  mkdir -p $out/bin
+
+  cp src/zynaddsubfx.exe $out/bin
+  cp src/Plugin/ZynAddSubFX/vst/ZynAddSubFX.dll $out/bin
+
+  cp -r ../instruments/banks $out/bin
+
+	mkdir -p $out/bin/qml
+	touch $out/bin/qml/MainWindow.qml
+
+	ln -s ${mruby-zest}/bin/{font,schema} $out/bin
+	ln -s ${mruby-zest}/bin/zest.exe $out/bin/zyn-fusion.exe
+	ln -s ${mruby-zest}/bin/libzest.dll $out/bin
+  '';
+
   # Use Zyn-Fusion logo for zest build
   # An SVG version of the logo isn't hosted anywhere we can fetch, I
   # had to manually derive it from the code that draws it in-app:
@@ -186,7 +222,7 @@ stdenv.mkDerivation rec {
 
   # When building with zest GUI, patch plugins
   # and standalone executable to properly locate zest
-  postFixup = lib.optionalString (guiModule == "zest") ''
+  postFixup = lib.optionalString (guiModule == "zest" && (!stdenv.hostPlatform.isWindows)) ''
     for lib in "$out/lib/lv2/ZynAddSubFX.lv2/ZynAddSubFX_ui.so" "$out/lib/vst/ZynAddSubFX.so"; do
       patchelf --set-rpath "${mruby-zest}:$(patchelf --print-rpath "$lib")" "$lib"
     done

--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/0001-use-system-libuv-for-mingw-w64-builds.patch
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/0001-use-system-libuv-for-mingw-w64-builds.patch
@@ -1,0 +1,60 @@
+From 716be9d1c5ff2fbf7cd9d046ea393920a8690ab3 Mon Sep 17 00:00:00 2001
+From: Daniel Hill <daniel@gluo.nz>
+Date: Mon, 21 Apr 2025 02:33:18 +1200
+Subject: [PATCH] use system libuv for mingw-w64 builds
+
+---
+ Makefile        | 10 +++++-----
+ build_config.rb |  4 +++-
+ 2 files changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 7bc3788..6506120 100644
+--- a/Makefile
++++ b/Makefile
+@@ -36,15 +36,15 @@ osx: deps/libuv.a
+ 		./deps/libuv/.libs/libuv.a  -lm -framework OpenGL -lpthread
+ 	$(CC) test-libversion.c deps/pugl/build/libpugl-0.a -ldl -o zest -framework OpenGL -framework AppKit -lpthread -I deps/pugl -std=gnu99
+ 
+-windows: buildpuglwin deps/libuv-win.a
++windows: buildpuglwin
+ 	cd deps/nanovg/src   && $(CC) -mstackrealign nanovg.c -c
+ 	$(AR) rc deps/libnanovg.a deps/nanovg/src/*.o
+-	cd src/osc-bridge    && CFLAGS="-mstackrealign -I ../../deps/libuv/include " make lib
+-	cd mruby             && WINDOWS=1 MRUBY_CONFIG=../build_config.rb rake
+-	$(CC) -mstackrealign -shared -o libzest.dll -static-libgcc `find mruby/build/w64 -type f | grep -e "\.o$$" | grep -v bin` \
++	cd src/osc-bridge    && CFLAGS="-mstackrealign " make lib
++	cd mruby             && WINDOWS=1 MRUBY_CONFIG=../build_config.rb rake -j
++	$(CC) -mstackrealign -shared -o libzest.dll -static-libstdc++ -static-libgcc `find mruby/build/w64 -type f | grep -e "\.o$$" | grep -v bin` \
+         ./deps/libnanovg.a \
+         src/osc-bridge/libosc-bridge.a \
+-        ./deps/libuv-win.a \
++		`$(PKG_CONFIG) --libs --static libuv` \
+         -lm -lpthread -lws2_32 -lkernel32 -lpsapi -luserenv -liphlpapi -lglu32 -lgdi32 -lopengl32
+ 	$(CC) -mstackrealign -DWIN32 test-libversion.c deps/pugl/build/libpugl-0.a -o zest.exe -lpthread -I deps/pugl -std=c99 -lws2_32 -lkernel32 -lpsapi -luserenv -liphlpapi -lglu32 -lgdi32 -lopengl32
+ 
+diff --git a/build_config.rb b/build_config.rb
+index e72b5ab..e9518bf 100644
+--- a/build_config.rb
++++ b/build_config.rb
+@@ -6,6 +6,8 @@ windows = ENV.include? "WINDOWS"
+ mac     = ENV['OS'] == "Mac"
+ linux   = false if windows || mac
+ 
++pkg_config = ENV['PKG_CONFIG'] || "pkg-config"
++
+ RUBY_PLATFORM = "mingw" if windows
+ 
+ if(windows)
+@@ -156,7 +158,7 @@ build_type.new(build_name) do |conf|
+         end
+         linker.flags_after_libraries  << "-lpthread -ldl -lm"
+       else
+-        linker.flags_after_libraries  << "#{`pwd`.strip}/../deps/libuv-win.a"
++        linker.flags_after_libraries << `#{pkg_config} --libs libuv`.strip
+         linker.flags_after_libraries  << "-lws2_32 -lkernel32 -lpsapi -luserenv -liphlpapi"
+         linker.flags_after_libraries  << "-lglu32 -lgdi32 -lopengl32"
+       end
+-- 
+2.48.1
+

--- a/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/mruby-zest/default.nix
@@ -9,9 +9,13 @@
   libGL,
   libuv,
   libX11,
-}:
-
-stdenv.mkDerivation rec {
+  pkgsBuildBuild,
+  windows,
+  makeStaticLibraries,
+}: let
+  makeStatic = p: p.override {stdenv = makeStaticLibraries stdenv ;};
+in
+  (makeStaticLibraries stdenv).mkDerivation rec {
   pname = "mruby-zest";
   version = "3.0.6";
 
@@ -25,20 +29,26 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./force-cxx-as-linker.patch
+    ./0001-use-system-libuv-for-mingw-w64-builds.patch
   ];
+
+  postPatch = ''
+    cd mruby
+    patch -p1 -N < ../string-backtraces.diff
+    cd ..
+  '';
 
   nativeBuildInputs = [
     bison
     pkg-config
     rake
     ruby
+    pkgsBuildBuild.stdenv.cc
   ];
 
-  buildInputs = [
-    libGL
-    libuv
-    libX11
-  ];
+  buildInputs =
+    lib.optionals (!stdenv.hostPlatform.isWindows) [ libuv libGL libX11 ]
+  ++ lib.optionals (stdenv.hostPlatform.isMinGW) (map makeStatic [ libuv windows.mingw_w64_pthreads ]);
 
   # Force optimization to fix:
   # warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O)
@@ -47,21 +57,41 @@ stdenv.mkDerivation rec {
   # Remove pre-built y.tab.c to generate with nixpkgs bison
   preBuild = ''
     rm mruby/mrbgems/mruby-compiler/core/y.tab.c
+  '' +
+  lib.optionals stdenv.hostPlatform.isWindows ''
+    ruby rebuild-fcache.rb
   '';
 
-  installTargets = [ "pack" ];
+  makeFlags = lib.optionals stdenv.hostPlatform.isWindows "windows";
 
-  postInstall = ''
+  installTargets = lib.optionals (!stdenv.hostPlatform.isWindows) "pack";
+
+  installPhase = lib.optionals stdenv.hostPlatform.isWindows ''
+    mkdir -p $out/bin
+    cp {zest.exe,libzest.dll} "$out/bin"
+
+    mkdir -p $out/bin/font
+    mkdir -p $out/bin/schema
+
+    cp $(find ./deps/nanovg -type f | grep ttf) $out/bin/font/
+
+    cp ./src/osc-bridge/schema/test.json $out/bin/schema/
+    cp -r ./src/mruby-zest/{qml,example} $out/bin
+  '';
+
+  postInstall = lib.optionalString (!stdenv.hostPlatform.isWindows) ''
     ln -s "$out/zest" "$out/zyn-fusion"
     cp -a package/{font,libzest.so,schema,zest} "$out"
-
+    '' +
+    ''
     # mruby-widget-lib/src/api.c requires MainWindow.qml as part of a
     # sanity check, even though qml files are compiled into the binary
     # https://github.com/mruby-zest/mruby-zest-build/blob/3.0.6/src/mruby-widget-lib/src/api.c#L107-L124
     # https://github.com/mruby-zest/mruby-zest-build/blob/3.0.6/linux-pack.sh#L17-L18
     mkdir -p "$out/qml"
     touch "$out/qml/MainWindow.qml"
-  '';
+    '';
+
 
   meta = with lib; {
     description = "Zest Framework used in ZynAddSubFX's UI";

--- a/pkgs/by-name/li/liblo/package.nix
+++ b/pkgs/by-name/li/liblo/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  isStatic ? false,
 }:
 
 stdenv.mkDerivation rec {
@@ -12,6 +13,12 @@ stdenv.mkDerivation rec {
     url = "mirror://sourceforge/liblo/liblo/${version}/${pname}-${version}.tar.gz";
     sha256 = "sha256-XfBfKgOV/FrJD2tTi4yCuyGUFAb9GnCnZcczakfXAgg=";
   };
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isWindows ''
+    substituteInPlace configure --replace-fail "_WIN32_WINNT=0x501" "_WIN32_WINNT=0x601"
+  '';
+
+  configureFlags = lib.optionals isStatic [ "--enable-static" ];
 
   doCheck = false; # fails 1 out of 3 tests
 

--- a/pkgs/by-name/mi/minixml/0001-fix-building-for-mingw-w64.patch
+++ b/pkgs/by-name/mi/minixml/0001-fix-building-for-mingw-w64.patch
@@ -1,0 +1,44 @@
+From de4aedb2b5a2e637dc71918f621c86da8ce40b5d Mon Sep 17 00:00:00 2001
+From: Daniel Hill <daniel@gluo.nz>
+Date: Sun, 20 Apr 2025 23:49:23 +1200
+Subject: [PATCH] fix building for mingw-w64
+
+---
+ Makefile.in | 6 ++++++
+ mxml-file.c | 2 --
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 5df074e..387bbbd 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -148,6 +148,12 @@ install:	$(TARGETS) install-$(LIBMXML) install-libmxml.a
+ 	$(INSTALL_DIR) $(BUILDROOT)$(mandir)/man3
+ 	$(INSTALL_MAN) doc/mxml.3 $(BUILDROOT)$(mandir)/man3/mxml.3
+ 
++install-mxml1.dll: mxml1.dll
++	echo Installing mxml1.dll to $(BUILDROOT)$(libdir)...
++	$(INSTALL_DIR) $(BUILDROOT)$(libdir)
++	$(INSTALL_LIB) mxml1.dll $(BUILDROOT)$(libdir)
++	$(RM) $(BUILDROOT)$(libdir)/mxml1.dll
++
+ install-libmxml.a:	libmxml.a
+ 	echo Installing libmxml.a to $(BUILDROOT)$(libdir)...
+ 	$(INSTALL_DIR) $(BUILDROOT)$(libdir)
+diff --git a/mxml-file.c b/mxml-file.c
+index 07bdc24..bbc0809 100644
+--- a/mxml-file.c
++++ b/mxml-file.c
+@@ -13,9 +13,7 @@
+  * Include necessary headers...
+  */
+ 
+-#ifndef _WIN32
+ #  include <unistd.h>
+-#endif /* !_WIN32 */
+ #include "mxml-private.h"
+ 
+ 
+-- 
+2.48.1
+

--- a/pkgs/by-name/mi/minixml/package.nix
+++ b/pkgs/by-name/mi/minixml/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  isStatic ? false,
 }:
 
 stdenv.mkDerivation rec {
@@ -15,10 +16,12 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-l7GUA+vlSECi/72eU3Y9COpGtLTRh3vYcHUi+uRkCn8=";
   };
 
+  patches = lib.optional stdenv.hostPlatform.isMinGW ./0001-fix-building-for-mingw-w64.patch;
+
   # remove the -arch flags which are set by default in the build
   configureFlags = lib.optionals stdenv.hostPlatform.isDarwin [
     "--with-archflags=\"-mmacosx-version-min=10.14\""
-  ];
+  ] ++ lib.optional isStatic "--enable-static";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I made these fixes a while back to get Zyn-Fusion to build for windows, I was generally underwhelmed by it as a plugin in Ableton Live, and Ableton Live itself was a PITA on Linux, so quickly abandoned this.

Posting this here as it fixes build failures for other packages and maybe someone else would be interested in taking these changes, or reading it as an example on how to approach patching nixpkgs for a mingw target.

Libraries touched:
zyn-fusion: @kira-bruneau
jack: (no maintainers)
portaudio: @lovek323
fftw: (no maintainers)
minixml: (no maintainers)
liblo: @MarcWeber 


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
