### PR TITLE
python3Packages.inscriptis: fix build-system

### DIFF
--- a/pkgs/development/python-modules/inscriptis/default.nix
+++ b/pkgs/development/python-modules/inscriptis/default.nix
@@ -2,11 +2,12 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  poetry-core,
+  hatchling,
   lxml,
   fastapi,
   httpx,
   pytestCheckHook,
+  pytest-cov-stub,
   requests,
 }:
 
@@ -22,7 +23,7 @@ buildPythonPackage rec {
     hash = "sha256-m1LZiGu79I9fMQXtL1MuzHxUd6KSwuc87Edkt9sp0DE=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     lxml
@@ -33,7 +34,10 @@ buildPythonPackage rec {
     fastapi
     httpx
     pytestCheckHook
+    pytest-cov-stub
   ];
+
+  pythonRelaxDeps = [ "lxml" ];
 
   pythonImportsCheck = [ "inscriptis" ];
 


### PR DESCRIPTION
Fix broken build, see https://hydra.nixos.org/build/322182516

Successful nixpkgs-review depends on fix provided by #493714.

Part of fixes for changedetection-io build failure.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
