### PR TITLE
python3Packages.gpytorch: fix build

### DIFF
--- a/pkgs/development/python-modules/botorch/default.nix
+++ b/pkgs/development/python-modules/botorch/default.nix
@@ -27,16 +27,16 @@
   pythonAtLeast,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "botorch";
-  version = "0.16.1";
+  version = "0.17.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "meta-pytorch";
     repo = "botorch";
-    tag = "v${version}";
-    hash = "sha256-8tmNw1Qa3lXxvndljRijGNN5RMjsYlT8zFFau23yp1U=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-NDdXsmVdrTEXMXXVf89EkGXVOYnEcXwtzarB5niTNaw=";
   };
 
   build-system = [
@@ -102,10 +102,10 @@ buildPythonPackage rec {
   requiredSystemFeatures = [ "big-parallel" ];
 
   meta = {
-    changelog = "https://github.com/meta-pytorch/botorch/blob/${src.tag}/CHANGELOG.md";
+    changelog = "https://github.com/meta-pytorch/botorch/blob/${finalAttrs.src.tag}/CHANGELOG.md";
     description = "Bayesian Optimization in PyTorch";
     homepage = "https://botorch.org";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ veprbl ];
   };
-}
+})

--- a/pkgs/development/python-modules/gpytorch/default.nix
+++ b/pkgs/development/python-modules/gpytorch/default.nix
@@ -20,7 +20,7 @@
   pytestCheckHook,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "gpytorch";
   version = "1.15.1";
   pyproject = true;
@@ -28,9 +28,17 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "cornellius-gp";
     repo = "gpytorch";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ftiAY02K0EwVQZufk8xR+/21A+2ONWchuWPF3a5lRW0=";
   };
+
+  # AttributeError: module 'numpy' has no attribute 'trapz'
+  postPatch = ''
+    substituteInPlace gpytorch/kernels/spectral_mixture_kernel.py \
+      --replace-fail \
+        "np.trapz(emp_spect, freq)" \
+        "np.trapezoid(emp_spect, freq)"
+  '';
 
   build-system = [
     setuptools
@@ -73,8 +81,8 @@ buildPythonPackage rec {
     description = "Highly efficient and modular implementation of Gaussian Processes, with GPU acceleration";
     homepage = "https://gpytorch.ai";
     downloadPage = "https://github.com/cornellius-gp/gpytorch";
-    changelog = "https://github.com/cornellius-gp/gpytorch/releases/tag/${src.tag}";
+    changelog = "https://github.com/cornellius-gp/gpytorch/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ veprbl ];
   };
-}
+})

--- a/pkgs/development/python-modules/syne-tune/default.nix
+++ b/pkgs/development/python-modules/syne-tune/default.nix
@@ -36,7 +36,7 @@
   ray,
   writableTmpDirAsHomeHook,
 }:
-buildPythonPackage rec {
+buildPythonPackage (finalAttrs: {
   pname = "syne-tune";
   version = "0.15.0";
   pyproject = true;
@@ -44,16 +44,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "syne-tune";
     repo = "syne-tune";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-UNBpfC+aLXhkbyvCG2K00yedJnpYpfldqisZ/wDPtuA=";
   };
-
-  postPatch = ''
-    substituteInPlace syne_tune/optimizer/schedulers/synchronous/hyperband.py \
-     --replace-fail 'metric_val=np.NAN' 'metric_val=np.nan'
-    substituteInPlace syne_tune/optimizer/schedulers/synchronous/dehb.py \
-     --replace-fail 'result_failed.metric_val = np.NAN' 'result_failed.metric_val = np.nan'
-  '';
 
   build-system = [
     setuptools
@@ -108,12 +101,12 @@ buildPythonPackage rec {
     writableTmpDirAsHomeHook
   ]
   ++ ray.optional-dependencies.tune
-  ++ optional-dependencies.blackbox-repository
-  ++ optional-dependencies.bore
-  ++ optional-dependencies.botorch
-  ++ optional-dependencies.gpsearchers
-  ++ optional-dependencies.kde
-  ++ optional-dependencies.sklearn;
+  ++ finalAttrs.passthru.optional-dependencies.blackbox-repository
+  ++ finalAttrs.passthru.optional-dependencies.bore
+  ++ finalAttrs.passthru.optional-dependencies.botorch
+  ++ finalAttrs.passthru.optional-dependencies.gpsearchers
+  ++ finalAttrs.passthru.optional-dependencies.kde
+  ++ finalAttrs.passthru.optional-dependencies.sklearn;
 
   disabledTests = [
     # NameError: name 'HV' is not defined
@@ -129,11 +122,6 @@ buildPythonPackage rec {
     "test_cholesky_factorization"
   ];
 
-  disabledTestPaths = [
-    # legacy test
-    "tst/schedulers/test_legacy_schedulers_api.py"
-  ];
-
   pythonImportsCheck = [
     "syne_tune"
   ];
@@ -141,8 +129,8 @@ buildPythonPackage rec {
   meta = {
     description = "Large scale asynchronous hyperparameter and architecture optimization library";
     homepage = "https://github.com/syne-tune/syne-tune";
-    changelog = "https://github.com/syne-tune/syne-tune/releases/tag/${src.tag}";
+    changelog = "https://github.com/syne-tune/syne-tune/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ daspk04 ];
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes an incompatibility with the latest `numpy`.

```
=========================== short test summary info ============================
FAILED test/examples/test_spectral_mixture_gp_regression.py::TestSpectralMixtureGPRegression::test_spectral_mixture_gp_mean_abs_error - AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
FAILED test/kernels/test_spectral_mixture_kernel.py::TestSpectralMixtureKernel::test_active_dims_list - AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
FAILED test/kernels/test_spectral_mixture_kernel.py::TestSpectralMixtureKernel::test_active_dims_range - AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
FAILED test/kernels/test_spectral_mixture_kernel.py::TestSpectralMixtureKernel::test_no_batch_kernel_single_batch_x - AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
FAILED test/kernels/test_spectral_mixture_kernel.py::TestSpectralMixtureKernel::test_single_batch_kernel_single_batch_x - AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
FAILED test/kernels/test_spectral_mixture_kernel.py::TestSpectralMixtureKernel::test_smoke_double_batch_kernel_double_batch_x - AttributeError: module 'numpy' has no attribute 'trapz'. Did you mean: 'trace'?
==== 6 failed, 2275 passed, 1 skipped, 9 deselected, 440 warnings in 29.91s ====
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
