### PR TITLE
pkgsStatic.dbus: fix

### DIFF
--- a/pkgs/by-name/db/dbus/package.nix
+++ b/pkgs/by-name/db/dbus/package.nix
@@ -95,6 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   __darwinAllowLocalNetworking = true;
 
+  env = lib.optionalAttrs stdenv.hostPlatform.isStatic {
+    NIX_LDFLAGS = "-lcap-ng";
+  };
+
   mesonFlags = [
     "--libexecdir=${placeholder "out"}/libexec"
     # datadir from which dbus will load files will be managed by the NixOS module:


### PR DESCRIPTION
Plausibly broken by 4db1e1cf1356bf7569db932fb339efa83657ee5d:

```
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/jp3n4kccjv0zbz50kw3qbrlnfb0mp43d-audit-static-x86_64-unknown-linux-musl-4.1.2-unstable-2025-09-06-lib/lib/libaudit.a(libaudit.o): in function `audit_can_control':
(.text+0x36a8): undefined reference to `capng_save_state'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text+0x36bb): undefined reference to `capng_have_capability'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text+0x36c7): undefined reference to `capng_restore_state'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/jp3n4kccjv0zbz50kw3qbrlnfb0mp43d-audit-static-x86_64-unknown-linux-musl-4.1.2-unstable-2025-09-06-lib/lib/libaudit.a(libaudit.o): in function `audit_can_write':
(.text+0x3838): undefined reference to `capng_save_state'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text+0x384b): undefined reference to `capng_have_capability'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text+0x3857): undefined reference to `capng_restore_state'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: /nix/store/jp3n4kccjv0zbz50kw3qbrlnfb0mp43d-audit-static-x86_64-unknown-linux-musl-4.1.2-unstable-2025-09-06-lib/lib/libaudit.a(libaudit.o): in function `audit_can_read':
(.text+0x3898): undefined reference to `capng_save_state'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text+0x38ab): undefined reference to `capng_have_capability'
/nix/store/6iy5zryd4b8hmwpj9mky2by0ajardffk-x86_64-unknown-linux-musl-binutils-2.44/bin/x86_64-unknown-linux-musl-ld: (.text+0x38b7): undefined reference to `capng_restore_state'
collect2: error: ld returned 1 exit status
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
