### PR TITLE
tetro-tui: init at 3.6.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9987,6 +9987,12 @@
     github = "gkleen";
     githubId = 20089782;
   };
+  gl1tchxd = {
+    name = "Felix Buchsteiner";
+    github = "gl1tchxd-git";
+    githubId = 92686452;
+    email = "contact@gl1tchxd.at";
+  };
   gleber = {
     email = "gleber.p@gmail.com";
     github = "gleber";

--- a/pkgs/by-name/te/tetro-tui/package.nix
+++ b/pkgs/by-name/te/tetro-tui/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nix-update-script,
+  makeDesktopItem,
+  copyDesktopItems,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "tetro-tui";
+  version = "3.6.1";
+  __structuredAttrs = true;
+
+  src = fetchFromGitHub {
+    owner = "Strophox";
+    repo = "tetro-tui";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-i/d+i6E0ClMAAjC6zB9Lt26LYEcjvR01MCzGne2EXNQ=";
+  };
+
+  cargoHash = "sha256-LTHokF9T7nRvvzfQWSL9igTHmvV+w40Pm4z/i0y7goA=";
+
+  nativeBuildInputs = [
+    copyDesktopItems
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "tetro-tui";
+      desktopName = "Tetro TUI";
+      exec = "tetro-tui";
+      terminal = true;
+      comment = "Cross-platform terminal game where tetrominos fall and stack";
+      categories = [
+        "Game"
+        "ArcadeGame"
+      ];
+    })
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Cross-platform terminal game where tetrominos fall and stack";
+    homepage = "https://github.com/Strophox/tetro-tui";
+    changelog = "https://github.com/Strophox/tetro-tui/blob/${finalAttrs.src.tag}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ gl1tchxd ];
+    mainProgram = "tetro-tui";
+  };
+})


### PR DESCRIPTION
New Package: [tetro-tui](https://crates.io/crates/tetro-tui)

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
