### PR TITLE
lager: 0.1.2 -> 0.1.3

### DIFF
--- a/pkgs/by-name/la/lager/package.nix
+++ b/pkgs/by-name/la/lager/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   boost,
   cereal,
@@ -14,23 +13,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lager";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "arximboldi";
     repo = "lager";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-ssGBQu8ba798MSTtJeCBE3WQ7AFfvSGLhZ7WBYHEgfw=";
+    hash = "sha256-xJxLLvOQxti0s1Lr1EWqYiuJLoHkSOUHiz5COnE5aog=";
   };
-
-  patches = lib.optionals finalAttrs.finalPackage.doCheck [
-    # https://github.com/arximboldi/lager/pull/233
-    (fetchpatch {
-      name = "Stop-using-Boost-system.patch";
-      url = "https://github.com/arximboldi/lager/commit/0eb1d3d3a6057723c5b57b3e0ee3e41924ff419a.patch";
-      hash = "sha256-peGpuyuCznCDqYo+9zk1FytLV+a6Um8fvjLmrm7Y2CI=";
-    })
-  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
Lager 0.1.3 has been released and now builds against Boost 1.89 without needing to be patched.

https://github.com/arximboldi/lager/compare/refs/tags/v0.1.2...refs/tags/v0.1.3


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
