### PR TITLE
nixos/tailscale: add `relayServerPort` option for peer relay

### DIFF
--- a/nixos/modules/services/networking/tailscale.nix
+++ b/nixos/modules/services/networking/tailscale.nix
@@ -138,6 +138,22 @@ in
       default = [ ];
       example = [ "--no-logs-no-support" ];
     };
+
+    relayServerPort = mkOption {
+      type = types.nullOr (types.either types.port (types.enum [ "" ]));
+      default = null;
+      description = ''
+        The port to use for Tailscale peer relay.
+
+        Set to a port number to enable, `""` to explicitly disable, or `null` (default) to leave the setting unmanaged.
+
+        Note: Tailscale settings are persistent. If you previously set a port and now want to disable it, set this to `""`,
+        or run {command}`tailscale set --relay-server-port=""` manually.
+        Setting it back to `null` will leave the last configured port active in Tailscale's state.
+
+        See <https://tailscale.com/docs/features/peer-relay>
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
@@ -234,27 +250,37 @@ in
         '';
     };
 
-    systemd.services.tailscaled-set = mkIf (cfg.extraSetFlags != [ ]) {
-      after = [
-        "tailscaled.service"
-        "tailscaled-autoconnect.service"
-      ];
-      wants = [ "tailscaled.service" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
+    systemd.services.tailscaled-set =
+      let
+        setFlags =
+          cfg.extraSetFlags
+          ++ lib.cli.toCommandLineGNU { } {
+            relay-server-port = cfg.relayServerPort;
+          };
+      in
+      mkIf (setFlags != [ ]) {
+        after = [
+          "tailscaled.service"
+          "tailscaled-autoconnect.service"
+        ];
+        wants = [ "tailscaled.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+        };
+        script = ''
+          ${lib.getExe cfg.package} set ${escapeShellArgs setFlags}
+        '';
       };
-      script = ''
-        ${lib.getExe cfg.package} set ${escapeShellArgs cfg.extraSetFlags}
-      '';
-    };
 
     boot.kernel.sysctl = mkIf (cfg.useRoutingFeatures == "server" || cfg.useRoutingFeatures == "both") {
       "net.ipv4.conf.all.forwarding" = mkOverride 97 true;
       "net.ipv6.conf.all.forwarding" = mkOverride 97 true;
     };
 
-    networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [ cfg.port ];
+    networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall (
+      [ cfg.port ] ++ lib.optional (builtins.isInt cfg.relayServerPort) cfg.relayServerPort
+    );
 
     networking.firewall.checkReversePath = mkIf (
       cfg.useRoutingFeatures == "client" || cfg.useRoutingFeatures == "both"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add the `relayServerPort` option to support [Tailscale Peer Relays](https://tailscale.com/docs/features/peer-relay).

Since Tailscale's `set` command modifies persistent state, this option support the following value.
- `null` (Default): Leaves the setting unmanaged by NixOS. This ensures no side effects for existing users who may have configured this manually. 
- Port number: Enables the relay on the specified port and opens the corresponding UDP port in the firewall if `openFirewall` is enabled.
- Empty string (`""`): Explicitly disables the peer relay by adding `--relay-server-port=""` in `tailscaled-set` service. This is useful for clearing previously configured state.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
