### PR TITLE
cgit: 1.2.3 -> 1.3

### DIFF
--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -300,7 +300,7 @@ in
       lib.mapAttrsToList (name: cfg: {
         ${cfg.nginx.virtualHost} = {
           locations =
-            (genAttrs' [ "cgit.css" "cgit.png" "favicon.ico" "robots.txt" ] (
+            (genAttrs' [ "cgit.css" "cgit.js" "cgit.png" "favicon.ico" "robots.txt" ] (
               fileName:
               lib.nameValuePair "= ${stripLocation cfg}/${fileName}" {
                 alias = lib.mkDefault "${cfg.package}/cgit/${fileName}";

--- a/nixos/modules/services/web-servers/lighttpd/cgit.nix
+++ b/nixos/modules/services/web-servers/lighttpd/cgit.nix
@@ -13,6 +13,7 @@ let
   configFile = pkgs.writeText "cgitrc" ''
     # default paths to static assets
     css=${pathPrefix}/cgit.css
+    js=${pathPrefix}/cgit.js
     logo=${pathPrefix}/cgit.png
     favicon=${pathPrefix}/favicon.ico
 
@@ -82,6 +83,7 @@ in
           )
           alias.url = (
               "${pathPrefix}/cgit.css" => "${pkgs.cgit}/cgit/cgit.css",
+              "${pathPrefix}/cgit.js" => "${pkgs.cgit}/cgit/cgit.js",
               "${pathPrefix}/cgit.png" => "${pkgs.cgit}/cgit/cgit.png",
               "${pathPrefix}"          => "${pkgs.cgit}/cgit/cgit.cgi"
           )

--- a/pkgs/applications/version-management/cgit/default.nix
+++ b/pkgs/applications/version-management/cgit/default.nix
@@ -25,19 +25,19 @@
 
 stdenv.mkDerivation {
   pname = "cgit";
-  version = "1.2.3";
+  version = "1.3";
 
   src = fetchurl {
-    url = "https://git.zx2c4.com/cgit/snapshot/cgit-1.2.3.tar.xz";
-    sha256 = "193d990ym10qlslk0p8mjwp2j6rhqa7fq0y1iff65lvbyv914pss";
+    url = "https://git.zx2c4.com/cgit/snapshot/cgit-1.3.tar.xz";
+    sha256 = "836b6edbc7f99e11037a8b928d609ce346ed77a55545e17fff8cea59b5b7aa42";
   };
 
   # cgit is tightly coupled with git and needs a git source tree to build.
   # IMPORTANT: Remember to check which git version cgit needs on every version
   # bump (look for "GIT_VER" in the top-level Makefile).
   gitSrc = fetchurl {
-    url = "mirror://kernel/software/scm/git/git-2.25.1.tar.xz";
-    sha256 = "09lzwa183nblr6l8ib35g2xrjf9wm9yhk3szfvyzkwivdv69c9r2";
+    url = "mirror://kernel/software/scm/git/git-2.53.0.tar.xz";
+    hash = "sha256-WBi9fYCwYbu9/sikM9YJ3IgYoFmR9zH/xKVh4soYxlM=";
   };
 
   separateDebugInfo = true;
@@ -92,15 +92,9 @@ stdenv.mkDerivation {
     "AR=${stdenv.cc.targetPrefix}ar"
   ];
 
-  # Install manpage.
   postInstall = ''
-    # xmllint fails:
-    #make install-man
-
-    # bypassing xmllint works:
-    a2x --no-xmllint -f manpage cgitrc.5.txt
-    mkdir -p "$out/share/man/man5"
-    cp cgitrc.5 "$out/share/man/man5"
+    # Install manpage.
+    make install-man $makeFlags
 
     wrapPythonProgramsIn "$out/lib/cgit/filters" "$out ''${pythonPath[*]}"
 


### PR DESCRIPTION
https://lists.zx2c4.com/pipermail/cgit/2026-February/004968.html


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
