### PR TITLE
xlibre-xserver: init at unstable-2026-08-01

### DIFF
--- a/pkgs/by-name/xl/xlibre-xserver/package.nix
+++ b/pkgs/by-name/xl/xlibre-xserver/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  nix-update-script,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  fetchFromGitHub,
+  xorgproto,
+  libx11,
+  libxau,
+  libxcb,
+  libxcb-util,
+  libxcb-wm,
+  libxcb-image,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxdmcp,
+  libxfixes,
+  libxkbfile,
+  libxfont_2,
+  libxcvt,
+  pixman,
+  testers,
+  openssl,
+  libGL,
+  libepoxy,
+  libpciaccess,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xlibre-xserver";
+  version = "25.1.3";
+  src = fetchFromGitHub {
+    owner = "X11Libre";
+    repo = "xserver";
+    hash = "sha256-MgBOlynq05O74SRMtkGo7bNJMWDiHz1MJwssl6CX5RQ=";
+    tag = "xlibre-xserver-${finalAttrs.version}";
+  };
+  hardeningDisable = [
+    "bindnow"
+    "relro"
+  ];
+  __structuredAttrs = true;
+  strictDeps = true;
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+  buildInputs = [
+    xorgproto
+    libx11
+    libxau
+    libxcb
+    libxcb-util
+    libxcb-wm
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    libxdmcp
+    libxfixes
+    libxkbfile
+    libxfont_2
+    libxcvt
+    pixman
+    openssl
+    libGL
+    libepoxy
+    libpciaccess
+  ];
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    passthru.updateScript = nix-update-script { };
+  };
+  meta = {
+    description = "X server implementation by X11Libre";
+    homepage = "https://github.com/X11Libre/xserver";
+    license = [
+      lib.licenses.x11
+      lib.licenses.mit
+      lib.licenses.hpndSellVariant
+      lib.licenses.mitOpenGroup
+      lib.licenses.hpnd
+      lib.licenses.dec3Clause
+      lib.licenses.x11NoPermitPersons
+      lib.licenses.sgi-b-20
+      lib.licenses.bsd3
+      lib.licenses.adobeDisplayPostScript
+      lib.licenses.ntp
+      lib.licenses.hpndUc
+      lib.licenses.isc
+      lib.licenses.icu
+      lib.licenses.hpndSellVariantMitDisclaimerXserver
+    ];
+    mainProgram = "X";
+    maintainers = [ lib.maintainers.theoparis ];
+    pkgConfigModules = [ "xorg-server" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/xl/xlibre-xserver/package.nix
+++ b/pkgs/by-name/xl/xlibre-xserver/package.nix
@@ -1,0 +1,121 @@
+{
+  lib,
+  nix-update-script,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  fetchFromGitHub,
+  xorgproto,
+  libx11,
+  libxau,
+  libxext,
+  libxcb,
+  libxcb-util,
+  libxcb-wm,
+  libxcb-image,
+  libxcb-keysyms,
+  libxcb-render-util,
+  libxdmcp,
+  libxfixes,
+  libxkbfile,
+  libxfont_2,
+  libxcvt,
+  xkeyboard_config,
+  xkbcomp,
+  pixman,
+  testers,
+  openssl,
+  libGL,
+  libepoxy,
+  libpciaccess,
+  libapplewm,
+  darwin,
+  enableGlx ? stdenv.hostPlatform.isLinux,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xlibre-xserver";
+  version = "unstable-2026-08-01";
+  src = fetchFromGitHub {
+    owner = "X11Libre";
+    repo = "xserver";
+    hash = "sha256-i+12SGYSehwuf3sZdz2lWkET6lUKRp3mjtUi9UWblQg=";
+    rev = "856d325dea7addc4dd9c2c78a6bfedf37cbeeead";
+  };
+  hardeningDisable = [
+    "bindnow"
+    "relro"
+  ];
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ darwin.bootstrap_cmds ];
+
+  buildInputs = [
+    xorgproto
+    libx11
+    libxau
+    libxext
+    libxcb
+    libxcb-util
+    libxcb-wm
+    libxcb-image
+    libxcb-keysyms
+    libxcb-render-util
+    libxdmcp
+    libxfixes
+    libxkbfile
+    libxfont_2
+    libxcvt
+    pixman
+    openssl
+    libGL
+    libepoxy
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isLinux) [ libpciaccess ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [ libapplewm ];
+
+  mesonFlags = [
+    (lib.mesonBool "glx" enableGlx)
+    (lib.mesonOption "xkb_dir" "${xkeyboard_config}/share/X11/xkb")
+    (lib.mesonOption "xkb_bin_dir" "${xkbcomp}/bin")
+  ]
+  ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+    "-Dapple-applications-dir=${placeholder "out"}/Applications/Utilities"
+  ];
+
+  passthru = {
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    passthru.updateScript = nix-update-script { };
+  };
+  meta = {
+    description = "X server implementation by X11Libre";
+    homepage = "https://github.com/X11Libre/xserver";
+    license = [
+      lib.licenses.x11
+      lib.licenses.mit
+      lib.licenses.hpndSellVariant
+      lib.licenses.mitOpenGroup
+      lib.licenses.hpnd
+      lib.licenses.dec3Clause
+      lib.licenses.x11NoPermitPersons
+      lib.licenses.sgi-b-20
+      lib.licenses.bsd3
+      lib.licenses.adobeDisplayPostScript
+      lib.licenses.ntp
+      lib.licenses.hpndUc
+      lib.licenses.isc
+      lib.licenses.icu
+      lib.licenses.hpndSellVariantMitDisclaimerXserver
+    ];
+    mainProgram = "X";
+    maintainers = [ lib.maintainers.theoparis ];
+    pkgConfigModules = [ "xorg-server" ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
I figured it be worth a try to get this upstreamed to nixpkgs...  I am currently testing this experimental derivation with an overlay like so:
```nix
 nixpkgs.overlays = [
    (final: previous: {
      xorg-server = final.xlibre-xserver;
      xvfb = final.xlibre-xserver;
    })
  ];
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
