### PR TITLE
beamPackages.expert: init at 0.1.0-rc.2

### DIFF
--- a/pkgs/development/beam-modules/default.nix
+++ b/pkgs/development/beam-modules/default.nix
@@ -90,6 +90,7 @@ let
       };
 
       elixir-ls = callPackage ./elixir-ls { inherit elixir; };
+      expert = callPackage ./expert { };
 
       lfe = callPackage ../interpreters/lfe { inherit erlang buildRebar3 buildHex; };
 

--- a/pkgs/development/beam-modules/expert/default.nix
+++ b/pkgs/development/beam-modules/expert/default.nix
@@ -1,0 +1,75 @@
+{
+  erlang,
+  fetchFromGitHub,
+  mixRelease,
+  lib,
+  fetchMixDeps,
+}:
+let
+  version = "0.1.0-rc.2";
+
+  src = fetchFromGitHub {
+    owner = "elixir-lang";
+    repo = "expert";
+    tag = "v${version}";
+    hash = "sha256-5BGI0bLGCvYyMT4GNHLalin1jg9UW6qtFC7B8OssHCc=";
+  };
+
+  engineDeps = fetchMixDeps {
+    pname = "mix-deps-expert-engine";
+
+    inherit src version;
+    hash = "sha256-PTyPLyo85N0BltX9oIRhHDGKgmNScb10N129wC8o6Q4=";
+
+    preConfigure = ''
+      cd apps/engine
+    '';
+  };
+in
+mixRelease rec {
+  pname = "expert";
+  inherit src version;
+
+  mixFodDeps = fetchMixDeps {
+    pname = "mix-deps-${pname}";
+    inherit src version;
+    hash = "sha256-T5OSjoglZfQa1lMO2lOZJ7yWoyxf6m33rKGuy4zq2AE=";
+
+    preConfigure = ''
+      cd apps/expert
+    '';
+  };
+
+  mixReleaseName = "plain";
+
+  preConfigure = ''
+    ln -sv ${engineDeps} apps/engine/deps
+
+    cd apps/expert
+  '';
+
+  postInstall = ''
+    mv $out/bin/plain $out/bin/expert
+
+    wrapProgram $out/bin/expert --add-flag "eval" --add-flag "System.no_halt(true); Application.ensure_all_started(:xp_expert)"
+  '';
+
+  removeCookie = false;
+
+  passthru = {
+    inherit engineDeps;
+  };
+
+  meta = {
+    homepage = "https://github.com/elixir-lang/expert";
+    changelog = "https://github.com/elixir-lang/expert/releases/tag/v${version}";
+    description = "Official Elixir Language Server Protocol implementation";
+    longDescription = ''
+      Expert is the official language server implementation for the Elixir programming language.
+    '';
+    license = lib.licenses.asl20;
+    inherit (erlang.meta) platforms;
+    mainProgram = "expert";
+    teams = [ lib.teams.beam ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
