### PR TITLE
makemkv: Add expat

### DIFF
--- a/pkgs/by-name/ma/makemkv/package.nix
+++ b/pkgs/by-name/ma/makemkv/package.nix
@@ -2,6 +2,7 @@
   autoPatchelfHook,
   common-updater-scripts,
   curl,
+  expat,
   fetchurl,
   ffmpeg,
   lib,
@@ -51,6 +52,7 @@ stdenv.mkDerivation (
       qt5.wrapQtAppsHook
     ];
     buildInputs = [
+      expat
       ffmpeg
       openssl
       qt5.qtbase


### PR DESCRIPTION
makemkv needs expat. Compiling complains about it.

```
configure: error: expat library header files not found
See `config.log' for more details
error: Cannot build '/nix/store/nkf65g1c74svhrz0ylk9s1ydabm0kklv-makemkv-1.18.3.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/pbrw1mshxwnzzgqg5wmawn33671qa726-makemkv-1.18.3
       Last 25 log lines:
       > checking how to run the C++ preprocessor... g++ -E
       > checking for ld used by g++... ld -m elf_x86_64
       > checking if the linker (ld -m elf_x86_64) is GNU ld... yes
       > checking whether the g++ linker (ld -m elf_x86_64) supports shared libraries... yes
       > /nix/store/8laf6k81j9ckylrigj3xsk76j69knhvl-gnugrep-3.12/bin/grep: warning: stray \ before -
       > checking for g++ option to produce PIC... -fPIC -DPIC
       > checking if g++ PIC flag -fPIC -DPIC works... yes
       > checking if g++ static flag -static works... no
       > checking if g++ supports -c -o file.o... yes
       > checking if g++ supports -c -o file.o... (cached) yes
       > checking whether the g++ linker (ld -m elf_x86_64) supports shared libraries... yes
       > checking dynamic linker characteristics... (cached) GNU/Linux ld.so
       > checking how to hardcode library paths into programs... immediate
       > checking for -objcopy... objcopy
       > checking for -ld... ld -m elf_x86_64
       > checking for a BSD-compatible install... /nix/store/hlxw2q9qansq7bn52xvlb5badw3z1v8s-coreutils-9.10/bin/install -c
       > checking whether g++ supports C++11 features with -std=c++11... yes
       > checking for zlib.h... yes
       > checking for compress2 in -lz... yes
       > checking for openssl/opensslconf.h... yes
       > checking for AES_encrypt in -lcrypto... yes
       > checking for expat.h... no
       > configure: error: in `/build/makemkv-oss-1.18.3':
       > configure: error: expat library header files not found
       > See `config.log' for more details
       For full logs, run:
         nix log /nix/store/nkf65g1c74svhrz0ylk9s1ydabm0kklv-makemkv-1.18.3.drv
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [X] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
