### PR TITLE
Add ur_rtde C++ library and python binding

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -25566,6 +25566,11 @@
     github = "StephenWithPH";
     githubId = 2990492;
   };
+  stepisptr-t = {
+    name = "Štěpán Beran";
+    github = "stepisptr-t";
+    githubId = 77941720;
+  };
   sterfield = {
     email = "sterfield@gmail.com";
     github = "sterfield";

--- a/pkgs/by-name/ur/ur-rtde/package.nix
+++ b/pkgs/by-name/ur/ur-rtde/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  cmake,
+  boost183,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "ur-rtde";
+  version = "1.6.0";
+
+  src = fetchFromGitLab {
+    owner = "sdurobotics";
+    repo = "ur_rtde";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-Aj/+XVlcjloNctf4lUU2Rb+Zu+GkzckqHdAZGvyIqZQ=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ boost183 ];
+
+  cmakeFlags = [
+    "-DPYTHON_BINDINGS=OFF"
+  ];
+
+  meta = with lib; {
+    description = "A C++ interface for controlling and receiving data from a UR robot using the Real-Time Data Exchange (RTDE) interface";
+    homepage = "https://gitlab.com/sdurobotics/ur_rtde";
+    license = licenses.mit;
+    maintainers = with maintainers; [ stepisptr-t ];
+    platforms = platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/ur-rtde/default.nix
+++ b/pkgs/development/python-modules/ur-rtde/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitLab,
+  cmake,
+  pybind11,
+  setuptools,
+  setuptools-scm,
+  boost183,
+  ncurses,
+  pythonOlder,
+  pythonAtLeast,
+}:
+
+buildPythonPackage rec {
+  pname = "ur-rtde";
+  version = "1.6.0";
+  pyproject = true;
+
+  # newer versions fails on deprecations
+  disabled = pythonOlder "3.11" || pythonAtLeast "3.12";
+
+  src = fetchFromGitLab {
+    owner = "sdurobotics";
+    repo = "ur_rtde";
+    rev = "v${version}";
+    fetchSubmodules = true;
+    hash = "sha256-Aj/+XVlcjloNctf4lUU2Rb+Zu+GkzckqHdAZGvyIqZQ=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pybind11
+  ];
+
+  buildInputs = [
+    # boost has to be pinned to 1.83 for compilation to succeed
+    boost183
+    ncurses
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [
+    "rtde_control"
+    "rtde_receive"
+    "rtde_io"
+  ];
+
+  postPatch = ''
+    # Prevent CMake from trying to download pybind11 via git during the build
+    # Use the system pybind11 instead
+    substituteInPlace CMakeLists.txt \
+      --replace-fail "add_subdirectory(pybind11)" "find_package(pybind11 REQUIRED)" \
+      --replace-fail "FetchContent_MakeAvailable(pybind11-src)" "find_package(pybind11 REQUIRED)"
+  '';
+
+  meta = with lib; {
+    description = "A python binding for C++ library used to controll and data collection from a UR robot using the Real-Time Data Exchange (RTDE) interface";
+    homepage = "https://gitlab.com/sdurobotics/ur_rtde";
+    license = licenses.mit;
+    maintainers = with maintainers; [ stepisptr-t ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -20327,6 +20327,8 @@ self: super: with self; {
 
   uqbar = callPackage ../development/python-modules/uqbar { };
 
+  ur-rtde = callPackage ../development/python-modules/ur-rtde { };
+
   uranium = callPackage ../development/python-modules/uranium { };
 
   uri-template = callPackage ../development/python-modules/uri-template { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add of [ur_rtde](https://gitlab.com/sdurobotics/ur_rtde) C++ library and its python binding.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage]. (Not enough RAM, sorry...)
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`. (No binaries, but basic includes do work)
- Nixpkgs Release Notes
  - [x] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
