### PR TITLE
nixos/foot: add option xdg.serverAutostart, don't hardcode package

### DIFF
--- a/nixos/modules/programs/foot/default.nix
+++ b/nixos/modules/programs/foot/default.nix
@@ -48,6 +48,10 @@ in
       };
     };
 
+    xdg = {
+      serverAutostart = lib.mkEnableOption "starting the foot server via xdg-autostart";
+    };
+
     theme = lib.mkOption {
       type = with lib.types; nullOr str;
       default = null;
@@ -74,7 +78,11 @@ in
     environment = {
       systemPackages = [ cfg.package ];
       etc."xdg/foot/foot.ini".source = settingsFormat.generate "foot.ini" cfg.settings;
+
+      etc."xdg/autostart/foot-server.desktop".source =
+        lib.mkIf cfg.xdg.serverAutostart "${cfg.package}/share/applications/foot-server.desktop";
     };
+
     programs = {
       foot.settings.main.include = lib.optionals (cfg.theme != null) [
         "${pkgs.foot.themes}/share/foot/themes/${cfg.theme}"

--- a/nixos/modules/programs/foot/default.nix
+++ b/nixos/modules/programs/foot/default.nix
@@ -85,7 +85,7 @@ in
 
     programs = {
       foot.settings.main.include = lib.optionals (cfg.theme != null) [
-        "${pkgs.foot.themes}/share/foot/themes/${cfg.theme}"
+        "${cfg.package.themes}/share/foot/themes/${cfg.theme}"
       ];
       # https://codeberg.org/dnkl/foot/wiki#user-content-shell-integration
       bash.interactiveShellInit = lib.mkIf cfg.enableBashIntegration ". ${./bashrc} # enable shell integration for foot terminal";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Added a new option into the foot module, which adds the server `.desktop` file into `/etc/xdg/autostart`

On desktops which include xdg-autostart, the server will be avaliable and you can use `footclient` instead of `foot` to save on system resources.
Further explanation (upstream) https://codeberg.org/dnkl/foot#server-daemon-mode

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
