### PR TITLE
python3Packages.tinygrad: skip failing test on aarch64-darwin

### DIFF
--- a/pkgs/development/python-modules/tinygrad/default.nix
+++ b/pkgs/development/python-modules/tinygrad/default.nix
@@ -254,6 +254,10 @@ buildPythonPackage (finalAttrs: {
     "test_gen_from_header"
     "test_struct_ordering"
   ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+    # Exception: forward pass failed shape (2, 3, 64, 64)
+    "test_cast"
+  ]
   ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
     # AssertionError: Expected 1 operations, got 3
     # assert 3 == 1


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

```
=========================== short test summary info ============================
FAILED test/test_ops.py::TestOpsUint8::test_cast - Exception: forward pass failed shape (2, 3, 64, 64):
Arrays are not equal

Mismatched elements: 6288 / 24576 (25.6%)
First 5 mismatches are at indices:
 [0, 0, 0, 14]: 255 (ACTUAL), 0 (DESIRED)
 [0, 0, 0, 15]: 255 (ACTUAL), 0 (DESIRED)
 [0, 0, 0, 16]: 255 (ACTUAL), 0 (DESIRED)
 [0, 0, 0, 24]: 255 (ACTUAL), 0 (DESIRED)
 [0, 0, 0, 26]: 255 (ACTUAL), 0 (DESIRED)
Max absolute difference among violations: 1
Max relative difference among violations: inf
 ACTUAL: array([[[[  0,   0,   0, ..., 255,   0, 255],
         [255,   0,   1, ...,   0, 255,   0],
         [  0,   0,   0, ...,   0,   0, 255],...
 DESIRED: array([[[[0, 0, 0, ..., 0, 0, 0],
         [0, 0, 1, ..., 0, 0, 0],
         [0, 0, 0, ..., 0, 0, 0],...
= 1 failed, 2531 passed, 503 skipped, 44 xfailed, 16 warnings in 83.37s (0:01:23) =
```

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
