### PR TITLE
hpcc: init at 1.5.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25222,6 +25222,12 @@
     githubId = 7669898;
     name = "Katharina Fey";
   };
+  spaghetti-stack = {
+    email = "spaghetti_stack@protonmail.com";
+    github = "spaghetti-stack";
+    githubId = 44814450;
+    name = "spaghetti-stack";
+  };
   spalf = {
     email = "tom@tombarrett.xyz";
     name = "tom barrett";

--- a/pkgs/by-name/hp/hpcc/package.nix
+++ b/pkgs/by-name/hp/hpcc/package.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  gfortran,
+  mpi,
+  blas,
+  lapack,
+}:
+
+let
+  mpiDev = lib.getDev mpi;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hpcc";
+  version = "1.5.0";
+
+  src = fetchurl {
+    url = "https://hpcchallenge.org/projectsfiles/hpcc/download/hpcc-${finalAttrs.version}.tar.gz";
+    hash = "sha256-Cm/vernzNH5Un+1l67mCNP7qnuGK6gyPWbrvvjz3/7g=";
+  };
+
+  # HPCC uses old version of MPI: Fix compatibility with MPI-3 (OpenMPI 5.x)
+  # MPI_Address -> MPI_Get_address, MPI_Type_struct -> MPI_Type_create_struct
+  postPatch = ''
+    substituteInPlace hpl/src/comm/HPL_packL.c \
+      --replace-fail "MPI_Address" "MPI_Get_address" \
+      --replace-fail "MPI_Type_struct" "MPI_Type_create_struct"
+  '';
+
+  nativeBuildInputs = [ gfortran ];
+
+  buildInputs = [
+    mpi
+    blas
+    lapack
+  ];
+
+  postUnpack = ''
+    cat > $sourceRoot/hpl/Make.nix << 'MAKEFILE'
+    SHELL        = /bin/sh
+    CD           = cd
+    CP           = cp
+    LN_S         = ln -s
+    MKDIR        = mkdir
+    RM           = /bin/rm -f
+    TOUCH        = touch
+    ARCH         = nix
+    TOPdir       = ../../..
+    INCdir       = $(TOPdir)/include
+    BINdir       = $(TOPdir)/bin/$(ARCH)
+    LIBdir       = $(TOPdir)/lib/$(ARCH)
+    HPLlib       = $(LIBdir)/libhpl.a
+    MAKEFILE
+    cat >> $sourceRoot/hpl/Make.nix << EOF
+    MPdir        = ${mpiDev}
+    MPinc        = -I\$(MPdir)/include
+    MPlib        = -L${lib.getLib mpi}/lib -lmpi
+    LAdir        = ${lapack}/lib
+    LAinc        =
+    LAlib        = -L${blas}/lib -L${lapack}/lib -L${gfortran.cc.lib}/lib -lblas -llapack -lgfortran -lm
+    F2CDEFS      =
+    HPL_INCLUDES = -I\$(INCdir) -I\$(INCdir)/\$(ARCH) \$(LAinc) \$(MPinc)
+    HPL_LIBS     = \$(HPLlib) \$(LAlib) \$(MPlib)
+    HPL_OPTS     = -DHPL_CALL_CBLAS
+    HPL_DEFS     = \$(F2CDEFS) \$(HPL_OPTS) \$(HPL_INCLUDES)
+    CC           = ${mpiDev}/bin/mpicc
+    CCNOOPT      = \$(HPL_DEFS)
+    CCFLAGS      = \$(HPL_DEFS) -O3
+    LINKER       = ${mpiDev}/bin/mpicc
+    LINKFLAGS    = \$(CCFLAGS)
+    ARCHIVER     = ar
+    ARFLAGS      = r
+    RANLIB       = ranlib
+    EOF
+  '';
+
+  makeFlags = [ "arch=nix" ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 hpcc $out/bin/hpcc
+    install -Dm644 _hpccinf.txt $out/share/hpcc/hpccinf.txt
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "HPC Challenge Benchmark";
+    longDescription = ''
+      HPCC is a benchmark suite that measures a range of memory access
+      patterns. It includes HPL (High Performance Linpack), DGEMM,
+      STREAM, PTRANS, RandomAccess, FFT, and communication bandwidth
+      and latency benchmarks. It is used to stress test and compare
+      high performance computing systems.
+    '';
+    homepage = "https://hpcchallenge.org/";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ spaghetti-stack ];
+    mainProgram = "hpcc";
+  };
+})

--- a/pkgs/by-name/hp/hpcc/package.nix
+++ b/pkgs/by-name/hp/hpcc/package.nix
@@ -8,10 +8,6 @@
   lapack,
 }:
 
-let
-  mpiDev = lib.getDev mpi;
-in
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "hpcc";
   version = "1.5.0";
@@ -21,8 +17,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-Cm/vernzNH5Un+1l67mCNP7qnuGK6gyPWbrvvjz3/7g=";
   };
 
-  # HPCC uses old version of MPI: Fix compatibility with MPI-3 (OpenMPI 5.x)
-  # MPI_Address -> MPI_Get_address, MPI_Type_struct -> MPI_Type_create_struct
+  # HPCC uses MPI-1 standard: Fix compatibility with MPI-3.
+  # MPI_Address -> MPI_Get_address, MPI_Type_struct -> MPI_Type_create_struct.
   postPatch = ''
     substituteInPlace hpl/src/comm/HPL_packL.c \
       --replace-fail "MPI_Address" "MPI_Get_address" \
@@ -35,48 +31,45 @@ stdenv.mkDerivation (finalAttrs: {
     mpi
     blas
     lapack
+    gfortran.cc.lib
   ];
 
+  # HPCC bundles HPL 2.0 which does not have autotools, and instead requires a Make.<arch> file.
+  # See the INSTALL readme of HPCC: https://github.com/icl-utk-edu/hpcc/blob/main/hpl/INSTALL .
   postUnpack = ''
-    cat > $sourceRoot/hpl/Make.nix << 'MAKEFILE'
+    cat > $sourceRoot/hpl/Make.nixpkgs << 'MAKEFILE'
     SHELL        = /bin/sh
     CD           = cd
     CP           = cp
     LN_S         = ln -s
-    MKDIR        = mkdir
+    MKDIR        = mkdir -p
     RM           = /bin/rm -f
     TOUCH        = touch
-    ARCH         = nix
+    ARCH         = nixpkgs
     TOPdir       = ../../..
     INCdir       = $(TOPdir)/include
     BINdir       = $(TOPdir)/bin/$(ARCH)
     LIBdir       = $(TOPdir)/lib/$(ARCH)
     HPLlib       = $(LIBdir)/libhpl.a
-    MAKEFILE
-    cat >> $sourceRoot/hpl/Make.nix << EOF
-    MPdir        = ${mpiDev}
-    MPinc        = -I\$(MPdir)/include
-    MPlib        = -L${lib.getLib mpi}/lib -lmpi
-    LAdir        = ${lapack}/lib
-    LAinc        =
-    LAlib        = -L${blas}/lib -L${lapack}/lib -L${gfortran.cc.lib}/lib -lblas -llapack -lgfortran -lm
-    F2CDEFS      =
-    HPL_INCLUDES = -I\$(INCdir) -I\$(INCdir)/\$(ARCH) \$(LAinc) \$(MPinc)
-    HPL_LIBS     = \$(HPLlib) \$(LAlib) \$(MPlib)
+    MPinc        =
+    MPlib        = -lmpi
+    LAlib        = -lblas -llapack -lgfortran -lm
+    HPL_INCLUDES = -I$(INCdir) -I$(INCdir)/$(ARCH) $(MPinc)
+    HPL_LIBS     = $(HPLlib) $(LAlib) $(MPlib)
     HPL_OPTS     = -DHPL_CALL_CBLAS
-    HPL_DEFS     = \$(F2CDEFS) \$(HPL_OPTS) \$(HPL_INCLUDES)
-    CC           = ${mpiDev}/bin/mpicc
-    CCNOOPT      = \$(HPL_DEFS)
-    CCFLAGS      = \$(HPL_DEFS) -O3
-    LINKER       = ${mpiDev}/bin/mpicc
-    LINKFLAGS    = \$(CCFLAGS)
+    HPL_DEFS     = $(HPL_OPTS) $(HPL_INCLUDES)
+    CC           = mpicc
+    CCNOOPT      = $(HPL_DEFS)
+    CCFLAGS      = $(HPL_DEFS) -O3
+    LINKER       = mpicc
+    LINKFLAGS    = $(CCFLAGS)
     ARCHIVER     = ar
     ARFLAGS      = r
     RANLIB       = ranlib
-    EOF
+    MAKEFILE
   '';
 
-  makeFlags = [ "arch=nix" ];
+  makeFlags = [ "arch=nixpkgs" ];
 
   enableParallelBuilding = true;
 
@@ -97,6 +90,10 @@ stdenv.mkDerivation (finalAttrs: {
       STREAM, PTRANS, RandomAccess, FFT, and communication bandwidth
       and latency benchmarks. It is used to stress test and compare
       high performance computing systems.
+
+      Note: HPCC bundles older versions of these benchmarks (HPL 2.0,
+      MPI-1). For new deployments, consider using the
+      standalone packages.
     '';
     homepage = "https://hpcchallenge.org/";
     license = lib.licenses.bsd3;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^


For new packages please briefly describe the package or provide a link to its homepage.
-->
HPCC is a benchmark suite for high performance computing systems. It includes HPL (High Performance Linpack), DGEMM, STREAM, PTRANS, RandomAccess, FFT, and b_eff. [homepage](https://www.hpcchallenge.org/hpcc/index.html)

The package builds the `hpcc` binary, and adds an example `hpccinf.txt` configuration file.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
