### PR TITLE
openbao: fix interactive cli missing stty

### DIFF
--- a/pkgs/by-name/op/openbao/package.nix
+++ b/pkgs/by-name/op/openbao/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  fetchpatch2,
   buildGoModule,
   installShellFiles,
   versionCheckHook,
@@ -23,7 +24,7 @@ buildGoModule (finalAttrs: {
     hash = "sha256-pVFsyNg9ccSFAdHb/fjeVoMBh1nKcjwcFfVBBqFalIo=";
   };
 
-  vendorHash = "sha256-lfabvwO+p54SREvpCZdw5z/QMLDZqaf1UZTXWGm6sdg=";
+  vendorHash = "sha256-8F8HCbpk8st1o/64Y442lzzFXBnCs+mEYREYcj/s5KI=";
 
   proxyVendor = true;
 
@@ -36,6 +37,15 @@ buildGoModule (finalAttrs: {
     "-X github.com/openbao/openbao/version.GitCommit=${finalAttrs.src.rev}"
     "-X github.com/openbao/openbao/version.fullVersion=${finalAttrs.version}"
     "-X github.com/openbao/openbao/version.buildDate=1970-01-01T00:00:00Z"
+  ];
+
+  patches = [
+    # Fixes interactive CLI usage that needs stty https://github.com/openbao/openbao/pull/2535
+    (fetchpatch2 {
+      name = "pr2535-fix-interactive-cli.patch";
+      url = "https://github.com/openbao/openbao/commit/e3fec111e3f6fd543c79c08f46d2256cd93f78e7.patch";
+      hash = "sha256-Q/hmJj+JbpWjDhXp+p2qjlAMSUVP279Ca7ihh/9khOQ=";
+    })
   ];
 
   postConfigure = lib.optionalString withUi ''


### PR DESCRIPTION
Apply upstream patch that fixes interactive CLI usage when it needs stty https://github.com/openbao/openbao/pull/2535


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
