### PR TITLE
python3Packages.greenplanet-energy-api: init at 0.1.8

### DIFF
--- a/pkgs/development/python-modules/greenplanet-energy-api/default.nix
+++ b/pkgs/development/python-modules/greenplanet-energy-api/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  aiohttp,
+  pytest-asyncio,
+  pytest-cov,
+  aioresponses,
+  pytestCheckHook,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "greenplanet-energy-api";
+  version = "0.1.8";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "petschni";
+    repo = "greenplanet-energy-api";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ffmb4UUVfFhSNAy3Fq+3ERYSfD09JnrR8rKUV0sXjNI=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+  ];
+
+  nativeCheckInputs = [
+    pytest-asyncio
+    pytest-cov
+    aioresponses
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [ "greenplanet_energy_api" ];
+
+  meta = {
+    description = "Async Python library for querying the Green Planet Energy API";
+    homepage = "https://github.com/petschni/greenplanet-energy-api";
+    changelog = "https://github.com/petschni/greenplanet-energy-api/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.jamiemagee ];
+  };
+})

--- a/pkgs/servers/home-assistant/component-packages.nix
+++ b/pkgs/servers/home-assistant/component-packages.nix
@@ -2260,7 +2260,8 @@
       ];
     "green_planet_energy" =
       ps: with ps; [
-      ]; # missing inputs: greenplanet-energy-api
+        greenplanet-energy-api
+      ];
     "greeneye_monitor" =
       ps: with ps; [
         greeneye-monitor
@@ -7498,6 +7499,7 @@
     "gpslogger"
     "graphite"
     "gree"
+    "green_planet_energy"
     "greeneye_monitor"
     "group"
     "growatt_server"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6658,6 +6658,8 @@ self: super: with self; {
   # built-in for pypi
   greenlet = if isPyPy then null else callPackage ../development/python-modules/greenlet { };
 
+  greenplanet-energy-api = callPackage ../development/python-modules/greenplanet-energy-api { };
+
   greenwavereality = callPackage ../development/python-modules/greenwavereality { };
 
   gremlinpython = callPackage ../development/python-modules/gremlinpython { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- https://pypi.org/project/greenplanet-energy-api/
- https://github.com/petschni/greenplanet-energy-api
- https://www.home-assistant.io/integrations/green_planet_energy/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
