### PR TITLE
python3Packages.sqlcipher3: fix build by removing conan build dependency

### DIFF
--- a/pkgs/development/python-modules/sqlcipher3/default.nix
+++ b/pkgs/development/python-modules/sqlcipher3/default.nix
@@ -19,6 +19,14 @@ buildPythonPackage {
     hash = "sha256-orZ1KJuoiJ84liWiHzoB8f8VmlUbW4j7qP2S2g4COAo=";
   };
 
+  postPatch = ''
+    # Remove conan from build dependencies; it is used upstream to fetch
+    # OpenSSL at build time, but we provide it via buildInputs instead.
+    # setup.py already handles the missing conan case gracefully.
+    substituteInPlace pyproject.toml \
+      --replace-fail '"conan>=2.0",' ""
+  '';
+
   build-system = [
     setuptools
   ];


### PR DESCRIPTION
Upstream added conan to pyproject.toml's build-system requires. Conan is used to fetch OpenSSL at build time for CI wheel builds, but is unnecessary in nixpkgs since OpenSSL is provided via buildInputs. The setup.py already handles missing conan gracefully.

closes #493476


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
