### PR TITLE
x265: enable multibitdepth on aarch64-linux

### DIFF
--- a/pkgs/by-name/x2/x265/package.nix
+++ b/pkgs/by-name/x2/x265/package.nix
@@ -15,9 +15,7 @@
   numactl,
 
   # Multi bit-depth support (8bit+10bit+12bit):
-  multibitdepthSupport ? (
-    stdenv.hostPlatform.is64bit && !(stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux)
-  ),
+  multibitdepthSupport ? stdenv.hostPlatform.is64bit,
 
   # Other options:
   cliSupport ? true, # Build standalone CLI application


### PR DESCRIPTION
The `multibitdepthSupport` parameter currently excludes aarch64-linux:

```nix
multibitdepthSupport ? (
  stdenv.hostPlatform.is64bit && !(stdenv.hostPlatform.isAarch64 && stdenv.hostPlatform.isLinux)
),
```

This exclusion was added with the original multibitdepth support in #92052 (2020), back when x265 3.x didn't have 10-bit or 12-bit aarch64 assembly primitives. The `PFX` macro would expand to symbols like `x265_12bit_pixel_satd_4x4_neon` that didn't exist, causing link failures (see #154347 for details).

x265 has had working aarch64 HBD support since 4.0 ([release notes](https://x265.readthedocs.io/en/master/releasenotes.html#version-4-0)).

Without multibitdepth, the only supported pixel format on aarch64 is `yuv420p` (8-bit). Any 10-bit input, which is common from modern cameras, causes ffmpeg's libx265 encoder to fail with:

```
[libx265] Invalid video pixel format: -1
```

I hit this running Home Assistant's `stream` component on a Raspberry Pi 5. Camera streams using HEVC would crash in PyAV's `avcodec_open2(libx265)` call.

This PR removes the aarch64-linux exclusion so `multibitdepthSupport` is just `stdenv.hostPlatform.is64bit`.

<details>
<summary>Before</summary>

```shell
$ curl -s https://media.xiph.org/video/derf/y4m/akiyo_qcif.y4m
$ x265 --version
x265 [info]: HEVC encoder version 4.1+1-1d117be
x265 [info]: build info [Linux][GCC 15.2.0][64 bit] 8bit
x265 [info]: using cpu capabilities: NEON Neon_DotProd
$ x265 --input akiyo_qcif.y4m --output before_12bit.hevc --output-depth 12
x265 [warning]: falling back to default bit-depth
y4m  [info]: 176x144 fps 30000/1001 i420p8 sar 128:117 frames 0 - 299 of 300
raw  [info]: output file: before_12bit.hevc
x265 [info]: HEVC encoder version 4.1+1-1d117be
x265 [info]: build info [Linux][GCC 15.2.0][64 bit] 8bit
x265 [info]: using cpu capabilities: NEON Neon_DotProd
x265 [info]: Main profile, Level-2 (Main tier)
x265 [info]: Thread pool created using 4 threads
x265 [info]: Slices                              : 1
x265 [info]: frame threads / pool features       : 2 / wpp(3 rows)
x265 [warning]: Source height < 720p; disabling lookahead-slices
x265 [info]: Coding QT: max CU size, min CU size : 64 / 8
x265 [info]: Residual QT: max TU size, max depth : 32 / 1 inter / 1 intra
x265 [info]: ME / range / subpel / merge         : hex / 57 / 2 / 3
x265 [info]: Keyframe min / max / scenecut / bias  : 25 / 250 / 40 / 5.00
x265 [info]: Lookahead / bframes / badapt        : 20 / 4 / 2
x265 [info]: b-pyramid / weightp / weightb       : 1 / 1 / 0
x265 [info]: References / ref-limit  cu / depth  : 3 / off / on
x265 [info]: AQ: mode / str / qg-size / cu-tree  : 2 / 1.0 / 32 / 1
x265 [info]: Rate Control / qCompress            : CRF-28.0 / 0.60
x265 [info]: tools: rd=3 psy-rd=2.00 early-skip rskip mode=1 signhide tmvp
x265 [info]: tools: b-intra strong-intra-smoothing deblock sao dhdr10-info
x265 [info]: frame I:      2, Avg QP:24.58  kb/s: 612.11
x265 [info]: frame P:     83, Avg QP:29.73  kb/s: 48.99
x265 [info]: frame B:    215, Avg QP:35.57  kb/s: 5.58
x265 [info]: Weighted P-Frames: Y:0.0% UV:0.0%

encoded 300 frames in 0.35s (847.14 fps), 21.63 kb/s, Avg QP:33.88
$ ffprobe -v error -show_streams -select_streams v:0 before_12bit.hevc                                                       [STREAM]
index=0
codec_name=hevc
codec_long_name=H.265 / HEVC (High Efficiency Video Coding)
profile=Main
codec_type=video
codec_tag_string=[0][0][0][0]
codec_tag=0x0000
width=176
height=144
coded_width=176
coded_height=144
has_b_frames=2
sample_aspect_ratio=128:117
display_aspect_ratio=1408:1053
pix_fmt=yuv420p
level=60
color_range=tv
color_space=unknown
color_transfer=unknown
color_primaries=unknown
chroma_location=left
field_order=unknown
refs=1
view_ids_available=
view_pos_available=
id=N/A
r_frame_rate=30000/1001
avg_frame_rate=25/1
time_base=1/1200000
start_pts=N/A
start_time=N/A
duration_ts=N/A
duration=N/A
bit_rate=N/A
max_bit_rate=N/A
bits_per_raw_sample=N/A
nb_frames=N/A
nb_read_frames=N/A
nb_read_packets=N/A
extradata_size=86
DISPOSITION:default=0
DISPOSITION:dub=0
DISPOSITION:original=0
DISPOSITION:comment=0
DISPOSITION:lyrics=0
DISPOSITION:karaoke=0
DISPOSITION:forced=0
DISPOSITION:hearing_impaired=0
DISPOSITION:visual_impaired=0
DISPOSITION:clean_effects=0
DISPOSITION:attached_pic=0
DISPOSITION:timed_thumbnails=0
DISPOSITION:non_diegetic=0
DISPOSITION:captions=0
DISPOSITION:descriptions=0
DISPOSITION:metadata=0
DISPOSITION:dependent=0
DISPOSITION:still_image=0
DISPOSITION:multilayer=0
[/STREAM]
```

</details>

<details>
<summary>After</summary>

```shell
$ curl -s https://media.xiph.org/video/derf/y4m/akiyo_qcif.y4m
$ ./result/bin/x265 --version
x265 [info]: HEVC encoder version 4.1+1-1d117be
x265 [info]: build info [Linux][GCC 15.2.0][64 bit] 8bit+10bit+12bit
x265 [info]: using cpu capabilities: NEON Neon_DotProd
$ ./result/bin/x265 --input akiyo_qcif.y4m --output after_12bit.hevc --output-depth 12
y4m  [info]: 176x144 fps 30000/1001 i420p8 sar 128:117 frames 0 - 299 of 300
raw  [info]: output file: after_12bit.hevc
x265 [info]: HEVC encoder version 4.1
x265 [info]: build info [Linux][GCC 15.2.0][64 bit] 12bit
x265 [info]: using cpu capabilities: NEON Neon_DotProd
x265 [info]: Main 12 profile, Level-2 (Main tier)
x265 [info]: Thread pool created using 4 threads
x265 [info]: Slices                              : 1
x265 [info]: frame threads / pool features       : 2 / wpp(3 rows)
x265 [warning]: Source height < 720p; disabling lookahead-slices
x265 [info]: Coding QT: max CU size, min CU size : 64 / 8
x265 [info]: Residual QT: max TU size, max depth : 32 / 1 inter / 1 intra
x265 [info]: ME / range / subpel / merge         : hex / 57 / 2 / 3
x265 [info]: Keyframe min / max / scenecut / bias  : 25 / 250 / 40 / 5.00
x265 [info]: Lookahead / bframes / badapt        : 20 / 4 / 2
x265 [info]: b-pyramid / weightp / weightb       : 1 / 1 / 0
x265 [info]: References / ref-limit  cu / depth  : 3 / off / on
x265 [info]: AQ: mode / str / qg-size / cu-tree  : 2 / 1.0 / 32 / 1
x265 [info]: Rate Control / qCompress            : CRF-28.0 / 0.60
x265 [info]: tools: rd=3 psy-rd=2.00 early-skip rskip mode=1 signhide tmvp
x265 [info]: tools: b-intra strong-intra-smoothing deblock sao
x265 [info]: frame I:      2, Avg QP:26.84  kb/s: 485.03
x265 [info]: frame P:     73, Avg QP:31.33  kb/s: 36.56
x265 [info]: frame B:    225, Avg QP:35.56  kb/s: 5.74
x265 [info]: Weighted P-Frames: Y:0.0% UV:0.0%

encoded 300 frames in 0.41s (723.01 fps), 16.43 kb/s, Avg QP:34.47
$ ffprobe -v error -show_streams -select_streams v:0 after_12bit.hevc
[STREAM]
index=0
codec_name=hevc
codec_long_name=H.265 / HEVC (High Efficiency Video Coding)
profile=Rext
codec_type=video
codec_tag_string=[0][0][0][0]
codec_tag=0x0000
width=176
height=144
coded_width=176
coded_height=144
has_b_frames=2
sample_aspect_ratio=128:117
display_aspect_ratio=1408:1053
pix_fmt=yuv420p12le
level=60
color_range=tv
color_space=unknown
color_transfer=unknown
color_primaries=unknown
chroma_location=left
field_order=unknown
refs=1
view_ids_available=
view_pos_available=
id=N/A
r_frame_rate=30000/1001
avg_frame_rate=25/1
time_base=1/1200000
start_pts=N/A
start_time=N/A
duration_ts=N/A
duration=N/A
bit_rate=N/A
max_bit_rate=N/A
bits_per_raw_sample=N/A
nb_frames=N/A
nb_read_frames=N/A
nb_read_packets=N/A
extradata_size=85
DISPOSITION:default=0
DISPOSITION:dub=0
DISPOSITION:original=0
DISPOSITION:comment=0
DISPOSITION:lyrics=0
DISPOSITION:karaoke=0
DISPOSITION:forced=0
DISPOSITION:hearing_impaired=0
DISPOSITION:visual_impaired=0
DISPOSITION:clean_effects=0
DISPOSITION:attached_pic=0
DISPOSITION:timed_thumbnails=0
DISPOSITION:non_diegetic=0
DISPOSITION:captions=0
DISPOSITION:descriptions=0
DISPOSITION:metadata=0
DISPOSITION:dependent=0
DISPOSITION:still_image=0
DISPOSITION:multilayer=0
[/STREAM]
```

</details>

The key differences in the outputs above are:
- `x265 --version`
  - `x265 [info]: build info [Linux][GCC 15.2.0][64 bit] 8bit`
  - `x265 [info]: build info [Linux][GCC 15.2.0][64 bit] 8bit+10bit+12bit`
- x265 log:
  - `x265 [info]: Main profile, Level-2 (Main tier)`
  - `x265 [info]: Main 12 profile, Level-2 (Main tier)`
- ffprobe
  - `pix_fmt=yuv420p`
  - `pix_fmt=yuv420p12le`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
