### PR TITLE
libopusenc: 0.2.1 -> 0.3

### DIFF
--- a/pkgs/by-name/li/libopusenc/package.nix
+++ b/pkgs/by-name/li/libopusenc/package.nix
@@ -1,35 +1,52 @@
 {
   lib,
   stdenv,
-  fetchurl,
   pkg-config,
   libopus,
+  testers,
+  autoreconfHook,
+  fetchFromGitLab,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libopusenc";
-  version = "0.2.1";
+  version = "0.3";
 
-  src = fetchurl {
-    url = "mirror://mozilla/opus/libopusenc-${finalAttrs.version}.tar.gz";
-    sha256 = "1ffb0vhlymlsq70pxsjj0ksz77yfm2x0a1x8q50kxmnkm1hxp642";
+  src = fetchFromGitLab {
+    domain = "gitlab.xiph.org";
+    owner = "xiph";
+    repo = "libopusenc";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-n4wmIUyCNPpgHhyRpv4Xpw292M6XRFhQtuY77x6+7JA=";
   };
+
+  postPatch = ''
+    echo PACKAGE_VERSION="${finalAttrs.version}" > ./package_version
+  '';
 
   outputs = [
     "out"
     "dev"
+    "doc"
   ];
 
   doCheck = true;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
   buildInputs = [ libopus ];
+
+  passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
 
   meta = {
     description = "Library for encoding .opus audio files and live streams";
     license = lib.licenses.bsd3;
     homepage = "https://www.opus-codec.org/";
     platforms = lib.platforms.unix;
+    pkgConfigModules = [ "libopusenc" ];
     maintainers = with lib.maintainers; [ pmiddend ];
   };
 })


### PR DESCRIPTION
fixes #493680

https://gitlab.xiph.org/xiph/libopusenc/-/releases/v0.3

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
