### PR TITLE
lf: include icon files in the derivation

### DIFF
--- a/pkgs/by-name/lf/lf/package.nix
+++ b/pkgs/by-name/lf/lf/package.nix
@@ -34,6 +34,7 @@ buildGoModule (finalAttrs: {
 
   postInstall = ''
     install -D --mode=444 lf.desktop $out/share/applications/lf.desktop
+    install -D --mode=444 -t $out/etc/ etc/icons.example etc/icons_colored.example
     installManPage lf.1
     installShellCompletion etc/lf.{bash,zsh,fish}
   '';


### PR DESCRIPTION
_Accidentally closed #493327, here it is again._

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] ~[NixOS tests] in [nixos/tests].~
  - [x] ~[Package tests] at `passthru.tests`.~
  - [x] ~Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.~
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [x] ~Package update: when the change is major or breaking.~
- NixOS Release Notes
  - [x] ~Module addition: when adding a new NixOS module.~
  - [x] ~Module update: when the change is significant.~
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
