### PR TITLE
gogcli: init at 0.11.0

### DIFF
--- a/pkgs/by-name/go/gogcli/package.nix
+++ b/pkgs/by-name/go/gogcli/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "gogcli";
+  version = "0.11.0";
+
+  src = fetchFromGitHub {
+    owner = "steipete";
+    repo = "gogcli";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hJU40ysjRx4p9SWGmbhhpToYCpk3DcMAWCnKqxHRmh0=";
+  };
+
+  vendorHash = "sha256-WGRlv3UsK3SVBQySD7uZ8+FiRl03p0rzjBm9Se1iITs=";
+
+  subPackages = [ "cmd/gog" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs";
+    homepage = "https://github.com/steipete/gogcli";
+    changelog = "https://github.com/steipete/gogcli/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "gog";
+  };
+})


### PR DESCRIPTION
Add new package `gogcli` (Google Workspace CLI) at `pkgs/by-name/go/gogcli/package.nix`.

This packages upstream `steipete/gogcli` version `0.11.0`, builds the `gog` binary
from `cmd/gog`, and sets `meta.mainProgram = "gog"`.

Homepage: https://github.com/steipete/gogcli
Changelog/releases: https://github.com/steipete/gogcli/releases/tag/v0.11.0

  ## Things done

  - Built on platform:
    - [x] x86_64-linux
    - [ ] aarch64-linux
    - [ ] x86_64-darwin
    - [ ] aarch64-darwin
  - Tested, as applicable:
    - [ ] [NixOS tests] in [nixos/tests].
    - [ ] [Package tests] at `passthru.tests`.
    - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
  - [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
  - [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
  - Nixpkgs Release Notes
    - [ ] Package update: when the change is major or breaking.
  - NixOS Release Notes
    - [ ] Module addition: when adding a new NixOS module.
    - [ ] Module update: when the change is significant.
  - [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other
  READMEs.