### PR TITLE
openmolcas: 25.10 -> 26.02

### DIFF
--- a/pkgs/by-name/op/openmolcas/nevpt2.patch
+++ b/pkgs/by-name/op/openmolcas/nevpt2.patch
@@ -1,5 +1,3 @@
-diff --git a/src/gctime.c b/src/gctime.c
-index 34fcb6f..832459c 100644
 --- a/src/gctime.c
 +++ b/src/gctime.c
 @@ -1,14 +1,15 @@
@@ -20,3 +18,9 @@ index 34fcb6f..832459c 100644
     long time(), t;
     char *ctime();
     t = time ( (long *) 0);
+
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.2)
++cmake_minimum_required(VERSION 3.5)

--- a/pkgs/by-name/op/openmolcas/package.nix
+++ b/pkgs/by-name/op/openmolcas/package.nix
@@ -40,8 +40,8 @@ let
   qcmaquisSrc = fetchFromGitHub {
     owner = "qcscine";
     repo = "qcmaquis";
-    rev = "release-3.1.4"; # Must match tag in cmake/custom/qcmaquis.cmake
-    hash = "sha256-vhC5k+91IPFxdCi5oYt1NtF9W08RxonJjPpA0ls4I+o=";
+    rev = "9ff551fecbdbad43d17600c441a9c9bfb9811d3e"; # Current head of "nag-compiler-fix-internal" as pinned in OpenMolcas' Cmake
+    hash = "sha256-+EtfgYg6apREDOltXu8zfUbpuiV56k4RvuPAYO0fbsM=";
   };
 
   # NEVPT2 sources must be patched to be valid C code in gctime.c
@@ -64,13 +64,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "openmolcas";
-  version = "25.10";
+  version = "26.02";
 
   src = fetchFromGitLab {
     owner = "Molcas";
     repo = "OpenMolcas";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-z5RNLUP1DjvQ+LvNzOBwiPrYqGeZoPPbtaJv9gIefuM=";
+    hash = "sha256-+DU651GiGZRHdkLuGLCPU/95uOhG+kENCTi1T+8Hz1g=";
   };
 
   patches = [
@@ -158,6 +158,8 @@ stdenv.mkDerivation (finalAttrs: {
   # DMRG executables contain references to /build, however, they are properly
   # removed by autopatchelf
   noAuditTmpdir = true;
+
+  enableParallelBuilding = true;
 
   # Wrong store path in shebang (bare Python, no Python pkgs), force manual re-patching
   postFixup = ''

--- a/pkgs/by-name/op/openmolcas/qcmaquis.patch
+++ b/pkgs/by-name/op/openmolcas/qcmaquis.patch
@@ -1,29 +1,23 @@
 diff --git a/cmake/custom/nevpt2.cmake b/cmake/custom/nevpt2.cmake
-index 789739ec8..6c86a7b8c 100644
+index fa2ef9940f..ab6ce50eae 100644
 --- a/cmake/custom/nevpt2.cmake
 +++ b/cmake/custom/nevpt2.cmake
-@@ -67,6 +67,8 @@ list(APPEND NEVPT2CMakeArgs
-   "-DMOLCAS_BUILD_DIR=${PROJECT_BINARY_DIR}"
-   "-DCMAKE_Fortran_MODULE_DIRECTORY=${mod_dir}"
-   "-DDMRG_INCLUDE=${HDF5_QCM_INCLUDE}"
-+  "-DCMAKE_SKIP_BUILD_RPATH=ON"
-+      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-   )
-
- if(HDF5_ROOT)
-@@ -118,9 +119,7 @@ endif ()
-
+@@ -118,11 +118,8 @@ endif ()
+ 
  ExternalProject_Add(${EP_PROJECT}
                      PREFIX ${CUSTOM_NEVPT2_LOCATION}
 -                    GIT_REPOSITORY ${reference_git_repo}
 -                    GIT_TAG ${reference_git_commit}
+-                    GIT_PROGRESS 1
 -                    UPDATE_DISCONNECTED ${EP_SkipUpdate}
+-                    CMAKE_ARGS "${NEVPT2CMakeArgs}"
 +                    URL @nevpt2_src_url@
-                     CMAKE_ARGS "${NEVPT2CMakeArgs}"
++                    CMAKE_ARGS ${NEVPT2CMakeArgs}
                      INSTALL_DIR "${PROJECT_BINARY_DIR}/qcmaquis"
                     )
+ 
 diff --git a/cmake/custom/qcmaquis.cmake b/cmake/custom/qcmaquis.cmake
-index 5fd1ef207..8d2957c6e 100644
+index f144fcb4d9..5a7befd4e1 100644
 --- a/cmake/custom/qcmaquis.cmake
 +++ b/cmake/custom/qcmaquis.cmake
 @@ -77,6 +77,8 @@ list (APPEND QCMaquisCMakeArgs
@@ -35,26 +29,10 @@ index 5fd1ef207..8d2957c6e 100644
  )
  if (HDF5_ROOT)
    list (APPEND QCMaquisCMakeArgs
-@@ -274,10 +275,7 @@ if (NOT MAQUIS_DMRG_FOUND) # Does the opposite work?
-
-   ExternalProject_Add (${EP_PROJECT}
-                        PREFIX ${extprojpath}
--                       GIT_REPOSITORY ${reference_git_repo}
--                       GIT_TAG ${reference_git_commit}
--                       UPDATE_DISCONNECTED ${EP_SkipUpdate}
--
-+                       URL @qcmaquis_src_url@
-                        SOURCE_SUBDIR dmrg
-                        CMAKE_ARGS ${EP_CMAKE_ARGS}
-                        CMAKE_CACHE_ARGS ${EP_CMAKE_CACHE_ARGS}
-diff --git a/cmake/custom/qcmaquis.cmake b/cmake/custom/qcmaquis.cmake
-index 5fd1ef207..4291ec3d7 100644
---- a/cmake/custom/qcmaquis.cmake
-+++ b/cmake/custom/qcmaquis.cmake
-@@ -94,47 +94,9 @@ if (NOT MAQUIS_DMRG_FOUND) # Does the opposite work?
+@@ -94,47 +96,9 @@ if (NOT MAQUIS_DMRG_FOUND) # Does the opposite work?
      )
    endif (BOOST_ROOT)
-
+ 
 -  if (LINALG STREQUAL "Manual")
 -    target_files (LINALG_LIBRARIES_FILES ${LINALG_LIBRARIES})
 -    list (APPEND LINALG_LIBRARIES_FILES ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
@@ -99,6 +77,19 @@ index 5fd1ef207..4291ec3d7 100644
 +  list (APPEND QCMaquisCMakeArgs
 +        "-DBLAS_LAPACK_SELECTOR=auto"
 +  )
-
+ 
    # Enabling source changes to keep ExternalProject happy
-   set (CMAKE_DISABLE_SOURCE_CHANGES OFF
+   set (CMAKE_DISABLE_SOURCE_CHANGES OFF)
+@@ -278,11 +242,7 @@ if (NOT MAQUIS_DMRG_FOUND) # Does the opposite work?
+ 
+   ExternalProject_Add (${EP_PROJECT}
+                        PREFIX ${extprojpath}
+-                       GIT_REPOSITORY ${reference_git_repo}
+-                       GIT_TAG ${reference_git_commit}
+-                       GIT_PROGRESS 1
+-                       UPDATE_DISCONNECTED ${EP_SkipUpdate}
+-
++                       URL @qcmaquis_src_url@
+                        SOURCE_SUBDIR dmrg
+                        CMAKE_ARGS ${EP_CMAKE_ARGS}
+                        CMAKE_CACHE_ARGS ${EP_CMAKE_CACHE_ARGS}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11715,6 +11715,10 @@ with pkgs;
     hdf5 = hdf5-fortran;
   };
 
+  openmolcas = callPackage ../by-name/op/openmolcas/package.nix {
+    boost = boost188;
+  };
+
   siesta-mpi = callPackage ../by-name/si/siesta/package.nix { useMpi = true; };
 
   ### SCIENCE/BIOLOGY


### PR DESCRIPTION
Updates OpenMolcas to its latest release, see <https://gitlab.com/Molcas/OpenMolcas/-/releases/v26.02>

This requires multiple patches to the QCMaquis and NEVPT2 builds. Also, QCMaquis only works up to Boost 1.88, so that I had to introduce an override for OpenMolcas to use that boost version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
