### PR TITLE
kissat: fix static build by setting AR for cross toolchains

### DIFF
--- a/pkgs/by-name/ki/kissat/package.nix
+++ b/pkgs/by-name/ki/kissat/package.nix
@@ -66,6 +66,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     ./configure
 
+    # Kissat's configure only detects cross-compilation for *-linux-gnu-gcc,
+    # missing other cross toolchains (e.g. musl). Fix AR in the generated makefile.
+    substituteInPlace build/makefile \
+      --replace-fail "AR=ar" "AR=${stdenv.cc.targetPrefix}ar"
+
     runHook postConfigure
   '';
 


### PR DESCRIPTION
## Things done

* Replaced AR to allow cross compilation.
* Now we can do:
    * ```$ nix build nixpkgs#pkgsStatic.kissat```

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
