### PR TITLE
python3Packages.crewai: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/crewai/default.nix
+++ b/pkgs/development/python-modules/crewai/default.nix
@@ -35,6 +35,8 @@
   uv,
 
   # tests
+  a2a-sdk,
+  aiocache,
   pytestCheckHook,
   pytest-asyncio,
   pytest-xdist,
@@ -136,6 +138,12 @@ buildPythonPackage rec {
     "tests/llms/litellm"
     "tests/llms/hooks/test_anthropic_interceptor.py"
     "tests/llms/hooks/test_unsupported_providers.py"
+
+    # a2a integration test requires network (A2A_TEST_ENDPOINT)
+    "tests/a2a/test_a2a_integration.py"
+
+    # Tests requiring missing optional providers + network
+    "tests/llms/test_tool_call_streaming.py"
 
     # Tests requiring network/API access
     "tests/llms/openai"
@@ -381,6 +389,7 @@ buildPythonPackage rec {
     "test_multiple_handlers_for_same_event"
     "test_llm_emits_event_with_lite_agent"
     "test_tools_emits_finished_events"
+    "test_agent_emits_execution_error_event"
     "test_agent_emits_execution_started_and_completed_events"
     "test_crew_emits_end_kickoff_event"
     "test_llm_emits_stream_chunk_events"
@@ -433,6 +442,8 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
+    a2a-sdk
+    aiocache
     pytestCheckHook
     pytest-asyncio
     pytest-xdist


### PR DESCRIPTION
Just disabling few tests to make the package build again. Didn't yet test much more than trying to run `--help` and version and checked that it did output something.

This needs another PR as a dependency: https://github.com/NixOS/nixpkgs/pull/493783

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
