### PR TITLE
red-trul: init at 2.3.13

### DIFF
--- a/pkgs/by-name/fl/flac2mp3/package.nix
+++ b/pkgs/by-name/fl/flac2mp3/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
+  makeWrapper,
+  perl,
+  perlPackages,
+  flac,
+  lame,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "flac2mp3";
+  version = "1.0.1";
+
+  src = fetchFromGitHub {
+    owner = "robinbowes";
+    repo = "flac2mp3";
+    tag = version;
+    hash = "sha256-mzZAlCMQYcKEkeJ0464zE1+F5KwA9IjvAbx6aZVCaxI=";
+  };
+
+  patches = [
+    (fetchpatch {
+      # Fix https://github.com/robinbowes/flac2mp3/issues/58
+      url = "https://github.com/lfence/flac2mp3/commit/cf89d4abe09595299fcced61a42ed423a0186c20.patch";
+      hash = "sha256-XKNF1uxzHL0xGeMeVHro8r4EImf1VSTTt7rH4T4zodc=";
+    })
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ perl ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib
+    cp -r lib/* $out/lib/
+    install -Dm755 flac2mp3.pl $out/bin/flac2mp3
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/flac2mp3 \
+      --prefix PERL5LIB : "$out/lib" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          flac
+          lame
+        ]
+      }"
+  '';
+
+  meta = with lib; {
+    mainProgram = "flac2mp3";
+    description = "Tool to convert audio files from flac to mp3 format including the copying of tags";
+    homepage = "https://github.com/robinbowes/flac2mp3";
+    changelog = "https://github.com/robinbowes/flac2mp3/releases/tag/${src.tag}";
+    license = with lib.licenses; [ gpl3Plus ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+}

--- a/pkgs/by-name/re/red-trul/package.nix
+++ b/pkgs/by-name/re/red-trul/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  flac2mp3,
+  ffmpeg,
+  sox,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "red-trul";
+  version = "2.3.13";
+
+  src = fetchFromGitHub {
+    owner = "lfence";
+    repo = "red-trul";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-t8P59diMwYKaGuPuNajWDmRU0fBNT6yRwMBLIRfUhTk";
+  };
+
+  npmDepsHash = "sha256-BYgNgV0hTkfDByi/86X7ZLcAYKveVDiSKnvUfdjyfHc=";
+  dontNpmBuild = true;
+
+  postPatch = ''
+    substituteInPlace config.js \
+      --replace-fail '|| `''${__dirname}/flac2mp3/flac2mp3.pl`' '|| "${lib.getExe flac2mp3}"'
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/red-trul \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          ffmpeg
+          sox
+        ]
+      }"
+  '';
+
+  meta = {
+    mainProgram = "red-trul";
+    description = "Lightweight utility to transcode FLAC releases";
+    homepage = "https://github.com/lfence/red-trul";
+    changelog = "https://github.com/lfence/red-trul/releases/tag/${finalAttrs.src.tag}";
+    license = with lib.licenses; [ isc ];
+    maintainers = with lib.maintainers; [ lilahummel ];
+  };
+})


### PR DESCRIPTION
red-trul: init at 2.3.13

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
