### PR TITLE
nano-syntax-highlighting: init at 2025.07.01

### DIFF
--- a/pkgs/by-name/na/nano-syntax-highlighting/package.nix
+++ b/pkgs/by-name/na/nano-syntax-highlighting/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  runCommand,
+  writeScriptBin,
+  expect,
+  nano,
+}:
+stdenv.mkDerivation (finalAttrs: rec {
+  pname = "nano-syntax-highlighting";
+  version = "2025.07.01";
+
+  src = fetchFromGitHub {
+    owner = "galenguyer";
+    repo = pname;
+    tag = version;
+    hash = "sha256-+ydaxjF0CzARxyJU9h1Iq2Yj5JgtAd59sf9yH+PyavY=";
+  };
+
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share
+
+    install *.nanorc $out/share/
+  '';
+
+  passthru = {
+    tests.noSyntaxError =
+      let
+        expectScript = writeScriptBin "${pname}-test-syntax.exp" (builtins.readFile ./test-syntax.exp);
+      in
+      (runCommand "${pname}-test-noSyntaxError"
+        {
+          nativeBuildInputs = [
+            expect
+            nano
+          ];
+        }
+        ''
+          set -euo pipefail
+          # For each nanorc file and each syntax, execute text-syntax.exp
+          for nanorcPath in ${finalAttrs.finalPackage}/share/*.nanorc; do
+            nano --rcfile "$nanorcPath" --listsyntaxes \
+            | tail --lines +2 \
+            | xargs --max-args 1 expect -f ${expectScript}/bin/${pname}-test-syntax.exp "$nanorcPath"
+          done;
+          touch $out
+        ''
+      );
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Improved Nano Syntax Highlighting Files, fork of nanorc";
+    homepage = "https://github.com/galenguyer/nano-syntax-highlighting";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      ilai-deutel
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/na/nano-syntax-highlighting/test-syntax.exp
+++ b/pkgs/by-name/na/nano-syntax-highlighting/test-syntax.exp
@@ -1,0 +1,42 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -p expect -p nano -i "expect -f"
+
+proc abort {error} {
+    puts stderr "\n\n\033\[31m$error\033\[39m"
+    exit 1
+}
+
+if {$argc != 2} {
+    abort [format "Usage: %s <nanorcPath> <syntaxName>" [file tail "$argv0"]]
+}
+lassign $argv nanorcPath syntaxName
+
+puts stderr "Testing $syntaxName ($nanorcPath)"
+
+set timeout 10
+# Ensure nano generates ANSI colors so that we can detect errors
+set env(TERM) xterm-256color
+spawn nano --rcfile "$nanorcPath" --syntax "$syntaxName"
+# Send Ctrl-X (exit)
+send "\030"
+lassign [wait] _ _ osError exitCode
+
+if {$osError == -1} {
+    abort "errno: $exitCode"
+} elseif {$exitCode != 0} {
+    abort "nano exited with status $exitCode"
+}
+
+expect {
+    # Check for errors printed to stderr after the nano buffer is closed
+    # Example: "Error in /nix/store/.../nano.nanorc on line 26: Color 'normal' takes no prefix"
+    -re {Error.*} {
+      abort $expect_out(0,string)
+    }
+
+    # Check for Nano status bar errors (red background: \033[41m)
+    # Example: "Unknown syntax name: Invalid"
+    -re {\e\[41m[\s\[]*([^\e]*?)[\s\]]*\e} {
+      abort $expect_out(1,string)
+    }
+}


### PR DESCRIPTION
Add the [`nano-syntax-highlighting`](https://github.com/galenguyer/nano-syntax-highlighting) package. It is a fork of `nanorc`, which hasn't had a release in 15+ years.  

## Things done

- Built on platform:
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [x] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [x] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [x] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test
