### PR TITLE
python3Packages.sphinxcontrib-newsfeed: make it work with sphinx 9.1

### DIFF
--- a/pkgs/development/python-modules/sphinxcontrib-newsfeed/default.nix
+++ b/pkgs/development/python-modules/sphinxcontrib-newsfeed/default.nix
@@ -16,6 +16,11 @@ buildPythonPackage rec {
     sha256 = "1d7gam3mn8v4in4p16yn3v10vps7nnaz6ilw99j4klij39dqd37p";
   };
 
+  patches = [
+    # reference: https://github.com/prometheusresearch/sphinxcontrib-newsfeed/pull/7
+    ./fix-for-sphinx-9.1.patch
+  ];
+
   nativeBuildInputs = [ setuptools ];
 
   propagatedBuildInputs = [ sphinx ];

--- a/pkgs/development/python-modules/sphinxcontrib-newsfeed/fix-for-sphinx-9.1.patch
+++ b/pkgs/development/python-modules/sphinxcontrib-newsfeed/fix-for-sphinx-9.1.patch
@@ -1,0 +1,16 @@
+diff --git a/sphinxcontrib/newsfeed.py b/sphinxcontrib/newsfeed.py
+index 2e155cd..64b30d9 100644
+--- a/sphinxcontrib/newsfeed.py
++++ b/sphinxcontrib/newsfeed.py
+@@ -265,8 +265,9 @@ def process_feed(app, doctree, fromdocname):
+                 replacement.append(section_node)
+                 env.resolve_references(rss_item_description, docname, app.builder)
+                 if app.builder.format == 'html':
+-                    rss_item_description = app.builder.render_partial(
+-                                                    rss_item_description)['body']
++                    rendered = app.builder.render_partial(rss_item_description)
++                    # Sphinx 9.1+ changed 'body' to 'fragment'
++                    rss_item_description = rendered.get('fragment', rendered.get('body', ''))
+                     rss_item_date = meta['date']
+                     rss_item = RSSItem(rss_item_title, rss_item_link,
+                                        rss_item_description, rss_item_date)


### PR DESCRIPTION
This commit fixes the build of khal.

Patch source:

- https://github.com/sphinx-doc/sphinx/issues/14272
- https://github.com/prometheusresearch/sphinxcontrib-newsfeed/pull/7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
