### PR TITLE
python3Packages.torchao: 0.16.0 -> 0.17.0; python3Packages.executorch: 1.0.1 -> 1.2.0

### DIFF
--- a/pkgs/development/python-modules/executorch/default.nix
+++ b/pkgs/development/python-modules/executorch/default.nix
@@ -49,7 +49,7 @@
 }:
 buildPythonPackage (finalAttrs: {
   pname = "executorch";
-  version = "1.0.1";
+  version = "1.2.0";
   pyproject = true;
 
   src = fetchFromGitHub {
@@ -62,7 +62,7 @@ buildPythonPackage (finalAttrs: {
     name = "executorch";
 
     fetchSubmodules = true;
-    hash = "sha256-h+nmipFDO/cdPTQXrjM5EkH//wHKBAvlDIp6SBbGN/8=";
+    hash = "sha256-Rkw6+keOygQaf6iOCpGoW9JgXiCimgx8gsxLEH3bxME=";
   };
 
   postPatch =
@@ -77,7 +77,7 @@ buildPythonPackage (finalAttrs: {
     + ''
       substituteInPlace pyproject.toml \
         --replace-fail '"pip>=23",' "" \
-        --replace-fail "cmake>=3.29,<4.0.0" "cmake"
+        --replace-fail "cmake>=3.24,<4.0.0" "cmake"
     ''
     # CMake 4 dropped support of versions lower than 3.5, versions lower than 3.10 are deprecated.
     # https://github.com/NixOS/nixpkgs/issues/445447
@@ -95,10 +95,19 @@ buildPythonPackage (finalAttrs: {
           'static char hexdigits[17] = "0123456789ABCDEF";'
 
       sed -i "1i #include <cstdint>" backends/apple/coreml/runtime/inmemoryfs/memory_buffer.hpp
+      sed -i "1i #include <cstdint>" extension/llm/tokenizers/third-party/sentencepiece/src/sentencepiece_processor.h
     '';
 
   env = {
     BUILD_VERSION = finalAttrs.version;
+
+    # Can't use cmakeFlags since we do not control invocation of cmake.
+    # But the build script is sensitive to this env variable.
+    # Fixes:
+    #  Some binaries contain forbidden references to /build/. Check the error above!
+    CMAKE_ARGS = lib.concatStringsSep " " [
+      (lib.cmakeBool "CMAKE_SKIP_BUILD_RPATH" true)
+    ];
   };
 
   build-system = [
@@ -186,6 +195,7 @@ buildPythonPackage (finalAttrs: {
     # AssertionError (Numerical comparison fails)
     "test_sdpa_with_cache_seq_len_13"
     "test_sdpa_with_custom_quantized_seq_len_130_gqa"
+    "test_within_transformer"
 
     # Try to download models from the internet
     "test_all_models_with_recipes"
@@ -199,6 +209,9 @@ buildPythonPackage (finalAttrs: {
     "test_resnet18_export_to_executorch"
     "test_resnet50_export_to_executorch"
     "test_vit_export_to_executorch"
+
+    # RuntimeError: Failed to compile /build/tmplb6i266d/data.json to /build/tmplb6i266d/data.pte
+    "test_flatbuffer_paths_match"
   ]
   ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86_64) [
     # RuntimeError: Error in dlopen:

--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -27,27 +27,37 @@
   pytestCheckHook,
   parameterized,
   tabulate,
+  torchvision,
   transformers,
   unittest-xml-reporting,
 }:
-
+let
+  inherit (stdenv.hostPlatform)
+    isDarwin
+    isLinux
+    isAarch64
+    isx86_64
+    ;
+  isAarch64Darwin = isDarwin && isAarch64;
+  isAarch64Linux = isLinux && isAarch64;
+in
 buildPythonPackage (finalAttrs: {
   pname = "torchao";
-  version = "0.16.0";
+  version = "0.17.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "ao";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-FyBsIVb3zdKtA8Vqjt301bRrGIoyeqiOUADVFGxiRPY=";
+    hash = "sha256-Mry6jsZKkoC8dq3fYNsRyGbL4+S8ZYuHpkETNDy5qsg=";
   };
 
   # AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting
   # new attributes. Did you mean: '__reduce__'?
   disabled = pythonAtLeast "3.14";
 
-  patches = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+  patches = lib.optionals isAarch64Darwin [
     ./use-system-cpuinfo.patch
     (replaceVars ./use-llvm-openmp.patch {
       inherit (llvmPackages) openmp;
@@ -58,16 +68,16 @@ buildPythonPackage (finalAttrs: {
     setuptools
   ];
 
-  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+  nativeBuildInputs = lib.optionals isAarch64Darwin [
     cmake
   ];
   dontUseCmakeConfigure = true;
 
-  buildInputs = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+  buildInputs = lib.optionals isAarch64Darwin [
     cpuinfo
   ];
 
-  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+  propagatedBuildInputs = lib.optionals isDarwin [
     # Otherwise, torch will fail to include `omp.h`:
     # torch._inductor.exc.InductorError: CppCompileError: C++ compile error
     # OpenMP support not found.
@@ -97,6 +107,7 @@ buildPythonPackage (finalAttrs: {
     pytest-xdist
     pytestCheckHook
     tabulate
+    torchvision
     transformers
     unittest-xml-reporting
   ];
@@ -160,7 +171,7 @@ buildPythonPackage (finalAttrs: {
     # execnet.gateway_base.DumpError: can't serialize <class 'torch.dtype'>
     "test_numerical_consistency_per_tensor"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
+  ++ lib.optionals isAarch64Linux [
     # AssertionError: tensor(False) is not true
     "test_quantize_per_token_cpu"
 
@@ -177,7 +188,7 @@ buildPythonPackage (finalAttrs: {
     "test_save_load_int8woqtensors_0_cpu"
     "test_save_load_int8woqtensors_1_cpu"
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  ++ lib.optionals isDarwin [
     # AssertionError: Scalars are not equal!
     "test_comm"
     "test_fsdp2"
@@ -237,6 +248,13 @@ buildPythonPackage (finalAttrs: {
     "test_optim_smoke_optim_name_AdamFp8_float32_device_mps"
     "test_subclass_slice_subclass0_shape1_device_mps"
 
+    # RuntimeError: Expected to find "triton_per_fused" but did not find it
+    "test_available_gpu_kernels_device_mps"
+
+    # RuntimeError: quantized engine NoQEngine is not supported
+    "test_qat_mobilenet_v2"
+    "test_qat_resnet18"
+
     # Crash (Trace/BPT trap: 5)
     "test_copy__mismatch_metadata_apply_quant0"
     "test_copy__mismatch_metadata_apply_quant1"
@@ -278,7 +296,7 @@ buildPythonPackage (finalAttrs: {
     "test_workflow_e2e_numerics_config4"
     "test_workflow_e2e_numerics_config5"
   ]
-  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+  ++ lib.optionals (isDarwin && isx86_64) [
     # Flaky: [gw0] node down: keyboard-interrupt
     "test_int8_weight_only_quant_with_freeze_0_cpu"
     "test_int8_weight_only_quant_with_freeze_1_cpu"
@@ -296,7 +314,7 @@ buildPythonPackage (finalAttrs: {
     # ImportError: cannot import name 'fp8_blockwise_weight_dequant' from 'torchao.kernel.blockwise_quantization'
     "test/kernel/test_blockwise_triton.py"
   ]
-  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+  ++ lib.optionals isDarwin [
     # Require unpackaged 'coremltools'
     "test/prototype/test_groupwise_lowbit_weight_lut_quantizer.py"
 
@@ -315,6 +333,8 @@ buildPythonPackage (finalAttrs: {
     "test/test_low_bit_optim.py::TestQuantize::test_bf16_stochastic_round_dtensor_device_mps_compile_False"
     "test/test_low_bit_optim.py::TestQuantize::test_bf16_stochastic_round_dtensor_device_mps_compile_True"
   ];
+
+  __darwinAllowLocalNetworking = true;
 
   meta = {
     description = "PyTorch native quantization and sparsity for training and inference";

--- a/pkgs/development/python-modules/torchao/default.nix
+++ b/pkgs/development/python-modules/torchao/default.nix
@@ -345,5 +345,9 @@ buildPythonPackage (finalAttrs: {
       GaetanLepage
       sarahec
     ];
+    badPlatforms = [
+      # Many tests failing and hanging indefinitely
+      "aarch64-linux"
+    ];
   };
 })

--- a/pkgs/development/python-modules/torchao/use-llvm-openmp.patch
+++ b/pkgs/development/python-modules/torchao/use-llvm-openmp.patch
@@ -1,13 +1,17 @@
 diff --git a/torchao/csrc/cpu/shared_kernels/Utils.cmake b/torchao/csrc/cpu/shared_kernels/Utils.cmake
-index be7004784..0e1a2ed0e 100644
+index 3ff024538..0763cab67 100644
 --- a/torchao/csrc/cpu/shared_kernels/Utils.cmake
 +++ b/torchao/csrc/cpu/shared_kernels/Utils.cmake
-@@ -21,7 +21,7 @@ function(target_link_torchao_parallel_backend target_name torchao_parallel_backe
-         target_link_libraries(${target_name} PRIVATE "${TORCH_LIBRARIES}")
- 
-         target_compile_definitions(${target_name} PRIVATE TORCHAO_PARALLEL_ATEN=1 AT_PARALLEL_OPENMP=1 INTRA_OP_PARALLEL=1)
--        target_link_libraries(${target_name} PRIVATE ${TORCH_INSTALL_PREFIX}/lib/libomp${CMAKE_SHARED_LIBRARY_SUFFIX})
-+        target_link_libraries(${target_name} PRIVATE @openmp@/lib/libomp${CMAKE_SHARED_LIBRARY_SUFFIX})
+@@ -30,10 +30,10 @@ function(target_link_torchao_parallel_backend target_name torchao_parallel_backe
+             if(_TORCH_OMP_RUNTIME)
+                 target_link_libraries(${target_name} PRIVATE "${_TORCH_OMP_RUNTIME}")
+             else()
+-                target_link_libraries(${target_name} PRIVATE ${TORCH_INSTALL_PREFIX}/lib/libomp${CMAKE_SHARED_LIBRARY_SUFFIX})
++                target_link_libraries(${target_name} PRIVATE @openmp@/lib/libomp${CMAKE_SHARED_LIBRARY_SUFFIX})
+             endif()
+         else()
+-            target_link_libraries(${target_name} PRIVATE ${TORCH_INSTALL_PREFIX}/lib/libomp${CMAKE_SHARED_LIBRARY_SUFFIX})
++            target_link_libraries(${target_name} PRIVATE @openmp@/lib/libomp${CMAKE_SHARED_LIBRARY_SUFFIX})
+         endif()
  
      elseif(TORCHAO_PARALLEL_BACKEND_TOUPPER STREQUAL "EXECUTORCH")
-         message(STATUS "Building with TORCHAO_PARALLEL_BACKEND=TORCHAO_PARALLEL_EXECUTORCH")


### PR DESCRIPTION
## Things done

- `python3Packages.torchao: 0.16.0 -> 0.17.0`
  - Diff: https://github.com/pytorch/ao/compare/v0.16.0...v0.17.0
  - Changelog: https://github.com/pytorch/ao/releases/tag/v0.17.0
- `python3Packages.executorch: 1.0.1 -> 1.2.0`
  - Changelog: https://github.com/pytorch/executorch/releases/tag/v1.2.0
  - Diff: https://github.com/pytorch/executorch/compare/v1.0.1...v1.2.0

---

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
