### PR TITLE
papis: fix build failure with optional deps

### DIFF
--- a/pkgs/development/python-modules/papis/default.nix
+++ b/pkgs/development/python-modules/papis/default.nix
@@ -126,6 +126,10 @@ buildPythonPackage (finalAttrs: {
     "test_yaml_unicode_dump"
     # FileNotFoundError: Command not found: 'init'
     "test_git_cli"
+  ]
+  ++ lib.optionals withOptDeps [
+    # Require network access
+    "test_csl_style_download"
   ];
 
   meta = {


### PR DESCRIPTION
"test_csl_style_download" requires network access but only enabled with optional dependencies, which was missed on the original commit c07476ce4d412. Disable also this test if derivation is overriden for optional dependencies.

Pointed out kindly by @choreutes, [ref](https://github.com/NixOS/nixpkgs/commit/c07476ce4d412beb2cb2c3fa29200c6c2eb5def1#commitcomment-177775858).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] ~[Package tests] at `passthru.tests`.~
  - [x] ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - [x] ~Module addition: when adding a new NixOS module.~
  - [x] ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
