### PR TITLE
Revert "python313Packages.picosvg: disable failing tests"

### DIFF
--- a/pkgs/development/python-modules/picosvg/default.nix
+++ b/pkgs/development/python-modules/picosvg/default.nix
@@ -44,11 +44,6 @@ buildPythonPackage rec {
   # a few tests are failing on aarch64
   doCheck = !stdenv.hostPlatform.isAarch64;
 
-  disabledTests = [
-    # test fixtures need to be regenerated after skia-pathops update
-    "test_topicosvg"
-  ];
-
   meta = {
     description = "Tool to simplify SVGs";
     mainProgram = "picosvg";


### PR DESCRIPTION
Reverts NixOS/nixpkgs#493391

This got propery fixed by github.com/NixOS/nixpkgs/pull/493376 and I tested it locally that only that commit is required.