### PR TITLE
python3Packages.termgraph: fix build

### DIFF
--- a/pkgs/development/python-modules/termgraph/default.nix
+++ b/pkgs/development/python-modules/termgraph/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   colorama,
   fetchFromGitHub,
+  hatchling,
   lib,
   pytestCheckHook,
 }:
@@ -9,7 +10,7 @@
 buildPythonPackage rec {
   pname = "termgraph";
   version = "0.7.5";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mkaz";
@@ -17,6 +18,8 @@ buildPythonPackage rec {
     tag = "v${version}";
     hash = "sha256-DptokK79yAfQDuhN2d/HfcaRq//0pF81VkhMfz05Hb0=";
   };
+
+  build-system = [ hatchling ];
 
   propagatedBuildInputs = [ colorama ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

after updating to latest unstable, I got:

```
error: Cannot build '/nix/store/013sqjfjczvrdv8lhvr7xh78chckgbd9-python3.13-termgraph-0.7.5.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/18lkyqabglbq9dvpd1b7v6yjlhk7xl0s-python3.13-termgraph-0.7.5
         /nix/store/z7pqcfavq9ran7gj7401ha65rwx937wn-python3.13-termgraph-0.7.5-dist
       Last 25 log lines:
       > Using pypaInstallPhase
       > Sourcing python-imports-check-hook.sh
       > Using pythonImportsCheckPhase
       > Sourcing python-namespaces-hook
       > Sourcing python-catch-conflicts-hook.sh
       > Sourcing pytest-check-hook
       > Using pytestCheckPhase
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/824yqzsblp1rqs0dv1hyihvhdq2n037g-source
       > source root is source
       > setting SOURCE_DATE_EPOCH to timestamp 315619200 of file "source/tests/test_read_data.py"
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > Executing setuptoolsBuildPhase
       > setup.py build flags: ''
       > Traceback (most recent call last):
       >   File "/build/source/nix_run_setup", line 8, in <module>
       >     exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
       >                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
       >   File "/nix/store/m1fw8l8y9ycxh5dzispbb7cwl6rra14l-python3-3.13.12/lib/python3.13/tokenize.py", line 455, in open
       >     buffer = _builtin_open(filename, 'rb')
       > FileNotFoundError: [Errno 2] No such file or directory: 'setup.py'
       For full logs, run:
         nix log /nix/store/013sqjfjczvrdv8lhvr7xh78chckgbd9-python3.13-termgraph-0.7.5.drv
```

This change fixes the problem by specifying pyproject / hatchling.

@samuela

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
