### PR TITLE
python3Packages: Move uefi-firmware-parser to python-modules

### DIFF
--- a/pkgs/by-name/ue/uefi-firmware-parser/package.nix
+++ b/pkgs/by-name/ue/uefi-firmware-parser/package.nix
@@ -1,38 +1,10 @@
 {
-  fetchFromGitHub,
-  lib,
-  nix-update-script,
-  python3,
+  python3Packages,
 }:
-
-python3.pkgs.buildPythonApplication (finalAttrs: {
-  pname = "uefi-firmware-parser";
-  version = "1.13";
-  pyproject = true;
-
-  src = fetchFromGitHub {
-    owner = "theopolis";
-    repo = "uefi-firmware-parser";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-JPNur7Ipi+Ite9B7lqDm7h7iYUga8D+l18J2knCWZpk=";
-  };
-
-  build-system = [
-    python3.pkgs.setuptools
-    python3.pkgs.wheel
-  ];
-
-  pythonRemoveDeps = [ "future" ];
-
-  pythonImportsCheck = [ "uefi_firmware" ];
-
-  passthru.updateScript = nix-update-script { };
-
-  meta = {
-    description = "Tool for parsing, extracting, and recreating UEFI firmware volumes";
-    homepage = "https://github.com/theopolis/uefi-firmware-parser";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
-    mainProgram = "uefi-firmware-parser";
-  };
-})
+let
+  inherit (python3Packages)
+    toPythonApplication
+    uefi-firmware-parser
+    ;
+in
+toPythonApplication uefi-firmware-parser

--- a/pkgs/development/python-modules/uefi-firmware-parser/default.nix
+++ b/pkgs/development/python-modules/uefi-firmware-parser/default.nix
@@ -1,0 +1,40 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  setuptools,
+  wheel,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "uefi-firmware-parser";
+  version = "1.13";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "theopolis";
+    repo = "uefi-firmware-parser";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-JPNur7Ipi+Ite9B7lqDm7h7iYUga8D+l18J2knCWZpk=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  pythonRemoveDeps = [ "future" ];
+
+  pythonImportsCheck = [ "uefi_firmware" ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Tool for parsing, extracting, and recreating UEFI firmware volumes";
+    homepage = "https://github.com/theopolis/uefi-firmware-parser";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    mainProgram = "uefi-firmware-parser";
+  };
+})

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20155,6 +20155,8 @@ self: super: with self; {
     inherit (pkgs) libx11 libxext;
   };
 
+  uefi-firmware-parser = callPackage ../development/python-modules/uefi-firmware-parser { };
+
   ufal-chu-liu-edmonds = callPackage ../development/python-modules/ufal-chu-liu-edmonds { };
 
   ufmt = callPackage ../development/python-modules/ufmt { };


### PR DESCRIPTION
uefi-firmware-parser is a Python module that is *also* an application. Move the base Python module definition to
pkgs/development/python-modules and use toPythonApplication in the top-level by-name.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
