### PR TITLE
ncps: 0.9.1 -> 0.9.2

### DIFF
--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -3,7 +3,6 @@
   curl,
   dbmate,
   fetchFromGitHub,
-  go,
   jq,
   lib,
   makeWrapper,
@@ -29,15 +28,6 @@ buildGoModule (finalAttrs: {
     tag = "v${finalAttrs.version}";
     hash = "sha256-cu7fgzQTpo8aLpK0/kJ3xcCVFCmFMQ6RKwUWW5Zwu6s=";
   };
-
-  # XXX: ncps is built with Go 1.25.6 that is available in release-25.11 but
-  # master is currently still using 1.25.5 (update waiting in the
-  # staging/staging-next branches.) This is a workaround for this issue and
-  # will automatically becomes no-op once Go is updated.
-  preBuild = lib.optionalString (go.version == "1.25.5") ''
-    sed -e 's:go 1.25.6:go 1.25.5:g' -i go.mod
-    sed -e 's:go 1.25.6:go 1.25.5:g' -i nix/dbmate-wrapper/src/go.mod
-  '';
 
   vendorHash = "sha256-QZikr0kE/kvnI4RG02lxVpG4teTg3Uo68st9xLlbfm0=";
 
@@ -111,14 +101,6 @@ buildGoModule (finalAttrs: {
       inherit (finalAttrs) version;
 
       src = "${finalAttrs.src}/nix/dbmate-wrapper/src";
-
-      # XXX: ncps is built with Go 1.25.6 that is available in release-25.11 but
-      # master is currently still using 1.25.5 (update waiting in the
-      # staging/staging-next branches.) This is a workaround for this issue and
-      # will automatically becomes no-op once Go is updated.
-      preBuild = lib.optionalString (go.version == "1.25.5") ''
-        sed -e 's:go 1.25.6:go 1.25.5:g' -i go.mod
-      '';
 
       vendorHash = null;
 

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -20,16 +20,16 @@
 
 buildGoModule (finalAttrs: {
   pname = "ncps";
-  version = "0.9.1";
+  version = "0.9.2";
 
   src = fetchFromGitHub {
     owner = "kalbasit";
     repo = "ncps";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cu7fgzQTpo8aLpK0/kJ3xcCVFCmFMQ6RKwUWW5Zwu6s=";
+    hash = "sha256-LRabKv+4xYQn2XH4AIacFkn3ewUd2S3UlVWCA6MUweU=";
   };
 
-  vendorHash = "sha256-QZikr0kE/kvnI4RG02lxVpG4teTg3Uo68st9xLlbfm0=";
+  vendorHash = "sha256-PpHSkD7+csPfUXoYRuKhBm1iBtTSwJhOxuW/4ayv9hY=";
 
   ldflags = [
     "-X github.com/kalbasit/ncps/pkg/ncps.Version=v${finalAttrs.version}"


### PR DESCRIPTION
https://github.com/kalbasit/ncps/releases/tag/v0.9.2

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
