### PR TITLE
python3Packages.pycdlib: init at 1.15.0

### DIFF
--- a/pkgs/development/python-modules/pycdlib/default.nix
+++ b/pkgs/development/python-modules/pycdlib/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pycdlib";
+  version = "1.15.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "clalancette";
+    repo = "pycdlib";
+    tag = "v${version}";
+    hash = "sha256-BD33nA60x6YvwkYGXPA0E6s8N/XhWaY/+tTRbFN9ai4=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTestPaths = [
+    # These tests require a Fedora-patched genisoimage
+    "tests/integration/test_hybrid.py"
+    "tests/integration/test_parse.py"
+    "tests/tools/test_pycdlib_genisoimage.py"
+  ];
+
+  disabledTests = [
+    # Timezone-dependent tests fail in the sandbox
+    "test_volumedescdate_new_nonzero"
+    "test_gmtoffset_from_tm"
+    "test_gmtoffset_from_tm_day_rollover"
+    "test_gmtoffset_from_tm_2023_rollover"
+  ];
+
+  pythonImportsCheck = [ "pycdlib" ];
+
+  meta = {
+    description = "Pure python library to read and write ISO9660 files";
+    homepage = "https://github.com/clalancette/pycdlib";
+    license = lib.licenses.lgpl2Only;
+    maintainers = with lib.maintainers; [ Enzime ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13199,6 +13199,8 @@ self: super: with self; {
 
   pycdio = callPackage ../development/python-modules/pycdio { };
 
+  pycdlib = callPackage ../development/python-modules/pycdlib { };
+
   pycec = callPackage ../development/python-modules/pycec { };
 
   pycep-parser = callPackage ../development/python-modules/pycep-parser { };


### PR DESCRIPTION
> PyCdlib is a pure python library to parse, write (master), and create ISO9660 files, suitable for writing to a CD or USB.

https://clalancette.github.io/pycdlib/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
