### PR TITLE
home-assistant-custom-lovelace-modules.kiosk-mode: init at 10.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -26308,6 +26308,12 @@
     github = "teczito";
     githubId = 15378834;
   };
+  teeco123 = {
+    name = "Kacper Gajko";
+    email = "kacper.gajko1@icloud.com";
+    github = "teeco123";
+    githubId = 116846689;
+  };
   teh = {
     email = "tehunger@gmail.com";
     github = "teh";

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/kiosk-mode/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/kiosk-mode/package.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  pnpmConfigHook,
+  pnpm,
+  nodejs,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "kiosk-mode";
+  version = "10.0.1";
+
+  src = fetchFromGitHub {
+    owner = "nemesisre";
+    repo = "kiosk-mode";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-y8ck4Y8tmZkUv35n78u+PRc+i6wF6iuhYbQJ7wQPVqE=";
+  };
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs) pname version src;
+    fetcherVersion = 3;
+    hash = "sha256-4pTI5d1Mn/GtbjkOAyemxXN2k2rRj8kYS4t2C6OLVSc=";
+  };
+
+  nativeBuildInputs = [
+    pnpmConfigHook
+    pnpm
+    nodejs
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm run build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp dist/* "$out"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Hides the Home Assistant header and/or sidebar";
+    homepage = "https://github.com/NemesisRE/kiosk-mode";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ teeco123 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added a [package](https://github.com/NemesisRE/kiosk-mode) adds kiosk mode for home assistant. It disables parts of UI specified by user.

Its my first PR hope everything is alright.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
