### PR TITLE
heaptrack: fix build with CMake 4 and Boost 1.89

### DIFF
--- a/pkgs/by-name/he/heaptrack/boost-189.patch
+++ b/pkgs/by-name/he/heaptrack/boost-189.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b859fbd..4ed051c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,7 +25,7 @@ if (APPIMAGE_BUILD)
+ endif()
+
+ include(FeatureSummary)
+-find_package(Boost 1.60.0 ${REQUIRED_IN_APPIMAGE} COMPONENTS system filesystem iostreams container)
++find_package(Boost 1.60.0 ${REQUIRED_IN_APPIMAGE} COMPONENTS filesystem iostreams container)
+ set_package_properties(Boost PROPERTIES TYPE RECOMMENDED PURPOSE "Boost container libraries can greatly improve performance (via pmr allocators)")
+ find_package(Threads REQUIRED)
+ find_package(ZLIB REQUIRED)
+diff --git a/src/analyze/CMakeLists.txt b/src/analyze/CMakeLists.txt
+index 8e16ff2..340eb7f 100644
+--- a/src/analyze/CMakeLists.txt
++++ b/src/analyze/CMakeLists.txt
+@@ -2,7 +2,7 @@ if (ECM_FOUND)
+     include(ECMEnableSanitizers)
+ endif()
+
+-find_package(Boost 1.41.0 REQUIRED COMPONENTS iostreams program_options system filesystem)
++find_package(Boost 1.41.0 REQUIRED COMPONENTS iostreams program_options filesystem)
+
+ configure_file(analyze_config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/analyze_config.h)
+

--- a/pkgs/by-name/he/heaptrack/cmake-minimum-required.patch
+++ b/pkgs/by-name/he/heaptrack/cmake-minimum-required.patch
@@ -1,0 +1,10 @@
+diff --git a/3rdparty/robin-map/CMakeLists.txt b/3rdparty/robin-map/CMakeLists.txt
+index fab865a..6cbd8c9 100644
+--- a/3rdparty/robin-map/CMakeLists.txt
++++ b/3rdparty/robin-map/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.5)
++cmake_minimum_required(VERSION 3.10)
+
+ project(tsl-robin-map VERSION 1.3.0 LANGUAGES CXX)
+

--- a/pkgs/by-name/he/heaptrack/package.nix
+++ b/pkgs/by-name/he/heaptrack/package.nix
@@ -25,7 +25,10 @@ stdenv.mkDerivation {
     hash = "sha256-8NLpp/+PK3wIB5Sx0Z1185DCDQ18zsGj9Wp5YNKgX8E=";
   };
 
-  patches = [ ./cmake-minimum-required.patch ];
+  patches = [
+    ./boost-189.patch
+    ./cmake-minimum-required.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/he/heaptrack/package.nix
+++ b/pkgs/by-name/he/heaptrack/package.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation {
     hash = "sha256-8NLpp/+PK3wIB5Sx0Z1185DCDQ18zsGj9Wp5YNKgX8E=";
   };
 
+  patches = [ ./cmake-minimum-required.patch ];
+
   nativeBuildInputs = [
     cmake
     kdePackages.extra-cmake-modules


### PR DESCRIPTION
```
commit 60050a1c3ed896612d1366c779f3db26d02067ec
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2026-02-25 00:24:34 +0100

    heaptrack: fix build with CMake 4

    Link: https://github.com/NixOS/nixpkgs/issues/445447

 pkgs/by-name/he/heaptrack/cmake-minimum-required.patch | 10 ++++++++++
 pkgs/by-name/he/heaptrack/package.nix                  |  2 ++
 2 files changed, 12 insertions(+)

commit 1e6073cf9d25ba66b09527d847d31a50ddd29625
Author: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date:   2026-02-25 00:25:11 +0100

    heaptrack: fix build with boost 1.89

 pkgs/by-name/he/heaptrack/boost-189.patch | 26 ++++++++++++++++++++++++++
 pkgs/by-name/he/heaptrack/package.nix     |  5 ++++-
 2 files changed, 30 insertions(+), 1 deletion(-)
```

CC: @Mrmaxmeier

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
