### PR TITLE
nixos/nftables: replace script with file

### DIFF
--- a/nixos/modules/services/networking/nftables.nix
+++ b/nixos/modules/services/networking/nftables.nix
@@ -298,7 +298,6 @@ in
         let
           enabledTables = lib.filterAttrs (_: table: table.enable) cfg.tables;
           deletionsScript = pkgs.writeScript "nftables-deletions" ''
-            #! ${pkgs.nftables}/bin/nft -f
             ${
               if cfg.flushRuleset then
                 "flush ruleset"
@@ -313,9 +312,9 @@ in
             ${cfg.extraDeletions}
           '';
           deletionsScriptVar = "/var/lib/nftables/deletions.nft";
+          makeDeletions = "${pkgs.nftables}/bin/nft -f ${deletionsScriptVar}";
           ensureDeletions = pkgs.writeShellScript "nftables-ensure-deletions" ''
             touch ${deletionsScriptVar}
-            chmod +x ${deletionsScriptVar}
           '';
           saveDeletionsScript = pkgs.writeShellScript "nftables-save-deletions" ''
             cp ${deletionsScript} ${deletionsScriptVar}
@@ -380,7 +379,7 @@ in
             saveDeletionsScript
           ];
           ExecStop = [
-            deletionsScriptVar
+            makeDeletions
             cleanupDeletionsScript
           ];
           StateDirectory = "nftables";


### PR DESCRIPTION
nftables service successfully restarts or reloads if the file `/var/lib/nftables/deletions.nft` is on a partition that was mounted as noexec, and delete previous rules.
Instead of writing a deletion script, the service creates a simple file where nftables rules are written to that is used as an argument for the `nft` command to delete rules upon stop,restart, or reload.

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
