### PR TITLE
nixos/ncps: add options for cdc

### DIFF
--- a/nixos/modules/services/networking/ncps.nix
+++ b/nixos/modules/services/networking/ncps.nix
@@ -66,6 +66,14 @@ let
         max-open-conns = cfg.cache.database.pool.maxOpenConns;
         max-idle-conns = cfg.cache.database.pool.maxIdleConns;
       };
+      cdc = {
+        inherit (cfg.cache.cdc)
+          enabled
+          min
+          avg
+          max
+          ;
+      };
       max-size = cfg.cache.maxSize;
       lru = {
         schedule = cfg.cache.lru.schedule;
@@ -214,6 +222,36 @@ in
           Whether to allow the PUT verb to push narinfo and nar files directly
           to the cache.
         '';
+
+        cdc = {
+          enabled = lib.mkEnableOption ''
+            Whether to enable Content-Defined Chunking (CDC) for deduplication (experimental).
+          '';
+
+          min = lib.mkOption {
+            type = lib.types.ints.u32;
+            default = 16384;
+            description = ''
+              The minimum chunk size for CDC in bytes.
+            '';
+          };
+
+          avg = lib.mkOption {
+            type = lib.types.ints.u32;
+            default = 65536;
+            description = ''
+              The average chunk size for CDC in bytes.
+            '';
+          };
+
+          max = lib.mkOption {
+            type = lib.types.ints.u32;
+            default = 262144;
+            description = ''
+              The maximum chunk size for CDC in bytes.
+            '';
+          };
+        };
 
         hostName = lib.mkOption {
           type = lib.types.str;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1050,6 +1050,10 @@ in
     defaults.services.ncps.cache.storage.local = "/path/to/ncps";
   };
   ncps-ha-pg-redis = runTest ./ncps-ha-pg-redis.nix;
+  ncps-ha-pg-redis-cdc = runTest {
+    imports = [ ./ncps-ha-pg-redis.nix ];
+    defaults.services.ncps.cache.cdc.enabled = true;
+  };
   ndppd = runTest ./ndppd.nix;
   nebula-lighthouse-service = runTest ./nebula-lighthouse-service.nix;
   nebula.connectivity = runTest ./nebula/connectivity.nix;

--- a/pkgs/by-name/nc/ncps/package.nix
+++ b/pkgs/by-name/nc/ncps/package.nix
@@ -121,6 +121,7 @@ buildGoModule (finalAttrs: {
         ncps-custom-sqlite-directory
         ncps-custom-storage-local
         ncps-ha-pg-redis
+        ncps-ha-pg-redis-cdc
         ;
     };
 


### PR DESCRIPTION
ncps v0.9 has a new CDC feature. Update the module to expose this feature.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
