### PR TITLE
backblaze-b2: 4.5.1 -> 4.6.0

### DIFF
--- a/pkgs/by-name/ba/backblaze-b2/package.nix
+++ b/pkgs/by-name/ba/backblaze-b2/package.nix
@@ -46,7 +46,10 @@ python3Packages.buildPythonApplication (finalAttrs: {
     setuptools
   ];
 
-  pythonRelaxDeps = [ "phx-class-registry" ];
+  pythonRelaxDeps = [
+    "docutils"
+    "phx-class-registry"
+  ];
 
   nativeCheckInputs = with python3Packages; [
     backoff

--- a/pkgs/by-name/ba/backblaze-b2/package.nix
+++ b/pkgs/by-name/ba/backblaze-b2/package.nix
@@ -11,14 +11,14 @@
 
 python3Packages.buildPythonApplication (finalAttrs: {
   pname = "backblaze-b2";
-  version = "4.5.1";
+  version = "4.6.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "B2_Command_Line_Tool";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-0BF4+L47Cx7GNGeNm8nJkEfTLYb6jLxSH3WE+h9B6zA=";
+    hash = "sha256-/JCvCydW+oaPSs94Crfia9VFNSuHO02j6n+CFnxMKDE=";
   };
 
   patches = [ ./0001-fix-error-with-pytest-4.0.patch ];
@@ -28,28 +28,21 @@ python3Packages.buildPythonApplication (finalAttrs: {
     argcomplete
   ];
 
-  build-system = with python3Packages; [
-    pdm-backend
-  ];
+  build-system = with python3Packages; [ pdm-backend ];
 
   dependencies = with python3Packages; [
     argcomplete
     arrow
     b2sdk
-    phx-class-registry
     docutils
+    platformdirs
     rst2ansi
+    setuptools
     tabulate
     tqdm
-    platformdirs
-    packaging
-    setuptools
   ];
 
-  pythonRelaxDeps = [
-    "docutils"
-    "phx-class-registry"
-  ];
+  pythonRelaxDeps = [ "docutils" ];
 
   nativeCheckInputs = with python3Packages; [
     backoff

--- a/pkgs/development/python-modules/b2sdk/default.nix
+++ b/pkgs/development/python-modules/b2sdk/default.nix
@@ -4,8 +4,8 @@
   fetchFromGitHub,
   logfury,
   annotated-types,
-  packaging,
-  pdm-backend,
+  hatchling,
+  hatch-vcs,
   pytest-lazy-fixtures,
   pytest-mock,
   pytest-timeout,
@@ -14,27 +14,30 @@
   pythonOlder,
   requests,
   responses,
+  tenacity,
   tqdm,
   typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "b2sdk";
-  version = "2.10.2";
+  version = "2.10.3";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Backblaze";
     repo = "b2-sdk-python";
     tag = "v${version}";
-    hash = "sha256-RWHD1ARPSKHmGKY0xdCBn3Qj4GxAfn4o8eacMQ5RT1k=";
+    hash = "sha256-Gu4MRfjNWuwEFn13U49dEndWA/HNPwrQdX9VEz1ny+M=";
   };
 
-  build-system = [ pdm-backend ];
+  build-system = [
+    hatchling
+    hatch-vcs
+  ];
 
   dependencies = [
     annotated-types
-    packaging
     logfury
     requests
   ]
@@ -46,6 +49,7 @@ buildPythonPackage rec {
     pytest-timeout
     pytestCheckHook
     responses
+    tenacity
     tqdm
   ];
 

--- a/pkgs/development/python-modules/rst2ansi/default.nix
+++ b/pkgs/development/python-modules/rst2ansi/default.nix
@@ -1,18 +1,20 @@
 {
   lib,
   buildPythonPackage,
-  fetchPypi,
+  fetchFromGitHub,
   docutils,
 }:
 
-buildPythonPackage rec {
+buildPythonPackage {
   pname = "rst2ansi";
-  version = "0.1.5";
+  version = "0.1.5-unstable-2025-02-12";
   format = "setuptools";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-Gxf7mmKNQPV5M60aOqlSNGREvgaUaVCOc+lQYNoz/m8=";
+  src = fetchFromGitHub {
+    owner = "Snaipe";
+    repo = "python-rst2ansi";
+    rev = "3728e16f8b8b1dc338e5df90ba2c4a93ee054b3f";
+    hash = "sha256-V7tl/YJcPvEgBfH334t6CU7OXKQqBqRo/zZPiOlyCmE=";
   };
 
   propagatedBuildInputs = [ docutils ];


### PR DESCRIPTION
Updates & fixes backblaze-b2 and dependencies, superseeds https://github.com/NixOS/nixpkgs/pull/493623

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
