### PR TITLE
python3Packages.edalize: 0.6.1 -> 0.6.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17914,6 +17914,12 @@
     githubId = 830082;
     name = "Nathan Moos";
   };
+  Mop-u = {
+    email = "moppu@pm.me";
+    github = "Mop-u";
+    githubId = 48605993;
+    name = "Quinn Unger";
+  };
   moraxyc = {
     name = "Moraxyc Xu";
     email = "i@qaq.li";

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "edalize";
-  version = "0.6.1";
+  version = "0.6.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "olofk";
     repo = "edalize";
     tag = "v${version}";
-    hash = "sha256-5c3Szq0tXQdlyzFTFCla44qB/O6RK8vezVOaFOv8sw4=";
+    hash = "sha256-kcv/n0anQN/7v1KCRtrP91u2nFAJ55E1OxuPwxaHfGA=";
   };
 
   postPatch = ''
@@ -102,6 +102,9 @@ buildPythonPackage rec {
     homepage = "https://github.com/olofk/edalize";
     changelog = "https://github.com/olofk/edalize/releases/tag/${src.tag}";
     license = lib.licenses.bsd2;
-    maintainers = with lib.maintainers; [ astro ];
+    maintainers = with lib.maintainers; [
+      astro
+      Mop-u
+    ];
   };
 }

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   setuptools,
   setuptools-scm,
+  cocotb,
   coreutils,
   jinja2,
   pandas,
@@ -37,6 +38,8 @@ buildPythonPackage rec {
   ];
 
   propagatedBuildInputs = [ jinja2 ];
+
+  dependencies = [ cocotb ];
 
   optional-dependencies = {
     reporting = [

--- a/pkgs/development/python-modules/edalize/default.nix
+++ b/pkgs/development/python-modules/edalize/default.nix
@@ -13,7 +13,15 @@
   which,
   yosys,
 }:
-
+let
+  # cocotb should build if it is at at least v2.1 or python is v3.13 or lower
+  # https://github.com/cocotb/cocotb/issues/4708#issuecomment-2923059120
+  cocotbPyVer =
+    (lib.head (lib.filter (x: x.pname == "python3") cocotb.propagatedBuildInputs)).version;
+  cocotbCanBuild =
+    ((lib.compareVersions cocotb.version "2.1.0") != -1)
+    || ((lib.compareVersions cocotbPyVer "3.14.0") == -1);
+in
 buildPythonPackage rec {
   pname = "edalize";
   version = "0.6.4";
@@ -39,7 +47,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs = [ jinja2 ];
 
-  dependencies = [ cocotb ];
+  dependencies = lib.optional cocotbCanBuild cocotb;
 
   optional-dependencies = {
     reporting = [


### PR DESCRIPTION
Update edalize from 0.6.1 to 0.6.4
Changelog: https://github.com/olofk/edalize/releases/tag/v0.6.4

This should fix issues with edalize being unable to build projects for Quartus Prime Pro due to issues parsing quartus' patch version.

In a separate commit I added cocotb as a dependency, as edalize complained about it being unavailable when running our existing fusesoc/verilator/c++ simulation flows. Without this dependency the update may break people's existing flows.
Error message in question:
`ERROR: Failed to run my:fusesoc:package:0.1 : Command 'cocotb-config' not found. Make sure it is in $PATH`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
