### PR TITLE
haskellPackages.cabal2nix-unstable: 2026-01-25 -> 2026-03-07

### DIFF
--- a/pkgs/development/haskell-modules/cabal2nix-unstable/cabal2nix.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/cabal2nix.nix
@@ -35,10 +35,10 @@
 }:
 mkDerivation {
   pname = "cabal2nix";
-  version = "2.21.0-unstable-2026-01-25";
+  version = "2.21.2-unstable-2026-03-07";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/751a8eccfc92f8ce3ca9d517c554e7dcb3f409bd.tar.gz";
-    sha256 = "1i9ifxmh5bqgpa7a6l46lqkzpr7z3zfm7bdkllq56hz1nmj4gbqx";
+    url = "https://github.com/NixOS/cabal2nix/archive/977a1c199f7f8092ce9eef7d322b0eecebde22a2.tar.gz";
+    sha256 = "0nl5502mpwhmav7qxx051zzyx8ag9mibwhh33bf4aj07ywziza4c";
   };
   postUnpack = "sourceRoot+=/cabal2nix; echo source root reset to $sourceRoot";
   isLibrary = true;

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/distribution-nixpkgs.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/distribution-nixpkgs.nix
@@ -18,10 +18,10 @@
 }:
 mkDerivation {
   pname = "distribution-nixpkgs";
-  version = "1.7.1.1-unstable-2026-01-25";
+  version = "1.7.1.1-unstable-2026-03-07";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/751a8eccfc92f8ce3ca9d517c554e7dcb3f409bd.tar.gz";
-    sha256 = "1i9ifxmh5bqgpa7a6l46lqkzpr7z3zfm7bdkllq56hz1nmj4gbqx";
+    url = "https://github.com/NixOS/cabal2nix/archive/977a1c199f7f8092ce9eef7d322b0eecebde22a2.tar.gz";
+    sha256 = "0nl5502mpwhmav7qxx051zzyx8ag9mibwhh33bf4aj07ywziza4c";
   };
   postUnpack = "sourceRoot+=/distribution-nixpkgs; echo source root reset to $sourceRoot";
   enableSeparateDataOutput = true;

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/hackage-db.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/hackage-db.nix
@@ -13,14 +13,13 @@
   lib,
   tar,
   time,
-  utf8-string,
 }:
 mkDerivation {
   pname = "hackage-db";
-  version = "2.1.3-unstable-2026-01-25";
+  version = "2.1.3-unstable-2026-03-07";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/751a8eccfc92f8ce3ca9d517c554e7dcb3f409bd.tar.gz";
-    sha256 = "1i9ifxmh5bqgpa7a6l46lqkzpr7z3zfm7bdkllq56hz1nmj4gbqx";
+    url = "https://github.com/NixOS/cabal2nix/archive/977a1c199f7f8092ce9eef7d322b0eecebde22a2.tar.gz";
+    sha256 = "0nl5502mpwhmav7qxx051zzyx8ag9mibwhh33bf4aj07ywziza4c";
   };
   postUnpack = "sourceRoot+=/hackage-db; echo source root reset to $sourceRoot";
   isLibrary = true;
@@ -36,7 +35,6 @@ mkDerivation {
     filepath
     tar
     time
-    utf8-string
   ];
   homepage = "https://github.com/NixOS/cabal2nix/tree/master/hackage-db#readme";
   description = "Access cabal-install's Hackage database via Data.Map";

--- a/pkgs/development/haskell-modules/cabal2nix-unstable/language-nix.nix
+++ b/pkgs/development/haskell-modules/cabal2nix-unstable/language-nix.nix
@@ -14,10 +14,10 @@
 }:
 mkDerivation {
   pname = "language-nix";
-  version = "2.3.0-unstable-2026-01-25";
+  version = "2.3.0-unstable-2026-03-07";
   src = fetchzip {
-    url = "https://github.com/NixOS/cabal2nix/archive/751a8eccfc92f8ce3ca9d517c554e7dcb3f409bd.tar.gz";
-    sha256 = "1i9ifxmh5bqgpa7a6l46lqkzpr7z3zfm7bdkllq56hz1nmj4gbqx";
+    url = "https://github.com/NixOS/cabal2nix/archive/977a1c199f7f8092ce9eef7d322b0eecebde22a2.tar.gz";
+    sha256 = "0nl5502mpwhmav7qxx051zzyx8ag9mibwhh33bf4aj07ywziza4c";
   };
   postUnpack = "sourceRoot+=/language-nix; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -143,6 +143,8 @@ with haskellLib;
 
         cabal-install-solver = super.cabal-install-solver.overrideScope cabalInstallOverlay;
 
+        cabal2nix-unstable = super.cabal2nix-unstable.overrideScope cabalInstallOverlay;
+
         # Needs cabal-install >= 3.8 /as well as/ matching Cabal
         guardian = lib.pipe (super.guardian.overrideScope cabalInstallOverlay) [
           # Tests need internet access (run stack)
@@ -156,25 +158,6 @@ with haskellLib;
     cabal-install-solver
     guardian
     ;
-
-  # cabal2nix depends on hpack which doesn't support Cabal >= 3.16
-  cabal2nix-unstable = super.cabal2nix-unstable.override (
-    prev:
-    # Manually override the relevant dependencies to reduce rebuild amount
-    let
-      cabalOverride = {
-        Cabal = self.Cabal_3_14_2_0;
-      };
-    in
-    cabalOverride
-    // lib.mapAttrs (_: drv: drv.override cabalOverride) {
-      inherit (prev)
-        distribution-nixpkgs
-        hackage-db
-        hpack
-        ;
-    }
-  );
 
   # Extensions wants a specific version of Cabal for its list of Haskell
   # language extensions.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
