### PR TITLE
[Backport release-25.11] nixos/oci-containers: set Restart to on-failure when autoStart is disabled

### DIFF
--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -536,7 +536,7 @@ let
         ExecStartPre = [ "${preStartScript}/bin/pre-start" ];
         TimeoutStartSec = 0;
         TimeoutStopSec = 120;
-        Restart = "always";
+        Restart = "on-failure";
       }
       // optionalAttrs (cfg.backend == "podman") {
         Environment = "PODMAN_SYSTEMD_UNIT=%n";


### PR DESCRIPTION
Manual backport of https://github.com/NixOS/nixpkgs/pull/485421 to `release-25.11`.