### PR TITLE
mqtt-exporter: fix build using newer prometheus-client

### DIFF
--- a/pkgs/by-name/mq/mqtt-exporter/package.nix
+++ b/pkgs/by-name/mq/mqtt-exporter/package.nix
@@ -23,6 +23,11 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
       url = "https://github.com/kpetremann/mqtt-exporter/commit/53f5f31b28cb5aeec1c8d0bb7d1aea56f036082e.diff";
       hash = "sha256-LS+kO6bHofNQxk9o+ExsJnaecwfY/40S0MIJwpJxCAI=";
     })
+    (fetchpatch {
+      name = "updated prometheus-client from 0.22.1 to 0.24.1";
+      url = "https://patch-diff.githubusercontent.com/raw/kpetremann/mqtt-exporter/pull/130.diff";
+      hash = "sha256-9xdZ4HCVfi64HawcyfI/nlg0l5Npl+qbAaW8l/VhFO0=";
+    })
   ];
 
   build-system = with python3.pkgs; [ setuptools ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Solves the build issue reported in https://github.com/NixOS/nixpkgs/issues/493580 by picking up the changes I proposed upstream in https://github.com/kpetremann/mqtt-exporter/pull/130

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
