### PR TITLE
ungoogled-chromium: 145.0.7632.109-1 -> 145.0.7632.116-1

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -823,7 +823,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "145.0.7632.109",
+    "version": "145.0.7632.116",
     "deps": {
       "depot_tools": {
         "rev": "fb0b652edba70f5c4ac867f3beca9e535f905b4c",
@@ -835,16 +835,16 @@
         "hash": "sha256-SoXVnpCuNee80N4YdsTEHQd3jZNoHOwKVP6O8a67Ym0="
       },
       "ungoogled-patches": {
-        "rev": "145.0.7632.109-1",
-        "hash": "sha256-IKt/88bzppdwewWJpim8JL7u6N42o6W2VygvWd+XdVo="
+        "rev": "145.0.7632.116-1",
+        "hash": "sha256-5rixK6Hp5Czz0I+UISyhi2hPgPhgt+f4JFqd8ERvCV0="
       },
       "npmHash": "sha256-13sgV/5BD7QvDLBAEmoLN5vongw+S5v5znvZcctxhWc="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "61eff07de4f37ac1c6969c91034a447ef6cd394d",
-        "hash": "sha256-b498JyyvsN/+0Gqjdrq+eT1HW54/ayEENRHa1Sw69Xw=",
+        "rev": "7d28075c6a9ba147e6df449209001258bb82a122",
+        "hash": "sha256-ljqK297kBByDGHKwH+yz6XcLO7l0+GDIrR0Hznh6X8c=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -954,8 +954,8 @@
       },
       "src/third_party/dawn": {
         "url": "https://dawn.googlesource.com/dawn.git",
-        "rev": "d9f5a980bb5a4baeb7d9c1fef89a39789a6cd9fb",
-        "hash": "sha256-DaNsRQm9bR2lfbiP6vWr2R7KD8mYWOaJ72VJyrUkJvI="
+        "rev": "3df397b5b33f950da92787d9a6ac655e0601bca2",
+        "hash": "sha256-UAKnxnEScteAj+14i56K6VA34JM+J4KCpG4HbY2bT4s="
       },
       "src/third_party/dawn/third_party/glfw": {
         "url": "https://chromium.googlesource.com/external/github.com/glfw/glfw",
@@ -1639,8 +1639,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "a8b42c8fae7c7f1ce4e32b08ee61c22775185c01",
-        "hash": "sha256-HZ4JbSoMNVqUrCWoxk0/AxzlcpMgKhe/HJ7DGeTeE9M="
+        "rev": "ce21eb288e9b86bf6a294968a5113a2646d7b8dd",
+        "hash": "sha256-ayAzZOrJYOLqGunDs9t/x6HBUy32y+0ISjaGkEUK+hk="
       }
     }
   }


### PR DESCRIPTION
Same underlying changes as #493458

https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop_23.html

This update includes 3 security fixes.

CVEs:
CVE-2026-3061 CVE-2026-3062 CVE-2026-3063

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
