### PR TITLE
osu-micro-benchmarks: init at 7.5.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25222,6 +25222,12 @@
     githubId = 7669898;
     name = "Katharina Fey";
   };
+  spaghetti-stack = {
+    email = "spaghetti_stack@protonmail.com";
+    github = "spaghetti-stack";
+    githubId = 44814450;
+    name = "spaghetti-stack";
+  };
   spalf = {
     email = "tom@tombarrett.xyz";
     name = "tom barrett";

--- a/pkgs/by-name/os/osu-micro-benchmarks/package.nix
+++ b/pkgs/by-name/os/osu-micro-benchmarks/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  mpi,
+}:
+
+let
+  mpiDev = lib.getDev mpi;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "osu-micro-benchmarks";
+  version = "7.5.2";
+
+  src = fetchurl {
+    url = "https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-${finalAttrs.version}.tar.gz";
+    hash = "sha256-YY3j0LESL3OpIpF30toeXNYuQxGQWAy5FfJgWEnLu9w=";
+  };
+
+  nativeBuildInputs = [ mpi ];
+
+  buildInputs = [ mpi ];
+
+  configureFlags = [
+    "CC=${mpiDev}/bin/mpicc"
+    "CXX=${mpiDev}/bin/mpicxx"
+  ];
+
+  enableParallelBuilding = true;
+
+  postInstall = ''
+    mkdir -p $out/bin
+    find $out/libexec -name 'osu_*' -type f -executable | while read -r f; do
+      ln -s "$f" "$out/bin/"
+    done
+  '';
+
+  meta = {
+    description = "OSU Micro-Benchmarks for MPI";
+    longDescription = ''
+      The OSU microbenchmark suite is a collection of independent message passing interface (MPI) performance
+      benchmarks. It includes performance measures such as latency, bandwidth, and host overhead.
+
+       Common benchmarks:
+       - osu_latency: Point-to-point latency
+       - osu_bw: Point-to-point bandwidth
+       - osu_bibw: Bidirectional bandwidth
+       - osu_allreduce: Collective allreduce
+       - osu_alltoall: Collective all-to-all
+    '';
+    homepage = "https://mvapich.cse.ohio-state.edu/benchmarks/";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ spaghetti-stack ];
+    mainProgram = "osu_latency";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The [OSU microbenchmark](https://mvapich.cse.ohio-state.edu/benchmarks/) suite is a collection of independent message passing interface (MPI) performance benchmarks. It includes measures such as latency, bandwidth, and host overhead. 

OSU is included in MVAPICH, added to nixpkgs with #125267 , but this package offers an independent version that can run with other MPI implementations such as OpenMPI and MPICH.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
