### PR TITLE
eden: 0.1.1 -> 0.2.0-rc1

### DIFF
--- a/pkgs/by-name/ed/eden/aarch64-disable-fastmem.patch
+++ b/pkgs/by-name/ed/eden/aarch64-disable-fastmem.patch
@@ -1,11 +1,11 @@
 diff --git a/src/common/settings.cpp b/src/common/settings.cpp
-index 2c88356888..96198006b7 100644
+index c952567e63..ac19b9cf84 100644
 --- a/src/common/settings.cpp
 +++ b/src/common/settings.cpp
-@@ -176,7 +176,7 @@ bool IsFastmemEnabled() {
-     if (values.cpu_accuracy.GetValue() == CpuAccuracy::Unsafe) {
+@@ -178,7 +178,7 @@ bool IsFastmemEnabled() {
+         return bool(values.cpuopt_fastmem);
+     else if (values.cpu_accuracy.GetValue() == CpuAccuracy::Unsafe)
          return bool(values.cpuopt_unsafe_host_mmu);
-     }
 -#if !defined(__APPLE__) && !defined(__linux__) && !defined(__ANDROID__) && !defined(_WIN32)
 +#if !defined(__APPLE__) && !defined(__linux__) && !defined(__ANDROID__) && !defined(_WIN32) || (defined(__linux__) && defined(__aarch64__))
      return false;

--- a/pkgs/by-name/ed/eden/package.nix
+++ b/pkgs/by-name/ed/eden/package.nix
@@ -90,14 +90,14 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "eden";
-  version = "0.1.1";
+  version = "0.2.0-rc1";
 
   src = fetchFromGitea {
     domain = "git.eden-emu.dev";
     owner = "eden-emu";
     repo = "eden";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-tkro7ZHgn2809Utf/Li5+OiseywyQKH15eqphxlJZQQ=";
+    hash = "sha256-6vUtNI4lqPffcCpctVv0tDfoqTShaUDGNPEOmfmnkbU=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://git.eden-emu.dev/eden-emu/eden/releases/tag/v0.2.0-rc1

Hey, this isn't a full release, but a release candidate.
If I should wait for a full release, just let me know and I put this pull request into draft.

The patch for aarch64 didn't apply to the new version, so I've updated it as well.
The rest of the build system didn't change for us, as far as I know.

Have a great day!

This version brings a some new features like

> - Updates and DLC without installing to NAND
> - A grid and icon-only view for desktop
> - Direct mod import from a folder or zip file
> - Turbo and Slow mode toggles

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
