### PR TITLE
dma: init at 0.14

### DIFF
--- a/pkgs/by-name/dm/dma/package.nix
+++ b/pkgs/by-name/dm/dma/package.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  bison,
+  flex,
+  openssl,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "dma";
+  version = "0.14";
+
+  src = fetchFromGitHub {
+    owner = "corecode";
+    repo = "dma";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-rmgEWkV/ZmOcO1J1uTMMO5tJWq8DTyT7ANRjHyWUGNw=";
+  };
+
+  nativeBuildInputs = [
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail " -m 2755 -o root -g mail" "" \
+      --replace-fail " -m 4754 -o root -g mail" ""
+    substituteInPlace local.c \
+      --replace-fail "LIBEXEC_PATH" '"/run/wrappers/bin"'
+  '';
+
+  makeFlags = [
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = {
+    description = "Small Mail Transport Agent, designed for home and office use";
+    homepage = "https://github.com/corecode/dma";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ aanderse ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

very nice and easy mta

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
