### PR TITLE
nixos/envfs: fix compatibility with systemd in initrd

### DIFF
--- a/nixos/modules/tasks/filesystems/envfs.nix
+++ b/nixos/modules/tasks/filesystems/envfs.nix
@@ -74,5 +74,39 @@ in
     # We no longer need those when using envfs
     system.activationScripts.usrbinenv = lib.mkForce "";
     system.activationScripts.binsh = lib.mkForce "";
+
+    # Disabling the activation scripts above prevents the creation of 2
+    # directories, which would normally be created just before switch-root at
+    # stage1. This causes problems when systemd is used in the initrd.
+    #
+    # This only affects fresh installations or systems using impermanence/tmpfs
+    # root, where these directories don't persist from a previous activation.
+    boot.initrd.systemd.tmpfiles.settings = lib.mkIf config.boot.initrd.systemd.enable {
+      "50-envfs" = {
+        # During switch-root, systemd's base_filesystem_create_fd() creates an
+        # empty /usr. Later at stage2, systemd initialize_runtime() checks
+        # dir_is_empty("/usr/"), which returns 1 for an empty but existing
+        # directory causing a fatal boot failure: "Refusing to run in
+        # unsupported environment where /usr/ is not populated."
+        "/sysroot/usr/bin" = {
+          d = {
+            group = "root";
+            mode = "0755";
+            user = "root";
+          };
+        };
+        # During switch-root, base_filesystem_create_fd() creates a symlink
+        # /bin -> /usr/bin if /bin does not exist. systemd-fstab-generator then
+        # canonicalizes the /bin fstab entry through this symlink, producing a
+        # duplicate usr-bin.mount. Create /bin to avoid this behaviour.
+        "/sysroot/bin" = {
+          d = {
+            group = "root";
+            mode = "0755";
+            user = "root";
+          };
+        };
+      };
+    };
   };
 }

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -518,7 +518,14 @@ in
   enlightenment = runTest ./enlightenment.nix;
   ente = runTest ./ente;
   env = runTest ./env.nix;
-  envfs = runTest ./envfs.nix;
+  envfs = runTest {
+    imports = [ ./envfs.nix ];
+    _module.args.systemdStage1 = false;
+  };
+  envfs-systemd-stage-1 = runTest {
+    imports = [ ./envfs.nix ];
+    _module.args.systemdStage1 = true;
+  };
   envoy = runTest {
     imports = [ ./envoy.nix ];
     _module.args.envoyPackage = pkgs.envoy;

--- a/nixos/tests/envfs.nix
+++ b/nixos/tests/envfs.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, ... }:
+{
+  pkgs,
+  systemdStage1 ? false,
+  ...
+}:
+
 let
   pythonShebang = pkgs.writeScript "python-shebang" ''
     #!/usr/bin/python
@@ -12,7 +17,11 @@ let
 in
 {
   name = "envfs";
-  nodes.machine.services.envfs.enable = true;
+
+  nodes.machine = {
+    services.envfs.enable = true;
+    boot.initrd.systemd.enable = systemdStage1;
+  };
 
   testScript = ''
     start_all()

--- a/pkgs/by-name/en/envfs/package.nix
+++ b/pkgs/by-name/en/envfs/package.nix
@@ -25,7 +25,7 @@ rustPlatform.buildRustPackage (finalAttrs: {
 
   passthru = {
     tests = {
-      envfs = nixosTests.envfs;
+      inherit (nixosTests) envfs envfs-systemd-stage-1;
     };
 
     updateScript = nix-update-script { };


### PR DESCRIPTION
## Description

Fixes 2 issues caused by the disabling of `system.activationScripts.{usrbinenv,binsh}` within the envfs NixOS module when running systemd in initrd.

Note that this only affects fresh installations or systems using impermanence/tmpfs root, where these directories don't persist from a previous activation.

Disabling these activation scripts prevents the creation of `/usr/bin/env` and `/bin/sh` (and their parent directories), which would normally be created just before switch-root at stage1.

We use `boot.initrd.systemd.tmpfiles.settings` to create these directories at stage1 manually.

## disabling `system.activationScripts.usrbinenv` (no `/usr`)

> [!IMPORTANT]
> This is a critical problem as it prevents booting!

During switch-root, systemd's [base_filesystem_create_fd()](https://github.com/systemd/systemd/blob/09c92eef12323eab06e9af8e55920654814c00b7/src/shared/switch-root.c#L118) creates an empty [/usr](https://github.com/systemd/systemd/blob/09c92eef12323eab06e9af8e55920654814c00b7/src/shared/base-filesystem.c#L43).

Later at stage2, systemd initialize_runtime() [checks](https://github.com/systemd/systemd/blob/09c92eef12323eab06e9af8e55920654814c00b7/src/core/main.c#L2492) dir_is_empty("/usr/"), which returns 1 for an empty but existing directory causing a fatal boot failure:
> "Refusing to run in unsupported environment where /usr/ is not populated."

## disabling `system.activationScripts.binsh` (no `/bin`)

> [!NOTE]
> This issue only manifests after issue 1 is fixed, since `base_filesystem_create_fd()` only creates the `/bin` symlink when `/usr/bin` exists.

During switch-root, systemd's base_filesystem_create_fd() creates a [symlink /bin -> /usr/bin](https://github.com/systemd/systemd/blob/09c92eef12323eab06e9af8e55920654814c00b7/src/shared/base-filesystem.c#L39). systemd-fstab-generator then [canonicalizes](https://man.archlinux.org/man/systemd-fstab-generator.8.en) the /bin fstab entry through this symlink, producing a duplicate usr-bin.mount.

Since `base_filesystem_create_fd()` skips entries where the path already exists, creating `/sysroot/bin` as a directory prevents the symlink from being created.

This is not a boot failure but it is still better to prevent non-zero exit status codes showing up in `journalctl`.

---

Resolves: #462556, https://github.com/Mic92/envfs/issues/203, https://discourse.nixos.org/t/impermanence-25-05-not-populating-usr/64567/7

## Attribution

The workarounds for these issues were originally identified by @linyinfeng in their [dotfiles](https://github.com/linyinfeng/dotfiles/blob/c8cc1e012d266ebd04fa9876f4b988991da1340d/nixos/profiles/services/envfs/default.nix).

Thank you to @dramforever for pointing me to the right direction throughout this PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

cc @Mic92 @linyinfeng
