### PR TITLE
sgfutils: fix `gcc-15` build

### DIFF
--- a/pkgs/by-name/sg/sgfutils/gcc-15.patch
+++ b/pkgs/by-name/sg/sgfutils/gcc-15.patch
@@ -1,0 +1,26 @@
+Generated as:
+$ curl -L https://github.com/yangboz/sgfutils/pull/3.diff > gcc-15.patch
+
+Fix `gcc-15` build failure related to `c23` changes.
+--- a/gib2sgf.c
++++ b/gib2sgf.c
+@@ -433,7 +433,7 @@ static void stoline(char *buf) {
+ 	readmove(buf);
+ }
+ 
+-static void (*inputline[])() = {
++static void (*inputline[])(char*) = {
+ 	inline0, inline1, iniline, stoline
+ };
+ 
+--- a/sgfinfo.c
++++ b/sgfinfo.c
+@@ -940,7 +940,7 @@ void report_on_single_game() {
+ 	if (optM) {
+ 		int imin, imax;
+ 		void (*fns[3])(int) = { outmove, outmovec, outmovex };
+-		void (*outmovefn)();
++		void (*outmovefn)(int);
+ 
+ 		/* 1..3 moves / 4..6 init / 7..9 both */
+ 		imin = ((optM < 4) ? initct : 0);

--- a/pkgs/by-name/sg/sgfutils/package.nix
+++ b/pkgs/by-name/sg/sgfutils/package.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation {
     rev = "11ab171c46cc16cc71ac6fc901d38ea88d6532a4";
     hash = "sha256-KWYgTxz32WK3MKouj1WAJtZmleKt5giCpzQPwfWruZQ=";
   };
+  patches = [
+    # FIx gcc-15 build failure: https://github.com/yangboz/sgfutils/pull/3
+    ./gcc-15.patch
+  ];
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
   buildPhase = ''


### PR DESCRIPTION
Without the chnage the build fails on `master` as:

```
sgfinfo.c: In function 'report_on_single_game':
sgfinfo.c:948:27: error: assignment to 'void (*)(void)' from incompatible pointer type 'void (*)(int)' [-Wincompatible-pointer-types]
  948 |                 outmovefn = fns[(optM-1) % 3];
      |                           ^
sgfinfo.c:952:25: error: too many arguments to function 'outmovefn'; expected 0, have 1
  952 |                         outmovefn(i);
      |                         ^~~~~~~~~ ~
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
