### PR TITLE
matrix-synapse-plugins.matrix-synapse-ldap3: remove setuptools pkg_resources usage

### DIFF
--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/ldap3.nix
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/ldap3.nix
@@ -5,6 +5,7 @@
   ldap3,
   ldaptor,
   matrix-synapse-unwrapped,
+  packaging,
   pytestCheckHook,
   service-identity,
   setuptools,
@@ -21,11 +22,17 @@ buildPythonPackage rec {
     hash = "sha256-i7ZRcXMWTUucxE9J3kEdjOvbLnBdXdHqHzhzPEoAnh0=";
   };
 
+  patches = [
+    # https://github.com/matrix-org/matrix-synapse-ldap3/pull/200
+    ./setuptools-pkg_resources.patch
+  ];
+
   build-system = [ setuptools ];
 
   dependencies = [
     service-identity
     ldap3
+    packaging
     twisted
   ];
 

--- a/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/setuptools-pkg_resources.patch
+++ b/pkgs/by-name/ma/matrix-synapse-unwrapped/plugins/setuptools-pkg_resources.patch
@@ -1,0 +1,24 @@
+From a879613c79861597525cdbab0d53dc4672c9a5a1 Mon Sep 17 00:00:00 2001
+From: Timotheus Pokorra <mailinglists@tpokorra.de>
+Date: Wed, 11 Feb 2026 06:54:10 +0100
+Subject: [PATCH] Replace pkg_resources.parse_version with
+ packaging.version.parse
+
+fixes #199
+---
+ ldap_auth_provider.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ldap_auth_provider.py b/ldap_auth_provider.py
+index 25dd81b..1f1c9ef 100644
+--- a/ldap_auth_provider.py
++++ b/ldap_auth_provider.py
+@@ -21,7 +21,7 @@
+ import ldap3
+ import ldap3.core.exceptions
+ import synapse
+-from pkg_resources import parse_version
++from packaging.version import parse as parse_version
+ from synapse.module_api import ModuleApi
+ from synapse.types import JsonDict
+ from twisted.internet import threads


### PR DESCRIPTION

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
