### PR TITLE
python3Packages.compressed-tensors: fix build, adopt

### DIFF
--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   setuptools,
@@ -34,6 +35,9 @@ buildPythonPackage (finalAttrs: {
     tag = finalAttrs.version;
     hash = "sha256-XsQRP186ISarMMES3P+ov4t/1KKJdl0tXBrfpjyM3XA=";
   };
+
+  #  RuntimeError("torch.compile is not supported on Python 3.14+")
+  disabled = pythonAtLeast "3.14";
 
   postPatch = ''
     substituteInPlace pyproject.toml \

--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -1,14 +1,17 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
 
   # build-system
   setuptools,
   setuptools-scm,
+  llvmPackages,
 
   # dependencies
   frozendict,
+  loguru,
   pydantic,
   torch,
   transformers,
@@ -42,8 +45,11 @@ buildPythonPackage rec {
     setuptools-scm
   ];
 
+  buildInputs = lib.optional stdenv.cc.isClang llvmPackages.openmp;
+
   dependencies = [
     frozendict
+    loguru
     pydantic
     torch
     transformers
@@ -72,11 +78,17 @@ buildPythonPackage rec {
     "test_model_forward_pass"
     "test_save_compressed_model"
     "test_target_prioritization"
+    "test_expand_targets_with_llama_stories"
   ];
 
   disabledTestPaths = [
     # these try to download models from HF Hub
     "tests/test_quantization/lifecycle/test_apply.py"
+    # RuntimeError: The weights trying to be saved contained shared tensors
+    "tests/test_transform/factory/test_serialization.py::test_serialization[True-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[True-random-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[False-hadamard]"
+    "tests/test_transform/factory/test_serialization.py::test_serialization[False-random-hadamard]"
   ];
 
   meta = {

--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -22,7 +22,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "compressed-tensors";
   version = "0.13.0";
   pyproject = true;
@@ -31,7 +31,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "neuralmagic";
     repo = "compressed-tensors";
-    tag = version;
+    tag = finalAttrs.version;
     hash = "sha256-XsQRP186ISarMMES3P+ov4t/1KKJdl0tXBrfpjyM3XA=";
   };
 
@@ -94,8 +94,8 @@ buildPythonPackage rec {
   meta = {
     description = "Safetensors extension to efficiently store sparse quantized tensors on disk";
     homepage = "https://github.com/neuralmagic/compressed-tensors";
-    changelog = "https://github.com/neuralmagic/compressed-tensors/releases/tag/${src.tag}";
+    changelog = "https://github.com/neuralmagic/compressed-tensors/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = [ ];
   };
-}
+})

--- a/pkgs/development/python-modules/compressed-tensors/default.nix
+++ b/pkgs/development/python-modules/compressed-tensors/default.nix
@@ -100,6 +100,6 @@ buildPythonPackage (finalAttrs: {
     homepage = "https://github.com/neuralmagic/compressed-tensors";
     changelog = "https://github.com/neuralmagic/compressed-tensors/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ sarahec ];
   };
 })


### PR DESCRIPTION
1. Added missing dependency
2. Disabled broken tests
3. Migrated to finalAttrs
4. Added self as maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [x] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
