### PR TITLE
sratom: 0.6.20 -> 0.6.22, modernize derivation

### DIFF
--- a/pkgs/by-name/sr/sratom/package.nix
+++ b/pkgs/by-name/sr/sratom/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   src = fetchurl {
-    url = "https://download.drobilla.net/sratom-${version}.tar.xz";
+    url = "https://download.drobilla.net/sratom-${finalAttrs.version}.tar.xz";
     hash = "sha256-Agm30PIslqu0FnIu1zWwkzvkeTHs/0qksm3td2C08lI=";
   };
 

--- a/pkgs/by-name/sr/sratom/package.nix
+++ b/pkgs/by-name/sr/sratom/package.nix
@@ -11,7 +11,7 @@
   writeScript,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "sratom";
   version = "0.6.22";
 
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "https://download.drobilla.net/${pname}-${version}.tar.xz";
+    url = "https://download.drobilla.net/sratom-${version}.tar.xz";
     hash = "sha256-Agm30PIslqu0FnIu1zWwkzvkeTHs/0qksm3td2C08lI=";
   };
 
@@ -50,15 +50,13 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = writeScript "update-sratom" ''
       #!/usr/bin/env nix-shell
-      #!nix-shell -i bash -p curl pcre common-updater-scripts
+      #!nix-shell -i bash -p curl pcre2 common-updater-scripts
 
       set -eu -o pipefail
 
       # Expect the text in format of 'download.drobilla.net/sratom-0.30.16.tar.xz">'
-      new_version="$(curl -s https://drobilla.net/category/sratom/ |
-          pcregrep -o1 'download.drobilla.net/sratom-([0-9.]+).tar.xz' |
-          head -n1)"
-      update-source-version ${pname} "$new_version"
+      new_version="$(curl -s https://drobilla.net/category/sratom/ | pcre2grep -o1 'Sratom ([0-9]+\.[0-9]+\.[0-9]+)' | sort -V | tail -n1)"
+      update-source-version sratom "$new_version"
     '';
   };
 
@@ -69,4 +67,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
This pull request updates the `sratom` package definition in `pkgs/by-name/sr/sratom/package.nix` to use a newer version and modernizes the update script. The most important changes are grouped below:

**Version and Source Update:**

* Updated the `sratom` package version from `0.6.20` to `0.6.22` and changed the source hash to match the new release. The URL construction was also updated to use `finalAttrs.version` for consistency.

**Update Script Improvements:**

* Modified the update script to use `pcre2grep` instead of `pcregrep` and switched from `pcre` to `pcre2` in the dependencies. The script now extracts the latest version from the webpage using a different regex pattern and sorts versions to select the newest one.

**Code Modernization:**

* Refactored the derivation to use the `finalAttrs` argument style instead of `rec { ... }`, aligning with current Nixpkgs best practices.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
