### PR TITLE
eez-studio: init at 0.29.0-unstable-2026-08-29

### DIFF
--- a/pkgs/by-name/ee/eez-studio/mime-info.xml
+++ b/pkgs/by-name/ee/eez-studio/mime-info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+<mime-type type="application/x-eez-project">
+  <glob pattern="*.eez-project"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+<mime-type type="application/x-eez-dashboard">
+  <glob pattern="*.eez-dashboard"/>
+
+  <icon name="x-office-document" />
+</mime-type>
+</mime-info>

--- a/pkgs/by-name/ee/eez-studio/package.nix
+++ b/pkgs/by-name/ee/eez-studio/package.nix
@@ -1,0 +1,144 @@
+{
+  lib,
+  buildNpmPackage,
+  cmake,
+  copyDesktopItems,
+  electron,
+  fetchFromGitHub,
+  icoutils,
+  makeDesktopItem,
+  makeWrapper,
+  nix-update-script,
+  pngquant,
+  udev,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "eez-studio";
+  version = "0.29.0-unstable-2026-08-29";
+
+  src = fetchFromGitHub {
+    owner = "eez-open";
+    repo = "studio";
+    # There isn't any release that include the fixes to support electron_43.
+    # Switch to using `tag` instead of `rev` after 0.29.1+.
+    rev = "453b39c13ea4ca5914c3901af5b518077fa75fde";
+    hash = "sha256-QB50e4aIb2O/gw5YBftvFLNs4snVoy3WHx4fd34xOkQ=";
+  };
+
+  npmDepsHash = "sha256-bKVb41kpx/5J28pgsqpD1ET6yYxYAzPbTwFq2hhuhuo=";
+
+  __structuredAttrs = true;
+
+  env = {
+    ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+    npm_config_build_from_source = "true";
+  };
+
+  npmFlags = [
+    "--nodedir=${electron.headers}" # better-sqlite3 needs to be built against electron's ABI
+  ];
+
+  # pngquant-bin otherwise tries to download a prebuilt binary during npm rebuild.
+  npmRebuildFlags = [ "--ignore-scripts" ];
+
+  makeCacheWritable = true;
+
+  nativeBuildInputs = [
+    cmake
+    copyDesktopItems
+    icoutils
+    makeWrapper
+  ];
+
+  dontUseCmakeConfigure = true; # cmake is used to build a dependency
+
+  buildInputs = [
+    udev
+  ];
+
+  postPatch = ''
+    # Workaround for https://github.com/electron/electron/issues/31121
+    substituteInPlace packages/project-editor/flow/expression/parser.ts \
+      --replace-fail 'process.resourcesPath!' "'$out/share/eez-studio/resources'"
+    substituteInPlace packages/project-editor/lvgl/build.ts \
+      --replace-fail 'process.resourcesPath!' "'$out/share/eez-studio/resources'"
+    substituteInPlace packages/project-editor/lvgl/docker-build/build-manager.ts \
+      --replace-fail 'process.resourcesPath' "'$out/share/eez-studio/resources'"
+  '';
+
+  preBuild = ''
+    install -Dm755 ${lib.getExe pngquant} node_modules/pngquant-bin/vendor/pngquant
+    npm rebuild ${lib.escapeShellArgs finalAttrs.npmFlags}
+  '';
+
+  postBuild = ''
+    npm exec electron-builder -- \
+      --linux \
+      --dir \
+      --config.electronDist=${electron.dist} \
+      --config.electronVersion=${electron.version} \
+    ;
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/eez-studio $out/bin
+    cp -r dist/*-unpacked/{locales,resources{,.pak}} $out/share/eez-studio
+
+    makeWrapper ${lib.getExe electron} $out/bin/eez-studio \
+      --add-flags $out/share/eez-studio/resources/app.asar \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
+      --inherit-argv0
+
+    install -Dm644 ${./mime-info.xml} $out/share/mime/packages/eez-studio.xml
+
+    icotool -x icon.ico
+    for f in icon_*.png; do
+      res=$(basename "$f" ".png" | cut -d"_" -f3 | cut -d"x" -f1-2)
+      install -Dm644 "$f" "$out/share/icons/hicolor/$res/apps/eez-studio.png"
+    done;
+
+    runHook postInstall
+  '';
+
+  # https://github.com/eez-open/studio/blob/master/installation/make-electron-builder-yml.ts
+  desktopItems = [
+    (makeDesktopItem {
+      name = finalAttrs.pname;
+      desktopName = "EEZ Studio";
+      exec = "eez-studio %U";
+      terminal = false;
+      type = "Application";
+      icon = "eez-studio";
+      startupWMClass = "EEZ Studio";
+      comment = "EEZ Studio is a free and open source cross-platform low-code tool for embedded GUIs. Built-in EEZ Flow enables the creation of complex scenarios for test and measurement automation, and the Instruments feature offers remote control of multiple T&M equipment.";
+      mimeTypes = [
+        "application/x-eez-project"
+        "application/x-eez-dashboard"
+      ];
+      categories = [
+        "Utility"
+      ];
+    })
+  ];
+
+  # TODO remove `extraArgs` after 0.29.1+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version"
+      "branch"
+    ];
+  };
+
+  meta = {
+    description = "Cross-platform low-code GUI and automation tool for embedded systems and T&M equipment";
+    homepage = "https://www.envox.eu/studio/studio-introduction/";
+    changelog = "https://github.com/eez-open/studio/releases/tag/v0.29.0"; # TODO use `finalAttrs.src.tag` after 0.29.1+
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ilkecan ];
+    platforms = lib.platforms.linux;
+    mainProgram = "eez-studio";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~4.5 years ago, I packaged EEZ Studio as an upstream flake as part of SoN (https://github.com/eez-open/studio/pull/137). But since the maintainers themselves don't use Nix, the Nix files has not been updated since then.

Recently a user has reported to upstream that the Nix packaging is not working (https://github.com/eez-open/studio/issues/940). I suggested to the maintainers that maintaining the Nix derivation on Nixpkgs might be easier, which they agreed.

### Note
Introducing this package to nixpkgs is currently blocked by https://github.com/NixOS/nixpkgs/pull/547948.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
