### PR TITLE
python3Packages.srctools: fix build failure due to meson-python & pythoncapi-compat

### DIFF
--- a/pkgs/development/python-modules/srctools/default.nix
+++ b/pkgs/development/python-modules/srctools/default.nix
@@ -25,6 +25,17 @@ buildPythonPackage {
     hash = "sha256-c+NmrTntpNTEI782aoC4bNpoKpWe4cqSAkxpYS5HH30=";
   };
 
+  # TODO remove when https://github.com/python/pythoncapi-compat/pull/169 is merged
+  # and new srctools version is released with fix
+  patches = [
+    ./fix-tests.diff
+  ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "meson-python == 0.18.0" "meson-python >= 0.18.0"
+  '';
+
   build-system = [
     meson
     meson-python

--- a/pkgs/development/python-modules/srctools/fix-tests.diff
+++ b/pkgs/development/python-modules/srctools/fix-tests.diff
@@ -1,0 +1,13 @@
+diff --git a/src/pythoncapi-compat/tests/test_pythoncapi_compat.py b/src/pythoncapi-compat/tests/test_pythoncapi_compat.py
+index 8480415..4137489 100644
+--- a/src/pythoncapi-compat/tests/test_pythoncapi_compat.py
++++ b/src/pythoncapi-compat/tests/test_pythoncapi_compat.py
+@@ -21,7 +21,7 @@ except ImportError:
+     faulthandler = None
+ 
+ # test.utils
+-from utils import run_command, command_stdout
++from .utils import run_command, command_stdout
+ 
+ 
+ # Windows uses MSVC compiler


### PR DESCRIPTION
Fixes: #493634

Build failure caused by two issues:

1. meson-python was updated 0.18.0 -> 0.19.0, while srctools requires meson-python == 0.18.0
2. For some reason, pythoncapi-compat tests are failing - see https://github.com/python/pythoncapi-compat/pull/169

Relaxed deps for meson-python to >= 0.18.0
Patched pythoncapi-compat to fix test import error

Patch can be removed once PR for pythoncapi-compat is merged, and a new srctools release is made with a fixed version of pythoncapi-compat

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
