### PR TITLE
calibre-web: 0.6.25 -> 0.6.26-unstable-2026-03-01

### DIFF
--- a/pkgs/by-name/ca/calibre-web/package.nix
+++ b/pkgs/by-name/ca/calibre-web/package.nix
@@ -8,14 +8,15 @@
 }:
 python3Packages.buildPythonApplication rec {
   pname = "calibre-web";
-  version = "0.6.25";
+  version = "0.6.26-unstable-2026-03-01";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "janeczku";
     repo = "calibre-web";
-    tag = version;
-    hash = "sha256-tmSp6ABQ4KnNdUHYZPnXGfhhyhM6aczEUPd57APZnLA=";
+    # remember changing this back (and changelog below) to tag after new release come out
+    rev = "6157f5027c979aa05f8d97a09f1388ceb3085ac5";
+    hash = "sha256-1ljMsf8Puvq4ELUSi8Vl3T7EHcd7MO3zGgT4j5PYsT0=";
   };
 
   patches = [
@@ -148,7 +149,9 @@ python3Packages.buildPythonApplication rec {
   meta = {
     description = "Web app for browsing, reading and downloading eBooks stored in a Calibre database";
     homepage = "https://github.com/janeczku/calibre-web";
-    changelog = "https://github.com/janeczku/calibre-web/releases/tag/${src.tag}";
+    # revert back to tag based changelog
+    # changelog = "https://github.com/janeczku/calibre-web/releases/tag/${src.tag}";
+    changelog = "https://github.com/janeczku/calibre-web/compare/0.6.26...${src.rev}";
     license = lib.licenses.gpl3Plus;
     maintainers = with lib.maintainers; [ pborzenkov ];
     mainProgram = "calibre-web";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

supersedes #488655

closes #493387

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
