### PR TITLE
renode-bin: build on macOS

### DIFF
--- a/pkgs/by-name/re/renode-bin/package.nix
+++ b/pkgs/by-name/re/renode-bin/package.nix
@@ -7,6 +7,7 @@
   autoPatchelfHook,
   makeWrapper,
   nix-update-script,
+  _7zz,
   glibcLocales,
   python3Packages,
   dotnetCorePackages,
@@ -53,21 +54,41 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "renode";
   version = "1.16.1";
 
-  src = fetchurl {
-    url = "https://github.com/renode/renode/releases/download/v${finalAttrs.version}/renode-${finalAttrs.version}.linux-dotnet.tar.gz";
-    hash = "sha256-YmKcqjMe1L1Ot6vhPuLkg0+8qnDeSS2zll+vpO3FaU8=";
-  };
+  src = fetchurl (
+    {
+      x86_64-linux = {
+        url = "https://github.com/renode/renode/releases/download/v${finalAttrs.version}/renode-${finalAttrs.version}.linux-dotnet.tar.gz";
+        hash = "sha256-YmKcqjMe1L1Ot6vhPuLkg0+8qnDeSS2zll+vpO3FaU8=";
+      };
+      aarch64-darwin = {
+        url = "https://github.com/renode/renode/releases/download/v${finalAttrs.version}/renode-${finalAttrs.version}-dotnet.osx-arm64-portable.dmg";
+        hash = "sha256-mbiuWJe4km7xeYaNOaUE/lKWVV3JyblzcY3fOrCRddk=";
+      };
+    }
+    .${stdenv.hostPlatform.system} or (throw "Unsupported system: ${stdenv.hostPlatform.system}")
+  );
 
   nativeBuildInputs = [
-    autoPatchelfHook
     makeWrapper
-  ];
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [ _7zz ];
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     gtk-sharp-3_0
   ];
 
   strictDeps = true;
+
+  # The DMG extracts to Renode.app/; we want Contents/MacOS/ as the root
+  sourceRoot = lib.optionalString stdenv.hostPlatform.isDarwin "Renode.app/Contents/MacOS";
+
+  # The DMG uses APFS and contains symlinks that 7zz rejects by default
+  unpackCmd = lib.optionalString stdenv.hostPlatform.isDarwin "7zz x -snld $curSrc";
+
+  # The aarch64-darwin build is a self-contained .NET application;
+  # stripping corrupts the bundled runtime
+  dontStrip = stdenv.hostPlatform.isDarwin;
 
   installPhase = ''
     runHook preInstall
@@ -77,21 +98,35 @@ stdenv.mkDerivation (finalAttrs: {
     mv * $out/libexec/renode
     mv .renode-root $out/libexec/renode
 
+    renodePath="$out/libexec/renode"
+    wrapperArgs=(--prefix PYTHONPATH : "${pythonLibs}")
+  ''
+  + lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Pre-extract the .NET single-file bundle at build time so nothing
+    # is written at runtime
+    bundleExtractDir=$out/libexec/renode/.dotnet-bundle
+    DOTNET_BUNDLE_EXTRACT_BASE_DIR=$bundleExtractDir \
+      $out/libexec/renode/renode --version > /dev/null 2>&1 || true
+    wrapperArgs+=(--set DOTNET_BUNDLE_EXTRACT_BASE_DIR "$bundleExtractDir")
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    renodePath="$renodePath:${lib.makeBinPath [ dotnetCorePackages.runtime_8_0 ]}"
+    wrapperArgs+=(
+      --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"
+      --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk3-x11 ]}"
+      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+    )
+  ''
+  + ''
     makeWrapper "$out/libexec/renode/renode" "$out/bin/renode" \
-      --prefix PATH : "$out/libexec/renode:${lib.makeBinPath [ dotnetCorePackages.runtime_8_0 ]}" \
-      --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules" \
-      --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk3-x11 ]}" \
-      --prefix PYTHONPATH : "${pythonLibs}" \
-      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+      --prefix PATH : "$renodePath" \
+      "''${wrapperArgs[@]}"
     makeWrapper "$out/libexec/renode/renode-test" "$out/bin/renode-test" \
-      --prefix PATH : "$out/libexec/renode:${lib.makeBinPath [ dotnetCorePackages.runtime_8_0 ]}" \
-      --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules" \
-      --suffix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ gtk3-x11 ]}" \
-      --prefix PYTHONPATH : "${pythonLibs}" \
-      --set LOCALE_ARCHIVE "${glibcLocales}/lib/locale/locale-archive"
+      --prefix PATH : "$renodePath:${python3Packages.python}/bin" \
+      "''${wrapperArgs[@]}"
 
     substituteInPlace "$out/libexec/renode/renode-test" \
-      --replace '$PYTHON_RUNNER' '${python3Packages.python}/bin/python3'
+      --replace-fail '$PYTHON_RUNNER' '${python3Packages.python}/bin/python3'
 
     runHook postInstall
   '';
@@ -106,6 +141,9 @@ stdenv.mkDerivation (finalAttrs: {
       otavio
       znaniye
     ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+    ];
   };
 })


### PR DESCRIPTION
Package prebuilt renode for macOS

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
