### PR TITLE
qt6.qtbase: fix incorrect substitution in setupHook

### DIFF
--- a/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
+++ b/pkgs/development/libraries/qt-6/hooks/qtbase-setup-hook.sh
@@ -1,13 +1,13 @@
 if [[ -n "${__nix_qtbase-}" ]]; then
     # Throw an error if a different version of Qt was already set up.
-    if [[ "$__nix_qtbase" != "@out@" ]]; then
+    if [[ "$__nix_qtbase" != "@qtbaseOut@" ]]; then
         echo >&2 "Error: detected mismatched Qt dependencies:"
-        echo >&2 "    @out@"
+        echo >&2 "    @qtbaseOut@"
         echo >&2 "    $__nix_qtbase"
         exit 1
     fi
 else # Only set up Qt once.
-    __nix_qtbase="@out@"
+    __nix_qtbase="@qtbaseOut@"
 
     qtPluginPrefix=@qtPluginPrefix@
     qtQmlPrefix=@qtQmlPrefix@
@@ -16,7 +16,7 @@ else # Only set up Qt once.
     . @fix_qt_module_paths@
 
     # Build tools are often confused if QMAKE is unset.
-    export QMAKE=@out@/bin/qmake
+    export QMAKE=@qtbaseOut@/bin/qmake
 
     export QMAKEPATH=
 

--- a/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtbase/default.nix
@@ -321,6 +321,13 @@ stdenv.mkDerivation {
     moveToOutput      "mkspecs/modules" "$dev"
     fixQtModulePaths  "$dev/mkspecs/modules"
     fixQtBuiltinPaths "$out" '*.pr?'
+
+    # @out@ would be automagically replaced inside makeSetupHook by the output of that derivation,
+    # but we need it to be the output of this derivation.
+    # Use a different placeholder and explicitly substitute this
+    # to keep compatibility with __structuredAttrs and avoid substituteAll.
+    substituteInPlace "''${!outputDev}/nix-support/setup-hook" \
+      --replace-fail "@qtbaseOut@" $out
   ''
   + lib.optionalString stdenv.hostPlatform.isLinux ''
     # FIXME: not sure why this isn't added automatically?


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/493843 , introduced by https://github.com/NixOS/nixpkgs/pull/472656 .

Still running a build for `calibre`, which was the breakage referenced in the issue.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
