### PR TITLE
nixos-rebuild-ng: make --diff works with 'dry-activate'

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -265,22 +265,12 @@ def parse_args(
     if args.no_build_nix:
         parser_warn("--no-build-nix is deprecated, we do not build nix anymore")
 
-    if args.diff and args.action not in (
-        # case for calling build_and_activate_system
-        # except excluding DRY_BUILD and DRY_ACTIVATE,
-        # in which --diff is uniquely a no-op
-        Action.SWITCH.value,
-        Action.BOOT.value,
-        Action.TEST.value,
-        Action.BUILD.value,
-        Action.BUILD_IMAGE.value,
-        Action.BUILD_VM.value,
-        Action.BUILD_VM_WITH_BOOTLOADER.value,
-    ):
+    if args.action == Action.DRY_BUILD.value and args.diff:
         parser_warn(f"--diff is a no-op with '{args.action}'")
+        args.diff = False
 
     if args.action == Action.EDIT.value and (args.file or args.attr):
-        parser.error("--file and --attr are not supported with 'edit'")
+        parser.error(f"--file and --attr are not supported with '{args.action}'")
 
     if (args.target_host or args.build_host) and args.action not in (
         Action.SWITCH.value,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -265,7 +265,16 @@ def parse_args(
     if args.no_build_nix:
         parser_warn("--no-build-nix is deprecated, we do not build nix anymore")
 
-    if args.action == Action.DRY_BUILD.value and args.diff:
+    if (
+        args.action
+        in (
+            Action.DRY_BUILD.value,  # --diff breaks dry-build
+            Action.EDIT.value,
+            Action.LIST_GENERATIONS.value,
+            Action.REPL.value,
+        )
+        and args.diff
+    ):
         parser_warn(f"--diff is a no-op with '{args.action}'")
         args.diff = False
 


### PR DESCRIPTION
Also make it actually a no-op with dry-build, since it breaks this specific command.

```
$ sudo nixos-rebuild dry-activate --diff
nixos-rebuild: warning: --diff is a no-op with 'dry-activate'
building the system configuration...
<<< /nix/store/qiy7vnwffy1s095wgpsmsjm4aik0wys8-nixos-system-blackrockshooter-nixos-26.05.20260217.0182a36
>>> /nix/store/sd9ys9ind45aqg5va3fxph0fmd36v21z-nixos-system-blackrockshooter-nixos-26.05.20260223.2fc6539
<diff>
Checking switch inhibitors... done
would stop the following units: accounts-daemon.service, cron.service, earlyoom.service, flood.service, fwupd.service, inputplumber.service, jovian-updater-logo-helper.service, kmod-static-nodes.service, lactd.service, logrotate-checkconf.service, ModemManager.service, NetworkManager.service, nscd.service, ollama.service, plex.service, plymouth-quit-wait.service, plymouth-read-write.service, power-profiles-daemon.service, rtkit-daemon.service, rtorrent.service, scx.service, smartd.service, steamos-manager.service, systemd-ask-password-plymouth.service, systemd-binfmt.service, systemd-fsck-root.service, systemd-machined.service, systemd-modules-load.service, systemd-oomd.service, systemd-oomd.socket, systemd-sysctl.service, systemd-timesyncd.service, systemd-vconsole-setup.service, systemd-zram-setup@zram0.service, udisks2.service, upower.service
would NOT stop the following changed units: greetd.service, libvirt-guests.service, libvirtd.service, plymouth-start.service, post-boot.service, systemd-fsck@dev-disk-by\x2dpartlabel-disk\x2dmain\x2dESP.service, systemd-journal-flush.service, systemd-logind.service, systemd-random-seed.service, systemd-remount-fs.service, systemd-update-utmp.service, systemd-user-sessions.service, user-runtime-dir@1000.service, user@1000.service
would activate the configuration...
would restart systemd
would reload the following units: dbus-broker.service, nftables.service, reload-systemd-vconsole-setup.service
would restart the following units: home-manager-thiagoko.service, nix-daemon.service, polkit.service, sshd.service, systemd-journald.service, systemd-networkd.service, systemd-resolved.service, systemd-udevd.service, tailscaled.service, wpa_supplicant.service
would start the following units: accounts-daemon.service, cron.service, earlyoom.service, flood.service, fwupd.service, inputplumber.service, jovian-updater-logo-helper.service, kmod-static-nodes.service, lactd.service, logrotate-checkconf.service, ModemManager.service, NetworkManager.service, nscd.service, ollama.service, plex.service, plymouth-quit-wait.service, plymouth-read-write.service, power-profiles-daemon.service, rtkit-daemon.service, rtorrent.service, scx.service, smartd.service, steamos-manager.service, systemd-ask-password-plymouth.service, systemd-binfmt.service, systemd-fsck-root.service, systemd-machined.service, systemd-modules-load.service, systemd-oomd.socket, systemd-sysctl.service, systemd-timesyncd.service, systemd-vconsole-setup.service, systemd-zram-setup@zram0.service, udisks2.service, upower.service
Done. The new configuration is /nix/store/sd9ys9ind45aqg5va3fxph0fmd36v21z-nixos-system-blackrockshooter-nixos-26.05.20260223.2fc6539
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
