### PR TITLE
odroid-xu3-bootloader: use correct pkgsCross semantics

### DIFF
--- a/pkgs/by-name/od/odroid-xu3-bootloader/package.nix
+++ b/pkgs/by-name/od/odroid-xu3-bootloader/package.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  pkgsCross,
   coreutils,
   ubootOdroidXU3,
   runtimeShell,
@@ -21,7 +22,12 @@ stdenv.mkDerivation {
   buildCommand = ''
     install -Dm644 -t $out/lib/sd_fuse-xu3 $src/sd_fuse/hardkernel_1mb_uboot/{bl2,tzsw}.*
     install -Dm644 -t $out/lib/sd_fuse-xu3 $src/sd_fuse/hardkernel/bl1.*
-    ln -sf ${ubootOdroidXU3}/u-boot-dtb.bin $out/lib/sd_fuse-xu3/u-boot-dtb.bin
+    ln -sf ${
+      if stdenv.targetPlatform.system == "armv7l-linux" then
+        ubootOdroidXU3
+      else
+        pkgsCross.armv7l-hf-multiplatform.ubootOdroidXU3
+    }/u-boot-dtb.bin $out/lib/sd_fuse-xu3/u-boot-dtb.bin
 
     install -Dm755 $src/sd_fuse/hardkernel_1mb_uboot/sd_fusing.1M.sh $out/bin/sd_fuse-xu3
     sed -i \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

When I cross compiled and ran this script, it provided the `dd` for the wrong architecture, and it doesn't run when you compile it on x86 because the u-boot is not cross compiled in this case, this PR fixes that.

```
sudo ./result/bin/sd_fuse-xu3 /dev/sda
/dev/sda reader is identified.
BL1 fusing
/nix/store/850vwginm8div9ki0z33i1pmjcr9ydfp-coreutils-armv7l-unknown-linux-gnueabihf-9.10/bin/dd: /nix/store/850vwginm8div9ki0z33i1pmjcr9ydfp-coreutils-armv7l-unknown-linux-gnueabihf-9.10/bin/dd: cannot execute binary file 
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
