### PR TITLE
haskell.compiler.ghc912: 9.12.2 -> 9.12.3, haskell.packages.ghc9123.fourmolu,cabal-add: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -260,6 +260,15 @@ with haskellLib;
     disableCabalFlag "auto" super.ghc-lib-parser-ex
   );
 
+  # Work around test suite not finding executable due to https://github.com/haskell/cabal/issues/11598
+  cabal-add = appendPatches [
+    (pkgs.fetchpatch {
+      name = "cabal-add-absolute-build-tool-paths.patch";
+      url = "https://github.com/Bodigrim/cabal-add/commit/3b94b0175c294c2d0a30b6d8da3f56189216816c.patch";
+      hash = "sha256-4Nbro9Gl+RC78yprO8fYG/IWS7QvJPd0dKqSZb5jq9k=";
+    })
+  ] super.cabal-add;
+
   ###########################################
   ### END HASKELL-LANGUAGE-SERVER SECTION ###
   ###########################################

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -220,6 +220,15 @@ with haskellLib;
       lib.mapAttrs (_: pkg: pkg.overrideScope hls_overlay) (
         super
         // {
+          # Work around test suite not finding executable due to https://github.com/haskell/cabal/issues/11598
+          fourmolu = appendPatches [
+            (pkgs.fetchpatch {
+              name = "fourmolu-absolute-build-tool-paths.patch";
+              url = "https://github.com/fourmolu/fourmolu/commit/9217bc926ab80d20b815f0486be2184db07df4fc.patch";
+              hash = "sha256-ANzuKy5WfWCGZ7HFVBpTtuyUqzFfef/xR/v1KiyJEX4=";
+            })
+          ] super.fourmolu;
+
           # HLS 2.11: Too strict bound on Diff 1.0.
           haskell-language-server = lib.pipe super.haskell-language-server [
             dontCheck

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -56,10 +56,18 @@ builtins.intersectAttrs super {
   ### HASKELL-LANGUAGE-SERVER SECTION ###
   #######################################
 
-  cabal-add = overrideCabal (drv: {
-    # tests depend on executable
-    preCheck = ''export PATH="$PWD/dist/build/cabal-add:$PATH"'';
-  }) super.cabal-add;
+  cabal-add =
+    # Can't find executable without https://github.com/haskell/cabal/pull/9912
+    if lib.versionOlder self.ghc.version "9.12" then
+      overrideCabal (drv: {
+        # tests depend on executable
+        preCheck = ''
+          ${drv.preCheck or ""}
+          export PATH="$PWD/dist/build/cabal-add:$PATH"
+        '';
+      }) super.cabal-add
+    else
+      super.cabal-add;
 
   haskell-language-server = overrideCabal (drv: {
     # starting with 1.6.1.1 haskell-language-server wants to be linked dynamically
@@ -1817,11 +1825,16 @@ builtins.intersectAttrs super {
   inherit
     (
       let
-        fourmoluTestFix = overrideCabal (drv: {
-          preCheck = drv.preCheck or "" + ''
-            export PATH="$PWD/dist/build/fourmolu:$PATH"
-          '';
-        });
+        fourmoluTestFix =
+          # Can't find executable without https://github.com/haskell/cabal/pull/9912
+          if lib.versionOlder self.ghc.version "9.12" then
+            overrideCabal (drv: {
+              preCheck = drv.preCheck or "" + ''
+                export PATH="$PWD/dist/build/fourmolu:$PATH"
+              '';
+            })
+          else
+            lib.id;
       in
       builtins.mapAttrs (_: fourmoluTestFix) super
     )

--- a/pkgs/top-level/haskell-packages.nix
+++ b/pkgs/top-level/haskell-packages.nix
@@ -66,7 +66,7 @@ let
     ghc96 = sets.ghc967;
     ghc98 = sets.ghc984;
     ghc910 = sets.ghc9103;
-    ghc912 = sets.ghc9122;
+    ghc912 = sets.ghc9123;
     ghc914 = sets.ghc9141;
   };
 in

--- a/pkgs/top-level/release-haskell.nix
+++ b/pkgs/top-level/release-haskell.nix
@@ -67,7 +67,6 @@ let
     ghc967
     ghc984
     ghc9103
-    ghc9122 # TODO(@sternenseemann): drop
     ghc9123
   ];
 
@@ -526,7 +525,6 @@ let
       ] released;
       Cabal_3_10_3_0 = lib.subtractLists [
         # time < 1.13 conflicts with time == 1.14.*
-        compilerNames.ghc9122
         compilerNames.ghc9123
       ] released;
       Cabal_3_12_1_0 = released;
@@ -538,7 +536,6 @@ let
       haskell-language-server = released;
       hoogle = released;
       hlint = lib.subtractLists [
-        compilerNames.ghc9122
         compilerNames.ghc9123
       ] released;
       hpack = released;
@@ -551,11 +548,9 @@ let
       ghc-lib-parser = released;
       ghc-lib-parser-ex = released;
       ghc-source-gen = lib.subtractLists [
-        compilerNames.ghc9122
         compilerNames.ghc9123
       ] released;
       ghc-tags = lib.subtractLists [
-        compilerNames.ghc9122
         compilerNames.ghc9123
       ] released;
       hashable = released;
@@ -566,7 +561,6 @@ let
         compilerNames.ghc967
       ];
       weeder = lib.subtractLists [
-        compilerNames.ghc9122
         compilerNames.ghc9123
       ] released;
     })


### PR DESCRIPTION
After #490755, the problematic regression has been patched, so we can actually update. Also HLS compiles with 9.12.3 nowadays.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
