### PR TITLE
wayshot: 1.3.1 -> 1.4.5

### DIFF
--- a/pkgs/by-name/wa/wayshot/package.nix
+++ b/pkgs/by-name/wa/wayshot/package.nix
@@ -1,23 +1,36 @@
 {
   lib,
+  libgbm,
+  libjxl,
+  libGL,
   fetchFromGitHub,
+  nix-update-script,
+  pango,
+  pkg-config,
   rustPlatform,
+  wayland,
 }:
 rustPlatform.buildRustPackage (finalAttrs: {
   pname = "wayshot";
-  version = "1.3.1";
+  version = "1.4.5";
 
   src = fetchFromGitHub {
     owner = "waycrate";
     repo = "wayshot";
-    rev = finalAttrs.version;
-    hash = "sha256-nUpIN4WTePtFZTmKAjv0tgj4VTdZeXjoQX6am9+M3ig=";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-Xw3UN0linKp0jcAYYE0eX7x/bQ97gIQPDCIY9tlEhN4=";
   };
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    pango
+    libgbm
+    libjxl
+    libGL
+    wayland
+  ];
+  cargoHash = "sha256-z5cqpC+Yt0PsEj9iab+7buO+OudbtzNYJulEUE10eZY=";
 
-  cargoHash = "sha256-uKETDGi1n6VcdGCrjrnEM1sQ0vVjd/vCXMUn9Hby2m8=";
-
-  # tests are off as they are broken and pr for integration testing is still WIP
-  doCheck = false;
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Native, blazing-fast screenshot tool for wlroots based compositors such as sway and river";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update `wayshot` to 1.4.5, re-enable tests and add `passthru.updateScript = nix-update-script { }`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
