### PR TITLE
sage: unbreak after staging-next merge

### DIFF
--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -96,6 +96,41 @@ stdenv.mkDerivation rec {
       url = "https://github.com/sagemath/sage/commit/9bd5304f1a222e215d7006a04854ff66616748bf.patch?full_index=1";
       hash = "sha256-7bgouXV3pM20IX5PM24ZpJWOBlZjQksGtjopgouEbyg=";
     })
+
+    # https://github.com/sagemath/sage/pull/41078, landed in 10.8.beta8
+    (fetchpatch2 {
+      name = "docutils-0.22-update.patch";
+      url = "https://github.com/sagemath/sage/commit/e206e205a6841cc5251dfb37fdd36ed29345fba4.patch?full_index=1";
+      hash = "sha256-Y8DqwGBkRnL+6ejZibCmkEJ7q/Qs0wD2KGmAefVdd94=";
+    })
+
+    # https://github.com/sagemath/sage/pull/41342, landed in 10.9.beta1
+    (fetchpatch2 {
+      name = "numpy-2.4-update.patch";
+      url = "https://github.com/sagemath/sage/commit/97ceea842a39fa2f2e9098daae2738a2f2765b9e.patch?full_index=1";
+      hash = "sha256-/Tk3tIy0syOjaNRMCyot6kma3jj4288QJ3zypS79jZo=";
+    })
+
+    # https://github.com/sagemath/sage/pull/41346, landed in 10.9.beta2
+    (fetchpatch2 {
+      name = "ipython-9.8-updte.patch";
+      url = "https://github.com/sagemath/sage/commit/380949e6eeda80cca6e5dd971e2c6f367647a863.patch?full_index=1";
+      hash = "sha256-e4zmgfHrenOixgbUS1uFHzftmwNGGoSb7yFhYmqT0yc=";
+    })
+
+    # https://github.com/sagemath/sage/pull/41395, landed in 10.9.beta2
+    (fetchpatch2 {
+      name = "pyparsing-3.3-update.patch";
+      url = "https://github.com/sagemath/sage/commit/1b5a5dd78b5dcb4b3c7d1f94461ddbc647c5679f.patch?full_index=1";
+      hash = "sha256-kFXg2O3IpwaOwAaNIy6Wscx8/XSDWXrqAXS2ZJgdqsg=";
+    })
+
+    # https://github.com/sagemath/sage/pull/41433, landed in 10.9.beta3
+    (fetchpatch2 {
+      name = "scipy-1.17-update.patch";
+      url = "https://github.com/sagemath/sage/commit/ff58afe27c80c067a8965e1d70966e25d0355aaf.patch?full_index=1";
+      hash = "sha256-gWoXwhUVXL2RSVLPRbxtlP0LCSEkJ9z1PJ1wKLXef1k=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;

--- a/pkgs/by-name/sa/sage/sagelib.nix
+++ b/pkgs/by-name/sa/sage/sagelib.nix
@@ -106,7 +106,7 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
-    "networkx"
+    "sphinx"
   ];
 
   buildInputs = [

--- a/pkgs/development/python-modules/jupyter-sphinx/default.nix
+++ b/pkgs/development/python-modules/jupyter-sphinx/default.nix
@@ -42,8 +42,13 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTests = [
-    # https://github.com/jupyter/jupyter-sphinx/issues/280"
+    # https://github.com/jupyter/jupyter-sphinx/issues/280
     "test_builder_priority"
+  ];
+
+  pytestFlags = [
+    # https://github.com/jupyter/jupyter-sphinx/issues/287
+    "-Wignore::sphinx.deprecation.RemovedInSphinx11Warning"
   ];
 
   preCheck = ''

--- a/pkgs/development/python-modules/rpy2-robjects/default.nix
+++ b/pkgs/development/python-modules/rpy2-robjects/default.nix
@@ -53,6 +53,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  pytestFlags = [
+    # https://github.com/rpy2/rpy2/issues/1218
+    "-Wignore::pytest.PytestRemovedIn9Warning"
+  ];
+
   meta = {
     homepage = "https://rpy2.github.io/";
     description = "Python interface to R";


### PR DESCRIPTION
#488406 contained various package updates which introduced new warnings. Fixes #493375.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
