### PR TITLE
doc/neovim: more details on how to configure providers

### DIFF
--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -20,9 +20,12 @@ You can configure the former via:
 
 ```nix
 neovim.override {
+  withPython3 = true; # see `:h g:python3_host_prog`
+  withNodeJs = false;
+  withRuby = false;
   configure = {
     customRC = ''
-      # here your custom configuration goes!
+      # here your custom viml configuration goes!
     '';
     packages.myVimPackage = with pkgs.vimPlugins; {
       # See examples below on how to use custom packages.
@@ -44,7 +47,7 @@ neovim-qt.override {
   neovim = neovim.override {
     configure = {
       customRC = ''
-        # your custom configuration
+        # your custom viml configuration
       '';
     };
   };
@@ -61,6 +64,8 @@ For instance, `sqlite-lua` needs `g:sqlite_clib_path` to be set to work. Nixpkgs
 - `wrapRc`: Nix, not being able to write in your `$HOME`, loads the
   generated Neovim configuration via the `$VIMINIT` environment variable, i.e. : `export VIMINIT='lua dofile("/nix/store/…-init.lua")'`. This has side effects like preventing Neovim from sourcing your `init.lua` in `$XDG_CONFIG_HOME/nvim` (see bullet 7 of [`:help startup`](https://neovim.io/doc/user/starting.html#startup) in Neovim). Disable it if you want to generate your own wrapper. You can still reuse the generated vimscript init code via `neovim.passthru.initRc`.
 - `plugins`: A list of plugins to add to the wrapper.
+- `withPython3`, `withNodeJs`, `withRuby` control when to enable neovim
+  providers (see `:h provider`).
 
 ```
 wrapNeovimUnstable neovim-unwrapped {
@@ -85,6 +90,9 @@ wrapNeovimUnstable neovim-unwrapped {
     (nvim-treesitter.withPlugins (p: [ p.nix p.python ]))
     hex-nvim
   ];
+  withPython3 = true;
+  withNodeJs = false;
+  withRuby = false;
 }
 ```
 


### PR DESCRIPTION
see `:help provider` in neovim.

Precised what language to use in customRc


Requested in https://github.com/NixOS/nixpkgs/pull/492131#pullrequestreview-3827845246


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
