### PR TITLE
charcoal: init at 0.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -9837,6 +9837,12 @@
     githubId = 77560236;
     name = "Gordon Clark";
   };
+  gorgeous-patrick = {
+    email = "baichuanli@yahoo.com";
+    github = "Gorgeous-Patrick";
+    githubId = 33488623;
+    name = "Patrick Li";
+  };
   gotcha = {
     email = "gotcha@bubblenet.be";
     github = "gotcha";

--- a/pkgs/by-name/ch/charcoal/package.nix
+++ b/pkgs/by-name/ch/charcoal/package.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  makeWrapper,
+  installShellFiles,
+  openssl,
+  alsa-lib,
+  didyoumean,
+  nix-update-script,
+  withAutocorrect ? true,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  __structuredAttrs = true;
+  pname = "charcoal";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "LighghtEeloo";
+    repo = "charcoal";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-cEwYyPS3KBZVzeZERI5jT1NR1xYnc/FZPZCi3gwyAeg=";
+  };
+
+  cargoHash = "sha256-ySFwL/y1mthVuie77vh9EjVLfVqIezjz0HoQ5CBG6nk=";
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ]
+  ++ lib.optionals withAutocorrect [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    openssl
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    alsa-lib
+  ];
+
+  postInstall = lib.optionalString withAutocorrect ''
+    wrapProgram $out/bin/charcoal \
+      --prefix PATH : ${lib.makeBinPath [ didyoumean ]}
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Command line dictionary using youdao dict API";
+    homepage = "https://github.com/LighghtEeloo/charcoal";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gorgeous-patrick ];
+    mainProgram = "charcoal";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
## Description

Add [charcoal](https://github.com/LighghtEeloo/charcoal), a command line dictionary using youdao dict API. Inspired by [wudao-dict](https://github.com/ChestnutHeng/Wudao-dict).

Charcoal is a Rust CLI tool that provides:
- Online dictionary lookup via youdao dict API
- Colorized terminal output
- Optional text-to-speech
- Shell completions (bash, fish, zsh)
- Query caching (text and audio)

## Things done

- [x] Built on platform(s)
  - [x] x86_64-linux
- [x] Tested with `nix-build -A charcoal`
- [x] Added to `pkgs/by-name` following the [by-name convention](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name)
- [x] `meta.maintainers` is set
- [x] `meta.license` matches upstream license (MIT)
- [x] `meta.mainProgram` is set
- [x] `passthru.updateScript` is set (`nix-update-script`)
- [x] New maintainer added in separate commit

## Technical details

- Uses `rustPlatform.buildRustPackage` with `fetchFromGitHub`
- Build dependencies: `pkg-config`, `makeWrapper`, `installShellFiles`
- Runtime dependencies: `openssl`, `alsa-lib` (Linux), `didyoumean` (via PATH wrapper)
- Shell completions generated by build.rs and installed via `installShellFiles`
