### PR TITLE
[staging-next-25.11] alsa-lib: fix patch for CVE-2026-25068 for v1.2.14

### DIFF
--- a/pkgs/by-name/al/alsa-lib/CVE-2026-25068.patch
+++ b/pkgs/by-name/al/alsa-lib/CVE-2026-25068.patch
@@ -1,0 +1,31 @@
+From 5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40 Mon Sep 17 00:00:00 2001
+From: Jaroslav Kysela <perex@perex.cz>
+Date: Thu, 29 Jan 2026 16:51:09 +0100
+Subject: [PATCH] topology: decoder - add boundary check for channel mixer
+ count
+
+Malicious binary topology file may cause heap corruption.
+
+CVE: CVE-2026-25068
+
+Signed-off-by: Jaroslav Kysela <perex@perex.cz>
+---
+ src/topology/ctl.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/topology/ctl.c b/src/topology/ctl.c
+index a0c24518..322c461c 100644
+--- a/src/topology/ctl.c
++++ b/src/topology/ctl.c
+@@ -1250,6 +1250,11 @@ int tplg_decode_control_mixer1(snd_tplg_t *tplg,
+ 	if (mc->num_channels > 0) {
+ 		map = tplg_calloc(heap, sizeof(*map));
+ 		map->num_channels = mc->num_channels;
++		if (map->num_channels > SND_TPLG_MAX_CHAN ||
++		    map->num_channels > SND_SOC_TPLG_MAX_CHAN) {
++			SNDERR("mixer: unexpected channel count %d", map->num_channels);
++			return -EINVAL;
++		}
+ 		for (i = 0; i < map->num_channels; i++) {
+ 			map->channel[i].reg = mc->channel[i].reg;
+ 			map->channel[i].shift = mc->channel[i].shift;

--- a/pkgs/by-name/al/alsa-lib/package.nix
+++ b/pkgs/by-name/al/alsa-lib/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   alsa-topology-conf,
   alsa-ucm-conf,
   testers,
@@ -24,11 +23,16 @@ stdenv.mkDerivation (finalAttrs: {
     # "libs" field to declare locations for both native and 32bit plugins, in
     # order to support apps with 32bit sound running on x86_64 architecture.
     ./alsa-plugin-conf-multilib.patch
-    (fetchpatch {
-      name = "CVE-2026-25068.patch";
-      url = "https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40.patch";
-      hash = "sha256-4memtcg+FDOctX6wgiCdmnlG+IUS+5rL1f3LcsWS5lw=";
-    })
+
+    # Patch for CVE-2026-25058. Relies on a function `snd_error` which does not
+    # exist in alsa-lib 1.2.14, so we vendor the change to use the old `SNDERR`
+    # macro instead.
+    #
+    # Upstream fix:
+    # https://github.com/alsa-project/alsa-lib/commit/5f7fe33002d2d98d84f72e381ec2cccc0d5d3d40
+    # Introduction of `snd_error`:
+    # https://github.com/alsa-project/alsa-lib/commit/62c8e635dcce3d750985505ad20f8711d6dabf0d
+    ./CVE-2026-25068.patch
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
#492079 introduced a patch for CVE-2026-25068, which was backported to staging-25.11 in #492453. However, the patch fails to compile when ported directly to 25.11 since the way of doing error handling changed from an `SNDERR` macro to an `snd_error` function between v1.2.14 (which is on 25.11) and on v1.2.15. In order to fix this, we vendor the patch and change the offending line like so:

```diff
- +			snd_error(TOPOLOGY, "mixer: unexpected channel count %d", map->num_channels);
+ +			SNDERR("mixer: unexpected channel count %d", map->num_channels);
```

Alternatively, the package itself could be updated? Not familiar enough with alsa-lib to assess whether that should happen/is liable to cause breakage. This is probably the lowest impact option, but I don't know if it's the best.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
