### PR TITLE
python3Packages.tyro: 1.0.5 -> 1.0.8

### DIFF
--- a/pkgs/development/python-modules/tyro/default.nix
+++ b/pkgs/development/python-modules/tyro/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  pythonAtLeast,
 
   # build-system
   hatchling,
@@ -23,18 +24,19 @@
   pydantic,
   pytestCheckHook,
   torch,
+  universal-pathlib,
 }:
 
 buildPythonPackage rec {
   pname = "tyro";
-  version = "1.0.5";
+  version = "1.0.8";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "brentyi";
     repo = "tyro";
     tag = "v${version}";
-    hash = "sha256-/6z3XDN5WdVPVfA1LckpIAUis3dNOwg5hobR2sHlocA=";
+    hash = "sha256-GTgbzGIIZrkMUgjqMWZVXRVhp9mcxfnDQ/dRApotjww=";
   };
 
   build-system = [ hatchling ];
@@ -57,6 +59,20 @@ buildPythonPackage rec {
     pydantic
     pytestCheckHook
     torch
+    universal-pathlib
+  ];
+
+  disabledTests = lib.optionals (pythonAtLeast "3.13") [
+    # Bash path completion relies on the programmable-completion builtin `compgen`,
+    # which is unavailable in the stdenv build shell.
+    "test_bash_path_completion_marker"
+
+    # In Nix builds, the long `python -m pytest` argv[0] path gets line-wrapped in
+    # argparse error output, splitting `class-b` and `)` so this literal-match fails.
+    "test_similar_arguments_subcommands_multiple_contains_match"
+
+    # Same wrapped-output literal-match issue as above for the cascading-args variant.
+    "test_similar_arguments_subcommands_multiple_contains_match_cascading"
   ];
 
   pythonImportsCheck = [ "tyro" ];


### PR DESCRIPTION
Fixes: Build failure: python3Packages.tyro #493873

Add universal-pathlib to nativeCheckInputs to satisfy upath tests.

Disable three Python 3.13 tests that are build-environment specific:

- test_bash_path_completion_marker: requires bash programmable completion builtin compgen, unavailable in the stdenv build shell.

- test_similar_arguments_subcommands_multiple_contains_match

- test_similar_arguments_subcommands_multiple_contains_match_cascading

  These two assert a literal class-b) substring that is split by line wrapping with long pytest argv[0] paths in Nix builds.

Resolves #493873.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
