### PR TITLE
mqtt-exporter: 1.9.0 -> 1.11.2

### DIFF
--- a/pkgs/by-name/mq/mqtt-exporter/package.nix
+++ b/pkgs/by-name/mq/mqtt-exporter/package.nix
@@ -1,29 +1,20 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   python3,
 }:
 
 python3.pkgs.buildPythonApplication (finalAttrs: {
   pname = "mqtt-exporter";
-  version = "1.9.0";
+  version = "1.11.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kpetremann";
     repo = "mqtt-exporter";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-z2y43sRlwgy3Bwhu8rvlTkf6HOT+v8kjo5FT3lo5CEA=";
+    hash = "sha256-pWXdd82K1BhUKHGVGpTRW4f/Xa9nf0Ww/l2pxdw/Jw8=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "Fix `mqtt-exporter` script";
-      url = "https://github.com/kpetremann/mqtt-exporter/commit/53f5f31b28cb5aeec1c8d0bb7d1aea56f036082e.diff";
-      hash = "sha256-LS+kO6bHofNQxk9o+ExsJnaecwfY/40S0MIJwpJxCAI=";
-    })
-  ];
 
   build-system = with python3.pkgs; [ setuptools ];
 


### PR DESCRIPTION
Closes #493580

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Update `mqtt-expoter` to version `1.11.2`. This also solves https://github.com/NixOS/nixpkgs/issues/493580

The new upstream version also includes the patch we were applying, so that can be removed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
