### PR TITLE
gemini-cli: add agy compatibility symlink

### DIFF
--- a/pkgs/by-name/ge/gemini-cli/package.nix
+++ b/pkgs/by-name/ge/gemini-cli/package.nix
@@ -109,6 +109,12 @@ buildNpmPackage (finalAttrs: {
     runHook postInstall
   '';
 
+  postInstall = ''
+    # Create the 'agy' symlink for compatibility with tools expecting that name
+    # We point it to the main 'gemini' binary created in the installPhase
+    ln -s $out/bin/gemini $out/bin/agy
+  '';
+
   passthru.updateScript = nix-update-script { };
 
   meta = {


### PR DESCRIPTION
This PR adds a compatibility symbolic link named agy that points to the main Gemini binary.

The Gemini CLI ecosystem, specifically when integrated with the Google Antigravity IDE, expects the command-line tool to be accessible via the agy alias. Currently, the Nixpkgs derivation only provides the Gemini binary, leading to "command not found" errors when the IDE attempts to interface with the CLI. This change ensures out-of-the-box compatibility for NixOS users utilizing the Antigravity extension.

## Things done

Verification:

- Confirmed the creation of the symlink in the Nix store.
- Verified that running ./result/bin/agy correctly invokes the Gemini CLI.

- Built on platform:
  - [X ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
