### PR TITLE
daggerfall-unity: Add missing zlib build dependency

### DIFF
--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -6,14 +6,14 @@
   fetchzip,
   lib,
   libGL,
-  libxscrnsaver,
+  libpulseaudio,
+  libudev0-shim,
   libxcursor,
   libxi,
   libxinerama,
   libxrandr,
+  libxscrnsaver,
   libxxf86vm,
-  libpulseaudio,
-  libudev0-shim,
   makeDesktopItem,
   nix-update-script,
   stdenv,
@@ -57,14 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     alsa-lib
     libGL
-    libxscrnsaver
+    libpulseaudio
+    libudev0-shim
     libxcursor
     libxi
     libxinerama
     libxrandr
+    libxscrnsaver
     libxxf86vm
-    libpulseaudio
-    libudev0-shim
     vulkan-loader
     zlib
   ];

--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -18,6 +18,7 @@
   nix-update-script,
   stdenv,
   vulkan-loader,
+  zlib,
   pname ? "daggerfall-unity",
   includeUnfree ? false,
 }:
@@ -65,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     libpulseaudio
     libudev0-shim
     vulkan-loader
+    zlib
   ];
 
   strictDeps = true;


### PR DESCRIPTION
Closes #493611:

```console
❯ nix-build --attr daggerfall-unity && NIXPKGS_ALLOW_UNFREE=1 nix-build --attr daggerfall-unity-unfree
/nix/store/f2iyahgnaa5gar1m3h2jwyhb5nm56457-daggerfall-unity-1.1.1
/nix/store/sdl7yhwwcfkpaxqxk6680q9qgspyqnx5-daggerfall-unity-unfree-1.1.1
```

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
