### PR TITLE
libsoup_3: drop patches incorporated in 3.6.6

### DIFF
--- a/pkgs/development/libraries/libsoup/3.x.nix
+++ b/pkgs/development/libraries/libsoup/3.x.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchurl,
-  fetchpatch,
   glib,
   meson,
   ninja,
@@ -37,19 +36,6 @@ stdenv.mkDerivation rec {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
     hash = "sha256-Ue0K4G+dWkD0Af9Fni5fZS+aUQt3MOE1nuZtFNSHJ0A=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "soup-init-use-libdl-instead-of-gmodule-in-soup2_is_loaded.patch";
-      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/2316e56a5502ac4c41ef4ff56a3266e680aca129.patch";
-      hash = "sha256-6TOM6sygVPpBWjTNgFG37JFbJDl0t2f9Iwidvh/isa4=";
-    })
-    (fetchpatch {
-      name = "CVE-2025-11021.patch";
-      url = "https://gitlab.gnome.org/GNOME/libsoup/-/commit/9e1a427d2f047439d0320defe1593e6352595788.patch";
-      hash = "sha256-08WiDnqg4//y8uPhIcV6svWdpRo27FmW+6DHy4OEZk8=";
-    })
-  ];
 
   depsBuildBuild = [
     pkg-config


### PR DESCRIPTION
This package currently fails to build during the patch application step as it includes patches that were incorporated into libsoup 3.6.6. These patches were introduced in #468891 and #489681. Since they are now part of a regular release (which we already have on both staging and staging-next-25.11), we thus drop these patches.

The list of commits where these changes are present can be seen at https://gitlab.gnome.org/GNOME/libsoup/-/compare/3.6.5...3.6.6.

~~This has *not* been tested on staging, as I don't have the compute to build up from stdenv.~~ However, I *have* tested this build on both x86_64-linux and aarch64-linux by picking this commit on top of staging-next-25.11. It is currently failing there, and succeeds after this commit.

Edit: Nevermind, I let it run overnight and `libsoup_3` successfully built for x86_64-linux on top of staging.

I'm not sure how to mark this for backport to staging-next-25.11, since there's not a label to do so. However, that backport should happen.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
