### PR TITLE
gimme-aws-creds: pin okta version

### DIFF
--- a/pkgs/by-name/gi/gimme-aws-creds/package.nix
+++ b/pkgs/by-name/gi/gimme-aws-creds/package.nix
@@ -3,12 +3,33 @@
   installShellFiles,
   python3,
   fetchFromGitHub,
+  fetchPypi,
   nix-update-script,
   testers,
   gimme-aws-creds,
 }:
 
-python3.pkgs.buildPythonApplication (finalAttrs: {
+let
+  python =
+    let
+      packageOverrides = _: super: {
+        # okta>=3.0.0 breaks gimme-aws-creds, need to pin to 2.9.latest
+        okta = super.okta.overridePythonAttrs (_: rec {
+          version = "2.9.13";
+          src = fetchPypi {
+            pname = "okta";
+            inherit version;
+            hash = "sha256-jY6SZ1G3+NquF5TfLsGw6T9WO4smeBYT0gXLnRDoN+8=";
+          };
+        });
+      };
+    in
+    python3.override {
+      inherit packageOverrides;
+      self = python;
+    };
+in
+python.pkgs.buildPythonApplication (finalAttrs: {
   pname = "gimme-aws-creds";
   version = "2.8.2"; # N.B: if you change this, check if overrides are still up-to-date
   format = "setuptools";
@@ -28,7 +49,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     "configparser"
   ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python.pkgs; [
     boto3
     beautifulsoup4
     ctap-keyring-device
@@ -44,7 +65,7 @@ python3.pkgs.buildPythonApplication (finalAttrs: {
     export PYTHON_KEYRING_BACKEND="keyring.backends.fail.Keyring"
   '';
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with python.pkgs; [
     pytestCheckHook
     responses
   ];


### PR DESCRIPTION
gimme-aws-creds won't build with `python313Packages.okta` on version 3.1.0. This PR pins the package on version 2.9.13 according to [`requirements.txt` on gimme-aws-creds](https://github.com/Nike-Inc/gimme-aws-creds/blob/728bef8c1afd586952027eb87d4e5a2680cc1faa/requirements.txt).

```
ImportError: cannot import name 'APIClient' from 'okta.api_client' (/nix/store/zbrhcjfr228l2xj49kbbjvwmiaz7qng1-python3.13-okta-3.1.0/lib/python3.13/site-packages/okta/api_client.py)
```

## Things done

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
