### PR TITLE
python3Packages.instructor: 1.14.4 -> 1.14.5

### DIFF
--- a/pkgs/development/python-modules/instructor/default.nix
+++ b/pkgs/development/python-modules/instructor/default.nix
@@ -103,6 +103,9 @@ buildPythonPackage (finalAttrs: {
     # pydantic validation mismatch
     "test_control_characters_not_allowed_in_anthropic_json_strict_mode"
     "test_control_characters_allowed_in_anthropic_json_non_strict_mode"
+
+    # Upstream bug: test expects TypeError but code raises ConfigurationError
+    "test_openai_schema_raises_error"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Just a simple version bump. Added one test to be ignored, jsonref now needed in checkPhase. Didn't manually verify anything else than that the package's tests build during checkPhase

## Things done

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
