### PR TITLE
python3Packages.dvc-sv3: fix build

### DIFF
--- a/pkgs/development/python-modules/dvc-s3/default.nix
+++ b/pkgs/development/python-modules/dvc-s3/default.nix
@@ -1,13 +1,12 @@
 {
   lib,
-  aiobotocore,
-  boto3,
   buildPythonPackage,
   dvc-objects,
   fetchPypi,
   flatten-dict,
   s3fs,
   setuptools-scm,
+  funcy,
 }:
 
 buildPythonPackage rec {
@@ -24,20 +23,13 @@ buildPythonPackage rec {
   # Prevent circular dependency
   pythonRemoveDeps = [ "dvc" ];
 
-  # dvc-s3 uses boto3 directly, we add in propagatedBuildInputs
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "aiobotocore[boto3]" "aiobotocore"
-  '';
-
   build-system = [ setuptools-scm ];
 
   dependencies = [
-    aiobotocore
-    boto3
     dvc-objects
     flatten-dict
     s3fs
+    funcy
   ];
 
   # Network access is needed for tests


### PR DESCRIPTION
Dropped dependencies on boto3 and aiobotocore as they were dropped upstream ([4bb81c1](https://github.com/treeverse/dvc-s3/commit/4bb81c1e6c994c6b1b6715c82bb6403521a27883) and [a4132b8](https://github.com/treeverse/dvc-s3/commit/a4132b82b8dd63729ba1730238e578e37f1824c9)). Also pulled in `funcy` as its a required dependency. This also fixes the build of `dvc-with-remotes` as dvc-s3 is a dependency.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
