### PR TITLE
audio-mirroring: init at 0.1.0

### DIFF
--- a/pkgs/by-name/au/audio-mirroring/package.nix
+++ b/pkgs/by-name/au/audio-mirroring/package.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  cargo,
+  desktop-file-utils,
+  fetchFromGitHub,
+  glib,
+  gtk4,
+  libadwaita,
+  meson,
+  ninja,
+  pipewire,
+  pkg-config,
+  rustPlatform,
+  rustc,
+  stdenv,
+  wrapGAppsHook4,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "audio-mirroring";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mkg20001";
+    repo = "audio-mirroring";
+    tag = "v${version}";
+    hash = "sha256-GMgFrA8fxaB4W+FDkxfe++RBSChbh59RvWZZwmd/CRo=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit pname version src;
+    hash = "sha256-tTnrwtLw251aQaM2zUh/sS4MGlmRbZxFROgTRwo9ZlU=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    rustPlatform.cargoSetupHook
+    cargo
+    rustc
+    rustPlatform.bindgenHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    desktop-file-utils
+    glib
+    gtk4
+    libadwaita
+    pipewire
+  ];
+
+  meta = with lib; {
+    description = "Audio Mirroring for Linux";
+    homepage = "https://github.com/mkg20001/audio-mirroring";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ mkg20001 ];
+    platforms = platforms.linux;
+    mainProgram = "audio-mirroring";
+  };
+}


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [x] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
