### PR TITLE
snouty: init at 0.3.1

### DIFF
--- a/pkgs/by-name/sn/snouty/package.nix
+++ b/pkgs/by-name/sn/snouty/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  openssl,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "snouty";
+  version = "0.3.1";
+
+  src = fetchFromGitHub {
+    owner = "antithesishq";
+    repo = "snouty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-YLB4A5Ol+4sZF1RB28npJZ4pVF2Y2lSMBD8QoV8wZUg=";
+  };
+
+  cargoHash = "sha256-TJy9mJSXgJQMMDK6TFOXQVU8PujMjd3k2gdlW5Kf//4=";
+
+  nativeBuildInputs = [
+    installShellFiles
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  env.OPENSSL_NO_VENDOR = true;
+
+  postInstall = ''
+    installShellCompletion \
+      $releaseDir/build/snouty-*/out/snouty.{bash,fish} \
+      --zsh $releaseDir/build/snouty-*/out/_snouty
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI for the Antithesis API";
+    homepage = "https://github.com/antithesishq/snouty";
+    changelog = "https://github.com/antithesishq/snouty/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      carlsverre
+      winter
+    ];
+    mainProgram = "snouty";
+  };
+})


### PR DESCRIPTION
Adding snouty to nixpkgs. Snouty is a CLI for Antithesis. Snouty currently helps you run Antithesis test runs and kick off debugger sessions.

See more details about the project here: https://github.com/antithesishq/snouty


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
