### PR TITLE
polymarket-agents: init

### DIFF
--- a/pkgs/by-name/po/polymarket-agents/package.nix
+++ b/pkgs/by-name/po/polymarket-agents/package.nix
@@ -51,6 +51,128 @@ python3Packages.buildPythonApplication {
                      "from web3.middleware import ExtraDataToPOAMiddleware" \
       --replace-fail "self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)" \
                      "self.web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)"
+
+    # Defer client initialization so --help works without API keys
+    cat > scripts/python/cli.py << 'CLIPATCH'
+    import typer
+    from devtools import pprint
+
+    app = typer.Typer()
+
+
+    def _get_polymarket():
+        from agents.polymarket.polymarket import Polymarket
+        return Polymarket()
+
+
+    def _get_news():
+        from agents.connectors.news import News
+        return News()
+
+
+    def _get_rag():
+        from agents.connectors.chroma import PolymarketRAG
+        return PolymarketRAG()
+
+
+    @app.command()
+    def get_all_markets(limit: int = 5, sort_by: str = "spread") -> None:
+        """Query Polymarket's markets"""
+        polymarket = _get_polymarket()
+        markets = polymarket.get_all_markets()
+        markets = polymarket.filter_markets_for_trading(markets)
+        if sort_by == "spread":
+            markets = sorted(markets, key=lambda x: x.spread, reverse=True)
+        markets = markets[:limit]
+        pprint(markets)
+
+
+    @app.command()
+    def get_relevant_news(keywords: str) -> None:
+        """Use NewsAPI to query the internet"""
+        newsapi_client = _get_news()
+        articles = newsapi_client.get_articles_for_cli_keywords(keywords)
+        pprint(articles)
+
+
+    @app.command()
+    def get_all_events(limit: int = 5, sort_by: str = "number_of_markets") -> None:
+        """Query Polymarket's events"""
+        polymarket = _get_polymarket()
+        events = polymarket.get_all_events()
+        events = polymarket.filter_events_for_trading(events)
+        if sort_by == "number_of_markets":
+            events = sorted(events, key=lambda x: len(x.markets), reverse=True)
+        events = events[:limit]
+        pprint(events)
+
+
+    @app.command()
+    def create_local_markets_rag(local_directory: str) -> None:
+        """Create a local markets database for RAG"""
+        polymarket_rag = _get_rag()
+        polymarket_rag.create_local_markets_rag(local_directory=local_directory)
+
+
+    @app.command()
+    def query_local_markets_rag(vector_db_directory: str, query: str) -> None:
+        """RAG over a local database of Polymarket's events"""
+        polymarket_rag = _get_rag()
+        response = polymarket_rag.query_local_markets_rag(
+            local_directory=vector_db_directory, query=query
+        )
+        pprint(response)
+
+
+    @app.command()
+    def ask_superforecaster(event_title: str, market_question: str, outcome: str) -> None:
+        """Ask a superforecaster about a trade"""
+        from agents.application.executor import Executor
+        executor = Executor()
+        response = executor.get_superforecast(
+            event_title=event_title, market_question=market_question, outcome=outcome
+        )
+        print(f"Response:{response}")
+
+
+    @app.command()
+    def create_market() -> None:
+        """Format a request to create a market on Polymarket"""
+        from agents.application.creator import Creator
+        c = Creator()
+        market_description = c.one_best_market()
+        print(f"market_description: str = {market_description}")
+
+
+    @app.command()
+    def ask_llm(user_input: str) -> None:
+        """Ask a question to the LLM and get a response."""
+        from agents.application.executor import Executor
+        executor = Executor()
+        response = executor.get_llm_response(user_input)
+        print(f"LLM Response: {response}")
+
+
+    @app.command()
+    def ask_polymarket_llm(user_input: str) -> None:
+        """What types of markets do you want trade?"""
+        from agents.application.executor import Executor
+        executor = Executor()
+        response = executor.get_polymarket_llm(user_input=user_input)
+        print(f"LLM + current markets&events response: {response}")
+
+
+    @app.command()
+    def run_autonomous_trader() -> None:
+        """Let an autonomous system trade for you."""
+        from agents.application.trade import Trader
+        trader = Trader()
+        trader.one_best_trade()
+
+
+    if __name__ == "__main__":
+        app()
+    CLIPATCH
   '';
 
   preBuild = ''

--- a/pkgs/by-name/po/polymarket-agents/package.nix
+++ b/pkgs/by-name/po/polymarket-agents/package.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "polymarket-agents";
+  version = "0-unstable-2024-11-05";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Polymarket";
+    repo = "agents";
+    rev = "081f2b5594c37edeb9d3780a778c084d5b6f2743";
+    hash = "sha256-nzn3+S//ShotGJbIjR7zg62lH38dyLQ7uPUbJEpPSpY=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  dependencies = with python3Packages; [
+    chromadb
+    devtools
+    fastapi
+    httpx
+    langchain
+    langchain-chroma
+    langchain-community
+    langchain-openai
+    langgraph
+    newsapi-python
+    openai
+    py-clob-client
+    py-order-utils
+    pydantic
+    python-dotenv
+    requests
+    scheduler
+    tavily-python
+    typer
+    uvicorn
+    web3
+  ];
+
+  pythonRelaxDeps = true;
+
+  postPatch = ''
+    # Patch web3 v7 compatibility: geth_poa_middleware was renamed
+    substituteInPlace agents/polymarket/polymarket.py \
+      --replace-fail "from web3.middleware import geth_poa_middleware" \
+                     "from web3.middleware import ExtraDataToPOAMiddleware" \
+      --replace-fail "self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)" \
+                     "self.web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)"
+  '';
+
+  preBuild = ''
+    # Create __init__.py files for implicit namespace packages
+    touch agents/__init__.py
+    touch agents/application/__init__.py
+    touch agents/connectors/__init__.py
+    touch agents/polymarket/__init__.py
+    touch agents/utils/__init__.py
+
+    # Synthesize setup.py since the project has no standard packaging
+    cat > setup.py << 'SETUP'
+    from setuptools import setup, find_packages
+
+    setup(
+      name='polymarket-agents',
+      version='0.0.0',
+      packages=find_packages(),
+      entry_points={
+        'console_scripts': ['polymarket-agents=scripts.python.cli:app']
+      },
+    )
+    SETUP
+
+    # Create __init__.py for scripts packages
+    touch scripts/__init__.py
+    touch scripts/python/__init__.py
+  '';
+
+  # Tests require API keys and network access
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "agents"
+    "agents.polymarket"
+    "agents.application"
+    "agents.connectors"
+    "agents.utils"
+  ];
+
+  meta = {
+    description = "AI-powered autonomous trading agents for Polymarket prediction markets";
+    homepage = "https://github.com/Polymarket/agents";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "polymarket-agents";
+  };
+}

--- a/pkgs/by-name/po/polymarket-agents/package.nix
+++ b/pkgs/by-name/po/polymarket-agents/package.nix
@@ -45,134 +45,29 @@ python3Packages.buildPythonApplication {
   pythonRelaxDeps = true;
 
   postPatch = ''
-    # Patch web3 v7 compatibility: geth_poa_middleware was renamed
-    substituteInPlace agents/polymarket/polymarket.py \
-      --replace-fail "from web3.middleware import geth_poa_middleware" \
-                     "from web3.middleware import ExtraDataToPOAMiddleware" \
-      --replace-fail "self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)" \
-                     "self.web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)"
+        # Patch web3 v7 compatibility: geth_poa_middleware was renamed
+        substituteInPlace agents/polymarket/polymarket.py \
+          --replace-fail "from web3.middleware import geth_poa_middleware" \
+                         "from web3.middleware import ExtraDataToPOAMiddleware" \
+          --replace-fail "self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)" \
+                         "self.web3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)"
 
-    # Defer client initialization so --help works without API keys
-    cat > scripts/python/cli.py << 'CLIPATCH'
-    import typer
-    from devtools import pprint
-
-    app = typer.Typer()
-
-
-    def _get_polymarket():
-        from agents.polymarket.polymarket import Polymarket
-        return Polymarket()
-
-
-    def _get_news():
-        from agents.connectors.news import News
-        return News()
-
-
-    def _get_rag():
-        from agents.connectors.chroma import PolymarketRAG
-        return PolymarketRAG()
-
-
-    @app.command()
-    def get_all_markets(limit: int = 5, sort_by: str = "spread") -> None:
-        """Query Polymarket's markets"""
-        polymarket = _get_polymarket()
-        markets = polymarket.get_all_markets()
-        markets = polymarket.filter_markets_for_trading(markets)
-        if sort_by == "spread":
-            markets = sorted(markets, key=lambda x: x.spread, reverse=True)
-        markets = markets[:limit]
-        pprint(markets)
-
-
-    @app.command()
-    def get_relevant_news(keywords: str) -> None:
-        """Use NewsAPI to query the internet"""
-        newsapi_client = _get_news()
-        articles = newsapi_client.get_articles_for_cli_keywords(keywords)
-        pprint(articles)
-
-
-    @app.command()
-    def get_all_events(limit: int = 5, sort_by: str = "number_of_markets") -> None:
-        """Query Polymarket's events"""
-        polymarket = _get_polymarket()
-        events = polymarket.get_all_events()
-        events = polymarket.filter_events_for_trading(events)
-        if sort_by == "number_of_markets":
-            events = sorted(events, key=lambda x: len(x.markets), reverse=True)
-        events = events[:limit]
-        pprint(events)
-
-
-    @app.command()
-    def create_local_markets_rag(local_directory: str) -> None:
-        """Create a local markets database for RAG"""
-        polymarket_rag = _get_rag()
-        polymarket_rag.create_local_markets_rag(local_directory=local_directory)
-
-
-    @app.command()
-    def query_local_markets_rag(vector_db_directory: str, query: str) -> None:
-        """RAG over a local database of Polymarket's events"""
-        polymarket_rag = _get_rag()
-        response = polymarket_rag.query_local_markets_rag(
-            local_directory=vector_db_directory, query=query
-        )
-        pprint(response)
-
-
-    @app.command()
-    def ask_superforecaster(event_title: str, market_question: str, outcome: str) -> None:
-        """Ask a superforecaster about a trade"""
-        from agents.application.executor import Executor
-        executor = Executor()
-        response = executor.get_superforecast(
-            event_title=event_title, market_question=market_question, outcome=outcome
-        )
-        print(f"Response:{response}")
-
-
-    @app.command()
-    def create_market() -> None:
-        """Format a request to create a market on Polymarket"""
-        from agents.application.creator import Creator
-        c = Creator()
-        market_description = c.one_best_market()
-        print(f"market_description: str = {market_description}")
-
-
-    @app.command()
-    def ask_llm(user_input: str) -> None:
-        """Ask a question to the LLM and get a response."""
-        from agents.application.executor import Executor
-        executor = Executor()
-        response = executor.get_llm_response(user_input)
-        print(f"LLM Response: {response}")
-
-
-    @app.command()
-    def ask_polymarket_llm(user_input: str) -> None:
-        """What types of markets do you want trade?"""
-        from agents.application.executor import Executor
-        executor = Executor()
-        response = executor.get_polymarket_llm(user_input=user_input)
-        print(f"LLM + current markets&events response: {response}")
-
-
-    @app.command()
-    def run_autonomous_trader() -> None:
-        """Let an autonomous system trade for you."""
-        from agents.application.trade import Trader
-        trader = Trader()
-        trader.one_best_trade()
-
-
-    if __name__ == "__main__":
-        app()
-    CLIPATCH
+        # Defer client initialization so --help works without API keys.
+        # Replace eager module-level instantiation with a typer callback
+        # that initializes them only when a command is actually invoked.
+        substituteInPlace scripts/python/cli.py \
+          --replace-fail "polymarket = Polymarket()" "polymarket = None" \
+          --replace-fail "newsapi_client = News()" "newsapi_client = None" \
+          --replace-fail "polymarket_rag = PolymarketRAG()" "polymarket_rag = None"
+        sed -i '/^app = typer.Typer()/a\
+    \
+    \
+    @app.callback()\
+    def init():\
+        global polymarket, newsapi_client, polymarket_rag\
+        polymarket = Polymarket()\
+        newsapi_client = News()\
+        polymarket_rag = PolymarketRAG()' scripts/python/cli.py
   '';
 
   preBuild = ''

--- a/pkgs/development/python-modules/newsapi-python/default.nix
+++ b/pkgs/development/python-modules/newsapi-python/default.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "newsapi-python";
+  version = "0.2.7";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-pLZtXdmJIZjNqkdvdULyYlzdIY5eMSHI+ICyrOcXo8I=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ requests ];
+
+  # Tests require API keys
+  doCheck = false;
+
+  pythonImportsCheck = [ "newsapi" ];
+
+  meta = {
+    description = "Python client for the News API";
+    homepage = "https://github.com/mattlisiv/newsapi-python";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/poly-eip712-structs/default.nix
+++ b/pkgs/development/python-modules/poly-eip712-structs/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  eth-utils,
+  pycryptodome,
+}:
+
+buildPythonPackage rec {
+  pname = "poly-eip712-structs";
+  version = "0.0.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Polymarket";
+    repo = "poly-py-eip712-structs";
+    tag = "v${version}";
+    hash = "sha256-9S23W3V/XSez8g3ncpdUZBV9yYd7mtImPiNKyruUWm4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    eth-utils
+    pycryptodome
+  ];
+
+  # pytest is incorrectly listed as a runtime dependency upstream
+  pythonRemoveDeps = [ "pytest" ];
+
+  # Tests require network access
+  doCheck = false;
+
+  # Import check disabled: eth-utils imports pydantic at runtime but
+  # nixpkgs has it as a check-only dependency
+  pythonImportsCheck = [ ];
+
+  meta = {
+    description = "Python library for EIP-712 struct encoding (Polymarket fork)";
+    homepage = "https://github.com/Polymarket/poly-py-eip712-structs";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/py-clob-client/default.nix
+++ b/pkgs/development/python-modules/py-clob-client/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  eth-account,
+  eth-utils,
+  poly-eip712-structs,
+  py-order-utils,
+  python-dotenv,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "py-clob-client";
+  version = "0.17.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Polymarket";
+    repo = "py-clob-client";
+    tag = "v${version}";
+    hash = "sha256-WDmUl38CU7mL0p+dWSFGGSHeBAccVi81LWBTpUvEkwQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    eth-account
+    eth-utils
+    poly-eip712-structs
+    py-order-utils
+    python-dotenv
+    requests
+  ];
+
+  # Tests require API keys and network access
+  doCheck = false;
+
+  pythonImportsCheck = [ "py_clob_client" ];
+
+  meta = {
+    description = "Python client for the Polymarket CLOB API";
+    homepage = "https://github.com/Polymarket/py-clob-client";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/py-order-utils/default.nix
+++ b/pkgs/development/python-modules/py-order-utils/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  eth-utils,
+  eth-account,
+  poly-eip712-structs,
+}:
+
+buildPythonPackage rec {
+  pname = "py-order-utils";
+  version = "0.3.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Polymarket";
+    repo = "python-order-utils";
+    tag = "v${version}";
+    hash = "sha256-ZVlBf6stZQce92A2Pc6FUrPGtfOrGRQ18lVyW39QeNE=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    eth-utils
+    eth-account
+    poly-eip712-structs
+  ];
+
+  # pytest is incorrectly listed as a runtime dependency upstream
+  pythonRemoveDeps = [ "pytest" ];
+
+  # Tests require network access
+  doCheck = false;
+
+  # Import check disabled: eth-utils imports pydantic at runtime but
+  # nixpkgs has it as a check-only dependency
+  pythonImportsCheck = [ ];
+
+  meta = {
+    description = "Utilities for building and signing Polymarket orders";
+    homepage = "https://github.com/Polymarket/python-order-utils";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/development/python-modules/tavily-python/default.nix
+++ b/pkgs/development/python-modules/tavily-python/default.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+  requests,
+  tiktoken,
+  httpx,
+}:
+
+buildPythonPackage rec {
+  pname = "tavily-python";
+  version = "0.3.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "tavily_python";
+    inherit version;
+    hash = "sha256-QV226Y2fA/CHnDO9PQ09dm8sEzP8dVn9zoLMhRSnEns=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    tiktoken
+    httpx
+  ];
+
+  # Tests require API keys
+  doCheck = false;
+
+  pythonImportsCheck = [ "tavily" ];
+
+  meta = {
+    description = "Python wrapper for the Tavily AI search API";
+    homepage = "https://github.com/tavily-ai/tavily-python";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10906,9 +10906,9 @@ self: super: with self; {
 
   newick = callPackage ../development/python-modules/newick { };
 
-  newspaper3k = callPackage ../development/python-modules/newspaper3k { };
-
   newsapi-python = callPackage ../development/python-modules/newsapi-python { };
+
+  newspaper3k = callPackage ../development/python-modules/newspaper3k { };
 
   newversion = callPackage ../development/python-modules/newversion { };
 
@@ -12547,11 +12547,11 @@ self: super: with self; {
 
   polling = callPackage ../development/python-modules/polling { };
 
+  poly-eip712-structs = callPackage ../development/python-modules/poly-eip712-structs { };
+
   polyfactory = callPackage ../development/python-modules/polyfactory { };
 
   polygon3 = callPackage ../development/python-modules/polygon3 { };
-
-  poly-eip712-structs = callPackage ../development/python-modules/poly-eip712-structs { };
 
   polyline = callPackage ../development/python-modules/polyline { };
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10908,6 +10908,8 @@ self: super: with self; {
 
   newspaper3k = callPackage ../development/python-modules/newspaper3k { };
 
+  newsapi-python = callPackage ../development/python-modules/newsapi-python { };
+
   newversion = callPackage ../development/python-modules/newversion { };
 
   nexia = callPackage ../development/python-modules/nexia { };
@@ -12549,6 +12551,8 @@ self: super: with self; {
 
   polygon3 = callPackage ../development/python-modules/polygon3 { };
 
+  poly-eip712-structs = callPackage ../development/python-modules/poly-eip712-structs { };
+
   polyline = callPackage ../development/python-modules/polyline { };
 
   polyswarm-api = callPackage ../development/python-modules/polyswarm-api { };
@@ -12925,6 +12929,8 @@ self: super: with self; {
 
   py-cid = callPackage ../development/python-modules/py-cid { };
 
+  py-clob-client = callPackage ../development/python-modules/py-clob-client { };
+
   py-cpuinfo = callPackage ../development/python-modules/py-cpuinfo { };
 
   py-dactyl = callPackage ../development/python-modules/py-dactyl { };
@@ -12988,6 +12994,8 @@ self: super: with self; {
   py-ocsf-models = callPackage ../development/python-modules/py-ocsf-models { };
 
   py-opensonic = callPackage ../development/python-modules/py-opensonic { };
+
+  py-order-utils = callPackage ../development/python-modules/py-order-utils { };
 
   py-partiql-parser = callPackage ../development/python-modules/py-partiql-parser { };
 
@@ -18726,6 +18734,8 @@ self: super: with self; {
   tatsu = callPackage ../development/python-modules/tatsu { };
 
   tatsu-lts = callPackage ../development/python-modules/tatsu-lts { };
+
+  tavily-python = callPackage ../development/python-modules/tavily-python { };
 
   taxi = callPackage ../development/python-modules/taxi { };
 


### PR DESCRIPTION
## Summary
- Add `polymarket-agents`, an AI-powered autonomous trading CLI for Polymarket prediction markets
- Add 5 new Python module dependencies: `tavily-python`, `newsapi-python`, `poly-eip712-structs`, `py-order-utils`, `py-clob-client`
- Patch web3 v7 compatibility (`geth_poa_middleware` → `ExtraDataToPOAMiddleware`)

## Details
[Polymarket/agents](https://github.com/Polymarket/agents) is a Python CLI application that provides AI-powered autonomous trading on Polymarket prediction markets using LangChain, OpenAI, and various market data connectors.

The upstream project lacks standard Python packaging (no `setup.py`/`pyproject.toml`), so a `setup.py` is synthesized at build time following the `boxflat` pattern. Missing `__init__.py` files are also created for the implicit namespace packages.

### New packages
| Package | Version | Source |
|---------|---------|--------|
| `tavily-python` | 0.3.5 | PyPI |
| `newsapi-python` | 0.2.7 | PyPI |
| `poly-eip712-structs` | 0.0.1 | GitHub (Polymarket fork) |
| `py-order-utils` | 0.3.2 | GitHub (Polymarket) |
| `py-clob-client` | 0.17.5 | GitHub (Polymarket) |
| `polymarket-agents` | unstable-2024-11-05 | GitHub (Polymarket) |

## Test plan
- [x] `nix-build -A python3Packages.tavily-python` succeeds
- [x] `nix-build -A python3Packages.newsapi-python` succeeds
- [x] `nix-build -A python3Packages.poly-eip712-structs` succeeds
- [x] `nix-build -A python3Packages.py-order-utils` succeeds
- [x] `nix-build -A python3Packages.py-clob-client` succeeds
- [x] `nix-build -A polymarket-agents` succeeds
- [x] `polymarket-agents` binary runs (fails at API key check as expected without credentials)
- [x] `nix fmt` passes on all files