### PR TITLE
streamripper: fix build

### DIFF
--- a/pkgs/by-name/st/streamripper/package.nix
+++ b/pkgs/by-name/st/streamripper/package.nix
@@ -35,6 +35,13 @@ stdenv.mkDerivation rec {
       patch = "873964-http";
       hash = "sha256-D6koUCbnJHtRuq2zZy9VrxymuGXN1COacbQhphgB8qo=";
     })
+    # fix build with gcc 15
+    (fetchDebianPatch {
+      inherit pname version;
+      debianRevision = "4";
+      patch = "1097944-gcc15";
+      hash = "sha256-yBFDxd2sNlavQDmg/MCORFdpJY8p1Lzo131T4sBby5g=";
+    })
     # fix SR_ERROR_INVALID_METADATA caused by HTTP chunking
     # (https://sourceforge.net/p/streamripper/bugs/193/#6a82)
     (fetchpatch {

--- a/pkgs/by-name/st/streamripper/package.nix
+++ b/pkgs/by-name/st/streamripper/package.nix
@@ -64,5 +64,6 @@ stdenv.mkDerivation rec {
     description = "Application that lets you record streaming mp3 to your hard drive";
     license = lib.licenses.gpl2;
     mainProgram = "streamripper";
+    maintainers = with lib.maintainers; [ cybershadow ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes #494130

Part of #475479

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
