### PR TITLE
nixos/eintopf: rename service to lauti

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -135,7 +135,7 @@
 
 - [QGroundControl], a ground station support and configuration manager for the PX4 and APM Flight Stacks. Available as [programs.qgroundcontrol](options.html#opt-programs.qgroundcontrol.enable).
 
-- [Eintopf](https://eintopf.info), a community event and calendar web application. Available as [services.eintopf](options.html#opt-services.eintopf.enable).
+- [Eintopf](https://eintopf.info), a community event and calendar web application. Available as `services.eintopf`.
 
 - [`pay-respects`](https://codeberg.org/iff/pay-respects), a terminal command correction program, alternative to `thefuck`, written in Rust. Available as [programs.pay-respects](options.html#opt-programs.pay-respects).
 

--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -90,6 +90,8 @@ of pulling the upstream container image from Docker Hub. If you want the old beh
   - `systemd.services.stalwart` owned by `stalwart:stalwart`. The `user` and `group` are configurable via `services.stalwart.user` and `services.stalwart.group`, respectively. By default, if `stateVersion` is older than `26.05`, will fallback to legacy value of `stalwart-mail` for both `user` and `group`.
   - Default value for `services.stalwart.dataDir` has changed to `/var/lib/stalwart`. If `stateVersion` is older than `26.05`, will fallback to legacy value of `/var/lib/stalwart-mail`.
 
+- `services.eintopf` has been renamed to `services.lauti` to align with upstream re-brand as a community online calendar.
+
 - `services.oauth2-proxy.clientSecret` and `services.oauth2-proxy.cookie.secret` have been replaced with `services.oauth2-proxy.clientSecretFile` and `services.oauth2-proxy.cookie.secretFile` respectively. This was done to ensure secrets don't get made world-readable.
 
 - Ethercalc and its associated module have been removed, as the package is unmaintained and cannot be installed from source with npm now.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1620,7 +1620,6 @@
   ./services/web-apps/dolibarr.nix
   ./services/web-apps/drupal.nix
   ./services/web-apps/echoip.nix
-  ./services/web-apps/eintopf.nix
   ./services/web-apps/engelsystem.nix
   ./services/web-apps/ente.nix
   ./services/web-apps/fediwall.nix
@@ -1675,6 +1674,7 @@
   ./services/web-apps/lanraragi.nix
   ./services/web-apps/lasuite-docs.nix
   ./services/web-apps/lasuite-meet.nix
+  ./services/web-apps/lauti.nix
   ./services/web-apps/lemmy.nix
   ./services/web-apps/librechat.nix
   ./services/web-apps/librespeed.nix

--- a/nixos/modules/services/web-apps/lauti.nix
+++ b/nixos/modules/services/web-apps/lauti.nix
@@ -9,13 +9,30 @@ with lib;
 
 let
 
-  cfg = config.services.eintopf;
+  cfg = config.services.lauti;
+  useLegacyDefault = lib.versionOlder config.system.stateVersion "26.05";
+  default = if useLegacyDefault then "eintopf" else "lauti";
 
 in
 {
-  options.services.eintopf = {
 
-    enable = mkEnableOption "Lauti (Eintopf) community event calendar web app";
+  imports = [
+    # since 0.12.0 (2025-05-26) release, upstream re-branded project to 'stalwart' due to inclusion of collaboration features (CalDAV, CardDAV, and WebDAV)
+    #  https://github.com/stalwartlabs/stalwart/releases/tag/v0.12.0
+    (lib.mkRenamedOptionModule [ "services" "eintopf" ] [ "services" "lauti" ])
+  ];
+
+  options.services.lauti = {
+
+    enable = mkEnableOption "Lauti community event calendar web app";
+
+    dataDir = lib.mkOption {
+      type = lib.types.path;
+      default = if useLegacyDefault then "/var/lib/eintopf" else "/var/lib/lauti";
+      description = ''
+        Data directory for Lauti
+      '';
+    };
 
     settings = mkOption {
       type = types.attrsOf types.str;
@@ -27,9 +44,9 @@ in
       '';
       example = literalExpression ''
         {
-          EINTOPF_ADDR = ":1234";
-          EINTOPF_ADMIN_EMAIL = "admin@example.org";
-          EINTOPF_TIMEZONE = "Europe/Berlin";
+          LAUTI_ADDR = ":1234";
+          LAUTI_ADMIN_EMAIL = "admin@example.org";
+          LAUTI_TIMEZONE = "Europe/Berlin";
         }
       '';
     };
@@ -47,7 +64,7 @@ in
 
   config = mkIf cfg.enable {
 
-    systemd.services.eintopf = {
+    systemd.services.lauti = {
       description = "Community event calendar web app";
       wantedBy = [ "multi-user.target" ];
       after = [ "network-online.target" ];
@@ -55,8 +72,8 @@ in
       environment = cfg.settings;
       serviceConfig = {
         ExecStart = lib.getExe pkgs.lauti;
-        WorkingDirectory = "/var/lib/eintopf";
-        StateDirectory = "eintopf";
+        WorkingDirectory = cfg.dataDir;
+        StateDirectory = default;
         EnvironmentFile = [ cfg.secrets ];
 
         # hardening

--- a/nixos/tests/lauti.nix
+++ b/nixos/tests/lauti.nix
@@ -5,20 +5,20 @@
 }:
 
 {
-  name = "eintopf";
+  name = "lauti";
   meta.maintainers = with lib.maintainers; [ onny ];
 
   nodes = {
-    eintopf = {
-      services.eintopf.enable = true;
+    lauti = {
+      services.lauti.enable = true;
     };
   };
 
   testScript = ''
-    eintopf.start
-    eintopf.wait_for_unit("eintopf.service")
-    eintopf.wait_for_open_port(3333)
-    eintopf.succeed("curl -sSfL http://eintopf:3333 | grep 'No events available'")
+    lauti.start
+    lauti.wait_for_unit("lauti.service")
+    lauti.wait_for_open_port(3333)
+    lauti.succeed("curl -sSfL http://lauti:3333 | grep 'No events available'")
   '';
 
 }


### PR DESCRIPTION
The eintopf package already got renamed to lauti, now renaming the service itself too

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [x] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
