### PR TITLE
kirimoto: init at 4.6.3

### DIFF
--- a/pkgs/by-name/ki/kirimoto/package.nix
+++ b/pkgs/by-name/ki/kirimoto/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
+
+let
+  version = "4.6.3";
+  pname = "kirimoto";
+
+  src = fetchurl {
+    url = "https://github.com/GridSpace/grid-apps/releases/download/${version}/KiriMoto-linux-x86_64.AppImage";
+    hash = "sha256-YCfDCR92xtwL3634iIMYf6IjkeqoWrF7/YNCwKSjnfs==";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/grid-apps.desktop -t $out/share/applications/
+    install -Dm444 ${appimageContents}/grid-apps.png -t $out/share/icons/hicolor/512x512/apps/
+
+    substituteInPlace $out/share/applications/grid-apps.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${meta.mainProgram} --no-sandbox --ozone-platform=x11 --disable-gpu-sandbox --in-process-gpu'
+  '';
+
+  meta = {
+    description = "Open source Slicer for CAM, Laser and 3D-printer";
+    homepage = "https://grid.space/";
+    downloadPage = "https://grid.space/downloads.html";
+    changelog = "https://grid.space/news";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ FlorisMenninga ];
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "kirimoto";
+  };
+}


### PR DESCRIPTION
Add KiriMoto, an open source slicer for CAM, Laser and 3D printers.

Homepage: https://grid.space/

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.
