### PR TITLE
gamescope: build by wlroots 0.18

### DIFF
--- a/pkgs/by-name/ga/gamescope/package.nix
+++ b/pkgs/by-name/ga/gamescope/package.nix
@@ -42,7 +42,7 @@
   glslang,
   hwdata,
   stb,
-  wlroots_0_17,
+  wlroots_0_18,
   libdecor,
   lcms,
   lib,
@@ -151,7 +151,7 @@ stdenv.mkDerivation (finalAttrs: {
     vulkan-headers
   ]
   ++ lib.optionals enableExecutable (
-    wlroots_0_17.buildInputs
+    wlroots_0_18.buildInputs
     ++ [
       # gamescope uses a custom wlroots branch
       libxcomposite


### PR DESCRIPTION
Technically, gamescope already uses wlroots 0.18. Only the build inputs from wlroots 0.17 are passed in, since gamescope has its own vendored copy of wlroots 0.18.

I went ahead and verified: the only difference between the derivations is that lcms2 is added to the build inputs.

<details>
<summary>
Diff of derivation
</summary>

```
diff --git a/nix/store/232gcj4s19sv6zzx2r8z89jlbssf132r-gamescope-3.16.20.drv b/nix/store/navy3xl9nrwx908qip5v3r7hxh8120rk-gamescope-3.16.20.drv
index b4472db6e0ca..0a5f8ea29c90 100644
--- a/nix/store/232gcj4s19sv6zzx2r8z89jlbssf132r-gamescope-3.16.20.drv
+++ b/nix/store/navy3xl9nrwx908qip5v3r7hxh8120rk-gamescope-3.16.20.drv
@@ -1 +1 @@
 Derive([("out","/nix/store/5
-jk6vjv2ykd55bzb5rj13fq6hadf2vla
+ljaqlca8n8mfn0k095s6mncg1nk3vxg
 -gamescope-3.16.20","","")],[("/nix/store/0c4aq0f8djzdz6wj6invszglbp4r8cbm-wayland-scanner-1.24.0.drv",["dev"]),("/nix/store/0yf4qwx2j2hynq5j0k1l01jpxmr08xhg-libcap-2.77.drv",["dev"]),("/nix/store/10chqyh36xx7jg0lmzmz5kwgjn90rd4q-meson-1.10.1.drv",["out"]),("/nix/store/1vsmbjn6qscs627qjy38sx7sig3lz81v-libinput-1.29.2.drv",["dev"]),("/nix/store/3v0p7ar8jamvbjhxycj0mbz5wyh0iczz-libxcb-errors-1.0.1.drv",["dev"]),("/nix/store/47wrxvnq81536rjmfs6f4chrbfnyqshc-xprop-1.2.8.drv",["out"]),("/nix/store/4bqkd9nxc4nbs0gfgfk6hzdhwj35p92z-wayland-protocols-1.47.drv",["out"]),("/nix/store/4sflgpi32p1q6znl8c320hncgs1sp9d5-pkg-config-wrapper-0.29.2.drv",["out"]),("/nix/store/6j4r0x9927ci1c7wfvvrr8sy88l9izjw-wayland-1.24.0.drv",["dev"]),("/nix/store/71g65hf0w0jba5r7fc9786njjx1v5rr9-bash-5.3p9.drv",["out"]),("/nix/store/7p4bydr4blmyabm8n995yc6xpkfk2nhd-libx11-1.8.12.drv",["dev"]),("/nix/store/8p7vijh4pnk7j3jffqar0bcq6x52lfgn-libxext-1.3.7.drv",["dev"]),("/nix/store/9sqyqgv97qqp5bi398dlm8f8vaagg9xq-libdecor-0.2.5.drv",["dev"]),("/nix/store/a51j3nmwa6jskd8qy74wjawg1fcwb2y9-cmake-4.1.2.drv",["out"]),("/nix/store/arwdkac5w8wng44yxjqlyh1xc9shvb3a-libxi-1.8.2.drv",["dev"]),("/nix/store/ay0skgdxqcsr38daychivwy97j982i1h-vulkan-loader-1.4.341.0.drv",["dev","out"]),("/nix/store/bpad3kdlchyaa8j83pbq2qs5phf2hjc7-libavif-1.3.0.drv",["dev"]),("/nix/store/cjkrbjygc5ndwvh9cg33iqk1p5aiq0a6-libxres-1.2.3.drv",["dev"]),("/nix/store/cy31jlqac1640vvmdwr1baphjrqvppfv-libxcomposite-0.4.7.drv",["dev"]),("/nix/store/dv8k62wqmp62bsj967qcqab9akm558ar-stb-0-unstable-2023-01-29.drv",["out"]),("/nix/store/g3jn5k5ankwfxbws7gbbs8rj3p035sd5-libglvnd-1.7.0.drv",["dev"]),("/nix/store/g4im1iawnzv3iw7klavl58qa4dxyq9dg-libei-1.5.0.drv",["out"]),("/nix/store/g4kpf1wrzs36jvqas9810lxpycfl1agl-libdisplay-info-0.3.0.drv",["out"]),("/nix/store/hcqs2vmi3m2rkpf98nya4hbr113fmw42-libxcb-1.17.0.drv",["dev"]),("/nix/store/hvjx2md50w1xk6qycvjyldpq0487lcql-gbenchmark-1.9.4.drv",["out"]),("/nix/store/if7vfb9n1qvmf7h35jc7bzrgpzmy294h-glm-1.0.2.drv",["out"]),("/nix/store/ipfvs60xafdzyb7hdv4scl0f2afgswnh-pixman-0.46.4.drv",["out"]),("/nix/store/jijdlgzj37k7h30ya1ljprswxjmg946n-libxcb-render-util-0.3.10.drv",["dev"]),("/nix/store/kdf5yvl26davw822xy154v1bghpfpbn5-4ce1a91fb219f570b0871071a2ec8ac97d90c0bc.diff.drv",["out"]),("/nix/store/kip6iyrs98zdf9m4fmk7cfld8lda39bw-pipewire-1.4.10.drv",["dev"]),("/nix/store/lbi7s1gh87lc2mw79czx7ky817m2ivln-libxcursor-1.2.3.drv",["dev"]),("/nix/store/lmvxacc3hirfnfayxywzb91zq20qcvph-libxmu-1.3.1.drv",["dev"]),("/nix/store/mfl1j2mmnd7b4j97b653raqnrszim5ff-make-binary-wrapper-hook.drv",["out"]),("/nix/store/ndrvv2w7javplvczr8awdg5ljvprf8zq-libxdamage-1.1.7.drv",["dev"]),("/nix/store/nmsm38bdg51jrk31k5wrzlbhxg3998pc-ninja-1.13.2.drv",["out"]),("/nix/store/nx4bb7wpmq48wcv9y4aww4bs65j7gb9h-libxxf86vm-1.1.7.drv",["dev"]),("/nix/store/q8mll3d3hv258ib9qypkvpvs24kmdkz8-hwdata-0.404.drv",["out"]),("/nix/store/qh8i16a5a2i21wlbl5qxivggsc52q8aw-sdl2-compat-2.32.64.drv",["dev"]),("/nix/store/rmfqfhpwcifhmcmi24dljykgrmx0fpq6-git.drv",["out"]),("/nix/store/rzk44pd4vfrzh6v5kg5abp83x22v0wg1-libliftoff-0.5.0.drv",["out"]),("/nix/store/s1lqhrh6k8cibxj5481rgwnv4iidxp6a-libxkbcommon-1.11.0.drv",["dev"]),("/nix/store/s1xwskq8mmirknxqn30sa8bwbb902167-stdenv-linux.drv",["out"]),("/nix/store/s2h0lp0m59cpragags7p355hhj7vrh1s-python3-3.13.12.drv",["out"]),("/nix/store/sasnhv9bx39hlx3b8qdnksf27qnip1ak-v4l-utils-1.32.0.drv",["dev"]),("/nix/store/sx9ilc38b0wzn72j33q6qxbg1zv91sn7-seatd-0.9.2.drv",["dev"]),("/nix/store/vbg0z739yxndlp2anc58x7sa2mzf4w62-mesa-libgbm-25.1.0.drv",["out"]),("/nix/store/vqdprdiidhcl18xna53la3m8x0nmgsmc-xwayland-24.1.9.drv",["out"]),("/nix/store/wc0awffwqnk9y8j46ln8wwcsc2rscfda-source.drv",["out"]),("/nix/store/x6b7sqnprhaw6ciaivxqbarqykvhrhx0-lcms2-2.18.drv",["dev"]),("/nix/store/x6sk28f6y8b1zhzykswjjgmfj0r3jhjm-xwininfo-1.1.6.drv",["out"]),("/nix/store/xgj8z8xaplllb4yj695lmsz26lri612p-glslang-16.2.0.drv",["dev"]),("/nix/store/xivvlhj283qvzm1f43mf9bkdbwfcd7n7-libxcb-wm-0.4.2.drv",["dev"]),("/nix/store/xk47lhhagqsmc8w5nks9023gb805bn15-luajit-2.1.1741730670.drv",["out"]),("/nix/store/xki37wjr182gh3wlhmmjas0vxzhc6pr1-source.drv",["out"]),("/nix/store/xlsgy5195wgs3xsp8qv7xpb763nrv519-patchelf-0.18.0-unstable-2025-08-13.drv",["out"]),("/nix/store/ygr7mlmsrblbqmay0x0b4ry50pdhazxd-libxtst-1.2.5.drv",["out"]),("/nix/store/za8zrkp2g8z8wxvs2p6jqdi8aw8dlnwl-libdrm-2.4.131.drv",["dev"]),("/nix/store/zd2d35xly2dbh312fldq4dm95gh7a8zj-libxrender-0.9.12.drv",["dev"]),("/nix/store/zx070i8avbiwc7vz5fcwxl2h13rx5ajs-libxcb-image-0.4.1.drv",["dev"])],["/nix/store/34n3w4pdkxn4vv0yr8mw7l2vmhzx4c5v-gamescopereaper.patch","/nix/store/fbijw6qf0b1h2frv275x36wa9vavasbx-shaders-path.patch","/nix/store/l622p70vy8k5sh7y5wizi5f2mic6ynpg-source-stdenv.sh","/nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02r39-default-builder.sh"],"x86_64-linux","/nix/store/2hjsch59amjs3nbgh7ahcfzm2bfwl8zi-bash-5.3p9/bin/bash",["-e","/nix/store/l622p70vy8k5sh7y5wizi5f2mic6ynpg-source-stdenv.sh","/nix/store/shkw4qm9qcw5sc5n1k5jznc83ny02r39-default-builder.sh"],[("NIX_MAIN_PROGRAM","gamescope"),("__structuredAttrs",""),("buildInputs","/nix/store/6yhggj3nvdnw6sjazy37gsm777i6dcq7-pipewire-1.4.10-dev /nix/store/m3b3fnv33pzhhbadwg3qdqpcjvlg83jn-hwdata-0.404 /nix/store/hppiap02zqbx9d3bh0xpzbmnp5ai2d11-libx11-1.8.12-dev /nix/store/lhzl3z3rgn2zif730ww2fyb1d8gfrnk1-libxcb-1.17.0-dev /nix/store/blr5zdnxfckm1690cdx6anmh3s17sx5p-wayland-1.24.0-dev /nix/store/djsln0xc25vs7cng9vdd7zljb0i1flyk-wayland-protocols-1.47 /nix/store/5vq341gkk6ydjw8zkxskg9kzq2j71zpk-vulkan-loader-1.4.341.0-dev /nix/store/ish3i81wmmjigpnwldqav0m7xx268whl-libliftoff-0.5.0 /nix/store/lh0swn5rqchl3njjl9n37rl43i5qiakr-libdisplay-info-0.3.0 /nix/store/3drkfkyzxfb9rcpnv1xy0nvdj78qngy8-libglvnd-1.7.0-dev /nix/store/6hga7ryjvv3f94lpi5d2qmsacs14ixmj-libcap-2.77-dev /nix/store/ixxx8nb52qxl25lix063rb35lk94p7r8-libxkbcommon-1.11.0-dev /nix/store/6nmmqzmb1sw5fdyd4fs2yfara8gcidd9-mesa-libgbm-25.1.0 /nix/store/s60msvirzaknyjgpsc8yyld1qg5i3hn5-pixman-0.46.4 /nix/store/nsvinpilr39fw19xcj8nizaspjjk5209-seatd-0.9.2-dev /nix/store/5vq341gkk6ydjw8zkxskg9kzq2j71zpk-vulkan-loader-1.4.341.0-dev /nix/store/blr5zdnxfckm1690cdx6anmh3s17sx5p-wayland-1.24.0-dev /nix/store/djsln0xc25vs7cng9vdd7zljb0i1flyk-wayland-protocols-1.47 /nix/store/hppiap02zqbx9d3bh0xpzbmnp5ai2d11-libx11-1.8.12-dev /nix/store/1ssj40scx81hsxriwzmwrdwj9j9y19jp-libxcb-errors-1.0.1-dev /nix/store/p0qjpj7da5pmr4m7mq5gpsh9gvdqnb7z-libxcb-image-0.4.1-dev /nix/store/yg9jd5q345c1xq4zwzik3wh9hhfsf8hx-libxcb-render-util-0.3.10-dev /nix/store/cmkhcjaky7nc8cr1j7v84rwhfmy34g4h-libxcb-wm-0.4.2-dev /nix/store/ps0i6lzz3r7g77kfq6y36v98iaxg2dc1-xwayland-24.1.9 /nix/store/65
+rix70m2gbnmdjpn36ipxj8mxip2hxd-lcms2-2.18-dev /nix/store
 /hkrxxm9zaq7sk5r4641af435blrj0rs1-libxcomposite-0.4.7-dev /nix/store/95slvq54fq3i2253cbarw474073amznp-libxcursor-1.2.3-dev /nix/store/v0p05yhqamh1w8avs6g7gyyg7w2zjcc8-libxdamage-1.1.7-dev /nix/store/7cxd1fc7plwpfr1k4l9d58xv46dingpw-libxext-1.3.7-dev /nix/store/84npw6vm45bid1glazws5j15ibc8nm61-libxi-1.8.2-dev /nix/store/xr3fbzqmnpy4jc1ychjnhnfjwiyhhjjz-libxmu-1.3.1-dev /nix/store/xr8bh0qk2d1jj3yvi2k8flhdal3svy0q-libxrender-0.9.12-dev /nix/store/706fqv1jk3w4cwij85biqjg9dw5v84ws-libxres-1.2.3-dev /nix/store/dsiscq5967bw476v50xq294qq4kwhzvs-libxtst-1.2.5 /nix/store/i1icx7y6gm7md9mhxql4i0kw303139sv-libxxf86vm-1.1.7-dev /nix/store/k3cpr762l5psk2s5ff89yyl67s4jxaw6-libavif-1.3.0-dev /nix/store/6g92fqnx6cwza2243r78p7rqmay8ssik-libdrm-2.4.131-dev /nix/store/v0r9hcsvddbb91wm8pzbib1jr98qimrw-libei-1.5.0 /nix/store/9668vm336d1v4z53yx7x57savnvh1bbx-sdl2-compat-2.32.64-dev /nix/store/22x05q9pd7m11kwym4flkq8zlh9j93r2-libdecor-0.2.5-dev /nix/store/kiw1h4pbwcfxcfr8ipkb8915avawq3q8-libinput-1.29.2-dev /nix/store/ixxx8nb52qxl25lix063rb35lk94p7r8-libxkbcommon-1.11.0-dev /nix/store/n0fmlcfrfhp0q6hnhlynszajmsq6zkkd-gbenchmark-1.9.4 /nix/store/s60msvirzaknyjgpsc8yyld1qg5i3hn5-pixman-0.46.4 /nix/store/6hga7ryjvv3f94lpi5d2qmsacs14ixmj-libcap-2.77-dev /nix/store/65rix70m2gbnmdjpn36ipxj8mxip2hxd-lcms2-2.18-dev /nix/store/7rk2ic67w77kvirns0c14151q253jxra-luajit-2.1.1741730670"),("builder","/nix/store/2hjsch59amjs3nbgh7ahcfzm2bfwl8zi-bash-5.3p9/bin/bash"),("cmakeFlags",""),("configureFlags",""),("depsBuildBuild","/nix/store/1nv3i8mpypy3d516f4pd95m0w72r73jy-pkg-config-wrapper-0.29.2"),("depsBuildBuildPropagated",""),("depsBuildTarget",""),("depsBuildTargetPropagated",""),("depsHostHost",""),("depsHostHostPropagated",""),("depsTargetTarget",""),("depsTargetTargetPropagated",""),("doCheck",""),("doInstallCheck",""),("mesonFlags","-Denable_gamescope=true -Denable_gamescope_wsi_layer=false -Dglm_include_dir=/nix/store/n86w3samll36nmayl4w4b8c13n9saib0-glm-1.0.2/include -Dstb_include_dir=/nix/store/gf4qg96gci07mzs2a7ng5i5xz0p82ccq-stb-0-unstable-2023-01-29/include/stb"),("mesonInstallFlags","--skip-subprojects"),("name","gamescope-3.16.20"),("nativeBuildInputs","/nix/store/qds74v6m6fky8cpwrgd7jwfy3clga3i9-meson-1.10.1 /nix/store/1nv3i8mpypy3d516f4pd95m0w72r73jy-pkg-config-wrapper-0.29.2 /nix/store/4siii6hvzs9ymbq37k04vcpx6xnybz21-ninja-1.13.2 /nix/store/3njk768xl6ia4hdvp9gh2cqr3n5w3sya-wayland-scanner-1.24.0-dev /nix/store/1m0z4ixir10fg7ba7g131js04bxgv265-cmake-4.1.2 /nix/store/bckcp8nkmnd77lxhqj6kgh78ikybhvg4-git /nix/store/vnipz01anjnx9psrraiak58085lhw75b-make-binary-wrapper-hook /nix/store/g6rm2n1pj97gwblrqrbc3wm2zhkk57cz-glslang-16.2.0-dev /nix/store/m1fw8l8y9ycxh5dzispbb7cwl6rra14l-python3-3.13.12 /nix/store/m3b3fnv33pzhhbadwg3qdqpcjvlg83jn-hwdata-0.404 /nix/store/bjwc1qsdwiz4xxy6jz2c5f0sjnq3srw8-v4l-utils-1.32.0-dev"),("out","/nix/store/5
-jk6vjv2ykd55bzb5rj13fq6hadf2vla
+ljaqlca8n8mfn0k095s6mncg1nk3vxg
 -gamescope-3.16.20"),("outputs","out"),("patches","/nix/store/fbijw6qf0b1h2frv275x36wa9vavasbx-shaders-path.patch /nix/store/34n3w4pdkxn4vv0yr8mw7l2vmhzx4c5v-gamescopereaper.patch /nix/store/ymwhqbbx3qigmjgwvwdz9d654x15v1qp-4ce1a91fb219f570b0871071a2ec8ac97d90c0bc.diff"),("pname","gamescope"),("postInstall","# using patchelf unstable because the stable version corrupts the binary\n/nix/store/hhp05alxwa9nsk7yqdh2x9a7w3q9ad4m-patchelf-0.18.0-unstable-2025-08-13/bin/patchelf $out/bin/gamescope \\\n  --add-rpath /nix/store/1il4q8s87v0p8xp1g2q8mmbswbwkj23l-vulkan-loader-1.4.341.0/lib --add-needed libvulkan.so.1\n\n# --debug-layers flag expects these in the path\nwrapProgram \"$out/bin/gamescope\" \\\n  --prefix PATH : /nix/store/4kljicprjqg8hwf0dqw88gw9jy0lb859-xprop-1.2.8/bin:/nix/store/g49xskmhajpkim7ai75g5wrk84b97sj0-xwininfo-1.1.6/bin\n\n# Install ReShade shaders\nmkdir -p $out/share/gamescope/reshade\ncp -r /nix/store/8gvk5549pbj354cxij1sci9yzx5hrf55-source/* $out/share/gamescope/reshade/\n"),("postPatch","substituteInPlace src/reshade_effect_manager.cpp --replace-fail \"@out@\" \"$out\"\n\n# Patching shebangs in the main `libdisplay-info` build\npatchShebangs subprojects/libdisplay-info/tool/gen-search-table.py\n\n# Replace gamescopereeaper with absolute path\nsubstituteInPlace src/Utils/Process.cpp --subst-var-by \"gamescopereaper\" \"$out/bin/gamescopereaper\"\npatchShebangs default_extras_install.sh\n"),("propagatedBuildInputs",""),("propagatedNativeBuildInputs",""),("src","/nix/store/h01xw1ia0ffbkw6w5p9x7xzx9k0m22xc-source"),("stdenv","/nix/store/zkiy4zv8wz3v95bj6fdmkqwql8x1vnhb-stdenv-linux"),("strictDeps","1"),("system","x86_64-linux"),("version","3.16.20")])
~
```

</details>



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
