### PR TITLE
python3Packages.mathutils: 3.3.0 -> 5.1.0

### DIFF
--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -128,12 +128,12 @@ freecad-utils.makeCustomizable (
 
     cmakeFlags = [
       "-Wno-dev" # turns off warnings which otherwise makes it hard to see what is going on
-      "-DBUILD_DRAWING=ON"
-      "-DBUILD_FLAT_MESH:BOOL=ON"
-      "-DINSTALL_TO_SITEPACKAGES=OFF"
-      "-DFREECAD_USE_PYBIND11=ON"
-      "-DBUILD_QT5=OFF"
-      "-DBUILD_QT6=ON"
+      (lib.cmakeBool "BUILD_DRAWING" true)
+      (lib.cmakeBool "BUILD_FLAT_MESH" true)
+      (lib.cmakeBool "INSTALL_TO_SITEPACKAGES" false)
+      (lib.cmakeBool "FREECAD_USE_PYBIND11" true)
+      (lib.cmakeBool "BUILD_QT5" false)
+      (lib.cmakeBool "BUILD_QT6" true)
     ];
 
     qtWrapperArgs =

--- a/pkgs/development/python-modules/mathutils/default.nix
+++ b/pkgs/development/python-modules/mathutils/default.nix
@@ -1,37 +1,45 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitLab,
-  pythonAtLeast,
+  fetchPypi,
 
   # build-system
   setuptools,
+
+  # nativeBuildInputs
+  pkg-config,
+
+  # buildInputs
+  eigen,
 }:
 
-buildPythonPackage {
+buildPythonPackage (finalAttrs: {
   pname = "mathutils";
-  version = "3.3.0";
+  version = "5.1.0";
   pyproject = true;
 
-  src = fetchFromGitLab {
-    owner = "ideasman42";
-    repo = "blender-mathutils";
-    rev = "d63d623a9e580a567eb6acb7dbed7cad0e4f8c28";
-    hash = "sha256-c28kt2ADw4wHNLN0CBPcJU/kqm6g679QRaICk4WwaBc=";
+  # No tags on GitLab
+  src = fetchPypi {
+    inherit (finalAttrs) pname version;
+    hash = "sha256-sXGvnWtUoSE4yd6tT1kwo/qvkjh8xf+qgvGPvuFVQWg=";
   };
-
-  # error: implicit declaration of function ‘_PyLong_AsInt’; did you mean ‘PyLong_AsInt’? [-Wimplicit-function-declaration]
-  # https://github.com/python/cpython/issues/108444
-  postPatch = lib.optionalString (pythonAtLeast "3.13") ''
-    substituteInPlace src/generic/py_capi_utils.{c,h} \
-      --replace-fail "_PyLong_AsInt" "PyLong_AsInt"
-  '';
 
   build-system = [
     setuptools
   ];
 
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    eigen
+  ];
+
   pythonImportsCheck = [ "mathutils" ];
+
+  # no tests
+  doCheck = false;
 
   meta = {
     description = "General math utilities library providing Matrix, Vector, Quaternion, Euler and Color classes, written in C for speed";
@@ -39,4 +47,4 @@ buildPythonPackage {
     license = lib.licenses.gpl2Plus;
     maintainers = with lib.maintainers; [ autra ];
   };
-}
+})


### PR DESCRIPTION
## Things done

- **python3Packages.mathutils: 3.3.0 -> 5.1.0**
- **freecad: use lib.cmakeBool where applicable**
- **freecad: fix cmake configure by patching SetupBoost.cmake**

---

- Built on platform:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
