### PR TITLE
prometheus-fail2ban-exporter: init at 0.10.3, nixos/prometheus-exporters/fail2ban: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -3011,6 +3011,14 @@
     githubId = 75235;
     name = "Michael Walker";
   };
+  bartoostveen = {
+    name = "Bart Oostveen";
+    github = "bartoostveen";
+    githubId = 50515369;
+    email = "bart@bartoostveen.nl";
+    matrix = "@bart:bartoostveen.nl";
+    keys = [ { fingerprint = "81FF AB19 BAA5 6FFD 6571  890B 992D 94B5 7AC4 3430"; } ];
+  };
   bartuka = {
     email = "wand@hey.com";
     github = "wandersoncferreira";

--- a/nixos/modules/services/monitoring/prometheus/exporters.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters.nix
@@ -66,6 +66,7 @@ let
         "domain"
         "dovecot"
         "ebpf"
+        "fail2ban"
         "fastly"
         "flow"
         "fritz"
@@ -341,6 +342,31 @@ let
       services.udev.extraRules = mkIf (name == "smartctl") ''
         ACTION=="add", SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", RUN+="${pkgs.acl}/bin/setfacl -m g:smartctl-exporter-access:rw /dev/$kernel"
       '';
+      systemd.services.prometheus-fail2ban-exporter-setup =
+        mkIf (config.services.fail2ban.enable && name == "fail2ban")
+          {
+            description = "Set fail2ban socket ACLs";
+            after = [ "fail2ban.service" ];
+            requires = [ "fail2ban.service" ];
+            before = [ "prometheus-fail2ban-exporter.service" ];
+            wantedBy = [ "prometheus-fail2ban-exporter.service" ];
+            path = [
+              pkgs.acl
+              pkgs.coreutils
+            ];
+            script = ''
+              while [ ! -S ${conf.fail2banSocket} ]; do
+                sleep 0.1
+              done
+
+              setfacl -m u:${conf.user}:x $(dirname ${conf.fail2banSocket})
+              setfacl -m u:${conf.user}:rwx ${conf.fail2banSocket}
+            '';
+            serviceConfig = {
+              Type = "oneshot";
+              User = "root";
+            };
+          };
       networking.firewall.extraCommands = mkIf (conf.openFirewall && !nftables) (concatStrings [
         "ip46tables -A nixos-fw ${conf.firewallFilter} "
         "-m comment --comment ${name}-exporter -j nixos-fw-accept"

--- a/nixos/modules/services/monitoring/prometheus/exporters/fail2ban.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/fail2ban.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.prometheus.exporters.fail2ban;
+
+  inherit (lib)
+    mkOption
+    types
+    getExe
+    optionalString
+    mkIf
+    ;
+in
+{
+  port = 9191;
+  extraOpts = {
+    host = mkOption {
+      description = "The host that the fail2ban exporter should listen on";
+      type = types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+    };
+    fail2banSocket = mkOption {
+      description = "Path to the fail2ban server socket. Permissions will be set automatically if fail2ban runs on this system.";
+      type = types.str;
+      default = config.services.fail2ban.daemonSettings.Definition.socket;
+      defaultText = "config.services.fail2ban.daemonSettings.Definition.socket";
+    };
+    exitOnError = mkOption {
+      description = "When set to true the exporter will immediately exit on a fail2ban socket connection error";
+      type = types.bool;
+      default = true;
+      example = false;
+    };
+    username = mkOption {
+      description = "Username to protect endpoints with HTTP basic authentication";
+      type = types.nullOr types.str;
+      default = null;
+      example = "admin";
+    };
+    passwordFile = mkOption {
+      description = "File that contains the password to protect endpoints with HTTP basic authentication";
+      type = types.nullOr types.path;
+      default = null;
+      example = "/run/secrets/prometheus-fail2ban-exporter-password.txt";
+    };
+  };
+
+  assertions = [
+    {
+      assertion = (cfg.username != null) -> (cfg.passwordFile != null);
+      message = "Setting an http basic auth username requires the password to be non-null";
+    }
+  ];
+
+  serviceOpts = {
+    requires = mkIf config.services.fail2ban.enable [ "prometheus-fail2ban-exporter-setup.service" ];
+    serviceConfig = {
+      DynamicUser = false;
+      ExecStart = ''
+        ${getExe pkgs.prometheus-fail2ban-exporter} \
+          ${optionalString cfg.exitOnError ''--collector.f2b.exit-on-socket-connection-error \''}
+          ${optionalString (cfg.username != null) ''
+            --web.basic-auth.username="${cfg.username}" \
+            --web.basic-auth.password="$(cat ${cfg.passwordFile})" \
+          ''}
+          --web.listen-address="${cfg.host}:${toString cfg.port}" \
+          --collector.f2b.socket=${cfg.fail2banSocket}
+      '';
+      RestrictAddressFamilies = [
+        "AF_INET"
+        "AF_INET6"
+        "AF_UNIX"
+      ];
+    };
+  };
+}

--- a/nixos/tests/prometheus-exporters.nix
+++ b/nixos/tests/prometheus-exporters.nix
@@ -436,6 +436,24 @@ let
         '';
       };
 
+    fail2ban =
+      { ... }:
+      {
+        exporterConfig = {
+          enable = true;
+          exitOnError = true;
+        };
+        metricProvider = {
+          services.fail2ban.enable = true;
+        };
+        exporterTest = ''
+          wait_for_unit("fail2ban.service")
+          wait_for_unit("prometheus-fail2ban-exporter.service")
+          wait_for_open_port(9191)
+          succeed("curl -sSf http://localhost:9191/metrics | grep 'f2b_errors'")
+        '';
+      };
+
     fastly =
       { pkgs, ... }:
       {

--- a/pkgs/by-name/pr/prometheus-fail2ban-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-fail2ban-exporter/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitLab,
+}:
+
+buildGoModule (finalAttrs: {
+  pname = "prometheus-fail2ban-exporter";
+  version = "0.10.3";
+
+  src = fetchFromGitLab {
+    owner = "hctrdev";
+    repo = "fail2ban-prometheus-exporter";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-CyYGY6SovnvgExB22G+LEKRDRzbDZWhWUjctJMkprYs=";
+  };
+
+  vendorHash = "sha256-ogdRXbS1EG402qlnj5SfuI/1P/Pi0+xwJrJsc6vwdds=";
+
+  ldflags = [ "-s" ];
+
+  meta = {
+    description = "Collect and export metrics on Fail2Ban";
+    homepage = "https://gitlab.com/hctrdev/fail2ban-prometheus-exporter";
+    license = lib.licenses.mit;
+    mainProgram = "fail2ban-prometheus-exporter";
+    maintainers = with lib.maintainers; [
+      bartoostveen
+    ];
+  };
+})


### PR DESCRIPTION
- **maintainers: add bartoostveen**
- **prometheus-fail2ban-exporter: init at 0.10.3**
- **nixos/prometheus-exporters/fail2ban: init**

I packaged the de-facto standard fail2ban exporter for Prometheus. I also added NixOS options to `services.prometheus.exporters`. Note for the reviewer: it seems like with the Prometheus exporters in NixOS it is standard practice to add additional NixOS configuration needed for it to work in `nixos/modules/services/monitoring/prometheus/exporters.nix`, so I'm not entirely sure if this is the right way to go, and feedback is definitely welcome! Since this is also technically not a module addition, I did not add anything to the 26.05 release notes. Let me know if I did it right.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [x] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
