### PR TITLE
vaultwarden: 1.35.3 -> 1.35.4, vaultwarden.webvault: 2026.1.0+0 -> 2026.1.1+0

### DIFF
--- a/nixos/tests/vaultwarden.nix
+++ b/nixos/tests/vaultwarden.nix
@@ -30,6 +30,7 @@ let
               libraries = [ pkgs.python3Packages.selenium ];
               flakeIgnore = [ "E501" ];
             }
+            # python
             ''
 
               from selenium.webdriver.common.by import By
@@ -79,6 +80,13 @@ let
               driver.find_element(By.XPATH, "//button[contains(., 'Create account')]").click()
 
               wait.until_not(EC.title_contains("Set a strong password"))
+
+              wait.until_not(EC.title_contains("Join organization"))
+
+              # NOTE: When testing this locally, the extensions must not be installed, otherwise this screen does not appear
+              click_when_unobstructed((By.XPATH, "//button[contains(., 'Add it later')]"))
+
+              click_when_unobstructed((By.XPATH, "//a[contains(., 'Skip to web app')]"))
 
               click_when_unobstructed((By.XPATH, "//button[contains(., 'New item')]"))
 
@@ -205,7 +213,7 @@ let
             testScript
           else
             ''
-              import json
+              # import json
 
               start_all()
               server.wait_for_unit("vaultwarden.service")
@@ -222,18 +230,20 @@ let
               with subtest("use the web interface to sign up, log in, and save a password"):
                   server.succeed("PYTHONUNBUFFERED=1 systemd-cat -t test-runner test-runner")
 
-              with subtest("log in with the cli"):
-                  key = client.succeed(
-                      "bw --nointeraction --raw login ${userEmail} ${userPassword}"
-                  ).strip()
+              # Upstreams sees offline usage as a new feature...
+              # https://github.com/bitwarden/clients/issues/18110
+              # with subtest("log in with the cli"):
+              #     key = client.succeed(
+              #         "bw --nointeraction --raw login ${userEmail} ${userPassword}"
+              #     ).strip()
 
-              with subtest("sync with the cli"):
-                  client.succeed(f"bw --nointeraction --raw --session {key} sync -f")
+              # with subtest("sync with the cli"):
+              #     client.succeed(f"bw --nointeraction --raw --session {key} sync -f")
 
-              with subtest("get the password with the cli"):
-                  output = json.loads(client.succeed(f"bw --nointeraction --raw --session {key} list items"))
+              # with subtest("get the password with the cli"):
+              #     output = json.loads(client.succeed(f"bw --nointeraction --raw --session {key} list items"))
 
-                  assert output[0]['login']['password'] == "${storedPassword}"
+              #     assert output[0]['login']['password'] == "${storedPassword}"
             '';
       }
     );

--- a/pkgs/by-name/va/vaultwarden/package.nix
+++ b/pkgs/by-name/va/vaultwarden/package.nix
@@ -19,16 +19,16 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "vaultwarden";
-  version = "1.35.3";
+  version = "1.35.4";
 
   src = fetchFromGitHub {
     owner = "dani-garcia";
     repo = "vaultwarden";
     tag = version;
-    hash = "sha256-Q/kMdrKMBB5Tbfi4Cy9ucI6iH8eOr+fzi876+ef2kV4=";
+    hash = "sha256-NphgKTlyVsH42TEGU8unhL798jTQMkS5JyNckKhk8YM=";
   };
 
-  cargoHash = "sha256-3wS8LoFMYhd8uwjDyNfWLMQEK3USotTzTHEJNimG3pM=";
+  cargoHash = "sha256-PkFxHhFrdVB/hfSoT6j87K4IEknl+ZO1omGHrXBWEMg=";
 
   # used for "Server Installed" version in admin panel
   env.VW_VERSION = version;

--- a/pkgs/by-name/va/vaultwarden/webvault.nix
+++ b/pkgs/by-name/va/vaultwarden/webvault.nix
@@ -10,16 +10,16 @@
 
 buildNpmPackage rec {
   pname = "vaultwarden-webvault";
-  version = "2026.1.0+0";
+  version = "2026.1.1+0";
 
   src = fetchFromGitHub {
     owner = "vaultwarden";
     repo = "vw_web_builds";
     tag = "v${version}";
-    hash = "sha256-u0axJFwXZr3iPcDskD6oDfuh3uWjOawoWEYFfSwiN5g=";
+    hash = "sha256-ehL3DDjCav20XJgUR+ED2x0lax4fm1jMZ0rRiqR78a4=";
   };
 
-  npmDepsHash = "sha256-wzndpxxxgc7DfVcriAC7C8OxvhMBcXW6VcY33k0CEdc=";
+  npmDepsHash = "sha256-/S0itw2m2k7GiiwBEzeqFQ8oUYD4yIO4knTTn37qkfA=";
 
   nativeBuildInputs = [
     python3


### PR DESCRIPTION
Backports the changes from #493483 to release-25.11.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
