### PR TITLE
vikunja, vikunja-desktop 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/by-name/vi/vikunja-desktop/package.nix
+++ b/pkgs/by-name/vi/vikunja-desktop/package.nix
@@ -15,12 +15,12 @@
 
 let
   executableName = "vikunja-desktop";
-  version = "1.1.0";
+  version = "2.0.0";
   src = fetchFromGitHub {
     owner = "go-vikunja";
     repo = "vikunja";
     rev = "v${version}";
-    hash = "sha256-xxfn3UoKreRDRC5GR7pLL8gkBLe6VmBYdps9eFc5c3g=";
+    hash = "sha256-EfAhJq2LPuCF8Pwyg0TYqSjNCaG15iZ2paDLfA6JI5w=";
   };
 in
 stdenv.mkDerivation (finalAttrs: {
@@ -40,7 +40,7 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmInstallFlags
       ;
     fetcherVersion = 1;
-    hash = "sha256-mzrck/JdfN3Qu+xhf/iM4HFamVmQkVSwUwU2KBK5XsA=";
+    hash = "sha256-9KPQaRLep4n+2b9mk8KQoK22zdlMFrCb1VT6SEHxanQ=";
   };
 
   env = {

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -14,12 +14,12 @@
 }:
 
 let
-  version = "1.1.0";
+  version = "2.0.0";
   src = fetchFromGitHub {
     owner = "go-vikunja";
     repo = "vikunja";
     rev = "v${version}";
-    hash = "sha256-xxfn3UoKreRDRC5GR7pLL8gkBLe6VmBYdps9eFc5c3g=";
+    hash = "sha256-EfAhJq2LPuCF8Pwyg0TYqSjNCaG15iZ2paDLfA6JI5w=";
   };
 
   frontend = stdenv.mkDerivation (finalAttrs: {
@@ -37,7 +37,7 @@ let
         ;
       pnpm = pnpm_10;
       fetcherVersion = 1;
-      hash = "sha256-NrysokKNmKAUdiC0o4qEPvsHr7KH7mMrcrEjxwmgb+g=";
+      hash = "sha256-ME9sGKGRY3vaOTFwbFyzsDT20HnEnrfq3Z5nrL19k0A=";
     };
 
     nativeBuildInputs = [
@@ -97,7 +97,7 @@ buildGoModule {
       mage
     ];
 
-  vendorHash = "sha256-PV6WlJlG839FtWUR6QONMuuBnmo+AA53xmUNbodQdzk=";
+  vendorHash = "sha256-VLy5yybeueVEjb9SijYPQnXoTz7lxBksHTzBxt+TdG4=";
 
   inherit frontend;
 


### PR DESCRIPTION
Upgrade to Vikunja 2.0.0: https://vikunja.io/changelog/vikunja-v2.0.0-was-released/

Fixes four CVEs:

- `CVE-2026-27819`
- `CVE-2026-27575`
- `CVE-2026-27616`
- `CVE-2026-27116`

The release post has links to the GitHub advisory for each with more details. 

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
