### PR TITLE
python3Packages.ocrmypdf: 17.1.0 -> 17.3.0

### DIFF
--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -32,7 +32,7 @@
 
 buildPythonPackage rec {
   pname = "ocrmypdf";
-  version = "17.1.0";
+  version = "17.3.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -45,7 +45,7 @@ buildPythonPackage rec {
     postFetch = ''
       rm "$out/.git_archival.txt"
     '';
-    hash = "sha256-MlsrssmuEzFXy+N6kWjkF3wtcDCncjYmAi43PUeYuJg=";
+    hash = "sha256-/R/W8TMBaFBTjPiOIroZ1CNQAKMTLJH+cQvY2177e0U=";
   };
 
   patches = [

--- a/pkgs/development/python-modules/ocrmypdf/paths.patch
+++ b/pkgs/development/python-modules/ocrmypdf/paths.patch
@@ -1,8 +1,8 @@
 diff --git a/src/ocrmypdf/_exec/ghostscript.py b/src/ocrmypdf/_exec/ghostscript.py
-index eaa48117..30201d97 100644
+index ec9017ca..0986641d 100644
 --- a/src/ocrmypdf/_exec/ghostscript.py
 +++ b/src/ocrmypdf/_exec/ghostscript.py
-@@ -31,7 +31,7 @@ COLOR_CONVERSION_STRATEGIES = frozenset(
+@@ -35,7 +35,7 @@ COLOR_CONVERSION_STRATEGIES = frozenset(
      ]
  )
  # Ghostscript executable - gswin32c is not supported
@@ -12,7 +12,7 @@ index eaa48117..30201d97 100644
  
  log = logging.getLogger(__name__)
 diff --git a/src/ocrmypdf/_exec/jbig2enc.py b/src/ocrmypdf/_exec/jbig2enc.py
-index 1c6dd5fe..b689a091 100644
+index 736de67e..d8c24ebd 100644
 --- a/src/ocrmypdf/_exec/jbig2enc.py
 +++ b/src/ocrmypdf/_exec/jbig2enc.py
 @@ -15,7 +15,7 @@ from ocrmypdf.subprocess import get_version, run
@@ -24,16 +24,7 @@ index 1c6dd5fe..b689a091 100644
      except CalledProcessError as e:
          # TeX Live for Windows provides an incompatible jbig2.EXE which may
          # be on the PATH.
-@@ -33,7 +33,7 @@ def available():
- 
- def convert_group(cwd, infiles, out_prefix, threshold):
-     args = [
--        'jbig2',
-+        '@jbig2@',
-         '-b',
-         out_prefix,
-         '--symbol-mode',  # symbol mode (lossy)
-@@ -50,7 +50,7 @@ def convert_group(cwd, infiles, out_prefix, threshold):
+@@ -32,7 +32,7 @@ def available():
  
  
  def convert_single(cwd, infile, outfile, threshold):
@@ -65,10 +56,10 @@ index 5b8600d0..fcad771b 100644
              '--skip-if-larger',
              '--quality',
 diff --git a/src/ocrmypdf/_exec/tesseract.py b/src/ocrmypdf/_exec/tesseract.py
-index 102bdab8..bfef4400 100644
+index d41a0af7..b189b0de 100644
 --- a/src/ocrmypdf/_exec/tesseract.py
 +++ b/src/ocrmypdf/_exec/tesseract.py
-@@ -95,7 +95,7 @@ class TesseractVersion(Version):
+@@ -116,7 +116,7 @@ class TesseractVersion(Version):
  
  
  def version() -> Version:
@@ -77,7 +68,7 @@ index 102bdab8..bfef4400 100644
  
  
  def has_thresholding() -> bool:
-@@ -113,7 +113,7 @@ def get_languages() -> set[str]:
+@@ -134,7 +134,7 @@ def get_languages() -> set[str]:
          msg += output
          return msg
  
@@ -86,7 +77,7 @@ index 102bdab8..bfef4400 100644
      try:
          proc = run(
              args_tess,
-@@ -135,7 +135,7 @@ def get_languages() -> set[str]:
+@@ -156,7 +156,7 @@ def get_languages() -> set[str]:
  
  
  def tess_base_args(langs: list[str], engine_mode: int | None) -> list[str]:
@@ -96,10 +87,10 @@ index 102bdab8..bfef4400 100644
          args.extend(['-l', '+'.join(langs)])
      if engine_mode is not None:
 diff --git a/src/ocrmypdf/_exec/unpaper.py b/src/ocrmypdf/_exec/unpaper.py
-index a5a92f4c..6cf56eb3 100644
+index 065fc9ef..4fab9313 100644
 --- a/src/ocrmypdf/_exec/unpaper.py
 +++ b/src/ocrmypdf/_exec/unpaper.py
-@@ -48,7 +48,7 @@ class UnpaperImageTooLargeError(Exception):
+@@ -47,7 +47,7 @@ class UnpaperImageTooLargeError(Exception):
  
  
  def version() -> Version:
@@ -108,7 +99,7 @@ index a5a92f4c..6cf56eb3 100644
  
  
  @contextmanager
-@@ -70,7 +70,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[tuple[Path, Path, Path]]:
+@@ -69,7 +69,7 @@ def _setup_unpaper_io(input_file: Path) -> Iterator[tuple[Path, Path, Path]]:
  def run_unpaper(
      input_file: Path, output_file: Path, *, dpi: DecFloat, mode_args: list[str]
  ) -> None:


### PR DESCRIPTION
Diff: https://github.com/ocrmypdf/OCRmyPDF/compare/v17.1.0...v17.3.0

Changelog: https://github.com/ocrmypdf/OCRmyPDF/blob/v17.3.0/docs/release_notes.md

fixes #493608

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
