### PR TITLE
root: 6.38.00 -> 6.38.02

### DIFF
--- a/pkgs/by-name/ro/root/package.nix
+++ b/pkgs/by-name/ro/root/package.nix
@@ -54,7 +54,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "root";
-  version = "6.38.00";
+  version = "6.38.02";
 
   passthru = {
     tests = import ./tests { inherit callPackage; };
@@ -62,7 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://root.cern.ch/download/root_v${finalAttrs.version}.source.tar.gz";
-    hash = "sha256-pEKUIsRg+DLN5RSlgN0gKx08luiRnCQ2PD1C+M9azNw=";
+    hash = "sha256-d9NNK8oOpyCs/UN5i8tdCaKFhAE7TQopEII8hn1L+kI=";
   };
 
   clad_src = fetchFromGitHub {


### PR DESCRIPTION
ROOT 6.38.02 contains many changes and bugfixes, so it's worth to upgrade:

https://root.cern/doc/v638/release-notes.html#release-6.38.02