### PR TITLE
utsushi: remove boost_system from autoconfig

### DIFF
--- a/pkgs/by-name/ut/utsushi/package.nix
+++ b/pkgs/by-name/ut/utsushi/package.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitweb.gentoo.org/repo/gentoo.git/plain/media-gfx/iscan/files/iscan-3.65.0-sane-backends-1.1.patch?id=dec60bb6900d6ebdaaa6aa1dcb845b30b739f9b5";
       sha256 = "sha256-AmMZ+/lrUMR7IU+S8MEn0Ji5pqOiD6izFJBsJ0tCCCw=";
     })
+    # original source: https://aur.archlinux.org/cgit/aur.git/plain/remove-boost-system.patch?h=imagescan&id=78b5d1fac2599ca7ef7d6e2c2a632e2ee70ed5c0
+    ./remove-boost.system.patch
   ];
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ut/utsushi/remove-boost.system.patch
+++ b/pkgs/by-name/ut/utsushi/remove-boost.system.patch
@@ -1,0 +1,31 @@
+diff --git a/configure.ac.original b/configure.ac
+index 8997eb9..8613429 100644
++++ b/configure.ac
+--- a/configure.ac.original
+@@ -245,8 +245,7 @@ AM_CONDITIONAL([with_static_enabled], [test xyes = x$enable_static])
+                                 dnl  cross-platform C++ extensions
+ AS_IF([test xyes != x$with_included_boost],
+   [AX_BOOST_BASE([1.49.0],
+-     [AX_BOOST_SYSTEM
+-      AX_BOOST_FILESYSTEM
++     [AX_BOOST_FILESYSTEM
+       AX_BOOST_IOSTREAMS
+       AX_BOOST_PROGRAM_OPTIONS
+       AS_IF([test $__cplusplus -lt 201103], [AX_BOOST_REGEX])
+@@ -270,7 +269,6 @@ AS_IF([test xyes = x$with_included_boost],
+       aux_dir=`echo $ac_aux_dir | sed "s,^$srcdir/,,"`
+       BOOST_CPPFLAGS="-I\$(top_srcdir)/$aux_dir/boost"
+       BOOST_LDFLAGS="-L\$(top_builddir)/$aux_dir/boost/lib"
+-      BOOST_SYSTEM_LIB=-lboost_system
+       BOOST_FILESYSTEM_LIB=-lboost_filesystem
+       BOOST_IOSTREAMS_LIB=-lboost_iostreams
+       BOOST_PROGRAM_OPTIONS_LIB=-lboost_program_options
+@@ -324,7 +322,7 @@ AS_IF([test xyes = x$with_boost_unit_test_framework],
+ #  Work around implicit dependencies on Boost.System through the use
+ #  of Boost.Filesystem in several locations.
+ 
+-BOOST_FILESYSTEM_LIB="$BOOST_FILESYSTEM_LIB $BOOST_SYSTEM_LIB"
++BOOST_FILESYSTEM_LIB="$BOOST_FILESYSTEM_LIB"
+ 
+                                 dnl  documentation generation tools
+ AC_CHECK_PROGS([DOXYGEN], [doxygen])


### PR DESCRIPTION
applies https://aur.archlinux.org/cgit/aur.git/plain/remove-boost-system.patch?h=imagescan&id=78b5d1fac2599ca7ef7d6e2c2a632e2ee70ed5c0 

the AUR patch is not included directly via fetchpatch as it cannot be applied as is

## Things done


- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
