### PR TITLE
haskell.packages.ghc914: fix build of dependencies of cabal2nix

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -112,10 +112,12 @@ with haskellLib;
     (
       let
         # !!! Use cself/csuper inside for the actual overrides
-        cabalInstallOverlay = cself: csuper: {
-          Cabal = cself.Cabal_3_16_1_0;
-          Cabal-syntax = cself.Cabal-syntax_3_16_1_0;
-        };
+        cabalInstallOverlay =
+          cself: csuper:
+          lib.optionalAttrs (lib.versionOlder csuper.ghc.version "9.14") {
+            Cabal = cself.Cabal_3_16_1_0;
+            Cabal-syntax = cself.Cabal-syntax_3_16_1_0;
+          };
       in
       {
         cabal-install =

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -75,6 +75,7 @@ with haskellLib;
   #
 
   parallel = doDistribute self.parallel_3_3_0_0;
+  tagged = doDistribute self.tagged_0_8_10;
 
   #
   # Jailbreaks

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -74,6 +74,8 @@ with haskellLib;
   # Version upgrades
   #
 
+  parallel = doDistribute self.parallel_3_3_0_0;
+
   #
   # Jailbreaks
   #

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -85,6 +85,24 @@ with haskellLib;
   primitive = doJailbreak (dontCheck super.primitive); # base <4.22 and a lot of dependencies on packages not yet working.
   splitmix = doJailbreak super.splitmix; # base <4.22
 
+  # https://github.com/haskellari/indexed-traversable/issues/49
+  indexed-traversable = doJailbreak super.indexed-traversable;
+  # https://github.com/haskellari/indexed-traversable/issues/50
+  indexed-traversable-instances = doJailbreak super.indexed-traversable-instances;
+  # https://github.com/haskellari/these/issues/211
+  these = doJailbreak super.these;
+  # https://github.com/haskellari/these/issues/207
+  semialign = doJailbreak super.semialign;
+  # https://github.com/haskellari/time-compat/issues/48
+  time-compat = doJailbreak super.time-compat;
+  # https://github.com/haskell-hvr/uuid/issues/95
+  uuid-types = doJailbreak super.uuid-types;
+  # https://github.com/haskellari/qc-instances/issues/110
+  quickcheck-instances = doJailbreak super.quickcheck-instances;
+  # https://github.com/haskell/aeson/issues/1155
+  text-iso8601 = doJailbreak super.text-iso8601;
+  aeson = doJailbreak super.aeson;
+
   # https://github.com/sjakobi/newtype-generics/pull/28/files
   newtype-generics = warnAfterVersion "0.6.2" (doJailbreak super.newtype-generics);
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -124,4 +124,7 @@ with haskellLib;
   #
   # Test suite issues
   #
+
+  # Fails to compile with GHC 9.14 https://github.com/snoyberg/mono-traversable/pull/261
+  mono-traversable = dontCheck super.mono-traversable;
 }

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -76,6 +76,7 @@ with haskellLib;
 
   parallel = doDistribute self.parallel_3_3_0_0;
   tagged = doDistribute self.tagged_0_8_10;
+  unordered-containers = doDistribute self.unordered-containers_0_2_21;
 
   #
   # Jailbreaks

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -103,6 +103,21 @@ with haskellLib;
   text-iso8601 = doJailbreak super.text-iso8601;
   aeson = doJailbreak super.aeson;
 
+  # https://github.com/well-typed/cborg/issues/373
+  cborg = doJailbreak super.cborg;
+  serialise = doJailbreak (
+    appendPatches [
+      # This removes support for older versions of time (think GHC 8.6) and, in doing so,
+      # drops a Cabal flag that prevents jailbreak from working
+      (pkgs.fetchpatch {
+        name = "serialise-no-old-time.patch";
+        url = "https://github.com/well-typed/cborg/commit/308afc2795062f847171463958e5e1bbd9c03381.patch";
+        hash = "sha256-Gutu9c+houcwAvq2Z+ZQUQbNK+u+OCJRZfKBtx8/V4c=";
+        relative = "serialise";
+      })
+    ] super.serialise
+  );
+
   # https://github.com/sjakobi/newtype-generics/pull/28/files
   newtype-generics = warnAfterVersion "0.6.2" (doJailbreak super.newtype-generics);
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

cabal2nix itself needs 2.21.2 to reach nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
