### PR TITLE
[Backport release-25.11] cloud-hypervisor: 50.1 → 50.2

### DIFF
--- a/pkgs/by-name/cl/cloud-hypervisor/package.nix
+++ b/pkgs/by-name/cl/cloud-hypervisor/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cloud-hypervisor";
-  version = "50.1";
+  version = "50.2";
 
   src = fetchFromGitHub {
     owner = "cloud-hypervisor";
     repo = "cloud-hypervisor";
     rev = "v${version}";
-    hash = "sha256-18A0Sl3/sclKtjkZLKFR3RfjqceKOddxFEnBQF76+xU=";
+    hash = "sha256-UqagcomatsoSmmdFLg+hIguctiVTSasDVtXZFi8ILew=";
   };
 
-  cargoHash = "sha256-9QYSbnirQBG/WkfIBQ47wHE478RjWQ9rTJe/aJ436bU=";
+  cargoHash = "sha256-FHBp7Aeq1qubkhrOPDbZ1LX12P7PrMVWIoS6DLy4mpU=";
 
   separateDebugInfo = true;
 


### PR DESCRIPTION
* https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v50.2

Not-cherry-picked-because: minor version bump

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [X] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [X] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
