### PR TITLE
openscad: apply boost 1.89 patch

### DIFF
--- a/pkgs/by-name/op/openscad/boost-1.89.patch
+++ b/pkgs/by-name/op/openscad/boost-1.89.patch
@@ -1,0 +1,65 @@
+diff --git a/features/boost.prf b/features/boost.prf
+index 518d08b8f..4e092f6e7 100644
+--- a/features/boost.prf
++++ b/features/boost.prf
+@@ -17,7 +17,7 @@ CONFIG(mingw-cross-env)|CONFIG(mingw-cross-env-shared) {
+     DEFINES += BOOST_STATIC
+     DEFINES += Boost_USE_STATIC_LIBS
+   }
+-  BOOST_LINK_FLAGS = -lboost_thread_win32-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt -lboost_chrono-mt
++  BOOST_LINK_FLAGS = -lboost_thread_win32-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_regex-mt -lboost_chrono-mt
+ }
+ 
+ # MSYS2
+@@ -25,7 +25,7 @@ isEmpty(BOOST_LINK_FLAGS):win32-g++ {
+   DEFINES += BOOST_STATIC
+   DEFINES += BOOST_THREAD_USE_LIB
+   DEFINES += Boost_USE_STATIC_LIBS
+-  BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt
++  BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_regex-mt
+ } 
+ 
+ # check for OPENSCAD_LIBDIR + multithread
+@@ -33,10 +33,10 @@ isEmpty(BOOST_LINK_FLAGS) {
+   OPENSCAD_LIBDIR = $$(OPENSCAD_LIBRARIES)
+   !isEmpty(OPENSCAD_LIBDIR) {
+     exists($$OPENSCAD_LIBDIR/lib/libboost*thread-mt*) {
+-      BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt
++      BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_regex-mt
+     } else {
+       exists($$OPENSCAD_LIBDIR/lib/libboost*thread*) {
+-        BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_system -lboost_regex
++        BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_regex
+       }
+     }
+   }
+@@ -47,10 +47,10 @@ isEmpty(BOOST_LINK_FLAGS) {
+   BOOST_DIR = $$(BOOSTDIR)
+   !isEmpty(BOOST_DIR) {
+     exists($$BOOST_DIR/lib/libboost*thread-mt*) {
+-      BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt
++      BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_regex-mt
+     } else {
+       exists($$BOOST_DIR/lib/libboost*thread*) {
+-        BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_system -lboost_regex
++        BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_regex
+       }
+     }
+   }
+@@ -64,14 +64,14 @@ isEmpty(BOOST_LINK_FLAGS) {
+     BMT_TEST4 = /usr/local/lib/libboost*thread-mt* # homebrew
+     BMT_TEST5 = /opt/local/lib/libboost*thread-mt* # macports
+     exists($$BMT_TEST1)|exists($$BMT_TEST2)|exists($$BMT_TEST3)|exists($$BMT_TEST4)|exists($$BMT_TEST5) {
+-      BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_system-mt -lboost_regex-mt
++      BOOST_LINK_FLAGS = -lboost_thread-mt -lboost_program_options-mt -lboost_filesystem-mt -lboost_regex-mt
+     }
+   }
+ }
+ 
+ isEmpty(BOOST_LINK_FLAGS) {
+   unix|macx {
+-    BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_system -lboost_regex
++    BOOST_LINK_FLAGS = -lboost_thread -lboost_program_options -lboost_filesystem -lboost_regex
+   }
+ }
+ 

--- a/pkgs/by-name/op/openscad/package.nix
+++ b/pkgs/by-name/op/openscad/package.nix
@@ -32,16 +32,17 @@
   cairo,
   openscad,
   runCommand,
+  versionCheckHook,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "openscad";
   version = "2021.01";
 
   src = fetchFromGitHub {
     owner = "openscad";
     repo = "openscad";
-    rev = "${pname}-${version}";
+    rev = "${finalAttrs.pname}-${finalAttrs.version}";
     sha256 = "sha256-2tOLqpFt5klFPxHNONnHVzBKEFWn4+ufx/MU+eYbliA=";
   };
 
@@ -119,6 +120,7 @@ stdenv.mkDerivation rec {
     libsForQt5.qmake
     libsForQt5.wrapQtAppsHook
     wrapGAppsHook3
+    versionCheckHook
   ];
 
   buildInputs = [
@@ -152,7 +154,7 @@ stdenv.mkDerivation rec {
   ++ lib.optional spacenavSupport libspnav;
 
   qmakeFlags = [
-    "VERSION=${version}"
+    "VERSION=${finalAttrs.version}"
     "LIB3MF_INCLUDEPATH=${lib3mf.dev}/include/lib3mf/Bindings/Cpp"
     "LIB3MF_LIBPATH=${lib3mf}/lib"
   ]
@@ -167,6 +169,8 @@ stdenv.mkDerivation rec {
   preBuild = ''
     make objects/parser.cxx
   '';
+
+  doInstallCheck = true;
 
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir $out/Applications
@@ -204,9 +208,9 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     lib3mf_support =
-      runCommand "${pname}-lib3mf-support-test"
+      runCommand "${finalAttrs.pname}-lib3mf-support-test"
         {
-          nativeBuildInputs = [ openscad ];
+          nativeBuildInputs = [ finalAttrs.finalPackage ];
         }
         ''
           echo "cube([1, 1, 1]);" | openscad -o cube.3mf -
@@ -214,4 +218,4 @@ stdenv.mkDerivation rec {
           mv cube-import.3mf $out
         '';
   };
-}
+})

--- a/pkgs/by-name/op/openscad/package.nix
+++ b/pkgs/by-name/op/openscad/package.nix
@@ -84,6 +84,9 @@ stdenv.mkDerivation rec {
         sed -i 's/& / \&/g;s/\*\*/\0 /g;s/^\(.\)  /\1\t/' "$out"
       '';
     })
+    # unfortunately the archlinux patch does not apply cleanly
+    # source: https://gitlab.archlinux.org/archlinux/packaging/packages/openscad/-/raw/ecc27e16ae6fee51c6806690d76f9ba326af79c1/boost-1.89.patch
+    ./boost-1.89.patch
   ]
   ++ lib.optionals stdenv.hostPlatform.isDarwin [
     # ref. https://github.com/openscad/openscad/pull/4013 merged upstream


### PR DESCRIPTION
openscad currently fails to build with boost 1.89
applies archlinux upstream patch https://gitlab.archlinux.org/archlinux/packaging/packages/openscad/-/raw/ecc27e16ae6fee51c6806690d76f9ba326af79c1/boost-1.89.patch

additionally versionCheckHook is added to test the executable
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
