### PR TITLE
ashpd-demo: upgrade outdated project link

### DIFF
--- a/pkgs/by-name/as/ashpd-demo/package.nix
+++ b/pkgs/by-name/as/ashpd-demo/package.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Tool for playing with XDG desktop portals";
     mainProgram = "ashpd-demo";
-    homepage = "https://github.com/bilelmoussaoui/ashpd/tree/master/ashpd-demo";
+    homepage = "https://bilelmoussaoui.github.io/ashpd/ashpd/#demo";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ jtojnar ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
i tryd to upgrde the link to the metadata of the package package 
the link pointed to an emty destenation: 

homepage = "https://github.com/bilelmoussaoui/ashpd/tree/master/ashpd-demo";

## Things done
 I added the link mention under the project site , with the demo section marked https://bilelmoussaoui.github.io/ashpd/ashpd/#demo 


- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
