### PR TITLE
ndlocr-lite-cli: init at 1.2.3

### DIFF
--- a/pkgs/by-name/nd/ndlocr-lite-cli/package.nix
+++ b/pkgs/by-name/nd/ndlocr-lite-cli/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  runCommand,
+  gnugrep,
+  nix-update-script,
+  ndlocr-lite-cli,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ndlocr-lite-cli";
+  version = "1.2.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ndl-lab";
+    repo = "ndlocr-lite";
+    tag = finalAttrs.version;
+    hash = "sha256-OTeOzePLtIjF4T6hsfX7n/K4A6V6zWE+Pmw2h/SXm2k=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  pythonRemoveDeps = [
+    "flet" # Required only for GUI
+  ];
+
+  pythonRelaxDeps = true;
+
+  dependencies = with python3Packages; [
+    dill
+    lxml
+    networkx
+    onnxruntime
+    pillow
+    ordered-set
+    protobuf
+    pyparsing
+    pyyaml
+    tqdm
+    reportlab
+    pypdfium2
+    numpy
+    opencv-python-headless
+  ];
+
+  pythonImportsCheck = [
+    "ocr"
+    "deim"
+    "parseq"
+    "ndl_parser"
+  ];
+
+  # has no tests
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    "$out/bin/ndlocr-lite" --help
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    tests = {
+      sample-ocr =
+        runCommand "${finalAttrs.pname}-sample-ocr-test"
+          {
+            nativeBuildInputs = [
+              ndlocr-lite-cli
+              gnugrep
+            ];
+          }
+          ''
+            basename='digidepo_2531162_0024'
+            ndlocr-lite --sourceimg "${finalAttrs.src}/resource/$basename.jpg" --output ./
+            grep --fixed-strings '5.3' "$basename.txt" | tee "$out"
+          '';
+    };
+
+    updateScript = nix-update-script {
+      # Upstream sometimes marks stable tags as "Pre-release".
+      extraArgs = [ "--use-github-releases" ];
+    };
+  };
+
+  meta = {
+    description = "OCR for Japanese documents";
+    longDescription = ''
+      Lightweight version of NDLOCR. It works without a GPU.
+    '';
+    homepage = "https://github.com/ndl-lab/ndlocr-lite";
+    changelog = "https://github.com/ndl-lab/ndlocr-lite/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.cc-by-40;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "ndlocr-lite";
+    platforms = with lib.platforms; unix ++ windows;
+
+    # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox:
+    # terminate called after throwing an instance of 'onnxruntime::OnnxRuntimeException'
+    broken = with stdenv.hostPlatform; isLinux && isAarch64;
+  };
+})

--- a/pkgs/by-name/nd/ndlocr-lite-cli/package.nix
+++ b/pkgs/by-name/nd/ndlocr-lite-cli/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  runCommand,
+  gnugrep,
+  nix-update-script,
+  ndlocr-lite-cli,
+}:
+
+python3Packages.buildPythonApplication (finalAttrs: {
+  pname = "ndlocr-lite-cli";
+  version = "1.2.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ndl-lab";
+    repo = "ndlocr-lite";
+    tag = finalAttrs.version;
+    hash = "sha256-oYnZEWeYqpvMwyGCQ5YllRkce2wUQYCVoxFTFc3BmQY=";
+  };
+
+  __structuredAttrs = true;
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  pythonRemoveDeps = [
+    "flet" # Required only for GUI
+  ];
+
+  pythonRelaxDeps = true;
+
+  dependencies = with python3Packages; [
+    dill
+    lxml
+    networkx
+    onnxruntime
+    pillow
+    ordered-set
+    protobuf
+    pyparsing
+    pypdf
+    pyyaml
+    tqdm
+    reportlab
+    pypdfium2
+    numpy
+    opencv-python-headless
+  ];
+
+  pythonImportsCheck = [
+    "ocr"
+    "deim"
+    "parseq"
+    "ndl_parser"
+  ];
+
+  # has no tests
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    "$out/bin/ndlocr-lite" --help
+    runHook postInstallCheck
+  '';
+
+  passthru = {
+    tests = {
+      sample-ocr =
+        runCommand "${finalAttrs.pname}-sample-ocr-test"
+          {
+            nativeBuildInputs = [
+              ndlocr-lite-cli
+              gnugrep
+            ];
+          }
+          ''
+            basename='digidepo_2531162_0024'
+            ndlocr-lite --sourceimg "${finalAttrs.src}/resource/$basename.jpg" --output ./
+            grep --fixed-strings '5.3' "$basename.txt" | tee "$out"
+          '';
+    };
+
+    updateScript = nix-update-script {
+      # Upstream sometimes marks stable tags as "Pre-release".
+      extraArgs = [ "--use-github-releases" ];
+    };
+  };
+
+  meta = {
+    description = "OCR for Japanese documents";
+    longDescription = ''
+      Lightweight version of NDLOCR. It works without a GPU.
+    '';
+    homepage = "https://github.com/ndl-lab/ndlocr-lite";
+    changelog = "https://github.com/ndl-lab/ndlocr-lite/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.cc-by-40;
+    maintainers = with lib.maintainers; [
+      kachick
+    ];
+    mainProgram = "ndlocr-lite";
+    platforms = with lib.platforms; unix ++ windows;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [NDLOCR-Lite](https://github.com/ndl-lab/ndlocr-lite) as a new package. This is a CPU-only variant of [NDLOCR](https://github.com/ndl-lab/ndlocr_cli).

Although upstream provides a GUI, this PR currently only includes the CLI.

I considered using Japanese characters for the test case. But I used only ASCII characters instead, as I am unsure about adding non-English text to this repository.

Related upstream issue: https://github.com/ndl-lab/ndlocr-lite/issues/10

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
