### PR TITLE
python3Packages.tracerite: enable tests, fix license

### DIFF
--- a/pkgs/development/python-modules/tracerite/default.nix
+++ b/pkgs/development/python-modules/tracerite/default.nix
@@ -43,7 +43,12 @@ buildPythonPackage rec {
     description = "Tracebacks for Humans in Jupyter notebooks";
     homepage = "https://github.com/sanic-org/tracerite";
     changelog = "https://github.com/sanic-org/tracerite/releases/tag/${src.tag}";
-    license = lib.licenses.unlicense;
+    # See https://github.com/sanic-org/tracerite/issues/13
+    license = with lib.licenses; [
+      mit
+      publicDomain
+      unlicense
+    ];
     maintainers = with lib.maintainers; [ p0lyw0lf ];
   };
 }

--- a/pkgs/development/python-modules/tracerite/default.nix
+++ b/pkgs/development/python-modules/tracerite/default.nix
@@ -5,7 +5,6 @@
   hatchling,
   hatch-vcs,
   html5tagger,
-  python,
   pytestCheckHook,
   beautifulsoup4,
   torch,
@@ -31,10 +30,6 @@ buildPythonPackage rec {
   dependencies = [
     html5tagger
   ];
-
-  postInstall = ''
-    cp tracerite/style.css $out/${python.sitePackages}/tracerite
-  '';
 
   nativeCheckInputs = [
     pytestCheckHook

--- a/pkgs/development/python-modules/tracerite/default.nix
+++ b/pkgs/development/python-modules/tracerite/default.nix
@@ -6,6 +6,9 @@
   hatch-vcs,
   html5tagger,
   python,
+  pytestCheckHook,
+  beautifulsoup4,
+  torch,
 }:
 
 buildPythonPackage rec {
@@ -33,8 +36,11 @@ buildPythonPackage rec {
     cp tracerite/style.css $out/${python.sitePackages}/tracerite
   '';
 
-  # no tests
-  doCheck = false;
+  nativeCheckInputs = [
+    pytestCheckHook
+    beautifulsoup4
+    torch
+  ];
 
   pythonImportsCheck = [ "tracerite" ];
 


### PR DESCRIPTION
- Enable tests
- Remove redundant `postInstall` command (`style.css` gets installed automatically)
- Fix license, see https://github.com/sanic-org/tracerite/issues/13 (weird situation)

Split out from https://github.com/NixOS/nixpkgs/pull/479175

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux — `python3{12,13,14}Packages.tracerite`
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
