### PR TITLE
maintainers: remove jsierles

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13166,13 +13166,6 @@
     githubId = 1186444;
     name = "James Short";
   };
-  jsierles = {
-    email = "joshua@hey.com";
-    matrix = "@jsierles:matrix.org";
-    name = "Joshua Sierles";
-    github = "jsierles";
-    githubId = 82;
-  };
   jsimonetti = {
     email = "jeroen+nixpkgs@simonetti.nl";
     matrix = "@jeroen:simonetti.nl";

--- a/pkgs/by-name/fl/flyctl/package.nix
+++ b/pkgs/by-name/fl/flyctl/package.nix
@@ -84,7 +84,6 @@ buildGoModule rec {
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [
       adtya
-      jsierles
       techknowlogick
       RaghavSood
       SchahinRohani


### PR DESCRIPTION
## Reasons

- Last commented in [August 2022](https://github.com/NixOS/nixpkgs/issues?q=commenter%3Ajsierles)
- Hasn't created any PRs / Issues since [January 2022](https://github.com/NixOS/nixpkgs/issues?q=author%3Ajsierles)
- About 200 [unanswered ](https://github.com/NixOS/nixpkgs/issues?q=involves%3Ajsierles%20-commenter%3Ajsierles%20-author%3Ajsierles%20-reviewed-by%3Ajsierles) PRs / Issues

See [lossing maintainer status](https://github.com/NixOS/nixpkgs/tree/master/maintainers#losing-maintainer-status) in the docs. You have one week to respond to this.